### PR TITLE
feat: expand pull request review context and panel tabs

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -54,6 +54,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.pullRequestsListStats]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsDetail]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsDiff]: AuthOrchestrationReadScope,
+  [WS_METHODS.pullRequestsDiffFileContents]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsRunAction]: AuthOrchestrationOperateScope,
   [WS_METHODS.pullRequestsComment]: AuthOrchestrationOperateScope,
   [WS_METHODS.pullRequestsSubmitReview]: AuthOrchestrationOperateScope,

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -69,6 +69,8 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
           timedOut: false,
           stdoutTruncated: false,
           stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
         };
       }),
   });

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -31,6 +31,8 @@ const successfulRunner = (fs: FileSystem.FileSystem, path: Path.Path) =>
           timedOut: false,
           stdoutTruncated: false,
           stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
         };
       }),
   });

--- a/apps/server/src/cloud/selfUpdate.test.ts
+++ b/apps/server/src/cloud/selfUpdate.test.ts
@@ -45,6 +45,8 @@ const makeHarness = Effect.fn("test.make_self_update_harness")(function* (
             timedOut: false,
             stdoutTruncated: false,
             stderrTruncated: false,
+            stdoutInvalidUtf8: false,
+            stderrInvalidUtf8: false,
           };
         }
         order.push("preflight");
@@ -64,6 +66,8 @@ const makeHarness = Effect.fn("test.make_self_update_harness")(function* (
           timedOut: false,
           stdoutTruncated: false,
           stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
         };
       }),
   });

--- a/apps/server/src/environment/ServerEnvironmentLabel.test.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.test.ts
@@ -81,6 +81,8 @@ describe("resolveServerEnvironmentLabel", () => {
           timedOut: false,
           stdoutTruncated: false,
           stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
         }),
       );
 
@@ -120,6 +122,8 @@ describe("resolveServerEnvironmentLabel", () => {
           timedOut: false,
           stdoutTruncated: false,
           stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
         }),
       );
 
@@ -223,6 +227,8 @@ describe("resolveServerEnvironmentLabel", () => {
         timedOut: false,
         stdoutTruncated: false,
         stderrTruncated: false,
+        stdoutInvalidUtf8: false,
+        stderrInvalidUtf8: false,
       }),
     );
 
@@ -264,6 +270,8 @@ describe("resolveServerEnvironmentLabel", () => {
           timedOut: false,
           stdoutTruncated: false,
           stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
         }),
       );
 

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -13,6 +13,7 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import {
   collectUint8StreamText,
+  decodeUtf8,
   type CollectedUint8StreamText,
 } from "./stream/collectUint8StreamText.ts";
 
@@ -41,6 +42,8 @@ export interface ProcessRunOutput {
   readonly timedOut: boolean;
   readonly stdoutTruncated: boolean;
   readonly stderrTruncated: boolean;
+  readonly stdoutInvalidUtf8: boolean;
+  readonly stderrInvalidUtf8: boolean;
 }
 
 const ProcessInvocationFields = {
@@ -238,7 +241,7 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
     ),
     Effect.map(
       (state): CollectedUint8StreamText => ({
-        text: Buffer.concat(state.chunks, state.bytes).toString("utf8"),
+        ...decodeUtf8(Buffer.concat(state.chunks, state.bytes)),
         bytes: state.bytes,
         truncated: false,
       }),
@@ -268,6 +271,8 @@ function finalizeRunProcess<R>(
           timedOut: true,
           stdoutTruncated: false,
           stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
         } satisfies ProcessRunOutput);
       }
       return Effect.fail(
@@ -394,6 +399,8 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
     timedOut: false,
     stdoutTruncated: stdout.truncated,
     stderrTruncated: stderr.truncated,
+    stdoutInvalidUtf8: stdout.invalidUtf8,
+    stderrInvalidUtf8: stderr.invalidUtf8,
   } satisfies ProcessRunOutput;
 });
 

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
@@ -29,19 +29,24 @@ function output(stdout: string) {
   };
 }
 
+function pullRequestRows(
+  count: number,
+  firstNumber: number,
+): ReadonlyArray<Record<string, unknown>> {
+  return Array.from({ length: count }, (_, index) => ({
+    pullRequestId: firstNumber + index,
+    title: `Pull request ${firstNumber + index}`,
+    status: "active",
+    sourceRefName: "refs/heads/feat/page",
+    targetRefName: "refs/heads/main",
+    creationDate: "2026-07-01T00:00:00Z",
+    repository: { name: "web", project: { name: "platform" } },
+    url: `https://dev.azure.com/acme/_apis/git/repositories/web/pullRequests/${firstNumber + index}`,
+  }));
+}
+
 function pullRequests(count: number, firstNumber: number): string {
-  return JSON.stringify(
-    Array.from({ length: count }, (_, index) => ({
-      pullRequestId: firstNumber + index,
-      title: `Pull request ${firstNumber + index}`,
-      status: "active",
-      sourceRefName: "refs/heads/feat/page",
-      targetRefName: "refs/heads/main",
-      creationDate: "2026-07-01T00:00:00Z",
-      repository: { name: "web", project: { name: "platform" } },
-      url: `https://dev.azure.com/acme/_apis/git/repositories/web/pullRequests/${firstNumber + index}`,
-    })),
-  );
+  return JSON.stringify(pullRequestRows(count, firstNumber));
 }
 
 /** The arguments of the nth az invocation. */
@@ -172,6 +177,44 @@ layer("AzureDevOpsPullRequestCli.layer", (it) => {
 
       assert.strictEqual(batch.items.length, 10);
       assert.isTrue(batch.truncated);
+      assert.strictEqual(batch.cursorAdvance, 10);
+    }),
+  );
+
+  it.effect("advances by malformed raw rows and keeps reading until the page is full", () =>
+    Effect.gen(function* () {
+      mockedExecute
+        .mockReturnValueOnce(
+          Effect.succeed(
+            output(
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify([
+                { pullRequestId: "malformed" },
+                pullRequestRows(1, 1)[0],
+                { pullRequestId: "also malformed" },
+              ]),
+            ),
+          ),
+        )
+        .mockReturnValueOnce(Effect.succeed(output(pullRequests(2, 2))));
+      const cli = yield* AzureDevOpsPullRequestCli.AzureDevOpsPullRequestCli;
+
+      const batch = yield* cli.listPullRequests({
+        cwd: "/w",
+        repository: "web",
+        state: "open",
+        involvement: "all",
+        viewer: "bilal@acme.dev",
+        limit: 2,
+      });
+
+      expect(batch.items.map((item) => item.number)).toEqual([1, 2]);
+      assert.isTrue(batch.truncated);
+      // Three raw rows from the first request and one from the second produced this page.
+      assert.strictEqual(batch.cursorAdvance, 4);
+      const secondArgs = argsOfCall(1);
+      assert.strictEqual(secondArgs[secondArgs.indexOf("--skip") + 1], "3");
+      assert.strictEqual(secondArgs[secondArgs.indexOf("--top") + 1], "2");
     }),
   );
 

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
@@ -132,7 +132,12 @@ export class AzureDevOpsPullRequestCli extends Context.Service<
        */
       readonly cursor?: ProviderListCursor | undefined;
     }) => Effect.Effect<
-      { readonly items: ReadonlyArray<AzureDevOpsPullRequest>; readonly truncated: boolean },
+      {
+        readonly items: ReadonlyArray<AzureDevOpsPullRequest>;
+        readonly truncated: boolean;
+        /** Raw Azure rows consumed to produce this page, including malformed rows. */
+        readonly cursorAdvance: number;
+      },
       AzureDevOpsPullRequestCliError
     >;
 
@@ -242,6 +247,98 @@ export const make = Effect.gen(function* () {
       args: [...input.args, "--only-show-errors", "--output", "json"],
     });
 
+  /**
+   * Azure pages by raw offset. Keep reading when malformed rows leave the decoded page short, and
+   * retain the raw count so the next public cursor skips every row this walk consumed.
+   */
+  const listPullRequestPage = (input: {
+    readonly cwd: string;
+    readonly repository: string;
+    readonly state: PullRequestListState;
+    readonly involvement: PullRequestInvolvement;
+    readonly viewer: string;
+    readonly limit: number;
+    readonly skip: number;
+    readonly cursorAdvance: number;
+    readonly items: ReadonlyArray<AzureDevOpsPullRequest>;
+  }): Effect.Effect<
+    {
+      readonly items: ReadonlyArray<AzureDevOpsPullRequest>;
+      readonly truncated: boolean;
+      readonly cursorAdvance: number;
+    },
+    AzureDevOpsPullRequestCliError
+  > => {
+    const remaining = input.limit - input.items.length;
+    const top = remaining + 1;
+    return executeJson({
+      cwd: input.cwd,
+      args: [
+        "repos",
+        "pr",
+        "list",
+        ...detectArgs,
+        "--repository",
+        input.repository,
+        ...statusArgs(input.state),
+        ...involvementArgs(input),
+        // A web link per row, which is the only url that needs no assembling.
+        "--include-links",
+        ...(input.skip === 0 ? [] : ["--skip", String(input.skip)]),
+        "--top",
+        String(top),
+      ],
+    }).pipe(
+      Effect.flatMap((result) => {
+        const raw = result.stdout.trim();
+        if (raw.length === 0) {
+          return Effect.succeed({
+            items: input.items,
+            truncated: false,
+            cursorAdvance: input.cursorAdvance,
+          });
+        }
+        const decoded = decodePullRequestListJson(raw);
+        if (!Result.isSuccess(decoded)) {
+          return Effect.fail(
+            new AzureDevOpsPullRequestReadError({
+              command: "az",
+              cwd: input.cwd,
+              operation: "listPullRequests",
+              cause: decoded.failure,
+            }),
+          );
+        }
+
+        const lastItemIndex = decoded.success.rawIndexes[remaining - 1];
+        if (lastItemIndex !== undefined) {
+          const consumed = lastItemIndex + 1;
+          return Effect.succeed({
+            items: [...input.items, ...decoded.success.items.slice(0, remaining)],
+            // A full raw response may have more rows even when malformed entries used the probe.
+            truncated: consumed < decoded.success.rawCount || decoded.success.rawCount === top,
+            cursorAdvance: input.cursorAdvance + consumed,
+          });
+        }
+
+        const items = [...input.items, ...decoded.success.items];
+        if (decoded.success.rawCount < top) {
+          return Effect.succeed({
+            items,
+            truncated: false,
+            cursorAdvance: input.cursorAdvance + decoded.success.rawCount,
+          });
+        }
+        return listPullRequestPage({
+          ...input,
+          skip: input.skip + decoded.success.rawCount,
+          cursorAdvance: input.cursorAdvance + decoded.success.rawCount,
+          items,
+        });
+      }),
+    );
+  };
+
   return AzureDevOpsPullRequestCli.of({
     getViewer: (input) =>
       executeJson({ cwd: input.cwd, args: ["account", "show", "--query", "user"] }).pipe(
@@ -266,51 +363,21 @@ export const make = Effect.gen(function* () {
       ),
 
     listPullRequests: (input) =>
-      executeJson({
+      listPullRequestPage({
         cwd: input.cwd,
-        args: [
-          "repos",
-          "pr",
-          "list",
-          ...detectArgs,
-          "--repository",
-          input.repository,
-          ...statusArgs(input.state),
-          ...involvementArgs(input),
-          // A web link per row, which is the only url that needs no assembling.
-          "--include-links",
-          // Azure counts rather than filters, so a slice carries on by stepping over what has
-          // already been handed over. That is an offset into a list that can shift underneath
-          // it: a pull request opened between two slices moves everything down one, and the row
-          // on the seam is the one that pays for it.
-          ...(input.cursor === undefined ? [] : ["--skip", String(input.cursor.delivered)]),
-          "--top",
-          // One row over the page reveals that the repository has more than the page shows.
-          String(input.limit + 1),
-        ],
-      }).pipe(
-        Effect.flatMap((result) => {
-          const raw = result.stdout.trim();
-          if (raw.length === 0) {
-            return Effect.succeed({ items: [], truncated: false });
-          }
-          const decoded = decodePullRequestListJson(raw);
-          return Result.isSuccess(decoded)
-            ? Effect.succeed({
-                items: decoded.success.items.slice(0, input.limit),
-                // Counted before decoding, so a skipped malformed row cannot end paging early.
-                truncated: decoded.success.rawCount > input.limit,
-              })
-            : Effect.fail(
-                new AzureDevOpsPullRequestReadError({
-                  command: "az",
-                  cwd: input.cwd,
-                  operation: "listPullRequests",
-                  cause: decoded.failure,
-                }),
-              );
-        }),
-      ),
+        repository: input.repository,
+        state: input.state,
+        involvement: input.involvement,
+        viewer: input.viewer,
+        limit: input.limit,
+        // Azure counts rather than filters, so a slice carries on by stepping over every raw row
+        // the prior slice consumed. That is an offset into a list that can shift underneath it:
+        // a pull request opened between two slices moves everything down one, and the row on the
+        // seam is the one that pays for it.
+        skip: input.cursor?.delivered ?? 0,
+        cursorAdvance: 0,
+        items: [],
+      }),
 
     getPullRequest: (input) =>
       executeJson({

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestProvider.ts
@@ -131,6 +131,7 @@ export const make = Effect.gen(function* () {
           Effect.map((batch) => ({
             items: batch.items.map(toChangeRequest),
             truncated: batch.truncated,
+            cursorAdvance: batch.cursorAdvance,
             // Azure answers in one order whether or not it is being carried on from, so a slice
             // can always be stepped past — by counting, which is all Azure offers.
             continues: true,

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -40,6 +40,10 @@ function page(count: number, firstNumber: number, next?: string): string {
   });
 }
 
+function valuePage(values: ReadonlyArray<unknown>, next?: string): string {
+  return JSON.stringify({ values, ...(next === undefined ? {} : { next }) });
+}
+
 /** Who opened the pull request, and two accounts that could review it. */
 const bilal = { uuid: "{bilal}", nickname: "bilal" };
 const octocat = { uuid: "{octocat}", nickname: "octocat" };
@@ -355,6 +359,93 @@ layer("BitbucketPullRequestApi.layer", (it) => {
 
       assert.strictEqual(error._tag, "BitbucketDiffCommitError");
       assert.strictEqual(mockedRequest.mock.calls.length, 0);
+    }),
+  );
+
+  it.effect("aggregates every diffstat page", () =>
+    Effect.gen(function* () {
+      const next = "https://api.bitbucket.org/2.0/diffstat?page=2";
+      mockedRequest
+        .mockReturnValueOnce(
+          Effect.succeed(
+            response(
+              valuePage(
+                [
+                  { lines_added: 9, lines_removed: 2 },
+                  { lines_added: 3, lines_removed: 1 },
+                ],
+                next,
+              ),
+            ),
+          ),
+        )
+        .mockReturnValueOnce(
+          Effect.succeed(response(valuePage([{ lines_added: 4, lines_removed: 7 }]))),
+        );
+      const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
+
+      const stat = yield* api.getDiffStat({ repository: "acme/web", number: 7 });
+
+      expect(stat).toEqual({ additions: 16, deletions: 10, changedFiles: 3 });
+      expect(callAt(1).url).toBe(next);
+    }),
+  );
+
+  it.effect("returns the complete commit timeline oldest first across pages", () =>
+    Effect.gen(function* () {
+      const next = "https://api.bitbucket.org/2.0/commits?page=2";
+      mockedRequest
+        .mockReturnValueOnce(
+          Effect.succeed(
+            response(
+              valuePage(
+                [
+                  { hash: "ddd", message: "fourth", date: "2026-07-04T00:00:00Z" },
+                  { hash: "ccc", message: "third", date: "2026-07-03T00:00:00Z" },
+                ],
+                next,
+              ),
+            ),
+          ),
+        )
+        .mockReturnValueOnce(
+          Effect.succeed(
+            response(
+              valuePage([
+                { hash: "bbb", message: "second", date: "2026-07-02T00:00:00Z" },
+                { hash: "aaa", message: "first", date: "2026-07-01T00:00:00Z" },
+              ]),
+            ),
+          ),
+        );
+      const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
+
+      const commits = yield* api.listCommits({ repository: "acme/web", number: 7 });
+
+      expect(commits.map((commit) => commit.oid)).toEqual(["aaa", "bbb", "ccc", "ddd"]);
+      expect(callAt(1).url).toBe(next);
+    }),
+  );
+
+  it.effect("returns build statuses from every page", () =>
+    Effect.gen(function* () {
+      const next = "https://api.bitbucket.org/2.0/statuses?page=2";
+      mockedRequest
+        .mockReturnValueOnce(
+          Effect.succeed(response(valuePage([{ name: "Build", state: "SUCCESSFUL" }], next))),
+        )
+        .mockReturnValueOnce(
+          Effect.succeed(response(valuePage([{ name: "Lint", state: "FAILED" }]))),
+        );
+      const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
+
+      const checks = yield* api.listChecks({ repository: "acme/web", number: 7 });
+
+      expect(checks.map((check) => [check.name, check.status])).toEqual([
+        ["Build", "success"],
+        ["Lint", "failure"],
+      ]);
+      expect(callAt(1).url).toBe(next);
     }),
   );
 

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -114,7 +114,7 @@ export type BitbucketPullRequestApiError =
 const MAX_PAGE_SIZE = 50;
 /** Pages to walk before a listing is reported as truncated. */
 const MAX_LIST_PAGES = 10;
-/** Commits and checks are read one page deep; the conversation is walked to its end. */
+/** The page size for pull request conversations, commits, and checks. */
 const CONVERSATION_PAGE_SIZE = 50;
 /**
  * Pages of the conversation to follow before it is reported as truncated. Bitbucket serves
@@ -446,6 +446,46 @@ export const make = Effect.gen(function* () {
       }),
     );
 
+  /** Walks a Bitbucket cursor to its end and combines every decoded item. */
+  const itemPages = <A>(input: {
+    readonly operation: string;
+    readonly url: string;
+    readonly decode: (
+      body: string,
+    ) => Result.Result<{ readonly items: ReadonlyArray<A>; readonly next: string | null }, unknown>;
+    readonly items: ReadonlyArray<A>;
+    /** Commit pages are individually oldest-first, so older pages are prepended. */
+    readonly prepend: boolean;
+  }): Effect.Effect<ReadonlyArray<A>, BitbucketPullRequestApiError> =>
+    readPage({ operation: input.operation, url: input.url, decode: input.decode }).pipe(
+      Effect.flatMap((page) => {
+        const items = input.prepend
+          ? [...page.items, ...input.items]
+          : [...input.items, ...page.items];
+        return page.next === null
+          ? Effect.succeed(items)
+          : itemPages({ ...input, url: page.next, items });
+      }),
+    );
+
+  /** Diffstat has one aggregate per page, so its totals are folded while following `next`. */
+  const diffStatPages = (input: {
+    readonly url: string;
+    readonly totals: BitbucketDiffStat;
+  }): Effect.Effect<BitbucketDiffStat, BitbucketPullRequestApiError> =>
+    readPage({ operation: "getDiffStat", url: input.url, decode: decodeDiffstatJson }).pipe(
+      Effect.flatMap((page) => {
+        const totals = {
+          additions: input.totals.additions + page.additions,
+          deletions: input.totals.deletions + page.deletions,
+          changedFiles: input.totals.changedFiles + page.changedFiles,
+        };
+        return page.next === null
+          ? Effect.succeed(totals)
+          : diffStatPages({ url: page.next, totals });
+      }),
+    );
+
   return BitbucketPullRequestApi.of({
     getViewer: () =>
       bitbucket.request({ method: "GET", url: "/user" }).pipe(
@@ -533,10 +573,9 @@ export const make = Effect.gen(function* () {
 
     getDiffStat: (input) =>
       withRepository(input.repository, (path) =>
-        readPage({
-          operation: "getDiffStat",
+        diffStatPages({
           url: `${path}/pullrequests/${input.number}/diffstat?pagelen=${MAX_PAGE_SIZE}`,
-          decode: decodeDiffstatJson,
+          totals: { additions: 0, deletions: 0, changedFiles: 0 },
         }),
       ),
 
@@ -561,19 +600,23 @@ export const make = Effect.gen(function* () {
 
     listCommits: (input) =>
       withRepository(input.repository, (path) =>
-        readPage({
+        itemPages({
           operation: "listCommits",
           url: `${path}/pullrequests/${input.number}/commits?pagelen=${CONVERSATION_PAGE_SIZE}`,
           decode: decodeCommitsJson,
+          items: [],
+          prepend: true,
         }),
       ),
 
     listChecks: (input) =>
       withRepository(input.repository, (path) =>
-        readPage({
+        itemPages({
           operation: "listChecks",
           url: `${path}/pullrequests/${input.number}/statuses?pagelen=${CONVERSATION_PAGE_SIZE}`,
           decode: decodeStatusesJson,
+          items: [],
+          prepend: false,
         }),
       ),
 

--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { bitbucketViewerPermissions } from "./BitbucketPullRequestProvider.ts";
+import * as BitbucketApi from "../sourceControl/BitbucketApi.ts";
+import {
+  bitbucketErrorReason,
+  bitbucketViewerPermissions,
+} from "./BitbucketPullRequestProvider.ts";
+
+describe("bitbucketErrorReason", () => {
+  it("treats only an HTTP 401 as unusable credentials", () => {
+    const responseError = (status: number) =>
+      new BitbucketApi.BitbucketResponseError({
+        operation: "request",
+        status,
+        responseBodyLength: 0,
+      });
+
+    expect(bitbucketErrorReason(responseError(401))).toBe("unauthenticated");
+    expect(bitbucketErrorReason(responseError(403))).toBe("failed");
+  });
+});
 
 describe("bitbucketViewerPermissions", () => {
   it("offers both actions to credentials with write access", () => {

--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
@@ -54,12 +54,12 @@ export function bitbucketViewerPermissions(input: {
 }
 
 /** The failures that mean the credentials are the problem, rather than one request. */
-function reasonFor(
+export function bitbucketErrorReason(
   error: BitbucketPullRequestApi.BitbucketPullRequestApiError,
 ): PullRequestProviderError["reason"] {
   // Bitbucket is read over HTTP with credentials from the environment, so there is no tool to be
   // missing: unusable always means the credentials are absent or refused.
-  if (error._tag === "BitbucketResponseError" && (error.status === 401 || error.status === 403)) {
+  if (error._tag === "BitbucketResponseError" && error.status === 401) {
     return "unauthenticated";
   }
   return "failed";
@@ -95,7 +95,7 @@ export const make = Effect.gen(function* () {
       new PullRequestProviderError({
         provider: "bitbucket",
         operation,
-        reason: reasonFor(error),
+        reason: bitbucketErrorReason(error),
         // Every Bitbucket failure states its own fact; this names the operation around it, so
         // the two do not stack into "failed in x: failed in y: ...".
         detail: error.detail,

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -728,6 +728,41 @@ layer("GitHubPullRequestCli.layer", (it) => {
     }),
   );
 
+  it.effect("grows the search-free fallback until it fills the filtered page", () =>
+    Effect.gen(function* () {
+      const unrelated = () => ({ reviewRequests: [{ login: "somebody-else" }] });
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("[]")));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(pullRequests(3, 1, unrelated))));
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            pullRequests(4, 1, (number) =>
+              number === 4 ? { reviewRequests: [{ login: "bilal" }] } : unrelated(),
+            ),
+          ),
+        ),
+      );
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const batch = yield* cli.listPullRequests({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        state: "open",
+        involvement: "reviewing",
+        viewer: "bilal",
+        limit: 2,
+      });
+
+      expect(batch.items.map((item) => item.number)).toEqual([4]);
+      const firstFallbackArgs = callAt(1).args;
+      const secondFallbackArgs = callAt(2).args;
+      expect(firstFallbackArgs[firstFallbackArgs.indexOf("--limit") + 1]).toBe("3");
+      expect(secondFallbackArgs[secondFallbackArgs.indexOf("--limit") + 1]).toBe("6");
+      assert.isFalse(batch.truncated);
+    }),
+  );
+
   it.effect("takes an empty slice for a repository that has run out, not one to read again", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValue(Effect.succeed(output("[]")));

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -28,7 +28,11 @@ function output(stdout: string, stdoutTruncated = false) {
   };
 }
 
-function pullRequests(count: number, firstNumber: number): string {
+function pullRequests(
+  count: number,
+  firstNumber: number,
+  overrides: (number: number) => Readonly<Record<string, unknown>> = () => ({}),
+): string {
   return JSON.stringify(
     Array.from({ length: count }, (_, index) => ({
       number: firstNumber + index,
@@ -38,6 +42,7 @@ function pullRequests(count: number, firstNumber: number): string {
       baseRefName: "main",
       createdAt: "2026-07-01T00:00:00Z",
       updatedAt: "2026-07-02T00:00:00Z",
+      ...overrides(firstNumber + index),
     })),
   );
 }
@@ -665,7 +670,9 @@ layer("GitHubPullRequestCli.layer", (it) => {
     Effect.gen(function* () {
       // GitHub answers for a repository outside its search index with no rows and no error.
       mockedExecute.mockReturnValueOnce(Effect.succeed(output("[]")));
-      mockedExecute.mockReturnValueOnce(Effect.succeed(output(pullRequests(3, 1))));
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output(pullRequests(3, 1, () => ({ state: "CLOSED" })))),
+      );
       const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
 
       const batch = yield* cli.listPullRequests({
@@ -679,9 +686,41 @@ layer("GitHubPullRequestCli.layer", (it) => {
       });
 
       assert.strictEqual(batch.items.length, 3);
-      // Nothing of the search survives the fallback, not even the tab's own qualifier: this read
-      // happens precisely because search answered nothing here, and `is:unmerged` is a search
-      // too. Those rows arrive in gh's own order, so nothing can carry on from them.
+      // The fallback itself uses no search, then narrows the decoded rows locally. They still
+      // arrive in gh's own order, so nothing can carry on from them.
+      expect(searchOfCall(1)).toBeUndefined();
+      assert.isFalse(batch.continues);
+    }),
+  );
+
+  it.effect("keeps state and involvement filters on the search-free fallback", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("[]")));
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            pullRequests(4, 1, (number) => ({
+              state: number === 4 ? "OPEN" : "CLOSED",
+              ...(number === 3 ? { mergedAt: "2026-07-03T00:00:00Z" } : {}),
+              reviewRequests: [{ login: number === 2 ? "somebody-else" : "bilal" }],
+            })),
+          ),
+        ),
+      );
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const batch = yield* cli.listPullRequests({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        state: "closed",
+        involvement: "reviewing",
+        viewer: "bilal",
+        limit: 10,
+      });
+
+      // Only the closed, unmerged pull request asking this viewer for a review survives.
+      expect(batch.items.map((item) => item.number)).toEqual([1]);
       expect(searchOfCall(1)).toBeUndefined();
       assert.isFalse(batch.continues);
     }),
@@ -1006,6 +1045,107 @@ layer("GitHubPullRequestCli.layer", (it) => {
 
       assert.strictEqual(error._tag, "GitHubDiffCommitError");
       assert.strictEqual(mockedExecute.mock.calls.length, 0);
+    }),
+  );
+
+  it.effect("expands a new file from a root commit without requiring a parent", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("\ta1b2c3d\n")));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("root contents\n")));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const contents = yield* cli.getPullRequestDiffFileContents({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        number: 7,
+        commit: "a1b2c3d",
+        changeType: "new",
+        oldPath: "src/root.ts",
+        newPath: "src/root.ts",
+      });
+
+      expect(contents).toEqual({ oldContents: "", newContents: "root contents\n" });
+      assert.strictEqual(mockedExecute.mock.calls.length, 2);
+      expect(callAt(1).args.join(" ")).toContain("contents/src/root.ts?ref=a1b2c3d");
+    }),
+  );
+
+  it.effect("reports unusable diff revisions as a structured error", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("not-a-sha\tstill-not-a-sha\n")));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const error = yield* Effect.flip(
+        cli.getPullRequestDiffFileContents({
+          cwd: "/w",
+          repository: "acme/web",
+          host: "github.com",
+          number: 7,
+          commit: "a1b2c3d",
+          changeType: "change",
+          oldPath: "src/a.ts",
+          newPath: "src/a.ts",
+        }),
+      );
+
+      assert.strictEqual(error._tag, "GitHubDiffRevisionsUnavailableError");
+      if (error._tag === "GitHubDiffRevisionsUnavailableError") {
+        assert.strictEqual(error.number, 7);
+        assert.strictEqual(error.commit, "a1b2c3d");
+      }
+    }),
+  );
+
+  it.effect("reports an oversized diff file with its path and reason", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("a1b2c3d\tb1c2d3e\n")));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("partial", true)));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const error = yield* Effect.flip(
+        cli.getPullRequestDiffFileContents({
+          cwd: "/w",
+          repository: "acme/web",
+          host: "github.com",
+          number: 7,
+          changeType: "deleted",
+          oldPath: "src/large.ts",
+          newPath: "src/large.ts",
+        }),
+      );
+
+      assert.strictEqual(error._tag, "GitHubDiffFileContentsUnavailableError");
+      if (error._tag === "GitHubDiffFileContentsUnavailableError") {
+        assert.strictEqual(error.path, "src/large.ts");
+        assert.strictEqual(error.reason, "oversized");
+      }
+    }),
+  );
+
+  it.effect("reports a binary diff file with its path and reason", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("a1b2c3d\tb1c2d3e\n")));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("binary\0contents")));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const error = yield* Effect.flip(
+        cli.getPullRequestDiffFileContents({
+          cwd: "/w",
+          repository: "acme/web",
+          host: "github.com",
+          number: 7,
+          changeType: "deleted",
+          oldPath: "assets/logo.png",
+          newPath: "assets/logo.png",
+        }),
+      );
+
+      assert.strictEqual(error._tag, "GitHubDiffFileContentsUnavailableError");
+      if (error._tag === "GitHubDiffFileContentsUnavailableError") {
+        assert.strictEqual(error.path, "assets/logo.png");
+        assert.strictEqual(error.reason, "binary");
+      }
     }),
   );
 

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -18,13 +18,14 @@ const layer = it.layer(
   ),
 );
 
-function output(stdout: string, stdoutTruncated = false) {
+function output(stdout: string, stdoutTruncated = false, stdoutInvalidUtf8 = false) {
   return {
     exitCode: ChildProcessSpawner.ExitCode(0),
     stdout,
     stderr: "",
     stdoutTruncated,
     stderrTruncated: false,
+    stdoutInvalidUtf8,
   };
 }
 
@@ -1163,7 +1164,9 @@ layer("GitHubPullRequestCli.layer", (it) => {
   it.effect("reports undecodable diff file contents as binary", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(Effect.succeed(output("a1b2c3d\tb1c2d3e\n")));
-      mockedExecute.mockReturnValueOnce(Effect.succeed(output("binary\uFFFDcontents")));
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output("binary\uFFFDcontents", false, true)),
+      );
       const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
 
       const error = yield* Effect.flip(
@@ -1183,6 +1186,26 @@ layer("GitHubPullRequestCli.layer", (it) => {
         assert.strictEqual(error.path, "assets/logo.png");
         assert.strictEqual(error.reason, "binary");
       }
+    }),
+  );
+
+  it.effect("returns valid text containing a literal replacement character", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("a1b2c3d\tb1c2d3e\n")));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("before\uFFFDafter")));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const contents = yield* cli.getPullRequestDiffFileContents({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        number: 7,
+        changeType: "deleted",
+        oldPath: "docs/encoding.md",
+        newPath: "docs/encoding.md",
+      });
+
+      assert.strictEqual(contents.oldContents, "before\uFFFDafter");
     }),
   );
 

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -702,7 +702,8 @@ layer("GitHubPullRequestCli.layer", (it) => {
             pullRequests(4, 1, (number) => ({
               state: number === 4 ? "OPEN" : "CLOSED",
               ...(number === 3 ? { mergedAt: "2026-07-03T00:00:00Z" } : {}),
-              reviewRequests: [{ login: number === 2 ? "somebody-else" : "bilal" }],
+              reviewRequests:
+                number === 2 ? [{ slug: "platform", name: "Platform" }] : [{ login: "bilal" }],
             })),
           ),
         ),
@@ -719,8 +720,9 @@ layer("GitHubPullRequestCli.layer", (it) => {
         limit: 10,
       });
 
