### PR TITLE
fix(server): one disconnecting client no longer blocks every reconnect

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -2,6 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
@@ -211,6 +212,70 @@ it.effect("memoizes editor discovery and refreshes after the cache window", () =
           }),
         ),
         TestClock.layer(),
+      ),
+    ),
+  );
+});
+
+// A client that disconnects mid-scan interrupts the shared discovery effect on
+// the connection fiber. The cache must not retain that interrupt: doing so
+// replayed it to every later connect for the whole TTL, so `server.getConfig`
+// failed and no client could reconnect until the server restarted.
+it.effect("rescans after an interrupted discovery instead of caching the interrupt", () => {
+  const fileInfo = { type: "File" } as FileSystem.File.Info;
+  let blockFirstScan = true;
+  let scans = 0;
+  const launcherLayer = ExternalLauncher.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        FileSystem.layerNoop({
+          // The first scan parks inside `stat` so the interrupt lands while
+          // discovery is in flight, which is what a client disconnecting
+          // mid-connect does to the shared effect.
+          stat: () =>
+            Effect.gen(function* () {
+              scans += 1;
+              if (blockFirstScan) {
+                return yield* Effect.never;
+              }
+              return fileInfo;
+            }),
+        }),
+        Path.layer,
+        Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make(() => Effect.sync(() => makeMockDetachedHandle())),
+        ),
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const launcher = yield* ExternalLauncher.ExternalLauncher;
+
+    const fiber = yield* Effect.forkChild(launcher.resolveAvailableEditors());
+    yield* Effect.yieldNow;
+    yield* Fiber.interrupt(fiber);
+
+    // The next connect must still get a real answer well inside the TTL.
+    blockFirstScan = false;
+    scans = 0;
+    const editors = yield* launcher.resolveAvailableEditors();
+    assert.equal(editors.includes("vscode"), true);
+    assert.isAbove(scans, 0);
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        launcherLayer,
+        Layer.succeed(HostProcessPlatform, "win32"),
+        ConfigProvider.layer(
+          ConfigProvider.fromEnv({
+            env: {
+              PATH: "C:\\t3-editor-discovery-interrupt-test",
+              PATHEXT: ".COM;.EXE;.BAT;.CMD",
+            },
+          }),
+        ),
       ),
     ),
   );

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -22,7 +22,6 @@ import { isCommandAvailable, resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Clock from "effect/Clock";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
-import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
@@ -313,11 +312,14 @@ const resolveAvailableEditors = Effect.fn("externalLauncher.resolveAvailableEdit
 // to every later connect for the whole TTL, breaking `server.getConfig`
 // permanently. Storing only on success means an interrupted scan leaves the
 // cache untouched and the next connect simply rescans.
-const EDITOR_DISCOVERY_CACHE_TTL = Duration.seconds(60);
+// Expiry uses the monotonic clock (Clock.currentTimeNanos), matching the
+// command-resolution cache in @t3tools/shared/shell, so a backward wall-clock
+// adjustment cannot keep an expired entry alive.
+const EDITOR_DISCOVERY_CACHE_TTL_NANOS = 60_000_000_000n;
 
 interface EditorDiscoveryCacheEntry {
   readonly editors: ReadonlyArray<EditorId>;
-  readonly expiresAtMillis: number;
+  readonly expiresAtNanos: bigint;
 }
 
 /**
@@ -469,9 +471,9 @@ export const make = Effect.gen(function* () {
     Option.none(),
   );
   const cachedAvailableEditors = Effect.gen(function* () {
-    const nowMillis = yield* Clock.currentTimeMillis;
+    const nowNanos = yield* Clock.currentTimeNanos;
     const entry = yield* Ref.get(editorDiscoveryCache);
-    if (Option.isSome(entry) && entry.value.expiresAtMillis > nowMillis) {
+    if (Option.isSome(entry) && entry.value.expiresAtNanos > nowNanos) {
       return entry.value.editors;
     }
     const editors = yield* provideCommandResolutionServices(resolveAvailableEditors());
@@ -479,7 +481,7 @@ export const make = Effect.gen(function* () {
       editorDiscoveryCache,
       Option.some({
         editors,
-        expiresAtMillis: nowMillis + Duration.toMillis(EDITOR_DISCOVERY_CACHE_TTL),
+        expiresAtNanos: nowNanos + EDITOR_DISCOVERY_CACHE_TTL_NANOS,
       }),
     );
     return editors;

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -19,14 +19,17 @@ import {
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { isCommandAvailable, resolveSpawnCommand } from "@t3tools/shared/shell";
+import * as Clock from "effect/Clock";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
@@ -302,7 +305,20 @@ const resolveAvailableEditors = Effect.fn("externalLauncher.resolveAvailableEdit
 // client connect (the server config embeds the available editors). Memoize
 // the discovered set for a bounded window so repeat connects skip even the
 // per-command cache lookups in @t3tools/shared/shell.
-const EDITOR_DISCOVERY_CACHE_TTL = "60 seconds";
+//
+// This deliberately does not use `Effect.cachedWithTTL`: that memoizes the
+// first caller's Exit whatever it is, including an interrupt. Callers run this
+// on the connection fiber under a timeout (`resolveAvailableEditorsForConfig`),
+// so one client disconnecting mid-scan would cache the interrupt and replay it
+// to every later connect for the whole TTL, breaking `server.getConfig`
+// permanently. Storing only on success means an interrupted scan leaves the
+// cache untouched and the next connect simply rescans.
+const EDITOR_DISCOVERY_CACHE_TTL = Duration.seconds(60);
+
+interface EditorDiscoveryCacheEntry {
+  readonly editors: ReadonlyArray<EditorId>;
+  readonly expiresAtMillis: number;
+}
 
 /**
  * ExternalLauncher - Service tag for browser/editor launch operations.
@@ -449,10 +465,25 @@ export const make = Effect.gen(function* () {
       Effect.provideService(Path.Path, path),
     );
 
-  const cachedAvailableEditors = yield* Effect.cachedWithTTL(
-    provideCommandResolutionServices(resolveAvailableEditors()),
-    EDITOR_DISCOVERY_CACHE_TTL,
+  const editorDiscoveryCache = yield* Ref.make<Option.Option<EditorDiscoveryCacheEntry>>(
+    Option.none(),
   );
+  const cachedAvailableEditors = Effect.gen(function* () {
+    const nowMillis = yield* Clock.currentTimeMillis;
+    const entry = yield* Ref.get(editorDiscoveryCache);
+    if (Option.isSome(entry) && entry.value.expiresAtMillis > nowMillis) {
+      return entry.value.editors;
+    }
+    const editors = yield* provideCommandResolutionServices(resolveAvailableEditors());
+    yield* Ref.set(
+      editorDiscoveryCache,
+      Option.some({
+        editors,
+        expiresAtMillis: nowMillis + Duration.toMillis(EDITOR_DISCOVERY_CACHE_TTL),
+      }),
+    );
+    return editors;
+  });
 
   return ExternalLauncher.of({
     resolveAvailableEditors: () => cachedAvailableEditors,


### PR DESCRIPTION
My machine stopped accepting connections and stayed broken. Reloading did nothing. The server was healthy and the relay was fine: the WebSocket authenticated, then the very first RPC died and the socket closed ~100ms later, on every attempt.

Editor discovery is memoized with `Effect.cachedWithTTL`, which stores whatever Exit the first caller produces — including an interrupt. Callers run it on the connection fiber under a timeout, so a client that disconnects mid-scan caches the interrupt. Every later connect then replays it, `server.getConfig` fails, and nothing can reconnect. Worse, each failed connect re-runs discovery and re-poisons the cache, so the 60s TTL keeps refreshing and it never self-heals. Only a restart clears it.

Cache the discovered set only on success. An interrupted scan now leaves the cache untouched and the next connect simply rescans. The memoization that #5561 added is preserved.

Trace from the stuck server, showing where the connection died:

```
EnvironmentAuth.authenticateWebSocketUpgrade  Success
SessionStore.markConnected                    Success
ws.rpc.server.getConfig                       Interrupted
SessionStore.markDisconnected                 Success
```

The regression test reproduces this: it fails on the current code with the same interrupt through the same `isExecutableFile` → `resolveAvailableCommand` stack, and passes with the fix. Verified by reverting the source and re-running. Full server suite: 1,901 passing, typecheck clean.

Introduced by #5561, which is in nightly `.1021`.

Made by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection-time config path (`getConfig` / editor discovery) with custom caching semantics; scope is narrow and covered by a targeted regression test.
> 
> **Overview**
> **Editor discovery memoization no longer caches interrupts**, fixing reconnects that failed on every `server.getConfig` until restart.
> 
> `ExternalLauncher.resolveAvailableEditors` drops `Effect.cachedWithTTL` for a `Ref`-backed cache that **writes only after a successful PATH scan**. If discovery is interrupted (e.g. client disconnect mid-connect on the connection fiber), the cache stays empty and the next connect rescans instead of replaying the interrupt for the full 60s TTL. TTL expiry uses **`Clock.currentTimeNanos`** (monotonic), aligned with shell command-resolution caching.
> 
> A regression test interrupts discovery mid-scan and asserts a later call still returns editors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d0847b01ac5dfdb98e91dfbd54f7563121625c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveAvailableEditors` to skip caching interrupted or failed discoveries
> - `Effect.cachedWithTTL` was replaying cached interrupts, blocking reconnects when a client disconnected mid-discovery. Replaced with a manual `Ref`-backed cache in [`externalLauncher.ts`](https://github.com/pingdotgg/t3code/pull/5572/files#diff-157ca66b5181820e0a628ef443d244577cda2329dd1d88fe5f2aff441da05e56).
> - The new cache only stores successful results and uses a monotonic nanosecond TTL (`60_000_000_000n`) via `Clock.currentTimeNanos` to avoid system clock skew issues.
> - A regression test in [`externalLauncher.test.ts`](https://github.com/pingdotgg/t3code/pull/5572/files#diff-f9009ae89a140555a41340a33170f91688ae528ad831d3e5f016056b18fa8024) verifies that an interrupted discovery is not cached and a subsequent call rescans correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76d0847.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->