### PR TITLE
fix(dev): agents get --share right on the first try

### DIFF
--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -40,7 +40,7 @@ Treat the overall testing or implementation loop—not an assistant turn or one 
 - Do not stop the server merely because one verification pass completed or because you are yielding a response to the user.
 - Before starting another environment, check whether the existing process and browser tab still serve the task. Reuse them when healthy instead of discarding useful state.
 - On a later turn, verify that the existing process is alive and reuse its printed ports and base directory. If it exited, restart with the same base directory; create a new pairing token only when the browser session is no longer valid.
-- Tell the user when a test environment remains available, including its non-secret web URL when useful. Never include a pairing token.
+- Tell the user when a test environment remains available, including its non-secret web URL when useful. Include a pairing token only when the user still needs to pair (see below).
 
 ## Authenticate the browser on the first navigation
 
@@ -50,24 +50,13 @@ Treat the overall testing or implementation loop—not an assistant turn or one 
 4. Wait for the pairing exchange and redirect to finish before navigating elsewhere.
 5. Continue in the same browser context so its stored bearer session remains available.
 
-Treat pairing URLs as secrets. Do not copy them into final responses, screenshots, committed files, or durable logs. A pairing token is short-lived and single-use; opening the URL in another browser or opening it twice can consume it.
+Keep pairing URLs out of screenshots, committed files, and durable logs. When the user asked for a shared environment, the deliverable IS the full pairing URL — paste it in your reply, token and all; a bare origin is useless to them. A pairing token is short-lived and single-use; opening the URL in another browser or opening it twice can consume it, so never open a URL you handed to the user.
 
 ## Recover a consumed or expired pairing token
 
-Create another token against the same database and web URL as the running dev server:
+Run `node apps/server/src/bin.ts pair` from the repository root. It discovers the running dev server (worktree `.t3` first, same precedence as the dev runner) and prints a fresh `Pair URL` against the server's current web origin, including a `--share` tailnet origin. Pass `--base-dir <base-dir>` only when the server was started with `--home-dir`, using the identical path.
 
-```bash
-T3CODE_PORT=<server-port> node apps/server/src/bin.ts auth pairing create \
-  --base-dir <base-dir> \
-  --dev-url <web-url> \
-  --base-url <web-url> \
-  --ttl 15m \
-  --label agent-ui-test
-```
-
-Use the `Pair URL` from this command once. Derive `<server-port>` and `<web-url>` from the current dev-runner output, including any automatically selected port offset. Setting `T3CODE_PORT` keeps the administrative CLI from probing for an unrelated free port.
-
-Always pass `--dev-url` for a dev-runner environment so the generated pairing URL uses the current web origin. An explicit base directory stores runtime state in `<base-dir>/userdata`; the `<base-dir>/dev` fallback is only used by an implicit dev home. A worktree-local `.t3` counts as explicit, so its state lives in `<worktree>/.t3/userdata`. Use `auth pairing list` to inspect active token metadata; it intentionally cannot reveal token secrets.
+Tokens from `pair` carry standard client scopes. The startup pairing URL carries admin scopes; if the user needs Settings → Connections management (`access:write`), restart the server and hand over the new startup URL instead.
 
 ## Inspect or seed SQLite state
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,8 @@ The most common defect in this repo is a change that works on the path you teste
 - `vp i` installs. Worktrees get this from the t3.json setup script; if module resolution looks broken, it probably did not run.
 - `vp run dev` starts server and web. In a worktree, state defaults to that worktree's gitignored `.t3`, which deliberately outranks an ambient `T3CODE_HOME` so you cannot land on shared state by accident. An explicit `--home-dir` still wins.
 - Ports derive from the worktree path and are stable across restarts, but read the real ones from the `[dev-runner]` line since occupied ports shift.
