### PR TITLE
fix(server): stopping a Claude thread no longer shows an ede_diagnostic error

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1450,6 +1450,67 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("treats aborted_tools results as interrupted and hides ede_diagnostic errors", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 6).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      // Exact shape the CLI emits when Stop lands mid-tool-call: is_error
+      // is true and the only error is internal diagnostic telemetry.
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use"],
+        stop_reason: "tool_use",
+        terminal_reason: "aborted_tools",
+        session_id: "sdk-session-abort-tools",
+        uuid: "result-abort-tools",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.deepEqual(
+        runtimeEvents.map((event) => event.type),
+        [
+          "session.started",
+          "session.configured",
+          "session.state.changed",
+          "turn.started",
+          "thread.started",
+          "turn.completed",
+        ],
+      );
+
+      const turnCompleted = runtimeEvents[runtimeEvents.length - 1];
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(String(turnCompleted.turnId), String(turn.turnId));
+        assert.equal(turnCompleted.payload.state, "interrupted");
+        assert.equal(turnCompleted.payload.errorMessage, undefined);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("interruptTurn stops every live task before interrupting the turn", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -348,7 +348,29 @@ function resultErrorsText(result: SDKResultMessage): string {
     : "";
 }
 
+/**
+ * First user-facing error from a non-success result. "[ede_diagnostic] ..."
+ * entries are CLI-internal telemetry (the CLI hides them from its own UI too),
+ * so they must never become the error banner.
+ */
+function resultUserFacingError(result: SDKResultMessage): string | undefined {
+  if (result.subtype === "success" || !Array.isArray(result.errors)) {
+    return undefined;
+  }
+  return result.errors.find((error) => !error.startsWith("[ede_diagnostic]"));
+}
+
 function isInterruptedResult(result: SDKResultMessage): boolean {
+  // The CLI stamps user aborts explicitly: interrupting mid-tool-call yields
+  // "aborted_tools" (with an internal "[ede_diagnostic] ..." error and
+  // is_error: true), interrupting mid-stream yields "aborted_streaming".
+  if (
+    result.terminal_reason === "aborted_tools" ||
+    result.terminal_reason === "aborted_streaming"
+  ) {
+    return true;
+  }
+
   const errors = resultErrorsText(result);
   if (errors.includes("interrupt")) {
     return true;
@@ -2919,7 +2941,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     const status = turnStatusFromResult(message);
-    const errorMessage = message.subtype === "success" ? undefined : message.errors[0];
+    const errorMessage = resultUserFacingError(message);
 
     if (status === "failed") {
       yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");


### PR DESCRIPTION
## Problem

Stopping a thread running on Claude Code frequently surfaced a red error banner with internal telemetry:

`[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use`

## Cause

When Stop lands while Claude is mid-tool-call, the Claude Code CLI ends the turn with an `error_during_execution` result whose `is_error` is `true` and whose only `errors` entry is that internal diagnostic string (the CLI filters `[ede_diagnostic]` out of its own UI, but it still crosses the SDK wire). Reproduced against claude CLI 2.1.222 by interrupting a running Bash tool over stream-json: the result carries `terminal_reason: "aborted_tools"` and the ede_diagnostic error.

Our adapter's interrupt detection only matched abort/interrupt wording in the error text, so this shape was classified as a failed turn and the raw diagnostic became the thread's error banner.

## Fix

- Treat results with `terminal_reason` `aborted_tools` / `aborted_streaming` as interrupted — the CLI stamps user aborts explicitly, so this is more robust than string matching.
- Filter `[ede_diagnostic]` entries out of user-facing error messages, matching what the CLI's own UI does.

Added an adapter test with the exact result shape the CLI emits on stop-during-tool-call.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to Claude result parsing and error display on user-initiated stop; no auth, persistence, or security surface.
> 
> **Overview**
> Stopping a Claude thread while a tool is running no longer surfaces a red error banner with internal `[ede_diagnostic]` telemetry.
> 
> The Claude adapter now treats SDK results with `terminal_reason` **`aborted_tools`** or **`aborted_streaming`** as **interrupted** turns (matching how the CLI marks user aborts), instead of relying only on interrupt wording in error text. Turn completion uses **`resultUserFacingError`**, which skips `[ede_diagnostic]` entries when choosing the banner message—aligned with the CLI’s own UI. A test covers the stop-during-tool-call result shape (`is_error: true`, diagnostic-only `errors`, `terminal_reason: aborted_tools`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b692c4a0d9e7a0aa3c3024c7ff11dc0e292d102f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude thread stop to hide `[ede_diagnostic]` errors from turn completion
> - Adds `resultUserFacingError` helper in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/5557/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) that filters out errors prefixed with `[ede_diagnostic]` from the result message's errors array, returning the first non-diagnostic error or `undefined`.
> - Updates `handleResultMessage` to use this helper, so turns stopped via thread abort complete without surfacing internal diagnostic errors to users.
> - Updates `isInterruptedResult` to explicitly classify results with `terminal_reason` of `aborted_tools` or `aborted_streaming` as interrupted rather than failed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b692c4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->