### PR TITLE
fix(web): update tooltip no longer dismisses when scrolling release notes

### DIFF
--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -44,7 +44,7 @@ function SidebarUpdateReleaseNotesTooltip({
       <div className="px-1">
         <div className="text-sm leading-5 font-medium">{tooltip}</div>
       </div>
-      <div className="pointer-events-auto max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
+      <div className="max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
         {state.releaseNotes.map((releaseNote, index) => (
           <div key={releaseNote.version}>
             {index > 0 && <Separator className="my-3 bg-border/60" />}
@@ -203,7 +203,9 @@ export function SidebarUpdatePill() {
               align="start"
               className={
                 state?.channel === "nightly" && state.releaseNotes.length > 0
-                  ? "max-w-none text-balance"
+                  ? // pointer-events-auto overrides the positioner's pointer-events-none so the
+                    // release notes stay open (and scrollable) when the cursor moves into them.
+                    "pointer-events-auto max-w-none text-balance"
                   : undefined
               }
               side="top"


### PR DESCRIPTION
Hovering the sidebar "Update available" pill shows the nightly release notes in a scrollable tooltip, but moving the mouse up into it dismissed the tooltip, so you could never actually scroll the notes.

The tooltip positioner has `pointer-events-none`, and only the inner scroll div opted back in with `pointer-events-auto`. Base UI's safe-polygon hover logic only keeps a tooltip open when the cursor lands on the floating element itself, and with the popup body still `pointer-events-none`, cursor entry didn't register as landing on it, closing the tooltip. Moving `pointer-events-auto` to the popup makes the whole release-notes tooltip hoverable and scrollable; plain text tooltips are unchanged.

---

Written by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS/pointer-events tweak scoped to the nightly release-notes tooltip; no auth, data, or API changes.
> 
> **Overview**
> Fixes the sidebar **Update available** nightly release-notes tooltip closing as soon as the cursor moves into the scrollable list.
> 
> **`pointer-events-auto`** is applied on **`TooltipPopup`** (only when release notes are shown) instead of the inner scroll container, so the floating popup registers hover against Base UI’s safe-polygon logic while the positioner stays **`pointer-events-none`**. Plain text tooltips are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9635e4149e7f215e28952302c49ca7a951e16cc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix update tooltip dismissal when scrolling release notes in sidebar
> The tooltip for nightly release notes was dismissing when the user moved the cursor into the scrollable area. Adds `pointer-events-auto` to the `TooltipPopup` element in [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/5547/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf) and removes it from the inner scroll container, so pointer events are inherited correctly and the tooltip stays open during scroll.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9635e41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->