### PR TITLE
feat(server): record runtime mode per turn and on mode changes

### DIFF
--- a/apps/server/integration/providerService.integration.test.ts
+++ b/apps/server/integration/providerService.integration.test.ts
@@ -8,6 +8,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 
 import { ProviderAdapterRegistry } from "../src/provider/Services/ProviderAdapterRegistry.ts";
@@ -54,34 +55,57 @@ interface IntegrationFixture {
   readonly layer: Layer.Layer<ProviderService, unknown, never>;
 }
 
-const makeIntegrationFixture = Effect.gen(function* () {
-  const cwd = yield* makeWorkspaceDirectory;
-  const harness = yield* makeTestProviderAdapterHarness();
+interface RecordedAnalyticsEvent {
+  readonly event: string;
+  readonly properties: Readonly<Record<string, unknown>> | undefined;
+}
 
-  const registry = makeAdapterRegistryMock({
-    [ProviderDriverKind.make("codex")]: harness.adapter,
-  });
-
-  const directoryLayer = ProviderSessionDirectoryLive.pipe(
-    Layer.provide(ProviderSessionRuntime.layer),
+/**
+ * Analytics layer that keeps captured events in memory so tests can assert on
+ * telemetry payloads. `AnalyticsService.layerTest` discards them.
+ */
+const makeRecordingAnalytics = Effect.gen(function* () {
+  const recorded = yield* Ref.make<ReadonlyArray<RecordedAnalyticsEvent>>([]);
+  const layer = Layer.succeed(
+    AnalyticsService,
+    AnalyticsService.of({
+      record: (event, properties) =>
+        Ref.update(recorded, (current) => [...current, { event, properties }]),
+      flush: Effect.void,
+    }),
   );
-
-  const shared = Layer.mergeAll(
-    directoryLayer,
-    Layer.succeed(ProviderAdapterRegistry, registry),
-    ServerSettingsService.layerTest(DEFAULT_SERVER_SETTINGS),
-    AnalyticsService.layerTest,
-    Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers),
-  ).pipe(Layer.provide(SqlitePersistenceMemory));
-
-  const layer = makeProviderServiceLive().pipe(Layer.provide(shared));
-
-  return {
-    cwd,
-    harness,
-    layer,
-  } satisfies IntegrationFixture;
+  return { layer, get: Ref.get(recorded) } as const;
 });
+
+const makeIntegrationFixture = (options?: { readonly analytics?: Layer.Layer<AnalyticsService> }) =>
+  Effect.gen(function* () {
+    const cwd = yield* makeWorkspaceDirectory;
+    const harness = yield* makeTestProviderAdapterHarness();
+
+    const registry = makeAdapterRegistryMock({
+      [ProviderDriverKind.make("codex")]: harness.adapter,
+    });
+
+    const directoryLayer = ProviderSessionDirectoryLive.pipe(
+      Layer.provide(ProviderSessionRuntime.layer),
+    );
+
+    const shared = Layer.mergeAll(
+      directoryLayer,
+      Layer.succeed(ProviderAdapterRegistry, registry),
+      ServerSettingsService.layerTest(DEFAULT_SERVER_SETTINGS),
+      options?.analytics ?? AnalyticsService.layerTest,
+      Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers),
+    ).pipe(Layer.provide(SqlitePersistenceMemory));
+
+    const layer = makeProviderServiceLive().pipe(Layer.provide(shared));
+
+    return {
+      cwd,
+      harness,
+      layer,
+    } satisfies IntegrationFixture;
+  });
 
 const collectEventsDuring = <A, E, R>(
   stream: Stream.Stream<ProviderRuntimeEvent>,
@@ -126,7 +150,7 @@ const runTurn = (input: {
 
 it.live("replays typed runtime fixture events", () =>
   Effect.gen(function* () {
-    const fixture = yield* makeIntegrationFixture;
+    const fixture = yield* makeIntegrationFixture();
 
     yield* Effect.gen(function* () {
       const provider = yield* ProviderService;
@@ -161,7 +185,7 @@ it.live("replays typed runtime fixture events", () =>
 
 it.live("replays file-changing fixture turn events", () =>
   Effect.gen(function* () {
-    const fixture = yield* makeIntegrationFixture;
+    const fixture = yield* makeIntegrationFixture();
     const { join } = yield* Path.Path;
     const { writeFileString } = yield* FileSystem.FileSystem;
 
@@ -198,7 +222,7 @@ it.live("replays file-changing fixture turn events", () =>
 
 it.live("runs multi-turn tool/approval flow", () =>
   Effect.gen(function* () {
-    const fixture = yield* makeIntegrationFixture;
+    const fixture = yield* makeIntegrationFixture();
     const { join } = yield* Path.Path;
     const { writeFileString } = yield* FileSystem.FileSystem;
 
@@ -250,7 +274,7 @@ it.live("runs multi-turn tool/approval flow", () =>
 
 it.live("rolls back provider conversation state only", () =>
   Effect.gen(function* () {
-    const fixture = yield* makeIntegrationFixture;
+    const fixture = yield* makeIntegrationFixture();
     const { join } = yield* Path.Path;
     const { writeFileString, readFileString } = yield* FileSystem.FileSystem;
 
@@ -299,6 +323,62 @@ it.live("rolls back provider conversation state only", () =>
 
       const readme = yield* readFileString(join(fixture.cwd, "README.md"));
       assert.equal(readme, "v3\n");
+    }).pipe(Effect.provide(fixture.layer));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.live("reports runtime mode per turn and on mode transitions", () =>
+  Effect.gen(function* () {
+    const analytics = yield* makeRecordingAnalytics;
+    const fixture = yield* makeIntegrationFixture({ analytics: analytics.layer });
+    const threadId = ThreadId.make("thread-integration-runtime-mode");
+
+    yield* Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const startSession = (runtimeMode: "approval-required" | "full-access") =>
+        provider.startSession(threadId, {
+          threadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: fixture.cwd,
+          runtimeMode,
+        });
+
+      yield* startSession("approval-required");
+      yield* runTurn({
+        provider,
+        harness: fixture.harness,
+        threadId,
+        userText: "supervised turn",
+        response: { events: codexTurnTextFixture },
+      });
+
+      // Toggling the mode restarts the session, which is the only place the
+      // transition is observable.
+      yield* startSession("full-access");
+      yield* runTurn({
+        provider,
+        harness: fixture.harness,
+        threadId,
+        userText: "full access turn",
+        response: { events: codexTurnTextFixture },
+      });
+
+      const recorded = yield* analytics.get;
+
+      assert.deepEqual(
+        recorded
+          .filter((entry) => entry.event === "provider.turn.sent")
+          .map((entry) => entry.properties?.runtimeMode),
+        ["approval-required", "full-access"],
+      );
+
+      assert.deepEqual(
+        recorded
+          .filter((entry) => entry.event === "provider.runtime_mode.changed")
+          .map((entry) => [entry.properties?.from, entry.properties?.to]),
+        [["approval-required", "full-access"]],
+      );
     }).pipe(Effect.provide(fixture.layer));
   }).pipe(Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -459,6 +459,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         adapter,
         instanceId,
         threadId: input.threadId,
+        runtimeMode: binding.runtimeMode,
         isActive: true,
       } as const;
     }
@@ -468,6 +469,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         adapter,
         instanceId,
         threadId: input.threadId,
+        runtimeMode: binding.runtimeMode,
         isActive: false,
       } as const;
     }
@@ -480,6 +482,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       adapter: recovered.adapter,
       instanceId,
       threadId: input.threadId,
+      runtimeMode: recovered.session.runtimeMode,
       isActive: true,
     } as const;
   });
@@ -629,6 +632,19 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
             input.modelSelection.model.trim().length > 0,
         });
 
+        // Changing runtime mode restarts the session, so the transition is only
+        // observable here, by diffing against the mode the previous session for
+        // this thread was bound to. Recording it separately is what makes the
+        // "started supervised, switched to full access" funnel answerable.
+        const previousRuntimeMode = persistedBinding?.runtimeMode;
+        if (previousRuntimeMode !== undefined && previousRuntimeMode !== input.runtimeMode) {
+          yield* analytics.record("provider.runtime_mode.changed", {
+            provider: sessionWithInstance.provider,
+            from: previousRuntimeMode,
+            to: input.runtimeMode,
+          });
+        }
+
         return sessionWithInstance;
       }).pipe(
         withMetrics({
@@ -703,6 +719,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         provider: routed.adapter.provider,
         model: input.modelSelection?.model,
         interactionMode: input.interactionMode,
+        // Session-start events alone skew runtime mode toward users who toggle
+        // often, since every toggle restarts the session. Recording it per turn
+        // gives a usage-weighted view and lets it cross with interactionMode.
+        runtimeMode: routed.runtimeMode,
         attachmentCount: input.attachments.length,
         hasInput: typeof input.input === "string" && input.input.trim().length > 0,
       });


### PR DESCRIPTION
## Problem

We could not answer basic questions about which permission mode people actually use.

Runtime mode (`approval-required` / `auto-accept-edits` / `auto` / `full-access`) was only reported on `provider.session.started`. Two problems with that as a denominator:

- A session restarts whenever runtime mode, cwd, model, or provider instance changes, so users who toggle often are overcounted.
- `provider.turn.sent` carries `interactionMode` (build vs plan) but not runtime mode, so the two could not be crossed.

Mode switches were not reported at all. The reactor computes the transition and logs it, but nothing reached analytics, so "started supervised, gave up, switched to full access" was unanswerable.

## Solution

Two additions, both in `ProviderService.ts` where `analytics` and the persisted binding are already in scope:

- `provider.turn.sent` now carries `runtimeMode`, giving a usage-weighted view that crosses with `interactionMode`. `resolveRoutableSession` already loaded the binding and dropped the mode; it now surfaces it.
- New `provider.runtime_mode.changed` event with `from`/`to`, emitted in `startSession` when the incoming mode differs from the previously persisted binding. Since a mode toggle restarts the session, this is the only place the transition is observable.

No schema, migration, or layer wiring changes. No new PII: both are existing anonymous events with one enum field added.

## Testing

Added one integration test covering both paths, with a recording analytics layer since `layerTest` discards events. Verified it is not vacuous: reverting each production change independently fails the corresponding assertion. `vitest` (496 passed), `typecheck`, and `vp lint` are clean.

## Follow-up not in this PR

Defaults still dominate and are invisible: `full-access` and `default` are the defaults, so nothing distinguishes a deliberate pick from never opening the menu. Separating those needs a client-side signal, which is a larger change. There is also no PostHog in web/mobile/desktop at all, so menu opens and abandoned selections remain dark.

---

Made with Claude Opus 5 (1M context) in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only additions on existing anonymous events; no auth, persistence schema, or routing behavior changes beyond surfacing binding runtimeMode for analytics.
> 
> **Overview**
> Improves **provider runtime mode** telemetry so analytics can answer how people actually use permission modes and when they switch.
> 
> **`provider.turn.sent`** now includes **`runtimeMode`** (from the persisted binding via `resolveRoutableSession`), giving a turn-weighted view that can be crossed with **`interactionMode`** instead of relying only on session-start counts (which over-weight frequent togglers because mode changes restart sessions).
> 
> **`provider.runtime_mode.changed`** is emitted from **`startSession`** when the new mode differs from the previously persisted binding, with **`from`** / **`to`** and provider— the natural hook because a mode toggle restarts the session.
> 
> Integration coverage adds a **recording analytics** layer, optional analytics on the fixture builder, and a test that asserts per-turn `runtimeMode` and a single transition from `approval-required` to `full-access`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f9921c830c4df2c54569e77c59f5fa1bedbee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record runtime mode per turn and emit analytics event on mode changes in provider service
> - Extends the `provider.turn.sent` analytics event to include a `runtimeMode` property on every turn in [`ProviderService.ts`](https://github.com/pingdotgg/t3code/pull/5593/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775).
> - Emits a new `provider.runtime_mode.changed` analytics event with `from` and `to` properties when a session starts with a different runtime mode than the previous persisted binding.
> - Adds a `makeRecordingAnalytics` test utility and a new integration test in [`providerService.integration.test.ts`](https://github.com/pingdotgg/t3code/pull/5593/files#diff-00c79c2b77f522e3dc96ab837ad64874bca9703754cd0d028ac263a1c9c6988d) that asserts both behaviors end-to-end.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 05f9921. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->