### PR TITLE
fix(web): stop the sidebar "Working" label from pulsing

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -502,13 +502,17 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       ? {
           label: "Working",
           icon: "working" as const,
-          className:
-            "animate-sidebar-working-text text-sky-600 motion-reduce:animate-none dark:text-sky-400",
+          // No shimmer: a label that animates forever is noise in a sidebar
+          // full of them (and repaints every vsync on high-refresh displays).
+          // Working is a background state, so it rests at the dim end of what
+          // the old pulse cycled through; only the thread you have open gets
+          // the label at full strength.
+          className: cn("text-sky-600 dark:text-sky-400", !props.isActive && "opacity-75"),
         }
       : status === "monitoring"
         ? {
-            // Steady label, no duty-cycled shimmer: monitoring is calm
-            // background presence, not active progress (monitoring-pill D6).
+            // Monitoring is calm background presence, not active progress
+            // (monitoring-pill D6), so it keeps the label at full strength.
             label: "Monitoring",
             icon: null,
             className: "text-sky-600 dark:text-sky-400",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -146,7 +146,6 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
      compositor updates discrete frames instead of every vsync. */
   --animate-status-pulse: status-pulse 2s infinite;
   --animate-status-ping: status-ping 2s infinite;
-  --animate-sidebar-working-text: sidebar-working-text 3.4s infinite;
   --color-warning-foreground: var(--warning-foreground);
   --color-warning: var(--warning);
   --color-success-foreground: var(--success-foreground);
@@ -221,21 +220,6 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     100% {
       opacity: 0;
       scale: 2;
-    }
-  }
-  @keyframes sidebar-working-text {
-    0%,
-    36% {
-      opacity: 1;
-      animation-timing-function: steps(10);
-    }
-    50%,
-    86% {
-      opacity: 0.75;
-      animation-timing-function: steps(10);
-    }
-    100% {
-      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
## Problem

Every working thread in the sidebar runs a forever shimmer on its "Working" label, cycling opacity between 1 and 0.75 on a 3.4s loop. With several threads in flight the sidebar is a wall of independently breathing text, and the animation repaints continuously.

## Solution

Drop the animation. The label now rests at the dim end of what the pulse used to cycle through (`opacity-75`), and only the thread you currently have open shows it at full strength. The `sidebar-working-text` keyframes and theme entry are removed since nothing else used them.

Typecheck, lint, and the 1825 web unit tests pass.

---
Made by Claude Opus 5 (1M context) in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only sidebar status styling with dead CSS removed; no behavior, API, or data-path changes.
> 
> **Overview**
> **Sidebar V2** no longer animates the **Working** status label. The text stays sky-colored without the duty-cycled opacity pulse, which cut continuous repaints when many threads were in flight.
> 
> Inactive rows use **`opacity-75`** (the dim end of the old cycle); the **active** thread keeps the label at full strength. **Monitoring** comment copy is updated to match that static treatment.
> 
> **`index.css`** drops the **`--animate-sidebar-working-text`** theme token and **`sidebar-working-text`** keyframes, which were only used for this effect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f0340e73a556df215fe530ebcc7c3f955604ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop the sidebar 'Working' label from pulsing
> Removes the shimmer animation from threads in 'working' status in [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/5580/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c). The label is now static and dimmed (opacity-75) when the row is not active, and full-strength color when active. The `--animate-sidebar-working-text` CSS variable and `@keyframes sidebar-working-text` definition are removed from [index.css](https://github.com/pingdotgg/t3code/pull/5580/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73f0340.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->