### PR TITLE
fix(web): keep agent panel rows stable

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -1,0 +1,82 @@
+import {
+  EventId,
+  ProviderDriverKind,
+  RuntimeTaskId,
+  ThreadId,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { runtimeEventToActivities } from "./ProviderRuntimeIngestion.ts";
+
+const base = {
+  provider: ProviderDriverKind.make("codex"),
+  createdAt: "2026-08-06T00:00:00.000Z",
+  threadId: ThreadId.make("thread-1"),
+};
+
+describe("runtimeEventToActivities task progress", () => {
+  it("persists usage independently from replaceable activity", () => {
+    const taskId = RuntimeTaskId.make("agent-1");
+    const usageOnly = {
+      ...base,
+      type: "task.progress",
+      eventId: EventId.make("evt-usage"),
+      payload: {
+        taskId,
+        description: "Agent one",
+        typedUsage: { totalTokens: 73_700_000 },
+      },
+    } satisfies ProviderRuntimeEvent;
+    const command = {
+      ...base,
+      type: "task.progress",
+      eventId: EventId.make("evt-command"),
+      payload: {
+        taskId,
+        description: "Agent one",
+        summary: "Running tests",
+        lastToolName: "exec_command",
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const usageActivities = runtimeEventToActivities(usageOnly);
+    const commandActivities = runtimeEventToActivities(command);
+
+    expect(usageActivities.map((activity) => activity.id)).toEqual(["task-usage:thread-1:agent-1"]);
+    expect(commandActivities.map((activity) => activity.id)).toEqual([
+      "task-progress:thread-1:agent-1",
+    ]);
+    const usagePayload = usageActivities[0]?.payload as Record<string, unknown> | undefined;
+    expect(usagePayload?.typedUsage).toEqual({ totalTokens: 73_700_000 });
+  });
+
+  it("splits combined progress and usage into their independent snapshots", () => {
+    const event = {
+      ...base,
+      type: "task.progress",
+      eventId: EventId.make("evt-combined"),
+      payload: {
+        taskId: RuntimeTaskId.make("agent-2"),
+        description: "Agent two",
+        summary: "Inspecting the panel",
+        typedUsage: { totalTokens: 4_200, toolUses: 7 },
+        status: "running",
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const activities = runtimeEventToActivities(event);
+    const progressPayload = activities[0]?.payload as Record<string, unknown>;
+    const usagePayload = activities[1]?.payload as Record<string, unknown>;
+
+    expect(activities.map((activity) => activity.id)).toEqual([
+      "task-progress:thread-1:agent-2",
+      "task-usage:thread-1:agent-2",
+    ]);
+    expect(progressPayload.summary).toBe("Inspecting the panel");
+    expect(progressPayload.status).toBe("running");
+    expect(progressPayload).not.toHaveProperty("typedUsage");
+    expect(usagePayload.typedUsage).toEqual({ totalTokens: 4_200, toolUses: 7 });
+    expect(usagePayload).not.toHaveProperty("status");
+  });
+});

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -49,6 +49,7 @@ describe("runtimeEventToActivities task progress", () => {
     ]);
     const usagePayload = usageActivities[0]?.payload as Record<string, unknown> | undefined;
     expect(usagePayload?.typedUsage).toEqual({ totalTokens: 73_700_000 });
+    expect(usagePayload?.usageSnapshot).toBe(true);
   });
 
   it("splits combined progress and usage into their independent snapshots", () => {
@@ -77,6 +78,7 @@ describe("runtimeEventToActivities task progress", () => {
     expect(progressPayload.status).toBe("running");
     expect(progressPayload).not.toHaveProperty("typedUsage");
     expect(usagePayload.typedUsage).toEqual({ totalTokens: 4_200, toolUses: 7 });
+    expect(usagePayload.usageSnapshot).toBe(true);
     expect(usagePayload).not.toHaveProperty("status");
   });
 });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -563,39 +563,79 @@ export function runtimeEventToActivities(
     }
 
     case "task.progress": {
+      const linkage = taskLinkageActivityFields(event.payload as Record<string, unknown>);
+      // Usage and activity are independent latest-state streams. Keeping them
+      // under separate stable ids prevents a command/reasoning update from
+      // replacing the last known token count (and prevents a usage-only tick
+      // from blanking the last meaningful activity).
+      const identityLinkage = { ...linkage };
+      delete identityLinkage.typedUsage;
+      delete identityLinkage.status;
+      delete identityLinkage.error;
+      const title =
+        event.payload.description.trim().length > 0
+          ? { title: truncateDetail(event.payload.description, 120) }
+          : {};
+      const hasProgressState =
+        event.payload.typedUsage === undefined ||
+        event.payload.summary !== undefined ||
+        event.payload.lastToolName !== undefined ||
+        event.payload.status !== undefined ||
+        event.payload.error !== undefined;
       return [
-        {
-          // Stable per-task id: progress is "latest state", not history, so
-          // each tick REPLACES the last via the activity upsert (PK + the
-          // replace-by-id apply in projector and client reducer). Keeps one
-          // progress row per task instead of thousands, so a large fleet's
-          // ticks can no longer evict its own start/terminal rows out of
-          // the 500-row retention window. Thread-scoped: activity_id is a
-          // GLOBAL primary key and Claude task ids are session-local, so a
-          // bare taskId could collide across threads and steal another
-          // thread's row (review finding).
-          id: EventId.make(`task-progress:${event.threadId}:${event.payload.taskId}`),
-          createdAt: event.createdAt,
-          tone: "info",
-          kind: "task.progress",
-          summary:
-            event.payload.description.trim().length > 0
-              ? truncateDetail(event.payload.description, 120)
-              : "Reasoning update",
-          payload: {
-            taskId: event.payload.taskId,
-            ...(event.payload.description.trim().length > 0
-              ? { title: truncateDetail(event.payload.description, 120) }
-              : {}),
-            detail: truncateDetail(event.payload.summary ?? event.payload.description),
-            ...(event.payload.summary ? { summary: truncateDetail(event.payload.summary) } : {}),
-            ...(event.payload.lastToolName ? { lastToolName: event.payload.lastToolName } : {}),
-            ...(event.payload.usage !== undefined ? { usage: event.payload.usage } : {}),
-            ...taskLinkageActivityFields(event.payload as Record<string, unknown>),
-          },
-          turnId: toTurnId(event.turnId) ?? null,
-          ...maybeSequence,
-        },
+        ...(hasProgressState
+          ? [
+              {
+                // Stable per-task id: activity is "latest state", not
+                // history, so each meaningful tick replaces the last. This
+                // bounds a large fleet to one activity row per task.
+                id: EventId.make(`task-progress:${event.threadId}:${event.payload.taskId}`),
+                createdAt: event.createdAt,
+                tone: "info" as const,
+                kind: "task.progress" as const,
+                summary:
+                  event.payload.description.trim().length > 0
+                    ? truncateDetail(event.payload.description, 120)
+                    : "Reasoning update",
+                payload: {
+                  taskId: event.payload.taskId,
+                  ...title,
+                  detail: truncateDetail(event.payload.summary ?? event.payload.description),
+                  ...(event.payload.summary
+                    ? { summary: truncateDetail(event.payload.summary) }
+                    : {}),
+                  ...(event.payload.lastToolName
+                    ? { lastToolName: event.payload.lastToolName }
+                    : {}),
+                  ...(event.payload.status ? { status: event.payload.status } : {}),
+                  ...(event.payload.error ? { error: event.payload.error } : {}),
+                  ...(event.payload.usage !== undefined ? { usage: event.payload.usage } : {}),
+                  ...identityLinkage,
+                },
+                turnId: toTurnId(event.turnId) ?? null,
+                ...maybeSequence,
+              },
+            ]
+          : []),
+        ...(event.payload.typedUsage !== undefined
+          ? [
+              {
+                id: EventId.make(`task-usage:${event.threadId}:${event.payload.taskId}`),
+                createdAt: event.createdAt,
+                tone: "info" as const,
+                kind: "task.progress" as const,
+                summary: "Task usage updated",
+                payload: {
+                  taskId: event.payload.taskId,
+                  ...title,
+                  ...identityLinkage,
+                  typedUsage: event.payload.typedUsage,
+                },
+                turnId: toTurnId(event.turnId) ?? null,
+                ...maybeSequence,
+              },
+            ]
+          : []),
       ];
     }
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -629,6 +629,7 @@ export function runtimeEventToActivities(
                   taskId: event.payload.taskId,
                   ...title,
                   ...identityLinkage,
+                  usageSnapshot: true,
                   typedUsage: event.payload.typedUsage,
                 },
                 turnId: toTurnId(event.turnId) ?? null,

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -312,8 +312,14 @@ function WorkflowScriptView({
  * that shape as it settles so completion never yanks rows out from under the
  * user. Manual toggles stick until a later activation begins.
  */
-function PhaseSection({ phase }: { phase: AgentPanelWorkflowGroup["phases"][number] }) {
-  const [open, setOpen] = useState(phase.state === "running");
+function PhaseSection({
+  phase,
+  defaultOpen = false,
+}: {
+  phase: AgentPanelWorkflowGroup["phases"][number];
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen || phase.state === "running");
   const previousState = useRef(phase.state);
 
   useEffect(() => {
@@ -430,7 +436,7 @@ function ExpandedWorkflowSection({
         />
       ) : null}
       {group.phases.map((phase) => (
-        <PhaseSection key={phase.index} phase={phase} />
+        <PhaseSection key={phase.index} phase={phase} defaultOpen={!workflowIsLive(group)} />
       ))}
       {group.unphasedMembers.map((member) => (
         <AgentRow key={member.id} agent={member} />

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -4,13 +4,11 @@
  * spawn batch).
  *
  * Visualization rules (from live-test feedback):
- * - Live work first: running workflows and direct spawns sort above settled.
- * - Rows are flat status lines — no expansion, no per-agent tool feeds. The
- *   row answers "who / what phase / how much"; anything deeper is a future
- *   drill-in, not an unfold.
- * - A settled workflow run collapses to a single summary line; click it to
- *   show its member list inline (the one allowed toggle — run granularity,
- *   not agent granularity).
+ * - Spawn order is stable. Activity and completion update rows in place.
+ * - Agent rows reserve three fixed lines for identity, activity, and metrics;
+ *   changing data must never change their height.
+ * - Workflow expansion is presentation state. A live run stays expanded when
+ *   it settles; older collapsed runs can still be opened at run granularity.
  * - Static status dots, DOM-write elapsed timers, plain token counters.
  */
 import { useAtomValue } from "@effect/atom-react";
@@ -143,54 +141,50 @@ function AgentRow({ agent }: { agent: RuntimeSubagent }) {
   const visuals = STATUS_VISUALS[agent.status];
   const activity = agentActivityText(agent);
   const modelLabel = formatSubagentModelLabel(agent.model, agent.effort);
+  const role =
+    agent.role?.trim().toLocaleLowerCase() === agent.title.trim().toLocaleLowerCase()
+      ? null
+      : agent.role;
+  const metadata = [
+    modelLabel,
+    agent.usage ? `${formatSubagentTokenCount(agent.usage.totalTokens)} tok` : "— tok",
+    agent.usage?.toolUses !== undefined ? `${agent.usage.toolUses} tools` : null,
+    agent.activationCount > 1 ? `run ${agent.activationCount}` : null,
+  ].filter((value): value is string => value !== null);
 
   return (
-    <div className="rounded-md px-1.5 py-1">
-      <div className="flex items-start gap-2">
-        <span className="flex h-5 items-center">
-          <StatusDot status={agent.status} />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-            <span className="truncate text-sm font-medium">{agent.title}</span>
-            {agent.role ? (
-              <span className="max-w-28 truncate rounded-sm border border-border/60 px-1 font-mono text-[.65rem] text-muted-foreground">
-                {agent.role}
-              </span>
-            ) : null}
-            <span className="ml-auto flex items-center gap-1 font-mono text-[.7rem] text-muted-foreground/80">
-              <AgentElapsed agent={agent} />
-              {agent.status === "completed" ? (
-                <Check aria-hidden className="size-3 text-success" />
-              ) : null}
-            </span>
+    <div className="grid h-[3.875rem] grid-cols-[0.375rem_minmax(0,1fr)_auto] grid-rows-[1.25rem_1.125rem_1rem] items-center gap-x-2 rounded-md px-1.5 py-1">
+      <span className="col-start-1 row-start-1 flex items-center">
+        <StatusDot status={agent.status} />
+      </span>
+      <span className="col-start-2 row-start-1 flex min-w-0 items-baseline gap-2">
+        <span className="min-w-0 truncate text-sm font-medium">{agent.title}</span>
+        {role ? (
+          <span className="max-w-28 shrink-0 truncate rounded-sm border border-border/60 px-1 font-mono text-[.65rem] text-muted-foreground">
+            {role}
           </span>
-          {activity ? (
-            <span
-              className={cn(
-                "mt-0.5 block truncate text-xs",
-                agent.status === "failed" ? "text-destructive-foreground" : "text-muted-foreground",
-              )}
-            >
-              {activity}
-            </span>
+        ) : null}
+      </span>
+      <span className="col-start-3 row-start-1 min-w-14 text-right font-mono text-[.7rem] text-muted-foreground/80">
+        <span className="inline-flex items-center gap-1">
+          <AgentElapsed agent={agent} />
+          {agent.status === "completed" ? (
+            <Check aria-hidden className="size-3 text-success" />
           ) : null}
-          <span className="mt-0.5 flex items-center gap-1 font-mono text-[.7rem] text-muted-foreground/70">
-            {modelLabel ? <span className="truncate">{modelLabel}</span> : null}
-            {agent.usage ? (
-              <span className="tabular-nums">
-                {modelLabel ? "· " : ""}
-                {formatSubagentTokenCount(agent.usage.totalTokens)} tok
-              </span>
-            ) : null}
-            {agent.usage?.toolUses !== undefined ? (
-              <span>· {agent.usage.toolUses} tools</span>
-            ) : null}
-            {agent.activationCount > 1 ? <span>· run {agent.activationCount}</span> : null}
-            <span className="sr-only">{visuals.label}</span>
-          </span>
         </span>
-      </div>
+      </span>
+      <span
+        className={cn(
+          "col-start-2 col-end-4 row-start-2 block truncate text-xs",
+          agent.status === "failed" ? "text-destructive-foreground" : "text-muted-foreground",
+        )}
+      >
+        {activity ?? visuals.label}
+      </span>
+      <span className="col-start-2 col-end-4 row-start-3 truncate font-mono text-[.7rem] tabular-nums text-muted-foreground/70">
+        {metadata.join(" · ")}
+      </span>
+      <span className="sr-only">{visuals.label}</span>
     </div>
   );
 }
@@ -314,18 +308,26 @@ function WorkflowScriptView({
 }
 
 /**
- * Collapsible phase section (Claude Code Background-tasks pattern): live
- * phases open by default, done phases collapsed to header + member dot row.
- * User toggles override the default and stick for the phase's lifetime.
+ * Collapsible phase section. A phase opens when it becomes active, then keeps
+ * that shape as it settles so completion never yanks rows out from under the
+ * user. Manual toggles stick until a later activation begins.
  */
 function PhaseSection({ phase }: { phase: AgentPanelWorkflowGroup["phases"][number] }) {
-  const [userOpen, setUserOpen] = useState<boolean | null>(null);
-  const open = userOpen ?? phase.state === "running";
+  const [open, setOpen] = useState(phase.state === "running");
+  const previousState = useRef(phase.state);
+
+  useEffect(() => {
+    if (previousState.current !== "running" && phase.state === "running") {
+      setOpen(true);
+    }
+    previousState.current = phase.state;
+  }, [phase.state]);
+
   return (
     <div>
       <button
         type="button"
-        onClick={() => setUserOpen(!open)}
+        onClick={() => setOpen((value) => !value)}
         aria-expanded={open}
         className={cn(
           "mt-2 flex w-full items-center gap-1.5 rounded-sm px-1.5 text-left text-[.65rem] font-medium uppercase tracking-wider hover:bg-accent/40",
@@ -363,15 +365,17 @@ function PhaseSection({ phase }: { phase: AgentPanelWorkflowGroup["phases"][numb
   );
 }
 
-/** Live workflow: phase rail + full phase tree. */
-function LiveWorkflowSection({
+/** Expanded workflow: phase rail + full phase tree. */
+function ExpandedWorkflowSection({
   group,
   environmentId,
   threadId,
+  onCollapse,
 }: {
   group: AgentPanelWorkflowGroup;
   environmentId: EnvironmentId | null;
   threadId: ThreadId | null;
+  onCollapse: () => void;
 }) {
   const [scriptOpen, setScriptOpen] = useState(false);
   const members = workflowMembers(group);
@@ -387,8 +391,10 @@ function LiveWorkflowSection({
   return (
     <section className="rounded-lg border border-border/50 bg-card/30 p-1.5">
       <div className="flex items-center gap-2 px-1.5 pt-0.5 text-[.65rem] font-medium uppercase tracking-wider text-muted-foreground">
-        <span aria-hidden className="size-1.5 rounded-full bg-info" />
-        <span>{group.workflow.workflowName ?? group.workflow.title}</span>
+        <StatusDot status={group.workflow.status} />
+        <span className="min-w-0 truncate">
+          {group.workflow.workflowName ?? group.workflow.title}
+        </span>
         {canShowScript ? (
           <button
             type="button"
@@ -405,6 +411,14 @@ function LiveWorkflowSection({
         <span className="ml-auto font-mono normal-case text-muted-foreground/80">
           {settled}/{members.length} settled
         </span>
+        <button
+          type="button"
+          onClick={onCollapse}
+          aria-label="Collapse workflow"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <ChevronDown aria-hidden className="size-3" />
+        </button>
       </div>
       <PhaseRail group={group} />
       {scriptOpen && canShowScript ? (
@@ -429,11 +443,16 @@ function LiveWorkflowSection({
 }
 
 /**
- * Settled workflow: one summary line. Click toggles the member list — the
- * only expansion in the panel, at run granularity.
+ * Collapsed workflow: one summary line. The parent owns expansion so a live
+ * workflow keeps its shape when it settles.
  */
-function SettledWorkflowSection({ group }: { group: AgentPanelWorkflowGroup }) {
-  const [open, setOpen] = useState(false);
+function CollapsedWorkflowSection({
+  group,
+  onExpand,
+}: {
+  group: AgentPanelWorkflowGroup;
+  onExpand: () => void;
+}) {
   const members = workflowMembers(group);
   const failed = members.filter((member) => member.status === "failed").length;
   // Coordinator usage may already aggregate members (panel-footer rule):
@@ -450,9 +469,9 @@ function SettledWorkflowSection({ group }: { group: AgentPanelWorkflowGroup }) {
     <section>
       <button
         type="button"
-        onClick={() => setOpen((value) => !value)}
+        onClick={onExpand}
         className="flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left hover:bg-accent/40"
-        aria-expanded={open}
+        aria-expanded={false}
       >
         <StatusDot status={failed > 0 ? "failed" : group.workflow.status} />
         <span className="truncate text-sm">
@@ -463,21 +482,33 @@ function SettledWorkflowSection({ group }: { group: AgentPanelWorkflowGroup }) {
           <span>{members.length} agents</span>
           <span className="tabular-nums">· {formatSubagentTokenCount(totalTokens)} tok</span>
           {elapsed ? <span className="tabular-nums">· {elapsed}</span> : null}
-          {open ? (
-            <ChevronDown aria-hidden className="size-3" />
-          ) : (
-            <ChevronRight aria-hidden className="size-3" />
-          )}
+          <ChevronRight aria-hidden className="size-3" />
         </span>
       </button>
-      {open ? (
-        <div className="ms-3 border-s border-border/45 ps-2">
-          {members.map((member) => (
-            <AgentRow key={member.id} agent={member} />
-          ))}
-        </div>
-      ) : null}
     </section>
+  );
+}
+
+/** A workflow's open state is presentation state, not a status derivative. */
+function WorkflowSection({
+  group,
+  environmentId,
+  threadId,
+}: {
+  group: AgentPanelWorkflowGroup;
+  environmentId: EnvironmentId | null;
+  threadId: ThreadId | null;
+}) {
+  const [open, setOpen] = useState(() => workflowIsLive(group));
+  return open ? (
+    <ExpandedWorkflowSection
+      group={group}
+      environmentId={environmentId}
+      threadId={threadId}
+      onCollapse={() => setOpen(false)}
+    />
+  ) : (
+    <CollapsedWorkflowSection group={group} onExpand={() => setOpen(true)} />
   );
 }
 
@@ -503,48 +534,24 @@ export function AgentsPanel({
     );
   }
 
-  const liveWorkflows = model.workflows.filter(workflowIsLive);
-  const settledWorkflows = model.workflows.filter((group) => !workflowIsLive(group));
-  const liveDirect = model.directAgents.filter(
-    (agent) =>
-      agent.status === "running" || agent.status === "pending" || agent.status === "waiting",
-  );
-  const settledDirect = model.directAgents.filter(
-    (agent) =>
-      agent.status !== "running" && agent.status !== "pending" && agent.status !== "waiting",
-  );
-
   return (
     <div className="flex h-full min-h-0 flex-col">
       <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-2 p-2">
-          {liveWorkflows.map((group) => (
-            <LiveWorkflowSection
+          {model.workflows.map((group) => (
+            <WorkflowSection
               key={group.workflow.id}
               group={group}
               environmentId={environmentId}
               threadId={threadId}
             />
           ))}
-          {liveDirect.length > 0 ? (
+          {model.directAgents.length > 0 ? (
             <section>
               <div className="px-1.5 pt-1 text-[.65rem] font-medium uppercase tracking-wider text-muted-foreground">
                 Direct spawns
               </div>
-              {liveDirect.map((agent) => (
-                <AgentRow key={agent.id} agent={agent} />
-              ))}
-            </section>
-          ) : null}
-          {settledWorkflows.length > 0 || settledDirect.length > 0 ? (
-            <section>
-              <div className="px-1.5 pt-2 text-[.65rem] font-medium uppercase tracking-wider text-muted-foreground/70">
-                Earlier
-              </div>
-              {settledWorkflows.map((group) => (
-                <SettledWorkflowSection key={group.workflow.id} group={group} />
-              ))}
-              {settledDirect.map((agent) => (
+              {model.directAgents.map((agent) => (
                 <AgentRow key={agent.id} agent={agent} />
               ))}
             </section>

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -378,6 +378,33 @@ describe("deriveAgentPanelModel", () => {
     ).toEqual(["direct-a", "direct-b"]);
   });
 
+  it("keeps first-seen order after the roster retention ranking runs", () => {
+    const starts = Array.from({ length: 101 }, (_, index) =>
+      activity(
+        "task.started",
+        { taskId: `capped-${index}`, title: `Agent ${index}` },
+        `2026-08-01T12:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(
+          index % 60,
+        ).padStart(2, "0")}.000Z`,
+      ),
+    );
+    const cappedRoster = fold([
+      ...starts,
+      activity(
+        "task.progress",
+        { taskId: "capped-0", summary: "Newest activity" },
+        "2026-08-01T12:02:00.000Z",
+      ),
+    ]);
+
+    const ids = deriveAgentPanelModel({ agents: cappedRoster }).directAgents.map(
+      (agent) => agent.id,
+    );
+    expect(ids).toHaveLength(100);
+    expect(ids.slice(0, 3)).toEqual(["capped-0", "capped-2", "capped-3"]);
+    expect(ids.at(-1)).toBe("capped-100");
+  });
+
   it("a phase with only pending members never reads as running", () => {
     const pendingRoster = fold([
       activity("task.started", { taskId: "wf-9", taskType: "local_workflow" }),

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -186,6 +186,34 @@ describe("foldSubagentActivities", () => {
     expect(agents[0]!.usage).toEqual({ totalTokens: 900, inputTokens: 700 });
   });
 
+  it("usage snapshots enrich an existing agent without changing its status", () => {
+    const [agent] = fold([
+      activity("task.started", { taskId: "usage-waiting", taskType: "local_agent" }),
+      activity("task.progress", { taskId: "usage-waiting", status: "waiting" }),
+      activity("task.progress", {
+        taskId: "usage-waiting",
+        usageSnapshot: true,
+        typedUsage: { totalTokens: 1_200 },
+      }),
+    ]);
+
+    expect(agent?.status).toBe("waiting");
+    expect(agent?.usage?.totalTokens).toBe(1_200);
+  });
+
+  it("a retained usage snapshot can still reconstruct a running agent", () => {
+    const [agent] = fold([
+      activity("task.progress", {
+        taskId: "usage-only",
+        usageSnapshot: true,
+        typedUsage: { totalTokens: 800 },
+      }),
+    ]);
+
+    expect(agent?.status).toBe("running");
+    expect(agent?.usage?.totalTokens).toBe(800);
+  });
+
   it("partial terminal usage preserves known breakdown fields", () => {
     const agents = fold([
       activity("task.started", { taskId: "task-6", taskType: "local_agent" }),

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -362,6 +362,22 @@ describe("deriveAgentPanelModel", () => {
     );
   });
 
+  it("keeps direct spawns in first-seen order as their activity changes", () => {
+    const directRoster = fold([
+      activity("task.started", { taskId: "direct-a", title: "First" }, "2026-08-01T11:00:00.000Z"),
+      activity("task.started", { taskId: "direct-b", title: "Second" }, "2026-08-01T11:00:01.000Z"),
+      activity(
+        "task.progress",
+        { taskId: "direct-a", summary: "Newest activity" },
+        "2026-08-01T11:00:02.000Z",
+      ),
+    ]);
+
+    expect(
+      deriveAgentPanelModel({ agents: directRoster }).directAgents.map((agent) => agent.id),
+    ).toEqual(["direct-a", "direct-b"]);
+  });
+
   it("a phase with only pending members never reads as running", () => {
     const pendingRoster = fold([
       activity("task.started", { taskId: "wf-9", taskType: "local_workflow" }),

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -504,14 +504,19 @@ export function foldSubagentActivities(
         // Membership is sticky per taskId: rows after the first (terminal
         // rows often carry only taskId+status, no marker fields) inherit the
         // first row's classification instead of being re-judged.
-        if (!agents.has(taskId) && isBackgroundTaskActivity(payload)) break;
+        const existed = agents.has(taskId);
+        if (!existed && isBackgroundTaskActivity(payload)) break;
         const agent = getOrCreate(agents, taskId, payload, at);
         fillMetadata(agent, payload);
         if (agent.activationCount === 0) agent.activationCount = 1;
         const explicitStatus = asRuntimeStatus(payload.status);
         if (explicitStatus) {
           applyStatus(agent, explicitStatus, at);
-        } else if (!isTerminalSubagentStatus(agent.status) && agent.status !== "idle") {
+        } else if (
+          (payload.usageSnapshot !== true || !existed) &&
+          !isTerminalSubagentStatus(agent.status) &&
+          agent.status !== "idle"
+        ) {
           applyStatus(agent, "running", at);
         }
         const summary = asString(payload.summary);

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -80,6 +80,8 @@ export interface RuntimeSubagent {
   readonly phases: ReadonlyArray<SubagentWorkflowPhase>;
   readonly runHandles: SubagentRunHandles | null;
   readonly recentActivity: ReadonlyArray<SubagentActivityEntry>;
+  /** First retained observation, used as the roster's stable display order. */
+  readonly firstSeenAt: string;
   readonly startedAt: string | null;
   readonly completedAt: string | null;
   readonly updatedAt: string;
@@ -247,6 +249,7 @@ interface MutableAgent {
   phases: ReadonlyArray<SubagentWorkflowPhase>;
   runHandles: SubagentRunHandles | null;
   recentActivity: ReadonlyArray<SubagentActivityEntry>;
+  firstSeenAt: string;
   startedAt: string | null;
   completedAt: string | null;
   updatedAt: string;
@@ -300,6 +303,7 @@ function getOrCreate(
     phases: [],
     runHandles: null,
     recentActivity: [],
+    firstSeenAt: at,
     startedAt: null,
     completedAt: null,
     updatedAt: at,
@@ -726,7 +730,10 @@ export function deriveAgentPanelModel({
     return EMPTY_PANEL_MODEL;
   }
 
-  const workflows = source.filter((agent) => agent.kind === "workflow");
+  const workflows = source
+    .filter((agent) => agent.kind === "workflow")
+    .slice()
+    .sort((a, b) => a.firstSeenAt.localeCompare(b.firstSeenAt) || a.id.localeCompare(b.id));
   const workflowIds = new Set(workflows.map((workflow) => workflow.id));
   const members = new Map<string, RuntimeSubagent[]>();
   const direct: RuntimeSubagent[] = [];
@@ -827,9 +834,11 @@ export function deriveAgentPanelModel({
 
   return {
     workflows: workflowGroups,
-    // The fold's insertion order is spawn order. Activity updates should
-    // change a row in place, never reshuffle the roster under the user.
-    directAgents: direct,
+    // Updates and the >100-agent retention ranking must never reshuffle rows
+    // that remain visible.
+    directAgents: direct
+      .slice()
+      .sort((a, b) => a.firstSeenAt.localeCompare(b.firstSeenAt) || a.id.localeCompare(b.id)),
     runningCount,
     waitingCount,
     idleCount,

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -827,7 +827,9 @@ export function deriveAgentPanelModel({
 
   return {
     workflows: workflowGroups,
-    directAgents: direct.slice().sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+    // The fold's insertion order is spawn order. Activity updates should
+    // change a row in place, never reshuffle the roster under the user.
+    directAgents: direct,
     runningCount,
     waitingCount,
     idleCount,


### PR DESCRIPTION
The Agents panel constantly changes height as live activity and usage arrive, making long subagent runs hard to scan. Token counts can disappear entirely when a later progress event replaces the usage update.

Agent rows now keep the selected fixed three-line shape, retain spawn order, and update status in place. Workflow expansion remains stable through completion. Task activity and cumulative usage persist as independent bounded snapshots, so neither can erase the other.

Design reference: https://aezsvd414hks.postplan.dev (variant C)

Focused verification:
- `vp test run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts packages/client-runtime/src/state/subagentRuntime.test.ts`
- `vp test run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts`
- touched-package typechecks and targeted lint

---
Made by gpt-5.6-sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes activity identity and ordering semantics for all threads; incorrect splitting could affect retention or panel state, but behavior is covered by new ingestion and client-runtime tests.
> 
> **Overview**
> Fixes the Agents panel jumping and losing token counts when live `task.progress` events arrive.
> 
> **Ingestion:** `task.progress` now emits up to two replaceable activities per task—`task-progress:<thread>:<task>` for status/summary/tool activity and `task-usage:<thread>:<task>` for `typedUsage` (`usageSnapshot: true`)—so usage-only ticks no longer wipe command/reasoning state and vice versa.
> 
> **Client fold:** Usage snapshots update `typedUsage` without forcing status back to running when the agent already exists; roster ordering uses new `firstSeenAt` (spawn order) instead of `updatedAt`, including after the >100-agent retention cap.
> 
> **UI:** Agent rows use a fixed three-line grid; workflows render in spawn order with parent-owned expand/collapse so a live run stays expanded when it settles; the live vs “Earlier” split is removed in favor of stable direct-spawn ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e493de7d1ed30879c52218cc114e363e211197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep agent panel rows stable by ordering on first-seen time and splitting progress/usage activities
> - [AgentsPanel](https://github.com/pingdotgg/t3code/pull/5569/files#diff-10464442e3a11a770b2b1a5718e7a452453347c492f6aa0533f267063e2c6494) now renders all workflows in stable spawn order via a new `WorkflowSection` controller that owns expand/collapse state independently of liveness, preventing rows from reordering as agents settle.
> - `AgentRow` uses a fixed-height 3-row CSS grid so row height stays constant regardless of changing content; role pill is hidden when it duplicates the title.
> - `foldSubagentActivities` in [subagentRuntime.ts](https://github.com/pingdotgg/t3code/pull/5569/files#diff-b28278fe62e259afab164f07d2e56800ca49f60942f6b12da5f748e9415c8259) adds a `firstSeenAt` timestamp to each agent and uses it for deterministic ordering; usage-only snapshots no longer accidentally transition an existing agent's status to `running`.
> - `runtimeEventToActivities` in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/5569/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) splits `task.progress` events into two separate activities: `task-progress:threadId:taskId` for progress/reasoning and `task-usage:threadId:taskId` for usage snapshots, so usage updates no longer overwrite progress state.
> - Behavioral Change: workflows and direct agents are now sorted by `firstSeenAt` instead of `updatedAt`, so the panel order reflects spawn time rather than most-recent-activity time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10e493d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->