-- `--share` publishes over the tailnet. Do not open the URL when you use this, just send it to the user with the pairing code included in url
-- The web app requires pairing. Hand over the pairing URL, not the bare origin. A URL without its token is useless to whoever you gave it to.
+- Sharing over the tailnet is three steps: run `vp run dev --share` in the background, wait for the `pairingUrl:` line in its output, paste that full URL (token included) in your reply. Do not use tsdev or raw `tailscale serve` for this, and do not open the URL yourself.
+- The web app requires pairing. Hand over the pairing URL, not the bare origin. A URL without its token is useless to whoever you gave it to. If the token got consumed, mint a fresh one with `node apps/server/src/bin.ts pair` — note it carries standard scopes, while the startup URL carries admin scopes (needed for Settings → Connections management).
 - Stop what you started, by the PID you tracked. See rule 1.
 
 ## Test data

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ The most common defect in this repo is a change that works on the path you teste
 - `vp i` installs. Worktrees get this from the t3.json setup script; if module resolution looks broken, it probably did not run.
 - `vp run dev` starts server and web. In a worktree, state defaults to that worktree's gitignored `.t3`, which deliberately outranks an ambient `T3CODE_HOME` so you cannot land on shared state by accident. An explicit `--home-dir` still wins.
 - Ports derive from the worktree path and are stable across restarts, but read the real ones from the `[dev-runner]` line since occupied ports shift.
-- Sharing over the tailnet is three steps: run `vp run dev --share` in the background, wait for the `pairingUrl:` line in its output, paste that full URL (token included) in your reply. Do not use tsdev or raw `tailscale serve` for this, and do not open the URL yourself.
+- Sharing over the tailnet is three steps: run `vp run dev --share` in the background, wait for the `pairingUrl:` line in its output, paste that full URL (token included) in your reply. Do not wire up `tailscale serve` by hand for this, and do not open the URL yourself.
 - The web app requires pairing. Hand over the pairing URL, not the bare origin. A URL without its token is useless to whoever you gave it to. If the token got consumed, mint a fresh one with `node apps/server/src/bin.ts pair` — note it carries standard scopes, while the startup URL carries admin scopes (needed for Settings → Connections management).
 - Stop what you started, by the PID you tracked. See rule 1.
 

--- a/scripts/dev-runner.test.ts
+++ b/scripts/dev-runner.test.ts
@@ -227,6 +227,30 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
       }),
     );
 
