### PR TITLE
Bump mobile app version to 1.0.2

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -161,7 +161,7 @@ const config: ExpoConfig = {
   slug: "t3-code",
   platforms: ["ios", "android"],
   scheme: variant.scheme,
-  version: "1.0.1",
+  version: "1.0.2",
   runtimeVersion: {
     // Fingerprint (not appVersion) so an OTA only reaches binaries whose native
     // project — native deps, config plugins, AND patches/ — matches the update.


### PR DESCRIPTION
## What Changed

Updated the mobile app version in `apps/mobile/app.config.ts` from `1.0.1` to `1.0.2`.

## Why

To prepare the mobile app for the 1.0.2 release.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version bump with no logic, native, or OTA policy changes.
> 
> **Overview**
> Bumps the **store-facing app version** in `apps/mobile/app.config.ts` from **1.0.1** to **1.0.2** for the next mobile release.
> 
> `runtimeVersion` is unchanged (still fingerprint-based via `MOBILE_VERSION_POLICY`), so this does not alter OTA/runtime compatibility rules—only the user-visible version string used for builds and store metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cadac55b7c85ec544360afc179875c20ac030c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->