### PR TITLE
fix(server): respect Codex default-mode user input

### DIFF
--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -153,7 +153,11 @@ ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
 
 const CODEX_DEFAULT_MODE_USER_INPUT_ENABLED_DEVELOPER_INSTRUCTIONS = `${CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS_HEADER}
 
-In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions.
+## request_user_input availability
+
+Use the \`request_user_input\` tool only when it is listed in the available tools for this turn.
+
+In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
 </collaboration_mode>`;
 

--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -134,11 +134,14 @@ Only produce at most one \`<proposed_plan>\` block per turn, and only when you a
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
 </collaboration_mode>`;
 
-export const CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Collaboration Mode: Default
+const CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS_HEADER = `<collaboration_mode># Collaboration Mode: Default
 
 You are now in Default mode. Any previous instructions for other modes (e.g. Plan mode) are no longer active.
 
 Your active mode changes only when new developer instructions with a different \`<collaboration_mode>...</collaboration_mode>\` change it; user requests or tool descriptions do not change mode by themselves. Known mode names are Default and Plan.
+`;
+
+export const CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS = `${CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS_HEADER}
 
 ## request_user_input availability
 
@@ -148,10 +151,24 @@ In Default mode, strongly prefer making reasonable assumptions and executing the
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
 </collaboration_mode>`;
 
+const CODEX_DEFAULT_MODE_USER_INPUT_ENABLED_DEVELOPER_INSTRUCTIONS = `${CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS_HEADER}
+
+In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions.
+${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
+</collaboration_mode>`;
+
 export interface CodexRuntimeInfo {
   readonly model: string;
   readonly reasoningEffort: string;
 }
