### PR TITLE
fix(web): live background-work banner no longer hides behind the update notice

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4372,8 +4372,12 @@ function ChatViewContent(props: ChatViewProps) {
     };
   }, [acknowledgeActiveThreadWoke, activeThread?.id, activeThreadWokeVisible]);
   // The stack renders items[0] front-most and tucks the rest behind hover, so
-  // ordering is priority: system banners, then the branch-mismatch notice,
-  // and the informational parked-thread banner last — it must never cover another.
+  // ordering is priority: urgent system banners (connection down, update
+  // failed), then background liveness — its Stop button is the only stop
+  // affordance for settled turns, so a calm "update available" notice must not
+  // cover it — then calm system banners, the woke and branch-mismatch
+  // notices, and the informational parked-thread banner last — it must never
+  // cover another.
   const parkedThreadBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
     if (!activeThreadSnoozed && !activeThreadSettled) {
       return null;
@@ -4423,21 +4427,29 @@ function ChatViewContent(props: ChatViewProps) {
     void handleSwitchCheckoutToThread();
   }, [gitStatusQuery.data?.hasWorkingTreeChanges, handleSwitchCheckoutToThread]);
   const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
+    const urgentSystemItems = systemComposerBannerItems.filter(
+      (item) => item.variant === "error" || item.variant === "warning",
+    );
+    const calmSystemItems = systemComposerBannerItems.filter(
+      (item) => item.variant !== "error" && item.variant !== "warning",
+    );
     const backgroundLivenessItems =
       backgroundLivenessBannerItem === null ? [] : [backgroundLivenessBannerItem];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];
     const parkedThreadItems = parkedThreadBannerItem === null ? [] : [parkedThreadBannerItem];
     if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
       return [
-        ...systemComposerBannerItems,
+        ...urgentSystemItems,
         ...backgroundLivenessItems,
+        ...calmSystemItems,
         ...wokeThreadItems,
         ...parkedThreadItems,
       ];
     }
     return [
-      ...systemComposerBannerItems,
+      ...urgentSystemItems,
       ...backgroundLivenessItems,
+      ...calmSystemItems,
       ...wokeThreadItems,
       {
         id: `branch-mismatch:${activeBranchMismatchKey}`,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1934,6 +1934,8 @@ function ChatViewContent(props: ChatViewProps) {
         items.push({
           id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
           variant: "default",
+          // Live connection status: calm styling, but it must front the stack.
+          urgent: true,
           icon: (
             <span
               className="size-1.5 animate-status-pulse rounded-full bg-foreground"
@@ -1988,6 +1990,9 @@ function ChatViewContent(props: ChatViewProps) {
       items.push({
         id: `server-version:${serverUpdateEnvironmentId}`,
         variant: updateFailed ? "error" : "default",
+        // A running update is live progress the user is waiting on; only the
+        // idle "update available" offer is calm enough to stack behind.
+        urgent: updateInProgress,
         // In-flight and failed states carry their own status dot inside
         // ServerUpdateProgress; only the idle offer needs an icon.
         icon:
@@ -4372,12 +4377,12 @@ function ChatViewContent(props: ChatViewProps) {
     };
   }, [acknowledgeActiveThreadWoke, activeThread?.id, activeThreadWokeVisible]);
   // The stack renders items[0] front-most and tucks the rest behind hover, so
-  // ordering is priority: urgent system banners (connection down, update
-  // failed), then background liveness — its Stop button is the only stop
-  // affordance for settled turns, so a calm "update available" notice must not
-  // cover it — then calm system banners, the woke and branch-mismatch
-  // notices, and the informational parked-thread banner last — it must never
-  // cover another.
+  // ordering is priority: urgent system banners (error/warning variants plus
+  // calm-styled live states flagged `urgent`, like update progress), then
+  // background liveness — its Stop button is the only stop affordance for
+  // settled turns, so a passive "update available" notice must not cover it —
+  // then calm system banners, the woke and branch-mismatch notices, and the
+  // informational parked-thread banner last — it must never cover another.
   const parkedThreadBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
     if (!activeThreadSnoozed && !activeThreadSettled) {
       return null;
@@ -4427,12 +4432,10 @@ function ChatViewContent(props: ChatViewProps) {
     void handleSwitchCheckoutToThread();
   }, [gitStatusQuery.data?.hasWorkingTreeChanges, handleSwitchCheckoutToThread]);
   const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
-    const urgentSystemItems = systemComposerBannerItems.filter(
-      (item) => item.variant === "error" || item.variant === "warning",
-    );
-    const calmSystemItems = systemComposerBannerItems.filter(
-      (item) => item.variant !== "error" && item.variant !== "warning",
-    );
+    const isUrgentSystemItem = (item: ComposerBannerStackItem) =>
+      item.urgent === true || item.variant === "error" || item.variant === "warning";
+    const urgentSystemItems = systemComposerBannerItems.filter(isUrgentSystemItem);
+    const calmSystemItems = systemComposerBannerItems.filter((item) => !isUrgentSystemItem(item));
     const backgroundLivenessItems =
       backgroundLivenessBannerItem === null ? [] : [backgroundLivenessBannerItem];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];

--- a/apps/web/src/components/chat/ComposerBannerStack.test.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.test.tsx
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./ComposerBannerStack";
 
-const banner = (id: string): ComposerBannerStackItem => ({
+const banner = (
+  id: string,
+  variant: ComposerBannerStackItem["variant"] = "warning",
+): ComposerBannerStackItem => ({
   id,
-  variant: "warning",
+  variant,
   icon: <span aria-hidden="true">!</span>,
   title: `${id} warning`,
 });
@@ -27,6 +30,19 @@ describe("ComposerBannerStack", () => {
     expect(markup.indexOf("front warning")).toBeLessThan(markup.indexOf("stacked warning"));
     expect(markup).toContain("invisible pointer-events-none");
     expect(markup).toContain("group-focus-within/banner-stack:visible");
+  });
+
+  it("colors the collapsed stack cap by the hidden banner's variant, not a fixed warning", () => {
+    const neutralBehind = renderToStaticMarkup(
+      <ComposerBannerStack items={[banner("front", "default"), banner("stacked", "default")]} />,
+    );
+    expect(neutralBehind).toContain("border-border");
+    expect(neutralBehind).not.toContain("border-warning/24");
+
+    const warningBehind = renderToStaticMarkup(
+      <ComposerBannerStack items={[banner("front", "default"), banner("stacked", "warning")]} />,
+    );
+    expect(warningBehind).toContain("border-warning/24");
   });
 
   it("does not render an expandable region for a single banner", () => {

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -36,6 +36,9 @@ const stackCapBorderClass: Record<ComposerBannerStackItem["variant"], string> = 
 export interface ComposerBannerStackItem {
   readonly id: string;
   readonly variant: "default" | "error" | "info" | "success" | "warning";
+  // Ordering hint for stack assemblers: front this banner even though its
+  // variant is calm (e.g. live update progress). The stack itself ignores it.
+  readonly urgent?: boolean;
   readonly icon: ReactNode;
   readonly title: ReactNode;
   readonly description?: ReactNode;

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -22,6 +22,17 @@ const exitTransitionStyle = {
   transition: `transform ${DISMISS_TRANSITION_MS}ms ease-in, opacity ${DISMISS_TRANSITION_MS}ms ease-in`,
 } satisfies CSSProperties;
 
+// The collapsed cap peeking above the front banner is the only hint that more
+// banners are stacked behind it, so its border must match the severity of the
+// first hidden banner — a neutral banner must not masquerade as a warning.
+const stackCapBorderClass: Record<ComposerBannerStackItem["variant"], string> = {
+  default: "border-border",
+  error: "border-destructive/24",
+  info: "border-info/24",
+  success: "border-success/24",
+  warning: "border-warning/24",
+};
+
 export interface ComposerBannerStackItem {
   readonly id: string;
   readonly variant: "default" | "error" | "info" | "success" | "warning";
@@ -67,6 +78,7 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
   const stackedItems = items.slice(1);
   const hasStack = stackedItems.length > 0;
   const showCollapsedStackCap = hasStack && exitingItemId !== frontItem.id;
+  const firstStackedItem = stackedItems[0];
 
   const requestDismiss = (item: ComposerBannerStackItem) => {
     if (!item.onDismiss || exitingItemId) {
@@ -90,11 +102,12 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
           hasStack ? "group-hover/banner-stack:z-50 group-focus-within/banner-stack:z-50" : null,
         )}
       >
-        {showCollapsedStackCap ? (
+        {showCollapsedStackCap && firstStackedItem ? (
           <div
             className={cn(
               "pointer-events-none absolute inset-x-0 -top-3 z-0 mx-auto h-3 rounded-t-[22px]",
-              "border border-b-0 border-warning/24 bg-background/96 shadow-[0_6px_18px_rgba(0,0,0,0.06)]",
+              "border border-b-0 bg-background/96 shadow-[0_6px_18px_rgba(0,0,0,0.06)]",
+              stackCapBorderClass[firstStackedItem.variant],
               "transition-opacity duration-150 ease-out",
               "group-hover/banner-stack:opacity-0 group-focus-within/banner-stack:opacity-0",
             )}


### PR DESCRIPTION
With a server update pending and subagents running, the composer showed the passive "Server update available" notice in front while the live "3 agents working in the background" banner hid behind it until hover. Worse, the collapsed stack cap peeking out behind the front banner is hardcoded warning-yellow, so the neutral subagent banner read as a mystery yellow warning that "transformed" on hover.

Two fixes:

- Banner ordering is now by urgency: error/warning system banners stay in front, the background-liveness banner comes next (its Stop button is the only stop affordance once a turn settles), and calm notices like the update offer stack behind it.
- The collapsed stack cap border now derives from the variant of the banner actually hidden behind the front one, instead of always faking a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Fable 5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only banner ordering and styling in the chat composer; no auth, data, or API changes.
> 
> **Overview**
> Fixes composer banner stacking so **live** states (background agents, in-flight server update, reconnect) stay in front of passive notices like “Server update available,” and so the collapsed stack peek no longer always looks like a warning.
> 
> **`ChatView`** splits system banners into urgent (error/warning variants or `urgent: true`) vs calm, then builds the stack as: urgent system → background liveness → calm system → woke / branch-mismatch / parked. Reconnect/version-skew and **running** server-update items are flagged `urgent` so they front the stack despite `default` styling.
> 
> **`ComposerBannerStack`** adds optional `urgent` on items (assembler-only) and maps the collapsed cap border to the **first hidden** banner’s variant instead of a fixed warning border. Tests cover neutral vs warning caps behind the front banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa08190e6146fa020dc7d1b839e63ca6a271720d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix live background-work banner being hidden behind the update notice in `ChatViewContent`
> - Reorders composer banners in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/5595/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) by partitioning system banners into 'urgent' (error/warning variants or items flagged `urgent: true`) and 'calm' sets, placing urgent items before background liveness and calm items after.
> - The reconnecting-through-version-skew and in-progress server update banners are now flagged `urgent: true` so they appear first; 'update available' (calm) no longer obscures the liveness banner.
> - The collapsed stack cap border in [ComposerBannerStack.tsx](https://github.com/pingdotgg/t3code/pull/5595/files#diff-70e682f5637e29152782d8d01713cd41d0ced0860f99ad7cefbdc07da06e364b) now reflects the severity of the first hidden banner instead of always using a warning color.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa08190.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->