### PR TITLE
docs: ship production T3 Connect public config in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,14 @@
 # Optional: T3 Connect source builds
-# Leave these unset to disable optional T3 Connect features in local source builds.
-# Release builds inject their public values at build time. Do not add server-side
-# secrets to this file.
+# `cp .env.example .env` enables T3 Connect against the production deployment.
+# These are the same public identifiers baked into official release builds, not
+# secrets. Remove or comment them out to build with cloud features disabled.
+# Do not add server-side secrets to this file.
 
-# Get these from the Clerk Dashboard under API keys, JWT templates, and OAuth applications.
-# T3CODE_CLERK_PUBLISHABLE_KEY=pk_test_...
-# T3CODE_CLERK_JWT_TEMPLATE=t3-relay
-# T3CODE_CLERK_CLI_OAUTH_CLIENT_ID=oauthapp_...
+# Production Clerk instance. To use your own, get these from the Clerk Dashboard
+# under API keys, JWT templates, and OAuth applications.
+T3CODE_CLERK_PUBLISHABLE_KEY=pk_live_Y2xlcmsudDMuY29kZXMk
+T3CODE_CLERK_JWT_TEMPLATE=t3-relay
+T3CODE_CLERK_CLI_OAUTH_CLIENT_ID=hzxSgY2cH10sDU2r
 
 # Optional: signed macOS passkey builds. The RP domain defaults to the Frontend API
 # hostname encoded in T3CODE_CLERK_PUBLISHABLE_KEY. Set the override only when Clerk
@@ -15,8 +17,9 @@
 # T3CODE_MACOS_PROVISIONING_PROFILE=/absolute/path/to/t3code.provisionprofile
 # T3CODE_CLERK_PASSKEY_RP_DOMAINS=example.clerk.accounts.dev,clerk.example.com
 
-# Get this from your relay deployment. `infra/relay` deploys update it automatically.
-# T3CODE_RELAY_URL=https://relay.example.com
+# Production relay. For a self-hosted relay, `infra/relay` deploys update it
+# automatically.
+T3CODE_RELAY_URL=https://relay.t3.codes
 
 # Optional: hosted app origin used by the CLI's out-of-band OAuth flow.
 # Defaults to https://app.t3.codes; override to test against a staging deployment.

--- a/docs/internals/t3-connect.md
+++ b/docs/internals/t3-connect.md
@@ -14,8 +14,16 @@ For the wider system diagram, see
 
 ## Application Keys
 
-T3 Connect is disabled in a fresh clone. To enable it for source builds, add a repository-root `.env`
-or `.env.local` file:
+T3 Connect is disabled in a fresh clone. To enable it for source builds against the production
+deployment, copy the repository-root example file:
+
+```sh
+cp .env.example .env
+```
+
+`.env.example` carries the production public identifiers (the same values baked into official
+release builds). To target a different Clerk application or relay, set the values yourself in a
+repository-root `.env` or `.env.local` file:
 
 ```dotenv
 T3CODE_CLERK_PUBLISHABLE_KEY=<publishable key>


### PR DESCRIPTION
## Problem

Enabling T3 Connect in a source build required hunting down four public values (Clerk publishable key, JWT template, CLI OAuth client ID, relay URL) out of band, even though all of them are public identifiers already baked into every release artifact and the hosted app bundle.

## Solution

Fill in the real production values in `.env.example` so `cp .env.example .env` is the entire setup step. A fresh clone still defaults to cloud-off, and pointing at prod stays an explicit, greppable action. Includes `T3CODE_CLERK_CLI_OAUTH_CLIENT_ID` so the CLI and the client apps enable together instead of producing a half-configured state. `docs/internals/t3-connect.md` updated to match.

No code changes; verified the example file resolves correctly through `resolvePublicConfig` in `scripts/lib/public-config.ts`.

---
Changes made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example env only; values are public identifiers with no runtime code changes.
> 
> **Overview**
> **Enables T3 Connect in source builds with one copy step** by putting the same production public Clerk and relay identifiers in `.env.example` that release builds already embed—`T3CODE_CLERK_PUBLISHABLE_KEY`, `T3CODE_CLERK_JWT_TEMPLATE`, `T3CODE_CLERK_CLI_OAUTH_CLIENT_ID`, and `T3CODE_RELAY_URL`—instead of leaving them commented placeholders.
> 
> Comments in `.env.example` now state that `cp .env.example .env` turns on T3 Connect against production and that removing or commenting those vars keeps cloud features off. **`docs/internals/t3-connect.md`** matches that flow: copy the example file for prod, or override in `.env` / `.env.local` for another Clerk app or relay.
> 
> No application or loader code changes; behavior is unchanged until a developer actually copies the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 506382f39e13c887ea7bc882cebdca2f68c4d9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ship production T3 Connect public identifiers in `.env.example` for source builds
> - Updates [`.env.example`](https://github.com/pingdotgg/t3code/pull/5573/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c) with uncommented production Clerk and relay values so copying it to `.env` immediately connects a source build to the production T3 Connect deployment.
> - Adds header comments clarifying these are public identifiers, not secrets, and are equivalent to what ships in release builds.
> - Updates [docs/internals/t3-connect.md](https://github.com/pingdotgg/t3code/pull/5573/files#diff-66b29665c8e001b0ae9ca92f9461d961ef7cf7e7257dce2366bcc3e69462fc4e) to instruct users to copy `.env.example` to `.env` to enable T3 Connect, with a note that targeting a different Clerk app or relay requires a local `.env`/`.env.local` override.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 506382f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->