### PR TITLE
fix(connection): refresh network status after app activation

### DIFF
--- a/apps/mobile/src/connection/platform.ts
+++ b/apps/mobile/src/connection/platform.ts
@@ -56,31 +56,12 @@ const connectivityLayer = Connectivity.layer({
   changes: Stream.callback((queue) =>
     Effect.acquireRelease(
       Effect.sync(() => {
-        let active = true;
         const networkSubscription = Network.addNetworkStateListener((state) => {
           Queue.offerUnsafe(queue, networkStatus(state));
         });
-        const appStateSubscription = AppState.addEventListener("change", (state) => {
-          if (state !== "active") {
-            return;
-          }
-          void Network.getNetworkStateAsync()
-            .then((current) => {
-              if (active) {
-                Queue.offerUnsafe(queue, networkStatus(current));
-              }
-            })
-            .catch(() => undefined);
-        });
-        return {
-          close: () => {
-            active = false;
-            networkSubscription.remove();
-            appStateSubscription.remove();
-          },
-        };
+        return networkSubscription;
       }),
-      ({ close }) => Effect.sync(close),
+      (subscription) => Effect.sync(() => subscription.remove()),
     ).pipe(Effect.asVoid),
   ),
 });

--- a/packages/client-runtime/src/connection/connectivity.test.ts
+++ b/packages/client-runtime/src/connection/connectivity.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+
+import * as ConnectionWakeups from "./wakeups.ts";
+import * as Connectivity from "./connectivity.ts";
+
+describe("followNetworkStatus", () => {
+  it.effect("applies the current status when the follower starts", () =>
+    Effect.gen(function* () {
+      const applied = yield* Ref.make<ReadonlyArray<string>>([]);
+
+      yield* Connectivity.followNetworkStatus({
+        apply: (status) => Ref.update(applied, (current) => [...current, status]),
+      });
+
+      expect(yield* Ref.get(applied)).toEqual(["offline"]);
+    }).pipe(
+      Effect.provideService(
+        Connectivity.Connectivity,
+        Connectivity.Connectivity.of({ status: Effect.succeed("offline"), changes: Stream.never }),
+      ),
+      Effect.provideService(
+        ConnectionWakeups.ConnectionWakeups,
+        ConnectionWakeups.ConnectionWakeups.of({ changes: Stream.never }),
+      ),
+      Effect.scoped,
+    ),
+  );
+
+  it.effect("lets a newer report invalidate an in-flight wakeup snapshot", () =>
+    Effect.gen(function* () {
+      const statusReads = yield* Ref.make(0);
+      const wake = yield* Deferred.make<void>();
+      const duplicate = yield* Deferred.make<void>();
+      const duplicateHandled = yield* Deferred.make<void>();
+      const secondReadStarted = yield* Deferred.make<void>();
+      const releaseSecondRead = yield* Deferred.make<void>();
+      const wakeHandled = yield* Deferred.make<void>();
+      const applied = yield* Ref.make<ReadonlyArray<string>>([]);
+
+      yield* Effect.gen(function* () {
+        yield* Connectivity.followNetworkStatus({
+          apply: (status) => Ref.update(applied, (current) => [...current, status]),
+        });
+
+        yield* Deferred.succeed(wake, undefined);
+        yield* Deferred.await(secondReadStarted);
+        yield* Deferred.succeed(duplicate, undefined);
+        yield* Deferred.await(duplicateHandled);
+        yield* Deferred.succeed(releaseSecondRead, undefined);
+        yield* Deferred.await(wakeHandled);
+
+        expect(yield* Ref.get(statusReads)).toBe(2);
+        expect(yield* Ref.get(applied)).toEqual(["offline"]);
+      }).pipe(
+        Effect.provideService(
+          Connectivity.Connectivity,
+          Connectivity.Connectivity.of({
+            status: Ref.updateAndGet(statusReads, (count) => count + 1).pipe(
+              Effect.flatMap((read) =>
+                read === 1
+                  ? Effect.succeed("offline" as const)
+                  : Deferred.succeed(secondReadStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(releaseSecondRead)),
+                      Effect.as("online" as const),
+                    ),
+              ),
+            ),
+            changes: Stream.fromEffect(
+              Deferred.await(duplicate).pipe(Effect.as("offline" as const)),
+            ).pipe(
+              Stream.concat(
+                Stream.fromEffect(
+                  Deferred.succeed(duplicateHandled, undefined).pipe(
+                    Effect.andThen(Effect.never),
+                  ),
+                ),
+              ),
+            ),
+          }),
+        ),
+        Effect.provideService(
+          ConnectionWakeups.ConnectionWakeups,
+          ConnectionWakeups.ConnectionWakeups.of({
+          changes: Stream.fromEffect(
+            Deferred.await(wake).pipe(Effect.as("application-active" as const)),
+          ).pipe(
+            Stream.concat(
+              Stream.fromEffect(
+                Deferred.succeed(wakeHandled, undefined).pipe(Effect.andThen(Effect.never)),
+              ),
+            ),
+          ),
+        }),
+        ),
+        Effect.scoped,
+      );
+    }),
+  );
+
+  it.effect("lets a wakeup refresh supersede the pending initial snapshot", () =>
+    Effect.gen(function* () {
+      const reads = yield* Ref.make(0);
+      const firstReadStarted = yield* Deferred.make<void>();
+      const releaseFirstRead = yield* Deferred.make<void>();
+      const wake = yield* Deferred.make<void>();
+      const onlineApplied = yield* Deferred.make<void>();
+
+      yield* Effect.gen(function* () {
+        const follower = yield* Connectivity.followNetworkStatus({
+          apply: (status) =>
+            status === "online"
+              ? Deferred.succeed(onlineApplied, undefined).pipe(Effect.asVoid)
+              : Effect.void,
+        }).pipe(Effect.forkChild);
+
+        yield* Deferred.await(firstReadStarted);
+        yield* Deferred.succeed(wake, undefined);
+        yield* Deferred.await(onlineApplied);
+        yield* Deferred.succeed(releaseFirstRead, undefined);
+        yield* Fiber.join(follower);
+
+        expect(yield* Ref.get(reads)).toBe(2);
+      }).pipe(
+        Effect.provideService(
+          Connectivity.Connectivity,
+          Connectivity.Connectivity.of({
+            status: Ref.updateAndGet(reads, (count) => count + 1).pipe(
+              Effect.flatMap((read) =>
+                read === 1
+                  ? Deferred.succeed(firstReadStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(releaseFirstRead)),
+                      Effect.as("offline" as const),
+                    )
+                  : Effect.succeed("online" as const),
+              ),
+            ),
+            changes: Stream.never,
+          }),
+        ),
+        Effect.provideService(
+          ConnectionWakeups.ConnectionWakeups,
+          ConnectionWakeups.ConnectionWakeups.of({
+            changes: Stream.fromEffect(
+              Deferred.await(wake).pipe(Effect.as("application-active" as const)),
+            ).pipe(Stream.concat(Stream.never)),
+          }),
+        ),
+        Effect.scoped,
+      );
+    }),
+  );
+});

