### PR TITLE
fix(web): stop the "requests are slow" warning from firing on every provider update

### DIFF
--- a/apps/web/src/components/SlowRpcRequestToastCoordinator.tsx
+++ b/apps/web/src/components/SlowRpcRequestToastCoordinator.tsx
@@ -5,7 +5,10 @@ import { toastManager } from "./ui/toast";
 
 function describeSlowRequests(requests: ReadonlyArray<SlowRpcAckRequest>): string {
   const count = requests.length;
-  const thresholdSeconds = Math.round((requests[0]?.thresholdMs ?? 0) / 1000);
+  // Thresholds vary per method, so report the smallest one the batch has passed.
+  const thresholdSeconds = Math.round(
+    Math.min(...requests.map((request) => request.thresholdMs)) / 1000,
+  );
 
   return `${count} request${count === 1 ? "" : "s"} waiting longer than ${thresholdSeconds}s.`;
 }

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -590,7 +590,7 @@ const rpcRequestObserverLayer = Layer.succeed(
       Effect.sync(() => {
         nextObservedRpcRequestId += 1;
         const requestId = `${environmentId}:${nextObservedRpcRequestId}`;
-        trackRpcRequestSent(requestId, `${method} · ${environmentId}`);
+        trackRpcRequestSent(requestId, method, `${method} · ${environmentId}`);
         return Effect.sync(() => {
           acknowledgeRpcRequest(requestId);
         });

--- a/apps/web/src/rpc/requestLatencyState.test.ts
+++ b/apps/web/src/rpc/requestLatencyState.test.ts
@@ -6,6 +6,7 @@ import {
   getSlowRpcAckRequests,
   resetRequestLatencyStateForTests,
   trackRpcRequestSent,
+  LONG_RUNNING_RPC_ACK_THRESHOLD_MS,
   SLOW_RPC_ACK_THRESHOLD_MS,
   MAX_TRACKED_RPC_ACK_REQUESTS,
 } from "./requestLatencyState";
@@ -56,6 +57,32 @@ describe("requestLatencyState", () => {
     vi.advanceTimersByTime(SLOW_RPC_ACK_THRESHOLD_MS * 2);
 
     expect(getSlowRpcAckRequests()).toEqual([]);
+  });
+
+  it("keeps ignoring untracked methods when a display tag is supplied", () => {
+    trackRpcRequestSent(
+      "1",
+      WS_METHODS.previewAutomationConnect,
+      `${WS_METHODS.previewAutomationConnect} · env-1`,
+    );
+    vi.advanceTimersByTime(SLOW_RPC_ACK_THRESHOLD_MS * 2);
+
+    expect(getSlowRpcAckRequests()).toEqual([]);
+  });
+
+  it("gives provider updates a longer threshold before warning", () => {
+    trackRpcRequestSent("1", WS_METHODS.serverUpdateProvider, "server.updateProvider · env-1");
+    vi.advanceTimersByTime(LONG_RUNNING_RPC_ACK_THRESHOLD_MS - 1);
+    expect(getSlowRpcAckRequests()).toEqual([]);
+
+    vi.advanceTimersByTime(1);
+    expect(getSlowRpcAckRequests()).toMatchObject([
+      {
+        requestId: "1",
+        tag: "server.updateProvider · env-1",
+        thresholdMs: LONG_RUNNING_RPC_ACK_THRESHOLD_MS,
+      },
+    ]);
   });
 
   it("evicts the oldest pending requests once the tracker reaches capacity", () => {

--- a/apps/web/src/rpc/requestLatencyState.ts
+++ b/apps/web/src/rpc/requestLatencyState.ts
@@ -5,6 +5,12 @@ import { Atom } from "effect/unstable/reactivity";
 import { appAtomRegistry } from "./atomRegistry";
 
 export const SLOW_RPC_ACK_THRESHOLD_MS = 15_000;
+/**
+ * Some requests are slow by design — they shell out to a package manager on the
+ * server and only respond once the install finishes. Warning about those after
+ * 15s is noise, so they get a much longer leash.
+ */
+export const LONG_RUNNING_RPC_ACK_THRESHOLD_MS = 120_000;
 export const MAX_TRACKED_RPC_ACK_REQUESTS = 256;
 let slowRpcAckThresholdMs = SLOW_RPC_ACK_THRESHOLD_MS;
 
@@ -22,7 +28,12 @@ interface PendingRpcAckRequest {
 }
 
 const pendingRpcAckRequests = new Map<string, PendingRpcAckRequest>();
-const untrackedRpcAckTags = new Set<string>([WS_METHODS.previewAutomationConnect]);
+const untrackedRpcAckMethods = new Set<string>([WS_METHODS.previewAutomationConnect]);
+const longRunningRpcAckMethods = new Set<string>([
+  WS_METHODS.serverUpdateProvider,
+  WS_METHODS.serverRefreshProviders,
+  WS_METHODS.serverUpdateServer,
+]);
 
 const slowRpcAckRequestsAtom = Atom.make<ReadonlyArray<SlowRpcAckRequest>>([]).pipe(
   Atom.keepAlive,
@@ -37,16 +48,27 @@ function getSlowRpcAckRequestsValue(): ReadonlyArray<SlowRpcAckRequest> {
   return appAtomRegistry.get(slowRpcAckRequestsAtom);
 }
 
-function shouldTrackRpcAck(tag: string): boolean {
-  return !tag.includes("subscribe") && !untrackedRpcAckTags.has(tag);
+function shouldTrackRpcAck(method: string): boolean {
+  return !method.includes("subscribe") && !untrackedRpcAckMethods.has(method);
+}
+
+function rpcAckThresholdMs(method: string): number {
+  return longRunningRpcAckMethods.has(method)
+    ? Math.max(slowRpcAckThresholdMs, LONG_RUNNING_RPC_ACK_THRESHOLD_MS)
+    : slowRpcAckThresholdMs;
 }
 
 export function getSlowRpcAckRequests(): ReadonlyArray<SlowRpcAckRequest> {
   return getSlowRpcAckRequestsValue();
 }
 
-export function trackRpcRequestSent(requestId: string, tag: string): void {
-  if (!shouldTrackRpcAck(tag)) {
+/**
+ * Starts the slow-request timer for one in-flight unary RPC. `method` is the
+ * bare WS method (used to decide whether and how long to wait); `tag` is the
+ * human-readable label shown in the toast, which defaults to the method.
+ */
+export function trackRpcRequestSent(requestId: string, method: string, tag = method): void {
+  if (!shouldTrackRpcAck(method)) {
     return;
   }
 
@@ -54,17 +76,18 @@ export function trackRpcRequestSent(requestId: string, tag: string): void {
   evictOldestPendingRpcRequestIfNeeded();
 
   const startedAtMs = Date.now();
+  const thresholdMs = rpcAckThresholdMs(method);
   const request: SlowRpcAckRequest = {
     requestId,
     startedAt: new Date(startedAtMs).toISOString(),
     startedAtMs,
     tag,
-    thresholdMs: slowRpcAckThresholdMs,
+    thresholdMs,
   };
   const timeoutId = setTimeout(() => {
     pendingRpcAckRequests.delete(requestId);
     appendSlowRpcAckRequest(request);
-  }, slowRpcAckThresholdMs);
+  }, thresholdMs);
 
   pendingRpcAckRequests.set(requestId, {
     request,


### PR DESCRIPTION
Updating a provider (Claude Code, etc) almost always pops a "Some requests are slow" warning. Nothing is actually wrong: the update shells out to a package install on the server and only responds once it finishes, which takes well over the flat 15s threshold the slow-request tracker uses for every RPC. The provider update flow already shows its own progress toast, so this warning is pure noise on top of it.

Known long-running methods (`updateProvider`, `refreshProviders`, `updateServer`) now get a 120s threshold instead. The global 15s stays put so the warning still means something for normal requests.

While in there: `trackRpcRequestSent` was being called with `"method · environmentId"` as its only identifier, so the existing `previewAutomation.connect` exemption never actually matched in production (only in tests, which passed the bare method). It now takes the method and the display tag separately.

---
Made with Claude Opus 5 (1M context) in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side timing and toast behavior only; no changes to RPC handling, auth, or server logic.
> 
> **Overview**
> **Fixes false "Some requests are slow" toasts** during provider updates and similar server work that routinely exceeds 15s while install/shell commands run (the UI already shows progress for those flows).
> 
> The slow-ack tracker now uses a **120s threshold** for `server.updateProvider`, `server.refreshProviders`, and `server.updateServer`, while other unary RPCs stay at **15s**. Each tracked request stores its own `thresholdMs`, and the warning copy uses the **smallest** threshold in the batch when several slow requests are shown together.
> 
> **`trackRpcRequestSent`** now takes the bare WS **method** (for skip rules and timing) and an optional **display tag** (toast label). The connection observer passes `method` plus `` `${method} · ${environmentId}` ``, so exemptions like `previewAutomation.connect` match in production—they previously failed because only the combined tag was passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a4683c902617875b4c5d7e79ddb080b619071a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix slow RPC warning from firing on every provider update
> - Introduces `longRunningRpcAckMethods` in [`requestLatencyState.ts`](https://github.com/pingdotgg/t3code/pull/5570/files#diff-084b89e2becd47f287bdcaaf7d1ac9de731014c0b96d196afd4d1f54814eb085) containing `serverUpdateProvider`, `serverRefreshProviders`, and `serverUpdateServer`, which now use a 120s threshold (`LONG_RUNNING_RPC_ACK_THRESHOLD_MS`) instead of the default slow-ack threshold.
> - Splits the `trackRpcRequestSent` signature into separate `method` and `tag` arguments so tracking and threshold decisions use the raw RPC method, while the display tag remains human-friendly.
> - Renames `untrackedRpcAckTags` to `untrackedRpcAckMethods` and gates tracking on method name rather than display tag.
> - Fixes `describeSlowRequests` to report the minimum threshold across all requests in a batch rather than always using the first request's value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a4683c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->