-      // Only the closed, unmerged pull request asking this viewer for a review survives.
-      expect(batch.items.map((item) => item.number)).toEqual([1]);
+      // Individual requests for this viewer and team requests survive. The fallback cannot
+      // resolve team membership, so dropping team-routed reviews would hide legitimate work.
+      expect(batch.items.map((item) => item.number)).toEqual([1, 2]);
       expect(searchOfCall(1)).toBeUndefined();
       assert.isFalse(batch.continues);
     }),
@@ -1123,10 +1125,10 @@ layer("GitHubPullRequestCli.layer", (it) => {
     }),
   );
 
-  it.effect("reports a binary diff file with its path and reason", () =>
+  it.effect("reports undecodable diff file contents as binary", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(Effect.succeed(output("a1b2c3d\tb1c2d3e\n")));
-      mockedExecute.mockReturnValueOnce(Effect.succeed(output("binary\0contents")));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("binary\uFFFDcontents")));
       const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
 
       const error = yield* Effect.flip(

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -764,6 +764,39 @@ layer("GitHubPullRequestCli.layer", (it) => {
     }),
   );
 
+  it.effect("bounds a sparse search-free fallback and reports the unread tail", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockImplementation((_input) => {
+        if (mockedExecute.mock.calls.length === 1) return Effect.succeed(output("[]"));
+        const args = callAt(mockedExecute.mock.calls.length - 1).args;
+        const limit = Number(args[args.indexOf("--limit") + 1]);
+        return Effect.succeed(
+          output(
+            pullRequests(limit, 1, () => ({
+              reviewRequests: [{ login: "somebody-else" }],
+            })),
+          ),
+        );
+      });
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const batch = yield* cli.listPullRequests({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        state: "open",
+        involvement: "reviewing",
+        viewer: "bilal",
+        limit: 2,
+      });
+
+      const finalArgs = callAt(mockedExecute.mock.calls.length - 1).args;
+      expect(finalArgs[finalArgs.indexOf("--limit") + 1]).toBe("1000");
+      assert.strictEqual(batch.items.length, 0);
+      assert.isTrue(batch.truncated);
+    }),
+  );
+
   it.effect("takes an empty slice for a repository that has run out, not one to read again", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValue(Effect.succeed(output("[]")));

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -131,6 +131,48 @@ export class GitHubDiffCommitError extends Schema.TaggedErrorClass<GitHubDiffCom
   }
 }
 
+/** The revisions read successfully, but cannot name both sides this file needs. */
+export class GitHubDiffRevisionsUnavailableError extends Schema.TaggedErrorClass<GitHubDiffRevisionsUnavailableError>()(
+  "GitHubDiffRevisionsUnavailableError",
+  {
+    command: Schema.Literal("gh"),
+    cwd: Schema.String,
+    number: Schema.Int,
+    commit: Schema.optional(Schema.String),
+  },
+) {
+  get detail(): string {
+    return this.commit === undefined
+      ? `Pull request #${this.number} reported no usable base and head revisions.`
+      : `Commit ${this.commit} reported no usable revisions for this file.`;
+  }
+
+  override get message(): string {
+    return `GitHub CLI failed in getPullRequestDiffFileContents: ${this.detail}`;
+  }
+}
+
+/** A blob exists, but expanding it would be unsafe or would not produce text. */
+export class GitHubDiffFileContentsUnavailableError extends Schema.TaggedErrorClass<GitHubDiffFileContentsUnavailableError>()(
+  "GitHubDiffFileContentsUnavailableError",
+  {
+    command: Schema.Literal("gh"),
+    cwd: Schema.String,
+    path: Schema.String,
+    reason: Schema.Literals(["oversized", "binary"]),
+  },
+) {
+  get detail(): string {
+    return this.reason === "oversized"
+      ? `The diff file '${this.path}' exceeds the 1 MB expansion limit.`
+      : `The diff file '${this.path}' is binary.`;
+  }
+
+  override get message(): string {
+    return `GitHub CLI failed in getPullRequestDiffFileContents: ${this.detail}`;
+  }
+}
+
 /**
  * Not a decode failure: a repository was named that cannot go into a search or into a GraphQL
  * document as itself. Every qualifier and every alias below is composed from `owner/name`, so a
@@ -159,6 +201,8 @@ export type GitHubPullRequestCliError =
   | GitHubPullRequestReadError
   | GitHubDiffCursorError
   | GitHubDiffCommitError
+  | GitHubDiffRevisionsUnavailableError
+  | GitHubDiffFileContentsUnavailableError
   | GitHubRepositorySelectorError
   | GitHubViewerLoginUnavailableError;
 
@@ -462,8 +506,8 @@ function involvementArgs(input: {
   // takes one `--search`, so the reader's text joins the qualifiers rather than replacing them.
   const query = input.query?.trim() ?? "";
   // The fallback read exists because this repository's search index answered nothing, so it goes
-  // nowhere near search: no order, no cursor, and no qualifiers either, since `review-requested:`
-  // and `is:unmerged` are searches too and would come back just as empty.
+  // nowhere near search: no order, cursor or qualifiers. Its decoded rows are narrowed by state
+  // and involvement below, since widening either would put unrelated pull requests on the page.
   const searchTerms = !input.sorted
     ? []
     : [
@@ -484,6 +528,25 @@ function involvementArgs(input: {
     ...(input.involvement === "authored" ? ["--author", input.viewer] : []),
     ...(searchTerms.length > 0 ? ["--search", searchTerms.join(" ")] : []),
   ];
+}
+
+/** The search-free fallback is wider than the request, so narrow its decoded rows locally. */
+function matchesUnsortedListing(
+  item: GitHubPullRequestListItem,
+  input: {
+    readonly state: PullRequestListState;
+    readonly involvement: PullRequestInvolvement;
+    readonly viewer: string;
+  },
+): boolean {
+  const matchesState = input.state === "all" || item.state === input.state;
+  const viewer = input.viewer.toLowerCase();
+  const matchesInvolvement =
+    input.involvement === "all" ||
+    (input.involvement === "authored"
+      ? item.author?.login.toLowerCase() === viewer
+      : item.reviewRequestLogins.some((login) => login.toLowerCase() === viewer));
+  return matchesState && matchesInvolvement;
 }
 
 /** What a repository selector may hold before it goes into a search as itself. */
@@ -748,20 +811,24 @@ export const make = Effect.gen(function* () {
           maxOutputBytes: 1024,
           timeoutMs: DIFF_TIMEOUT_MS,
         });