--- a/packages/client-runtime/src/connection/connectivity.test.ts
+++ b/packages/client-runtime/src/connection/connectivity.test.ts
@@ -31,7 +31,7 @@ describe("followNetworkStatus", () => {
     ),
   );
 
-  it.effect("lets a newer report invalidate an in-flight wakeup snapshot", () =>
+  it.effect("does not let a duplicate report invalidate an in-flight wakeup snapshot", () =>
     Effect.gen(function* () {
       const statusReads = yield* Ref.make(0);
       const wake = yield* Deferred.make<void>();
@@ -55,7 +55,7 @@ describe("followNetworkStatus", () => {
         yield* Deferred.await(wakeHandled);
 
         expect(yield* Ref.get(statusReads)).toBe(2);
-        expect(yield* Ref.get(applied)).toEqual(["offline"]);
+        expect(yield* Ref.get(applied)).toEqual(["offline", "online"]);
       }).pipe(
         Effect.provideService(
           Connectivity.Connectivity,
@@ -75,9 +75,7 @@ describe("followNetworkStatus", () => {
             ).pipe(
               Stream.concat(
                 Stream.fromEffect(
-                  Deferred.succeed(duplicateHandled, undefined).pipe(
-                    Effect.andThen(Effect.never),
-                  ),
+                  Deferred.succeed(duplicateHandled, undefined).pipe(Effect.andThen(Effect.never)),
                 ),
               ),
             ),
@@ -86,16 +84,16 @@ describe("followNetworkStatus", () => {
         Effect.provideService(
           ConnectionWakeups.ConnectionWakeups,
           ConnectionWakeups.ConnectionWakeups.of({
-          changes: Stream.fromEffect(
-            Deferred.await(wake).pipe(Effect.as("application-active" as const)),
-          ).pipe(
-            Stream.concat(
-              Stream.fromEffect(
-                Deferred.succeed(wakeHandled, undefined).pipe(Effect.andThen(Effect.never)),
+            changes: Stream.fromEffect(
+              Deferred.await(wake).pipe(Effect.as("application-active" as const)),
+            ).pipe(
+              Stream.concat(
+                Stream.fromEffect(
+                  Deferred.succeed(wakeHandled, undefined).pipe(Effect.andThen(Effect.never)),
+                ),
               ),
             ),
-          ),
-        }),
+          }),
         ),
         Effect.scoped,
       );

--- a/packages/client-runtime/src/connection/connectivity.ts
+++ b/packages/client-runtime/src/connection/connectivity.ts
@@ -1,9 +1,13 @@
 import * as Context from "effect/Context";
-import type * as Effect from "effect/Effect";
+import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type * as Stream from "effect/Stream";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
 
 import type { NetworkStatus } from "./model.ts";
+import * as ConnectionWakeups from "./wakeups.ts";
 
 export class Connectivity extends Context.Service<
   Connectivity,
@@ -17,3 +21,65 @@ export const make = (service: Connectivity["Service"]) => Connectivity.of(servic
 
 export const layer = (service: Connectivity["Service"]) =>
   Layer.succeed(Connectivity, make(service));
+
+/**
+ * Follows reported connectivity changes and repairs status drift whenever the
+ * application becomes active. Mobile platforms can suspend network listeners,
+ * which is especially visible while a VPN tunnel is restoring in the
+ * background. A report that arrives during the asynchronous status read always
+ * wins over that older snapshot.
+ */
+export const followNetworkStatus = Effect.fnUntraced(function* (options: {
+  readonly apply: (status: NetworkStatus) => Effect.Effect<void>;
+}) {
+  const connectivity = yield* Connectivity;
+  const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
+  const revision = yield* Ref.make(0);
+  const appliedStatus = yield* Ref.make<Option.Option<NetworkStatus>>(Option.none());
+  const applyLock = yield* Semaphore.make(1);
+
+  const applyStatus = Effect.fnUntraced(function* (status: NetworkStatus) {
+    const changed = yield* Ref.modify(appliedStatus, (current) =>
+      Option.isSome(current) && current.value === status
+        ? ([false, current] as const)
+        : ([true, Option.some(status)] as const),
+    );
+    if (changed) {
+      yield* options.apply(status);
+    }
+  });
+
+  const refreshCurrentStatus = Effect.gen(function* () {
+    const startedAt = yield* Ref.updateAndGet(revision, (current) => current + 1);
+    const status = yield* connectivity.status;
+    yield* applyLock.withPermits(1)(
+      Effect.gen(function* () {
+        if ((yield* Ref.get(revision)) === startedAt) {
+          yield* applyStatus(status);
+        }
+      }),
+    );
+  });
+
+  yield* connectivity.changes.pipe(
+    Stream.runForEach((status) =>
+      applyLock.withPermits(1)(
+        Ref.update(revision, (current) => current + 1).pipe(
+          Effect.andThen(applyStatus(status)),
+        ),
+      ),
+    ),
+    Effect.forkScoped({ startImmediately: true }),
+  );
+
+  yield* wakeups.changes.pipe(
+    Stream.runForEach((reason) =>
+      ConnectionWakeups.isApplicationActiveWakeup(reason)
+        ? refreshCurrentStatus
+        : Effect.void,
+    ),
+    Effect.forkScoped({ startImmediately: true }),
+  );
+
+  yield* refreshCurrentStatus;
+});

--- a/packages/client-runtime/src/connection/connectivity.ts
+++ b/packages/client-runtime/src/connection/connectivity.ts
@@ -31,6 +31,7 @@ export const layer = (service: Connectivity["Service"]) =>
  */
 export const followNetworkStatus = Effect.fnUntraced(function* (options: {
   readonly apply: (status: NetworkStatus) => Effect.Effect<void>;
+  readonly onWakeup?: (reason: ConnectionWakeups.ConnectionWakeup) => Effect.Effect<void>;
 }) {
   const connectivity = yield* Connectivity;
   const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
@@ -47,6 +48,7 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
     if (changed) {
       yield* options.apply(status);
     }
+    return changed;
   });
 
   const refreshCurrentStatus = Effect.gen(function* () {
@@ -64,8 +66,10 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
   yield* connectivity.changes.pipe(
     Stream.runForEach((status) =>
       applyLock.withPermits(1)(
-        Ref.update(revision, (current) => current + 1).pipe(
-          Effect.andThen(applyStatus(status)),
+        applyStatus(status).pipe(
+          Effect.flatMap((changed) =>
+            changed ? Ref.update(revision, (current) => current + 1) : Effect.void,
+          ),
         ),
       ),
     ),
@@ -74,9 +78,14 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
 
   yield* wakeups.changes.pipe(
     Stream.runForEach((reason) =>
-      ConnectionWakeups.isApplicationActiveWakeup(reason)
-        ? refreshCurrentStatus
-        : Effect.void,
+      Effect.gen(function* () {
+        if (options.onWakeup) {
+          yield* options.onWakeup(reason);
+        }
+        if (ConnectionWakeups.isApplicationActiveWakeup(reason)) {
+          yield* refreshCurrentStatus;
+        }
+      }),
     ),
     Effect.forkScoped({ startImmediately: true }),
   );

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -652,10 +652,9 @@ export const make = Effect.gen(function* () {
       ),
     ),
   );
-  yield* connectivity.changes.pipe(
-    Stream.runForEach((status) => SubscriptionRef.set(networkStatus, status)),
-    Effect.forkScoped,
-  );
+  yield* Connectivity.followNetworkStatus({
+    apply: (status) => SubscriptionRef.set(networkStatus, status),
+  });
 
   return EnvironmentRegistry.of({
     entries,

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -116,9 +116,10 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
   readonly ready?: (attempt: number) => Effect.Effect<void, ConnectionAttemptError>;
   readonly probe?: (attempt: number) => Effect.Effect<void, ConnectionAttemptError>;
 }) {
-  const networkStatus = yield* SubscriptionRef.make<NetworkStatus>(
+  const reportedNetworkStatus = yield* SubscriptionRef.make<NetworkStatus>(
     options?.networkStatus ?? "online",
   );
+  const liveNetworkStatus = yield* Ref.make<NetworkStatus>(options?.networkStatus ?? "online");
   const prepareCount = yield* Ref.make(0);
   const sessionCount = yield* Ref.make(0);
   const releaseCount = yield* Ref.make(0);
@@ -134,8 +135,8 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
   >([]);
 
   const connectivity = Connectivity.Connectivity.of({
-    status: SubscriptionRef.get(networkStatus),
-    changes: SubscriptionRef.changes(networkStatus),
+    status: Ref.get(liveNetworkStatus),
+    changes: SubscriptionRef.changes(reportedNetworkStatus),
   });
 
   const prepare = Effect.fn("TestConnectionDriver.prepare")(function* (target: ConnectionTarget) {
@@ -197,7 +198,11 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
     prepareCount,
     sessionCount,
     releaseCount,
-    setNetworkStatus: (status: NetworkStatus) => SubscriptionRef.set(networkStatus, status),
+    setNetworkStatus: (status: NetworkStatus) =>
+      Ref.set(liveNetworkStatus, status).pipe(
+        Effect.andThen(SubscriptionRef.set(reportedNetworkStatus, status)),
+      ),
+    setNetworkStatusWithoutNotifying: (status: NetworkStatus) => Ref.set(liveNetworkStatus, status),
     wake: (reason: ConnectionWakeups.ConnectionWakeup) =>
       SubscriptionRef.update(wakeups, (event) => ({
         sequence: event.sequence + 1,
@@ -305,6 +310,28 @@ describe("EnvironmentSupervisor", () => {
         phase: "connected",
         attempt: 1,
         generation: 1,
+        lastFailure: null,
+      });
+      expect(yield* Ref.get(harness.prepareCount)).toBe(1);
+    }),
+  );
+
+  it.effect("recovers a network transition missed while the application was suspended", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ networkStatus: "offline" });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "offline");
+      yield* harness.setNetworkStatusWithoutNotifying("online");
+      yield* harness.wake("application-active-reconnect");
+
+      const ready = yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      expect(ready).toMatchObject({
+        desired: true,
+        network: "online",
+        phase: "connected",
         lastFailure: null,
       });
       expect(yield* Ref.get(harness.prepareCount)).toBe(1);

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -10,7 +10,6 @@ import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Scope from "effect/Scope";
-import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import * as Tracer from "effect/Tracer";
 
@@ -224,7 +223,6 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
 
   const connectivity = yield* Connectivity.Connectivity;
   const driver = yield* ConnectionDriver.ConnectionDriver;
-  const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
   const initialIntent: SupervisorIntent = {
     desired: options?.initiallyDesired ?? false,
     network: yield* connectivity.status,
@@ -766,11 +764,8 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
 
   yield* Connectivity.followNetworkStatus({
     apply: applyNetworkStatus,
+    onWakeup: (reason) => signal({ _tag: "Wakeup", reason }),
   });
-  yield* wakeups.changes.pipe(
-    Stream.runForEach((reason) => signal({ _tag: "Wakeup", reason })),
-    Effect.forkScoped,
-  );
   yield* run().pipe(Effect.forkScoped);
 
   const connect = Ref.update(intent, (current) => ({

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -755,18 +755,18 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
     }
   });
 
-  yield* connectivity.changes.pipe(
-    Stream.runForEach((network) =>
-      Ref.modify(intent, (current) =>
-        current.network === network ? [false, current] : ([true, { ...current, network }] as const),
-      ).pipe(
-        Effect.flatMap((changed) =>
-          changed ? signal({ _tag: "NetworkChanged", network }) : Effect.void,
-        ),
-      ),
-    ),
-    Effect.forkScoped,
-  );
+  const applyNetworkStatus = Effect.fnUntraced(function* (network: NetworkStatus) {
+    const changed = yield* Ref.modify(intent, (current) =>
+      current.network === network ? [false, current] : ([true, { ...current, network }] as const),
+    );
+    if (changed) {
+      yield* signal({ _tag: "NetworkChanged", network });
+    }
+  });
+
+  yield* Connectivity.followNetworkStatus({
+    apply: applyNetworkStatus,
+  });
   yield* wakeups.changes.pipe(
     Stream.runForEach((reason) => signal({ _tag: "Wakeup", reason })),
     Effect.forkScoped,

--- a/packages/client-runtime/src/relay/discovery.test.ts
+++ b/packages/client-runtime/src/relay/discovery.test.ts
@@ -59,6 +59,9 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
   initialNetworkStatus: NetworkStatus = "online",
 ) {
   const networkStatus = yield* SubscriptionRef.make<NetworkStatus>(initialNetworkStatus);
+  const pauseNextStatusRead = yield* Ref.make(false);
+  const pausedStatusRead = yield* Deferred.make<void>();
+  const resumeStatusRead = yield* Deferred.make<void>();
   const listCalls = yield* Ref.make(0);
   const listFailure = yield* Ref.make<ManagedRelay.ManagedRelayClientError | null>(null);
   const secondListCall = yield* Deferred.make<void>();
@@ -118,7 +121,14 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
     resetTokenCache: Effect.void,
   } satisfies ManagedRelay.ManagedRelayClient["Service"]);
   const connectivity = Connectivity.Connectivity.of({
-    status: SubscriptionRef.get(networkStatus),
+    status: Effect.gen(function* () {
+      const status = yield* SubscriptionRef.get(networkStatus);
+      if (yield* Ref.getAndSet(pauseNextStatusRead, false)) {
+        yield* Deferred.succeed(pausedStatusRead, undefined);
+        yield* Deferred.await(resumeStatusRead);
+      }
+      return status;
+    }),
     changes: SubscriptionRef.changes(networkStatus),
   });
   const layer = RelayEnvironmentDiscovery.layer.pipe(
@@ -162,6 +172,9 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
     listFailure,
     clerkToken,
     networkStatus,
+    pauseNextStatusRead,
+    pausedStatusRead,
+    resumeStatusRead,
     secondListCall,
     statusRequests,
     wake: (reason: "application-active" | "credentials-changed") =>
@@ -276,6 +289,44 @@ describe("RelayEnvironmentDiscovery", () => {
 
         expect((yield* SubscriptionRef.get(discovery.state)).offline).toBe(false);
         expect(yield* Ref.get(harness.listCalls)).toBe(0);
+      }).pipe(Effect.provide(harness.layer));
+    }),
+  );
+
+  it.effect("keeps the offline state when connectivity changes during a refresh status read", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      yield* Effect.gen(function* () {
+        const discovery = yield* RelayEnvironmentDiscovery.RelayEnvironmentDiscovery;
+        const requests = yield* Ref.get(harness.statusRequests);
+        for (const environment of environments) {
+          yield* Deferred.succeed(
+            requests.get(environment.environmentId)!,
+            status(environment, "online"),
+          );
+        }
+        yield* discovery.refresh;
+
+        yield* SubscriptionRef.set(harness.networkStatus, "offline");
+        yield* SubscriptionRef.changes(discovery.state).pipe(
+          Stream.filter((state) => state.offline),
+          Stream.runHead,
+        );
+
+        yield* Ref.set(harness.pauseNextStatusRead, true);
+        yield* SubscriptionRef.set(harness.networkStatus, "online");
+        yield* Deferred.await(harness.pausedStatusRead);
+        const offlineFiber = yield* SubscriptionRef.changes(discovery.state).pipe(
+          Stream.filter((state) => state.offline),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* SubscriptionRef.set(harness.networkStatus, "offline");
+        yield* Deferred.succeed(harness.resumeStatusRead, undefined);
+        yield* Fiber.join(offlineFiber);
+        yield* Deferred.await(harness.secondListCall);
+
+        expect((yield* SubscriptionRef.get(discovery.state)).offline).toBe(true);
       }).pipe(Effect.provide(harness.layer));
     }),
   );

--- a/packages/client-runtime/src/relay/discovery.test.ts
+++ b/packages/client-runtime/src/relay/discovery.test.ts
@@ -55,8 +55,10 @@ function status(
   };
 }
 
-const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
-  const networkStatus = yield* SubscriptionRef.make<NetworkStatus>("online");
+const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
+  initialNetworkStatus: NetworkStatus = "online",
+) {
+  const networkStatus = yield* SubscriptionRef.make<NetworkStatus>(initialNetworkStatus);
   const listCalls = yield* Ref.make(0);
   const listFailure = yield* Ref.make<ManagedRelay.ManagedRelayClientError | null>(null);
   const secondListCall = yield* Deferred.make<void>();
@@ -250,6 +252,32 @@ describe("RelayEnvironmentDiscovery", () => {
           expect(yield* Ref.get(harness.listCalls)).toBe(2);
         }).pipe(Effect.provide(harness.layer));
       }),
+  );
+
+  it.effect("clears an initial offline state on the first online transition", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness("offline");
+      yield* Effect.gen(function* () {
+        const discovery = yield* RelayEnvironmentDiscovery.RelayEnvironmentDiscovery;
+        const offline = yield* SubscriptionRef.changes(discovery.state).pipe(
+          Stream.filter((state) => state.offline),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* Fiber.join(offline);
+
+        const online = yield* SubscriptionRef.changes(discovery.state).pipe(
+          Stream.filter((state) => !state.offline),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* SubscriptionRef.set(harness.networkStatus, "online");
+        yield* Fiber.join(online);
+
+        expect((yield* SubscriptionRef.get(discovery.state)).offline).toBe(false);
+        expect(yield* Ref.get(harness.listCalls)).toBe(0);
+      }).pipe(Effect.provide(harness.layer));
+    }),
   );
 
   it.effect("publishes listing failures without rejecting the refresh command", () =>

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -107,6 +107,7 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
   const session = yield* ClientCapabilities.CloudSession;
   const connectivity = yield* Connectivity.Connectivity;
   const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
+  const scope = yield* Effect.scope;
   const state = yield* SubscriptionRef.make(EMPTY_RELAY_ENVIRONMENT_DISCOVERY_STATE);
   const refreshLock = yield* Semaphore.make(1);
   const hasRefreshed = yield* Ref.make(false);
@@ -309,21 +310,24 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
     ),
   );
 
-  yield* connectivity.changes.pipe(
-    Stream.changes,
-    Stream.runForEach((networkStatus) =>
+  yield* Connectivity.followNetworkStatus({
+    apply: (networkStatus) =>
       networkStatus === "offline"
         ? SubscriptionRef.update(state, (current) => ({
             ...current,
             refreshing: false,
             offline: true,
           }))
-        : Ref.get(hasRefreshed).pipe(
-            Effect.flatMap((shouldRefresh) => (shouldRefresh ? refresh : Effect.void)),
-          ),
-    ),
-    Effect.forkScoped,
-  );
+        : Effect.gen(function* () {
+            yield* SubscriptionRef.update(state, (current) => ({
+              ...current,
+              offline: false,
+            }));
+            if (yield* Ref.get(hasRefreshed)) {
+              yield* refresh.pipe(Effect.forkIn(scope));
+            }
+          }),
+  });
   yield* wakeups.changes.pipe(
     Stream.runForEach((reason) =>
       reason === "credentials-changed"

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -110,6 +110,7 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
   const scope = yield* Effect.scope;
   const state = yield* SubscriptionRef.make(EMPTY_RELAY_ENVIRONMENT_DISCOVERY_STATE);
   const refreshLock = yield* Semaphore.make(1);
+  const networkStateLock = yield* Semaphore.make(1);
   const hasRefreshed = yield* Ref.make(false);
   const accountGeneration = yield* Ref.make(0);
   const activeAccountId = yield* Ref.make<Option.Option<string>>(Option.none());
@@ -205,23 +206,32 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
   const refresh = refreshLock.withPermits(1)(
     Effect.gen(function* () {
       yield* Ref.set(hasRefreshed, true);
-      if ((yield* connectivity.status) === "offline") {
-        yield* SubscriptionRef.update(state, (current) => ({
-          ...current,
-          refreshing: false,
-          offline: true,
-        }));
+      const canRefresh = yield* networkStateLock.withPermits(1)(
+        Effect.gen(function* () {
+          if ((yield* connectivity.status) === "offline") {
+            yield* SubscriptionRef.update(state, (current) => ({
+              ...current,
+              refreshing: false,
+              offline: true,
+            }));
+            return false;
+          }
+
+          yield* SubscriptionRef.set(state, {
+            environments: new Map(),
+            refreshing: true,
+            offline: false,
+            error: Option.none(),
+          });
+          return true;
+        }),
+      );
+      if (!canRefresh) {
         return;
       }
 
       let generation = yield* Ref.get(accountGeneration);
       yield* Ref.set(refreshGeneration, generation);
-      yield* SubscriptionRef.set(state, {
-        environments: new Map(),
-        refreshing: true,
-        offline: false,
-        error: Option.none(),
-      });
 
       // Signed out is the idle state, not a failure: the proactive refresh on
       // credentials-changed also runs on sign-out and must settle back to a
@@ -312,21 +322,23 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
 
   yield* Connectivity.followNetworkStatus({
     apply: (networkStatus) =>
-      networkStatus === "offline"
-        ? SubscriptionRef.update(state, (current) => ({
-            ...current,
-            refreshing: false,
-            offline: true,
-          }))
-        : Effect.gen(function* () {
-            yield* SubscriptionRef.update(state, (current) => ({
+      networkStateLock.withPermits(1)(
+        networkStatus === "offline"
+          ? SubscriptionRef.update(state, (current) => ({
               ...current,
-              offline: false,
-            }));
-            if (yield* Ref.get(hasRefreshed)) {
-              yield* refresh.pipe(Effect.forkIn(scope));
-            }
-          }),
+              refreshing: false,
+              offline: true,
+            }))
+          : Effect.gen(function* () {
+              yield* SubscriptionRef.update(state, (current) => ({
+                ...current,
+                offline: false,
+              }));
+              if (yield* Ref.get(hasRefreshed)) {
+                yield* refresh.pipe(Effect.forkIn(scope));
+              }
+            }),
+      ),
   });
   yield* wakeups.changes.pipe(
     Stream.runForEach((reason) =>


### PR DESCRIPTION
Mobile network listeners can miss connectivity changes while the app is suspended. After returning to the foreground, an environment could remain offline or continue an old retry ladder even though the live network was available again.

This change adds one shared connectivity follower that:
- applies the current network state when a connection runtime starts;
- refreshes the authoritative platform status on application activation;
- serializes live reports and refresh snapshots so later reports always win;
- ignores duplicate reports without invalidating a newer refresh;
- delivers wakeup signals and refreshed network state in one deterministic order;
- refreshes managed relay discovery through the same lifecycle path.

The behavior is shared by web, desktop, and mobile through client-runtime. No wire contract or provider adapter changes are required.

## Related independent PRs

These PRs all target `main` and can be merged in any order:

- #5597 — network status recovery
- #5598 — environment availability and management
- #5596 — mobile pairing-link paste

## Verification

- `vp test run packages/client-runtime/src/connection/connectivity.test.ts packages/client-runtime/src/connection/supervisor.test.ts packages/client-runtime/src/relay/discovery.test.ts`
  - 3 files passed
  - 48 tests passed
- `vp run --filter @t3tools/client-runtime typecheck`
  - passed; one pre-existing Effect suggestion remains in relay discovery
- targeted `vp lint` for the six changed runtime/test files
  - passed
- `fallow audit --base upstream/main`
  - passed the new-change gate; inherited repository findings were excluded

No screenshot is included because this PR changes lifecycle ordering rather than rendered UI.

Built and reviewed with GPT-5 Codex via Codex CLI.

## Fork validation PR

- [DominicVonk/t3code#7](https://github.com/DominicVonk/t3code/pull/7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection lifecycle (supervisor, registry, relay discovery) and ordering between wakeups and network state; behavior is heavily tested but regressions could affect reconnect timing or discovery offline flags.
> 
> **Overview**
> Fixes environments staying offline or on stale retry state when **mobile suspends network listeners** while the app is backgrounded.
> 
> Introduces **`Connectivity.followNetworkStatus`** in client-runtime: applies the current status at startup, streams `connectivity.changes`, and on application-active wakeups re-reads `connectivity.status` with **revision sequencing** and a lock so **live change events beat stale async snapshots** and duplicate applies are skipped.
> 
> **`EnvironmentSupervisor`**, **`EnvironmentRegistry`**, and **`RelayEnvironmentDiscovery`** now use this helper instead of separate subscriptions to network changes and wakeups; relay discovery adds **`networkStateLock`** so offline/refresh transitions stay consistent with in-flight status reads.
> 
> On **mobile** (`platform.ts`), connectivity `changes` no longer polls `Network.getNetworkStateAsync` on `AppState` active—that refresh is centralized in `followNetworkStatus` via wakeups.
> 
> New unit tests cover the follower, supervisor recovery when online was missed without a listener event, and relay offline/online edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cdcc1565f0e2305ed51ea4c283fd261902fd0e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh network status on app activation using `Connectivity.followNetworkStatus`
> - Introduces `Connectivity.followNetworkStatus` in [connectivity.ts](https://github.com/pingdotgg/t3code/pull/5597/files#diff-0c3ee6e174dbdeb40c2bc2adf111383534ce5d1c7fe7528ca7402fed727d514a), a new effect that consumes connectivity status, change events, and wakeup signals to apply network status updates via a callback, with deduplication and revision-based sequencing to prevent stale async reads from overwriting newer change events.
> - Wires `followNetworkStatus` into `EnvironmentSupervisor`, `EnvironmentRegistry`, and `RelayEnvironmentDiscovery`, replacing direct subscriptions to `connectivity.changes` and `ConnectionWakeups.changes`.
> - On app activation (wakeup), the current network status is re-read and applied only if no newer change event has arrived, fixing missed transitions while the app was suspended.
> - `RelayEnvironmentDiscovery` adds a `networkStateLock` semaphore to serialize offline/refresh transitions against concurrent connectivity changes.
> - Behavioral Change: the mobile platform layer in [platform.ts](https://github.com/pingdotgg/t3code/pull/5597/files#diff-43431ac4587aaf4c20899723816d4e16e36edd8cb877940960b5658a6aeca0ae) no longer emits a connectivity event on `AppState` active transitions; wakeup-driven refresh is now handled entirely within `followNetworkStatus`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cdcc15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->