+    it.effect("strips inherited service-launcher context", () =>
+      Effect.gen(function* () {
+        const env = yield* createDevRunnerEnv({
+          mode: "dev",
+          baseEnv: {
+            T3_SERVICE_LAUNCHER_CONTEXT: '{"childVersion":"9.9.9"}',
+            T3_BOOT_SERVICE_UNIT: "t3code.service",
+          },
+          serverOffset: 0,
+          webOffset: 0,
+          t3Home: undefined,
+          browser: undefined,
+          autoBootstrapProjectFromCwd: undefined,
+          logWebSocketEvents: undefined,
+          host: undefined,
+          port: undefined,
+          devUrl: undefined,
+        });
+
+        assert.equal(env.T3_SERVICE_LAUNCHER_CONTEXT, undefined);
+        assert.equal(env.T3_BOOT_SERVICE_UNIT, undefined);
+      }),
+    );
+
     it.effect("does not force websocket logging on in dev mode when unset", () =>
       Effect.gen(function* () {
         const env = yield* createDevRunnerEnv({

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -340,6 +340,14 @@ export function createDevRunnerEnv({
       delete output.T3CODE_HOME;
     }
 
+    // A dev-runner server is never launcher-managed. When the shell that runs
+    // this script was itself spawned by the machine's managed t3 service (an
+    // agent working inside T3 Code), these leak through and the child server
+    // fails startup with "The service launcher started a different t3 version"
+    // (serviceLauncherClient.ts resolveStartup).
+    delete output.T3_SERVICE_LAUNCHER_CONTEXT;
+    delete output.T3_BOOT_SERVICE_UNIT;
+
     if (!isDesktopMode) {
       output.T3CODE_PORT = String(serverPort);
       // HOST is Vite's own bind address, and the desktop branch below is the


### PR DESCRIPTION
## Problem

Agents asked to "spin up a dev server with --share" routinely take many turns and sometimes fail outright. An audit of 66 agent session logs found the time from request to a working pairing URL ranged from ~90 seconds to 46 minutes, with three recurring traps:

1. **Inherited `T3_SERVICE_LAUNCHER_CONTEXT`.** Agents working inside a managed t3 install leak the service-launcher env vars into the dev server, which dies with `ServiceLauncherClientError: The service launcher started a different t3 version` — *after* the `shared on tailnet:` line already printed, so the shared URL looks live but is dead. 26 sessions hit this; the `env -u ...` workaround existed only as per-agent folklore.
2. **Contradictory pairing-URL guidance.** AGENTS.md said to send the pairing URL to the user; the `test-t3-app` skill said pairing URLs are secrets that must never appear in responses. Agents that followed the skill withheld the token and got told off.
3. **Stale pairing recovery.** The skill documented a five-flag `auth pairing create` incantation from before `t3 pair` existed, and nothing mentioned that CLI-minted tokens carry weaker scopes than the startup URL (which cost one session 20 extra minutes of lockout debugging).

## Fix

- `createDevRunnerEnv` now deletes `T3_SERVICE_LAUNCHER_CONTEXT` and `T3_BOOT_SERVICE_UNIT` next to the other ambient-env deletions — a dev-runner server is never launcher-managed. One focused test.
- AGENTS.md states the whole flow as three steps (run `vp run dev --share` in the background, wait for `pairingUrl:`, paste the full URL) and names `bin.ts pair` for token recovery with the scope caveat.
- `test-t3-app` skill: when the user asked for a shared environment, the full pairing URL is the deliverable; recovery section rewritten around `pair` (which self-discovers the server) instead of the manual flag list — net 11 lines shorter.

Written by Claude Fable 5 on Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-runner env sanitization and documentation only; no production auth or data-path changes beyond preventing a false launcher-managed startup in local dev.
> 
> **Overview**
> Fixes agents spinning up **`vp run dev --share`** when they work inside a managed T3 install: **`createDevRunnerEnv`** now deletes **`T3_SERVICE_LAUNCHER_CONTEXT`** and **`T3_BOOT_SERVICE_UNIT`** so the child server is not treated as launcher-managed and no longer dies with a version-mismatch after tailnet output already looked healthy. A unit test locks in that behavior.
> 
> **`AGENTS.md`** and the **`test-t3-app`** skill are aligned on delivery: run dev with **`--share`**, wait for **`pairingUrl:`**, paste the **full URL including the token** when the user asked for a shared environment (not a bare origin). Pairing recovery is documented as **`node apps/server/src/bin.ts pair`** instead of the old multi-flag **`auth pairing create`** flow, with a note that CLI-minted tokens are standard-scope vs admin scopes on the startup URL for Settings → Connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7410b3420d9e3e63085878a14e960c197b333464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dev server startup to strip launcher context vars before spawning child processes
> - Removes `T3_SERVICE_LAUNCHER_CONTEXT` and `T3_BOOT_SERVICE_UNIT` from the environment built by `createDevRunnerEnv` in [dev-runner.ts](https://github.com/pingdotgg/t3code/pull/5586/files#diff-8ba446fc13205cee91be4164b3936316a911d90cfc2fb690c99c49ea439542bf), preventing child server startup failures when the dev runner is invoked from within a managed t3 service.
> - Updates [AGENTS.md](https://github.com/pingdotgg/t3code/pull/5586/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) and [SKILL.md](https://github.com/pingdotgg/t3code/pull/5586/files#diff-dff7b690a4370926371a9cb5f33e69be07ecad8d0466ee84cef7e17aa8ba69a4) with correct `--share` flow: run `vp run dev --share`, wait for `pairingUrl:` in output, and paste the full URL with token rather than manually configuring `tailscale serve`.
> - Documents that consumed pairing tokens can be refreshed with `node apps/server/src/bin.ts pair`, and clarifies standard vs admin scope differences.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7410b34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->