### PR TITLE
fix(server): dedupe codex subagent item events

### DIFF
--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -34,6 +34,36 @@ const [CHILD_A, CHILD_B] = wireFixture.childThreadIds as [string, string];
  */
 function buildScript() {
   const captured = wireFixture.notifications;
+  // Re-address the capture's schema-valid tool lifecycle pair to child A.
+  // Hand-written item shapes can drift from the generated Codex schema.
+  const childToolLifecycle = captured
+    .filter(
+      (entry) =>
+        (entry.method === "item/started" || entry.method === "item/completed") &&
+        (entry.params as { item?: { type?: string } }).item?.type === "collabAgentToolCall",
+    )
+    .map((entry) => {
+      const params = entry.params as {
+        readonly threadId: string;
+        readonly turnId: string;
+        readonly item: Record<string, unknown>;
+      };
+      return {
+        ...entry,
+        params: {
+          ...params,
+          threadId: CHILD_A,
+          turnId: `${CHILD_A}-turn-1`,
+          item: {
+            ...params.item,
+            id: "call_fixture_child_tool",
+            senderThreadId: CHILD_A,
+          },
+        },
+      };
+    });
+  const childCompletionOnly = childToolLifecycle.find((entry) => entry.method === "item/completed");
+  assert.isDefined(childCompletionOnly);
   const extras = [
     {
       method: "item/completed",
@@ -46,6 +76,19 @@ function buildScript() {
           status: "completed",
           senderThreadId: ROOT,
           receiverThreadIds: [CHILD_A, CHILD_B],
+        },
+      },
+    },
+    // Codex emits started + completed for one child item. They are one
+    // logical activity and must not become two synthetic agent updates.
+    ...childToolLifecycle,
+    {
+      ...childCompletionOnly,
+      params: {
+        ...childCompletionOnly.params,
+        item: {
+          ...childCompletionOnly.params.item,
+          id: "call_fixture_child_completion_only",
         },
       },
     },
@@ -122,6 +165,29 @@ describe("CodexSessionRuntime collab integration", () => {
           (event.payload as { agentThreadId?: string }).agentThreadId === CHILD_B,
       );
       assert.isDefined(childClosed, "child B's close becomes an agent event");
+
+      const childToolItems = events.filter(
+        (event) =>
+          event.method === "collabAgent/item" &&
+          (event.payload as { item?: { id?: string } }).item?.id === "call_fixture_child_tool",
+      );
+      assert.lengthOf(childToolItems, 1, "one child item must emit one agent activity");
+      assert.equal(childToolItems[0]?.itemId, "call_fixture_child_tool");
+      assert.equal(
+        (childToolItems[0]?.payload as { itemLifecycle?: string }).itemLifecycle,
+        "started",
+      );
+
+      const completionOnly = events.find(
+        (event) =>
+          event.method === "collabAgent/item" &&
+          (event.payload as { item?: { id?: string } }).item?.id ===
+            "call_fixture_child_completion_only",
+      );
+      assert.equal(
+        (completionOnly?.payload as { itemLifecycle?: string }).itemLifecycle,
+        "completed",
+      );
 
       // Parent-owned resolution passes through — not swallowed, not
       // re-labelled as an agent event.

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -855,6 +855,8 @@ export const makeCodexSessionRuntime = (
     const pendingUserInputsRef = yield* Ref.make(new Map<ApprovalRequestId, PendingUserInput>());
     const collabReceiverTurnsRef = yield* Ref.make(new Map<string, TurnId>());
     const collabChildAgentsRef = yield* Ref.make(new Map<string, CollabChildAgentState>());
+    /** Child provider-thread id → item ids already emitted during its lifetime. */
+    const collabChildSeenItemsRef = yield* Ref.make(new Map<string, ReadonlySet<string>>());
     /** Child provider-thread id → its currently running provider turn id. */
     const collabChildLiveTurnsRef = yield* Ref.make(new Map<string, string>());
     const closedRef = yield* Ref.make(false);
@@ -1179,23 +1181,48 @@ export const makeCodexSessionRuntime = (
             });
             return true;
           case "item/started":
-          case "item/completed":
+          case "item/completed": {
+            const item = notification.params.item;
+            const shouldEmit = yield* Ref.modify(collabChildSeenItemsRef, (current) => {
+              const seen = current.get(child.agentThreadId);
+              if (seen?.has(item.id) === true) {
+                return [false, current];
+              }
+              const next = new Map(current);
+              next.set(child.agentThreadId, new Set([...(seen ?? []), item.id]));
+              return [true, next];
+            });
+            // Codex emits both lifecycle notifications for the same child
+            // tool item. The adapter turns each synthetic event into agent
+            // activity, so only the first one is useful; completion-only
+            // items still pass through when no start was observed.
+            if (!shouldEmit) {
+              return true;
+            }
             yield* emitEvent({
               kind: "notification",
               threadId: options.threadId,
+              itemId: ProviderItemId.make(item.id),
               ...(child.spawnTurnId ? { turnId: child.spawnTurnId } : {}),
               method: "collabAgent/item",
               payload: {
                 ...childIdentity,
-                item: notification.params.item,
+                itemLifecycle: notification.method === "item/started" ? "started" : "completed",
+                item,
               },
             });
             return true;
+          }
           case "thread/closed":
             // The child is gone: drop its live-turn entry so a later Stop
             // doesn't waste a turn/interrupt RPC on a closed thread before
             // reaching the parent (review finding).
             yield* Ref.update(collabChildLiveTurnsRef, (current) => {
+              const next = new Map(current);
+              next.delete(child.agentThreadId);
+              return next;
+            });
+            yield* Ref.update(collabChildSeenItemsRef, (current) => {
               const next = new Map(current);
               next.delete(child.agentThreadId);
               return next;


### PR DESCRIPTION
## What Changed

- Deduplicate child Codex item lifecycle notifications by child thread and item ID.
- Preserve completion-only items while emitting a single activity when both `item/started` and `item/completed` arrive.
- Add a captured-wire integration regression for paired and completion-only events.

## Why

Codex emits both lifecycle notifications for a subagent tool item. The server translated each notification into a separate synthetic agent activity, so clients rendered the same work twice.

## Validation

- `vp test run apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts`
- `pnpm --dir apps/server typecheck`
- `vp fmt --check apps/server/src/provider/Layers/CodexSessionRuntime.ts apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dedupe `collabAgent/item` events for child agent tool calls in `makeCodexSessionRuntime`
> - Introduces a `collabChildSeenItemsRef` map to track which item ids have already been emitted per child agent thread, suppressing duplicate `collabAgent/item` events for the same item id.
> - Emitted `collabAgent/item` events now include a top-level `itemId` field and `payload.itemLifecycle` set to `'started'` or `'completed'`.
> - Clears the seen-items entry for a child thread when `thread/closed` is received.
> - Behavioral Change: only the first lifecycle event (`started` or `completed`) for a given child item id produces a `collabAgent/item` emission; subsequent events for the same id are suppressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 355a1c5. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->