+
+export interface CodexRuntimeCapabilities {
+  readonly defaultModeRequestUserInputEnabled: boolean;
+}
+
+const DEFAULT_CODEX_RUNTIME_CAPABILITIES: CodexRuntimeCapabilities = {
+  defaultModeRequestUserInputEnabled: false,
+};
 
 // Values come from trusted config, but keep the block single-line regardless.
 function toSingleLine(value: string): string {
@@ -161,11 +178,14 @@ function toSingleLine(value: string): string {
 export function buildCodexDeveloperInstructions(
   interactionMode: ProviderInteractionMode,
   runtime: CodexRuntimeInfo,
+  capabilities: CodexRuntimeCapabilities = DEFAULT_CODEX_RUNTIME_CAPABILITIES,
 ): string {
   const base =
     interactionMode === "plan"
       ? CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS
-      : CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS;
+      : capabilities.defaultModeRequestUserInputEnabled
+        ? CODEX_DEFAULT_MODE_USER_INPUT_ENABLED_DEVELOPER_INSTRUCTIONS
+        : CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS;
   return `${base}
 
 <runtime_info>In case you're asked: you are running in T3 Code through the Codex harness, as ${toSingleLine(runtime.model)} with ${toSingleLine(runtime.reasoningEffort)} reasoning effort. No need to mention this otherwise.</runtime_info>`;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -181,7 +181,7 @@ describe("buildTurnStartParams", () => {
     });
   });
 
-  it.effect("removes Default-mode user-input restrictions when Codex enables the feature", () =>
+  it.effect("uses enabled Default-mode user-input guidance when Codex enables the feature", () =>
     Effect.gen(function* () {
       const params = yield* buildTurnStartParams({
         threadId: "provider-thread-1",
@@ -193,9 +193,11 @@ describe("buildTurnStartParams", () => {
 
       const instructions = params.collaborationMode?.settings.developer_instructions;
       NodeAssert.ok(instructions);
-      NodeAssert.doesNotMatch(instructions, /request_user_input/);
-      NodeAssert.doesNotMatch(instructions, /plain-text question/);
-      NodeAssert.doesNotMatch(instructions, /multiple choice question/);
+      NodeAssert.match(instructions, /Use the `request_user_input` tool only when it is listed/);
+      NodeAssert.doesNotMatch(instructions, /unavailable in Default mode/);
+      NodeAssert.doesNotMatch(instructions, /will return an error/);
+      NodeAssert.match(instructions, /plain-text question/);
+      NodeAssert.match(instructions, /Never write a multiple choice question/);
       NodeAssert.match(instructions, /strongly prefer making reasonable assumptions/);
       NodeAssert.match(instructions, /preview_status/);
     }),

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -16,6 +16,7 @@ import {
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
+  detectCodexDefaultModeRequestUserInput,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
   openCodexThread,
@@ -98,6 +99,7 @@ describe("buildTurnStartParams", () => {
         model: "gpt-5.3-codex",
         effort: "medium",
         interactionMode: "plan",
+        defaultModeRequestUserInputEnabled: true,
       }),
     );
 
@@ -178,6 +180,26 @@ describe("buildTurnStartParams", () => {
       },
     });
   });
+
+  it.effect("removes Default-mode user-input restrictions when Codex enables the feature", () =>
+    Effect.gen(function* () {
+      const params = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "Implement it",
+        interactionMode: "default",
+        defaultModeRequestUserInputEnabled: true,
+      });
+
+      const instructions = params.collaborationMode?.settings.developer_instructions;
+      NodeAssert.ok(instructions);
+      NodeAssert.doesNotMatch(instructions, /request_user_input/);
+      NodeAssert.doesNotMatch(instructions, /plain-text question/);
+      NodeAssert.doesNotMatch(instructions, /multiple choice question/);
+      NodeAssert.match(instructions, /strongly prefer making reasonable assumptions/);
+      NodeAssert.match(instructions, /preview_status/);
+    }),
+  );
 
   it("reports the same fallback model and effort in settings and instructions", () => {
     const params = Effect.runSync(
@@ -466,6 +488,92 @@ describe("openCodexThread", () => {
 
       NodeAssert.ok(isCodexAppServerRequestError(error));
       NodeAssert.equal(error.errorMessage, "timed out waiting for server");
+    }),
+  );
+});
+
+describe("detectCodexDefaultModeRequestUserInput", () => {
+  const feature = (
+    name: string,
+    enabled: boolean,
+  ): CodexRpc.ClientRequestResponsesByMethod["experimentalFeature/list"]["data"][number] => ({
+    name,
+    enabled,
+    defaultEnabled: false,
+    stage: "underDevelopment",
+  });
+
+  it.effect("uses loaded-thread feature state across paginated results", () =>
+    Effect.gen(function* () {
+      const calls: Array<CodexRpc.ClientRequestParamsByMethod["experimentalFeature/list"]> = [];
+      const client = {
+        request: (
+          _method: "experimentalFeature/list",
+          payload: CodexRpc.ClientRequestParamsByMethod["experimentalFeature/list"],
+        ) => {
+          calls.push(payload);
+          return Effect.succeed(
+            payload.cursor === "page-2"
+              ? {
+                  data: [feature("default_mode_request_user_input", true)],
+                }
+              : {
+                  data: [feature("other_feature", true)],
+                  nextCursor: "page-2",
+                },
+          );
+        },
+      };
+
+      const enabled = yield* detectCodexDefaultModeRequestUserInput(client, "provider-thread-1");
+
+      NodeAssert.equal(enabled, true);
+      NodeAssert.deepStrictEqual(calls, [
+        { threadId: "provider-thread-1" },
+        { threadId: "provider-thread-1", cursor: "page-2" },
+      ]);
+    }),
+  );
+
+  it.effect("returns false when the effective feature is disabled or absent", () =>
+    Effect.gen(function* () {
+      const disabled = yield* detectCodexDefaultModeRequestUserInput(
+        {
+          request: () =>
+            Effect.succeed({
+              data: [feature("default_mode_request_user_input", false)],
+            }),
+        },
+        "provider-thread-1",
+      );
+      const absent = yield* detectCodexDefaultModeRequestUserInput(
+        {
+          request: () => Effect.succeed({ data: [feature("other_feature", true)] }),
+        },
+        "provider-thread-1",
+      );
+
+      NodeAssert.equal(disabled, false);
+      NodeAssert.equal(absent, false);
+    }),
+  );
+
+  it.effect("fails closed when feature discovery is unsupported", () =>
+    Effect.gen(function* () {
+      const enabled = yield* detectCodexDefaultModeRequestUserInput(
+        {
+          request: () =>
+            Effect.fail(
+              new CodexErrors.CodexAppServerRequestError({
+                code: -32601,
+                errorMessage: "Method not found",
+              }),
+            ),
+        },
+        "provider-thread-1",
+      );
+
+      NodeAssert.equal(enabled, false);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -59,6 +59,7 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "unknown thread",
   "does not exist",
 ];
+const DEFAULT_MODE_REQUEST_USER_INPUT_FEATURE = "default_mode_request_user_input";
 
 export function hasConfiguredMcpServer(appServerArgs: ReadonlyArray<string> | undefined): boolean {
   return appServerArgs?.some((argument) => argument.includes("mcp_servers.")) === true;
@@ -339,6 +340,7 @@ function buildCodexCollaborationMode(input: {
   readonly interactionMode?: ProviderInteractionMode;
   readonly model?: string;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort;
+  readonly defaultModeRequestUserInputEnabled?: boolean;
 }): EffectCodexSchema.V2TurnStartParams__CollaborationMode | undefined {
   if (input.interactionMode === undefined) {
     return undefined;
@@ -350,10 +352,16 @@ function buildCodexCollaborationMode(input: {
     settings: {
       model,
       reasoning_effort: reasoningEffort,
-      developer_instructions: buildCodexDeveloperInstructions(input.interactionMode, {
-        model,
-        reasoningEffort,
-      }),
+      developer_instructions: buildCodexDeveloperInstructions(
+        input.interactionMode,
+        {
+          model,
+          reasoningEffort,
+        },
+        {
+          defaultModeRequestUserInputEnabled: input.defaultModeRequestUserInputEnabled === true,
+        },
+      ),
     },
   };
 }
@@ -370,6 +378,7 @@ export function buildTurnStartParams(input: {
   readonly serviceTier?: CodexServiceTier;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort;
   readonly interactionMode?: ProviderInteractionMode;
+  readonly defaultModeRequestUserInputEnabled?: boolean;
 }): Effect.Effect<
   CodexTurnStartParamsWithCollaborationMode,
   CodexErrors.CodexAppServerProtocolParseError
@@ -390,6 +399,9 @@ export function buildTurnStartParams(input: {
     ...(input.interactionMode ? { interactionMode: input.interactionMode } : {}),
     ...(input.model ? { model: input.model } : {}),
     ...(input.effort ? { effort: input.effort } : {}),
+    ...(input.defaultModeRequestUserInputEnabled
+      ? { defaultModeRequestUserInputEnabled: true }
+      : {}),
   });
 
   return decodeCodexTurnStartParamsWithCollaborationMode({
@@ -453,6 +465,47 @@ interface CodexThreadOpenClient {
     payload: CodexRpc.ClientRequestParamsByMethod[M],
   ) => Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexErrors.CodexAppServerError>;
 }
+
+interface CodexExperimentalFeatureClient {
+  readonly request: (
+    method: "experimentalFeature/list",
+    payload: CodexRpc.ClientRequestParamsByMethod["experimentalFeature/list"],
+  ) => Effect.Effect<
+    CodexRpc.ClientRequestResponsesByMethod["experimentalFeature/list"],
+    CodexErrors.CodexAppServerError
+  >;
+}
+
+export const detectCodexDefaultModeRequestUserInput = Effect.fn(
+  "detectCodexDefaultModeRequestUserInput",
+)(
+  function* (
+    client: CodexExperimentalFeatureClient,
+    providerThreadId: string,
+  ): Effect.fn.Return<boolean, CodexErrors.CodexAppServerError> {
+    let cursor: string | null | undefined;
+    do {
+      const response = yield* client.request("experimentalFeature/list", {
+        threadId: providerThreadId,
+        ...(cursor ? { cursor } : {}),
+      });
+      const feature = response.data.find(
+        (candidate) => candidate.name === DEFAULT_MODE_REQUEST_USER_INPUT_FEATURE,
+      );
+      if (feature) {
+        return feature.enabled;
+      }
+      cursor = response.nextCursor;
+    } while (cursor);
+
+    return false;
+  },
+  Effect.catch((cause) =>
+    Effect.logDebug("Codex default-mode user input feature detection failed; using disabled.", {
+      cause,
+    }).pipe(Effect.as(false)),
+  ),
+);
 
 export const openCodexThread = (input: {
   readonly client: CodexThreadOpenClient;
@@ -857,6 +910,7 @@ export const makeCodexSessionRuntime = (
     const collabChildAgentsRef = yield* Ref.make(new Map<string, CollabChildAgentState>());
     /** Child provider-thread id → its currently running provider turn id. */
     const collabChildLiveTurnsRef = yield* Ref.make(new Map<string, string>());
+    const defaultModeRequestUserInputEnabledRef = yield* Ref.make(false);
     const closedRef = yield* Ref.make(false);
 
     // `~` is not shell-expanded when env vars are set via
@@ -1699,6 +1753,10 @@ export const makeCodexSessionRuntime = (
       });
 
       const providerThreadId = opened.thread.id;
+      yield* Ref.set(
+        defaultModeRequestUserInputEnabledRef,
+        yield* detectCodexDefaultModeRequestUserInput(client, providerThreadId),
+      );
       const session = {
         ...(yield* Ref.get(sessionRef)),
         status: "ready",
@@ -1761,6 +1819,9 @@ export const makeCodexSessionRuntime = (
           const normalizedModel = normalizeCodexModelSlug(
             input.model ?? (yield* Ref.get(sessionRef)).model,
           );
+          const defaultModeRequestUserInputEnabled = yield* Ref.get(
+            defaultModeRequestUserInputEnabledRef,
+          );
           const params = yield* buildTurnStartParams({
             threadId: providerThreadId,
             runtimeMode: options.runtimeMode,
@@ -1770,6 +1831,9 @@ export const makeCodexSessionRuntime = (
             ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
             ...(input.effort ? { effort: input.effort } : {}),
             ...(input.interactionMode ? { interactionMode: input.interactionMode } : {}),
+            ...(defaultModeRequestUserInputEnabled
+              ? { defaultModeRequestUserInputEnabled: true }
+              : {}),
           });
           const rawResponse = yield* client.raw.request("turn/start", params);
           const response = yield* decodeV2TurnStartResponse(rawResponse).pipe(

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -117,6 +117,12 @@ both.
 If you add a third Codex provider with a completely different `CODEX_HOME path`, T3 Code treats it
 as a different workspace. It will not be offered for existing threads created under `~/.codex`.
 
+## Structured Questions In Default Mode
+
+When Codex's effective configuration enables its experimental
+`default_mode_request_user_input` feature, T3 Code respects that state automatically. There is no
+separate T3 Code setting. Restart T3 Code and start a fresh thread after changing the flag.
+
 ## If Both Accounts Look The Same
 
 If two Codex providers show the same account or the same unexpected model list:


### PR DESCRIPTION
Fixes #5282

T3 Code always injected instructions saying `request_user_input` was unavailable in Default mode, even when the effective Codex configuration enabled `default_mode_request_user_input`.

This change queries Codex's `experimentalFeature/list` API using the loaded provider thread ID, caches the effective state for the session, and removes the conflicting Default-mode restrictions when enabled. Missing, disabled, unsupported, or failed feature detection preserves the existing behavior.

The existing web, desktop, and mobile structured-question flow remains unchanged. No T3-specific setting or universal override is added.

Checks:
- `vp test run apps/server/src/provider/Layers/CodexSessionRuntime.test.ts`
- `vp test run apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts`
- `vp run -F t3 typecheck`
- targeted type-aware lint

Implemented with gpt-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Codex developer-instruction text and one RPC at session start with safe fallback; no auth or data-model changes.
> 
> **Overview**
> T3 Code previously always told Codex that **`request_user_input` was unavailable in Default mode**, which conflicted when Codex had **`default_mode_request_user_input`** enabled.
> 
> On session start, after opening the provider thread, the runtime now calls **`experimentalFeature/list`** (with pagination), caches whether that feature is enabled, and passes that into **`buildCodexDeveloperInstructions`**. When enabled, Default mode uses alternate developer instructions that allow **`request_user_input`** when the tool is available for the turn instead of forbidding it.
> 
> Missing, disabled, or unsupported feature discovery **fails closed** to the old “unavailable in Default mode” wording. User docs note there is **no separate T3 setting**—restart and start a **fresh thread** after changing the flag in Codex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91aa7b3d3c2691bdecabcc6c3f20c795c4938f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Respect Codex `default_mode_request_user_input` experimental feature flag in session runtime
> - Adds `detectCodexDefaultModeRequestUserInput` in [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/5567/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c), which pages through `experimentalFeature/list` RPC calls after opening a provider thread to detect whether Codex has enabled the feature.
> - When the feature is detected, `buildTurnStartParams` passes `defaultModeRequestUserInputEnabled: true` through to `buildCodexDeveloperInstructions`, switching to a new instruction variant that permits and guides use of the `request_user_input` tool.
> - Adds the new `CODEX_DEFAULT_MODE_USER_INPUT_ENABLED_DEVELOPER_INSTRUCTIONS` constant in [CodexDeveloperInstructions.ts](https://github.com/pingdotgg/t3code/pull/5567/files#diff-bfed4010ccd0734199963a19269942f8abbe9e3b025dd0e8e0253dfe8af72c04) with guidance to ask concise plain-text questions only when necessary and avoid multiple-choice questions.
> - Documents the behavior in [providers-codex.md](https://github.com/pingdotgg/t3code/pull/5567/files#diff-6dfeeb32c01b3cdb47a08ab85207fa688100295d19274792e75b67465ee06a70): no separate setting is needed; users should restart and open a fresh thread after toggling the flag in Codex.
> - Behavioral Change: on session start the runtime now issues one or more `experimentalFeature/list` RPCs; errors are caught, logged at debug level, and fall back to `false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 81fedea. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->