### PR TITLE
fix(mobile): keep Android chat text from showing through the composer

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -21,6 +21,7 @@ import {
   Image,
   Platform,
   Pressable,
+  StyleSheet,
   useColorScheme,
   View,
   type ViewStyle,
@@ -698,11 +699,22 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       style={{
         paddingTop: isExpanded ? 8 : 6,
         paddingBottom: (props.bottomInset ?? 0) + (isExpanded ? 8 : 6),
-        experimental_backgroundImage: isDarkMode
-          ? "linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 55%, rgba(0,0,0,0.9) 100%)"
-          : "linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.6) 55%, rgba(255,255,255,0.9) 100%)",
       }}
     >
+      {/* The backdrop gradient lives on a plain View: Reanimated's Animated.View
+          silently drops experimental_backgroundImage on Android, which left this
+          strip fully transparent and the feed text legible through the composer. */}
+      <View
+        pointerEvents="none"
+        style={[
+          StyleSheet.absoluteFill,
+          {
+            experimental_backgroundImage: isDarkMode
+              ? "linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 55%, rgba(0,0,0,0.9) 100%)"
+              : "linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.6) 55%, rgba(255,255,255,0.9) 100%)",
+          },
+        ]}
+      />
       <Animated.View
         className="relative w-full self-center"
         layout={COMPOSER_LAYOUT_TRANSITION}

--- a/patches/@react-native__gradle-plugin@0.85.3.patch
+++ b/patches/@react-native__gradle-plugin@0.85.3.patch
@@ -1,0 +1,13 @@
+diff --git a/settings.gradle.kts b/settings.gradle.kts
+index b3c46a3bf5eb21c0bb1c9435b5582aecbc57d57a..14f1e9c2063ef10ca3f2ecbb2336b8a4aacfcc9c 100644
+--- a/settings.gradle.kts
++++ b/settings.gradle.kts
+@@ -13,7 +13,7 @@ pluginManagement {
+   }
+ }
+ 
+-plugins { id("org.gradle.toolchains.foojay-resolver-convention").version("0.5.0") }
++plugins { id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0") }
+ 
+ include(
+     ":react-native-gradle-plugin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,7 @@ patchedDependencies:
   '@legendapp/list@3.3.3': d162d67b73933ab077d00627cdf52b18ea88b28c4fae4e8340a854df25026f09
   '@pierre/diffs@1.3.0-beta.10': 7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa
   '@react-native-menu/menu@2.0.0': 5ea3ae4bf1d9baf5443b65c269bb09621c27a68d556f713778f37b1e8d46aaae
+  '@react-native/gradle-plugin@0.85.3': c1b594a16e682d621b6a960926f8ce13fc92edfb397884cfe7fcb0518996a784
   '@react-navigation/native-stack@7.17.6': c7fc101b78d434904425e5a24c22fb0042298dec6f807250486e784f3c717273
   effect@4.0.0-beta.103: af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6
   expo-modules-jsi@56.0.10: 9170f8074ae4e35a0a086e756c8f815794fd3abe51eac67ca3ba02804225ec1f
@@ -14210,7 +14211,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/gradle-plugin@0.85.3': {}
+  '@react-native/gradle-plugin@0.85.3(patch_hash=c1b594a16e682d621b6a960926f8ce13fc92edfb397884cfe7fcb0518996a784)': {}
 
   '@react-native/js-polyfills@0.85.3': {}
 
@@ -20059,7 +20060,7 @@ snapshots:
       '@react-native/assets-registry': 0.85.3
       '@react-native/codegen': 0.85.3(@babel/core@7.29.7)
       '@react-native/community-cli-plugin': 0.85.3(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@react-native/gradle-plugin': 0.85.3
+      '@react-native/gradle-plugin': 0.85.3(patch_hash=c1b594a16e682d621b6a960926f8ce13fc92edfb397884cfe7fcb0518996a784)
       '@react-native/js-polyfills': 0.85.3
       '@react-native/normalize-colors': 0.85.3
       '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.16)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -20104,7 +20105,7 @@ snapshots:
       '@react-native/assets-registry': 0.85.3
       '@react-native/codegen': 0.85.3(@babel/core@7.29.7)
       '@react-native/community-cli-plugin': 0.85.3(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@react-native/gradle-plugin': 0.85.3
+      '@react-native/gradle-plugin': 0.85.3(patch_hash=c1b594a16e682d621b6a960926f8ce13fc92edfb397884cfe7fcb0518996a784)
       '@react-native/js-polyfills': 0.85.3
       '@react-native/normalize-colors': 0.85.3
       '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.16)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -128,6 +128,7 @@ patchedDependencies:
   "@legendapp/list@3.3.3": patches/@legendapp__list@3.3.3.patch
   "@pierre/diffs@1.3.0-beta.10": patches/@pierre%2Fdiffs@1.3.0-beta.10.patch
   "@react-native-menu/menu@2.0.0": patches/@react-native-menu__menu@2.0.0.patch
+  "@react-native/gradle-plugin@0.85.3": patches/@react-native__gradle-plugin@0.85.3.patch
   "@react-navigation/native-stack@7.17.6": patches/@react-navigation%2Fnative-stack@7.17.6.patch
   effect@4.0.0-beta.103: patches/effect@4.0.0-beta.103.patch
   expo-modules-jsi@56.0.10: patches/expo-modules-jsi@56.0.10.patch


### PR DESCRIPTION
## Summary

On Android, thread feed text stays fully legible as it scrolls behind the composer, because the composer's backdrop gradient never renders there: Reanimated's `Animated.View` silently drops `experimental_backgroundImage` on Android, leaving the strip 100% transparent. iOS is unaffected (the gradient renders natively and the liquid-glass pill blurs whatever remains).

- Move the backdrop gradient from the animated container onto a plain `pointerEvents="none"` child `View` (`StyleSheet.absoluteFill`), where React Native renders it on both platforms. Same visual design, no new dependency.
- Ship `patches/@react-native__gradle-plugin@0.85.3.patch` bumping the foojay resolver to 1.0.0: without it `expo run:android` fails on Gradle 9 (`JvmVendorSpec.IBM_SEMERU` was removed), so Android builds are currently broken from a clean checkout.

The other `experimental_backgroundImage` usages (`NewTaskDraftScreen`, `ComposerToolbarTrigger`) already sit on plain `View`s and are unaffected.

## Before / After

Dark mode (left: before, feed text fully legible through the composer; right: after, faded like iOS):

![before/after dark](https://raw.githubusercontent.com/PollyGlot/t3code/pr-assets/android-composer-gradient/compare-dark.png)

Light mode:

![before/after light](https://raw.githubusercontent.com/PollyGlot/t3code/pr-assets/android-composer-gradient/compare-light.png)

## Test plan

- [x] Reproduced on a Pixel emulator (API 35, dev client built from this branch): before the fix, list text renders fully opaque behind the composer pill and toolbar.
- [x] After the fix, text scrolling behind the composer fades out in both light and dark mode, collapsed and expanded (keyboard open) states.
- [x] At-rest layout unchanged: content still parks above the composer (bottom inset path untouched).
- [x] `tsc --noEmit`, `vp lint`, `vp fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile UI layering fix and a build-tooling patch; no auth, data, or server behavior changes.
> 
> **Overview**
> Fixes **Android thread UI** where feed text stayed fully readable behind the composer because Reanimated’s `Animated.View` ignored `experimental_backgroundImage`.
> 
> The composer **backdrop gradient** is moved onto a non-interactive child `View` with `StyleSheet.absoluteFill` in `ThreadComposer`, keeping the same light/dark gradients while rendering on Android. Layout animation and padding on the outer `Animated.View` are unchanged.
> 
> Also adds a **pnpm patch** for `@react-native/gradle-plugin@0.85.3` that bumps the foojay toolchain resolver plugin to `1.0.0`, unblocking `expo run:android` on Gradle 9 where the older resolver references removed APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930155c342c45bcb01fc830131c93e6effa72c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android chat text showing through the composer backdrop gradient
> On Android, `Animated.View` drops the `experimental_backgroundImage` gradient property, leaving the composer backdrop transparent and allowing chat text to show through.
>
> - Moves the gradient from the outer `Animated.View` to a separate plain `View` with `StyleSheet.absoluteFill` in [ThreadComposer.tsx](https://github.com/pingdotgg/t3code/pull/5582/files#diff-4c62d895b68dd46f4d2858321c8942fde0d3ddd37c5e4253cba04c18c21a6024), which renders the gradient correctly on Android.
> - Also patches `@react-native/gradle-plugin@0.85.3` to update the `foojay-resolver-convention` Gradle plugin from `0.5.0` to `1.0.0` to fix an Android build issue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 930155c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->