### PR TITLE
fix(server): let stopped threads settle immediately

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1430,6 +1430,13 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       assert.deepEqual(settledRows, [
         { state: "completed", completedAt: "2026-01-01T00:01:00.000Z" },
       ]);
+
+      const threadRows = yield* sql<{ readonly latestTurnId: string | null }>`
+        SELECT latest_turn_id AS "latestTurnId"
+        FROM projection_threads
+        WHERE thread_id = ${threadId}
+      `;
+      assert.deepEqual(threadRows, [{ latestTurnId: turnId }]);
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -850,7 +850,8 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           }
           yield* projectionThreadRepository.upsert({
             ...existingRow.value,
-            latestTurnId: event.payload.session.activeTurnId,
+            // activeTurnId describes current work; a terminal session must not erase history.
+            latestTurnId: event.payload.session.activeTurnId ?? existingRow.value.latestTurnId,
             updatedAt: event.occurredAt,
           });
           yield* refreshThreadShellSummary(event.payload.threadId);


### PR DESCRIPTION
Stopping or interrupting a thread could make Settle fail for two minutes. The SQLite projection cleared the latest turn when the session returned to ready, so clients misclassified the last user message as a queued turn.

Keep the previous latest turn when a session has no active turn. The lifecycle test now verifies that turn history remains linked after the session ends.

Tested:
- `vp test run apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts`
- `vp run --filter t3 typecheck`
- targeted format and lint checks

Made by GPT-5.6 Sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration projection semantics for all threads when sessions clear `activeTurnId`; low blast radius but affects settle and client turn classification.
> 
> **Overview**
> Fixes **Settle** timing out and clients treating the last user message as a queued turn when a thread is stopped or interrupted.
> 
> On **`thread.session-set`**, the threads projector no longer writes `latestTurnId` from `session.activeTurnId` when that value is null. It keeps the existing **`projection_threads.latest_turn_id`** so a terminal session (e.g. `ready` with no active turn) does not wipe turn history.
> 
> The turn lifecycle test now asserts **`latest_turn_id`** stays set after the session ends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6374e09990b2571210935f4fcca8acd7e1d4e98e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `latestTurnId` in projection when `session.activeTurnId` is null
> When handling a `thread.session-set` event, the projector in [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/5553/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4) previously overwrote `latestTurnId` with `null` if `session.activeTurnId` was absent. It now falls back to the existing `latestTurnId` value using null-coalescing. A corresponding test assertion was added to verify `projection_threads.latest_turn_id` is preserved correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6374e09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->