### PR TITLE
fix(server): settle stopped Claude subagents

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1511,7 +1511,7 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("interruptTurn stops every live task before interrupting the turn", () => {
+  it.effect("interruptTurn settles every acknowledged live task before interrupting", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
@@ -1568,11 +1568,28 @@ describe("ClaudeAdapterLive", () => {
 
       yield* Fiber.join(taskEventsFiber);
 
+      const stoppedTaskEventFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "task.completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
       yield* adapter.interruptTurn(session.threadId);
 
       // Only the still-live task is stopped; interrupt always fires after.
       assert.deepEqual(harness.query.stopTaskCalls, ["task-live"]);
       assert.equal(harness.query.interruptCalls.length, 1);
+
+      const stoppedTaskEvents = Array.from(yield* Fiber.join(stoppedTaskEventFiber));
+      assert.equal(stoppedTaskEvents.length, 1);
+      const stoppedTaskEvent = stoppedTaskEvents[0];
+      assert.equal(stoppedTaskEvent?.type, "task.completed");
+      if (stoppedTaskEvent?.type === "task.completed") {
+        assert.equal(String(stoppedTaskEvent.payload.taskId), "task-live");
+        assert.equal(stoppedTaskEvent.payload.status, "stopped");
+        assert.equal(stoppedTaskEvent.payload.taskType, "local_agent");
+        assert.equal(stoppedTaskEvent.payload.title, "Agent A");
+      }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -65,6 +65,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
@@ -4419,11 +4420,40 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         yield* Effect.forEach(
           liveIds,
           (taskId) =>
-            Effect.tryPromise({
-              // Invoke through the query object: SDK methods rely on `this`.
-              try: () => context.query.stopTask!(taskId),
-              catch: () => undefined,
-            }).pipe(Effect.timeoutOption("3 seconds"), Effect.ignore),
+            Effect.gen(function* () {
+              const stopAcknowledged = yield* Effect.tryPromise({
+                // Invoke through the query object: SDK methods rely on `this`.
+                try: () => context.query.stopTask!(taskId),
+                catch: () => undefined,
+              }).pipe(
+                Effect.timeoutOption("3 seconds"),
+                Effect.orElseSucceed(() => Option.none()),
+              );
+              if (Option.isNone(stopAcknowledged) || !context.liveTaskIds.delete(taskId)) {
+                return;
+              }
+
+              // stopTask only acknowledges the control request. Its separate
+              // task_notification can lose the race with interrupt(), so make
+              // the acknowledged stop authoritative for the durable UI state.
+              const stamp = yield* makeEventStamp();
+              yield* offerRuntimeEvent({
+                type: "task.completed",
+                eventId: stamp.eventId,
+                provider: PROVIDER,
+                createdAt: stamp.createdAt,
+                threadId: context.session.threadId,
+                ...(context.turnState
+                  ? { turnId: asCanonicalTurnId(context.turnState.turnId) }
+                  : {}),
+                payload: {
+                  taskId: RuntimeTaskId.make(taskId),
+                  status: "stopped",
+                  ...taskLinkageFor(context.taskAgents, taskId),
+                },
+                providerRefs: nativeProviderRefs(context),
+              });
+            }).pipe(Effect.ignore),
           { concurrency: 8, discard: true },
         ).pipe(Effect.timeoutOption("10 seconds"), Effect.ignore);
       }


### PR DESCRIPTION
Claude stop requests are acknowledged separately from task notifications. Interrupting the parent immediately after acknowledgements can prevent the final notification from arriving, leaving stopped subagents persisted as running.

Emit a durable stopped completion as soon as each stop request is acknowledged. Keep the existing per-task and overall timeouts, and retain task linkage on the terminal event.

Tests: vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts; vp run --filter t3 typecheck; targeted vp lint.

Generated by GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn-interrupt and task lifecycle event ordering in the Claude adapter, which affects persisted subagent state but is scoped to stop/interrupt with existing timeouts and new test coverage.
> 
> **Overview**
> **Interrupt turn** now records subagent shutdown in durable UI state when Claude acknowledges `stopTask`, instead of relying only on a later `task_notification` that can lose a race with `interrupt()`.
> 
> On each live task, after `stopTask` succeeds within the existing per-task timeout, the adapter removes the task from `liveTaskIds` and emits **`task.completed`** with **`status: "stopped"`**, including existing task linkage (type, title). Parent **`interrupt()`** still runs afterward; per-task and fleet-wide timeouts are unchanged.
> 
> The **`interruptTurn`** test now asserts that only still-live tasks get `stopTask`, and that the emitted completion event matches the stopped subagent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6e1c413fe444fe253fa61bb88186c72bf358c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit `task.completed` stopped events for Claude subagents on `interruptTurn`
> Previously, `interruptTurn` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/5568/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) called `stopTask` for each live task but never emitted a `task.completed` event, leaving stopped subagents unsettled.
>
> - Each live task is now stopped with a 3-second timeout; on acknowledgment, the task is removed from `liveTaskIds` and a `task.completed` event with `status: 'stopped'` is emitted immediately.
> - The overall stop loop retains its 10-second timeout, after which `context.query.interrupt()` is called as before.
> - Behavioral Change: callers that previously received no completion event for stopped subagents will now receive one per acknowledged task.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a6e1c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->