-        const [baseRef, headRef, ...extraRefs] = refsResult.stdout.trim().split("\t");
+        // Keep a leading tab: a root commit has no parent, and jq represents that absent old
+        // revision as the empty field before the tab. Every file in it is new, so that is a
+        // usable answer whenever the caller does not need the old side.
+        const [baseRef, headRef, ...extraRefs] = refsResult.stdout.trimEnd().split("\t");
+        const rootCommitNewFile =
+          input.commit !== undefined && input.changeType === "new" && baseRef === "";
         if (
           refsResult.stdoutTruncated ||
-          !baseRef ||
           !headRef ||
           extraRefs.length > 0 ||
-          !isCommitSha(baseRef) ||
+          (!rootCommitNewFile && (baseRef === undefined || !isCommitSha(baseRef))) ||
           !isCommitSha(headRef)
         ) {
-          return yield* new GitHubPullRequestReadError({
+          return yield* new GitHubDiffRevisionsUnavailableError({
             command: "gh",
             cwd: input.cwd,
-            operation: "getPullRequestDiffFileContents",
-            cause: new Error("GitHub returned no usable base and head revisions."),
+            number: input.number,
+            ...(input.commit === undefined ? {} : { commit: input.commit }),
           });
         }
 
@@ -787,15 +854,11 @@ export const make = Effect.gen(function* () {
               Effect.flatMap((result) =>
                 result.stdoutTruncated || result.stdout.includes("\0")
                   ? Effect.fail(
-                      new GitHubPullRequestReadError({
+                      new GitHubDiffFileContentsUnavailableError({
                         command: "gh",
                         cwd: input.cwd,
-                        operation: "getPullRequestDiffFileContents",
-                        cause: new Error(
-                          result.stdoutTruncated
-                            ? `The diff file '${filePath}' exceeds the 1 MB expansion limit.`
-                            : `The diff file '${filePath}' is binary.`,
-                        ),
+                        path: filePath,
+                        reason: result.stdoutTruncated ? "oversized" : "binary",
                       }),
                     )
                   : Effect.succeed(result.stdout),
@@ -804,12 +867,8 @@ export const make = Effect.gen(function* () {
 
         const [oldContents, newContents] = yield* Effect.all(
           [
-            input.changeType === "new"
-              ? Effect.succeed("")
-              : readFile(baseRef, input.oldPath),
-            input.changeType === "deleted"
-              ? Effect.succeed("")
-              : readFile(headRef, input.newPath),
+            input.changeType === "new" ? Effect.succeed("") : readFile(baseRef, input.oldPath),
+            input.changeType === "deleted" ? Effect.succeed("") : readFile(headRef, input.newPath),
           ],
           { concurrency: 2 },
         );
@@ -855,22 +914,26 @@ export const make = Effect.gen(function* () {
                 return Effect.succeed({ items: [], truncated: false, continues });
               }
               const decoded = decodePullRequestListJson(raw);
-              return Result.isSuccess(decoded)
-                ? Effect.succeed({
-                    items: decoded.success.items.slice(0, input.limit),
-                    // One row over the page size is the probe for a next page, and it is
-                    // counted before decoding: a skipped malformed row must not end paging.
-                    truncated: decoded.success.rawCount > input.limit,
-                    continues,
-                  })
-                : Effect.fail(
-                    new GitHubPullRequestReadError({
-                      command: "gh",
-                      cwd: input.cwd,
-                      operation: "listPullRequests",
-                      cause: decoded.failure,
-                    }),
-                  );
+              if (Result.isSuccess(decoded)) {
+                const items = continues
+                  ? decoded.success.items
+                  : decoded.success.items.filter((item) => matchesUnsortedListing(item, input));
+                return Effect.succeed({
+                  items: items.slice(0, input.limit),
+                  // One row over the page size is the probe for a next page, and it is
+                  // counted before decoding: a skipped malformed row must not end paging.
+                  truncated: decoded.success.rawCount > input.limit,
+                  continues,
+                });
+              }
+              return Effect.fail(
+                new GitHubPullRequestReadError({
+                  command: "gh",
+                  cwd: input.cwd,
+                  operation: "listPullRequests",
+                  cause: decoded.failure,
+                }),
+              );
             }),
           );
       // GitHub does not index every repository for search, and one it will not search answers
@@ -1098,7 +1161,7 @@ export const make = Effect.gen(function* () {
         const entries: GitHubReviewThreadEntry[] = [];
         const avatarsByLogin = new Map<string, string>();
         let reviewers: ReadonlyArray<PullRequestActor> = [];
-        let viewer: GitHubReviewThreadPage["viewer"] = { canUpdate: true, didAuthor: true };
+        let viewer: GitHubReviewThreadPage["viewer"] = { canUpdate: true, didAuthor: false };
         let cursor: string | null = null;
         let page = 0;
         do {

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -212,6 +212,9 @@ const DIFF_TIMEOUT_MS = 60_000;
 /** Pierre expansion is for source files, not blobs large enough to stall a review surface. */
 const DIFF_FILE_MAX_OUTPUT_BYTES = 1024 * 1024;
 
+/** A search-free fallback may scan older rows for local filters, but never the whole repository. */
+const PULL_REQUEST_FALLBACK_MAX_ROWS = 1_000;
+
 /** What the files API serves at most in one response, which is what one slice is made of. */
 const DIFF_FILES_PAGE_SIZE = 100;
 
@@ -890,6 +893,7 @@ export const make = Effect.gen(function* () {
       ),
 
     listPullRequests: (input) => {
+      const fallbackMaxRows = Math.max(input.limit + 1, PULL_REQUEST_FALLBACK_MAX_ROWS);
       const read = (
         continues: boolean,
         requestedRows = input.limit + 1,
@@ -925,9 +929,10 @@ export const make = Effect.gen(function* () {
                 if (
                   !continues &&
                   items.length < input.limit &&
-                  decoded.success.rawCount >= requestedRows
+                  decoded.success.rawCount >= requestedRows &&
+                  requestedRows < fallbackMaxRows
                 ) {
-                  const nextRows = Math.min(requestedRows * 2, Number.MAX_SAFE_INTEGER);
+                  const nextRows = Math.min(requestedRows * 2, fallbackMaxRows);
                   if (nextRows > requestedRows) return read(false, nextRows);
                 }
                 return Effect.succeed({

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -855,7 +855,7 @@ export const make = Effect.gen(function* () {
               Effect.flatMap((result) =>
                 result.stdoutTruncated ||
                 result.stdout.includes("\0") ||
-                result.stdout.includes("\uFFFD")
+                result.stdoutInvalidUtf8 === true
                   ? Effect.fail(
                       new GitHubDiffFileContentsUnavailableError({
                         command: "gh",

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -545,7 +545,8 @@ function matchesUnsortedListing(
     input.involvement === "all" ||
     (input.involvement === "authored"
       ? item.author?.login.toLowerCase() === viewer
-      : item.reviewRequestLogins.some((login) => login.toLowerCase() === viewer));
+      : item.hasTeamReviewRequest ||
+        item.reviewRequestLogins.some((login) => login.toLowerCase() === viewer));
   return matchesState && matchesInvolvement;
 }
 
@@ -852,7 +853,9 @@ export const make = Effect.gen(function* () {
             })
             .pipe(
               Effect.flatMap((result) =>
-                result.stdoutTruncated || result.stdout.includes("\0")
+                result.stdoutTruncated ||
+                result.stdout.includes("\0") ||
+                result.stdout.includes("\uFFFD")
                   ? Effect.fail(
                       new GitHubDiffFileContentsUnavailableError({
                         command: "gh",

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -892,6 +892,7 @@ export const make = Effect.gen(function* () {
     listPullRequests: (input) => {
       const read = (
         continues: boolean,
+        requestedRows = input.limit + 1,
       ): Effect.Effect<GitHubPullRequestListBatch, GitHubPullRequestCliError> =>
         github
           .execute({
@@ -905,7 +906,7 @@ export const make = Effect.gen(function* () {
               input.state,
               "--limit",
               // One extra row reveals that the repository has more than the page shows.
-              String(input.limit + 1),
+              String(requestedRows),
               "--json",
               PULL_REQUEST_LIST_JSON_FIELDS,
             ],
@@ -921,11 +922,21 @@ export const make = Effect.gen(function* () {
                 const items = continues
                   ? decoded.success.items
                   : decoded.success.items.filter((item) => matchesUnsortedListing(item, input));
+                if (
+                  !continues &&
+                  items.length < input.limit &&
+                  decoded.success.rawCount >= requestedRows
+                ) {
+                  const nextRows = Math.min(requestedRows * 2, Number.MAX_SAFE_INTEGER);
+                  if (nextRows > requestedRows) return read(false, nextRows);
+                }
                 return Effect.succeed({
                   items: items.slice(0, input.limit),
                   // One row over the page size is the probe for a next page, and it is
                   // counted before decoding: a skipped malformed row must not end paging.
-                  truncated: decoded.success.rawCount > input.limit,
+                  truncated: continues
+                    ? decoded.success.rawCount > input.limit
+                    : items.length > input.limit || decoded.success.rawCount >= requestedRows,
                   continues,
                 });
               }

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -165,6 +165,8 @@ export type GitHubPullRequestCliError =
 /** A large pull request can produce a multi-megabyte patch; past this it is truncated. */
 const DIFF_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 const DIFF_TIMEOUT_MS = 60_000;
+/** Pierre expansion is for source files, not blobs large enough to stall a review surface. */
+const DIFF_FILE_MAX_OUTPUT_BYTES = 1024 * 1024;
 
 /** What the files API serves at most in one response, which is what one slice is made of. */
 const DIFF_FILES_PAGE_SIZE = 100;
@@ -286,6 +288,20 @@ export class GitHubPullRequestCli extends Context.Service<
       /** One commit's own changes, rather than everything the pull request carries. */
       readonly commit?: string | undefined;
     }) => Effect.Effect<GitHubPullRequestDiffSlice, GitHubPullRequestCliError>;
+
+    readonly getPullRequestDiffFileContents: (input: {
+      readonly cwd: string;
+      readonly repository: string;
+      readonly host: string;
+      readonly number: number;
+      readonly commit?: string | undefined;
+      readonly changeType: "change" | "rename-pure" | "rename-changed" | "new" | "deleted";
+      readonly oldPath: string;
+      readonly newPath: string;
+    }) => Effect.Effect<
+      { readonly oldContents: string; readonly newContents: string },
+      GitHubPullRequestCliError
+    >;
 
     readonly listReviewThreadComments: (input: {
       readonly cwd: string;
@@ -708,6 +724,98 @@ export const make = Effect.gen(function* () {
       );
   };
 
+  const getPullRequestDiffFileContents: GitHubPullRequestCli["Service"]["getPullRequestDiffFileContents"] =
+    (input) =>
+      Effect.gen(function* () {
+        if (input.commit !== undefined && !isCommitSha(input.commit)) {
+          return yield* new GitHubDiffCommitError({ command: "gh", cwd: input.cwd });
+        }
+        const { owner, name } = parseRepositorySelector(input.repository);
+        const refsResult = yield* github.execute({
+          cwd: input.cwd,
+          args: [
+            "api",
+            "--hostname",
+            input.host,
+            input.commit === undefined
+              ? `repos/${owner}/${name}/pulls/${input.number}`
+              : `repos/${owner}/${name}/commits/${input.commit}`,
+            "--jq",
+            input.commit === undefined
+              ? "[.base.sha, .head.sha] | @tsv"
+              : "[.parents[0].sha, .sha] | @tsv",
+          ],
+          maxOutputBytes: 1024,
+          timeoutMs: DIFF_TIMEOUT_MS,
+        });
+        const [baseRef, headRef, ...extraRefs] = refsResult.stdout.trim().split("\t");
+        if (
+          refsResult.stdoutTruncated ||
+          !baseRef ||
+          !headRef ||
+          extraRefs.length > 0 ||
+          !isCommitSha(baseRef) ||
+          !isCommitSha(headRef)
+        ) {
+          return yield* new GitHubPullRequestReadError({
+            command: "gh",
+            cwd: input.cwd,
+            operation: "getPullRequestDiffFileContents",
+            cause: new Error("GitHub returned no usable base and head revisions."),
+          });
+        }
+
+        const readFile = (revision: string, filePath: string) =>
+          github
+            .execute({
+              cwd: input.cwd,
+              args: [
+                "api",
+                "--hostname",
+                input.host,
+                "--header",
+                "Accept: application/vnd.github.raw+json",
+                `repos/${owner}/${name}/contents/${filePath
+                  .split("/")
+                  .map(encodeURIComponent)
+                  .join("/")}?ref=${encodeURIComponent(revision)}`,
+              ],
+              maxOutputBytes: DIFF_FILE_MAX_OUTPUT_BYTES,
+              timeoutMs: DIFF_TIMEOUT_MS,
+            })
+            .pipe(
+              Effect.flatMap((result) =>
+                result.stdoutTruncated || result.stdout.includes("\0")
+                  ? Effect.fail(
+                      new GitHubPullRequestReadError({
+                        command: "gh",
+                        cwd: input.cwd,
+                        operation: "getPullRequestDiffFileContents",
+                        cause: new Error(
+                          result.stdoutTruncated
+                            ? `The diff file '${filePath}' exceeds the 1 MB expansion limit.`
+                            : `The diff file '${filePath}' is binary.`,
+                        ),
+                      }),
+                    )
+                  : Effect.succeed(result.stdout),
+              ),
+            );
+
+        const [oldContents, newContents] = yield* Effect.all(
+          [
+            input.changeType === "new"
+              ? Effect.succeed("")
+              : readFile(baseRef, input.oldPath),
+            input.changeType === "deleted"
+              ? Effect.succeed("")
+              : readFile(headRef, input.newPath),
+          ],
+          { concurrency: 2 },
+        );
+        return { oldContents, newContents };
+      });
+
   return GitHubPullRequestCli.of({
     getViewerLogin: (input) =>
       github.execute({ cwd: input.cwd, args: ["api", "user", "--jq", ".login"] }).pipe(
@@ -946,6 +1054,8 @@ export const make = Effect.gen(function* () {
           ),
         );
     },
+
+    getPullRequestDiffFileContents,
 
     listReviewThreadComments: (input) =>
       Effect.gen(function* () {

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -80,6 +80,7 @@ describe("gitHubViewerPermissions", () => {
               createdAt: "2026-07-01T00:00:00Z",
               updatedAt: "2026-07-02T00:00:00Z",
               reviewRequestLogins: [],
+              hasTeamReviewRequest: false,
               labels: [],
               body: "",
               changedFiles: 1,

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 
-import { gitHubViewerPermissions, loginAvatarUrl } from "./GitHubPullRequestProvider.ts";
+import * as GitHubPullRequestCli from "./GitHubPullRequestCli.ts";
+import { gitHubViewerPermissions, loginAvatarUrl, make } from "./GitHubPullRequestProvider.ts";
 
 describe("gitHubViewerPermissions", () => {
   it("offers everything to a viewer who can write to the repository", () => {
@@ -39,6 +42,71 @@ describe("gitHubViewerPermissions", () => {
       requestReviewers: false,
     });
   });
+
+  it.effect("does not assume authorship when the review-thread read fails", () =>
+    Effect.gen(function* () {
+      const provider = yield* make;
+      const detail = yield* provider.getChangeRequest({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        number: 7,
+      });
+
+      expect(detail.viewerPermissions).toEqual({
+        actions: ["ready", "draft", "close", "reopen"],
+        comment: true,
+        resolve: false,
+        verdicts: ["comment", "approve", "request-changes"],
+        requestReviewers: false,
+      });
+    }).pipe(
+      Effect.provide(
+        Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
+          getPullRequestDetail: () =>
+            Effect.succeed({
+              authorId: null,
+              number: 7,
+              title: "Pull request 7",
+              url: "https://github.com/acme/web/pull/7",
+              author: null,
+              headBranch: "feat/page",
+              baseBranch: "main",
+              state: "open",
+              isDraft: false,
+              mergeability: "mergeable",
+              additions: 1,
+              deletions: 1,
+              createdAt: "2026-07-01T00:00:00Z",
+              updatedAt: "2026-07-02T00:00:00Z",
+              reviewRequestLogins: [],
+              labels: [],
+              body: "",
+              changedFiles: 1,
+              mergedAt: null,
+              closedAt: null,
+              checks: [],
+              comments: [],
+              commits: [],
+            }),
+          getRepositoryAccess: () =>
+            Effect.succeed({
+              canWrite: false,
+              mergeCapabilities: { merge: true, squash: true, rebase: true },
+            }),
+          listReviewThreadComments: () =>
+            Effect.fail(
+              new GitHubPullRequestCli.GitHubPullRequestReadError({
+                command: "gh",
+                cwd: "/w",
+                operation: "listReviewThreadComments",
+                cause: new Error("transient GraphQL failure"),
+              }),
+            ),
+        }),
+      ),
+    ),
+  );
 });
 
 describe("loginAvatarUrl", () => {

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -214,7 +214,7 @@ export const make = Effect.gen(function* () {
               avatarsByLogin: new Map<string, string>(),
               // A read that never happened says nothing about the reader, and an unknown
               // permission is granted: the controls stay live and GitHub explains any refusal.
-              viewer: { canUpdate: true, didAuthor: true },
+              viewer: { canUpdate: true, didAuthor: false },
             })),
           ),
         ],
@@ -264,9 +264,7 @@ export const make = Effect.gen(function* () {
     getDiff: (input) => cli.getPullRequestDiff(input).pipe(Effect.mapError(fail("getDiff"))),
 
     getDiffFileContents: (input) =>
-      cli
-        .getPullRequestDiffFileContents(input)
-        .pipe(Effect.mapError(fail("getDiffFileContents"))),
+      cli.getPullRequestDiffFileContents(input).pipe(Effect.mapError(fail("getDiffFileContents"))),
 
     listReviewerCandidates: (input) =>
       cli.listReviewerCandidates(input).pipe(Effect.mapError(fail("listReviewerCandidates"))),

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -263,6 +263,11 @@ export const make = Effect.gen(function* () {
 
     getDiff: (input) => cli.getPullRequestDiff(input).pipe(Effect.mapError(fail("getDiff"))),
 
+    getDiffFileContents: (input) =>
+      cli
+        .getPullRequestDiffFileContents(input)
+        .pipe(Effect.mapError(fail("getDiffFileContents"))),
+
     listReviewerCandidates: (input) =>
       cli.listReviewerCandidates(input).pipe(Effect.mapError(fail("listReviewerCandidates"))),
 

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -18,13 +18,14 @@ const layer = it.layer(
   ),
 );
 
-function output(stdout: string, stdoutTruncated = false) {
+function output(stdout: string, stdoutTruncated = false, stdoutInvalidUtf8 = false) {
   return {
     exitCode: ChildProcessSpawner.ExitCode(0),
     stdout,
     stderr: "",
     stdoutTruncated,
     stderrTruncated: false,
+    stdoutInvalidUtf8,
   };
 }
 
@@ -665,7 +666,9 @@ layer("GitLabPullRequestCli.layer", (it) => {
           ),
         ),
       );
-      mockedExecute.mockReturnValueOnce(Effect.succeed(output("binary\uFFFDcontents")));
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output("binary\uFFFDcontents", false, true)),
+      );
       const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
 
       const error = yield* Effect.flip(
@@ -684,6 +687,38 @@ layer("GitLabPullRequestCli.layer", (it) => {
         assert.strictEqual(error.path, "assets/logo.png");
         assert.strictEqual(error.reason, "binary");
       }
+    }),
+  );
+
+  it.effect("returns valid text containing a literal replacement character", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              diff_refs: {
+                base_sha: "a1b2c3d",
+                head_sha: "b1c2d3e",
+                start_sha: "a1b2c3d",
+              },
+            }),
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("before\uFFFDafter")));
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+
+      const contents = yield* cli.getMergeRequestDiffFileContents({
+        cwd: "/w",
+        repository: "acme/web",
+        number: 7,
+        changeType: "deleted",
+        oldPath: "docs/encoding.md",
+        newPath: "docs/encoding.md",
+      });
+
+      assert.strictEqual(contents.oldContents, "before\uFFFDafter");
     }),
   );
 

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -558,6 +558,30 @@ layer("GitLabPullRequestCli.layer", (it) => {
     }),
   );
 
+  it.effect("expands a new file from a root commit without requiring a parent", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        Effect.succeed(output(JSON.stringify({ id: "a1b2c3d", parent_ids: [] }))),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("first contents\n")));
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+
+      const contents = yield* cli.getMergeRequestDiffFileContents({
+        cwd: "/w",
+        repository: "acme/web",
+        number: 7,
+        commit: "a1b2c3d",
+        changeType: "new",
+        oldPath: "src/first.ts",
+        newPath: "src/first.ts",
+      });
+
+      expect(contents).toEqual({ oldContents: "", newContents: "first contents\n" });
+      expect(argsOfCall(1)[1]).toContain("raw?ref=a1b2c3d");
+    }),
+  );
+
   it.effect("reports an oversized diff file with its path and reason", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(
@@ -596,7 +620,7 @@ layer("GitLabPullRequestCli.layer", (it) => {
     }),
   );
 
-  it.effect("reports a binary diff file with its path and reason", () =>
+  it.effect("reports undecodable diff file contents as binary", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(
         Effect.succeed(
@@ -612,7 +636,7 @@ layer("GitLabPullRequestCli.layer", (it) => {
           ),
         ),
       );
-      mockedExecute.mockReturnValueOnce(Effect.succeed(output("binary\0contents")));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("binary\uFFFDcontents")));
       const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
 
       const error = yield* Effect.flip(

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -18,12 +18,12 @@ const layer = it.layer(
   ),
 );
 
-function output(stdout: string) {
+function output(stdout: string, stdoutTruncated = false) {
   return {
     exitCode: ChildProcessSpawner.ExitCode(0),
     stdout,
     stderr: "",
-    stdoutTruncated: false,
+    stdoutTruncated,
     stderrTruncated: false,
   };
 }
@@ -170,7 +170,7 @@ layer("GitLabPullRequestCli.layer", (it) => {
     }),
   );
 
-  it.effect("carries on from the instant the last slice ended on", () =>
+  it.effect("carries on from the number of rows already delivered", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(Effect.succeed(output(mergeRequests(3, 1))));
       const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
@@ -185,11 +185,37 @@ layer("GitLabPullRequestCli.layer", (it) => {
         cursor: { updatedBefore: "2026-07-02T00:00:00Z", delivered: 10 },
       });
 
-      // GitLab reads `updated_before` inclusively, so the rows already sent at that instant come
-      // back for the caller to drop rather than the ones beside them being skipped.
+      // GitLab's timestamp filter has no tie-breaker, so an offset is what advances through a
+      // boundary shared by more rows than one page can hold.
       const path = argsOfCall(0)[1] ?? "";
-      expect(path).toContain("updated_before=2026-07-02T00%3A00%3A00Z");
+      expect(path).not.toContain("updated_before=");
       expect(path).toContain("order_by=updated_at");
+      expect(path).toContain("per_page=100");
+      expect(path).toContain("page=1");
+    }),
+  );
+
+  it.effect("advances beyond several pages sharing the cursor timestamp", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(mergeRequests(100, 101))));
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+
+      const batch = yield* cli.listMergeRequests({
+        cwd: "/w",
+        repository: "acme/web",
+        state: "open",
+        involvement: "all",
+        viewer: "bilal",
+        limit: 10,
+        cursor: { updatedBefore: "2026-07-02T00:00:00Z", delivered: 150 },
+      });
+
+      expect(argsOfCall(0)[1]).toContain("per_page=100");
+      expect(argsOfCall(0)[1]).toContain("page=2");
+      expect(batch.items.map((item) => item.number)).toEqual([
+        151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
+      ]);
+      assert.isTrue(batch.truncated);
     }),
   );
 
@@ -502,6 +528,109 @@ layer("GitLabPullRequestCli.layer", (it) => {
 
       assert.strictEqual(error._tag, "GitLabDiffCommitError");
       assert.strictEqual(mockedExecute.mock.calls.length, 0);
+    }),
+  );
+
+  it.effect("reports a commit with no parent as a structured error", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        Effect.succeed(output(JSON.stringify({ id: "a1b2c3d", parent_ids: [] }))),
+      );
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+
+      const error = yield* Effect.flip(
+        cli.getMergeRequestDiffFileContents({
+          cwd: "/w",
+          repository: "acme/web",
+          number: 7,
+          commit: "a1b2c3d",
+          changeType: "change",
+          oldPath: "src/a.ts",
+          newPath: "src/a.ts",
+        }),
+      );
+
+      assert.strictEqual(error._tag, "GitLabDiffCommitParentUnavailableError");
+      if (error._tag === "GitLabDiffCommitParentUnavailableError") {
+        assert.strictEqual(error.commit, "a1b2c3d");
+      }
+    }),
+  );
+
+  it.effect("reports an oversized diff file with its path and reason", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              diff_refs: {
+                base_sha: "a1b2c3d",
+                head_sha: "b1c2d3e",
+                start_sha: "a1b2c3d",
+              },
+            }),
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("partial", true)));
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+
+      const error = yield* Effect.flip(
+        cli.getMergeRequestDiffFileContents({
+          cwd: "/w",
+          repository: "acme/web",
+          number: 7,
+          changeType: "deleted",
+          oldPath: "src/large.ts",
+          newPath: "src/large.ts",
+        }),
+      );
+
+      assert.strictEqual(error._tag, "GitLabDiffFileContentsUnavailableError");
+      if (error._tag === "GitLabDiffFileContentsUnavailableError") {
+        assert.strictEqual(error.path, "src/large.ts");
+        assert.strictEqual(error.reason, "oversized");
+      }
+    }),
+  );
+
+  it.effect("reports a binary diff file with its path and reason", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              diff_refs: {
+                base_sha: "a1b2c3d",
+                head_sha: "b1c2d3e",
+                start_sha: "a1b2c3d",
+              },
+            }),
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("binary\0contents")));
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+
+      const error = yield* Effect.flip(
+        cli.getMergeRequestDiffFileContents({
+          cwd: "/w",
+          repository: "acme/web",
+          number: 7,
+          changeType: "deleted",
+          oldPath: "assets/logo.png",
+          newPath: "assets/logo.png",
+        }),
+      );
+
+      assert.strictEqual(error._tag, "GitLabDiffFileContentsUnavailableError");
+      if (error._tag === "GitLabDiffFileContentsUnavailableError") {
+        assert.strictEqual(error.path, "assets/logo.png");
+        assert.strictEqual(error.reason, "binary");
+      }
     }),
   );
 

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -117,6 +117,7 @@ layer("GitLabPullRequestCli.layer", (it) => {
 
       assert.strictEqual(batch.items.length, 3);
       assert.isFalse(batch.truncated);
+      assert.strictEqual(batch.cursorAdvance, 3);
       const path = argsOfCall(0)[1] ?? "";
       expect(path).toContain("projects/acme%2Fweb/merge_requests");
       expect(path).toContain("per_page=11");
@@ -190,14 +191,16 @@ layer("GitLabPullRequestCli.layer", (it) => {
       const path = argsOfCall(0)[1] ?? "";
       expect(path).not.toContain("updated_before=");
       expect(path).toContain("order_by=updated_at");
-      expect(path).toContain("per_page=100");
+      expect(path).toContain("per_page=11");
       expect(path).toContain("page=1");
     }),
   );
 
   it.effect("advances beyond several pages sharing the cursor timestamp", () =>
     Effect.gen(function* () {
-      mockedExecute.mockReturnValueOnce(Effect.succeed(output(mergeRequests(100, 101))));
+      mockedExecute
+        .mockReturnValueOnce(Effect.succeed(output(mergeRequests(11, 144))))
+        .mockReturnValueOnce(Effect.succeed(output(mergeRequests(11, 155))));
       const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
 
       const batch = yield* cli.listMergeRequests({
@@ -210,11 +213,37 @@ layer("GitLabPullRequestCli.layer", (it) => {
         cursor: { updatedBefore: "2026-07-02T00:00:00Z", delivered: 150 },
       });
 
-      expect(argsOfCall(0)[1]).toContain("per_page=100");
-      expect(argsOfCall(0)[1]).toContain("page=2");
+      expect(argsOfCall(0)[1]).toContain("per_page=11");
+      expect(argsOfCall(0)[1]).toContain("page=14");
+      expect(argsOfCall(1)[1]).toContain("page=15");
       expect(batch.items.map((item) => item.number)).toEqual([
         151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
       ]);
+      assert.isTrue(batch.truncated);
+    }),
+  );
+
+  it.effect("advances the cursor through malformed raw rows", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const rows = JSON.parse(mergeRequests(2, 1)) as ReadonlyArray<unknown>;
+      mockedExecute.mockReturnValueOnce(
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        Effect.succeed(output(JSON.stringify([{ iid: "malformed" }, ...rows]))),
+      );
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+
+      const batch = yield* cli.listMergeRequests({
+        cwd: "/w",
+        repository: "acme/web",
+        state: "open",
+        involvement: "all",
+        viewer: "bilal",
+        limit: 2,
+      });
+
+      expect(batch.items.map((item) => item.number)).toEqual([1, 2]);
+      assert.strictEqual(batch.cursorAdvance, 3);
       assert.isTrue(batch.truncated);
     }),
   );

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -129,11 +129,52 @@ export class GitLabDiffCommitError extends Schema.TaggedErrorClass<GitLabDiffCom
   }
 }
 
+/** The commit exists and decoded, but it has no parent to use as the old revision. */
+export class GitLabDiffCommitParentUnavailableError extends Schema.TaggedErrorClass<GitLabDiffCommitParentUnavailableError>()(
+  "GitLabDiffCommitParentUnavailableError",
+  {
+    command: Schema.Literal("glab"),
+    cwd: Schema.String,
+    commit: Schema.String,
+  },
+) {
+  get detail(): string {
+    return `Commit ${this.commit} reported no parent revision.`;
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in getMergeRequestDiffFileContents: ${this.detail}`;
+  }
+}
+
+/** A blob exists, but expanding it would be unsafe or would not produce text. */
+export class GitLabDiffFileContentsUnavailableError extends Schema.TaggedErrorClass<GitLabDiffFileContentsUnavailableError>()(
+  "GitLabDiffFileContentsUnavailableError",
+  {
+    command: Schema.Literal("glab"),
+    cwd: Schema.String,
+    path: Schema.String,
+    reason: Schema.Literals(["oversized", "binary"]),
+  },
+) {
+  get detail(): string {
+    return this.reason === "oversized"
+      ? `The diff file '${this.path}' exceeds the 1 MB expansion limit.`
+      : `The diff file '${this.path}' is binary.`;
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in getMergeRequestDiffFileContents: ${this.detail}`;
+  }
+}
+
 export type GitLabPullRequestCliError =
   | GitLabCli.GitLabCliError
   | GitLabMergeRequestReadError
   | GitLabDiffCursorError
   | GitLabDiffCommitError
+  | GitLabDiffCommitParentUnavailableError
+  | GitLabDiffFileContentsUnavailableError
   | GitLabDiffRefsUnavailableError
   | GitLabViewerUnavailableError;
 
@@ -428,10 +469,15 @@ export const make = Effect.gen(function* () {
     readonly page: number;
     readonly collected: ReadonlyArray<GitLabMergeRequestListItem>;
   }): Effect.Effect<GitLabMergeRequestListBatch, GitLabPullRequestCliError> => {
-    // Fixed across the walk: GitLab pages by offset, so a page size that changed between
-    // requests would skip or repeat rows. One row over the limit probes for a next page.
-    const perPage = Math.min(input.limit + 1, MAX_PAGE_SIZE);
-    const lastPage = Math.ceil((input.limit + 1) / perPage);
+    // A continuation uses GitLab's offset pagination. Its timestamp filter is inclusive and has
+    // no tie-breaker, so a page where many rows share the boundary would otherwise return the
+    // same prefix forever. `delivered` is the stable offset the service has already handed over.
+    const delivered = input.cursor?.delivered ?? 0;
+    const perPage =
+      input.cursor === undefined ? Math.min(input.limit + 1, MAX_PAGE_SIZE) : MAX_PAGE_SIZE;
+    const firstPage = Math.floor(delivered / perPage) + 1;
+    const skipOnFirstPage = delivered % perPage;
+    const lastPage = Math.floor((delivered + input.limit) / perPage) + 1;
     return api({
       cwd: input.cwd,
       path: `projects/${projectPath(input.repository)}/merge_requests?${query([
@@ -442,12 +488,6 @@ export const make = Effect.gen(function* () {
         // matches title and description, and travels URL-encoded like every other value here,
         // so no text in it can become a parameter of its own.
         ...searchParams(input.query),
-        // The instant the last slice ended on, which GitLab reads inclusively — so the rows
-        // already sent at it come back and the caller drops them, rather than the ones beside
-        // them being lost to a strictly-older read.
-        ...(input.cursor === undefined
-          ? []
-          : [["updated_before", input.cursor.updatedBefore] as const]),
         ["order_by", "updated_at"],
         ["sort", "desc"],
         ["per_page", String(perPage)],
@@ -470,7 +510,11 @@ export const make = Effect.gen(function* () {
             }),
           );
         }
-        const collected = [...input.collected, ...decoded.success.items];
+        const pageItems =
+          input.page === firstPage
+            ? decoded.success.items.slice(skipOnFirstPage)
+            : decoded.success.items;
+        const collected = [...input.collected, ...pageItems];
         // Counted before decoding, so a skipped malformed row cannot end paging early.
         const exhausted = decoded.success.rawCount < perPage;
         if (exhausted || collected.length > input.limit || input.page >= lastPage) {
@@ -696,7 +740,7 @@ export const make = Effect.gen(function* () {
       cwd: input.cwd,
       path: `projects/${projectPath(input.repository)}/repository/commits/${input.commit}`,
     }).pipe(
-      Effect.flatMap((result) => {
+      Effect.flatMap((result): Effect.Effect<GitLabDiffRefs, GitLabPullRequestCliError> => {
         const decoded = decodeCommitDiffRefsJson(result.stdout.trim());
         if (!Result.isSuccess(decoded)) {
           return Effect.fail(
@@ -710,11 +754,10 @@ export const make = Effect.gen(function* () {
         }
         return decoded.success === null
           ? Effect.fail(
-              new GitLabMergeRequestReadError({
+              new GitLabDiffCommitParentUnavailableError({
                 command: "glab",
                 cwd: input.cwd,
-                operation: "getMergeRequestDiffFileContents",
-                cause: new Error("GitLab returned no usable parent for the commit."),
+                commit: input.commit,
               }),
             )
           : Effect.succeed(decoded.success);
@@ -796,7 +839,12 @@ export const make = Effect.gen(function* () {
         }),
       ),
 
-    listMergeRequests: (input) => listPage({ ...input, page: 1, collected: [] }),
+    listMergeRequests: (input) => {
+      const perPage =
+        input.cursor === undefined ? Math.min(input.limit + 1, MAX_PAGE_SIZE) : MAX_PAGE_SIZE;
+      const page = Math.floor((input.cursor?.delivered ?? 0) / perPage) + 1;
+      return listPage({ ...input, page, collected: [] });
+    },
 
     getMergeRequestDetail: mergeRequestDetail,
 
@@ -846,9 +894,7 @@ export const make = Effect.gen(function* () {
     getMergeRequestDiffFileContents: (input) =>
       Effect.gen(function* () {
         if (input.commit !== undefined && !isCommitSha(input.commit)) {
-          return yield* Effect.fail(
-            new GitLabDiffCommitError({ command: "glab", cwd: input.cwd }),
-          );
+          return yield* Effect.fail(new GitLabDiffCommitError({ command: "glab", cwd: input.cwd }));
         }
         const refs = yield* input.commit === undefined
           ? getDiffRefs(input)
@@ -870,15 +916,11 @@ export const make = Effect.gen(function* () {
             Effect.flatMap((result) =>
               result.stdoutTruncated || result.stdout.includes("\0")
                 ? Effect.fail(
-                    new GitLabMergeRequestReadError({
+                    new GitLabDiffFileContentsUnavailableError({
                       command: "glab",
                       cwd: input.cwd,
-                      operation: "getMergeRequestDiffFileContents",
-                      cause: new Error(
-                        result.stdoutTruncated
-                          ? `The diff file '${filePath}' exceeds the 1 MB expansion limit.`
-                          : `The diff file '${filePath}' is binary.`,
-                      ),
+                      path: filePath,
+                      reason: result.stdoutTruncated ? "oversized" : "binary",
                     }),
                   )
                 : Effect.succeed(result.stdout),
@@ -887,9 +929,7 @@ export const make = Effect.gen(function* () {
 
         const [oldContents, newContents] = yield* Effect.all(
           [
-            input.changeType === "new"
-              ? Effect.succeed("")
-              : readFile(refs.baseSha, input.oldPath),
+            input.changeType === "new" ? Effect.succeed("") : readFile(refs.baseSha, input.oldPath),
             input.changeType === "deleted"
               ? Effect.succeed("")
               : readFile(refs.headSha, input.newPath),

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -960,7 +960,7 @@ export const make = Effect.gen(function* () {
             Effect.flatMap((result) =>
               result.stdoutTruncated ||
               result.stdout.includes("\0") ||
-              result.stdout.includes("\uFFFD")
+              result.stdoutInvalidUtf8 === true
                 ? Effect.fail(
                     new GitLabDiffFileContentsUnavailableError({
                       command: "glab",

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -195,6 +195,8 @@ const DIFF_FILE_MAX_OUTPUT_BYTES = 1024 * 1024;
 export interface GitLabMergeRequestListBatch {
   readonly items: ReadonlyArray<GitLabMergeRequestListItem>;
   readonly truncated: boolean;
+  /** Raw GitLab rows consumed to produce this page, including malformed rows. */
+  readonly cursorAdvance: number;
 }
 
 export interface GitLabMergeRequestDiffSlice {
@@ -221,7 +223,7 @@ export class GitLabPullRequestCli extends Context.Service<
       readonly limit: number;
       /** Free text for GitLab's own `search`, which matches title and description. */
       readonly query?: string | undefined;
-      /** Where to carry on from, as GitLab's own `updated_before`. */
+      /** Where to carry on from in GitLab's stable update-ordered row set. */
       readonly cursor?: ProviderListCursor | undefined;
     }) => Effect.Effect<GitLabMergeRequestListBatch, GitLabPullRequestCliError>;
 
@@ -468,15 +470,18 @@ export const make = Effect.gen(function* () {
     readonly cursor?: ProviderListCursor | undefined;
     readonly page: number;
     readonly collected: ReadonlyArray<GitLabMergeRequestListItem>;
+    readonly cursorAdvance: number;
   }): Effect.Effect<GitLabMergeRequestListBatch, GitLabPullRequestCliError> => {
     // A continuation uses GitLab's offset pagination. Its timestamp filter is inclusive and has
     // no tie-breaker, so a page where many rows share the boundary would otherwise return the
     // same prefix forever. `delivered` is the stable offset the service has already handed over.
     const delivered = input.cursor?.delivered ?? 0;
-    const perPage =
-      input.cursor === undefined ? Math.min(input.limit + 1, MAX_PAGE_SIZE) : MAX_PAGE_SIZE;
+    const perPage = Math.min(input.limit + 1, MAX_PAGE_SIZE);
     const firstPage = Math.floor(delivered / perPage) + 1;
-    const skipOnFirstPage = delivered % perPage;
+    const skipOnFirstPage = input.page === firstPage ? delivered % perPage : 0;
+    // A page made entirely of malformed rows has no item from which the service can build a
+    // continuation. Bound the walk to the raw span this request asked for rather than recursing
+    // forever on a host that keeps returning full unusable pages.
     const lastPage = Math.floor((delivered + input.limit) / perPage) + 1;
     return api({
       cwd: input.cwd,
@@ -497,7 +502,11 @@ export const make = Effect.gen(function* () {
       Effect.flatMap((result) => {
         const raw = result.stdout.trim();
         if (raw.length === 0) {
-          return Effect.succeed({ items: input.collected, truncated: false });
+          return Effect.succeed({
+            items: input.collected,
+            truncated: false,
+            cursorAdvance: input.cursorAdvance,
+          });
         }
         const decoded = decodeMergeRequestListJson(raw);
         if (!Result.isSuccess(decoded)) {
@@ -510,22 +519,50 @@ export const make = Effect.gen(function* () {
             }),
           );
         }
-        const pageItems =
-          input.page === firstPage
-            ? decoded.success.items.slice(skipOnFirstPage)
-            : decoded.success.items;
-        const collected = [...input.collected, ...pageItems];
-        // Counted before decoding, so a skipped malformed row cannot end paging early.
-        const exhausted = decoded.success.rawCount < perPage;
-        if (exhausted || collected.length > input.limit || input.page >= lastPage) {
+        const pageItems: GitLabMergeRequestListItem[] = [];
+        const pageRawIndexes: number[] = [];
+        for (const [index, item] of decoded.success.items.entries()) {
+          const rawIndex = decoded.success.rawIndexes[index]!;
+          if (rawIndex < skipOnFirstPage) continue;
+          pageItems.push(item);
+          pageRawIndexes.push(rawIndex);
+        }
+        const remaining = input.limit - input.collected.length;
+        const lastItemRawIndex = pageRawIndexes[remaining - 1];
+        if (lastItemRawIndex !== undefined) {
+          const consumed = lastItemRawIndex + 1 - skipOnFirstPage;
           return Effect.succeed({
-            items: collected.slice(0, input.limit),
-            // Anything but a short final page means GitLab may still have rows, including the
-            // case where enough rows failed to decode to keep the collected count down.
-            truncated: !exhausted || collected.length > input.limit,
+            items: [...input.collected, ...pageItems.slice(0, remaining)],
+            truncated:
+              lastItemRawIndex + 1 < decoded.success.rawCount ||
+              decoded.success.rawCount === perPage,
+            cursorAdvance: input.cursorAdvance + consumed,
           });
         }
-        return listPage({ ...input, page: input.page + 1, collected });
+        const collected = [...input.collected, ...pageItems];
+        const consumed = Math.max(0, decoded.success.rawCount - skipOnFirstPage);
+        // Counted before decoding, so a skipped malformed row cannot end paging early.
+        const exhausted = decoded.success.rawCount < perPage;
+        if (exhausted) {
+          return Effect.succeed({
+            items: collected,
+            truncated: false,
+            cursorAdvance: input.cursorAdvance + consumed,
+          });
+        }
+        if (input.page >= lastPage) {
+          return Effect.succeed({
+            items: collected,
+            truncated: true,
+            cursorAdvance: input.cursorAdvance + consumed,
+          });
+        }
+        return listPage({
+          ...input,
+          page: input.page + 1,
+          collected,
+          cursorAdvance: input.cursorAdvance + consumed,
+        });
       }),
     );
   };
@@ -847,10 +884,9 @@ export const make = Effect.gen(function* () {
       ),
 
     listMergeRequests: (input) => {
-      const perPage =
-        input.cursor === undefined ? Math.min(input.limit + 1, MAX_PAGE_SIZE) : MAX_PAGE_SIZE;
+      const perPage = Math.min(input.limit + 1, MAX_PAGE_SIZE);
       const page = Math.floor((input.cursor?.delivered ?? 0) / perPage) + 1;
-      return listPage({ ...input, page, collected: [] });
+      return listPage({ ...input, page, collected: [], cursorAdvance: 0 });
     },
 
     getMergeRequestDetail: mergeRequestDetail,

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -735,6 +735,7 @@ export const make = Effect.gen(function* () {
     readonly cwd: string;
     readonly repository: string;
     readonly commit: string;
+    readonly allowRoot: boolean;
   }): Effect.Effect<GitLabDiffRefs, GitLabPullRequestCliError> =>
     api({
       cwd: input.cwd,
@@ -753,13 +754,19 @@ export const make = Effect.gen(function* () {
           );
         }
         return decoded.success === null
-          ? Effect.fail(
-              new GitLabDiffCommitParentUnavailableError({
-                command: "glab",
-                cwd: input.cwd,
-                commit: input.commit,
-              }),
-            )
+          ? input.allowRoot
+            ? Effect.succeed({
+                baseSha: "",
+                headSha: input.commit,
+                startSha: "",
+              })
+            : Effect.fail(
+                new GitLabDiffCommitParentUnavailableError({
+                  command: "glab",
+                  cwd: input.cwd,
+                  commit: input.commit,
+                }),
+              )
           : Effect.succeed(decoded.success);
       }),
     );
@@ -902,6 +909,7 @@ export const make = Effect.gen(function* () {
               cwd: input.cwd,
               repository: input.repository,
               commit: input.commit,
+              allowRoot: input.changeType === "new",
             });
 
         const readFile = (revision: string, filePath: string) =>
@@ -914,7 +922,9 @@ export const make = Effect.gen(function* () {
             timeoutMs: DIFF_TIMEOUT_MS,
           }).pipe(
             Effect.flatMap((result) =>
-              result.stdoutTruncated || result.stdout.includes("\0")
+              result.stdoutTruncated ||
+              result.stdout.includes("\0") ||
+              result.stdout.includes("\uFFFD")
                 ? Effect.fail(
                     new GitLabDiffFileContentsUnavailableError({
                       command: "glab",

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -19,6 +19,7 @@ import type {
 
 import * as GitLabCli from "../sourceControl/GitLabCli.ts";
 import {
+  decodeCommitDiffRefsJson,
   decodeCommitsJson,
   decodeDiffRefsJson,
   decodeDiscussionsJson,
@@ -148,6 +149,7 @@ const COMMIT_PAGE_SIZE = 100;
 const CONVERSATION_PAGES = 10;
 const DIFF_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 const DIFF_TIMEOUT_MS = 60_000;
+const DIFF_FILE_MAX_OUTPUT_BYTES = 1024 * 1024;
 
 export interface GitLabMergeRequestListBatch {
   readonly items: ReadonlyArray<GitLabMergeRequestListItem>;
@@ -212,6 +214,19 @@ export class GitLabPullRequestCli extends Context.Service<
       /** One commit's own changes, rather than everything the merge request carries. */
       readonly commit?: string | undefined;
     }) => Effect.Effect<GitLabMergeRequestDiffSlice, GitLabPullRequestCliError>;
+
+    readonly getMergeRequestDiffFileContents: (input: {
+      readonly cwd: string;
+      readonly repository: string;
+      readonly number: number;
+      readonly commit?: string | undefined;
+      readonly changeType: "change" | "rename-pure" | "rename-changed" | "new" | "deleted";
+      readonly oldPath: string;
+      readonly newPath: string;
+    }) => Effect.Effect<
+      { readonly oldContents: string; readonly newContents: string },
+      GitLabPullRequestCliError
+    >;
 
     readonly getProjectMergeCapabilities: (input: {
       readonly cwd: string;
@@ -672,6 +687,40 @@ export const make = Effect.gen(function* () {
       }),
     );
 
+  const getCommitDiffRefs = (input: {
+    readonly cwd: string;
+    readonly repository: string;
+    readonly commit: string;
+  }): Effect.Effect<GitLabDiffRefs, GitLabPullRequestCliError> =>
+    api({
+      cwd: input.cwd,
+      path: `projects/${projectPath(input.repository)}/repository/commits/${input.commit}`,
+    }).pipe(
+      Effect.flatMap((result) => {
+        const decoded = decodeCommitDiffRefsJson(result.stdout.trim());
+        if (!Result.isSuccess(decoded)) {
+          return Effect.fail(
+            new GitLabMergeRequestReadError({
+              command: "glab",
+              cwd: input.cwd,
+              operation: "getMergeRequestDiffFileContents",
+              cause: decoded.failure,
+            }),
+          );
+        }
+        return decoded.success === null
+          ? Effect.fail(
+              new GitLabMergeRequestReadError({
+                command: "glab",
+                cwd: input.cwd,
+                operation: "getMergeRequestDiffFileContents",
+                cause: new Error("GitLab returned no usable parent for the commit."),
+              }),
+            )
+          : Effect.succeed(decoded.success);
+      }),
+    );
+
   /**
    * The merge request itself, which several calls need for different parts of it: the detail for
    * everything, and the reviewer paths for the ids GitLab writes a reviewer set with.
@@ -793,6 +842,62 @@ export const make = Effect.gen(function* () {
         ? Effect.fail(new GitLabDiffCursorError({ command: "glab", cwd: input.cwd }))
         : diffPage({ ...target, page });
     },
+
+    getMergeRequestDiffFileContents: (input) =>
+      Effect.gen(function* () {
+        if (input.commit !== undefined && !isCommitSha(input.commit)) {
+          return yield* Effect.fail(
+            new GitLabDiffCommitError({ command: "glab", cwd: input.cwd }),
+          );
+        }
+        const refs = yield* input.commit === undefined
+          ? getDiffRefs(input)
+          : getCommitDiffRefs({
+              cwd: input.cwd,
+              repository: input.repository,
+              commit: input.commit,
+            });
+
+        const readFile = (revision: string, filePath: string) =>
+          api({
+            cwd: input.cwd,
+            path: `projects/${projectPath(input.repository)}/repository/files/${encodeURIComponent(
+              filePath,
+            )}/raw?ref=${encodeURIComponent(revision)}`,
+            maxOutputBytes: DIFF_FILE_MAX_OUTPUT_BYTES,
+            timeoutMs: DIFF_TIMEOUT_MS,
+          }).pipe(
+            Effect.flatMap((result) =>
+              result.stdoutTruncated || result.stdout.includes("\0")
+                ? Effect.fail(
+                    new GitLabMergeRequestReadError({
+                      command: "glab",
+                      cwd: input.cwd,
+                      operation: "getMergeRequestDiffFileContents",
+                      cause: new Error(
+                        result.stdoutTruncated
+                          ? `The diff file '${filePath}' exceeds the 1 MB expansion limit.`
+                          : `The diff file '${filePath}' is binary.`,
+                      ),
+                    }),
+                  )
+                : Effect.succeed(result.stdout),
+            ),
+          );
+
+        const [oldContents, newContents] = yield* Effect.all(
+          [
+            input.changeType === "new"
+              ? Effect.succeed("")
+              : readFile(refs.baseSha, input.oldPath),
+            input.changeType === "deleted"
+              ? Effect.succeed("")
+              : readFile(refs.headSha, input.newPath),
+          ],
+          { concurrency: 2 },
+        );
+        return { oldContents, newContents };
+      }),
 
     getProjectMergeCapabilities: (input) =>
       api({

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -71,6 +71,11 @@ export interface ProviderChangeRequestPage {
   /** True when the host has more rows than the page size asked for. */
   readonly truncated: boolean;
   /**
+   * Optional count-based cursor advance. Most hosts advance by the rows delivered after local
+   * de-duplication; an offset-paged host may need to count malformed raw rows it consumed too.
+   */
+  readonly cursorAdvance?: number;
+  /**
    * This page can be carried on from, so the service may hand the caller a cursor for it. False
    * where the host answered in an order a cursor means nothing in, which leaves a larger `limit`
    * as the only way to the rest — what every listing did before there were cursors.
@@ -93,8 +98,9 @@ export interface ProviderListCursor {
    */
   readonly updatedBefore: string;
   /**
-   * How many rows this repository has handed over so far, for a host that carries on by counting
-   * rather than by date.
+   * How many provider rows this repository has consumed so far, for a host that carries on by
+   * counting rather than by date. Usually this is the number handed over; malformed raw rows may
+   * count too when the provider reports a `cursorAdvance`.
    */
   readonly delivered: number;
 }
@@ -285,13 +291,15 @@ export interface PullRequestProviderApi {
    * Full files at the exact revisions the host used for its patch. Optional where the provider
    * exposes no diff at all; the service refuses expansion there just as it refuses the patch.
    */
-  readonly getDiffFileContents?: (input: ProviderRepositoryRef & {
-    readonly number: number;
-    readonly commit?: string | undefined;
-    readonly changeType: "change" | "rename-pure" | "rename-changed" | "new" | "deleted";
-    readonly oldPath: string;
-    readonly newPath: string;
-  }) => Effect.Effect<ProviderDiffFileContents, PullRequestProviderError>;
+  readonly getDiffFileContents?: (
+    input: ProviderRepositoryRef & {
+      readonly number: number;
+      readonly commit?: string | undefined;
+      readonly changeType: "change" | "rename-pure" | "rename-changed" | "new" | "deleted";
+      readonly oldPath: string;
+      readonly newPath: string;
+    },
+  ) => Effect.Effect<ProviderDiffFileContents, PullRequestProviderError>;
 
   readonly runAction: (
     input: ProviderRepositoryRef & {

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -157,6 +157,11 @@ export interface ProviderDiffSlice {
   readonly nextCursor: string | null;
 }
 
+export interface ProviderDiffFileContents {
+  readonly oldContents: string;
+  readonly newContents: string;
+}
+
 export interface ProviderRepositoryRef {
   readonly cwd: string;
   /** Provider-native repository identity, e.g. `owner/repo` or `group/subgroup/project`. */
@@ -275,6 +280,18 @@ export interface PullRequestProviderApi {
       readonly commit?: string | undefined;
     },
   ) => Effect.Effect<ProviderDiffSlice, PullRequestProviderError>;
+
+  /**
+   * Full files at the exact revisions the host used for its patch. Optional where the provider
+   * exposes no diff at all; the service refuses expansion there just as it refuses the patch.
+   */
+  readonly getDiffFileContents?: (input: ProviderRepositoryRef & {
+    readonly number: number;
+    readonly commit?: string | undefined;
+    readonly changeType: "change" | "rename-pure" | "rename-changed" | "new" | "deleted";
+    readonly oldPath: string;
+    readonly newPath: string;
+  }) => Effect.Effect<ProviderDiffFileContents, PullRequestProviderError>;
 
   readonly runAction: (
     input: ProviderRepositoryRef & {

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -296,6 +296,40 @@ it.effect("offers no continuation for a host that cannot be carried on from", ()
   }),
 );
 
+it.effect("uses a provider's raw cursor advance when it consumed malformed rows", () =>
+  Effect.gen(function* () {
+    const service = yield* makeService({
+      projects: [
+        project({
+          id: "p1",
+          title: "web",
+          workspaceRoot: "/a",
+          repository: "acme/web",
+          provider: "azure-devops",
+          host: "dev.azure.com",
+        }),
+      ],
+      providers: [
+        fakeProvider("azure-devops", {
+          listChangeRequests: () =>
+            Effect.succeed({
+              items: [changeRequest(7, "2026-07-02T00:00:00Z")],
+              truncated: true,
+              cursorAdvance: 4,
+              continues: true,
+            }),
+        }),
+      ],
+    });
+
+    const result = yield* service.list({ state: "open" });
+
+    assert.deepStrictEqual(result.nextCursors, {
+      "dev.azure.com acme/web": "2026-07-02T00:00:00Z|4|7",
+    });
+  }),
+);
+
 it.effect("reads only the repositories it was asked to carry on with", () =>
   Effect.gen(function* () {
     const listed: string[] = [];

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -252,6 +252,8 @@ function nextListCursor(
   fetched: ReadonlyArray<ProviderChangeRequest>,
   /** What is being sent on, which is what the count of delivered rows is about. */
   delivered: ReadonlyArray<ProviderChangeRequest>,
+  /** A provider may consume malformed offset-paged rows that never appear in `delivered`. */
+  cursorAdvance = delivered.length,
 ): string | null {
   // The host had nothing at all, so there is no row to carry on from — and repeating the cursor
   // that produced the empty slice would ask the same question forever.
@@ -261,7 +263,7 @@ function nextListCursor(
   // repository's boring afternoon — and reading "nothing new" as "nothing left" would end the
   // walk on the instant it was stuck on, with everything older unreachable for good.
   const oldest = fetched.reduce((left, right) => (right.updatedAt < left.updatedAt ? right : left));
-  return listCursorAt(previous, oldest.updatedAt, fetched, delivered.length);
+  return listCursorAt(previous, oldest.updatedAt, fetched, cursorAdvance);
 }
 
 /**
@@ -668,7 +670,7 @@ export const make = Effect.gen(function* () {
                   truncated: page.truncated,
                   nextCursor:
                     page.continues && page.truncated
-                      ? nextListCursor(cursor, page.items, items)
+                      ? nextListCursor(cursor, page.items, items, page.cursorAdvance)
                       : null,
                 };
               }),

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -14,6 +14,8 @@ import {
   type PullRequestActionInput,
   type PullRequestCommentInput,
   type PullRequestDetail,
+  type PullRequestDiffFileContentsInput,
+  type PullRequestDiffFileContentsResult,
   type PullRequestDiffStat,
   type PullRequestDiffInput,
   type PullRequestDiffResult,
@@ -104,6 +106,9 @@ export class PullRequestService extends Context.Service<
     readonly diff: (
       input: PullRequestDiffInput,
     ) => Effect.Effect<PullRequestDiffResult, PullRequestError>;
+    readonly diffFileContents: (
+      input: PullRequestDiffFileContentsInput,
+    ) => Effect.Effect<PullRequestDiffFileContentsResult, PullRequestError>;
     readonly runAction: (input: PullRequestActionInput) => Effect.Effect<void, PullRequestError>;
     readonly comment: (input: PullRequestCommentInput) => Effect.Effect<void, PullRequestError>;
     readonly submitReview: (
@@ -895,6 +900,30 @@ export const make = Effect.gen(function* () {
       ),
     );
 
+  const diffFileContents: PullRequestService["Service"]["diffFileContents"] = (input) =>
+    requireProject(input).pipe(
+      Effect.flatMap((project) => {
+        const read = project.api.getDiffFileContents;
+        return project.api.capabilities.diff && read
+          ? read({
+              cwd: project.project.workspaceRoot,
+              repository: project.repository,
+              host: project.host,
+              number: input.number,
+              ...(input.commit === undefined ? {} : { commit: input.commit }),
+              changeType: input.changeType,
+              oldPath: input.oldPath,
+              newPath: input.newPath,
+            }).pipe(Effect.mapError(toPullRequestError("diffFileContents")))
+          : Effect.fail(
+              new PullRequestOperationError({
+                operation: "diffFileContents",
+                detail: "This host cannot expand unchanged pull request lines.",
+              }),
+            );
+      }),
+    );
+
   const runAction: PullRequestService["Service"]["runAction"] = (input) =>
     requireProject(input).pipe(
       Effect.flatMap((project): Effect.Effect<void, PullRequestError> => {
@@ -1453,6 +1482,7 @@ export const make = Effect.gen(function* () {
     listStats,
     detail,
     diff,
+    diffFileContents,
     runAction: invalidatedByMutation(runAction),
     comment: invalidatedByMutation(comment),
     submitReview: invalidatedByMutation(submitReview),

--- a/apps/server/src/pullRequest/azureDevOpsPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/azureDevOpsPullRequestJson.test.ts
@@ -122,6 +122,7 @@ describe("decodePullRequestListJson", () => {
 
     expect(batch.items).toHaveLength(1);
     expect(batch.rawCount).toBe(2);
+    expect(batch.rawIndexes).toEqual([1]);
   });
 });
 

--- a/apps/server/src/pullRequest/azureDevOpsPullRequestJson.ts
+++ b/apps/server/src/pullRequest/azureDevOpsPullRequestJson.ts
@@ -237,6 +237,8 @@ type DecodeFailure = Cause.Cause<Schema.SchemaError>;
 
 export interface AzureDevOpsPullRequestBatch {
   readonly items: ReadonlyArray<AzureDevOpsPullRequest>;
+  /** Zero-based positions of the decoded items in Azure's raw page. */
+  readonly rawIndexes: ReadonlyArray<number>;
   /** Rows Azure returned, counted before decoding, so a skipped row cannot hide a next page. */
   readonly rawCount: number;
 }
@@ -250,13 +252,17 @@ export function decodePullRequestListJson(
     return Result.fail(decoded.failure);
   }
   const items: AzureDevOpsPullRequest[] = [];
-  for (const entry of decoded.success) {
+  const rawIndexes: number[] = [];
+  for (const [rawIndex, entry] of decoded.success.entries()) {
     const item = decodePullRequestEntry(entry);
     if (Exit.isFailure(item)) continue;
     const pullRequest = toPullRequest(item.value);
-    if (pullRequest !== null) items.push(pullRequest);
+    if (pullRequest !== null) {
+      items.push(pullRequest);
+      rawIndexes.push(rawIndex);
+    }
   }
-  return Result.succeed({ items, rawCount: decoded.success.length });
+  return Result.succeed({ items, rawIndexes, rawCount: decoded.success.length });
 }
 
 /** Null carries "Azure answered, but with too little to use", which the caller reports. */

--- a/apps/server/src/pullRequest/bitbucketPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/bitbucketPullRequestJson.test.ts
@@ -245,8 +245,9 @@ describe("decodeCommitsJson", () => {
       ),
     );
 
-    expect(decoded.map((commit) => commit.oid)).toEqual(["aaa", "bbb"]);
-    expect(decoded[1]?.messageHeadline).toBe("second");
+    expect(decoded.items.map((commit) => commit.oid)).toEqual(["aaa", "bbb"]);
+    expect(decoded.items[1]?.messageHeadline).toBe("second");
+    expect(decoded.next).toBeNull();
   });
 });
 
@@ -266,14 +267,17 @@ describe("decodeStatusesJson", () => {
       ),
     );
 
-    expect(decoded).toEqual([
-      {
-        name: "Pipeline - custom: check-version-and-pr",
-        status: "success",
-        description: null,
-        url: "https://bitbucket.org/acme/web/pipelines/results/8126",
-      },
-    ]);
+    expect(decoded).toEqual({
+      items: [
+        {
+          name: "Pipeline - custom: check-version-and-pr",
+          status: "success",
+          description: null,
+          url: "https://bitbucket.org/acme/web/pipelines/results/8126",
+        },
+      ],
+      next: null,
+    });
   });
 
   it.each([
@@ -285,7 +289,7 @@ describe("decodeStatusesJson", () => {
   ])("reads the %s build state as %s", (state, expected) => {
     const decoded = expectSuccess(decodeStatusesJson(page([{ name: "Pipeline", state }])));
 
-    expect(decoded[0]?.status).toBe(expected);
+    expect(decoded.items[0]?.status).toBe(expected);
   });
 });
 
@@ -300,7 +304,7 @@ describe("decodeDiffstatJson", () => {
       ),
     );
 
-    expect(decoded).toEqual({ additions: 41, deletions: 16, changedFiles: 2 });
+    expect(decoded).toEqual({ additions: 41, deletions: 16, changedFiles: 2, next: null });
   });
 });
 

--- a/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
+++ b/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
@@ -502,7 +502,7 @@ export function decodeCommentsJson(raw: string): Result.Result<BitbucketComments
 
 export function decodeCommitsJson(
   raw: string,
-): Result.Result<ReadonlyArray<PullRequestCommit>, DecodeFailure> {
+): Result.Result<BitbucketPage<PullRequestCommit>, DecodeFailure> {
   const decoded = decodePage(raw);
   if (!Result.isSuccess(decoded)) {
     return Result.fail(decoded.failure);
@@ -521,12 +521,12 @@ export function decodeCommitsJson(
     });
   }
   // Bitbucket lists a pull request's commits newest first; the timeline reads oldest first.
-  return Result.succeed(commits.toReversed());
+  return Result.succeed({ items: commits.toReversed(), next: trimmed(decoded.success.next) });
 }
 
 export function decodeStatusesJson(
   raw: string,
-): Result.Result<ReadonlyArray<PullRequestCheck>, DecodeFailure> {
+): Result.Result<BitbucketPage<PullRequestCheck>, DecodeFailure> {
   const decoded = decodePage(raw);
   if (!Result.isSuccess(decoded)) {
     return Result.fail(decoded.failure);
@@ -545,7 +545,7 @@ export function decodeStatusesJson(
       url: trimmed(status.url),
     });
   }
-  return Result.succeed(checks);
+  return Result.succeed({ items: checks, next: trimmed(decoded.success.next) });
 }
 
 export interface BitbucketDiffStat {
@@ -554,8 +554,14 @@ export interface BitbucketDiffStat {
   readonly changedFiles: number;
 }
 
+export interface BitbucketDiffStatPage extends BitbucketDiffStat {
+  readonly next: string | null;
+}
+
 /** One entry per changed file, each carrying that file's line counts. */
-export function decodeDiffstatJson(raw: string): Result.Result<BitbucketDiffStat, DecodeFailure> {
+export function decodeDiffstatJson(
+  raw: string,
+): Result.Result<BitbucketDiffStatPage, DecodeFailure> {
   const decoded = decodePage(raw);
   if (!Result.isSuccess(decoded)) {
     return Result.fail(decoded.failure);
@@ -570,7 +576,12 @@ export function decodeDiffstatJson(raw: string): Result.Result<BitbucketDiffStat
     deletions += decodedStat.value.lines_removed ?? 0;
     changedFiles += 1;
   }
-  return Result.succeed({ additions, deletions, changedFiles });
+  return Result.succeed({
+    additions,
+    deletions,
+    changedFiles,
+    next: trimmed(decoded.success.next),
+  });
 }
 
 /**

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -563,6 +563,8 @@ export interface GitHubPullRequestListItem {
   readonly createdAt: string;
   readonly updatedAt: string;
   readonly reviewRequestLogins: ReadonlyArray<string>;
+  /** At least one outstanding request targets a team rather than an individual login. */
+  readonly hasTeamReviewRequest: boolean;
   readonly labels: ReadonlyArray<PullRequestLabel>;
 }
 
@@ -645,9 +647,8 @@ function toLabels(
 }
 
 /**
- * User review requests only. A team request carries a slug, and the viewer check compares
- * these against a login, so keeping slugs here would let an unrelated team read as the
- * viewer. Team-routed requests need GitHub's review-requested search to resolve.
+ * User review requests only. Team requests are tracked separately because a slug cannot be
+ * compared with the viewer's login.
  */
 function toReviewRequestLogins(
   raw: ReadonlyArray<Schema.Schema.Type<typeof RawReviewRequestSchema>> | undefined,
@@ -656,6 +657,16 @@ function toReviewRequestLogins(
     const login = trimmed(request.login);
     return login === null ? [] : [login];
   });
+}
+
+function hasTeamReviewRequest(
+  raw: ReadonlyArray<Schema.Schema.Type<typeof RawReviewRequestSchema>> | undefined,
+): boolean {
+  return (raw ?? []).some(
+    (request) =>
+      trimmed(request.login) === null &&
+      (trimmed(request.slug) !== null || trimmed(request.name) !== null),
+  );
 }
 
 function toCheckStatus(raw: Schema.Schema.Type<typeof RawCheckSchema>): PullRequestCheckStatus {
@@ -779,6 +790,7 @@ function toListItem(raw: Schema.Schema.Type<typeof RawListItemSchema>): GitHubPu
     createdAt: raw.createdAt,
     updatedAt: raw.updatedAt,
     reviewRequestLogins: toReviewRequestLogins(raw.reviewRequests),
+    hasTeamReviewRequest: hasTeamReviewRequest(raw.reviewRequests),
     labels: toLabels(raw.labels),
   };
 }

--- a/apps/server/src/pullRequest/gitLabMergeRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitLabMergeRequestJson.test.ts
@@ -128,6 +128,7 @@ describe("decodeMergeRequestListJson", () => {
     );
 
     expect(batch.items).toHaveLength(1);
+    expect(batch.rawIndexes).toEqual([1]);
     expect(batch.rawCount).toBe(2);
   });
 });

--- a/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
+++ b/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
@@ -365,6 +365,8 @@ export interface GitLabProjectUsers {
 
 export interface GitLabMergeRequestListBatch {
   readonly items: ReadonlyArray<GitLabMergeRequestListItem>;
+  /** Zero-based positions of the decoded items in GitLab's raw page. */
+  readonly rawIndexes: ReadonlyArray<number>;
   /** Rows GitLab returned, counted before decoding, so a skipped row cannot hide a next page. */
   readonly rawCount: number;
 }
@@ -379,13 +381,15 @@ export function decodeMergeRequestListJson(
     return Result.fail(decoded.failure);
   }
   const items: GitLabMergeRequestListItem[] = [];
-  for (const entry of decoded.success) {
+  const rawIndexes: number[] = [];
+  for (const [rawIndex, entry] of decoded.success.entries()) {
     const item = decodeMergeRequestEntry(entry);
     if (Exit.isSuccess(item)) {
       items.push(toListItem(item.value));
+      rawIndexes.push(rawIndex);
     }
   }
-  return Result.succeed({ items, rawCount: decoded.success.length });
+  return Result.succeed({ items, rawIndexes, rawCount: decoded.success.length });
 }
 
 export function decodeMergeRequestDetailJson(
@@ -605,9 +609,7 @@ export function decodeCommitDiffRefsJson(
   const baseSha = trimmed(decoded.success.parent_ids?.[0]);
   const headSha = trimmed(decoded.success.id);
   return Result.succeed(
-    baseSha === null || headSha === null
-      ? null
-      : { baseSha, headSha, startSha: baseSha },
+    baseSha === null || headSha === null ? null : { baseSha, headSha, startSha: baseSha },
   );
 }
 

--- a/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
+++ b/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
@@ -137,6 +137,7 @@ const RawCommitSchema = Schema.Struct({
   title: Schema.optional(Schema.NullOr(Schema.String)),
   committed_date: Schema.optional(Schema.NullOr(Schema.String)),
   created_at: Schema.optional(Schema.NullOr(Schema.String)),
+  parent_ids: Schema.optional(Schema.Array(Schema.String)),
 });
 
 const RawDiffSchema = Schema.Struct({
@@ -347,6 +348,7 @@ const decodeMergeRequest = decodeJsonResult(RawMergeRequestSchema);
 const decodeNoteEntry = Schema.decodeUnknownExit(RawNoteSchema);
 const decodeUserEntry = Schema.decodeUnknownExit(RawUserSchema);
 const decodeCommitEntry = Schema.decodeUnknownExit(RawCommitSchema);
+const decodeCommit = decodeJsonResult(RawCommitSchema);
 const decodeDiffEntry = Schema.decodeUnknownExit(RawDiffSchema);
 const decodeDiscussionEntry = Schema.decodeUnknownExit(RawDiscussionSchema);
 const decodeDiffRefs = decodeJsonResult(RawDiffRefsSchema);
@@ -592,6 +594,21 @@ export function decodeCommitsJson(
   }
   // GitLab lists a merge request's commits newest first; the timeline reads oldest first.
   return Result.succeed(commits.toReversed());
+}
+
+/** The exact comparison GitLab uses for a commit-scoped diff. */
+export function decodeCommitDiffRefsJson(
+  raw: string,
+): Result.Result<GitLabDiffRefs | null, DecodeFailure> {
+  const decoded = decodeCommit(raw);
+  if (!Result.isSuccess(decoded)) return Result.fail(decoded.failure);
+  const baseSha = trimmed(decoded.success.parent_ids?.[0]);
+  const headSha = trimmed(decoded.success.id);
+  return Result.succeed(
+    baseSha === null || headSha === null
+      ? null
+      : { baseSha, headSha, startSha: baseSha },
+  );
 }
 
 function diffHeaderPaths(raw: Schema.Schema.Type<typeof RawDiffSchema>): {

--- a/apps/server/src/stream/collectUint8StreamText.test.ts
+++ b/apps/server/src/stream/collectUint8StreamText.test.ts
@@ -17,6 +17,7 @@ describe("collectUint8StreamText", () => {
         text: "hello world",
         bytes: 11,
         truncated: false,
+        invalidUtf8: false,
       });
     }),
   );
@@ -33,7 +34,24 @@ describe("collectUint8StreamText", () => {
         text: "abcde[truncated]",
         bytes: 5,
         truncated: true,
+        invalidUtf8: false,
       });
+    }),
+  );
+
+  it.effect("reports invalid UTF-8 separately from a literal replacement character", () =>
+    Effect.gen(function* () {
+      const invalid = yield* collectUint8StreamText({
+        stream: Stream.make(new Uint8Array([0x66, 0x80, 0x6f])),
+      });
+      const literal = yield* collectUint8StreamText({
+        stream: Stream.make(encoder.encode("before\uFFFDafter")),
+      });
+
+      assert.strictEqual(invalid.invalidUtf8, true);
+      assert.strictEqual(invalid.text, "f\uFFFDo");
+      assert.strictEqual(literal.invalidUtf8, false);
+      assert.strictEqual(literal.text, "before\uFFFDafter");
     }),
   );
 });

--- a/apps/server/src/stream/collectUint8StreamText.ts
+++ b/apps/server/src/stream/collectUint8StreamText.ts
@@ -1,11 +1,20 @@
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
+import * as NodeBuffer from "node:buffer";
 
 export interface CollectedUint8StreamText {
   readonly text: string;
   readonly truncated: boolean;
   readonly bytes: number;
+  readonly invalidUtf8: boolean;
 }
+
+export const decodeUtf8 = (
+  bytes: Uint8Array,
+): Pick<CollectedUint8StreamText, "text" | "invalidUtf8"> => ({
+  text: Buffer.from(bytes).toString("utf8"),
+  invalidUtf8: !NodeBuffer.isUtf8(bytes),
+});
 
 interface CollectState {
   chunks: Uint8Array[];
@@ -59,11 +68,15 @@ export const collectUint8StreamText = <E>(input: {
       },
     ),
     Effect.map((state): CollectedUint8StreamText => {
-      const text = Buffer.concat(state.chunks, state.bytes).toString("utf8");
+      const decoded = decodeUtf8(Buffer.concat(state.chunks, state.bytes));
       return {
-        text: state.truncated && truncatedMarker.length > 0 ? `${text}${truncatedMarker}` : text,
+        text:
+          state.truncated && truncatedMarker.length > 0
+            ? `${decoded.text}${truncatedMarker}`
+            : decoded.text,
         bytes: state.bytes,
         truncated: state.truncated,
+        invalidUtf8: decoded.invalidUtf8,
       };
     }),
   );

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -192,6 +192,8 @@ describe("VcsProcess.run", () => {
           timedOut: false,
           stdoutTruncated: false,
           stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
         }),
       );
 

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -37,6 +37,9 @@ export interface VcsProcessOutput {
   readonly stderr: string;
   readonly stdoutTruncated: boolean;
   readonly stderrTruncated: boolean;
+  /** Present on real process output; optional so narrow test doubles remain lightweight. */
+  readonly stdoutInvalidUtf8?: boolean;
+  readonly stderrInvalidUtf8?: boolean;
 }
 
 export class VcsProcess extends Context.Service<
@@ -163,6 +166,8 @@ export const make = Effect.gen(function* () {
       stderr: result.stderr,
       stdoutTruncated: result.stdoutTruncated,
       stderrTruncated: result.stderrTruncated,
+      stdoutInvalidUtf8: result.stdoutInvalidUtf8 ?? false,
+      stderrInvalidUtf8: result.stderrInvalidUtf8 ?? false,
     } satisfies VcsProcessOutput;
   });
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1593,6 +1593,12 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.pullRequestsDiff, pullRequests.diff(input), {
             "rpc.aggregate": "pull-requests",
           }),
+        [WS_METHODS.pullRequestsDiffFileContents]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.pullRequestsDiffFileContents,
+            pullRequests.diffFileContents(input),
+            { "rpc.aggregate": "pull-requests" },
+          ),
         [WS_METHODS.pullRequestsRunAction]: (input) =>
           observeRpcEffect(WS_METHODS.pullRequestsRunAction, pullRequests.runAction(input), {
             "rpc.aggregate": "pull-requests",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -119,6 +119,7 @@ import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import {
+  pullRequestSurfaceId,
   selectActiveRightPanel,
   selectActiveRightPanelSurface,
   selectThreadRightPanelState,
@@ -140,7 +141,7 @@ import {
   usePreviewMiniPlayerStore,
 } from "../previewMiniPlayerStore";
 import { PullRequestDetailPanel } from "./pullRequest/PullRequestDetailPanel";
-import { RightPanelTabs } from "./RightPanelTabs";
+import { RightPanelTabs, type PullRequestTabStatus } from "./RightPanelTabs";
 import { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
 import { BranchToolbar } from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
@@ -1522,6 +1523,17 @@ function ChatViewContent(props: ChatViewProps) {
   const activeRightPanelSurface = useRightPanelStore((state) =>
     selectActiveRightPanelSurface(state.byThreadKey, activeThreadRef),
   );
+  const [pullRequestTabStatuses, setPullRequestTabStatuses] = useState<
+    Record<string, PullRequestTabStatus>
+  >({});
+  const handlePullRequestTabStatusChange = useCallback((status: PullRequestTabStatus) => {
+    const id = pullRequestSurfaceId(status);
+    setPullRequestTabStatuses((current) =>
+      current[id]?.state === status.state && current[id]?.isDraft === status.isDraft
+        ? current
+        : { ...current, [id]: status },
+    );
+  }, []);
   const activeFileSurface =
     activeRightPanelSurface?.kind === "file" ? activeRightPanelSurface : null;
   const activePreviewState = useThreadPreviewState(activeThreadRef);
@@ -5794,6 +5806,7 @@ function ChatViewContent(props: ChatViewProps) {
             ? "thread"
             : "page"
         }
+        onStateChange={handlePullRequestTabStatusChange}
       />
     ) : activeRightPanelSurface?.kind === "plan" ? (
       <PlanSidebar
@@ -6241,9 +6254,11 @@ function ChatViewContent(props: ChatViewProps) {
           onAddFiles={addFilesSurface}
           onAddPullRequest={addPullRequestSurface}
           browserAvailable={isPreviewSupportedInRuntime()}
+          terminalAvailable={activeProject !== null}
           diffAvailable={isServerThread && isGitRepo}
           filesAvailable={activeProject !== null}
           pullRequestAvailable={pullRequestSurfaceAvailable}
+          pullRequestStatuses={pullRequestTabStatuses}
         >
           {rightPanelContent}
         </RightPanelTabs>
@@ -6270,9 +6285,11 @@ function ChatViewContent(props: ChatViewProps) {
             onAddFiles={addFilesSurface}
             onAddPullRequest={addPullRequestSurface}
             browserAvailable={isPreviewSupportedInRuntime()}
+            terminalAvailable={activeProject !== null}
             diffAvailable={isServerThread && isGitRepo}
             filesAvailable={activeProject !== null}
             pullRequestAvailable={pullRequestSurfaceAvailable}
+            pullRequestStatuses={pullRequestTabStatuses}
           >
             {rightPanelContent}
           </RightPanelTabs>

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -74,6 +74,7 @@ import { serverEnvironment } from "../state/server";
 import { reviewEnvironment } from "../state/review";
 import { vcsEnvironment } from "../state/vcs";
 import { buildBaseRefChoices, filterBaseRefChoices } from "../lib/baseRefChoices";
+import { createGitDiffFileContentsLoader } from "../lib/diffFileContents";
 
 type DiffRenderMode = "stacked" | "split";
 type DiffThemeType = "light" | "dark";
@@ -85,262 +86,6 @@ interface CollapsedDiffFilesState {
 }
 
 const EMPTY_COLLAPSED_DIFF_FILE_KEYS: ReadonlySet<string> = new Set();
-
-const DIFF_PANEL_UNSAFE_CSS = `
-[data-diffs-header],
-[data-diff],
-[data-file],
-[data-error-wrapper],
-[data-virtualizer-buffer] {
-  --diffs-header-font-family: var(--font-sans) !important;
-  --diffs-font-family: var(--font-mono) !important;
-  --diffs-bg: var(--background) !important;
-  --diffs-light-bg: var(--background) !important;
-  --diffs-dark-bg: var(--background) !important;
-  --diffs-token-light-bg: transparent;
-  --diffs-token-dark-bg: transparent;
-
-  --diffs-bg-context-override: color-mix(in srgb, var(--background) 97%, var(--foreground));
-  --diffs-bg-hover-override: color-mix(in srgb, var(--background) 94%, var(--foreground));
-  --diffs-bg-separator-override: color-mix(in srgb, var(--background) 95%, var(--foreground));
-  --diffs-bg-buffer-override: color-mix(in srgb, var(--background) 90%, var(--foreground));
-
-  --diffs-bg-addition-override: light-dark(
-    color-mix(in srgb, var(--background) 50%, var(--success)),
-    color-mix(in srgb, var(--background) 70%, var(--success))
-  );
-  --diffs-bg-addition-number-override: light-dark(
-    color-mix(in srgb, var(--background) 35%, var(--success)),
-    color-mix(in srgb, var(--background) 60%, var(--success))
-  );
-  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--background) 85%, var(--success));
-  --diffs-bg-addition-emphasis-override: color-mix(in srgb, var(--background) 80%, var(--success));
-
-  --diffs-bg-deletion-override: light-dark(
-    color-mix(in srgb, var(--background) 50%, var(--destructive)),
-    color-mix(in srgb, var(--background) 70%, var(--destructive))
-  );
-  --diffs-bg-deletion-number-override: light-dark(
-    color-mix(in srgb, var(--background) 35%, var(--destructive)),
-    color-mix(in srgb, var(--background) 60%, var(--destructive))
-  );
-  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--background) 85%, var(--destructive));
-  --diffs-bg-deletion-emphasis-override: color-mix(
-    in srgb,
-    var(--background) 80%,
-    var(--destructive)
-  );
-
-  background-color: var(--diffs-bg) !important;
-}
-
-:is(
-  [data-line],
-  [data-line-annotation],
-  [data-merge-conflict],
-  [data-merge-conflict-actions],
-  [data-no-newline]
-)[data-selected-line] {
-  --diffs-line-bg: light-dark(
-    color-mix(
-      in lab,
-      var(--background) 88%,
-      color-mix(in srgb, var(--background) 50%, var(--diffs-modified-base))
-    ),
-    color-mix(
-      in lab,
-      var(--background) 80%,
-      color-mix(in srgb, var(--background) 70%, var(--diffs-modified-base))
-    )
-  ) !important;
-}
-
-:is([data-gutter-buffer], [data-column-number])[data-selected-line] {
-  --diffs-line-bg: light-dark(
-    color-mix(
-      in lab,
-      var(--background) 91%,
-      color-mix(in srgb, var(--background) 35%, var(--diffs-modified-base))
-    ),
-    color-mix(
-      in lab,
-      var(--background) 85%,
-      color-mix(in srgb, var(--background) 60%, var(--diffs-modified-base))
-    )
-  ) !important;
-}
-
-[data-indicators="bars"]
-  :is([data-column-number], [data-gutter-buffer="annotation"])[data-selected-line] {
-  position: relative;
-}
-
-[data-indicators="bars"]
-  :is([data-column-number], [data-gutter-buffer="annotation"])[data-selected-line]::before {
-  position: absolute !important;
-  inset-block: 0 !important;
-  inset-inline-start: 0 !important;
-  display: block !important;
-  width: 4px !important;
-  min-width: 4px !important;
-  max-width: 4px !important;
-  height: auto !important;
-  padding: 0 !important;
-  content: "" !important;
-  background-color: var(--diffs-modified-base) !important;
-  background-image: none !important;
-}
-
-[data-file-info] {
-  background-color: var(--background) !important;
-  border-block-color: transparent !important;
-  color: var(--foreground) !important;
-}
-
-[data-diffs-header] {
-  position: sticky !important;
-  top: 0;
-  z-index: 4;
-  background-color: var(--background) !important;
-  border-bottom-color: transparent !important;
-  align-items: center !important;
-  font-family: var(--font-sans) !important;
-  font-size: 12px !important;
-  line-height: 1 !important;
-  min-height: 32px !important;
-  padding-block: 6px !important;
-  padding-inline: 8px 12px !important;
-}
-
-[data-diffs-header]:hover {
-  background-color: color-mix(in srgb, var(--background) 97%, var(--foreground)) !important;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"]) {
-  height: 24px !important;
-  margin-block: 0 !important;
-  background-color: var(--background) !important;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"])
-  [data-separator-wrapper] {
-  padding-inline: 8px 12px !important;
-  background-color: transparent !important;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"])
-  [data-separator-content] {
-  gap: 8px;
-  padding-inline: 0 !important;
-  background-color: transparent !important;
-  color: color-mix(in srgb, var(--foreground) 52%, var(--background)) !important;
-  font-family: var(--font-sans) !important;
-  font-size: 11px !important;
-  text-decoration: none !important;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"])
-  [data-unmodified-lines] {
-  display: flex !important;
-  min-width: 0;
-  flex: 1 1 auto;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"])
-  [data-unmodified-lines]::before,
-:is([data-separator="line-info"], [data-separator="line-info-basic"])
-  [data-unmodified-lines]::after {
-  width: auto;
-  height: 1px;
-  flex: 1 1 auto;
-  content: "";
-  background-color: color-mix(in srgb, var(--background) 92%, var(--foreground));
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"])[data-expand-index]
-  [data-separator-wrapper] {
-  grid-template-columns: 0 minmax(0, 1fr) !important;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"])[data-expand-index]
-  [data-separator-content] {
-  grid-column: 2 !important;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"])
-  [data-expand-button] {
-  display: none !important;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"]):has(
-    [data-expand-button]
-  )
-  [data-separator-content] {
-  cursor: pointer;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"]):has(
-    [data-expand-button]
-  ):hover
-  [data-separator-content] {
-  color: color-mix(in srgb, var(--foreground) 76%, var(--background)) !important;
-}
-
-:is([data-separator="line-info"], [data-separator="line-info-basic"]):has(
-    [data-expand-button]
-  ):hover
-  [data-unmodified-lines]::before,
-:is([data-separator="line-info"], [data-separator="line-info-basic"]):has(
-    [data-expand-button]
-  ):hover
-  [data-unmodified-lines]::after {
-  background-color: color-mix(in srgb, var(--background) 84%, var(--foreground));
-}
-
-[data-diffs-header] [data-header-content] {
-  align-items: center !important;
-  line-height: 1 !important;
-}
-
-[data-diffs-header] [data-metadata] {
-  align-items: center !important;
-  line-height: 1 !important;
-  font-variant-numeric: tabular-nums;
-}
-
-[data-diffs-header] [data-additions-count],
-[data-diffs-header] [data-deletions-count] {
-  font-family: var(--font-mono) !important;
-  font-size: 11px !important;
-  font-variant-numeric: tabular-nums;
-  line-height: 1 !important;
-}
-
-[data-diffs-header] [data-change-icon],
-[data-diffs-header] [data-rename-icon] {
-  display: block;
-  flex-shrink: 0;
-}
-
-[data-title] {
-  cursor: pointer;
-  transition:
-    color 120ms ease,
-    text-decoration-color 120ms ease;
-  text-decoration: underline;
-  text-decoration-color: transparent;
-  text-underline-offset: 2px;
-  font-family: var(--font-sans) !important;
-}
-
-[data-title]:hover {
-  color: color-mix(in srgb, var(--foreground) 84%, var(--primary)) !important;
-  text-decoration-color: currentColor;
-}
-`;
 
 interface DiffPanelProps {
   mode?: DiffPanelMode;
@@ -569,45 +314,14 @@ export default function DiffPanel({
       return undefined;
     }
 
-    const source = selectedGitSource;
-    return async (fileDiff) => {
-      const newPath = resolveFileDiffPath(fileDiff);
-      const oldPath = fileDiff.prevName
-        ? resolveFileDiffPath({ ...fileDiff, name: fileDiff.prevName })
-        : newPath;
-      const result = await getDiffFileContents({
-        environmentId: activeThread.environmentId,
-        input: {
-          cwd: preview.cwd,
-          sourceKind: source.kind,
-          changeType: fileDiff.type,
-          baseRef: source.baseRef,
-          headRef: source.headRef,
-          oldPath,
-          newPath,
-        },
-      });
-      if (result._tag !== "Success") {
-        throw squashAtomCommandFailure(result);
-      }
-
-      const newFile = {
-        name: newPath,
-        contents: result.value.newContents,
-        cacheKey: `${source.diffHash}:new:${newPath}`,
-      };
-      if (fileDiff.type === "rename-pure") {
-        return { oldFile: null, newFile };
-      }
-      return {
-        oldFile: {
-          name: oldPath,
-          contents: result.value.oldContents,
-          cacheKey: `${source.diffHash}:old:${oldPath}`,
-        },
-        newFile,
-      };
-    };
+    return createGitDiffFileContentsLoader(getDiffFileContents, {
+      environmentId: activeThread.environmentId,
+      cwd: preview.cwd,
+      sourceKind: selectedGitSource.kind,
+      baseRef: selectedGitSource.baseRef,
+      headRef: selectedGitSource.headRef,
+      cacheKey: selectedGitSource.diffHash,
+    });
   }, [
     activeThread,
     branchDiffPreview.data,
@@ -1160,7 +874,7 @@ export default function DiffPanel({
                   key={collapseScopeKey ?? reviewSectionId}
                   viewerRef={codeViewRef}
                   codeViewKey={codeViewMountKey}
-                  className="diff-render-surface h-full min-h-0 overflow-auto"
+                  className="h-full min-h-0 overflow-auto"
                   files={codeViewFiles}
                   sectionId={reviewSectionId}
                   sectionTitle={reviewSectionTitle}
@@ -1204,16 +918,8 @@ export default function DiffPanel({
                     overflow: wordWrap ? "wrap" : "scroll",
                     theme: resolveDiffThemeName(resolvedTheme),
                     themeType: resolvedTheme as DiffThemeType,
-                    unsafeCSS: DIFF_PANEL_UNSAFE_CSS,
                     stickyHeaders: true,
                     ...(loadDiffFiles ? { loadDiffFiles } : {}),
-                    itemMetrics: {
-                      diffHeaderHeight: 32,
-                      hunkSeparatorHeight: 24,
-                      paddingTop: 0,
-                      paddingBottom: 0,
-                    },
-                    layout: { paddingTop: 0, paddingBottom: 0, gap: 0 },
                   }}
                 />
               </div>

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -1,4 +1,4 @@
-import type { ContextMenuItem, PreviewSessionSnapshot } from "@t3tools/contracts";
+import type { ContextMenuItem, PreviewSessionSnapshot, PullRequestState } from "@t3tools/contracts";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import {
   ClipboardList,
@@ -55,14 +55,25 @@ interface RightPanelTabsProps {
   onAddFiles: () => void;
   onAddPullRequest: () => void;
   browserAvailable: boolean;
+  terminalAvailable: boolean;
   diffAvailable: boolean;
   filesAvailable: boolean;
   pullRequestAvailable: boolean;
+  pullRequestStatuses?: Readonly<Record<string, PullRequestTabStatus>>;
   children: ReactNode;
+}
+
+export interface PullRequestTabStatus {
+  projectId: string;
+  repository: string;
+  number: number;
+  state: PullRequestState;
+  isDraft: boolean;
 }
 
 const SURFACE_DISABLED_REASONS = {
   browser: "Browser previews are only available in the T3 Code desktop app.",
+  terminal: "Terminal surfaces are only available from a project thread.",
   files: "Files are only available when a project is open.",
   diff: "Diff is only available for server threads in Git repositories.",
   pullRequest: "This thread's branch has no pull request yet.",
@@ -105,6 +116,7 @@ function RightPanelEmptyState(props: {
   onAddFiles: () => void;
   onAddPullRequest: () => void;
   browserAvailable: boolean;
+  terminalAvailable: boolean;
   diffAvailable: boolean;
   filesAvailable: boolean;
   pullRequestAvailable: boolean;
@@ -116,16 +128,16 @@ function RightPanelEmptyState(props: {
       icon: Globe2,
       available: props.browserAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.browser,
-      wide: false,
+      centered: false,
       onClick: props.onAddBrowser,
     },
     {
       label: "Terminal",
       description: "Start a shell in this workspace.",
       icon: TerminalSquare,
-      available: true,
-      disabledReason: null,
-      wide: false,
+      available: props.terminalAvailable,
+      disabledReason: SURFACE_DISABLED_REASONS.terminal,
+      centered: false,
       onClick: props.onAddTerminal,
     },
     {
@@ -134,7 +146,7 @@ function RightPanelEmptyState(props: {
       icon: Files,
       available: props.filesAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.files,
-      wide: false,
+      centered: false,
       onClick: props.onAddFiles,
     },
     {
@@ -143,7 +155,7 @@ function RightPanelEmptyState(props: {
       icon: FileDiff,
       available: props.diffAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.diff,
-      wide: false,
+      centered: false,
       onClick: props.onAddDiff,
     },
     {
@@ -152,9 +164,7 @@ function RightPanelEmptyState(props: {
       icon: GitPullRequest,
       available: props.pullRequestAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.pullRequest,
-      // Last and across both columns, because it is the one surface that is about the thread's
-      // work as a whole rather than a tool to look at it with.
-      wide: true,
+      centered: true,
       onClick: props.onAddPullRequest,
     },
   ] as const;
@@ -171,7 +181,9 @@ function RightPanelEmptyState(props: {
         <div className="grid grid-cols-2 gap-2">
           {actions.map((action) => {
             const Icon = action.icon;
-            const spanClass = action.wide ? "col-span-2" : undefined;
+            const placementClass = action.centered
+              ? "col-span-2 w-[calc(50%-0.25rem)] justify-self-center"
+              : undefined;
             const content = (
               <>
                 <Icon className="mb-3 size-5" />
@@ -189,7 +201,7 @@ function RightPanelEmptyState(props: {
                   onClick={action.onClick}
                   className={cn(
                     "flex min-h-28 w-full flex-col items-start rounded-lg border border-border/80 bg-card p-4 text-left transition hover:border-border hover:bg-accent/60 dark:border-transparent dark:shadow-none dark:inset-ring-1 dark:inset-ring-white/5",
-                    spanClass,
+                    placementClass,
                   )}
                 >
                   {content}
@@ -201,7 +213,7 @@ function RightPanelEmptyState(props: {
                 type="button"
                 className={cn(
                   "flex min-h-28 w-full cursor-not-allowed flex-col items-start rounded-lg border border-border/80 bg-card p-4 text-left opacity-40 dark:border-transparent dark:shadow-none dark:inset-ring-1 dark:inset-ring-white/5",
-                  spanClass,
+                  placementClass,
                 )}
                 aria-disabled="true"
               >
@@ -276,10 +288,12 @@ function SurfaceIcon({
   surface,
   sessions,
   theme,
+  pullRequestStatuses,
 }: {
   surface: RightPanelSurface;
   sessions: Readonly<Record<string, PreviewSessionSnapshot>>;
   theme: "light" | "dark";
+  pullRequestStatuses: Readonly<Record<string, PullRequestTabStatus>> | undefined;
 }) {
   switch (surface.kind) {
     case "preview": {
@@ -304,8 +318,20 @@ function SurfaceIcon({
       return <TerminalSquare className="size-3 shrink-0" />;
     case "plan":
       return <ClipboardList className="size-3 shrink-0" />;
-    case "pull-request":
-      return <GitPullRequest className="size-3 shrink-0" />;
+    case "pull-request": {
+      const status = pullRequestStatuses?.[surface.id] ?? null;
+      const toneClassName =
+        status?.state === "merged"
+          ? "text-violet-600 dark:text-violet-300/90"
+          : status?.state === "closed"
+            ? "text-red-600 dark:text-red-300/90"
+            : status?.isDraft
+              ? "text-zinc-500 dark:text-zinc-400/80"
+              : status?.state === "open"
+                ? "text-emerald-600 dark:text-emerald-300/90"
+                : "text-muted-foreground";
+      return <GitPullRequest className={cn("size-3 shrink-0", toneClassName)} />;
+    }
   }
 }
 
@@ -399,7 +425,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
         className={cn(
           "workspace-topbar gap-1 pl-2",
           props.mode !== "inline" && "[--workspace-topbar-height:--spacing(11)]",
-          props.mode === "inline" ? "pr-28" : "pr-3",
+          props.mode === "inline" && !props.layoutControls ? "pr-28" : "pr-3",
           ownsDesktopTitleBar && "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
           props.mode === "inline" && props.maximized && COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
         )}
@@ -442,6 +468,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
                         surface={surface}
                         sessions={props.previewSessions}
                         theme={resolvedTheme}
+                        pullRequestStatuses={props.pullRequestStatuses}
                       />
                       {pending ? (
                         <span
@@ -486,7 +513,11 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
                     <Globe2 />
                     Browser
                   </SurfaceMenuItem>
-                  <SurfaceMenuItem available onClick={props.onAddTerminal}>
+                  <SurfaceMenuItem
+                    available={props.terminalAvailable}
+                    disabledReason={SURFACE_DISABLED_REASONS.terminal}
+                    onClick={props.onAddTerminal}
+                  >
                     <TerminalSquare />
                     Terminal
                   </SurfaceMenuItem>
@@ -530,6 +561,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
             onAddFiles={props.onAddFiles}
             onAddPullRequest={props.onAddPullRequest}
             browserAvailable={props.browserAvailable}
+            terminalAvailable={props.terminalAvailable}
             diffAvailable={props.diffAvailable}
             filesAvailable={props.filesAvailable}
             pullRequestAvailable={props.pullRequestAvailable}

--- a/apps/web/src/components/chat/PanelLayoutControls.tsx
+++ b/apps/web/src/components/chat/PanelLayoutControls.tsx
@@ -5,6 +5,7 @@ import { Toggle } from "../ui/toggle";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 interface PanelLayoutControlsProps {
+  showTerminalControl?: boolean;
   terminalAvailable: boolean;
   terminalOpen: boolean;
   terminalShortcutLabel: string | null;
@@ -16,6 +17,7 @@ interface PanelLayoutControlsProps {
 }
 
 export const PanelLayoutControls = memo(function PanelLayoutControls({
+  showTerminalControl = true,
   terminalAvailable,
   terminalOpen,
   terminalShortcutLabel,
@@ -30,28 +32,30 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
       className="flex h-full shrink-0 items-center gap-1 [-webkit-app-region:no-drag]"
       data-panel-layout-controls
     >
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Toggle
-              className="shrink-0 [-webkit-app-region:no-drag]"
-              pressed={terminalOpen}
-              onPressedChange={onToggleTerminal}
-              aria-label="Toggle terminal drawer"
-              variant="ghost"
-              size="sm"
-              disabled={!terminalAvailable}
-            >
-              <PanelBottomIcon className="size-3.5" />
-            </Toggle>
-          }
-        />
-        <TooltipPopup side="bottom">
-          {terminalAvailable
-            ? `Toggle terminal drawer${terminalShortcutLabel ? ` (${terminalShortcutLabel})` : ""}`
-            : "Terminal drawer is unavailable"}
-        </TooltipPopup>
-      </Tooltip>
+      {showTerminalControl ? (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Toggle
+                className="shrink-0 [-webkit-app-region:no-drag]"
+                pressed={terminalOpen}
+                onPressedChange={onToggleTerminal}
+                aria-label="Toggle terminal drawer"
+                variant="ghost"
+                size="sm"
+                disabled={!terminalAvailable}
+              >
+                <PanelBottomIcon className="size-3.5" />
+              </Toggle>
+            }
+          />
+          <TooltipPopup side="bottom">
+            {terminalAvailable
+              ? `Toggle terminal drawer${terminalShortcutLabel ? ` (${terminalShortcutLabel})` : ""}`
+              : "Terminal drawer is unavailable"}
+          </TooltipPopup>
+        </Tooltip>
+      ) : null}
       <Tooltip>
         <TooltipTrigger
           render={

--- a/apps/web/src/components/diffs/AnnotatableCodeView.test.tsx
+++ b/apps/web/src/components/diffs/AnnotatableCodeView.test.tsx
@@ -21,8 +21,8 @@ vi.mock("~/composerDraftStore", () => ({
     }),
 }));
 
-vi.mock("../files/LocalCommentAnnotation", () => ({
-  LocalCommentAnnotation: () => null,
+vi.mock("./DiffCommentAnnotation", () => ({
+  DiffCommentAnnotation: () => null,
 }));
 
 vi.mock("../files/fileCommentAnnotations", () => ({

--- a/apps/web/src/components/diffs/AnnotatableCodeView.tsx
+++ b/apps/web/src/components/diffs/AnnotatableCodeView.tsx
@@ -6,7 +6,7 @@ import type {
   FileDiffMetadata,
   SelectedLineRange,
 } from "@pierre/diffs";
-import { CodeView, type CodeViewHandle, type CodeViewProps } from "@pierre/diffs/react";
+import type { CodeViewHandle } from "@pierre/diffs/react";
 import type { ScopedThreadRef } from "@t3tools/contracts";
 import { useCallback, useMemo, useState, type ReactNode, type Ref } from "react";
 
@@ -18,8 +18,9 @@ import {
   type ReviewCommentContext,
 } from "~/reviewCommentContext";
 
-import { LocalCommentAnnotation } from "../files/LocalCommentAnnotation";
 import { nextFileCommentId } from "../files/fileCommentAnnotations";
+import { DiffCommentAnnotation } from "./DiffCommentAnnotation";
+import { StyledDiffCodeView, type StyledDiffCodeViewOptions } from "./StyledDiffCodeView";
 
 interface DiffCommentAnnotationEntry {
   id: string;
@@ -81,7 +82,7 @@ interface AnnotatableCodeViewProps {
   sectionId: string;
   sectionTitle: string;
   composerDraftTarget: ScopedThreadRef | DraftId;
-  options: NonNullable<CodeViewProps<DiffCommentAnnotationGroup>["options"]>;
+  options: StyledDiffCodeViewOptions<DiffCommentAnnotationGroup>;
   viewerRef?: Ref<AnnotatableCodeViewHandle>;
   className?: string;
   renderHeaderPrefix: (
@@ -237,9 +238,9 @@ export function AnnotatableCodeView({
 
   const hasOpenComment = draft !== null;
   return (
-    <CodeView<DiffCommentAnnotationGroup>
+    <StyledDiffCodeView<DiffCommentAnnotationGroup>
       key={codeViewKey}
-      {...(viewerRef ? { ref: viewerRef } : {})}
+      {...(viewerRef ? { viewerRef } : {})}
       {...(className ? { className } : {})}
       items={items}
       selectedLines={selectedLines}
@@ -262,7 +263,7 @@ export function AnnotatableCodeView({
             className={hasDraft ? "py-1" : "divide-y divide-border/30 border-y border-border/30"}
           >
             {annotation.metadata.entries.map((entry) => (
-              <LocalCommentAnnotation
+              <DiffCommentAnnotation
                 key={entry.id}
                 kind={entry.kind}
                 rangeLabel={entry.rangeLabel}

--- a/apps/web/src/components/diffs/DiffCommentAnnotation.test.tsx
+++ b/apps/web/src/components/diffs/DiffCommentAnnotation.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { LocalCommentAnnotation } from "./LocalCommentAnnotation";
+import { DiffCommentAnnotation } from "./DiffCommentAnnotation";
 
 const callbacks = {
   onTextChange: vi.fn(),
@@ -10,10 +10,10 @@ const callbacks = {
   onDelete: vi.fn(),
 };
 
-describe("LocalCommentAnnotation", () => {
-  it("renders the draft composer directly in the selected diff", () => {
+describe("DiffCommentAnnotation", () => {
+  it("renders the shared draft composer directly in the selected diff", () => {
     const markup = renderToStaticMarkup(
-      <LocalCommentAnnotation kind="draft" rangeLabel="+78" text="" {...callbacks} />,
+      <DiffCommentAnnotation kind="draft" rangeLabel="+78" text="" {...callbacks} />,
     );
 
     expect(markup).toContain("font-sans");
@@ -31,9 +31,35 @@ describe("LocalCommentAnnotation", () => {
     expect(markup).toContain("cursor-text");
   });
 
+  it("lets a pull-request diff configure actions without replacing the composer", () => {
+    const markup = renderToStaticMarkup(
+      <DiffCommentAnnotation
+        kind="draft"
+        rangeLabel="src/app.ts:4"
+        text=""
+        {...callbacks}
+        submitLabel="Add to review"
+        secondaryAction={{
+          label: "Ask",
+          icon: <span data-test-icon />,
+          allowEmpty: true,
+          onAction: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Add a comment…");
+    expect(markup).toContain(">Ask</button>");
+    expect(markup).toContain(">Add to review</button>");
+    expect(markup.match(/<button[^>]*disabled[^>]*>Add to review<\/button>/)).not.toBeNull();
+    const askButton = markup.match(/<button[^>]*>.*?Ask<\/button>/)?.[0];
+    expect(askButton).toBeDefined();
+    expect(askButton).not.toContain(' disabled=""');
+  });
+
   it("renders a saved comment without a nested card or redundant range label", () => {
     const markup = renderToStaticMarkup(
-      <LocalCommentAnnotation
+      <DiffCommentAnnotation
         kind="comment"
         rangeLabel="+78"
         text="Please keep this branch explicit."
@@ -53,7 +79,7 @@ describe("LocalCommentAnnotation", () => {
 
   it("renders draft text owned by the annotation wrapper", () => {
     const markup = renderToStaticMarkup(
-      <LocalCommentAnnotation
+      <DiffCommentAnnotation
         kind="draft"
         rangeLabel="+78"
         text="Keep this unsaved draft"

--- a/apps/web/src/components/diffs/DiffCommentAnnotation.tsx
+++ b/apps/web/src/components/diffs/DiffCommentAnnotation.tsx
@@ -4,6 +4,8 @@ import { useState, type ReactNode } from "react";
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/textarea";
 
+import { isCommentSubmitShortcut } from "./commentSubmitShortcut";
+
 interface DiffCommentSecondaryAction {
   readonly label: string;
   readonly icon?: ReactNode;
@@ -93,7 +95,7 @@ export function DiffCommentAnnotation({
             event.preventDefault();
             onCancel();
           }
-          if ((event.metaKey || event.ctrlKey) && event.key === "Enter" && trimmedText) {
+          if (isCommentSubmitShortcut(event, trimmedText, pending)) {
             event.preventDefault();
             onComment(trimmedText);
           }

--- a/apps/web/src/components/diffs/DiffCommentAnnotation.tsx
+++ b/apps/web/src/components/diffs/DiffCommentAnnotation.tsx
@@ -1,20 +1,32 @@
 import { MessageCircle, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/textarea";
 
-interface LocalCommentAnnotationProps {
+interface DiffCommentSecondaryAction {
+  readonly label: string;
+  readonly icon?: ReactNode;
+  readonly allowEmpty?: boolean;
+  readonly onAction: (text: string) => void;
+}
+
+interface DiffCommentAnnotationProps {
   kind: "draft" | "comment";
   rangeLabel: string;
   text: string;
   onTextChange?: (text: string) => void;
   onCancel: () => void;
   onComment: (text: string) => void;
-  onDelete: () => void;
+  onDelete?: () => void;
+  placeholder?: string;
+  submitLabel?: string;
+  pending?: boolean;
+  secondaryAction?: DiffCommentSecondaryAction;
 }
 
-export function LocalCommentAnnotation({
+/** The shared inline comment treatment for file previews, thread diffs, and pull-request diffs. */
+export function DiffCommentAnnotation({
   kind,
   rangeLabel,
   text,
@@ -22,36 +34,43 @@ export function LocalCommentAnnotation({
   onCancel,
   onComment,
   onDelete,
-}: LocalCommentAnnotationProps) {
+  placeholder = "Add a comment…",
+  submitLabel = "Comment",
+  pending = false,
+  secondaryAction,
+}: DiffCommentAnnotationProps) {
   const [localDraftText, setLocalDraftText] = useState("");
   const displayedText = kind === "draft" && !onTextChange ? localDraftText : text;
+  const trimmedText = displayedText.trim();
 
   if (kind === "comment") {
     return (
       <div
-        data-file-comment-annotation
+        data-diff-comment-annotation
         className="group/comment flex min-w-0 items-start gap-2.5 border-s-2 border-primary/55 bg-primary/[0.045] px-3 py-2.5 font-sans text-foreground"
         contentEditable={false}
         onPointerDown={(event) => event.stopPropagation()}
       >
         <MessageCircle className="mt-0.5 size-3.5 shrink-0 text-primary/70" aria-hidden="true" />
         <p className="min-w-0 flex-1 whitespace-pre-wrap text-[13px] leading-5">{displayedText}</p>
-        <Button
-          className="-my-1 -mr-1 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/comment:opacity-100 focus-visible:opacity-100 max-sm:opacity-100"
-          variant="ghost"
-          size="icon-xs"
-          aria-label="Delete comment"
-          onClick={onDelete}
-        >
-          <Trash2 className="size-3" />
-        </Button>
+        {onDelete ? (
+          <Button
+            className="-my-1 -mr-1 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/comment:opacity-100 focus-visible:opacity-100 max-sm:opacity-100"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Delete comment"
+            onClick={onDelete}
+          >
+            <Trash2 className="size-3" />
+          </Button>
+        ) : null}
       </div>
     );
   }
 
   return (
     <div
-      data-file-comment-annotation
+      data-diff-comment-annotation
       className="px-3 py-2 font-sans text-foreground"
       contentEditable={false}
       onPointerDown={(event) => event.stopPropagation()}
@@ -62,7 +81,7 @@ export function LocalCommentAnnotation({
         className="relative inline-flex w-full rounded-md border border-border/50 bg-background/20 font-sans text-foreground transition-colors focus-within:border-border/70 [&_[data-slot=textarea]]:min-h-12 [&_[data-slot=textarea]]:cursor-text [&_[data-slot=textarea]]:px-2.5 [&_[data-slot=textarea]]:py-1.5 [&_[data-slot=textarea]]:font-sans [&_[data-slot=textarea]]:text-xs [&_[data-slot=textarea]]:leading-5 max-sm:[&_[data-slot=textarea]]:min-h-12"
         size="sm"
         value={displayedText}
-        placeholder="Add a comment…"
+        placeholder={placeholder}
         aria-label={`Comment on lines ${rangeLabel}`}
         onChange={(event) => (onTextChange ?? setLocalDraftText)(event.target.value)}
         onFocus={(event) => {
@@ -74,9 +93,9 @@ export function LocalCommentAnnotation({
             event.preventDefault();
             onCancel();
           }
-          if ((event.metaKey || event.ctrlKey) && event.key === "Enter" && displayedText.trim()) {
+          if ((event.metaKey || event.ctrlKey) && event.key === "Enter" && trimmedText) {
             event.preventDefault();
-            onComment(displayedText.trim());
+            onComment(trimmedText);
           }
         }}
       />
@@ -90,12 +109,19 @@ export function LocalCommentAnnotation({
         >
           Cancel
         </Button>
-        <Button
-          size="xs"
-          disabled={!displayedText.trim()}
-          onClick={() => onComment(displayedText.trim())}
-        >
-          Comment
+        {secondaryAction ? (
+          <Button
+            size="xs"
+            variant="outline"
+            disabled={!secondaryAction.allowEmpty && !trimmedText}
+            onClick={() => secondaryAction.onAction(trimmedText)}
+          >
+            {secondaryAction.icon}
+            {secondaryAction.label}
+          </Button>
+        ) : null}
+        <Button size="xs" disabled={pending || !trimmedText} onClick={() => onComment(trimmedText)}>
+          {submitLabel}
         </Button>
       </div>
     </div>

--- a/apps/web/src/components/diffs/StyledDiffCodeView.test.tsx
+++ b/apps/web/src/components/diffs/StyledDiffCodeView.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => ({
+  codeViewClassName: null as string | null,
+  codeViewOptions: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@pierre/diffs/react", () => ({
+  CodeView: (props: { className: string; options: Record<string, unknown> }) => {
+    testState.codeViewClassName = props.className;
+    testState.codeViewOptions = props.options;
+    return null;
+  },
+}));
+
+import { StyledDiffCodeView } from "./StyledDiffCodeView";
+
+describe("StyledDiffCodeView", () => {
+  beforeEach(() => {
+    testState.codeViewClassName = null;
+    testState.codeViewOptions = null;
+  });
+
+  it("always pairs the shared diff styling with its virtualized geometry", () => {
+    const loadDiffFiles = vi.fn(async () => ({
+      oldFile: { name: "before.ts", contents: "before\n" },
+      newFile: { name: "after.ts", contents: "after\n" },
+    }));
+    renderToStaticMarkup(
+      <StyledDiffCodeView
+        className="min-h-0"
+        items={[]}
+        options={{ theme: "pierre-dark", stickyHeaders: true, loadDiffFiles }}
+      />,
+    );
+
+    expect(testState.codeViewClassName).toBe("diff-render-surface min-h-0");
+    expect(testState.codeViewOptions).toMatchObject({
+      theme: "pierre-dark",
+      stickyHeaders: true,
+      loadDiffFiles,
+      itemMetrics: {
+        diffHeaderHeight: 32,
+        hunkSeparatorHeight: 24,
+        paddingTop: 0,
+        paddingBottom: 0,
+      },
+      layout: { paddingTop: 0, paddingBottom: 0, gap: 0 },
+    });
+    expect(testState.codeViewOptions?.unsafeCSS).toEqual(
+      expect.stringContaining("[data-unmodified-lines]::before"),
+    );
+    expect(testState.codeViewOptions?.unsafeCSS).toEqual(
+      expect.stringContaining(")[data-expand-index]\n  [data-unmodified-lines]"),
+    );
+  });
+});

--- a/apps/web/src/components/diffs/StyledDiffCodeView.tsx
+++ b/apps/web/src/components/diffs/StyledDiffCodeView.tsx
@@ -1,0 +1,310 @@
+/* oxlint-disable eslint/no-restricted-imports -- This is the single styled adapter around Pierre's raw viewer. */
+import {
+  CodeView,
+  type CodeViewHandle,
+  type CodeViewProps,
+  type ControlledCodeViewProps,
+  type UncontrolledCodeViewProps,
+} from "@pierre/diffs/react";
+/* oxlint-enable eslint/no-restricted-imports */
+import type { Ref } from "react";
+
+const DIFF_VIEW_UNSAFE_CSS = `
+[data-diffs-header],
+[data-diff],
+[data-file],
+[data-error-wrapper],
+[data-virtualizer-buffer] {
+  --diffs-header-font-family: var(--font-sans) !important;
+  --diffs-font-family: var(--font-mono) !important;
+  --diffs-bg: var(--background) !important;
+  --diffs-light-bg: var(--background) !important;
+  --diffs-dark-bg: var(--background) !important;
+  --diffs-token-light-bg: transparent;
+  --diffs-token-dark-bg: transparent;
+
+  --diffs-bg-context-override: color-mix(in srgb, var(--background) 97%, var(--foreground));
+  --diffs-bg-hover-override: color-mix(in srgb, var(--background) 94%, var(--foreground));
+  --diffs-bg-separator-override: color-mix(in srgb, var(--background) 95%, var(--foreground));
+  --diffs-bg-buffer-override: color-mix(in srgb, var(--background) 90%, var(--foreground));
+
+  --diffs-bg-addition-override: light-dark(
+    color-mix(in srgb, var(--background) 50%, var(--success)),
+    color-mix(in srgb, var(--background) 70%, var(--success))
+  );
+  --diffs-bg-addition-number-override: light-dark(
+    color-mix(in srgb, var(--background) 35%, var(--success)),
+    color-mix(in srgb, var(--background) 60%, var(--success))
+  );
+  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--background) 85%, var(--success));
+  --diffs-bg-addition-emphasis-override: color-mix(in srgb, var(--background) 80%, var(--success));
+
+  --diffs-bg-deletion-override: light-dark(
+    color-mix(in srgb, var(--background) 50%, var(--destructive)),
+    color-mix(in srgb, var(--background) 70%, var(--destructive))
+  );
+  --diffs-bg-deletion-number-override: light-dark(
+    color-mix(in srgb, var(--background) 35%, var(--destructive)),
+    color-mix(in srgb, var(--background) 60%, var(--destructive))
+  );
+  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--background) 85%, var(--destructive));
+  --diffs-bg-deletion-emphasis-override: color-mix(
+    in srgb,
+    var(--background) 80%,
+    var(--destructive)
+  );
+
+  background-color: var(--diffs-bg) !important;
+}
+
+:is(
+  [data-line],
+  [data-line-annotation],
+  [data-merge-conflict],
+  [data-merge-conflict-actions],
+  [data-no-newline]
+)[data-selected-line] {
+  --diffs-line-bg: light-dark(
+    color-mix(
+      in lab,
+      var(--background) 88%,
+      color-mix(in srgb, var(--background) 50%, var(--diffs-modified-base))
+    ),
+    color-mix(
+      in lab,
+      var(--background) 80%,
+      color-mix(in srgb, var(--background) 70%, var(--diffs-modified-base))
+    )
+  ) !important;
+}
+
+:is([data-gutter-buffer], [data-column-number])[data-selected-line] {
+  --diffs-line-bg: light-dark(
+    color-mix(
+      in lab,
+      var(--background) 91%,
+      color-mix(in srgb, var(--background) 35%, var(--diffs-modified-base))
+    ),
+    color-mix(
+      in lab,
+      var(--background) 85%,
+      color-mix(in srgb, var(--background) 60%, var(--diffs-modified-base))
+    )
+  ) !important;
+}
+
+[data-indicators="bars"]
+  :is([data-column-number], [data-gutter-buffer="annotation"])[data-selected-line] {
+  position: relative;
+}
+
+[data-indicators="bars"]
+  :is([data-column-number], [data-gutter-buffer="annotation"])[data-selected-line]::before {
+  position: absolute !important;
+  inset-block: 0 !important;
+  inset-inline-start: 0 !important;
+  display: block !important;
+  width: 4px !important;
+  min-width: 4px !important;
+  max-width: 4px !important;
+  height: auto !important;
+  padding: 0 !important;
+  content: "" !important;
+  background-color: var(--diffs-modified-base) !important;
+  background-image: none !important;
+}
+
+[data-file-info] {
+  background-color: var(--background) !important;
+  border-block-color: transparent !important;
+  color: var(--foreground) !important;
+}
+
+[data-diffs-header] {
+  position: sticky !important;
+  top: 0;
+  z-index: 4;
+  background-color: var(--background) !important;
+  border-bottom-color: transparent !important;
+  align-items: center !important;
+  font-family: var(--font-sans) !important;
+  font-size: 12px !important;
+  line-height: 1 !important;
+  min-height: 32px !important;
+  padding-block: 6px !important;
+  padding-inline: 8px 12px !important;
+}
+
+[data-diffs-header]:hover {
+  background-color: color-mix(in srgb, var(--background) 97%, var(--foreground)) !important;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"]) {
+  height: 24px !important;
+  margin-block: 0 !important;
+  background-color: var(--background) !important;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"])
+  [data-separator-wrapper] {
+  padding-inline: 8px 12px !important;
+  background-color: transparent !important;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"])
+  [data-separator-content] {
+  gap: 8px;
+  padding-inline: 0 !important;
+  background-color: transparent !important;
+  color: color-mix(in srgb, var(--foreground) 52%, var(--background)) !important;
+  font-family: var(--font-sans) !important;
+  font-size: 11px !important;
+  text-decoration: none !important;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"])
+  [data-unmodified-lines] {
+  display: flex !important;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 8px;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"])[data-expand-index]
+  [data-unmodified-lines] {
+  cursor: pointer;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"])
+  [data-unmodified-lines]::before,
+:is([data-separator="line-info"], [data-separator="line-info-basic"])
+  [data-unmodified-lines]::after {
+  width: auto;
+  height: 1px;
+  flex: 1 1 auto;
+  content: "";
+  background-color: color-mix(in srgb, var(--background) 92%, var(--foreground));
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"])[data-expand-index]
+  [data-separator-wrapper] {
+  grid-template-columns: 0 minmax(0, 1fr) !important;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"])[data-expand-index]
+  [data-separator-content] {
+  grid-column: 2 !important;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"])
+  [data-expand-button] {
+  display: none !important;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"]):has(
+    [data-expand-button]
+  )
+  [data-separator-content] {
+  cursor: pointer;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"]):has(
+    [data-expand-button]
+  ):hover
+  [data-separator-content] {
+  color: color-mix(in srgb, var(--foreground) 76%, var(--background)) !important;
+}
+
+:is([data-separator="line-info"], [data-separator="line-info-basic"]):has(
+    [data-expand-button]
+  ):hover
+  [data-unmodified-lines]::before,
+:is([data-separator="line-info"], [data-separator="line-info-basic"]):has(
+    [data-expand-button]
+  ):hover
+  [data-unmodified-lines]::after {
+  background-color: color-mix(in srgb, var(--background) 84%, var(--foreground));
+}
+
+[data-diffs-header] [data-header-content] {
+  align-items: center !important;
+  line-height: 1 !important;
+}
+
+[data-diffs-header] [data-metadata] {
+  align-items: center !important;
+  line-height: 1 !important;
+  font-variant-numeric: tabular-nums;
+}
+
+[data-diffs-header] [data-additions-count],
+[data-diffs-header] [data-deletions-count] {
+  font-family: var(--font-mono) !important;
+  font-size: 11px !important;
+  font-variant-numeric: tabular-nums;
+  line-height: 1 !important;
+}
+
+[data-diffs-header] [data-change-icon],
+[data-diffs-header] [data-rename-icon] {
+  display: block;
+  flex-shrink: 0;
+}
+
+[data-title] {
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    text-decoration-color 120ms ease;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 2px;
+  font-family: var(--font-sans) !important;
+}
+
+[data-title]:hover {
+  color: color-mix(in srgb, var(--foreground) 84%, var(--primary)) !important;
+  text-decoration-color: currentColor;
+}
+`;
+
+export type StyledDiffCodeViewOptions<LAnnotation> = Omit<
+  NonNullable<CodeViewProps<LAnnotation>["options"]>,
+  "unsafeCSS" | "itemMetrics" | "layout"
+>;
+
+type StyledDiffCodeViewProps<LAnnotation> = (
+  | Omit<ControlledCodeViewProps<LAnnotation>, "options">
+  | Omit<UncontrolledCodeViewProps<LAnnotation>, "options">
+) & {
+  readonly options?: StyledDiffCodeViewOptions<LAnnotation>;
+  readonly viewerRef?: Ref<CodeViewHandle<LAnnotation>>;
+};
+
+/** The shared web CodeView surface: app styling and virtualized geometry stay paired here. */
+export function StyledDiffCodeView<LAnnotation = undefined>({
+  options,
+  viewerRef,
+  className,
+  ...props
+}: StyledDiffCodeViewProps<LAnnotation>) {
+  return (
+    <CodeView<LAnnotation>
+      {...props}
+      {...(viewerRef ? { ref: viewerRef } : {})}
+      className={className ? `diff-render-surface ${className}` : "diff-render-surface"}
+      options={{
+        ...options,
+        unsafeCSS: DIFF_VIEW_UNSAFE_CSS,
+        itemMetrics: {
+          diffHeaderHeight: 32,
+          hunkSeparatorHeight: 24,
+          paddingTop: 0,
+          paddingBottom: 0,
+        },
+        layout: { paddingTop: 0, paddingBottom: 0, gap: 0 },
+      }}
+    />
+  );
+}

--- a/apps/web/src/components/diffs/commentSubmitShortcut.test.ts
+++ b/apps/web/src/components/diffs/commentSubmitShortcut.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { isCommentSubmitShortcut } from "./commentSubmitShortcut";
+
+describe("isCommentSubmitShortcut", () => {
+  it("accepts Command or Ctrl+Enter only while an eligible comment is idle", () => {
+    expect(
+      isCommentSubmitShortcut({ key: "Enter", metaKey: true, ctrlKey: false }, "Looks good", false),
+    ).toBe(true);
+    expect(
+      isCommentSubmitShortcut({ key: "Enter", metaKey: false, ctrlKey: true }, "Looks good", false),
+    ).toBe(true);
+    expect(
+      isCommentSubmitShortcut({ key: "Enter", metaKey: true, ctrlKey: false }, "Looks good", true),
+    ).toBe(false);
+  });
+
+  it("rejects empty comments and unrelated key presses", () => {
+    expect(
+      isCommentSubmitShortcut({ key: "Enter", metaKey: true, ctrlKey: false }, "   ", false),
+    ).toBe(false);
+    expect(
+      isCommentSubmitShortcut({ key: "K", metaKey: true, ctrlKey: false }, "Looks good", false),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/diffs/commentSubmitShortcut.ts
+++ b/apps/web/src/components/diffs/commentSubmitShortcut.ts
@@ -1,0 +1,16 @@
+interface CommentSubmitShortcutEvent {
+  readonly key: string;
+  readonly metaKey: boolean;
+  readonly ctrlKey: boolean;
+}
+
+/** Shared guard for inline comment composers that submit on Command/Ctrl+Enter. */
+export function isCommentSubmitShortcut(
+  event: CommentSubmitShortcutEvent,
+  value: string,
+  pending: boolean,
+): boolean {
+  return (
+    !pending && (event.metaKey || event.ctrlKey) && event.key === "Enter" && value.trim().length > 0
+  );
+}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -52,7 +52,7 @@ import {
 } from "./fileCommentAnnotations";
 import { installFileEditorDismissal } from "./fileEditorDismissal";
 import { resolveCenteredFileLineScrollTop } from "./fileLineReveal";
-import { LocalCommentAnnotation } from "./LocalCommentAnnotation";
+import { DiffCommentAnnotation } from "../diffs/DiffCommentAnnotation";
 import { projectFileCacheKey, projectFileEditorCacheKey } from "./fileContentRevision";
 import { fileBreadcrumbs } from "./filePath";
 import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
@@ -668,7 +668,7 @@ function EditableFileSurface({
             renderAnnotation={(annotation) => (
               <div className="py-1">
                 {annotation.metadata.entries.map((entry) => (
-                  <LocalCommentAnnotation
+                  <DiffCommentAnnotation
                     key={entry.id}
                     kind={entry.kind}
                     rangeLabel={formatFileCommentRange(entry.startLine, entry.endLine)}

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -1,5 +1,5 @@
 import type { CodeViewItem, DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs";
-import { CodeView, type CodeViewDiffItem } from "@pierre/diffs/react";
+import type { CodeViewDiffItem } from "@pierre/diffs/react";
 import type {
   EnvironmentId,
   PullRequestDetail,
@@ -15,6 +15,7 @@ import {
   Columns2Icon,
   MessageSquareOffIcon,
   Rows3Icon,
+  SparklesIcon,
   TextWrapIcon,
   TriangleAlertIcon,
 } from "lucide-react";
@@ -36,12 +37,15 @@ import {
   type RenderablePatch,
 } from "~/lib/diffRendering";
 import { cn } from "~/lib/utils";
+import { createPullRequestDiffFileContentsLoader } from "~/lib/diffFileContents";
 import { buildDiffReviewComment, type ReviewCommentContext } from "~/reviewCommentContext";
 import { pullRequestEnvironment } from "~/state/pullRequests";
 import { useEnvironmentQuery } from "~/state/query";
 import { useAtomCommand } from "~/state/use-atom-command";
 
 import { DiffWorkerPoolProvider } from "../DiffWorkerPoolProvider";
+import { DiffCommentAnnotation } from "../diffs/DiffCommentAnnotation";
+import { StyledDiffCodeView } from "../diffs/StyledDiffCodeView";
 import { Button } from "../ui/button";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import {
@@ -54,11 +58,7 @@ import { Skeleton } from "../ui/skeleton";
 import { toastManager } from "../ui/toast";
 import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
-import {
-  PendingReviewCommentCard,
-  ReviewCommentComposer,
-  ReviewThreadCard,
-} from "./PullRequestReviewAnnotation";
+import { PendingReviewCommentCard, ReviewThreadCard } from "./PullRequestReviewAnnotation";
 import { PullRequestReviewBar } from "./PullRequestReviewBar";
 import {
   isFileDiffCollapsed,
@@ -287,6 +287,17 @@ export function PullRequestCodeTab({
   const setThreadResolution = useAtomCommand(pullRequestEnvironment.setThreadResolution, {
     reportFailure: false,
   });
+  const getDiffFileContents = useAtomCommand(pullRequestEnvironment.diffFileContents);
+  const loadDiffFiles = useMemo(
+    () =>
+      createPullRequestDiffFileContentsLoader(getDiffFileContents, {
+        environmentId,
+        reference,
+        commit,
+        cacheKey: `pull-request:${referenceKey}:${detail.updatedAt}:${commit ?? "all"}`,
+      }),
+    [commit, detail.updatedAt, environmentId, getDiffFileContents, reference, referenceKey],
+  );
 
   // What is offered is the intersection of two different questions: what this host can do at
   // all, and what this account may do on this repository. Either one saying no means a control
@@ -315,7 +326,9 @@ export function PullRequestCodeTab({
         const cacheKey = `pull-request:${scopeKey}:${resolvedTheme}:${slice.cursor ?? "first"}:${fnv1a32(slice.patch)}`;
         const cached = parseCache.current.get(cacheKey);
         if (cached) return cached;
-        const parsed = getRenderablePatch(slice.patch, cacheKey);
+        const parsed = getRenderablePatch(slice.patch, cacheKey, {
+          compactPartialHunkOffsets: true,
+        });
         if (parsed) parseCache.current.set(cacheKey, parsed);
         return parsed;
       }),
@@ -940,8 +953,8 @@ export function PullRequestCodeTab({
         {/* The viewer virtualizes against the element it is told is scrolling and places its
             rows absolutely, so it has to own that element — the thread diff panel hands it the
             same one. Scrolling from a parent instead leaves it painting over its neighbours. */}
-        <CodeView<ReviewAnnotationGroup>
-          className="diff-render-surface min-h-0 flex-1 overflow-auto"
+        <StyledDiffCodeView<ReviewAnnotationGroup>
+          className="min-h-0 flex-1 overflow-auto"
           items={items}
           selectedLines={selectedLines}
           onSelectedLinesChange={setSelectedLines}
@@ -952,8 +965,7 @@ export function PullRequestCodeTab({
             theme: resolveDiffThemeName(resolvedTheme),
             themeType: resolvedTheme,
             stickyHeaders: true,
-            itemMetrics: { diffHeaderHeight: 33 },
-            layout: { paddingTop: 0, paddingBottom: 8, gap: 8 },
+            loadDiffFiles,
             enableGutterUtility: canCommentOnLines && draft === null,
             enableLineSelection: canCommentOnLines && draft === null,
             // Two gestures reach the same place: dragging the line numbers selects a range,
@@ -1024,17 +1036,26 @@ export function PullRequestCodeTab({
                 />
               ))}
               {annotation.metadata.draft && draft ? (
-                <ReviewCommentComposer
-                  lineLabel={`${draft.path}:${draft.line}`}
-                  pending={false}
+                <DiffCommentAnnotation
+                  kind="draft"
+                  rangeLabel={`${draft.path}:${draft.line}`}
+                  text=""
+                  submitLabel="Add to review"
                   {...(onAskAboutSelection
-                    ? { onAsk: (question: string) => askAboutSelection(draft, question) }
+                    ? {
+                        secondaryAction: {
+                          label: "Ask",
+                          icon: <SparklesIcon className="size-3" />,
+                          allowEmpty: true,
+                          onAction: (question: string) => askAboutSelection(draft, question),
+                        },
+                      }
                     : {})}
                   onCancel={() => {
                     setDraft(null);
                     setSelectedLines(null);
                   }}
-                  onSubmit={(body) => {
+                  onComment={(body) => {
                     addComment(reviewKey, {
                       id: nextPendingReviewCommentId(),
                       path: draft.path,

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -5,11 +5,14 @@ import type {
   PullRequestAction,
   PullRequestMergeMethod,
   PullRequestRef,
+  PullRequestState,
 } from "@t3tools/contracts";
 import {
+  ArrowLeftIcon,
+  ArrowUpRightIcon,
   BookOpenIcon,
   ChevronDownIcon,
-  ExternalLinkIcon,
+  FilesIcon,
   FolderGit2Icon,
   GitBranchIcon,
   GitMergeIcon,
@@ -22,12 +25,13 @@ import {
   MoreHorizontalIcon,
   PanelRightIcon,
   RefreshCwIcon,
+  TriangleAlertIcon,
 } from "lucide-react";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
-import { writeTextToClipboard } from "~/hooks/useCopyToClipboard";
+import { useCopyToClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { usePreparePullRequestThreadAction } from "~/lib/sourceControlActions";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
@@ -36,6 +40,7 @@ import { useEnvironmentQuery } from "~/state/query";
 import { useLiveRefresh } from "~/hooks/useLiveRefresh";
 import { pullRequestEnvironment } from "~/state/pullRequests";
 import { useAtomCommand } from "~/state/use-atom-command";
+import { formatRelativeTimeLabel } from "~/timestampFormat";
 
 import {
   AlertDialog,
@@ -75,7 +80,12 @@ import {
   readableFailure,
   type PullRequestFinding,
 } from "./pullRequestDetail.logic";
-import { PullRequestStateGlyph } from "./pullRequestPresentation";
+import {
+  PullRequestActorLabel,
+  PullRequestDiffStat,
+  PullRequestMetaLine,
+  resolvePullRequestState,
+} from "./pullRequestPresentation";
 
 type DetailTab = "summary" | "timeline" | "code";
 
@@ -137,6 +147,7 @@ export function PullRequestDetailPanel({
   refreshToken: forcedRefreshToken = 0,
   onActed,
   onClose,
+  onStateChange,
   context = "page",
 }: {
   environmentId: EnvironmentId;
@@ -152,8 +163,16 @@ export function PullRequestDetailPanel({
    * Told rather than assumed: only the page knows whether it is showing one.
    */
   onActed?: () => void;
-  /** Absent when something around the panel already owns closing it — a surface tab's own X. */
+  /** Page-owned detail columns use this to clear the selected pull request. */
   onClose?: () => void;
+  /** Keeps compact chrome, such as the right-panel tab, in step with refreshed host state. */
+  onStateChange?: (status: {
+    projectId: string;
+    repository: string;
+    number: number;
+    state: PullRequestState;
+    isDraft: boolean;
+  }) => void;
   /**
    * Beside a thread, the checkout affordance disappears: the panel is showing that thread's
    * own pull request, so the branch is already under the reader's feet — and checking it out
@@ -168,11 +187,25 @@ export function PullRequestDetailPanel({
   // Which handoff is preparing, keyed so a per-finding button can say "Preparing..." on itself
   // alone. One at a time whatever the key: they all check the same pull request out.
   const [handoff, setHandoff] = useState<string | null>(null);
+  const { copyToClipboard: copyBranchToClipboard, isCopied: isBranchCopied } = useCopyToClipboard({
+    target: "branch name",
+    timeout: 1600,
+  });
 
   const detailQuery = useEnvironmentQuery(
     pullRequestEnvironment.detail({ environmentId, input: reference }),
   );
   const detail = detailQuery.data;
+  useEffect(() => {
+    if (!detail) return;
+    onStateChange?.({
+      projectId: detail.projectId,
+      repository: detail.repository,
+      number: detail.number,
+      state: detail.state,
+      isDraft: detail.isDraft,
+    });
+  }, [detail, onStateChange]);
   // A pull request changes while it is open in front of somebody — a push lands, a check
   // finishes, a review arrives — so the panel reads it again on the way back to the window and
   // while a reader sits on it. Keyed by the pull request rather than by the panel, because this
@@ -561,41 +594,37 @@ export function PullRequestDetailPanel({
             : allowedMergeMethods.length > 0
               ? "merge"
               : null;
+  // The pull request number carries this state in the overview and the right-panel tab mirrors
+  // it. Conflicts keep their own row below: an open pull request remains green there.
+  const statePresentation = detail
+    ? resolvePullRequestState({ state: detail.state, isDraft: detail.isDraft })
+    : null;
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-background">
-      <div className="surface-subheader gap-2 px-3" data-surface-subheader>
-        {detail ? (
-          <PullRequestStateGlyph
-            state={detail.state}
-            isDraft={detail.isDraft}
-            mergeability={detail.mergeability}
-            baseBranch={detail.baseBranch}
-          />
-        ) : null}
-        <nav className="flex min-w-0 items-center gap-0.5" aria-label="Pull request tabs">
-          {visibleTabs.map((item) => (
-            <button
-              key={item.value}
-              type="button"
-              aria-pressed={tab === item.value}
-              onClick={() => {
-                // Once opened, the diff viewer is kept alive for the rest of the panel's life.
-                if (item.value === "code") setCodeMounted(true);
-                setTab(item.value);
-              }}
-              className={cn(
-                "rounded-md px-2 py-1 text-xs transition-colors",
-                tab === item.value
-                  ? "bg-accent text-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              {item.label}
-            </button>
-          ))}
-        </nav>
-        <div className="ml-auto flex shrink-0 items-center gap-1">
+      <div className="grid shrink-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 border-b border-border/60">
+        <div className="ml-2 flex min-h-6 min-w-0 items-center gap-1 text-sm text-muted-foreground sm:text-xs">
+          {detail && statePresentation ? (
+            <>
+              <span className="min-w-0 truncate" title={detail.repository}>
+                {detail.repository}
+              </span>
+              <button
+                type="button"
+                onClick={() => void readLocalApi()?.shell.openExternal(detail.url)}
+                className={cn(
+                  "shrink-0 font-medium underline-offset-2 hover:underline",
+                  statePresentation.toneClassName,
+                )}
+                title={OPEN_ON_HOST_LABELS[detail.provider] ?? "Open on host"}
+                aria-label={`Open pull request #${detail.number} on host`}
+              >
+                #{detail.number}
+              </button>
+            </>
+          ) : null}
+        </div>
+        <div className="mr-2 flex min-w-0 flex-wrap items-center justify-end gap-1">
           {detail ? (
             <>
               <Menu>
@@ -605,14 +634,28 @@ export function PullRequestDetailPanel({
                 >
                   <MoreHorizontalIcon className="size-4" />
                 </MenuTrigger>
-                <MenuPopup align="end" side="bottom" className="min-w-52">
+                <MenuPopup align="end" side="bottom" className="min-w-72">
                   <MenuItem disabled={detailQuery.isPending} onClick={() => void refreshFromHost()}>
                     <RefreshCwIcon className="size-3.5" />
                     Refresh
                   </MenuItem>
-                  <MenuItem onClick={() => void readLocalApi()?.shell.openExternal(detail.url)}>
-                    <ExternalLinkIcon className="size-3.5" />
-                    {OPEN_ON_HOST_LABELS[detail.provider] ?? "Open on host"}
+                  <MenuItem disabled={handoff !== null} onClick={askAboutPullRequest}>
+                    <MessageCircleQuestionIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
+                    <span className="flex min-w-0 flex-col">
+                      <span>{handoff === "ask" ? "Opening..." : "Ask a question"}</span>
+                      <span className="text-xs text-muted-foreground">
+                        Opens a thread that knows which pull request you mean.
+                      </span>
+                    </span>
+                  </MenuItem>
+                  <MenuItem disabled={handoff !== null} onClick={explainPullRequest}>
+                    <BookOpenIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
+                    <span className="flex min-w-0 flex-col">
+                      <span>{handoff === "explain" ? "Opening..." : "Explain this PR"}</span>
+                      <span className="text-xs text-muted-foreground">
+                        A walk through the diff and what to read closely.
+                      </span>
+                    </span>
                   </MenuItem>
                   <MenuSeparator />
                   {detail.state === "open" ? (
@@ -701,6 +744,15 @@ export function PullRequestDetailPanel({
                   ) : null}
                 </MenuPopup>
               </Menu>
+              <Button
+                size="xs"
+                variant="ghost"
+                className="text-muted-foreground hover:text-foreground"
+                onClick={() => void readLocalApi()?.shell.openExternal(detail.url)}
+              >
+                {OPEN_ON_HOST_LABELS[detail.provider] ?? "Open on host"}
+                <ArrowUpRightIcon className="size-3" />
+              </Button>
               {/* Checking a pull request out is the reason to open one here at all, so it is a
                   button of its own rather than a side effect of asking an agent for something.
                   It asks where, because the two answers are not interchangeable: one leaves your
@@ -746,56 +798,9 @@ export function PullRequestDetailPanel({
                   </MenuPopup>
                 </Menu>
               ) : null}
-              {/* Beside checking out, because they are the two things somebody opening a pull
-                  request wants: the code, or an answer about it. Asking takes no checkout — a
-                  question is not a reason to move the working tree or to make a worktree nobody
-                  asked for — which is what keeps it a separate press rather than a mode of the
-                  one next to it. */}
-              <Menu>
-                <MenuTrigger
-                  disabled={handoff !== null}
-                  render={
-                    <Button size="xs" variant="outline">
-                      {handoff === "ask" || handoff === "explain" ? (
-                        "Opening..."
-                      ) : (
-                        <>
-                          <MessageCircleQuestionIcon className="size-3" />
-                          Ask
-                          <ChevronDownIcon className="size-3 text-muted-foreground" />
-                        </>
-                      )}
-                    </Button>
-                  }
-                />
-                <MenuPopup align="end" side="bottom" className="min-w-72">
-                  <MenuItem onClick={askAboutPullRequest}>
-                    <MessageCircleQuestionIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
-                    <span className="flex min-w-0 flex-col">
-                      <span>Ask a question</span>
-                      <span className="text-xs text-muted-foreground">
-                        Opens a thread that knows which pull request you mean.
-                      </span>
-                    </span>
-                  </MenuItem>
-                  <MenuItem onClick={explainPullRequest}>
-                    <BookOpenIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
-                    <span className="flex min-w-0 flex-col">
-                      <span>Explain this PR</span>
-                      <span className="text-xs text-muted-foreground">
-                        A walk through the diff: what it is for, and what to read closely.
-                      </span>
-                    </span>
-                  </MenuItem>
-                </MenuPopup>
-              </Menu>
               {primaryAction === "ready" ? (
                 <Button size="xs" disabled={actionPending} onClick={() => void perform("ready")}>
                   Ready for review
-                </Button>
-              ) : primaryAction === "resolve" ? (
-                <Button size="xs" disabled={handoff !== null} onClick={startResolveConflicts}>
-                  {handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
                 </Button>
               ) : primaryAction === "merge" ? (
                 <Button
@@ -809,8 +814,6 @@ export function PullRequestDetailPanel({
             </>
           ) : null}
           {onClose ? (
-            // Panel chrome rather than an action: the same collapse glyph the rest of the app
-            // uses for its right panel, ghosted so it does not compete with the buttons.
             <Button
               size="icon-xs"
               variant="ghost"
@@ -821,6 +824,109 @@ export function PullRequestDetailPanel({
             </Button>
           ) : null}
         </div>
+
+        {detail ? (
+          <div className="col-span-2 mt-3 min-w-0 px-2 pb-4">
+            <h1 className="text-base font-semibold leading-snug">{detail.title}</h1>
+            <PullRequestMetaLine className="mt-2 text-xs text-muted-foreground">
+              <PullRequestActorLabel actor={detail.author} className="font-medium" />
+              <span>updated {formatRelativeTimeLabel(detail.updatedAt)}</span>
+            </PullRequestMetaLine>
+
+            <div className="mt-4 flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <code
+                className="max-w-48 truncate rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground"
+                title={detail.baseBranch}
+              >
+                {detail.baseBranch}
+              </code>
+              <ArrowLeftIcon aria-label="receives changes from" className="size-4 shrink-0" />
+              <button
+                type="button"
+                className="grid max-w-64 min-w-0 cursor-pointer rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                aria-label={isBranchCopied ? "Branch name copied" : "Copy pull request branch"}
+                title={isBranchCopied ? "Copied" : "Copy pull request branch"}
+                onClick={() => copyBranchToClipboard(detail.headBranch)}
+              >
+                <code
+                  className={cn(
+                    "col-start-1 row-start-1 min-w-0 truncate transition-opacity duration-150 motion-reduce:transition-none",
+                    isBranchCopied ? "opacity-0" : "opacity-100",
+                  )}
+                  title={detail.headBranch}
+                >
+                  {detail.headBranch}
+                </code>
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "col-start-1 row-start-1 truncate text-center transition-opacity duration-150 motion-reduce:transition-none",
+                    isBranchCopied ? "opacity-100" : "opacity-0",
+                  )}
+                >
+                  Copied
+                </span>
+              </button>
+              <span className="ml-auto inline-flex shrink-0 items-center justify-end gap-2">
+                <span className="inline-flex items-center gap-1.5 tabular-nums">
+                  <FilesIcon className="size-3.5" />
+                  {detail.changedFiles.toLocaleString()}{" "}
+                  {detail.changedFiles === 1 ? "file" : "files"}
+                </span>
+                <PullRequestDiffStat
+                  additions={detail.additions}
+                  deletions={detail.deletions}
+                  className="shrink-0 font-mono text-xs"
+                />
+              </span>
+            </div>
+          </div>
+        ) : null}
+
+        {detail && conflicting ? (
+          <div className="col-span-2 flex min-h-12 items-center gap-2 border-t border-border/60 px-2 py-2.5">
+            <TriangleAlertIcon className="size-4 shrink-0 text-destructive" />
+            <span className="text-xs font-medium">Merge conflicts</span>
+            <span className="min-w-0 truncate text-xs text-muted-foreground">
+              with {detail.baseBranch}
+            </span>
+            <Button
+              size="xs"
+              variant="secondary"
+              className="ml-auto"
+              disabled={handoff !== null}
+              onClick={startResolveConflicts}
+            >
+              {handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
+            </Button>
+          </div>
+        ) : null}
+
+        <nav
+          className="col-span-2 flex min-w-0 items-center gap-1 border-t border-border/60 px-2 py-2"
+          aria-label="Pull request tabs"
+        >
+          {visibleTabs.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              aria-pressed={tab === item.value}
+              onClick={() => {
+                // Once opened, the diff viewer is kept alive for the rest of the panel's life.
+                if (item.value === "code") setCodeMounted(true);
+                setTab(item.value);
+              }}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition-colors",
+                tab === item.value
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
       </div>
 
       <div className="relative min-h-0 flex-1 overflow-hidden">

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
@@ -1,0 +1,130 @@
+import type { ProjectId, PullRequestProviderSummary } from "@t3tools/contracts";
+import { CircleIcon } from "lucide-react";
+import { Children, isValidElement, type ReactElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  PullRequestFilterPills,
+  PullRequestProjectFilter,
+  PullRequestProviderFilter,
+} from "./PullRequestListFilters";
+
+type Clickable = ReactElement<{
+  readonly "aria-pressed"?: boolean;
+  readonly children?: ReactNode;
+  readonly onClick?: () => void;
+}>;
+
+function buttonsIn(element: ReactElement<{ readonly children?: ReactNode }> | null): Clickable[] {
+  if (element === null) return [];
+  return Children.toArray(element.props.children).filter(isValidElement) as Clickable[];
+}
+
+function findValueChange(
+  node: ReactNode,
+):
+  | ReactElement<{ readonly children?: ReactNode; readonly onValueChange: (value: string) => void }>
+  | undefined {
+  for (const child of Children.toArray(node)) {
+    if (!isValidElement(child)) continue;
+    const props = child.props as {
+      readonly children?: ReactNode;
+      readonly onValueChange?: (value: string) => void;
+    };
+    if (props.onValueChange) {
+      return child as ReactElement<{
+        readonly children?: ReactNode;
+        readonly onValueChange: (value: string) => void;
+      }>;
+    }
+    const nested = findValueChange(props.children);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+describe("pull request list filters", () => {
+  it("does not emit a change when the selected filter pill is pressed again", () => {
+    const onChange = vi.fn();
+    const view = PullRequestFilterPills({
+      value: "open",
+      label: "State",
+      onChange,
+      options: [
+        { value: "open", label: "Open", Icon: CircleIcon },
+        { value: "closed", label: "Closed", Icon: CircleIcon },
+      ],
+    });
+    const [selected, unselected] = buttonsIn(view);
+
+    selected?.props.onClick?.();
+    expect(onChange).not.toHaveBeenCalled();
+
+    unselected?.props.onClick?.();
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("closed");
+  });
+
+  it("does not emit a change when the selected host or All is pressed again", () => {
+    const providers = [
+      {
+        host: "github.com",
+        kind: "github",
+        searchesOnHost: true,
+        projectCount: 1,
+        configured: true,
+        detail: null,
+      },
+      {
+        host: "gitlab.com",
+        kind: "gitlab",
+        searchesOnHost: true,
+        projectCount: 1,
+        configured: true,
+        detail: null,
+      },
+    ] as ReadonlyArray<PullRequestProviderSummary>;
+    const onChange = vi.fn();
+
+    const selectedHost = PullRequestProviderFilter({
+      providers,
+      value: "github.com",
+      expectedHosts: [],
+      onChange,
+    });
+    buttonsIn(selectedHost)
+      .find((button) => button.props["aria-pressed"])
+      ?.props.onClick?.();
+    expect(onChange).not.toHaveBeenCalled();
+
+    const allHosts = PullRequestProviderFilter({
+      providers,
+      value: undefined,
+      expectedHosts: [],
+      onChange,
+    });
+    buttonsIn(allHosts)
+      .find((button) => button.props["aria-pressed"])
+      ?.props.onClick?.();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not emit a change when the selected project is chosen again", () => {
+    const projectId = "project-1" as ProjectId;
+    const onChange = vi.fn();
+    const view = PullRequestProjectFilter({
+      projects: [{ id: projectId, title: "T3 Code" }],
+      value: projectId,
+      unavailable: new Map(),
+      onChange,
+    });
+    const radioGroup = findValueChange(view);
+    expect(radioGroup).toBeDefined();
+
+    radioGroup?.props.onValueChange(projectId);
+    expect(onChange).not.toHaveBeenCalled();
+
+    radioGroup?.props.onValueChange("all");
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -53,7 +53,9 @@ export function PullRequestFilterPills<Value extends string>({
           key={option.value}
           type="button"
           aria-pressed={option.value === value}
-          onClick={() => onChange(option.value)}
+          onClick={() => {
+            if (option.value !== value) onChange(option.value);
+          }}
           className={filterOptionClass(option.value === value)}
         >
           <option.Icon aria-hidden className="size-3.5" />
@@ -141,7 +143,9 @@ export function PullRequestProviderFilter({
       <button
         type="button"
         aria-pressed={value === undefined}
-        onClick={() => onChange(undefined)}
+        onClick={() => {
+          if (value !== undefined) onChange(undefined);
+        }}
         className={filterOptionClass(value === undefined)}
       >
         All
@@ -159,7 +163,9 @@ export function PullRequestProviderFilter({
             // The host itself when it reads as a provider name, so a switcher showing "GitHub"
             // still says which install it means.
             title={provider.configured ? provider.host : (provider.detail ?? undefined)}
-            onClick={() => onChange(provider.host)}
+            onClick={() => {
+              if (!active) onChange(provider.host);
+            }}
             // Opacity rather than a muted colour: the icons are brand-coloured, so text colour
             // alone would leave a disabled host looking active.
             className={filterOptionClass(active, !provider.configured)}
@@ -254,9 +260,10 @@ export function PullRequestProjectFilter({
       <MenuPopup align="end" side="bottom" className="min-w-56">
         <MenuRadioGroup
           value={value ?? ALL_PROJECTS_VALUE}
-          onValueChange={(next) =>
-            onChange(next === ALL_PROJECTS_VALUE ? undefined : (next as ProjectId))
-          }
+          onValueChange={(next) => {
+            const projectId = next === ALL_PROJECTS_VALUE ? undefined : (next as ProjectId);
+            if (projectId !== value) onChange(projectId);
+          }}
         >
           <MenuRadioItem value={ALL_PROJECTS_VALUE}>All projects</MenuRadioItem>
           {/* The ones that can be chosen first: a list that opens with three disabled rows reads

--- a/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
@@ -10,13 +10,14 @@ import {
   MessageSquareIcon,
   Trash2Icon,
 } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { formatRelativeTimeLabel } from "~/timestampFormat";
 import { cn } from "~/lib/utils";
 
 import { Button } from "../ui/button";
 import { Textarea } from "../ui/textarea";
+import { isCommentSubmitShortcut } from "../diffs/commentSubmitShortcut";
 import { PullRequestActorLabel } from "./pullRequestPresentation";
 import { PullRequestMarkdown } from "./PullRequestMarkdown";
 import type { PendingReviewComment } from "./pullRequestReviewStore";
@@ -27,6 +28,7 @@ const CARD_CLASS =
 /** Sends a reply on ⌘/Ctrl+Enter and abandons it on Escape. */
 function submitKeys(input: {
   readonly value: string;
+  readonly pending: boolean;
   readonly onSubmit: () => void;
   readonly onCancel?: (() => void) | undefined;
 }) {
@@ -35,7 +37,7 @@ function submitKeys(input: {
       event.preventDefault();
       input.onCancel();
     }
-    if ((event.metaKey || event.ctrlKey) && event.key === "Enter" && input.value.trim()) {
+    if (isCommentSubmitShortcut(event, input.value, input.pending)) {
       event.preventDefault();
       input.onSubmit();
     }
@@ -103,15 +105,21 @@ export function ReviewThreadCard({
   const [expanded, setExpanded] = useState(!thread.isResolved);
   const [replying, setReplying] = useState(false);
   const [reply, setReply] = useState("");
+  const sendingRef = useRef(false);
 
   const send = async () => {
     const trimmed = reply.trim();
-    if (trimmed.length === 0) return;
+    if (trimmed.length === 0 || pending || sendingRef.current) return;
+    sendingRef.current = true;
     // Cleared only once the host has it. Otherwise a failed reply leaves an error toast and an
     // empty box, and the words have to be written again.
-    if (await onReply(trimmed)) {
-      setReply("");
-      setReplying(false);
+    try {
+      if (await onReply(trimmed)) {
+        setReply("");
+        setReplying(false);
+      }
+    } finally {
+      sendingRef.current = false;
     }
   };
 
@@ -192,6 +200,7 @@ export function ReviewThreadCard({
                   onChange={(event) => setReply(event.target.value)}
                   onKeyDown={submitKeys({
                     value: reply,
+                    pending,
                     onSubmit: () => void send(),
                     onCancel: () => setReplying(false),
                   })}

--- a/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
@@ -1,6 +1,6 @@
 /**
- * What sits under a line of the diff: a conversation already on the host, a comment queued for
- * the review being written, or the box that writes one.
+ * Pull-request-specific annotations: conversations already on the host and comments queued for
+ * the review being written. New comment composition uses the shared diff annotation.
  */
 import type { PullRequestReviewThread } from "@t3tools/contracts";
 import {
@@ -8,7 +8,6 @@ import {
   CircleIcon,
   HammerIcon,
   MessageSquareIcon,
-  SparklesIcon,
   Trash2Icon,
 } from "lucide-react";
 import { useState } from "react";
@@ -25,7 +24,7 @@ import type { PendingReviewComment } from "./pullRequestReviewStore";
 const CARD_CLASS =
   "mx-3 my-2 rounded-xl border border-border/70 bg-background p-3 text-sm shadow-sm";
 
-/** Sends on ⌘/Ctrl+Enter and abandons on Escape, which is what every other composer here does. */
+/** Sends a reply on ⌘/Ctrl+Enter and abandons it on Escape. */
 function submitKeys(input: {
   readonly value: string;
   readonly onSubmit: () => void;
@@ -41,69 +40,6 @@ function submitKeys(input: {
       input.onSubmit();
     }
   };
-}
-
-/** The box that writes a new line comment into the review being drafted. */
-export function ReviewCommentComposer({
-  lineLabel,
-  pending,
-  onAsk,
-  onCancel,
-  onSubmit,
-}: {
-  lineLabel: string;
-  pending: boolean;
-  /**
-   * Hands the whole selection to an agent instead of the host. Absent where there is nothing to
-   * hand it to, since a button that cannot do its one thing is worse than no button.
-   */
-  onAsk?: ((question: string) => void) | undefined;
-  onCancel: () => void;
-  onSubmit: (body: string) => void;
-}) {
-  const [body, setBody] = useState("");
-  const submit = () => {
-    const trimmed = body.trim();
-    if (trimmed.length > 0) onSubmit(trimmed);
-  };
-  return (
-    <div
-      className={cn(CARD_CLASS, "shadow-lg")}
-      contentEditable={false}
-      onPointerDown={(event) => event.stopPropagation()}
-    >
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <MessageSquareIcon className="size-3.5" />
-        <span>Comment on {lineLabel}</span>
-      </div>
-      <Textarea
-        autoFocus
-        size="sm"
-        className="mt-2"
-        value={body}
-        placeholder="Leave a comment"
-        aria-label={`Comment on ${lineLabel}`}
-        onChange={(event) => setBody(event.target.value)}
-        onKeyDown={submitKeys({ value: body, onSubmit: submit, onCancel })}
-      />
-      <div className="mt-2 flex justify-end gap-2">
-        <Button size="xs" variant="ghost" onClick={onCancel}>
-          Cancel
-        </Button>
-        {/* Empty is allowed: handing the agent the lines and no question yet is a fair way to
-            start, and the words can follow in the composer the selection lands in. */}
-        {onAsk ? (
-          <Button size="xs" variant="outline" onClick={() => onAsk(body.trim())}>
-            <SparklesIcon className="size-3" />
-            Ask
-          </Button>
-        ) : null}
-        <Button size="xs" disabled={pending || body.trim().length === 0} onClick={submit}>
-          Add to review
-        </Button>
-      </div>
-    </div>
-  );
 }
 
 /** A comment waiting to be sent with the rest of the review. */

--- a/apps/web/src/components/pullRequest/PullRequestReviewBar.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReviewBar.tsx
@@ -4,7 +4,7 @@
  */
 import type { EnvironmentId, PullRequestRef, PullRequestReviewVerdict } from "@t3tools/contracts";
 import { CheckIcon, MessageSquareIcon, XCircleIcon } from "lucide-react";
-import { useEffect, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { pullRequestEnvironment } from "~/state/pullRequests";
 import { useAtomCommand } from "~/state/use-atom-command";
@@ -55,14 +55,17 @@ export function PullRequestReviewBar({
   verdicts: ReadonlyArray<PullRequestReviewVerdict>;
   onSubmitted: () => void;
 }) {
-  const [body, setBody] = useState("");
   const [pending, setPending] = useState(false);
   const comments = usePendingReviewComments(reference);
-  // The panel keeps this mounted across pull requests, so a summary typed for one would
-  // otherwise be sent with the next.
   const reviewKey = pullRequestReviewKey(reference);
-  useEffect(() => setBody(""), [reviewKey]);
+  // The panel stays mounted while the selected pull request changes. Keeping summaries beside
+  // the keyed line-comment drafts makes the selected pull request's body correct on the first
+  // render, before an effect could reset state left behind by the previous one.
+  const body = usePullRequestReviewStore((store) => store.summaries[reviewKey] ?? "");
   const clear = usePullRequestReviewStore((store) => store.clear);
+  const removeComments = usePullRequestReviewStore((store) => store.removeComments);
+  const setSummary = usePullRequestReviewStore((store) => store.setSummary);
+  const clearSummary = usePullRequestReviewStore((store) => store.clearSummary);
   const submitReview = useAtomCommand(pullRequestEnvironment.submitReview, {
     reportFailure: false,
   });
@@ -72,10 +75,17 @@ export function PullRequestReviewBar({
 
   const submit = async (verdict: (typeof VERDICTS)[number]) => {
     if (pending) return;
+    const submittedBody = body;
+    const submittedComments = comments;
     setPending(true);
     const result = await submitReview({
       environmentId,
-      input: { ...reference, verdict: verdict.value, body, comments },
+      input: {
+        ...reference,
+        verdict: verdict.value,
+        body: submittedBody,
+        comments: submittedComments,
+      },
     });
     setPending(false);
     if (result._tag === "Failure") {
@@ -83,8 +93,13 @@ export function PullRequestReviewBar({
       toastManager.add({ type: "error", title: "The review could not be submitted" });
       return;
     }
-    clear(reviewKey);
-    setBody("");
+    // More remarks may have been added while the host was accepting this snapshot. Leave those,
+    // and any summary revised in the meantime, ready for the next review.
+    removeComments(
+      reviewKey,
+      submittedComments.map((comment) => comment.id),
+    );
+    clearSummary(reviewKey, submittedBody);
     toastManager.add({ type: "success", title: verdict.sent });
     onSubmitted();
   };
@@ -113,7 +128,7 @@ export function PullRequestReviewBar({
         value={body}
         placeholder="Summarize your review (optional)"
         aria-label="Review summary"
-        onChange={(event) => setBody(event.target.value)}
+        onChange={(event) => setSummary(reviewKey, event.target.value)}
       />
       <div className="mt-2 flex flex-wrap justify-end gap-2">
         {offered.map((verdict) => (

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -367,7 +367,12 @@ export function PullRequestSummaryTab({
         )}
         {/* A host that cannot post a comment gets no composer, rather than one that fails. */}
         {detail.capabilities.comment && detail.viewerPermissions.comment ? (
-          <CommentComposer environmentId={environmentId} detail={detail} onCommented={onRefresh} />
+          <CommentComposer
+            key={`${environmentId}:${detail.projectId}/${detail.repository}#${detail.number}`}
+            environmentId={environmentId}
+            detail={detail}
+            onCommented={onRefresh}
+          />
         ) : null}
       </Section>
     </div>

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -2,8 +2,6 @@ import type { EnvironmentId, PullRequestDetail, PullRequestRef } from "@t3tools/
 import {
   ChevronRightIcon,
   CircleDotIcon,
-  GitBranchIcon,
-  GitMergeIcon,
   HammerIcon,
   MessageSquareIcon,
   SendIcon,
@@ -21,20 +19,16 @@ import { Button } from "../ui/button";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { Textarea } from "../ui/textarea";
 import { toastManager } from "../ui/toast";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
   PullRequestActorLabel,
   PullRequestCheckStatusIcon,
-  PullRequestDiffStat,
   PullRequestMetaLine,
   pullRequestCheckStatusLabel,
   summarizePullRequestChecks,
 } from "./pullRequestPresentation";
 import { PullRequestReviewerPicker } from "./PullRequestReviewerPicker";
-import {
-  describePullRequestState,
-  pullRequestFindingKey,
-  type PullRequestFinding,
-} from "./pullRequestDetail.logic";
+import { pullRequestFindingKey, type PullRequestFinding } from "./pullRequestDetail.logic";
 import { PullRequestMarkdown } from "./PullRequestMarkdown";
 
 function MetaRow({
@@ -189,47 +183,37 @@ export function PullRequestSummaryTab({
 
   return (
     <div className="h-full overflow-y-auto">
-      <section className="space-y-4 px-5 py-5">
-        <div className="min-w-0">
-          <h1 className="text-base font-semibold leading-snug">{detail.title}</h1>
-          <PullRequestMetaLine className="mt-1.5 text-xs text-muted-foreground">
-            <PullRequestActorLabel actor={detail.author} className="font-medium text-foreground" />
-            <span>{formatRelativeTimeLabel(detail.updatedAt)}</span>
-            <span>{describePullRequestState(detail.state, detail.isDraft)}</span>
-          </PullRequestMetaLine>
-        </div>
+      <section className="px-5 py-3">
         <div>
-          <MetaRow icon={<GitBranchIcon className="size-3.5" />} label="Branch">
-            <span className="flex items-center gap-1.5">
-              <span className="min-w-0 truncate" title={detail.headBranch}>
-                {detail.headBranch}
-              </span>
-              <span aria-hidden className="shrink-0 text-muted-foreground">
-                ›
-              </span>
-              <span className="min-w-0 truncate" title={detail.baseBranch}>
-                {detail.baseBranch}
-              </span>
-              <PullRequestDiffStat
-                additions={detail.additions}
-                deletions={detail.deletions}
-                className="ml-1 shrink-0"
-              />
-            </span>
-          </MetaRow>
-          {detail.state === "open" && detail.mergeability === "conflicting" ? (
-            <MetaRow icon={<GitMergeIcon className="size-3.5 text-destructive" />} label="Merge">
-              Conflicts with {detail.baseBranch}
-            </MetaRow>
-          ) : null}
           <MetaRow icon={<UsersIcon className="size-3.5" />} label="Reviewers">
             <span className="flex min-w-0 flex-wrap items-center gap-1.5">
               {detail.reviewers.length === 0 ? (
                 <span className="text-muted-foreground">None</span>
               ) : (
-                detail.reviewers.map((actor) => (
-                  <PullRequestActorLabel key={actor.login} actor={actor} className="max-w-32" />
-                ))
+                <span className="flex items-center -space-x-1">
+                  {detail.reviewers.map((actor) => (
+                    <Tooltip key={actor.login}>
+                      <TooltipTrigger
+                        render={
+                          <span
+                            className="relative rounded-full hover:z-10"
+                            aria-label={actor.name ?? actor.login}
+                          />
+                        }
+                      >
+                        <PullRequestActorLabel
+                          actor={actor}
+                          className="gap-0 [&>img]:ring-2 [&>img]:ring-background [&>span:first-child]:ring-2 [&>span:first-child]:ring-background [&>span:last-child]:sr-only"
+                        />
+                      </TooltipTrigger>
+                      <TooltipPopup side="bottom">
+                        {actor.name && actor.name !== actor.login
+                          ? `${actor.name} (@${actor.login})`
+                          : actor.login}
+                      </TooltipPopup>
+                    </Tooltip>
+                  ))}
+                </span>
               )}
               {/* Shown wherever the host can take a review request at all, and disabled with the
                   reason where this account may not make one: a control that vanishes teaches

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -22,14 +22,17 @@ function TimelineBody({ body, markdown, cwd }: { body: string; markdown: boolean
    * Measured rather than guessed from the text. A body's height depends on the width it is
    * given and on what the markdown turned into: a screenshot or a recording is a handful of
    * characters and half a screen tall, and a length heuristic would fold it away behind no
-   * control at all. Latched, because once expanded the content is no longer taller than its box.
+   * control at all. The body can change without this component unmounting, so both pieces of
+   * presentation state are recalculated for the new content.
    */
   useLayoutEffect(() => {
     const content = contentRef.current;
     if (content === null) return;
     const measure = () => {
-      if (content.getBoundingClientRect().height > COLLAPSED_BODY_HEIGHT) setOverflows(true);
+      setOverflows(content.getBoundingClientRect().height > COLLAPSED_BODY_HEIGHT);
     };
+    setExpanded(false);
+    setOverflows(false);
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(content);

--- a/apps/web/src/components/pullRequest/pullRequestDiff.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDiff.logic.test.ts
@@ -1,7 +1,10 @@
 import type { FileDiffMetadata } from "@pierre/diffs";
 import { describe, expect, it } from "vite-plus/test";
 
-import { isFileDiffCollapsed, isLineInFileDiff } from "./pullRequestDiff.logic";
+import {
+  isFileDiffCollapsed,
+  isLineInFileDiff,
+} from "./pullRequestDiff.logic";
 
 /** Only the hunk ranges matter here; the viewer fills the rest in when it renders. */
 function fileWithHunks(

--- a/apps/web/src/components/pullRequest/pullRequestReviewStore.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestReviewStore.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+import { type PendingReviewComment, usePullRequestReviewStore } from "./pullRequestReviewStore";
+
+function comment(id: string, body = id): PendingReviewComment {
+  return { id, body, path: "src/app.ts", line: 1, side: "right" };
+}
+
+describe("pull request review drafts", () => {
+  beforeEach(() => {
+    usePullRequestReviewStore.setState({ drafts: {}, summaries: {} });
+  });
+
+  it("removes only the line comments included in a submitted snapshot", () => {
+    const store = usePullRequestReviewStore.getState();
+    store.addComment("review-a", comment("submitted"));
+    const submittedIds =
+      usePullRequestReviewStore.getState().drafts["review-a"]?.map((entry) => entry.id) ?? [];
+
+    usePullRequestReviewStore.getState().addComment("review-a", comment("added-in-flight"));
+    usePullRequestReviewStore.getState().removeComments("review-a", submittedIds);
+
+    expect(usePullRequestReviewStore.getState().drafts["review-a"]).toEqual([
+      comment("added-in-flight"),
+    ]);
+  });
+
+  it("keeps summary bodies isolated by review key", () => {
+    const store = usePullRequestReviewStore.getState();
+    store.setSummary("review-a", "Summary A");
+    store.setSummary("review-b", "Summary B");
+    store.clearSummary("review-a", "Summary A");
+
+    expect(usePullRequestReviewStore.getState().summaries).toEqual({
+      "review-b": "Summary B",
+    });
+  });
+
+  it("does not clear a summary revised while submission is in flight", () => {
+    const store = usePullRequestReviewStore.getState();
+    store.setSummary("review-a", "Submitted body");
+    usePullRequestReviewStore.getState().setSummary("review-a", "Revised body");
+    usePullRequestReviewStore.getState().clearSummary("review-a", "Submitted body");
+
+    expect(usePullRequestReviewStore.getState().summaries["review-a"]).toBe("Revised body");
+  });
+});

--- a/apps/web/src/components/pullRequest/pullRequestReviewStore.ts
+++ b/apps/web/src/components/pullRequest/pullRequestReviewStore.ts
@@ -38,15 +38,20 @@ export function pullRequestReviewKey(reference: PullRequestRef): string {
 
 interface PullRequestReviewStoreState {
   readonly drafts: Readonly<Record<string, ReadonlyArray<PendingReviewComment>>>;
+  readonly summaries: Readonly<Record<string, string>>;
   readonly addComment: (key: string, comment: PendingReviewComment) => void;
   readonly removeComment: (key: string, commentId: string) => void;
+  readonly removeComments: (key: string, commentIds: ReadonlyArray<string>) => void;
   readonly clear: (key: string) => void;
+  readonly setSummary: (key: string, body: string) => void;
+  readonly clearSummary: (key: string, submittedBody: string) => void;
 }
 
 const EMPTY: ReadonlyArray<PendingReviewComment> = [];
 
 export const usePullRequestReviewStore = create<PullRequestReviewStoreState>()((set) => ({
   drafts: {},
+  summaries: {},
   addComment: (key, comment) =>
     set((state) => ({
       drafts: { ...state.drafts, [key]: [...(state.drafts[key] ?? EMPTY), comment] },
@@ -58,10 +63,27 @@ export const usePullRequestReviewStore = create<PullRequestReviewStoreState>()((
       const { [key]: _removed, ...rest } = state.drafts;
       return { drafts: rest };
     }),
+  removeComments: (key, commentIds) =>
+    set((state) => {
+      const submitted = new Set(commentIds);
+      const remaining = (state.drafts[key] ?? EMPTY).filter((entry) => !submitted.has(entry.id));
+      if (remaining.length > 0) return { drafts: { ...state.drafts, [key]: remaining } };
+      const { [key]: _removed, ...rest } = state.drafts;
+      return { drafts: rest };
+    }),
   clear: (key) =>
     set((state) => {
       const { [key]: _removed, ...rest } = state.drafts;
       return { drafts: rest };
+    }),
+  setSummary: (key, body) => set((state) => ({ summaries: { ...state.summaries, [key]: body } })),
+  clearSummary: (key, submittedBody) =>
+    set((state) => {
+      // The textarea stays editable while the request is in flight. Only remove the exact draft
+      // the host accepted; a revised summary for the same pull request is new work.
+      if (state.summaries[key] !== submittedBody) return state;
+      const { [key]: _removed, ...rest } = state.summaries;
+      return { summaries: rest };
     }),
 }));
 

--- a/apps/web/src/lib/diffFileContents.test.ts
+++ b/apps/web/src/lib/diffFileContents.test.ts
@@ -1,0 +1,80 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+import { EnvironmentId, type ReviewDiffFileContentsResult } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createGitDiffFileContentsLoader } from "./diffFileContents";
+
+const SOURCE = {
+  environmentId: EnvironmentId.make("environment-1"),
+  cwd: "/workspace",
+  sourceKind: "branch-range" as const,
+  baseRef: "main",
+  headRef: "feature",
+  cacheKey: "comparison-1",
+};
+
+function fileDiff(type: FileDiffMetadata["type"] = "rename-changed"): FileDiffMetadata {
+  return {
+    type,
+    prevName: "a/src/old-name.ts",
+    name: "b/src/new-name.ts",
+  } as FileDiffMetadata;
+}
+
+describe("createGitDiffFileContentsLoader", () => {
+  it("loads both sides with normalized paths and comparison-scoped cache keys", async () => {
+    const getDiffFileContents = vi.fn(async () =>
+      AsyncResult.success({ oldContents: "before\n", newContents: "after\n" }),
+    );
+    const load = createGitDiffFileContentsLoader(getDiffFileContents, SOURCE);
+
+    await expect(load(fileDiff())).resolves.toEqual({
+      oldFile: {
+        name: "src/old-name.ts",
+        contents: "before\n",
+        cacheKey: "comparison-1:old:src/old-name.ts",
+      },
+      newFile: {
+        name: "src/new-name.ts",
+        contents: "after\n",
+        cacheKey: "comparison-1:new:src/new-name.ts",
+      },
+    });
+    expect(getDiffFileContents).toHaveBeenCalledWith({
+      environmentId: "environment-1",
+      input: {
+        cwd: "/workspace",
+        sourceKind: "branch-range",
+        changeType: "rename-changed",
+        baseRef: "main",
+        headRef: "feature",
+        oldPath: "src/old-name.ts",
+        newPath: "src/new-name.ts",
+      },
+    });
+  });
+
+  it("loads a pure rename from its one shared file", async () => {
+    const getDiffFileContents = vi.fn(async () =>
+      AsyncResult.success({ oldContents: "same\n", newContents: "same\n" }),
+    );
+    const load = createGitDiffFileContentsLoader(getDiffFileContents, SOURCE);
+
+    await expect(load(fileDiff("rename-pure"))).resolves.toMatchObject({
+      oldFile: null,
+      newFile: { name: "src/new-name.ts", contents: "same\n" },
+    });
+  });
+
+  it("passes command failures through to Pierre's expansion handling", async () => {
+    const failure = new Error("revision is not available locally");
+    const getDiffFileContents = vi.fn(async () =>
+      AsyncResult.failure<ReviewDiffFileContentsResult, Error>(Cause.fail(failure)),
+    );
+    const load = createGitDiffFileContentsLoader(getDiffFileContents, SOURCE);
+
+    await expect(load(fileDiff())).rejects.toBe(failure);
+  });
+});

--- a/apps/web/src/lib/diffFileContents.ts
+++ b/apps/web/src/lib/diffFileContents.ts
@@ -1,0 +1,124 @@
+import type { FileDiffContentsLoader } from "@pierre/diffs";
+import {
+  squashAtomCommandFailure,
+  type AtomCommandResult,
+} from "@t3tools/client-runtime/state/runtime";
+import type {
+  EnvironmentId,
+  PullRequestDiffFileContentsInput,
+  PullRequestDiffFileContentsResult,
+  PullRequestRef,
+  ReviewDiffFileContentsInput,
+  ReviewDiffFileContentsResult,
+  ReviewDiffPreviewSourceKind,
+} from "@t3tools/contracts";
+
+import { resolveFileDiffPath } from "./diffRendering";
+
+interface GitDiffFileContentsSource {
+  readonly environmentId: EnvironmentId;
+  readonly cwd: string;
+  readonly sourceKind: ReviewDiffPreviewSourceKind;
+  readonly baseRef: string | null;
+  readonly headRef: string | null;
+  /** The comparison identity Pierre carries into its hydrated render cache. */
+  readonly cacheKey: string;
+}
+
+interface PullRequestDiffFileContentsSource {
+  readonly environmentId: EnvironmentId;
+  readonly reference: PullRequestRef;
+  readonly commit: string | null;
+  readonly cacheKey: string;
+}
+
+type GetDiffFileContents<E> = (request: {
+  readonly environmentId: EnvironmentId;
+  readonly input: ReviewDiffFileContentsInput;
+}) => Promise<AtomCommandResult<ReviewDiffFileContentsResult, E>>;
+
+type GetPullRequestDiffFileContents<E> = (request: {
+  readonly environmentId: EnvironmentId;
+  readonly input: PullRequestDiffFileContentsInput;
+}) => Promise<AtomCommandResult<PullRequestDiffFileContentsResult, E>>;
+
+function createDiffFileContentsLoader(
+  load: (input: {
+    readonly changeType: PullRequestDiffFileContentsInput["changeType"];
+    readonly oldPath: string;
+    readonly newPath: string;
+  }) => Promise<{ readonly oldContents: string; readonly newContents: string }>,
+  cacheKey: string,
+): FileDiffContentsLoader {
+  return async (fileDiff) => {
+    const newPath = resolveFileDiffPath(fileDiff);
+    const oldPath = fileDiff.prevName
+      ? resolveFileDiffPath({ ...fileDiff, name: fileDiff.prevName })
+      : newPath;
+    const contents = await load({ changeType: fileDiff.type, oldPath, newPath });
+    const newFile = {
+      name: newPath,
+      contents: contents.newContents,
+      cacheKey: `${cacheKey}:new:${newPath}`,
+    };
+    if (fileDiff.type === "rename-pure") {
+      return { oldFile: null, newFile };
+    }
+    return {
+      oldFile: {
+        name: oldPath,
+        contents: contents.oldContents,
+        cacheKey: `${cacheKey}:old:${oldPath}`,
+      },
+      newFile,
+    };
+  };
+}
+
+/** Turns the host's Git file-content RPC into the full-file loader Pierre uses for hunk expansion. */
+export function createGitDiffFileContentsLoader<E>(
+  getDiffFileContents: GetDiffFileContents<E>,
+  source: GitDiffFileContentsSource,
+): FileDiffContentsLoader {
+  return createDiffFileContentsLoader(async ({ changeType, oldPath, newPath }) => {
+    const result = await getDiffFileContents({
+      environmentId: source.environmentId,
+      input: {
+        cwd: source.cwd,
+        sourceKind: source.sourceKind,
+        changeType,
+        baseRef: source.baseRef,
+        headRef: source.headRef,
+        oldPath,
+        newPath,
+      },
+    });
+    if (result._tag !== "Success") {
+      throw squashAtomCommandFailure(result);
+    }
+    return result.value;
+  }, source.cacheKey);
+}
+
+/** Loads host-backed PR files, which may name revisions this checkout has never fetched. */
+export function createPullRequestDiffFileContentsLoader<E>(
+  getDiffFileContents: GetPullRequestDiffFileContents<E>,
+  source: PullRequestDiffFileContentsSource,
+): FileDiffContentsLoader {
+  return createDiffFileContentsLoader(async ({ changeType, oldPath, newPath }) => {
+    const result = await getDiffFileContents({
+      environmentId: source.environmentId,
+      input: {
+        ...source.reference,
+        ...(source.commit === null ? {} : { commit: source.commit }),
+        changeType,
+        oldPath,
+        newPath,
+      },
+    });
+    if (result._tag !== "Success") {
+      throw squashAtomCommandFailure(result);
+    }
+    return result.value;
+  }, source.cacheKey);
+}

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -7,6 +7,7 @@ import {
   pullRequestSurfaceId,
   selectActiveRightPanel,
   selectActiveRightPanelSurface,
+  selectSelectedRightPanelSurface,
   selectThreadRightPanelState,
   useRightPanelStore,
 } from "./rightPanelStore";
@@ -275,6 +276,9 @@ describe("rightPanelStore", () => {
     useRightPanelStore.getState().open(refA, "plan");
     useRightPanelStore.getState().close(refA);
     expect(selectActiveRightPanel(useRightPanelStore.getState().byThreadKey, refA)).toBeNull();
+    expect(
+      selectSelectedRightPanelSurface(useRightPanelStore.getState().byThreadKey, refA),
+    ).toEqual({ id: "plan", kind: "plan" });
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
       isOpen: false,
       activeSurfaceId: "plan",

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import {
   migratePersistedRightPanelState,
+  pullRequestSurfaceId,
   selectActiveRightPanel,
   selectActiveRightPanelSurface,
   selectThreadRightPanelState,
@@ -95,6 +96,49 @@ describe("rightPanelStore", () => {
               relativePath: "src/index.ts",
               revealLine: null,
               revealRequestId: 0,
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("upgrades the legacy singleton pull request surface to a reference-keyed tab", () => {
+    const id = pullRequestSurfaceId({
+      projectId: "project-a",
+      repository: "pingdotgg/t3code",
+      number: 4909,
+    });
+    expect(
+      migratePersistedRightPanelState({
+        byThreadKey: {
+          "env-1:thread-A": {
+            isOpen: true,
+            activeSurfaceId: "pull-request",
+            surfaces: [
+              {
+                id: "pull-request",
+                kind: "pull-request",
+                projectId: "project-a",
+                repository: "pingdotgg/t3code",
+                number: 4909,
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      byThreadKey: {
+        "env-1:thread-A": {
+          isOpen: true,
+          activeSurfaceId: id,
+          surfaces: [
+            {
+              id,
+              kind: "pull-request",
+              projectId: "project-a",
+              repository: "pingdotgg/t3code",
+              number: 4909,
             },
           ],
         },
@@ -290,6 +334,21 @@ describe("rightPanelStore", () => {
       kind: "preview",
       resourceId: "tab-b",
     });
+  });
+
+  it("tracks one surface per pull request", () => {
+    const first = { projectId: "project-a", repository: "pingdotgg/t3code", number: 4909 };
+    const second = { projectId: "project-a", repository: "pingdotgg/t3code", number: 4910 };
+    useRightPanelStore.getState().openPullRequest(refA, first);
+    useRightPanelStore.getState().openPullRequest(refA, second);
+    useRightPanelStore.getState().openPullRequest(refA, first);
+
+    const state = selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA);
+    expect(state.surfaces.map((surface) => surface.id)).toEqual([
+      pullRequestSurfaceId(first),
+      pullRequestSurfaceId(second),
+    ]);
+    expect(state.activeSurfaceId).toBe(pullRequestSurfaceId(first));
   });
 
   it("tracks one surface per terminal session", () => {

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -630,5 +630,14 @@ export function selectActiveRightPanelSurface(
 ): RightPanelSurface | null {
   const state = selectThreadRightPanelState(byThreadKey, ref);
   if (!state.isOpen) return null;
+  return selectSelectedRightPanelSurface(byThreadKey, ref);
+}
+
+/** The selected surface even while the panel is hidden, so a layout control can restore it. */
+export function selectSelectedRightPanelSurface(
+  byThreadKey: Record<string, ThreadRightPanelState>,
+  ref: ScopedThreadRef | null | undefined,
+): RightPanelSurface | null {
+  const state = selectThreadRightPanelState(byThreadKey, ref);
   return state.surfaces.find((surface) => surface.id === state.activeSurfaceId) ?? null;
 }

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -47,10 +47,10 @@ export type RightPanelSurface =
     }
   | {
       /**
-       * The thread's own change request, opened beside it rather than on the page, the way the
-       * browser opens beside it. One per thread, so its id carries no reference.
+       * A change request opened beside a thread or in the pull-request list's shared panel.
+       * The reference lives in the id so several pull requests can remain open as peer tabs.
        */
-      id: "pull-request";
+      id: `pull-request:${string}`;
       kind: "pull-request";
       projectId: string;
       repository: string;
@@ -59,7 +59,7 @@ export type RightPanelSurface =
   | { id: "plan"; kind: "plan" };
 
 const RIGHT_PANEL_STORAGE_KEY = "t3code:right-panel-state:v2";
-const RIGHT_PANEL_STORAGE_VERSION = 8;
+const RIGHT_PANEL_STORAGE_VERSION = 9;
 
 export interface ThreadRightPanelState {
   isOpen: boolean;
@@ -149,6 +149,30 @@ const terminalSurface = (terminalId: string): RightPanelSurface => ({
   activeTerminalId: terminalId,
 });
 
+export type PullRequestSurface = Extract<RightPanelSurface, { kind: "pull-request" }>;
+
+export function pullRequestSurfaceId(target: {
+  projectId: string;
+  repository: string;
+  number: number;
+}): PullRequestSurface["id"] {
+  return `pull-request:${encodeURIComponent(target.projectId)}:${encodeURIComponent(target.repository)}:${target.number}`;
+}
+
+export function pullRequestSurface(target: {
+  projectId: string;
+  repository: string;
+  number: number;
+}): PullRequestSurface {
+  return {
+    id: pullRequestSurfaceId(target),
+    kind: "pull-request",
+    projectId: target.projectId,
+    repository: target.repository,
+    number: target.number,
+  };
+}
+
 const upsertSurface = (
   current: ThreadRightPanelState,
   surface: RightPanelSurface,
@@ -213,6 +237,18 @@ export function migratePersistedRightPanelState(persistedState: unknown): {
                           : 0;
                       return [{ ...surface, revealLine, revealRequestId }];
                     }
+                    if (surface.kind === "pull-request") {
+                      if (
+                        typeof surface.projectId !== "string" ||
+                        typeof surface.repository !== "string" ||
+                        typeof surface.number !== "number" ||
+                        !Number.isSafeInteger(surface.number) ||
+                        surface.number < 1
+                      ) {
+                        return [];
+                      }
+                      return [pullRequestSurface(surface)];
+                    }
                     if (surface.kind !== "terminal") return [surface];
                     if (
                       !("resourceId" in surface) ||
@@ -247,11 +283,14 @@ export function migratePersistedRightPanelState(persistedState: unknown): {
                     ];
                   })
                 : [];
+              const persistedActiveSurfaceId = validThreadState?.activeSurfaceId;
               const activeSurfaceId = surfaces.some(
-                (surface) => surface.id === validThreadState?.activeSurfaceId,
+                (surface) => surface.id === persistedActiveSurfaceId,
               )
-                ? (validThreadState?.activeSurfaceId ?? null)
-                : null;
+                ? (persistedActiveSurfaceId ?? null)
+                : persistedActiveSurfaceId === "pull-request"
+                  ? (surfaces.find((surface) => surface.kind === "pull-request")?.id ?? null)
+                  : null;
               const isOpen =
                 typeof validThreadState?.isOpen === "boolean"
                   ? validThreadState.isOpen
@@ -291,22 +330,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
       openPullRequest: (ref, target) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
-            const surface = {
-              id: "pull-request",
-              kind: "pull-request",
-              projectId: target.projectId,
-              repository: target.repository,
-              number: target.number,
-            } as const;
-            // Replaced rather than added to: a thread has one change request, and reopening it
-            // for a different one should not leave the old tab behind.
-            return {
-              isOpen: true,
-              activeSurfaceId: surface.id,
-              surfaces: current.surfaces.some((entry) => entry.id === surface.id)
-                ? current.surfaces.map((entry) => (entry.id === surface.id ? surface : entry))
-                : [...current.surfaces, surface],
-            };
+            return upsertSurface(current, pullRequestSurface(target));
           }),
         })),
       openFile: (ref, relativePath, line) =>

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1,4 +1,5 @@
-import { pullRequestHostOf } from "@t3tools/contracts";
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { pullRequestHostOf, ThreadId } from "@t3tools/contracts";
 import type {
   EnvironmentId,
   ProjectId,
@@ -21,7 +22,15 @@ import {
   RefreshCwIcon,
   SearchIcon,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState, type ElementType, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ElementType,
+  type ReactNode,
+} from "react";
 
 import {
   filterPullRequestsByInvolvement,
@@ -47,14 +56,20 @@ import {
 import { PullRequestListEmptyState } from "../components/pullRequest/PullRequestListEmptyState";
 import { PullRequestRow } from "../components/pullRequest/PullRequestRow";
 import { PullRequestsUnavailableState } from "../components/pullRequest/PullRequestsUnavailableState";
+import { RightPanelTabs, type PullRequestTabStatus } from "../components/RightPanelTabs";
 import { PanelLayoutControls } from "../components/chat/PanelLayoutControls";
-import { RightPanelResizeHandle } from "../components/preview/RightPanelResizeHandle";
 import { Button } from "../components/ui/button";
 import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "../components/ui/menu";
 import { SidebarInset } from "../components/ui/sidebar";
 import { Skeleton } from "../components/ui/skeleton";
 import { useLiveRefresh } from "../hooks/useLiveRefresh";
-import { useResizableWidth } from "../hooks/useResizableWidth";
+import {
+  pullRequestSurfaceId,
+  selectActiveRightPanelSurface,
+  selectThreadRightPanelState,
+  useRightPanelStore,
+  type PullRequestSurface,
+} from "../rightPanelStore";
 import { useDebouncedValue } from "../state/queries";
 import { useAllEnvironmentShellsBootstrapped, useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
@@ -109,10 +124,11 @@ const PAGE_SIZE = 99;
 const MAX_PAGE_SIZE = 500;
 /** Stable empty map so the memos below do not see a new object on every render. */
 const EMPTY_VIEWERS: PullRequestListResult["viewers"] = {};
-const DETAIL_WIDTH_STORAGE_KEY = "t3code:pull-requests-detail-width";
-const DETAIL_MIN_WIDTH = 420;
-const DETAIL_DEFAULT_WIDTH = 640;
-const DETAIL_MAX_WIDTH = 1100;
+/** The list owns one environment-scoped right panel rather than borrowing a real thread's. */
+const PULL_REQUESTS_PANEL_ID = ThreadId.make("pull-requests-panel");
+const EMPTY_PREVIEW_SESSIONS = {};
+const EMPTY_TERMINAL_LABELS = new Map<string, string>();
+const EMPTY_PENDING_SURFACES = new Set<string>();
 
 export const Route = createFileRoute("/_chat/pull-requests")({
   validateSearch: (raw: Record<string, unknown>): PullRequestsSearch => ({
@@ -165,13 +181,29 @@ function PullRequestsRouteView() {
     () => resolveProjectScope(search.projectId, projects),
     [projects, search.projectId],
   );
-  const detailPanel = useResizableWidth({
-    storageKey: DETAIL_WIDTH_STORAGE_KEY,
-    defaultWidth: DETAIL_DEFAULT_WIDTH,
-    minWidth: DETAIL_MIN_WIDTH,
-    maxWidth: DETAIL_MAX_WIDTH,
-    edge: "left",
-  });
+  const rightPanelRef = useMemo(
+    () => (environmentId === null ? null : scopeThreadRef(environmentId, PULL_REQUESTS_PANEL_ID)),
+    [environmentId],
+  );
+  const rightPanelState = useRightPanelStore((state) =>
+    selectThreadRightPanelState(state.byThreadKey, rightPanelRef),
+  );
+  const activeRightPanelSurface = useRightPanelStore((state) =>
+    selectActiveRightPanelSurface(state.byThreadKey, rightPanelRef),
+  );
+  const activePullRequestSurface =
+    activeRightPanelSurface?.kind === "pull-request" ? activeRightPanelSurface : null;
+  const [pullRequestTabStatuses, setPullRequestTabStatuses] = useState<
+    Record<string, PullRequestTabStatus>
+  >({});
+  const handlePullRequestTabStatusChange = useCallback((status: PullRequestTabStatus) => {
+    const id = pullRequestSurfaceId(status);
+    setPullRequestTabStatuses((current) =>
+      current[id]?.state === status.state && current[id]?.isDraft === status.isDraft
+        ? current
+        : { ...current, [id]: status },
+    );
+  }, []);
 
   const updateSearch = (patch: {
     [Key in keyof PullRequestsSearch]?: PullRequestsSearch[Key] | undefined;
@@ -201,6 +233,14 @@ function PullRequestsRouteView() {
     repository: undefined,
     number: undefined,
     selectedProjectId: undefined,
+  };
+  const updateListScope = (patch: {
+    [Key in keyof PullRequestsSearch]?: PullRequestsSearch[Key] | undefined;
+  }) => {
+    if (rightPanelRef !== null) {
+      useRightPanelStore.getState().closeAllSurfaces(rightPanelRef);
+    }
+    updateSearch({ ...patch, ...clearedSelection });
   };
 
   // Searching asks the hosts, which takes a round trip, so the text is held for a moment before
@@ -515,9 +555,6 @@ function PullRequestsRouteView() {
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-    // `loadMore` closes over the page state it advances, which the rest of the list already
-    // depends on.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     entries.length,
     filterKey,
@@ -598,25 +635,48 @@ function PullRequestsRouteView() {
     [projects, search.selectedProjectId],
   );
   const selectedProjectId = linkedProjectId ?? projectIdForRepository;
+  const linkedSelection = useMemo(
+    () =>
+      search.repository && search.number && selectedProjectId
+        ? { repository: search.repository, number: search.number, projectId: selectedProjectId }
+        : null,
+    [search.number, search.repository, selectedProjectId],
+  );
+  useEffect(() => {
+    if (rightPanelRef === null || linkedSelection === null) return;
+    useRightPanelStore.getState().openPullRequest(rightPanelRef, linkedSelection);
+  }, [linkedSelection, rightPanelRef]);
+
   const selected =
-    search.repository && search.number && selectedProjectId
-      ? { repository: search.repository, number: search.number, projectId: selectedProjectId }
+    rightPanelState.isOpen && activePullRequestSurface !== null
+      ? {
+          repository: activePullRequestSurface.repository,
+          number: activePullRequestSurface.number,
+          projectId: activePullRequestSurface.projectId as ProjectId,
+        }
       : null;
-  const lastSelected = useRef<typeof selected>(null);
-  if (selected !== null) lastSelected.current = selected;
+
+  const selectSurfaceInUrl = (surface: PullRequestSurface | null) =>
+    updateSearch(
+      surface === null
+        ? clearedSelection
+        : {
+            repository: surface.repository,
+            number: surface.number,
+            selectedProjectId: surface.projectId as ProjectId,
+          },
+    );
 
   const toggleRightPanel = () => {
-    if (selected !== null) {
+    if (rightPanelRef === null) return;
+    if (rightPanelState.isOpen) {
+      useRightPanelStore.getState().close(rightPanelRef);
       updateSearch(clearedSelection);
       return;
     }
-    const previous = lastSelected.current;
-    if (previous === null) return;
-    updateSearch({
-      repository: previous.repository,
-      number: previous.number,
-      selectedProjectId: previous.projectId,
-    });
+    if (activePullRequestSurface === null) return;
+    useRightPanelStore.getState().show(rightPanelRef);
+    selectSurfaceInUrl(activePullRequestSurface);
   };
 
   // The provider list is the workspace's hosts, not the filtered ones, so switching to a host
@@ -653,19 +713,22 @@ function PullRequestsRouteView() {
     [listErrors],
   );
 
-  const selectEntry = (entry: PullRequestListEntry) =>
+  const selectEntry = (entry: PullRequestListEntry) => {
+    if (rightPanelRef === null) return;
+    useRightPanelStore.getState().openPullRequest(rightPanelRef, entry);
     updateSearch({
       repository: entry.repository,
       number: entry.number,
       selectedProjectId: entry.projectId,
     });
+  };
 
   const involvementPills = (
     <PullRequestFilterPills
       label="Filter by involvement"
       value={search.involvement}
       options={INVOLVEMENT_TABS}
-      onChange={(involvement) => updateSearch({ involvement, ...clearedSelection })}
+      onChange={(involvement) => updateListScope({ involvement })}
     />
   );
   const statePills = (
@@ -673,7 +736,7 @@ function PullRequestsRouteView() {
       label="Filter by state"
       value={search.state}
       options={STATE_TABS}
-      onChange={(state) => updateSearch({ state, ...clearedSelection })}
+      onChange={(state) => updateListScope({ state })}
     />
   );
   const providerFilter = (
@@ -681,7 +744,7 @@ function PullRequestsRouteView() {
       providers={hosts}
       value={search.host}
       expectedHosts={expectedHosts}
-      onChange={(host) => updateSearch({ host, ...clearedSelection })}
+      onChange={(host) => updateListScope({ host })}
     />
   );
   const searchInput = (
@@ -696,7 +759,7 @@ function PullRequestsRouteView() {
       projects={scopedProjects}
       value={scopedProjectId}
       unavailable={unavailableProjects}
-      onChange={(projectId) => updateSearch({ ...clearedSelection, projectId })}
+      onChange={(projectId) => updateListScope({ projectId })}
     />
   );
   const rightPanelControl = (
@@ -705,8 +768,8 @@ function PullRequestsRouteView() {
       terminalAvailable={false}
       terminalOpen={false}
       terminalShortcutLabel={null}
-      rightPanelAvailable={selected !== null || lastSelected.current !== null}
-      rightPanelOpen={selected !== null}
+      rightPanelAvailable={rightPanelState.surfaces.length > 0}
+      rightPanelOpen={rightPanelState.isOpen}
       rightPanelShortcutLabel={null}
       onToggleTerminal={() => undefined}
       onToggleRightPanel={toggleRightPanel}
@@ -836,10 +899,9 @@ function PullRequestsRouteView() {
     state: search.state,
     host: search.host,
     hostMenuOptions,
-    onInvolvement: (involvement: PullRequestInvolvement) =>
-      updateSearch({ involvement, ...clearedSelection }),
-    onState: (state: PullRequestListState) => updateSearch({ state, ...clearedSelection }),
-    onHost: (host: string | undefined) => updateSearch({ host, ...clearedSelection }),
+    onInvolvement: (involvement: PullRequestInvolvement) => updateListScope({ involvement }),
+    onState: (state: PullRequestListState) => updateListScope({ state }),
+    onHost: (host: string | undefined) => updateListScope({ host }),
     involvementPills,
     statePills,
     providerFilter,
@@ -849,21 +911,87 @@ function PullRequestsRouteView() {
     listBody,
   };
 
+  const activateSurface = (surface: PullRequestSurface) => {
+    if (rightPanelRef === null) return;
+    useRightPanelStore.getState().activateSurface(rightPanelRef, surface.id);
+    selectSurfaceInUrl(surface);
+  };
+  const closeSurface = (surface: PullRequestSurface) => {
+    if (rightPanelRef === null) return;
+    useRightPanelStore.getState().closeSurface(rightPanelRef, surface.id);
+    const next = selectActiveRightPanelSurface(
+      useRightPanelStore.getState().byThreadKey,
+      rightPanelRef,
+    );
+    selectSurfaceInUrl(next?.kind === "pull-request" ? next : null);
+  };
+  const closeOtherSurfaces = (surface: PullRequestSurface) => {
+    if (rightPanelRef === null) return;
+    useRightPanelStore.getState().closeOtherSurfaces(rightPanelRef, surface.id);
+    selectSurfaceInUrl(surface);
+  };
+  const closeSurfacesToRight = (surface: PullRequestSurface) => {
+    if (rightPanelRef === null) return;
+    useRightPanelStore.getState().closeSurfacesToRight(rightPanelRef, surface.id);
+    const next = selectActiveRightPanelSurface(
+      useRightPanelStore.getState().byThreadKey,
+      rightPanelRef,
+    );
+    selectSurfaceInUrl(next?.kind === "pull-request" ? next : null);
+  };
+  const closeAllSurfaces = () => {
+    if (rightPanelRef === null) return;
+    useRightPanelStore.getState().closeAllSurfaces(rightPanelRef);
+    selectSurfaceInUrl(null);
+  };
+
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden bg-background text-foreground">
       <div className="flex min-h-0 flex-1">
         <PullRequestsColumn {...columnProps} />
 
-        {selected && environmentId !== null ? (
-          <aside
-            className="relative flex shrink-0 border-l border-border"
-            style={{ width: `${detailPanel.width}px` }}
+        {rightPanelState.isOpen && activePullRequestSurface && environmentId !== null ? (
+          <RightPanelTabs
+            mode="inline"
+            surfaces={rightPanelState.surfaces}
+            activeSurfaceId={activePullRequestSurface.id}
+            pendingSurfaceIds={EMPTY_PENDING_SURFACES}
+            previewSessions={EMPTY_PREVIEW_SESSIONS}
+            terminalLabelsById={EMPTY_TERMINAL_LABELS}
+            onActivate={(surface) => {
+              if (surface.kind === "pull-request") activateSurface(surface);
+            }}
+            onCloseSurface={(surface) => {
+              if (surface.kind === "pull-request") closeSurface(surface);
+            }}
+            onCloseOtherSurfaces={(surface) => {
+              if (surface.kind === "pull-request") closeOtherSurfaces(surface);
+            }}
+            onCloseSurfacesToRight={(surface) => {
+              if (surface.kind === "pull-request") closeSurfacesToRight(surface);
+            }}
+            onCloseAllSurfaces={closeAllSurfaces}
+            onCopyFilePath={() => undefined}
+            onAddBrowser={() => undefined}
+            onAddTerminal={() => undefined}
+            onAddDiff={() => undefined}
+            onAddFiles={() => undefined}
+            onAddPullRequest={() => undefined}
+            browserAvailable={false}
+            terminalAvailable={false}
+            diffAvailable={false}
+            filesAvailable={false}
+            pullRequestAvailable={false}
+            pullRequestStatuses={pullRequestTabStatuses}
           >
-            <RightPanelResizeHandle handlers={detailPanel.handlers} />
             <PullRequestDetailPanel
-              key={`${selected.repository}#${selected.number}`}
+              key={activePullRequestSurface.id}
               environmentId={environmentId}
-              reference={selected}
+              reference={{
+                projectId: activePullRequestSurface.projectId as ProjectId,
+                repository: activePullRequestSurface.repository,
+                number: activePullRequestSurface.number,
+              }}
               refreshToken={detailRefreshToken}
               // Merging, closing or reopening changes the row this panel was opened from, so the
               // list behind it is out of date the moment the host takes the action.
@@ -871,9 +999,9 @@ function PullRequestsRouteView() {
                 listQuery.refresh();
                 baselineQuery.refresh();
               }}
-              onClose={() => updateSearch(clearedSelection)}
+              onStateChange={handlePullRequestTabStatusChange}
             />
-          </aside>
+          </RightPanelTabs>
         ) : null}
       </div>
     </SidebarInset>

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -66,6 +66,7 @@ import { useLiveRefresh } from "../hooks/useLiveRefresh";
 import {
   pullRequestSurfaceId,
   selectActiveRightPanelSurface,
+  selectSelectedRightPanelSurface,
   selectThreadRightPanelState,
   useRightPanelStore,
   type PullRequestSurface,
@@ -188,11 +189,12 @@ function PullRequestsRouteView() {
   const rightPanelState = useRightPanelStore((state) =>
     selectThreadRightPanelState(state.byThreadKey, rightPanelRef),
   );
-  const activeRightPanelSurface = useRightPanelStore((state) =>
-    selectActiveRightPanelSurface(state.byThreadKey, rightPanelRef),
+  const selectedRightPanelSurface = useRightPanelStore((state) =>
+    selectSelectedRightPanelSurface(state.byThreadKey, rightPanelRef),
   );
-  const activePullRequestSurface =
-    activeRightPanelSurface?.kind === "pull-request" ? activeRightPanelSurface : null;
+  const selectedPullRequestSurface =
+    selectedRightPanelSurface?.kind === "pull-request" ? selectedRightPanelSurface : null;
+  const activePullRequestSurface = rightPanelState.isOpen ? selectedPullRequestSurface : null;
   const [pullRequestTabStatuses, setPullRequestTabStatuses] = useState<
     Record<string, PullRequestTabStatus>
   >({});
@@ -674,9 +676,9 @@ function PullRequestsRouteView() {
       updateSearch(clearedSelection);
       return;
     }
-    if (activePullRequestSurface === null) return;
+    if (selectedPullRequestSurface === null) return;
     useRightPanelStore.getState().show(rightPanelRef);
-    selectSurfaceInUrl(activePullRequestSurface);
+    selectSurfaceInUrl(selectedPullRequestSurface);
   };
 
   // The provider list is the workspace's hosts, not the filtered ones, so switching to a host

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -764,7 +764,7 @@ function PullRequestsRouteView() {
       onChange={(projectId) => updateListScope({ projectId })}
     />
   );
-  const rightPanelControl = (
+  const panelToggleControls = (
     <PanelLayoutControls
       showTerminalControl={false}
       terminalAvailable={false}
@@ -776,6 +776,11 @@ function PullRequestsRouteView() {
       onToggleTerminal={() => undefined}
       onToggleRightPanel={toggleRightPanel}
     />
+  );
+  const openPanelControls = (
+    <div className="workspace-titlebar-controls right-2 z-50 gap-1 [-webkit-app-region:no-drag] wco:right-[var(--workspace-controls-right)]">
+      {panelToggleControls}
+    </div>
   );
   // The rows carried over from the last filters can also narrow to nothing one step further on,
   // where involvement is applied against the viewers of the answer they came from. "Nothing under
@@ -909,7 +914,7 @@ function PullRequestsRouteView() {
     providerFilter,
     searchInput,
     projectFilter,
-    rightPanelControl,
+    rightPanelControl: rightPanelState.isOpen ? null : panelToggleControls,
     listBody,
   };
 
@@ -949,7 +954,8 @@ function PullRequestsRouteView() {
 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden bg-background text-foreground">
-      <div className="flex min-h-0 flex-1">
+      <div className="relative flex min-h-0 flex-1">
+        {rightPanelState.isOpen ? openPanelControls : null}
         <PullRequestsColumn {...columnProps} />
 
         {rightPanelState.isOpen && activePullRequestSurface && environmentId !== null ? (

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -240,7 +240,8 @@ function PullRequestsRouteView() {
     [Key in keyof PullRequestsSearch]?: PullRequestsSearch[Key] | undefined;
   }) => {
     if (rightPanelRef !== null) {
-      useRightPanelStore.getState().closeAllSurfaces(rightPanelRef);
+      // Hide the old selection while retaining peer PR tabs for parallel reviews.
+      useRightPanelStore.getState().close(rightPanelRef);
     }
     updateSearch({ ...patch, ...clearedSelection });
   };

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -47,6 +47,7 @@ import {
 import { PullRequestListEmptyState } from "../components/pullRequest/PullRequestListEmptyState";
 import { PullRequestRow } from "../components/pullRequest/PullRequestRow";
 import { PullRequestsUnavailableState } from "../components/pullRequest/PullRequestsUnavailableState";
+import { PanelLayoutControls } from "../components/chat/PanelLayoutControls";
 import { RightPanelResizeHandle } from "../components/preview/RightPanelResizeHandle";
 import { Button } from "../components/ui/button";
 import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "../components/ui/menu";
@@ -601,6 +602,22 @@ function PullRequestsRouteView() {
     search.repository && search.number && selectedProjectId
       ? { repository: search.repository, number: search.number, projectId: selectedProjectId }
       : null;
+  const lastSelected = useRef<typeof selected>(null);
+  if (selected !== null) lastSelected.current = selected;
+
+  const toggleRightPanel = () => {
+    if (selected !== null) {
+      updateSearch(clearedSelection);
+      return;
+    }
+    const previous = lastSelected.current;
+    if (previous === null) return;
+    updateSearch({
+      repository: previous.repository,
+      number: previous.number,
+      selectedProjectId: previous.projectId,
+    });
+  };
 
   // The provider list is the workspace's hosts, not the filtered ones, so switching to a host
   // cannot make the switcher that got you there disappear.
@@ -680,6 +697,19 @@ function PullRequestsRouteView() {
       value={scopedProjectId}
       unavailable={unavailableProjects}
       onChange={(projectId) => updateSearch({ ...clearedSelection, projectId })}
+    />
+  );
+  const rightPanelControl = (
+    <PanelLayoutControls
+      showTerminalControl={false}
+      terminalAvailable={false}
+      terminalOpen={false}
+      terminalShortcutLabel={null}
+      rightPanelAvailable={selected !== null || lastSelected.current !== null}
+      rightPanelOpen={selected !== null}
+      rightPanelShortcutLabel={null}
+      onToggleTerminal={() => undefined}
+      onToggleRightPanel={toggleRightPanel}
     />
   );
   // The rows carried over from the last filters can also narrow to nothing one step further on,
@@ -815,6 +845,7 @@ function PullRequestsRouteView() {
     providerFilter,
     searchInput,
     projectFilter,
+    rightPanelControl,
     listBody,
   };
 
@@ -996,6 +1027,7 @@ function PullRequestsColumn({
   providerFilter,
   searchInput,
   projectFilter,
+  rightPanelControl,
   listBody,
 }: {
   refreshing: boolean;
@@ -1013,6 +1045,7 @@ function PullRequestsColumn({
   providerFilter: ReactNode;
   searchInput: ReactNode;
   projectFilter: ReactNode;
+  rightPanelControl: ReactNode;
   listBody: ReactNode;
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -1129,6 +1162,7 @@ function PullRequestsColumn({
         >
           <RefreshCwIcon className={cn("size-4", refreshing && "animate-spin")} />
         </Button>
+        {rightPanelControl}
       </header>
 
       <div

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -38,6 +38,7 @@ T3 Code works with the platforms your team already uses:
 **Stay on top of open reviews**
 
 - See if your current branch already has an open PR/MR
+- Open several reviews from the **Pull requests** page as tabs in the right panel
 - While working in a thread, open linked reviews in the same compact right-panel tabs without
   leaving the conversation
 - Open the review directly in your browser with one click

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -38,6 +38,8 @@ T3 Code works with the platforms your team already uses:
 **Stay on top of open reviews**
 
 - See if your current branch already has an open PR/MR
+- While working in a thread, open linked reviews in the same compact right-panel tabs without
+  leaving the conversation
 - Open the review directly in your browser with one click
 - Check out a teammate's branch to review code locally
 

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -48,6 +48,25 @@ export function createPullRequestEnvironmentAtoms<R, E>(
       tag: WS_METHODS.pullRequestsDiff,
       staleTimeMs: 60_000,
     }),
+    diffFileContents: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:pull-requests:diff-file-contents",
+      tag: WS_METHODS.pullRequestsDiffFileContents,
+      scheduler: commandScheduler,
+      concurrency: {
+        mode: "singleFlight",
+        key: ({ environmentId, input }) =>
+          JSON.stringify([
+            environmentId,
+            input.projectId,
+            input.repository,
+            input.number,
+            input.commit ?? null,
+            input.changeType,
+            input.oldPath,
+            input.newPath,
+          ]),
+      },
+    }),
     runAction: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:run-action",
       tag: WS_METHODS.pullRequestsRunAction,

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -541,6 +541,23 @@ export const PullRequestDiffResult = Schema.Struct({
 });
 export type PullRequestDiffResult = typeof PullRequestDiffResult.Type;
 
+/** The complete old and new files Pierre needs to open omitted context in a host-backed patch. */
+export const PullRequestDiffFileContentsInput = Schema.Struct({
+  ...PullRequestRef.fields,
+  /** One commit's own comparison; absent means the whole change request. */
+  commit: Schema.optional(TrimmedNonEmptyString),
+  changeType: Schema.Literals(["change", "rename-pure", "rename-changed", "new", "deleted"]),
+  oldPath: TrimmedNonEmptyString,
+  newPath: TrimmedNonEmptyString,
+});
+export type PullRequestDiffFileContentsInput = typeof PullRequestDiffFileContentsInput.Type;
+
+export const PullRequestDiffFileContentsResult = Schema.Struct({
+  oldContents: Schema.String,
+  newContents: Schema.String,
+});
+export type PullRequestDiffFileContentsResult = typeof PullRequestDiffFileContentsResult.Type;
+
 export const PullRequestActionInput = Schema.Struct({
   ...PullRequestRef.fields,
   action: PullRequestAction,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -70,6 +70,8 @@ import {
   PullRequestActionInput,
   PullRequestCommentInput,
   PullRequestDetail,
+  PullRequestDiffFileContentsInput,
+  PullRequestDiffFileContentsResult,
   PullRequestDiffInput,
   PullRequestInvalidateInput,
   PullRequestDiffResult,
@@ -273,6 +275,7 @@ export const WS_METHODS = {
   pullRequestsListStats: "pullRequests.listStats",
   pullRequestsDetail: "pullRequests.detail",
   pullRequestsDiff: "pullRequests.diff",
+  pullRequestsDiffFileContents: "pullRequests.diffFileContents",
   pullRequestsRunAction: "pullRequests.runAction",
   pullRequestsComment: "pullRequests.comment",
   pullRequestsSubmitReview: "pullRequests.submitReview",
@@ -483,6 +486,15 @@ export const WsPullRequestsDiffRpc = Rpc.make(WS_METHODS.pullRequestsDiff, {
   success: PullRequestDiffResult,
   error: PullRequestRpcError,
 });
+
+export const WsPullRequestsDiffFileContentsRpc = Rpc.make(
+  WS_METHODS.pullRequestsDiffFileContents,
+  {
+    payload: PullRequestDiffFileContentsInput,
+    success: PullRequestDiffFileContentsResult,
+    error: PullRequestRpcError,
+  },
+);
 
 export const WsPullRequestsRunActionRpc = Rpc.make(WS_METHODS.pullRequestsRunAction, {
   payload: PullRequestActionInput,
@@ -947,6 +959,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsPullRequestsListStatsRpc,
   WsPullRequestsDetailRpc,
   WsPullRequestsDiffRpc,
+  WsPullRequestsDiffFileContentsRpc,
   WsPullRequestsRunActionRpc,
   WsPullRequestsCommentRpc,
   WsPullRequestsSubmitReviewRpc,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -109,6 +109,12 @@ export default defineConfig({
               message:
                 "Import from an explicit @t3tools/client-runtime/* subpath. The package has no root export.",
             },
+            {
+              name: "@pierre/diffs/react",
+              importNames: ["CodeView"],
+              message:
+                "Use StyledDiffCodeView so web diff surfaces share styling and virtualized geometry.",
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Dependency

This is an upstream stacked follow-up to #4849. It is based directly on #4849's current head (`08225ba0`) and is not intended to replace that PR.

The temporary upstream base branch `stack/pr-4849-base` points exactly at that commit so this PR's commit list and Files changed view contain only this follow-up:

- `92f8ba5e1 refactor(web): share diff rendering foundations`
- `8b10e5bf0 feat(pull-requests): expand omitted diff context`
- `9393ecc32 feat(web): keep pull requests open as panel tabs`

This PR should merge only after #4849. Once #4849 lands, retarget this PR to `main` and delete the temporary base branch.

## Why

The in-app review flow in #4849 had three connected gaps:

1. Host patches contain only changed hunks. Expanding omitted lines therefore could not work reliably, especially when the local checkout did not have the pull request's exact remote revisions.
2. Diff styling, virtualized geometry, and inline comment composition had drifted across the thread diff, file preview, and pull request review surfaces.
3. A thread treated its pull request panel as a singleton, so opening another review replaced the first instead of preserving both as tabs. The compact panel chrome also did not reflect refreshed pull request state.

## What changed

### Shared diff foundations

- Added `StyledDiffCodeView`, the single web adapter around Pierre's `CodeView`. It keeps app styling and virtualized row measurements together so visual changes cannot silently desynchronize scrolling geometry.
- Replaced the file-only `LocalCommentAnnotation` and pull-request-only composer with `DiffCommentAnnotation`, shared by file previews, thread diffs, and pull request diffs.
- Extracted normalized full-file loaders with comparison-scoped cache keys for local Git comparisons and host-backed pull request comparisons.
- Added a lint restriction that directs new `CodeView` usage through the shared adapter.

### Expand omitted pull request context

- Added the typed `pullRequests.diffFileContents` RPC through contracts, authorization, WebSocket dispatch, client-runtime state, the pull request service, and provider adapters.
- GitHub resolves either the pull request base/head pair or a selected commit's parent/head pair, then reads both revisions through the raw contents API.
- GitLab performs the equivalent lookup with merge-request diff refs or commit parent refs and the repository files API.
- New, deleted, changed, and renamed files are handled explicitly. Invalid commit SHAs, binary files, unsupported hosts, and files above the 1 MB expansion limit produce bounded errors.
- The pull request Code tab supplies Pierre with full-file contents, so readers can reveal omitted context without checking out or fetching the review branch locally. Commit-scoped diffs retain a separate comparison identity.

### Keep reviews in compact panel tabs

- Pull request surfaces are keyed by project, repository, and number instead of one singleton ID. Existing persisted singleton state migrates to the new shape.
- Multiple reviews can coexist as peer tabs beside a thread, and refreshed open/draft/closed/merged state colors the corresponding tab icon.
- Empty-panel actions correctly disable Terminal when there is no project thread, and the pull request page can collapse and restore its detail panel with the standard layout control.
- The detail header now centers repository, pull request number, title, author, branches, changed-file count, and additions/deletions. The head branch can be copied directly, conflicts have a dedicated actionable row, and secondary agent handoffs live in the overflow menu.
- Reviewer display is condensed into accessible avatar stacks, while duplicate title, branch, and state metadata is removed from the Summary tab.
- User documentation calls out opening linked reviews in compact right-panel tabs without leaving the conversation.

## Impact and scope

- GitHub and GitLab reviews can reveal unchanged context directly in the in-app diff.
- File previews, thread diffs, and pull request diffs share the same comment interaction and rendering geometry.
- Readers can retain several pull request reviews beside a thread rather than losing the previous one when another opens.
- Providers without a diff-file API keep their existing behavior; the capability remains optional at the adapter boundary.
- The UI changes apply to web and the desktop surface that wraps it. No separate mobile UI behavior is introduced.

## Validation

```text
vp test run \
  apps/web/src/components/diffs/DiffCommentAnnotation.test.tsx \
  apps/web/src/components/diffs/StyledDiffCodeView.test.tsx \
  apps/web/src/lib/diffFileContents.test.ts \
  apps/web/src/rightPanelStore.test.ts \
  apps/web/src/components/diffs/AnnotatableCodeView.test.tsx \
  apps/web/src/components/pullRequest/pullRequestDiff.logic.test.ts
```

6 test files passed, 47 tests passed.

Built with GPT-5.6 Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-provider PR listing cursors, new host API paths for file contents, and persisted right-panel state migration; mistakes could skip or duplicate list rows or mis-handle auth/binary files.
> 
> **Overview**
> Extends in-app pull request review so readers can **expand omitted diff context** without a local checkout, **keep several PRs open as right-panel tabs**, and see **consistent diff rendering and inline comments** across thread diffs, file previews, and PR reviews.
> 
> **Diff file expansion:** New `pullRequests.diffFileContents` RPC (auth, WS, service, client atoms) fetches full old/new file text at the revisions used for the patch on **GitHub** and **GitLab** (1 MB cap, binary/oversized errors, root commits for new files). Providers wire through `getDiffFileContents`; the PR Code tab uses shared loaders like the thread `DiffPanel`.
> 
> **Shared web diff layer:** `StyledDiffCodeView` centralizes Pierre `CodeView` styling and virtualized geometry; `DiffCommentAnnotation` replaces the file-only composer. `DiffPanel` drops inline CSS in favor of the shared adapter and `createGitDiffFileContentsLoader`.
> 
> **Panel tabs:** PR surfaces are keyed by project/repository/number; tab icons reflect open/draft/closed/merged state from the detail panel. Terminal is disabled in the empty state when there is no project thread.
> 
> **Provider pagination and robustness:** Azure DevOps and GitLab list APIs return **`cursorAdvance`** (including malformed raw rows) and keep fetching until pages fill; GitLab continuation uses **offset** instead of `updated_before`. GitHub’s search-free fallback applies **local state/involvement filters**, grows scan up to 1k rows, and tracks **team review requests**. Bitbucket **paginates** diffstat, commits, and checks; **401-only** maps to unauthenticated. Process output gains **`stdoutInvalidUtf8` / `stderrInvalidUtf8`** via `decodeUtf8` for safer blob reads.
> 
> **Permissions fix:** When review-thread GraphQL fails, GitHub no longer assumes the viewer authored the PR (`didAuthor: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5136041ef56fca81b11586752b1759be7b24740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tabbed right panel for pull request reviews with full diff file contents expansion
> - The pull requests route replaces its single resizable detail pane with a right panel that supports multiple simultaneous PR tabs; each tab is keyed by PR identity and shows status-aware icons (open/draft/closed/merged).
> - A new `pullRequests.diffFileContents` RPC fetches full old/new file contents for diff entries, backed by provider-specific implementations for GitHub, GitLab, and Bitbucket; binary and oversized files (>1 MB) are rejected with structured errors.
> - `listMergeRequests` and `listPullRequests` pagination switches to stable offset-based cursoring using a `cursorAdvance` field that counts raw rows consumed including malformed ones.
> - Bitbucket commits, checks, and diffstat aggregation now follow `next` pagination links to retrieve complete multi-page results.
> - `DiffCommentAnnotation` replaces `LocalCommentAnnotation`/`ReviewCommentComposer` across diff surfaces, gaining configurable labels, an optional secondary action (AI Ask), and a pending guard; a shared `StyledDiffCodeView` wrapper centralizes diff viewer styling.
> - `PullRequestReviewBar` now snapshots comments at submit time and only removes those exact IDs afterward, preventing accidental loss of new drafts added during submission.
> - Risk: `RIGHT_PANEL_STORAGE_VERSION` bumps to 9, triggering migration of persisted right-panel state; legacy singleton pull-request surfaces are rebuilt with reference-keyed IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d513604.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->