### PR TITLE
[2/5] feat(connection): persist environment activation

### DIFF
--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
@@ -369,6 +369,7 @@ const migrateSavedEnvironmentRecords = Effect.fn(
   return {
     schemaVersion: 1,
     targets,
+    disabledEnvironmentIds: [],
     profiles,
     credentials,
     remoteDpopTokens: [],

--- a/apps/mobile/src/connection/migration.ts
+++ b/apps/mobile/src/connection/migration.ts
@@ -57,6 +57,7 @@ function migrateConnection(
           label: connection.environmentLabel,
         }),
       }),
+      { enabled: true },
     );
   }
 
@@ -84,6 +85,7 @@ function migrateConnection(
         token: connection.bearerToken,
       }),
     }),
+    { enabled: true },
   );
 }
 

--- a/apps/mobile/src/connection/platform.ts
+++ b/apps/mobile/src/connection/platform.ts
@@ -56,31 +56,12 @@ const connectivityLayer = Connectivity.layer({
   changes: Stream.callback((queue) =>
     Effect.acquireRelease(
       Effect.sync(() => {
-        let active = true;
         const networkSubscription = Network.addNetworkStateListener((state) => {
           Queue.offerUnsafe(queue, networkStatus(state));
         });
-        const appStateSubscription = AppState.addEventListener("change", (state) => {
-          if (state !== "active") {
-            return;
-          }
-          void Network.getNetworkStateAsync()
-            .then((current) => {
-              if (active) {
-                Queue.offerUnsafe(queue, networkStatus(current));
-              }
-            })
-            .catch(() => undefined);
-        });
-        return {
-          close: () => {
-            active = false;
-            networkSubscription.remove();
-            appStateSubscription.remove();
-          },
-        };
+        return networkSubscription;
       }),
-      ({ close }) => Effect.sync(close),
+      (subscription) => Effect.sync(() => subscription.remove()),
     ).pipe(Effect.asVoid),
   ),
 });

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -1,5 +1,6 @@
 import {
   ConnectionPersistenceError,
+  ConnectionActivationStore,
   ConnectionRegistrationStore,
   ConnectionTargetStore,
   registerConnectionInCatalog,
@@ -20,7 +21,13 @@ import * as Option from "effect/Option";
 import * as CatalogStore from "./catalog-store";
 
 function targetPersistenceError(
-  operation: "list-targets" | "register-connection" | "remove-connection",
+  operation:
+    | "list-targets"
+    | "register-connection"
+    | "remove-connection"
+    | "list-activation"
+    | "set-activation"
+    | "reconcile-activation",
   error: ConnectionTransientError,
 ) {
   return new ConnectionPersistenceError({
@@ -40,14 +47,38 @@ export const connectionStorageLayer = Layer.effectContext(
       ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
-      register: (registration) =>
+      register: (registration, options) =>
         catalog
-          .update((document) => registerConnectionInCatalog(document, registration))
+          .update((document) => registerConnectionInCatalog(document, registration, options))
           .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
       remove: (target) =>
         catalog
           .update((document) => removeConnectionFromCatalog(document, target))
           .pipe(Effect.mapError((error) => targetPersistenceError("remove-connection", error))),
+    });
+    const activationStore = ConnectionActivationStore.of({
+      listDisabled: catalog.read.pipe(
+        Effect.map((document) => new Set(document.disabledEnvironmentIds)),
+        Effect.mapError((error) => targetPersistenceError("list-activation", error)),
+      ),
+      setEnabled: (environmentId, enabled) =>
+        catalog
+          .update((document) => ({
+            ...document,
+            disabledEnvironmentIds: enabled
+              ? document.disabledEnvironmentIds.filter((candidate) => candidate !== environmentId)
+              : [...new Set([...document.disabledEnvironmentIds, environmentId])],
+          }))
+          .pipe(Effect.mapError((error) => targetPersistenceError("set-activation", error))),
+      reconcile: (environmentIds) =>
+        catalog
+          .update((document) => ({
+            ...document,
+            disabledEnvironmentIds: document.disabledEnvironmentIds.filter((environmentId) =>
+              environmentIds.has(environmentId),
+            ),
+          }))
+          .pipe(Effect.mapError((error) => targetPersistenceError("reconcile-activation", error))),
     });
     const profileStore = ProfileStore.make({
       get: (connectionId) =>
@@ -130,6 +161,7 @@ export const connectionStorageLayer = Layer.effectContext(
     });
     return Context.make(ConnectionTargetStore, targetStore).pipe(
       Context.add(ConnectionRegistrationStore, registrationStore),
+      Context.add(ConnectionActivationStore, activationStore),
       Context.add(ProfileStore.ConnectionProfileStore, profileStore),
       Context.add(CredentialStore.ConnectionCredentialStore, credentialStore),
       Context.add(TokenStore.RemoteDpopAccessTokenStore, remoteTokenStore),

--- a/apps/web/src/connection/storage.test.ts
+++ b/apps/web/src/connection/storage.test.ts
@@ -10,6 +10,7 @@ import { makeCatalogBackend, makeCatalogStore } from "./storage";
 const emptyCatalog = {
   schemaVersion: 1,
   targets: [],
+  disabledEnvironmentIds: [],
   profiles: [],
   credentials: [],
   remoteDpopTokens: [],

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -1,6 +1,7 @@
 import {
   ConnectionCatalogDocument,
   type ConnectionCatalogDocument as ConnectionCatalogDocumentType,
+  ConnectionActivationStore,
   ConnectionPersistenceError,
   ConnectionRegistrationStore,
   ConnectionTargetStore,
@@ -99,6 +100,9 @@ function persistenceError(
     | "list-targets"
     | "register-connection"
     | "remove-connection"
+    | "list-activation"
+    | "set-activation"
+    | "reconcile-activation"
     | "load-shell"
     | "save-shell"
     | "load-thread"
@@ -370,6 +374,30 @@ export const connectionStorageLayer = Layer.effectContext(
     );
     const catalog = yield* makeCatalogStore(makeCatalogBackend(database));
 
+    const activationStore = ConnectionActivationStore.of({
+      listDisabled: catalog.read.pipe(
+        Effect.map((document) => new Set(document.disabledEnvironmentIds)),
+        Effect.mapError((cause) => persistenceError("list-activation", cause)),
+      ),
+      setEnabled: (environmentId, enabled) =>
+        catalog
+          .update((document) => ({
+            ...document,
+            disabledEnvironmentIds: enabled
+              ? document.disabledEnvironmentIds.filter((candidate) => candidate !== environmentId)
+              : [...new Set([...document.disabledEnvironmentIds, environmentId])],
+          }))
+          .pipe(Effect.mapError((cause) => persistenceError("set-activation", cause))),
+      reconcile: (environmentIds) =>
+        catalog
+          .update((document) => ({
+            ...document,
+            disabledEnvironmentIds: document.disabledEnvironmentIds.filter((environmentId) =>
+              environmentIds.has(environmentId),
+            ),
+          }))
+          .pipe(Effect.mapError((cause) => persistenceError("reconcile-activation", cause))),
+    });
     const targetStore = ConnectionTargetStore.of({
       list: catalog.read.pipe(
         Effect.map((document) => document.targets),
@@ -377,9 +405,9 @@ export const connectionStorageLayer = Layer.effectContext(
       ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
-      register: (registration) =>
+      register: (registration, options) =>
         catalog
-          .update((document) => registerConnectionInCatalog(document, registration))
+          .update((document) => registerConnectionInCatalog(document, registration, options))
           .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
       remove: (target) =>
         catalog
@@ -664,6 +692,7 @@ export const connectionStorageLayer = Layer.effectContext(
 
     return Context.make(ConnectionTargetStore, targetStore).pipe(
       Context.add(ConnectionRegistrationStore, registrationStore),
+      Context.add(ConnectionActivationStore, activationStore),
       Context.add(ProfileStore.ConnectionProfileStore, profileStore),
       Context.add(CredentialStore.ConnectionCredentialStore, credentialStore),
       Context.add(TokenStore.RemoteDpopAccessTokenStore, remoteTokenStore),

--- a/packages/client-runtime/src/connection/connectivity.test.ts
+++ b/packages/client-runtime/src/connection/connectivity.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+
+import * as ConnectionWakeups from "./wakeups.ts";
+import * as Connectivity from "./connectivity.ts";
+
+describe("followNetworkStatus", () => {
+  it.effect("applies the current status when the follower starts", () =>
+    Effect.gen(function* () {
+      const applied = yield* Ref.make<ReadonlyArray<string>>([]);
+
+      yield* Connectivity.followNetworkStatus({
+        apply: (status) => Ref.update(applied, (current) => [...current, status]),
+      });
+
+      expect(yield* Ref.get(applied)).toEqual(["offline"]);
+    }).pipe(
+      Effect.provideService(
+        Connectivity.Connectivity,
+        Connectivity.Connectivity.of({ status: Effect.succeed("offline"), changes: Stream.never }),
+      ),
+      Effect.provideService(
+        ConnectionWakeups.ConnectionWakeups,
+        ConnectionWakeups.ConnectionWakeups.of({ changes: Stream.never }),
+      ),
+      Effect.scoped,
+    ),
+  );
+
+  it.effect("lets a newer report invalidate an in-flight wakeup snapshot", () =>
+    Effect.gen(function* () {
+      const statusReads = yield* Ref.make(0);
+      const wake = yield* Deferred.make<void>();
+      const duplicate = yield* Deferred.make<void>();
+      const duplicateHandled = yield* Deferred.make<void>();
+      const secondReadStarted = yield* Deferred.make<void>();
+      const releaseSecondRead = yield* Deferred.make<void>();
+      const wakeHandled = yield* Deferred.make<void>();
+      const applied = yield* Ref.make<ReadonlyArray<string>>([]);
+
+      yield* Effect.gen(function* () {
+        yield* Connectivity.followNetworkStatus({
+          apply: (status) => Ref.update(applied, (current) => [...current, status]),
+        });
+
+        yield* Deferred.succeed(wake, undefined);
+        yield* Deferred.await(secondReadStarted);
+        yield* Deferred.succeed(duplicate, undefined);
+        yield* Deferred.await(duplicateHandled);
+        yield* Deferred.succeed(releaseSecondRead, undefined);
+        yield* Deferred.await(wakeHandled);
+
+        expect(yield* Ref.get(statusReads)).toBe(2);
+        expect(yield* Ref.get(applied)).toEqual(["offline"]);
+      }).pipe(
+        Effect.provideService(
+          Connectivity.Connectivity,
+          Connectivity.Connectivity.of({
+            status: Ref.updateAndGet(statusReads, (count) => count + 1).pipe(
+              Effect.flatMap((read) =>
+                read === 1
+                  ? Effect.succeed("offline" as const)
+                  : Deferred.succeed(secondReadStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(releaseSecondRead)),
+                      Effect.as("online" as const),
+                    ),
+              ),
+            ),
+            changes: Stream.fromEffect(
+              Deferred.await(duplicate).pipe(Effect.as("offline" as const)),
+            ).pipe(
+              Stream.concat(
+                Stream.fromEffect(
+                  Deferred.succeed(duplicateHandled, undefined).pipe(
+                    Effect.andThen(Effect.never),
+                  ),
+                ),
+              ),
+            ),
+          }),
+        ),
+        Effect.provideService(
+          ConnectionWakeups.ConnectionWakeups,
+          ConnectionWakeups.ConnectionWakeups.of({
+          changes: Stream.fromEffect(
+            Deferred.await(wake).pipe(Effect.as("application-active" as const)),
+          ).pipe(
+            Stream.concat(
+              Stream.fromEffect(
+                Deferred.succeed(wakeHandled, undefined).pipe(Effect.andThen(Effect.never)),
+              ),
+            ),
+          ),
+        }),
+        ),
+        Effect.scoped,
+      );
+    }),
+  );
+
+  it.effect("lets a wakeup refresh supersede the pending initial snapshot", () =>
+    Effect.gen(function* () {
+      const reads = yield* Ref.make(0);
+      const firstReadStarted = yield* Deferred.make<void>();
+      const releaseFirstRead = yield* Deferred.make<void>();
+      const wake = yield* Deferred.make<void>();
+      const onlineApplied = yield* Deferred.make<void>();
+
+      yield* Effect.gen(function* () {
+        const follower = yield* Connectivity.followNetworkStatus({
+          apply: (status) =>
+            status === "online"
+              ? Deferred.succeed(onlineApplied, undefined).pipe(Effect.asVoid)
+              : Effect.void,
+        }).pipe(Effect.forkChild);
+
+        yield* Deferred.await(firstReadStarted);
+        yield* Deferred.succeed(wake, undefined);
+        yield* Deferred.await(onlineApplied);
+        yield* Deferred.succeed(releaseFirstRead, undefined);
+        yield* Fiber.join(follower);
+
+        expect(yield* Ref.get(reads)).toBe(2);
+      }).pipe(
+        Effect.provideService(
+          Connectivity.Connectivity,
+          Connectivity.Connectivity.of({
+            status: Ref.updateAndGet(reads, (count) => count + 1).pipe(
+              Effect.flatMap((read) =>
+                read === 1
+                  ? Deferred.succeed(firstReadStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(releaseFirstRead)),
+                      Effect.as("offline" as const),
+                    )
+                  : Effect.succeed("online" as const),
+              ),
+            ),
+            changes: Stream.never,
+          }),
+        ),
+        Effect.provideService(
+          ConnectionWakeups.ConnectionWakeups,
+          ConnectionWakeups.ConnectionWakeups.of({
+            changes: Stream.fromEffect(
+              Deferred.await(wake).pipe(Effect.as("application-active" as const)),
+            ).pipe(Stream.concat(Stream.never)),
+          }),
+        ),
+        Effect.scoped,
+      );
+    }),
+  );
+});

--- a/packages/client-runtime/src/connection/connectivity.test.ts
+++ b/packages/client-runtime/src/connection/connectivity.test.ts
@@ -31,7 +31,7 @@ describe("followNetworkStatus", () => {
     ),
   );
 
-  it.effect("lets a newer report invalidate an in-flight wakeup snapshot", () =>
+  it.effect("does not let a duplicate report invalidate an in-flight wakeup snapshot", () =>
     Effect.gen(function* () {
       const statusReads = yield* Ref.make(0);
       const wake = yield* Deferred.make<void>();
@@ -55,7 +55,7 @@ describe("followNetworkStatus", () => {
         yield* Deferred.await(wakeHandled);
 
         expect(yield* Ref.get(statusReads)).toBe(2);
-        expect(yield* Ref.get(applied)).toEqual(["offline"]);
+        expect(yield* Ref.get(applied)).toEqual(["offline", "online"]);
       }).pipe(
         Effect.provideService(
           Connectivity.Connectivity,
@@ -75,9 +75,7 @@ describe("followNetworkStatus", () => {
             ).pipe(
               Stream.concat(
                 Stream.fromEffect(
-                  Deferred.succeed(duplicateHandled, undefined).pipe(
-                    Effect.andThen(Effect.never),
-                  ),
+                  Deferred.succeed(duplicateHandled, undefined).pipe(Effect.andThen(Effect.never)),
                 ),
               ),
             ),
@@ -86,16 +84,16 @@ describe("followNetworkStatus", () => {
         Effect.provideService(
           ConnectionWakeups.ConnectionWakeups,
           ConnectionWakeups.ConnectionWakeups.of({
-          changes: Stream.fromEffect(
-            Deferred.await(wake).pipe(Effect.as("application-active" as const)),
-          ).pipe(
-            Stream.concat(
-              Stream.fromEffect(
-                Deferred.succeed(wakeHandled, undefined).pipe(Effect.andThen(Effect.never)),
+            changes: Stream.fromEffect(
+              Deferred.await(wake).pipe(Effect.as("application-active" as const)),
+            ).pipe(
+              Stream.concat(
+                Stream.fromEffect(
+                  Deferred.succeed(wakeHandled, undefined).pipe(Effect.andThen(Effect.never)),
+                ),
               ),
             ),
-          ),
-        }),
+          }),
         ),
         Effect.scoped,
       );

--- a/packages/client-runtime/src/connection/connectivity.ts
+++ b/packages/client-runtime/src/connection/connectivity.ts
@@ -1,9 +1,13 @@
 import * as Context from "effect/Context";
-import type * as Effect from "effect/Effect";
+import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type * as Stream from "effect/Stream";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
 
 import type { NetworkStatus } from "./model.ts";
+import * as ConnectionWakeups from "./wakeups.ts";
 
 export class Connectivity extends Context.Service<
   Connectivity,
@@ -17,3 +21,65 @@ export const make = (service: Connectivity["Service"]) => Connectivity.of(servic
 
 export const layer = (service: Connectivity["Service"]) =>
   Layer.succeed(Connectivity, make(service));
+
+/**
+ * Follows reported connectivity changes and repairs status drift whenever the
+ * application becomes active. Mobile platforms can suspend network listeners,
+ * which is especially visible while a VPN tunnel is restoring in the
+ * background. A report that arrives during the asynchronous status read always
+ * wins over that older snapshot.
+ */
+export const followNetworkStatus = Effect.fnUntraced(function* (options: {
+  readonly apply: (status: NetworkStatus) => Effect.Effect<void>;
+}) {
+  const connectivity = yield* Connectivity;
+  const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
+  const revision = yield* Ref.make(0);
+  const appliedStatus = yield* Ref.make<Option.Option<NetworkStatus>>(Option.none());
+  const applyLock = yield* Semaphore.make(1);
+
+  const applyStatus = Effect.fnUntraced(function* (status: NetworkStatus) {
+    const changed = yield* Ref.modify(appliedStatus, (current) =>
+      Option.isSome(current) && current.value === status
+        ? ([false, current] as const)
+        : ([true, Option.some(status)] as const),
+    );
+    if (changed) {
+      yield* options.apply(status);
+    }
+  });
+
+  const refreshCurrentStatus = Effect.gen(function* () {
+    const startedAt = yield* Ref.updateAndGet(revision, (current) => current + 1);
+    const status = yield* connectivity.status;
+    yield* applyLock.withPermits(1)(
+      Effect.gen(function* () {
+        if ((yield* Ref.get(revision)) === startedAt) {
+          yield* applyStatus(status);
+        }
+      }),
+    );
+  });
+
+  yield* connectivity.changes.pipe(
+    Stream.runForEach((status) =>
+      applyLock.withPermits(1)(
+        Ref.update(revision, (current) => current + 1).pipe(
+          Effect.andThen(applyStatus(status)),
+        ),
+      ),
+    ),
+    Effect.forkScoped({ startImmediately: true }),
+  );
+
+  yield* wakeups.changes.pipe(
+    Stream.runForEach((reason) =>
+      ConnectionWakeups.isApplicationActiveWakeup(reason)
+        ? refreshCurrentStatus
+        : Effect.void,
+    ),
+    Effect.forkScoped({ startImmediately: true }),
+  );
+
+  yield* refreshCurrentStatus;
+});

--- a/packages/client-runtime/src/connection/connectivity.ts
+++ b/packages/client-runtime/src/connection/connectivity.ts
@@ -31,6 +31,7 @@ export const layer = (service: Connectivity["Service"]) =>
  */
 export const followNetworkStatus = Effect.fnUntraced(function* (options: {
   readonly apply: (status: NetworkStatus) => Effect.Effect<void>;
+  readonly onWakeup?: (reason: ConnectionWakeups.ConnectionWakeup) => Effect.Effect<void>;
 }) {
   const connectivity = yield* Connectivity;
   const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
@@ -47,6 +48,7 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
     if (changed) {
       yield* options.apply(status);
     }
+    return changed;
   });
 
   const refreshCurrentStatus = Effect.gen(function* () {
@@ -64,8 +66,10 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
   yield* connectivity.changes.pipe(
     Stream.runForEach((status) =>
       applyLock.withPermits(1)(
-        Ref.update(revision, (current) => current + 1).pipe(
-          Effect.andThen(applyStatus(status)),
+        applyStatus(status).pipe(
+          Effect.flatMap((changed) =>
+            changed ? Ref.update(revision, (current) => current + 1) : Effect.void,
+          ),
         ),
       ),
     ),
@@ -74,9 +78,14 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
 
   yield* wakeups.changes.pipe(
     Stream.runForEach((reason) =>
-      ConnectionWakeups.isApplicationActiveWakeup(reason)
-        ? refreshCurrentStatus
-        : Effect.void,
+      Effect.gen(function* () {
+        if (options.onWakeup) {
+          yield* options.onWakeup(reason);
+        }
+        if (ConnectionWakeups.isApplicationActiveWakeup(reason)) {
+          yield* refreshCurrentStatus;
+        }
+      }),
     ),
     Effect.forkScoped({ startImmediately: true }),
   );

--- a/packages/client-runtime/src/connection/layer.ts
+++ b/packages/client-runtime/src/connection/layer.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 
 import * as ConnectionResolver from "./resolver.ts";
@@ -19,9 +20,13 @@ const driverLayer = ConnectionDriver.layer.pipe(
   Layer.provide(Layer.mergeAll(resolverLayer, RpcSession.layer)),
 );
 
-const registryLayer = EnvironmentRegistry.layer.pipe(Layer.provide(driverLayer));
+const registryLayer = EnvironmentRegistry.layer.pipe(
+  Layer.provide(driverLayer),
+);
 
-const onboardingLayer = ConnectionOnboarding.layer.pipe(Layer.provide(registryLayer));
+const onboardingLayer = ConnectionOnboarding.layer.pipe(
+  Layer.provide(registryLayer),
+);
 
 const connectionServicesLayer = Layer.mergeAll(
   registryLayer,
@@ -32,13 +37,26 @@ const connectionServicesLayer = Layer.mergeAll(
 const connectionStartupLayer = Layer.effectDiscard(
   Effect.gen(function* () {
     const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-    const platformSource = yield* PlatformConnectionSource.PlatformConnectionSource;
-    yield* registry.start;
-    yield* platformSource.registrations.pipe(
-      Stream.runForEach(registry.reconcilePlatform),
+    const platformSource =
+      yield* PlatformConnectionSource.PlatformConnectionSource;
+    yield* registry.start.pipe(
+      Effect.tapError((error) =>
+        Effect.logWarning(
+          "Could not initialize environment connections; retrying.",
+          { error },
+        ),
+      ),
+      Effect.retry(Schedule.exponential("1 second")),
+      Effect.andThen(
+        platformSource.registrations.pipe(
+          Stream.runForEach(registry.reconcilePlatform),
+        ),
+      ),
       Effect.forkScoped,
     );
   }).pipe(Effect.withSpan("clientRuntime.connection.application.start")),
 );
 
-export const layer = connectionStartupLayer.pipe(Layer.provideMerge(connectionServicesLayer));
+export const layer = connectionStartupLayer.pipe(
+  Layer.provideMerge(connectionServicesLayer),
+);

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -126,21 +126,42 @@ interface SessionControl {
 const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
   initialTargets: ReadonlyArray<ConnectionTarget>,
   initialProfiles: ReadonlyArray<ConnectionProfile> = [],
-  initialCredentials: ReadonlyArray<readonly [string, ConnectionCredential]> = [],
+  initialCredentials: ReadonlyArray<
+    readonly [string, ConnectionCredential]
+  > = [],
   options?: {
-    readonly beforeSessionConnect?: (environmentId: EnvironmentId) => Effect.Effect<void>;
+    readonly initiallyDisabled?: ReadonlyArray<EnvironmentId>;
+    readonly beforeSessionConnect?: (
+      environmentId: EnvironmentId,
+    ) => Effect.Effect<void>;
     readonly beforeRegistrationRegister?: (
       registration: ConnectionRegistration,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
     readonly beforeRegistrationRemove?: (
       target: ConnectionTarget,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
+    readonly beforeActivationSetEnabled?: (
+      environmentId: EnvironmentId,
+      enabled: boolean,
+    ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
+    readonly beforeActivationReconcile?: (
+      environmentIds: ReadonlySet<EnvironmentId>,
+    ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
+    readonly afterActivationListDisabled?: (
+      environmentIds: ReadonlySet<EnvironmentId>,
+    ) => Effect.Effect<void>;
   },
 ) {
   const storedTargets = yield* Ref.make(
     new Map(initialTargets.map((target) => [target.environmentId, target])),
   );
-  const shellCache = yield* Ref.make(new Map([[TARGET.environmentId, CACHED_SNAPSHOT]]));
+  const disabledEnvironmentIds = yield* Ref.make(
+    new Set(options?.initiallyDisabled ?? []),
+  );
+  const activationListCount = yield* Ref.make(0);
+  const shellCache = yield* Ref.make(
+    new Map([[TARGET.environmentId, CACHED_SNAPSHOT]]),
+  );
   const cacheClears = yield* Ref.make<ReadonlyArray<EnvironmentId>>([]);
   const ownedDataClears = yield* Ref.make<ReadonlyArray<EnvironmentId>>([]);
   const sessions = yield* Ref.make<ReadonlyArray<SessionControl>>([]);
@@ -169,18 +190,32 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
       ],
     ]),
   );
-  const disconnectedSshTargets = yield* Ref.make<ReadonlyArray<DesktopSshEnvironmentTarget>>([]);
+  const disconnectedSshTargets = yield* Ref.make<
+    ReadonlyArray<DesktopSshEnvironmentTarget>
+  >([]);
 
   const targetStore = Persistence.ConnectionTargetStore.of({
-    list: Ref.get(storedTargets).pipe(Effect.map((targets) => [...targets.values()])),
+    list: Ref.get(storedTargets).pipe(
+      Effect.map((targets) => [...targets.values()]),
+    ),
   });
   const registrationStore = Persistence.ConnectionRegistrationStore.of({
-    register: (registration) =>
+    register: (registration, registrationOptions) =>
       Effect.gen(function* () {
-        yield* options?.beforeRegistrationRegister?.(registration) ?? Effect.void;
+        yield* options?.beforeRegistrationRegister?.(registration) ??
+          Effect.void;
         yield* Ref.update(storedTargets, (current) => {
           const next = new Map(current);
           next.set(registration.target.environmentId, registration.target);
+          return next;
+        });
+        yield* Ref.update(disabledEnvironmentIds, (current) => {
+          const next = new Set(current);
+          if (registrationOptions.enabled) {
+            next.delete(registration.target.environmentId);
+          } else {
+            next.add(registration.target.environmentId);
+          }
           return next;
         });
         switch (registration._tag) {
@@ -194,7 +229,10 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
             });
             yield* Ref.update(storedCredentials, (current) => {
               const next = new Map(current);
-              next.set(registration.target.connectionId, registration.credential);
+              next.set(
+                registration.target.connectionId,
+                registration.credential,
+              );
               return next;
             });
             return;
@@ -214,7 +252,15 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
           next.delete(target.environmentId);
           return next;
         });
-        if (target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget") {
+        yield* Ref.update(disabledEnvironmentIds, (current) => {
+          const next = new Set(current);
+          next.delete(target.environmentId);
+          return next;
+        });
+        if (
+          target._tag === "BearerConnectionTarget" ||
+          target._tag === "SshConnectionTarget"
+        ) {
           yield* Ref.update(storedProfiles, (current) => {
             const next = new Map(current);
             next.delete(target.connectionId);
@@ -231,6 +277,47 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
           next.delete(target.environmentId);
           return next;
         });
+      }),
+  });
+  const activationStore = Persistence.ConnectionActivationStore.of({
+    listDisabled: Effect.gen(function* () {
+      const current = yield* Ref.get(disabledEnvironmentIds);
+      const listCount = yield* Ref.getAndUpdate(
+        activationListCount,
+        (count) => count + 1,
+      );
+      if (listCount > 0) {
+        yield* options?.afterActivationListDisabled?.(current) ?? Effect.void;
+      }
+      return current;
+    }),
+    setEnabled: (environmentId, enabled) =>
+      Effect.gen(function* () {
+        yield* options?.beforeActivationSetEnabled?.(environmentId, enabled) ??
+          Effect.void;
+        yield* Ref.update(disabledEnvironmentIds, (current) => {
+          const next = new Set(current);
+          if (enabled) {
+            next.delete(environmentId);
+          } else {
+            next.add(environmentId);
+          }
+          return next;
+        });
+      }),
+    reconcile: (environmentIds) =>
+      Effect.gen(function* () {
+        yield* options?.beforeActivationReconcile?.(environmentIds) ??
+          Effect.void;
+        yield* Ref.update(
+          disabledEnvironmentIds,
+          (current) =>
+            new Set(
+              [...current].filter((environmentId) =>
+                environmentIds.has(environmentId),
+              ),
+            ),
+        );
       }),
   });
   const cacheStore = Persistence.EnvironmentCacheStore.of({
@@ -260,15 +347,23 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
         return next;
       }).pipe(
         Effect.andThen(
-          Ref.update(cacheClears, (environmentIds) => [...environmentIds, environmentId]),
+          Ref.update(cacheClears, (environmentIds) => [
+            ...environmentIds,
+            environmentId,
+          ]),
         ),
       ),
   });
   const ownedDataCleanup = Persistence.EnvironmentOwnedDataCleanup.of({
     clear: (environmentId) =>
-      Ref.update(ownedDataClears, (environmentIds) => [...environmentIds, environmentId]),
+      Ref.update(ownedDataClears, (environmentIds) => [
+        ...environmentIds,
+        environmentId,
+      ]),
   });
-  const networkStatus = yield* SubscriptionRef.make<"unknown" | "offline" | "online">("online");
+  const networkStatus = yield* SubscriptionRef.make<
+    "unknown" | "offline" | "online"
+  >("online");
   const connectivity = Connectivity.Connectivity.of({
     status: SubscriptionRef.get(networkStatus),
     changes: SubscriptionRef.changes(networkStatus),
@@ -277,7 +372,9 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
     get: (connectionId) =>
       Ref.update(profileReadCount, (count) => count + 1).pipe(
         Effect.andThen(Ref.get(storedProfiles)),
-        Effect.map((current) => Option.fromUndefinedOr(current.get(connectionId))),
+        Effect.map((current) =>
+          Option.fromUndefinedOr(current.get(connectionId)),
+        ),
       ),
     put: (profile) =>
       Ref.update(storedProfiles, (current) => {
@@ -292,28 +389,33 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
         return next;
       }),
   });
-  const credentialStore = ConnectionCredentialStore.ConnectionCredentialStore.of({
-    get: (connectionId) =>
-      Ref.get(storedCredentials).pipe(
-        Effect.map((current) => Option.fromUndefinedOr(current.get(connectionId))),
-      ),
-    put: (connectionId, credential) =>
-      Ref.update(storedCredentials, (current) => {
-        const next = new Map(current);
-        next.set(connectionId, credential);
-        return next;
-      }),
-    remove: (connectionId) =>
-      Ref.update(storedCredentials, (current) => {
-        const next = new Map(current);
-        next.delete(connectionId);
-        return next;
-      }),
-  });
+  const credentialStore =
+    ConnectionCredentialStore.ConnectionCredentialStore.of({
+      get: (connectionId) =>
+        Ref.get(storedCredentials).pipe(
+          Effect.map((current) =>
+            Option.fromUndefinedOr(current.get(connectionId)),
+          ),
+        ),
+      put: (connectionId, credential) =>
+        Ref.update(storedCredentials, (current) => {
+          const next = new Map(current);
+          next.set(connectionId, credential);
+          return next;
+        }),
+      remove: (connectionId) =>
+        Ref.update(storedCredentials, (current) => {
+          const next = new Map(current);
+          next.delete(connectionId);
+          return next;
+        }),
+    });
   const tokenStore = TokenStore.RemoteDpopAccessTokenStore.of({
     get: (environmentId) =>
       Ref.get(storedRemoteTokens).pipe(
-        Effect.map((current) => Option.fromUndefinedOr(current.get(environmentId))),
+        Effect.map((current) =>
+          Option.fromUndefinedOr(current.get(environmentId)),
+        ),
       ),
     put: (token) =>
       Ref.update(storedRemoteTokens, (current) => {
@@ -331,7 +433,8 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
   const sshGateway = ClientCapabilities.SshEnvironmentGateway.of({
     provision: () => Effect.die(new Error("SSH provisioning is not used.")),
     prepare: () => Effect.die(new Error("SSH preparation is not used.")),
-    disconnect: (target) => Ref.update(disconnectedSshTargets, (current) => [...current, target]),
+    disconnect: (target) =>
+      Ref.update(disconnectedSshTargets, (current) => [...current, target]),
   });
   const driver = ConnectionDriver.ConnectionDriver.of({
     connect: (entry, reportProgress) =>
@@ -345,13 +448,16 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
         };
         yield* reportProgress({ stage: "preparing" });
         yield* reportProgress({ stage: "opening", prepared });
-        yield* options?.beforeSessionConnect?.(target.environmentId) ?? Effect.void;
+        yield* options?.beforeSessionConnect?.(target.environmentId) ??
+          Effect.void;
         const closed = yield* Deferred.make<never, ConnectionTransientError>();
         yield* Ref.update(sessions, (current) => [...current, { closed }]);
         const session = yield* Effect.acquireRelease(
           Effect.succeed({
             client: {} as RpcSession.RpcSession["client"],
-            initialConfig: Effect.die(new Error("Config is not used by registry tests.")),
+            initialConfig: Effect.die(
+              new Error("Config is not used by registry tests."),
+            ),
             ready: Effect.void,
             probe: Effect.void,
             closed: Deferred.await(closed),
@@ -364,14 +470,27 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
       }),
   });
 
-  const cacheLayer = Layer.succeed(Persistence.EnvironmentCacheStore, cacheStore);
+  const cacheLayer = Layer.succeed(
+    Persistence.EnvironmentCacheStore,
+    cacheStore,
+  );
   const layer = EnvironmentRegistry.layer.pipe(
     Layer.provide(
       Layer.mergeAll(
         Layer.succeed(Persistence.ConnectionTargetStore, targetStore),
-        Layer.succeed(Persistence.ConnectionRegistrationStore, registrationStore),
-        Layer.succeed(ConnectionProfileStore.ConnectionProfileStore, profileStore),
-        Layer.succeed(ConnectionCredentialStore.ConnectionCredentialStore, credentialStore),
+        Layer.succeed(
+          Persistence.ConnectionRegistrationStore,
+          registrationStore,
+        ),
+        Layer.succeed(Persistence.ConnectionActivationStore, activationStore),
+        Layer.succeed(
+          ConnectionProfileStore.ConnectionProfileStore,
+          profileStore,
+        ),
+        Layer.succeed(
+          ConnectionCredentialStore.ConnectionCredentialStore,
+          credentialStore,
+        ),
         Layer.succeed(TokenStore.RemoteDpopAccessTokenStore, tokenStore),
         Layer.succeed(ClientCapabilities.SshEnvironmentGateway, sshGateway),
         Layer.succeed(Connectivity.Connectivity, connectivity),
@@ -381,7 +500,10 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
         ),
         Layer.succeed(ConnectionDriver.ConnectionDriver, driver),
         cacheLayer,
-        Layer.succeed(Persistence.EnvironmentOwnedDataCleanup, ownedDataCleanup),
+        Layer.succeed(
+          Persistence.EnvironmentOwnedDataCleanup,
+          ownedDataCleanup,
+        ),
       ),
     ),
   );
@@ -389,6 +511,7 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
   return {
     layer,
     storedTargets,
+    disabledEnvironmentIds,
     shellCache,
     cacheClears,
     ownedDataClears,
@@ -415,11 +538,278 @@ function awaitConnectionState(
     }
     return yield* registry
       .stateChanges(environmentId)
-      .pipe(Stream.filter(predicate), Stream.runHead, Effect.map(Option.getOrThrow));
+      .pipe(
+        Stream.filter(predicate),
+        Stream.runHead,
+        Effect.map(Option.getOrThrow),
+      );
   });
 }
 
 describe("EnvironmentRegistry", () => {
+  it.effect(
+    "keeps disabled persisted environments disconnected and reconciles stale preferences",
+    () =>
+      Effect.gen(function* () {
+        const staleEnvironmentId = EnvironmentId.make("stale-environment");
+        const staleTarget = new RelayConnectionTarget({
+          environmentId: staleEnvironmentId,
+          label: "Previously stale environment",
+        });
+        const harness = yield* makeHarness([TARGET], [], [], {
+          initiallyDisabled: [TARGET.environmentId, staleEnvironmentId],
+        });
+
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.start;
+
+          expect((yield* registry.state(TARGET.environmentId)).phase).toBe(
+            "available",
+          );
+          expect(yield* Ref.get(harness.sessions)).toHaveLength(0);
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set([TARGET.environmentId]),
+          );
+
+          yield* registry.register(
+            new RelayConnectionRegistration({ target: staleTarget }),
+          );
+          yield* awaitConnectionState(
+            registry,
+            staleEnvironmentId,
+            (state) => state.phase === "connected",
+          );
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set([TARGET.environmentId]),
+          );
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
+  );
+
+  it.effect("can retry startup after activation reconciliation fails", () =>
+    Effect.gen(function* () {
+      const reconcileAttempts = yield* Ref.make(0);
+      const harness = yield* makeHarness([TARGET], [], [], {
+        beforeActivationReconcile: () =>
+          Ref.getAndUpdate(reconcileAttempts, (attempts) => attempts + 1).pipe(
+            Effect.flatMap((attempts) =>
+              attempts === 0
+                ? Effect.fail(
+                    new Persistence.ConnectionPersistenceError({
+                      operation: "reconcile-activation",
+                      message: "Transient reconciliation failure",
+                    }),
+                  )
+                : Effect.void,
+            ),
+          ),
+      });
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const error = yield* Effect.flip(registry.start);
+        expect(error.operation).toBe("reconcile-activation");
+
+        yield* registry.start;
+        yield* awaitConnectionState(
+          registry,
+          TARGET.environmentId,
+          (state) => state.phase === "connected",
+        );
+        expect(yield* Ref.get(reconcileAttempts)).toBe(2);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect(
+    "reconciles registrations added before startup from the current target set",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([]);
+
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.register(
+            new RelayConnectionRegistration({ target: RELAY_TARGET }),
+          );
+          yield* registry.setEnabled(RELAY_TARGET.environmentId, false);
+
+          yield* registry.start;
+          yield* awaitConnectionState(
+            registry,
+            RELAY_TARGET.environmentId,
+            (state) => state.phase === "available",
+          );
+
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set([RELAY_TARGET.environmentId]),
+          );
+          expect(
+            (yield* registry.state(RELAY_TARGET.environmentId)).phase,
+          ).toBe("available");
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
+  );
+
+  it.effect(
+    "serializes startup activation refresh with activation changes",
+    () =>
+      Effect.gen(function* () {
+        const activationRead = yield* Deferred.make<void>();
+        const continueStartup = yield* Deferred.make<void>();
+        const harness = yield* makeHarness([TARGET], [], [], {
+          afterActivationListDisabled: () =>
+            Deferred.succeed(activationRead, undefined).pipe(
+              Effect.andThen(Deferred.await(continueStartup)),
+            ),
+        });
+
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          const startup = yield* registry.start.pipe(
+            Effect.forkChild({ startImmediately: true }),
+          );
+          yield* Deferred.await(activationRead);
+          const disable = yield* registry
+            .setEnabled(TARGET.environmentId, false)
+            .pipe(Effect.forkChild({ startImmediately: true }));
+
+          yield* Effect.yieldNow;
+          yield* Deferred.succeed(continueStartup, undefined);
+          yield* Fiber.join(startup);
+          yield* Fiber.join(disable);
+
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set([TARGET.environmentId]),
+          );
+          expect((yield* registry.state(TARGET.environmentId)).phase).toBe(
+            "available",
+          );
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
+  );
+
+  it.effect(
+    "keeps registration and activation durable when removal fails",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([TARGET], [], [], {
+          initiallyDisabled: [TARGET.environmentId],
+          beforeRegistrationRemove: () =>
+            Effect.fail(
+              new Persistence.ConnectionPersistenceError({
+                operation: "remove-connection",
+                message: "Registration removal failed",
+              }),
+            ),
+        });
+
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          const error = yield* Effect.flip(
+            registry.remove(TARGET.environmentId),
+          );
+
+          expect(error._tag).toBe("ConnectionPersistenceError");
+          expect(
+            (yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId),
+          ).toBe(true);
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set([TARGET.environmentId]),
+          );
+          expect(
+            (yield* SubscriptionRef.get(registry.entries)).has(
+              TARGET.environmentId,
+            ),
+          ).toBe(true);
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
+  );
+
+  it.effect("serializes activation changes with environment removal", () =>
+    Effect.gen(function* () {
+      const activationStarted = yield* Deferred.make<void>();
+      const continueActivation = yield* Deferred.make<void>();
+      const harness = yield* makeHarness([TARGET], [], [], {
+        beforeActivationSetEnabled: (_environmentId, enabled) =>
+          enabled
+            ? Effect.void
+            : Deferred.succeed(activationStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(continueActivation)),
+              ),
+      });
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const disable = yield* registry
+          .setEnabled(TARGET.environmentId, false)
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(activationStarted);
+        const removal = yield* registry
+          .remove(TARGET.environmentId)
+          .pipe(Effect.forkChild({ startImmediately: true }));
+
+        yield* Effect.yieldNow;
+        expect(
+          (yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId),
+        ).toBe(true);
+
+        yield* Deferred.succeed(continueActivation, undefined);
+        yield* Fiber.join(disable);
+        yield* Fiber.join(removal);
+
+        expect(
+          (yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId),
+        ).toBe(false);
+        expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+          new Set(),
+        );
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect(
+    "disconnects and reconnects an environment without removing its registration",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([TARGET]);
+
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.start;
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => state.phase === "connected",
+          );
+
+          yield* registry.setEnabled(TARGET.environmentId, false);
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => state.phase === "available",
+          );
+          expect(
+            (yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId),
+          ).toBe(true);
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set([TARGET.environmentId]),
+          );
+
+          yield* registry.setEnabled(TARGET.environmentId, true);
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => state.phase === "connected",
+          );
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set(),
+          );
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
+  );
+
   it.effect("hydrates connection profiles into catalog entries", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness([SSH_CONNECTION], [SSH_PROFILE]);
@@ -431,31 +821,37 @@ describe("EnvironmentRegistry", () => {
         );
 
         expect(entry?.target).toEqual(SSH_CONNECTION);
-        expect(Option.getOrThrow(entry?.profile ?? Option.none())).toEqual(SSH_PROFILE);
+        expect(Option.getOrThrow(entry?.profile ?? Option.none())).toEqual(
+          SSH_PROFILE,
+        );
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );
 
-  it.effect("publishes network status changes independently of connection state", () =>
-    Effect.gen(function* () {
-      const harness = yield* makeHarness([]);
+  it.effect(
+    "publishes network status changes independently of connection state",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([]);
 
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        const offline = yield* Effect.forkChild(
-          SubscriptionRef.changes(registry.networkStatus).pipe(
-            Stream.filter((status) => status === "offline"),
-            Stream.runHead,
-            Effect.map(Option.getOrThrow),
-          ),
-        );
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          const offline = yield* Effect.forkChild(
+            SubscriptionRef.changes(registry.networkStatus).pipe(
+              Stream.filter((status) => status === "offline"),
+              Stream.runHead,
+              Effect.map(Option.getOrThrow),
+            ),
+          );
 
-        yield* SubscriptionRef.set(harness.networkStatus, "offline");
+          yield* SubscriptionRef.set(harness.networkStatus, "offline");
 
-        expect(yield* Fiber.join(offline)).toBe("offline");
-        expect(yield* SubscriptionRef.get(registry.networkStatus)).toBe("offline");
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
-    }),
+          expect(yield* Fiber.join(offline)).toBe("offline");
+          expect(yield* SubscriptionRef.get(registry.networkStatus)).toBe(
+            "offline",
+          );
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
   );
 
   it.effect("starts persisted environments independently", () =>
@@ -467,7 +863,9 @@ describe("EnvironmentRegistry", () => {
         beforeSessionConnect: () =>
           Ref.updateAndGet(loadCount, (count) => count + 1).pipe(
             Effect.tap((count) =>
-              count === 2 ? Deferred.succeed(bothLoadsStarted, undefined) : Effect.void,
+              count === 2
+                ? Deferred.succeed(bothLoadsStarted, undefined)
+                : Effect.void,
             ),
             Effect.andThen(Deferred.await(releaseLoads)),
           ),
@@ -477,7 +875,9 @@ describe("EnvironmentRegistry", () => {
         const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
         const start = yield* Effect.forkChild(registry.start);
 
-        yield* Deferred.await(bothLoadsStarted).pipe(Effect.timeout("1 second"));
+        yield* Deferred.await(bothLoadsStarted).pipe(
+          Effect.timeout("1 second"),
+        );
         yield* Deferred.succeed(releaseLoads, undefined);
         yield* Fiber.join(start);
 
@@ -486,94 +886,106 @@ describe("EnvironmentRegistry", () => {
     }),
   );
 
-  it.effect("exposes the current RPC generation to late query subscribers", () =>
-    Effect.gen(function* () {
-      const harness = yield* makeHarness([TARGET]);
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.start;
-        yield* awaitConnectionState(
-          registry,
-          TARGET.environmentId,
-          (state) => state.phase === "connected",
-        );
-
-        const generation = yield* registry
-          .runStream(
+  it.effect(
+    "exposes the current RPC generation to late query subscribers",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([TARGET]);
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.start;
+          yield* awaitConnectionState(
+            registry,
             TARGET.environmentId,
-            Stream.unwrap(
-              EnvironmentSupervisor.EnvironmentSupervisor.pipe(
-                Effect.map((supervisor) =>
-                  Stream.concat(
-                    Stream.fromEffect(SubscriptionRef.get(supervisor.state)),
-                    SubscriptionRef.changes(supervisor.state),
-                  ).pipe(
-                    Stream.filterMap((state) =>
-                      state.phase === "connected"
-                        ? Result.succeed(state.generation)
-                        : Result.failVoid,
+            (state) => state.phase === "connected",
+          );
+
+          const generation = yield* registry
+            .runStream(
+              TARGET.environmentId,
+              Stream.unwrap(
+                EnvironmentSupervisor.EnvironmentSupervisor.pipe(
+                  Effect.map((supervisor) =>
+                    Stream.concat(
+                      Stream.fromEffect(SubscriptionRef.get(supervisor.state)),
+                      SubscriptionRef.changes(supervisor.state),
+                    ).pipe(
+                      Stream.filterMap((state) =>
+                        state.phase === "connected"
+                          ? Result.succeed(state.generation)
+                          : Result.failVoid,
+                      ),
+                      Stream.changes,
                     ),
-                    Stream.changes,
                   ),
                 ),
               ),
-            ),
-          )
-          .pipe(Stream.runHead, Effect.map(Option.getOrThrow));
+            )
+            .pipe(Stream.runHead, Effect.map(Option.getOrThrow));
 
-        expect(generation).toBe(1);
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
-    }),
+          expect(generation).toBe(1);
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
   );
 
-  it.effect("preserves cached data on connection failure and clears it on explicit removal", () =>
-    Effect.gen(function* () {
-      const harness = yield* makeHarness([TARGET]);
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.start;
-        yield* awaitConnectionState(
-          registry,
-          TARGET.environmentId,
-          (state) => state.phase === "connected",
-        );
-        const controls = yield* Ref.get(harness.sessions);
-        expect(controls).toHaveLength(1);
-        const active = controls[0];
-        expect(active).toBeDefined();
-        expect((yield* Ref.get(harness.shellCache)).get(TARGET.environmentId)).toEqual(
-          CACHED_SNAPSHOT,
-        );
-
-        const retryFiber = yield* Effect.forkChild(
-          awaitConnectionState(
+  it.effect(
+    "preserves cached data on connection failure and clears it on explicit removal",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([TARGET]);
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.start;
+          yield* awaitConnectionState(
             registry,
             TARGET.environmentId,
-            (state) => state.phase === "backoff",
-          ),
-        );
-        yield* Effect.yieldNow;
-        yield* Deferred.fail(
-          active!.closed,
-          new ConnectionTransientError({
-            reason: "transport",
-            detail: "Disconnected.",
-          }),
-        );
-        yield* Fiber.join(retryFiber);
-        expect((yield* Ref.get(harness.shellCache)).get(TARGET.environmentId)).toEqual(
-          CACHED_SNAPSHOT,
-        );
+            (state) => state.phase === "connected",
+          );
+          const controls = yield* Ref.get(harness.sessions);
+          expect(controls).toHaveLength(1);
+          const active = controls[0];
+          expect(active).toBeDefined();
+          expect(
+            (yield* Ref.get(harness.shellCache)).get(TARGET.environmentId),
+          ).toEqual(CACHED_SNAPSHOT);
 
-        yield* registry.remove(TARGET.environmentId);
-        expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(false);
-        expect((yield* Ref.get(harness.shellCache)).has(TARGET.environmentId)).toBe(false);
-        expect(yield* Ref.get(harness.cacheClears)).toEqual([TARGET.environmentId]);
-        expect((yield* SubscriptionRef.get(registry.entries)).has(TARGET.environmentId)).toBe(
-          false,
-        );
-      }).pipe(Effect.provide(harness.layer));
-    }),
+          const retryFiber = yield* Effect.forkChild(
+            awaitConnectionState(
+              registry,
+              TARGET.environmentId,
+              (state) => state.phase === "backoff",
+            ),
+          );
+          yield* Effect.yieldNow;
+          yield* Deferred.fail(
+            active!.closed,
+            new ConnectionTransientError({
+              reason: "transport",
+              detail: "Disconnected.",
+            }),
+          );
+          yield* Fiber.join(retryFiber);
+          expect(
+            (yield* Ref.get(harness.shellCache)).get(TARGET.environmentId),
+          ).toEqual(CACHED_SNAPSHOT);
+
+          yield* registry.remove(TARGET.environmentId);
+          expect(
+            (yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId),
+          ).toBe(false);
+          expect(
+            (yield* Ref.get(harness.shellCache)).has(TARGET.environmentId),
+          ).toBe(false);
+          expect(yield* Ref.get(harness.cacheClears)).toEqual([
+            TARGET.environmentId,
+          ]);
+          expect(
+            (yield* SubscriptionRef.get(registry.entries)).has(
+              TARGET.environmentId,
+            ),
+          ).toBe(false);
+        }).pipe(Effect.provide(harness.layer));
+      }),
   );
 
   it.effect("persists and starts a newly registered environment", () =>
@@ -582,16 +994,20 @@ describe("EnvironmentRegistry", () => {
 
       yield* Effect.gen(function* () {
         const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.register(new RelayConnectionRegistration({ target: RELAY_TARGET }));
+        yield* registry.register(
+          new RelayConnectionRegistration({ target: RELAY_TARGET }),
+        );
         yield* awaitConnectionState(
           registry,
           RELAY_TARGET.environmentId,
           (state) => state.phase === "connected",
         );
 
-        expect((yield* Ref.get(harness.storedTargets)).get(RELAY_TARGET.environmentId)).toEqual(
-          RELAY_TARGET,
-        );
+        expect(
+          (yield* Ref.get(harness.storedTargets)).get(
+            RELAY_TARGET.environmentId,
+          ),
+        ).toEqual(RELAY_TARGET);
         expect(yield* Ref.get(harness.sessions)).toHaveLength(1);
       }).pipe(Effect.provide(harness.layer));
     }),
@@ -624,7 +1040,10 @@ describe("EnvironmentRegistry", () => {
               Stream.unwrap(
                 EnvironmentSupervisor.EnvironmentSupervisor.pipe(
                   Effect.map((supervisor) =>
-                    Stream.concat(Stream.succeed(supervisor.target.label), Stream.never),
+                    Stream.concat(
+                      Stream.succeed(supervisor.target.label),
+                      Stream.never,
+                    ),
                   ),
                 ),
               ),
@@ -644,53 +1063,72 @@ describe("EnvironmentRegistry", () => {
         );
 
         yield* Deferred.await(firstObserved).pipe(Effect.timeout("1 second"));
-        yield* registry.register(new RelayConnectionRegistration({ target: replacement }));
+        yield* registry.register(
+          new RelayConnectionRegistration({ target: replacement }),
+        );
         yield* Deferred.await(secondObserved).pipe(Effect.timeout("1 second"));
         yield* Fiber.interrupt(subscription);
 
-        expect(yield* Ref.get(labels)).toEqual([RELAY_TARGET.label, replacement.label]);
+        expect(yield* Ref.get(labels)).toEqual([
+          RELAY_TARGET.label,
+          replacement.label,
+        ]);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );
 
-  it.effect("ignores retry signals for environments that are no longer registered", () =>
-    Effect.gen(function* () {
-      const harness = yield* makeHarness([]);
+  it.effect(
+    "ignores retry signals for environments that are no longer registered",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([]);
 
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.retryNow(EnvironmentId.make("removed-environment"));
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
-    }),
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.retryNow(EnvironmentId.make("removed-environment"));
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
   );
 
-  it.effect("removes all relay-owned data without touching non-cloud connections", () =>
-    Effect.gen(function* () {
-      const harness = yield* makeHarness(
-        [RELAY_TARGET, SECOND_RELAY_TARGET, BEARER_TARGET],
-        [BEARER_PROFILE],
-        [[BEARER_TARGET.connectionId, BEARER_CREDENTIAL]],
-      );
-
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.removeRelayEnvironments();
-
-        const targets = yield* Ref.get(harness.storedTargets);
-        expect(targets.has(RELAY_TARGET.environmentId)).toBe(false);
-        expect(targets.has(SECOND_RELAY_TARGET.environmentId)).toBe(false);
-        expect(targets.get(BEARER_TARGET.environmentId)).toEqual(BEARER_TARGET);
-        expect(yield* Ref.get(harness.cacheClears)).toEqual(
-          expect.arrayContaining([RELAY_TARGET.environmentId, SECOND_RELAY_TARGET.environmentId]),
+  it.effect(
+    "removes all relay-owned data without touching non-cloud connections",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness(
+          [RELAY_TARGET, SECOND_RELAY_TARGET, BEARER_TARGET],
+          [BEARER_PROFILE],
+          [[BEARER_TARGET.connectionId, BEARER_CREDENTIAL]],
         );
-        expect(yield* Ref.get(harness.ownedDataClears)).toEqual(
-          expect.arrayContaining([RELAY_TARGET.environmentId, SECOND_RELAY_TARGET.environmentId]),
-        );
-        expect(
-          (yield* SubscriptionRef.get(registry.entries)).has(BEARER_TARGET.environmentId),
-        ).toBe(true);
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
-    }),
+
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.removeRelayEnvironments();
+
+          const targets = yield* Ref.get(harness.storedTargets);
+          expect(targets.has(RELAY_TARGET.environmentId)).toBe(false);
+          expect(targets.has(SECOND_RELAY_TARGET.environmentId)).toBe(false);
+          expect(targets.get(BEARER_TARGET.environmentId)).toEqual(
+            BEARER_TARGET,
+          );
+          expect(yield* Ref.get(harness.cacheClears)).toEqual(
+            expect.arrayContaining([
+              RELAY_TARGET.environmentId,
+              SECOND_RELAY_TARGET.environmentId,
+            ]),
+          );
+          expect(yield* Ref.get(harness.ownedDataClears)).toEqual(
+            expect.arrayContaining([
+              RELAY_TARGET.environmentId,
+              SECOND_RELAY_TARGET.environmentId,
+            ]),
+          );
+          expect(
+            (yield* SubscriptionRef.get(registry.entries)).has(
+              BEARER_TARGET.environmentId,
+            ),
+          ).toBe(true);
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
   );
 
   it.effect("keeps the runtime registered when durable removal fails", () =>
@@ -718,199 +1156,332 @@ describe("EnvironmentRegistry", () => {
 
         expect(error._tag).toBe("ConnectionPersistenceError");
         expect(yield* Ref.get(harness.releasedSessions)).toBe(0);
-        expect((yield* SubscriptionRef.get(registry.entries)).has(RELAY_TARGET.environmentId)).toBe(
-          true,
-        );
-        expect((yield* Ref.get(harness.storedTargets)).has(RELAY_TARGET.environmentId)).toBe(true);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).has(
+            RELAY_TARGET.environmentId,
+          ),
+        ).toBe(true);
+        expect(
+          (yield* Ref.get(harness.storedTargets)).has(
+            RELAY_TARGET.environmentId,
+          ),
+        ).toBe(true);
         expect(yield* Ref.get(harness.cacheClears)).toEqual([]);
         expect(yield* Ref.get(harness.ownedDataClears)).toEqual([]);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );
 
-  it.effect("starts a newly paired bearer environment without re-reading its profile", () =>
-    Effect.gen(function* () {
-      const harness = yield* makeHarness([]);
+  it.effect(
+    "starts a newly paired bearer environment without re-reading its profile",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([]);
 
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.register(
-          new BearerConnectionRegistration({
-            target: BEARER_TARGET,
-            profile: BEARER_PROFILE,
-            credential: BEARER_CREDENTIAL,
-          }),
-        );
-        yield* awaitConnectionState(
-          registry,
-          BEARER_TARGET.environmentId,
-          (state) => state.phase === "connected",
-        );
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.register(
+            new BearerConnectionRegistration({
+              target: BEARER_TARGET,
+              profile: BEARER_PROFILE,
+              credential: BEARER_CREDENTIAL,
+            }),
+          );
+          yield* awaitConnectionState(
+            registry,
+            BEARER_TARGET.environmentId,
+            (state) => state.phase === "connected",
+          );
 
-        expect(yield* Ref.get(harness.profileReadCount)).toBe(0);
-        expect(
-          Option.getOrThrow(
-            (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)
-              ?.profile ?? Option.none(),
-          ),
-        ).toEqual(BEARER_PROFILE);
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
-    }),
+          expect(yield* Ref.get(harness.profileReadCount)).toBe(0);
+          expect(
+            Option.getOrThrow(
+              (yield* SubscriptionRef.get(registry.entries)).get(
+                BEARER_TARGET.environmentId,
+              )?.profile ?? Option.none(),
+            ),
+          ).toEqual(BEARER_PROFILE);
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
   );
 
-  it.effect("starts platform environments without persisting or removing them", () =>
-    Effect.gen(function* () {
-      const harness = yield* makeHarness([]);
+  it.effect(
+    "starts platform environments without persisting or removing them",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([]);
 
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.registerPlatform(new PrimaryConnectionRegistration({ target: TARGET }));
-        yield* awaitConnectionState(
-          registry,
-          TARGET.environmentId,
-          (state) => state.phase === "connected",
-        );
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.registerPlatform(
+            new PrimaryConnectionRegistration({ target: TARGET }),
+          );
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => state.phase === "connected",
+          );
 
-        expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(false);
-        expect(
-          (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
-        ).toEqual(TARGET);
+          expect(
+            (yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId),
+          ).toBe(false);
+          expect(
+            (yield* SubscriptionRef.get(registry.entries)).get(
+              TARGET.environmentId,
+            )?.target,
+          ).toEqual(TARGET);
 
-        const error = yield* Effect.flip(registry.remove(TARGET.environmentId));
-        expect(error._tag).toBe("PlatformEnvironmentRemovalError");
-        expect(
-          (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
-        ).toEqual(TARGET);
-      }).pipe(Effect.provide(harness.layer));
-    }),
+          const error = yield* Effect.flip(
+            registry.remove(TARGET.environmentId),
+          );
+          expect(error._tag).toBe("PlatformEnvironmentRemovalError");
+          expect(
+            (yield* SubscriptionRef.get(registry.entries)).get(
+              TARGET.environmentId,
+            )?.target,
+          ).toEqual(TARGET);
+        }).pipe(Effect.provide(harness.layer));
+      }),
   );
 
-  it.effect("gives a primary platform registration precedence over persisted registrations", () =>
-    Effect.gen(function* () {
-      const shadowedTarget = new RelayConnectionTarget({
-        environmentId: TARGET.environmentId,
-        label: "Shadowed relay environment",
-      });
-      const harness = yield* makeHarness([shadowedTarget]);
+  it.effect(
+    "gives a primary platform registration precedence over persisted registrations",
+    () =>
+      Effect.gen(function* () {
+        const shadowedTarget = new RelayConnectionTarget({
+          environmentId: TARGET.environmentId,
+          label: "Shadowed relay environment",
+        });
+        const harness = yield* makeHarness([shadowedTarget], [], [], {
+          initiallyDisabled: [TARGET.environmentId],
+        });
 
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.registerPlatform(new PrimaryConnectionRegistration({ target: TARGET }));
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.registerPlatform(
+            new PrimaryConnectionRegistration({ target: TARGET }),
+          );
 
-        expect(
-          (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
-        ).toEqual(TARGET);
-        expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(false);
+          expect(
+            (yield* SubscriptionRef.get(registry.entries)).get(
+              TARGET.environmentId,
+            )?.target,
+          ).toEqual(TARGET);
+          expect(
+            (yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId),
+          ).toBe(false);
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set(),
+          );
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => state.phase === "connected",
+          );
 
-        yield* registry.register(new RelayConnectionRegistration({ target: shadowedTarget }));
+          yield* registry.register(
+            new RelayConnectionRegistration({ target: shadowedTarget }),
+          );
 
-        expect(
-          (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
-        ).toEqual(TARGET);
-        expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(false);
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
-    }),
+          expect(
+            (yield* SubscriptionRef.get(registry.entries)).get(
+              TARGET.environmentId,
+            )?.target,
+          ).toEqual(TARGET);
+          expect(
+            (yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId),
+          ).toBe(false);
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
   );
 
-  it.effect("rechecks platform ownership after waiting for the environment lease", () =>
-    Effect.gen(function* () {
-      const registrationStarted = yield* Deferred.make<void>();
-      const continueRegistration = yield* Deferred.make<void>();
-      const shadowedTarget = new RelayConnectionTarget({
-        environmentId: TARGET.environmentId,
-        label: "Shadowed relay environment",
-      });
-      const harness = yield* makeHarness([], [], [], {
-        beforeRegistrationRegister: () =>
-          Deferred.succeed(registrationStarted, undefined).pipe(
-            Effect.andThen(Deferred.await(continueRegistration)),
-          ),
-      });
+  it.effect(
+    "starts a platform environment when shadowed registration cleanup fails",
+    () =>
+      Effect.gen(function* () {
+        const shadowedTarget = new RelayConnectionTarget({
+          environmentId: TARGET.environmentId,
+          label: "Shadowed relay environment",
+        });
+        const harness = yield* makeHarness([shadowedTarget], [], [], {
+          initiallyDisabled: [TARGET.environmentId],
+          beforeRegistrationRemove: () =>
+            Effect.fail(
+              new Persistence.ConnectionPersistenceError({
+                operation: "remove-connection",
+                message: "Storage is unavailable.",
+              }),
+            ),
+        });
 
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        const persistedRegistration = yield* registry
-          .register(new RelayConnectionRegistration({ target: shadowedTarget }))
-          .pipe(Effect.forkChild({ startImmediately: true }));
-        yield* Deferred.await(registrationStarted);
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.registerPlatform(
+            new PrimaryConnectionRegistration({ target: TARGET }),
+          );
 
-        const platformRegistration = yield* registry
-          .registerPlatform(new PrimaryConnectionRegistration({ target: TARGET }))
-          .pipe(Effect.forkChild({ startImmediately: true }));
-        yield* Effect.yieldNow;
-        const removal = yield* Effect.flip(registry.remove(TARGET.environmentId)).pipe(
-          Effect.forkChild({ startImmediately: true }),
-        );
-
-        yield* Deferred.succeed(continueRegistration, undefined);
-        yield* Fiber.join(persistedRegistration);
-        yield* Fiber.join(platformRegistration);
-        const error = yield* Fiber.join(removal);
-
-        expect(error._tag).toBe("PlatformEnvironmentRemovalError");
-        expect(
-          (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
-        ).toEqual(TARGET);
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
-    }),
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => state.phase === "connected",
+          );
+          expect(
+            (yield* Ref.get(harness.storedTargets)).get(TARGET.environmentId),
+          ).toEqual(shadowedTarget);
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set(),
+          );
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
   );
 
-  it.effect("does not reacquire a runtime while its registration is being removed", () =>
-    Effect.gen(function* () {
-      const removalStarted = yield* Deferred.make<void>();
-      const continueRemoval = yield* Deferred.make<void>();
-      const harness = yield* makeHarness([TARGET], [], [], {
-        beforeRegistrationRemove: () =>
-          Deferred.succeed(removalStarted, undefined).pipe(
-            Effect.andThen(Deferred.await(continueRemoval)),
-          ),
-      });
+  it.effect(
+    "re-enables an equivalent platform environment during reconciliation",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([], [], []);
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          const registration = new PrimaryConnectionRegistration({
+            target: TARGET,
+          });
 
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.start;
-        yield* awaitConnectionState(
-          registry,
-          TARGET.environmentId,
-          (state) => state.phase === "connected",
-        );
+          yield* registry.registerPlatform(registration);
+          yield* registry.setEnabled(TARGET.environmentId, false);
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => !state.desired,
+          );
 
-        const removal = yield* Effect.forkChild(registry.remove(TARGET.environmentId));
-        yield* Deferred.await(removalStarted);
-
-        const stateLookup = yield* Effect.forkChild(
-          Effect.flip(registry.state(TARGET.environmentId)),
-        );
-        yield* Effect.yieldNow;
-        expect(yield* Ref.get(harness.sessions)).toHaveLength(1);
-
-        yield* Deferred.succeed(continueRemoval, undefined);
-        yield* Fiber.join(removal);
-        const error = yield* Fiber.join(stateLookup);
-        expect(error._tag).toBe("EnvironmentNotRegisteredError");
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
-    }),
+          yield* registry.registerPlatform(registration);
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => state.phase === "connected",
+          );
+          expect(yield* Ref.get(harness.disabledEnvironmentIds)).toEqual(
+            new Set(),
+          );
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
   );
 
-  it.effect("retains a healthy runtime when the platform repeats an identical registration", () =>
-    Effect.gen(function* () {
-      const harness = yield* makeHarness([]);
+  it.effect(
+    "rechecks platform ownership after waiting for the environment lease",
+    () =>
+      Effect.gen(function* () {
+        const registrationStarted = yield* Deferred.make<void>();
+        const continueRegistration = yield* Deferred.make<void>();
+        const shadowedTarget = new RelayConnectionTarget({
+          environmentId: TARGET.environmentId,
+          label: "Shadowed relay environment",
+        });
+        const harness = yield* makeHarness([], [], [], {
+          beforeRegistrationRegister: () =>
+            Deferred.succeed(registrationStarted, undefined).pipe(
+              Effect.andThen(Deferred.await(continueRegistration)),
+            ),
+        });
 
-      yield* Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        const registration = new PrimaryConnectionRegistration({ target: TARGET });
-        yield* registry.registerPlatform(registration);
-        yield* awaitConnectionState(
-          registry,
-          TARGET.environmentId,
-          (state) => state.phase === "connected",
-        );
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          const persistedRegistration = yield* registry
+            .register(
+              new RelayConnectionRegistration({ target: shadowedTarget }),
+            )
+            .pipe(Effect.forkChild({ startImmediately: true }));
+          yield* Deferred.await(registrationStarted);
 
-        yield* registry.registerPlatform(registration);
+          const platformRegistration = yield* registry
+            .registerPlatform(
+              new PrimaryConnectionRegistration({ target: TARGET }),
+            )
+            .pipe(Effect.forkChild({ startImmediately: true }));
+          yield* Effect.yieldNow;
+          const removal = yield* Effect.flip(
+            registry.remove(TARGET.environmentId),
+          ).pipe(Effect.forkChild({ startImmediately: true }));
 
-        expect(yield* Ref.get(harness.sessions)).toHaveLength(1);
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
-    }),
+          yield* Deferred.succeed(continueRegistration, undefined);
+          yield* Fiber.join(persistedRegistration);
+          yield* Fiber.join(platformRegistration);
+          const error = yield* Fiber.join(removal);
+
+          expect(error._tag).toBe("PlatformEnvironmentRemovalError");
+          expect(
+            (yield* SubscriptionRef.get(registry.entries)).get(
+              TARGET.environmentId,
+            )?.target,
+          ).toEqual(TARGET);
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
+  );
+
+  it.effect(
+    "does not reacquire a runtime while its registration is being removed",
+    () =>
+      Effect.gen(function* () {
+        const removalStarted = yield* Deferred.make<void>();
+        const continueRemoval = yield* Deferred.make<void>();
+        const harness = yield* makeHarness([TARGET], [], [], {
+          beforeRegistrationRemove: () =>
+            Deferred.succeed(removalStarted, undefined).pipe(
+              Effect.andThen(Deferred.await(continueRemoval)),
+            ),
+        });
+
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          yield* registry.start;
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => state.phase === "connected",
+          );
+
+          const removal = yield* Effect.forkChild(
+            registry.remove(TARGET.environmentId),
+          );
+          yield* Deferred.await(removalStarted);
+
+          const stateLookup = yield* Effect.forkChild(
+            Effect.flip(registry.state(TARGET.environmentId)),
+          );
+          yield* Effect.yieldNow;
+          expect(yield* Ref.get(harness.sessions)).toHaveLength(1);
+
+          yield* Deferred.succeed(continueRemoval, undefined);
+          yield* Fiber.join(removal);
+          const error = yield* Fiber.join(stateLookup);
+          expect(error._tag).toBe("EnvironmentNotRegisteredError");
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
+  );
+
+  it.effect(
+    "retains a healthy runtime when the platform repeats an identical registration",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness([]);
+
+        yield* Effect.gen(function* () {
+          const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+          const registration = new PrimaryConnectionRegistration({
+            target: TARGET,
+          });
+          yield* registry.registerPlatform(registration);
+          yield* awaitConnectionState(
+            registry,
+            TARGET.environmentId,
+            (state) => state.phase === "connected",
+          );
+
+          yield* registry.registerPlatform(registration);
+
+          expect(yield* Ref.get(harness.sessions)).toHaveLength(1);
+        }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }),
   );
 
   it.effect("removes all owned SSH state only on explicit removal", () =>
@@ -931,16 +1502,24 @@ describe("EnvironmentRegistry", () => {
         yield* registry.start;
         yield* registry.remove(SSH_CONNECTION.environmentId);
 
-        expect((yield* Ref.get(harness.storedProfiles)).has(SSH_CONNECTION.connectionId)).toBe(
-          false,
-        );
-        expect((yield* Ref.get(harness.storedCredentials)).has(SSH_CONNECTION.connectionId)).toBe(
-          false,
-        );
-        expect((yield* Ref.get(harness.storedRemoteTokens)).has(SSH_CONNECTION.environmentId)).toBe(
-          false,
-        );
-        expect(yield* Ref.get(harness.disconnectedSshTargets)).toEqual([SSH_TARGET]);
+        expect(
+          (yield* Ref.get(harness.storedProfiles)).has(
+            SSH_CONNECTION.connectionId,
+          ),
+        ).toBe(false);
+        expect(
+          (yield* Ref.get(harness.storedCredentials)).has(
+            SSH_CONNECTION.connectionId,
+          ),
+        ).toBe(false);
+        expect(
+          (yield* Ref.get(harness.storedRemoteTokens)).has(
+            SSH_CONNECTION.environmentId,
+          ),
+        ).toBe(false);
+        expect(yield* Ref.get(harness.disconnectedSshTargets)).toEqual([
+          SSH_TARGET,
+        ]);
       }).pipe(Effect.provide(harness.layer));
     }),
   );

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -652,10 +652,9 @@ export const make = Effect.gen(function* () {
       ),
     ),
   );
-  yield* connectivity.changes.pipe(
-    Stream.runForEach((status) => SubscriptionRef.set(networkStatus, status)),
-    Effect.forkScoped,
-  );
+  yield* Connectivity.followNetworkStatus({
+    apply: (status) => SubscriptionRef.set(networkStatus, status),
+  });
 
   return EnvironmentRegistry.of({
     entries,

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -66,11 +66,14 @@ export class EnvironmentRegistry extends Context.Service<
       ReadonlyMap<EnvironmentId, ConnectionCatalogEntry>
     >;
     readonly networkStatus: SubscriptionRef.SubscriptionRef<NetworkStatus>;
-    readonly start: Effect.Effect<void>;
+    readonly start: Effect.Effect<void, Persistence.ConnectionPersistenceError>;
     readonly register: (
       registration: ConnectionRegistration,
+      options?: { readonly enabled?: boolean },
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
-    readonly registerPlatform: (registration: PrimaryConnectionRegistration) => Effect.Effect<void>;
+    readonly registerPlatform: (
+      registration: PrimaryConnectionRegistration,
+    ) => Effect.Effect<void>;
     readonly reconcilePlatform: (
       registrations: ReadonlyArray<PlatformConnectionRegistration>,
     ) => Effect.Effect<void>;
@@ -90,12 +93,25 @@ export class EnvironmentRegistry extends Context.Service<
       | PlatformEnvironmentRemovalError
     >;
     readonly retryNow: (environmentId: EnvironmentId) => Effect.Effect<void>;
+    readonly setEnabled: (
+      environmentId: EnvironmentId,
+      enabled: boolean,
+    ) => Effect.Effect<
+      void,
+      Persistence.ConnectionPersistenceError | EnvironmentNotRegisteredError
+    >;
     readonly state: (
       environmentId: EnvironmentId,
-    ) => Effect.Effect<SupervisorConnectionState, EnvironmentNotRegisteredError>;
+    ) => Effect.Effect<
+      SupervisorConnectionState,
+      EnvironmentNotRegisteredError
+    >;
     readonly stateChanges: (
       environmentId: EnvironmentId,
-    ) => Stream.Stream<SupervisorConnectionState, EnvironmentNotRegisteredError>;
+    ) => Stream.Stream<
+      SupervisorConnectionState,
+      EnvironmentNotRegisteredError
+    >;
     readonly run: <A, E, R>(
       environmentId: EnvironmentId,
       effect: Effect.Effect<A, E, R>,
@@ -115,7 +131,11 @@ export class EnvironmentRegistry extends Context.Service<
     readonly followStream: <A, E, R>(
       environmentId: EnvironmentId,
       stream: Stream.Stream<A, E, R>,
-    ) => Stream.Stream<A, E, Exclude<R, EnvironmentSupervisor.EnvironmentSupervisor>>;
+    ) => Stream.Stream<
+      A,
+      E,
+      Exclude<R, EnvironmentSupervisor.EnvironmentSupervisor>
+    >;
   }
 >()("@t3tools/client-runtime/connection/registry/EnvironmentRegistry") {}
 
@@ -128,21 +148,25 @@ interface EnvironmentServiceScope {
 export const make = Effect.gen(function* () {
   const storage = yield* Persistence.ConnectionTargetStore;
   const registrations = yield* Persistence.ConnectionRegistrationStore;
+  const activation = yield* Persistence.ConnectionActivationStore;
   const cache = yield* Persistence.EnvironmentCacheStore;
   const ownedDataCleanup = yield* Persistence.EnvironmentOwnedDataCleanup;
   const profiles = yield* ConnectionProfileStore.ConnectionProfileStore;
-  const credentials = yield* ConnectionCredentialStore.ConnectionCredentialStore;
+  const credentials =
+    yield* ConnectionCredentialStore.ConnectionCredentialStore;
   const connectivity = yield* Connectivity.Connectivity;
   const driver = yield* ConnectionDriver.ConnectionDriver;
   const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
   const ssh = yield* ClientCapabilities.SshEnvironmentGateway;
   const persistedTargets = yield* storage.list;
+  const disabledEnvironmentIds = new Set(yield* activation.listDisabled);
   const initialEntries = new Map(
     yield* Effect.forEach(
       persistedTargets,
       Effect.fn("EnvironmentRegistry.loadCatalogEntry")(function* (target) {
         const profile =
-          target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget"
+          target._tag === "BearerConnectionTarget" ||
+          target._tag === "SshConnectionTarget"
             ? yield* profiles.get(target.connectionId)
             : Option.none();
         return [
@@ -154,12 +178,16 @@ export const make = Effect.gen(function* () {
     ),
   );
   const entries =
-    yield* SubscriptionRef.make<ReadonlyMap<EnvironmentId, ConnectionCatalogEntry>>(initialEntries);
+    yield* SubscriptionRef.make<
+      ReadonlyMap<EnvironmentId, ConnectionCatalogEntry>
+    >(initialEntries);
   const networkStatus = yield* SubscriptionRef.make(yield* connectivity.status);
   const serviceScopes = yield* SubscriptionRef.make<
     ReadonlyMap<EnvironmentId, EnvironmentServiceScope>
   >(new Map());
-  const platformEnvironmentIds = yield* Ref.make<ReadonlySet<EnvironmentId>>(new Set());
+  const platformEnvironmentIds = yield* Ref.make<ReadonlySet<EnvironmentId>>(
+    new Set(),
+  );
   const persistedTargetsByEnvironment = yield* Ref.make<
     ReadonlyMap<EnvironmentId, ConnectionTarget>
   >(new Map(persistedTargets.map((target) => [target.environmentId, target])));
@@ -168,8 +196,11 @@ export const make = Effect.gen(function* () {
     readonly users: number;
   }
 
-  const leaseLocks = yield* Ref.make<ReadonlyMap<EnvironmentId, LeaseLock>>(new Map());
+  const leaseLocks = yield* Ref.make<ReadonlyMap<EnvironmentId, LeaseLock>>(
+    new Map(),
+  );
   const leaseLocksGuard = yield* Semaphore.make(1);
+  const activationStateLock = yield* Semaphore.make(1);
   const started = yield* Ref.make(false);
 
   const withLeaseLock = <A, E, R>(
@@ -192,7 +223,10 @@ export const make = Effect.gen(function* () {
             return existing.semaphore;
           }
           const semaphore = yield* Semaphore.make(1);
-          yield* Ref.set(leaseLocks, new Map(current).set(environmentId, { semaphore, users: 1 }));
+          yield* Ref.set(
+            leaseLocks,
+            new Map(current).set(environmentId, { semaphore, users: 1 }),
+          );
           return semaphore;
         }),
       ),
@@ -230,75 +264,82 @@ export const make = Effect.gen(function* () {
     return entry;
   });
 
-  const closeServiceScope = Effect.fn("EnvironmentRegistry.closeServiceScope")(function* (
-    environmentId: EnvironmentId,
-  ) {
-    const current = yield* SubscriptionRef.get(serviceScopes);
-    const lease = current.get(environmentId);
-    if (lease === undefined) {
-      return;
-    }
-    const next = new Map(current);
-    next.delete(environmentId);
-    yield* SubscriptionRef.set(serviceScopes, next);
-    yield* Scope.close(lease.scope, Exit.void);
-  });
-
-  const createServiceScope = Effect.fn("EnvironmentRegistry.createServiceScope")(
-    (entry: ConnectionCatalogEntry) =>
-      Effect.uninterruptible(
-        Effect.gen(function* () {
-          const environmentId = entry.target.environmentId;
-          const scope = yield* Scope.make();
-          const supervisor = yield* EnvironmentSupervisor.make(entry, {
-            initiallyDesired: false,
-          }).pipe(
-            Effect.provideService(Connectivity.Connectivity, connectivity),
-            Effect.provideService(ConnectionDriver.ConnectionDriver, driver),
-            Effect.provideService(ConnectionWakeups.ConnectionWakeups, wakeups),
-            Scope.provide(scope),
-            Effect.onError(() => Scope.close(scope, Exit.void)),
-          );
-          yield* supervisor.connect;
-          yield* SubscriptionRef.update(serviceScopes, (current) => {
-            const next = new Map(current);
-            next.set(environmentId, { entry, supervisor, scope });
-            return next;
-          });
-          return supervisor;
-        }),
-      ),
-  );
-
-  const acquireSupervisor = Effect.fn("EnvironmentRegistry.acquireSupervisor")(function* (
-    environmentId: EnvironmentId,
-  ) {
-    return yield* withLeaseLock(
-      environmentId,
-      Effect.gen(function* () {
-        const entry = yield* getEntry(environmentId);
-        const existing = (yield* SubscriptionRef.get(serviceScopes)).get(environmentId);
-        if (existing !== undefined) {
-          if (Equal.equals(existing.entry, entry)) {
-            return existing.supervisor;
-          }
-          yield* closeServiceScope(environmentId);
-        }
-        return yield* createServiceScope(entry);
-      }),
-    );
-  });
-
-  const run: EnvironmentRegistry["Service"]["run"] = Effect.fn("EnvironmentRegistry.run")(
-    function* <A, E, R>(environmentId: EnvironmentId, effect: Effect.Effect<A, E, R>) {
-      const supervisor = yield* acquireSupervisor(environmentId);
-      return yield* Effect.provideService(
-        effect,
-        EnvironmentSupervisor.EnvironmentSupervisor,
-        supervisor,
-      );
+  const closeServiceScope = Effect.fn("EnvironmentRegistry.closeServiceScope")(
+    function* (environmentId: EnvironmentId) {
+      const current = yield* SubscriptionRef.get(serviceScopes);
+      const lease = current.get(environmentId);
+      if (lease === undefined) {
+        return;
+      }
+      const next = new Map(current);
+      next.delete(environmentId);
+      yield* SubscriptionRef.set(serviceScopes, next);
+      yield* Scope.close(lease.scope, Exit.void);
     },
   );
+
+  const createServiceScope = Effect.fn(
+    "EnvironmentRegistry.createServiceScope",
+  )((entry: ConnectionCatalogEntry, initiallyDesired?: boolean) =>
+    Effect.uninterruptible(
+      Effect.gen(function* () {
+        const environmentId = entry.target.environmentId;
+        const desired =
+          initiallyDesired ?? !disabledEnvironmentIds.has(environmentId);
+        const scope = yield* Scope.make();
+        const supervisor = yield* EnvironmentSupervisor.make(entry, {
+          initiallyDesired: desired,
+        }).pipe(
+          Effect.provideService(Connectivity.Connectivity, connectivity),
+          Effect.provideService(ConnectionDriver.ConnectionDriver, driver),
+          Effect.provideService(ConnectionWakeups.ConnectionWakeups, wakeups),
+          Scope.provide(scope),
+          Effect.onError(() => Scope.close(scope, Exit.void)),
+        );
+        yield* SubscriptionRef.update(serviceScopes, (current) => {
+          const next = new Map(current);
+          next.set(environmentId, { entry, supervisor, scope });
+          return next;
+        });
+        return supervisor;
+      }),
+    ),
+  );
+
+  const acquireSupervisorLocked = Effect.fn(
+    "EnvironmentRegistry.acquireSupervisorLocked",
+  )(function* (environmentId: EnvironmentId) {
+    const entry = yield* getEntry(environmentId);
+    const existing = (yield* SubscriptionRef.get(serviceScopes)).get(
+      environmentId,
+    );
+    if (existing !== undefined) {
+      if (Equal.equals(existing.entry, entry)) {
+        return existing.supervisor;
+      }
+      yield* closeServiceScope(environmentId);
+    }
+    return yield* createServiceScope(entry);
+  });
+
+  const acquireSupervisor = Effect.fn("EnvironmentRegistry.acquireSupervisor")(
+    (environmentId: EnvironmentId) =>
+      withLeaseLock(environmentId, acquireSupervisorLocked(environmentId)),
+  );
+
+  const run: EnvironmentRegistry["Service"]["run"] = Effect.fn(
+    "EnvironmentRegistry.run",
+  )(function* <A, E, R>(
+    environmentId: EnvironmentId,
+    effect: Effect.Effect<A, E, R>,
+  ) {
+    const supervisor = yield* acquireSupervisor(environmentId);
+    return yield* Effect.provideService(
+      effect,
+      EnvironmentSupervisor.EnvironmentSupervisor,
+      supervisor,
+    );
+  });
 
   const runStream: EnvironmentRegistry["Service"]["runStream"] = <A, E, R>(
     environmentId: EnvironmentId,
@@ -307,12 +348,20 @@ export const make = Effect.gen(function* () {
     Stream.unwrap(
       acquireSupervisor(environmentId).pipe(
         Effect.map((supervisor) =>
-          Stream.provideService(stream, EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+          Stream.provideService(
+            stream,
+            EnvironmentSupervisor.EnvironmentSupervisor,
+            supervisor,
+          ),
         ),
       ),
     );
 
-  const followStream: EnvironmentRegistry["Service"]["followStream"] = <A, E, R>(
+  const followStream: EnvironmentRegistry["Service"]["followStream"] = <
+    A,
+    E,
+    R,
+  >(
     environmentId: EnvironmentId,
     stream: Stream.Stream<A, E, R>,
   ) =>
@@ -320,7 +369,9 @@ export const make = Effect.gen(function* () {
       Stream.fromEffect(SubscriptionRef.get(entries)),
       SubscriptionRef.changes(entries),
     ).pipe(
-      Stream.map((current) => Option.fromUndefinedOr(current.get(environmentId))),
+      Stream.map((current) =>
+        Option.fromUndefinedOr(current.get(environmentId)),
+      ),
       Stream.changes,
       Stream.switchMap(
         Option.match({
@@ -344,11 +395,34 @@ export const make = Effect.gen(function* () {
     );
 
   const start = Effect.gen(function* () {
-    if (yield* Ref.getAndSet(started, true)) {
+    const targetsToStart = yield* activationStateLock.withPermits(1)(
+      Effect.gen(function* () {
+        if (yield* Ref.get(started)) {
+          return null;
+        }
+        const currentTargets = [
+          ...(yield* Ref.get(persistedTargetsByEnvironment)).values(),
+        ];
+        yield* activation.reconcile(
+          new Set([
+            ...currentTargets.map((target) => target.environmentId),
+            ...(yield* Ref.get(platformEnvironmentIds)),
+          ]),
+        );
+        const reconciledDisabledEnvironmentIds = yield* activation.listDisabled;
+        disabledEnvironmentIds.clear();
+        for (const environmentId of reconciledDisabledEnvironmentIds) {
+          disabledEnvironmentIds.add(environmentId);
+        }
+        yield* Ref.set(started, true);
+        return currentTargets;
+      }),
+    );
+    if (targetsToStart === null) {
       return;
     }
     yield* Effect.forEach(
-      persistedTargets,
+      targetsToStart,
       (target) =>
         acquireSupervisor(target.environmentId).pipe(
           Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
@@ -360,13 +434,22 @@ export const make = Effect.gen(function* () {
     );
   }).pipe(Effect.withSpan("EnvironmentRegistry.start"));
 
-  const installEntryLocked = Effect.fn("EnvironmentRegistry.installEntryLocked")(function* (
+  const installEntryLocked = Effect.fn(
+    "EnvironmentRegistry.installEntryLocked",
+  )(function* (
     entry: ConnectionCatalogEntry,
-    options?: { readonly retainEquivalentRuntime?: boolean },
+    options?: {
+      readonly retainEquivalentRuntime?: boolean;
+      readonly initiallyDesired?: boolean;
+    },
   ) {
     const target = entry.target;
-    const previous = (yield* SubscriptionRef.get(entries)).get(target.environmentId);
-    const existingScope = (yield* SubscriptionRef.get(serviceScopes)).get(target.environmentId);
+    const previous = (yield* SubscriptionRef.get(entries)).get(
+      target.environmentId,
+    );
+    const existingScope = (yield* SubscriptionRef.get(serviceScopes)).get(
+      target.environmentId,
+    );
     if (
       options?.retainEquivalentRuntime === true &&
       previous !== undefined &&
@@ -374,6 +457,11 @@ export const make = Effect.gen(function* () {
       existingScope !== undefined &&
       Equal.equals(existingScope.entry, entry)
     ) {
+      if (options.initiallyDesired === true) {
+        yield* existingScope.supervisor.connect;
+      } else if (options.initiallyDesired === false) {
+        yield* existingScope.supervisor.disconnect;
+      }
       return;
     }
 
@@ -383,74 +471,67 @@ export const make = Effect.gen(function* () {
       next.set(target.environmentId, entry);
       return next;
     });
-    yield* createServiceScope(entry);
+    yield* createServiceScope(entry, options?.initiallyDesired);
   });
 
   const register = Effect.fn("EnvironmentRegistry.register")(function* (
     registration: ConnectionRegistration,
+    options?: { readonly enabled?: boolean },
   ) {
     const entry = connectionRegistrationCatalogEntry(registration);
     const environmentId = entry.target.environmentId;
+    const enabled = options?.enabled ?? true;
     yield* withLeaseLock(
       environmentId,
       Effect.gen(function* () {
         if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
           return;
         }
-        yield* registrations.register(registration);
-        yield* Ref.update(persistedTargetsByEnvironment, (current) => {
-          const next = new Map(current);
-          next.set(environmentId, registration.target);
-          return next;
-        });
-        yield* installEntryLocked(entry);
+        yield* activationStateLock.withPermits(1)(
+          Effect.gen(function* () {
+            yield* registrations.register(registration, { enabled });
+            if (enabled) {
+              disabledEnvironmentIds.delete(environmentId);
+            } else {
+              disabledEnvironmentIds.add(environmentId);
+            }
+            yield* Ref.update(persistedTargetsByEnvironment, (current) => {
+              const next = new Map(current);
+              next.set(environmentId, registration.target);
+              return next;
+            });
+          }),
+        );
+        yield* installEntryLocked(entry, { initiallyDesired: enabled });
       }),
     );
   });
 
-  const installPlatformRegistration = Effect.fn("EnvironmentRegistry.installPlatformRegistration")(
-    function* (registration: PlatformConnectionRegistration) {
-      const entry = connectionRegistrationCatalogEntry(registration);
-      const target = entry.target;
-      yield* withLeaseLock(
-        target.environmentId,
-        Effect.gen(function* () {
-          yield* Ref.update(platformEnvironmentIds, (current) => {
-            const next = new Set(current);
-            next.add(target.environmentId);
-            return next;
-          });
+  const installPlatformRegistration = Effect.fn(
+    "EnvironmentRegistry.installPlatformRegistration",
+  )(function* (registration: PlatformConnectionRegistration) {
+    const entry = connectionRegistrationCatalogEntry(registration);
+    const target = entry.target;
+    yield* withLeaseLock(
+      target.environmentId,
+      Effect.gen(function* () {
+        yield* Ref.update(platformEnvironmentIds, (current) => {
+          const next = new Set(current);
+          next.add(target.environmentId);
+          return next;
+        });
 
-          // Secondary desktop-local backends (e.g. a parallel WSL backend) live
-          // on their own loopback origin, so they authenticate with a bearer
-          // token instead of the primary's same-origin cookie. Stash it where
-          // the resolver's bearer broker looks it up.
-          if (registration._tag === "BearerConnectionRegistration") {
-            yield* credentials.put(registration.target.connectionId, registration.credential).pipe(
-              Effect.catch((error) =>
-                Effect.logWarning("Could not store the platform bearer credential.", {
-                  environmentId: target.environmentId,
-                  error,
-                }),
-              ),
-            );
-          }
-
-          const persistedTarget = (yield* Ref.get(persistedTargetsByEnvironment)).get(
-            target.environmentId,
-          );
-          if (persistedTarget !== undefined) {
-            yield* registrations.remove(persistedTarget).pipe(
-              Effect.tap(() =>
-                Ref.update(persistedTargetsByEnvironment, (current) => {
-                  const next = new Map(current);
-                  next.delete(target.environmentId);
-                  return next;
-                }),
-              ),
+        // Secondary desktop-local backends (e.g. a parallel WSL backend) live
+        // on their own loopback origin, so they authenticate with a bearer
+        // token instead of the primary's same-origin cookie. Stash it where
+        // the resolver's bearer broker looks it up.
+        if (registration._tag === "BearerConnectionRegistration") {
+          yield* credentials
+            .put(registration.target.connectionId, registration.credential)
+            .pipe(
               Effect.catch((error) =>
                 Effect.logWarning(
-                  "Could not remove a persisted registration shadowed by a platform environment.",
+                  "Could not store the platform bearer credential.",
                   {
                     environmentId: target.environmentId,
                     error,
@@ -458,90 +539,152 @@ export const make = Effect.gen(function* () {
                 ),
               ),
             );
-          }
+        }
 
-          yield* installEntryLocked(entry, { retainEquivalentRuntime: true });
-        }),
-      );
-    },
-  );
+        const persistedTarget = (yield* Ref.get(
+          persistedTargetsByEnvironment,
+        )).get(target.environmentId);
+        yield* activationStateLock.withPermits(1)(
+          Effect.gen(function* () {
+            if (persistedTarget !== undefined) {
+              yield* registrations.remove(persistedTarget).pipe(
+                Effect.tap(() =>
+                  Ref.update(persistedTargetsByEnvironment, (current) => {
+                    const next = new Map(current);
+                    next.delete(target.environmentId);
+                    return next;
+                  }),
+                ),
+                Effect.catch((error) =>
+                  Effect.logWarning(
+                    "Could not remove a persisted registration shadowed by a platform environment.",
+                    {
+                      environmentId: target.environmentId,
+                      error,
+                    },
+                  ),
+                ),
+              );
+            }
+            yield* activation
+              .setEnabled(target.environmentId, true)
+              .pipe(
+                Effect.catch((error) =>
+                  Effect.logWarning(
+                    "Could not clear disabled state for a platform environment.",
+                    { environmentId: target.environmentId, error },
+                  ),
+                ),
+              );
+            disabledEnvironmentIds.delete(target.environmentId);
+          }),
+        );
+
+        yield* installEntryLocked(entry, {
+          retainEquivalentRuntime: true,
+          initiallyDesired: true,
+        });
+      }),
+    );
+  });
 
   // Tear down a platform-managed environment that the host no longer reports
   // (e.g. the user turned the parallel WSL backend off). Platform environments
   // bypass the user-facing `remove` guard since they are reconciled from the
   // bootstrap rather than removed by hand.
-  const removePlatformEnvironment = Effect.fn("EnvironmentRegistry.removePlatformEnvironment")(
-    function* (environmentId: EnvironmentId) {
-      yield* withLeaseLock(
-        environmentId,
-        Effect.gen(function* () {
-          const entry = (yield* SubscriptionRef.get(entries)).get(environmentId);
-          yield* Ref.update(platformEnvironmentIds, (current) => {
-            const next = new Set(current);
-            next.delete(environmentId);
-            return next;
-          });
-          yield* closeServiceScope(environmentId);
-          yield* SubscriptionRef.update(entries, (current) => {
-            const next = new Map(current);
-            next.delete(environmentId);
-            return next;
-          });
-          if (entry !== undefined && entry.target._tag === "BearerConnectionTarget") {
-            yield* credentials.remove(entry.target.connectionId).pipe(
-              Effect.catch((error) =>
-                Effect.logWarning("Could not clear the platform bearer credential.", {
+  const removePlatformEnvironment = Effect.fn(
+    "EnvironmentRegistry.removePlatformEnvironment",
+  )(function* (environmentId: EnvironmentId) {
+    yield* withLeaseLock(
+      environmentId,
+      Effect.gen(function* () {
+        const entry = (yield* SubscriptionRef.get(entries)).get(environmentId);
+        yield* Ref.update(platformEnvironmentIds, (current) => {
+          const next = new Set(current);
+          next.delete(environmentId);
+          return next;
+        });
+        yield* closeServiceScope(environmentId);
+        yield* SubscriptionRef.update(entries, (current) => {
+          const next = new Map(current);
+          next.delete(environmentId);
+          return next;
+        });
+        if (
+          entry !== undefined &&
+          entry.target._tag === "BearerConnectionTarget"
+        ) {
+          yield* credentials.remove(entry.target.connectionId).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning(
+                "Could not clear the platform bearer credential.",
+                {
                   environmentId,
                   error,
-                }),
+                },
               ),
-            );
-          }
-          yield* Effect.all(
-            [
-              cache.clear(environmentId).pipe(
-                Effect.catch((error) =>
-                  Effect.logWarning("Could not clear cached environment data after removal.", {
+            ),
+          );
+        }
+        yield* Effect.all(
+          [
+            cache.clear(environmentId).pipe(
+              Effect.catch((error) =>
+                Effect.logWarning(
+                  "Could not clear cached environment data after removal.",
+                  {
                     environmentId,
                     error,
-                  }),
+                  },
                 ),
               ),
-              ownedDataCleanup.clear(environmentId),
-            ],
-            { concurrency: "unbounded", discard: true },
-          );
-        }),
-      );
+            ),
+            ownedDataCleanup.clear(environmentId),
+          ],
+          { concurrency: "unbounded", discard: true },
+        );
+      }),
+    );
+  });
+
+  const registerPlatform = Effect.fn("EnvironmentRegistry.registerPlatform")(
+    function* (registration: PrimaryConnectionRegistration) {
+      yield* installPlatformRegistration(registration);
     },
   );
-
-  const registerPlatform = Effect.fn("EnvironmentRegistry.registerPlatform")(function* (
-    registration: PrimaryConnectionRegistration,
-  ) {
-    yield* installPlatformRegistration(registration);
-  });
 
   // Reconcile the full set of platform-managed environments against what the
   // host currently reports: add/refresh the desired ones and tear down any
   // platform environment that disappeared (WSL toggled off, distro switched).
-  const reconcilePlatform = Effect.fn("EnvironmentRegistry.reconcilePlatform")(function* (
-    platformRegistrations: ReadonlyArray<PlatformConnectionRegistration>,
-  ) {
-    const desiredIds = new Set(
-      platformRegistrations.map((registration) => registration.target.environmentId),
-    );
-    const currentPlatformIds = yield* Ref.get(platformEnvironmentIds);
-    yield* Effect.forEach(
-      currentPlatformIds,
-      (environmentId) =>
-        desiredIds.has(environmentId) ? Effect.void : removePlatformEnvironment(environmentId),
-      { discard: true },
-    );
-    yield* Effect.forEach(platformRegistrations, installPlatformRegistration, { discard: true });
-  });
+  const reconcilePlatform = Effect.fn("EnvironmentRegistry.reconcilePlatform")(
+    function* (
+      platformRegistrations: ReadonlyArray<PlatformConnectionRegistration>,
+    ) {
+      const desiredIds = new Set(
+        platformRegistrations.map(
+          (registration) => registration.target.environmentId,
+        ),
+      );
+      const currentPlatformIds = yield* Ref.get(platformEnvironmentIds);
+      yield* Effect.forEach(
+        currentPlatformIds,
+        (environmentId) =>
+          desiredIds.has(environmentId)
+            ? Effect.void
+            : removePlatformEnvironment(environmentId),
+        { discard: true },
+      );
+      yield* Effect.forEach(
+        platformRegistrations,
+        installPlatformRegistration,
+        { discard: true },
+      );
+    },
+  );
 
-  const remove = Effect.fn("EnvironmentRegistry.remove")(function* (environmentId: EnvironmentId) {
+  const remove = Effect.fn("EnvironmentRegistry.remove")(function* (
+    environmentId: EnvironmentId,
+  ) {
     return yield* withLeaseLock(
       environmentId,
       Effect.gen(function* () {
@@ -552,11 +695,20 @@ export const make = Effect.gen(function* () {
         }
         const target = (yield* getEntry(environmentId)).target;
         const profile =
-          target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget"
+          target._tag === "BearerConnectionTarget" ||
+          target._tag === "SshConnectionTarget"
             ? yield* profiles.get(target.connectionId)
             : Option.none();
 
-        yield* registrations.remove(target);
+        yield* activationStateLock.withPermits(1)(
+          registrations
+            .remove(target)
+            .pipe(
+              Effect.tap(() =>
+                Effect.sync(() => disabledEnvironmentIds.delete(environmentId)),
+              ),
+            ),
+        );
         yield* Ref.update(persistedTargetsByEnvironment, (current) => {
           const next = new Map(current);
           next.delete(environmentId);
@@ -572,10 +724,13 @@ export const make = Effect.gen(function* () {
           [
             cache.clear(environmentId).pipe(
               Effect.catch((error) =>
-                Effect.logWarning("Could not clear cached environment data after removal.", {
-                  environmentId,
-                  error,
-                }),
+                Effect.logWarning(
+                  "Could not clear cached environment data after removal.",
+                  {
+                    environmentId,
+                    error,
+                  },
+                ),
               ),
             ),
             ownedDataCleanup.clear(environmentId),
@@ -590,10 +745,13 @@ export const make = Effect.gen(function* () {
         ) {
           yield* ssh.disconnect(profile.value.target).pipe(
             Effect.tapError((error) =>
-              Effect.logWarning("Could not disconnect the managed SSH environment.", {
-                environmentId,
-                error,
-              }),
+              Effect.logWarning(
+                "Could not disconnect the managed SSH environment.",
+                {
+                  environmentId,
+                  error,
+                },
+              ),
             ),
             Effect.ignore,
           );
@@ -602,25 +760,27 @@ export const make = Effect.gen(function* () {
     );
   });
 
-  const removeRelayEnvironments = Effect.fn("EnvironmentRegistry.removeRelayEnvironments")(
-    function* () {
-      const relayEnvironmentIds = [...(yield* SubscriptionRef.get(entries)).values()]
-        .filter((entry) => entry.target._tag === "RelayConnectionTarget")
-        .map((entry) => entry.target.environmentId);
+  const removeRelayEnvironments = Effect.fn(
+    "EnvironmentRegistry.removeRelayEnvironments",
+  )(function* () {
+    const relayEnvironmentIds = [
+      ...(yield* SubscriptionRef.get(entries)).values(),
+    ]
+      .filter((entry) => entry.target._tag === "RelayConnectionTarget")
+      .map((entry) => entry.target.environmentId);
 
-      yield* Effect.forEach(
-        relayEnvironmentIds,
-        (environmentId) =>
-          remove(environmentId).pipe(
-            Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
-          ),
-        {
-          concurrency: "unbounded",
-          discard: true,
-        },
-      );
-    },
-  );
+    yield* Effect.forEach(
+      relayEnvironmentIds,
+      (environmentId) =>
+        remove(environmentId).pipe(
+          Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+        ),
+      {
+        concurrency: "unbounded",
+        discard: true,
+      },
+    );
+  });
 
   const retryNow = (environmentId: EnvironmentId) =>
     acquireSupervisor(environmentId).pipe(
@@ -628,7 +788,35 @@ export const make = Effect.gen(function* () {
       Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
       Effect.withSpan("EnvironmentRegistry.retryNow"),
     );
-  const state = Effect.fn("EnvironmentRegistry.state")(function* (environmentId: EnvironmentId) {
+  const setEnabled = Effect.fn("EnvironmentRegistry.setEnabled")(function* (
+    environmentId: EnvironmentId,
+    enabled: boolean,
+  ) {
+    yield* withLeaseLock(
+      environmentId,
+      Effect.gen(function* () {
+        yield* getEntry(environmentId);
+        yield* activationStateLock.withPermits(1)(
+          activation.setEnabled(environmentId, enabled).pipe(
+            Effect.tap(() =>
+              Effect.sync(() => {
+                if (enabled) {
+                  disabledEnvironmentIds.delete(environmentId);
+                } else {
+                  disabledEnvironmentIds.add(environmentId);
+                }
+              }),
+            ),
+          ),
+        );
+        const supervisor = yield* acquireSupervisorLocked(environmentId);
+        yield* enabled ? supervisor.connect : supervisor.disconnect;
+      }),
+    );
+  });
+  const state = Effect.fn("EnvironmentRegistry.state")(function* (
+    environmentId: EnvironmentId,
+  ) {
     const supervisor = yield* acquireSupervisor(environmentId);
     return yield* SubscriptionRef.get(supervisor.state);
   });
@@ -645,10 +833,14 @@ export const make = Effect.gen(function* () {
   yield* Effect.addFinalizer(() =>
     SubscriptionRef.get(serviceScopes).pipe(
       Effect.flatMap((current) =>
-        Effect.forEach(current.values(), (lease) => Scope.close(lease.scope, Exit.void), {
-          concurrency: "unbounded",
-          discard: true,
-        }),
+        Effect.forEach(
+          current.values(),
+          (lease) => Scope.close(lease.scope, Exit.void),
+          {
+            concurrency: "unbounded",
+            discard: true,
+          },
+        ),
       ),
     ),
   );
@@ -666,6 +858,7 @@ export const make = Effect.gen(function* () {
     remove,
     removeRelayEnvironments,
     retryNow,
+    setEnabled,
     state,
     stateChanges,
     run,

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -116,9 +116,10 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
   readonly ready?: (attempt: number) => Effect.Effect<void, ConnectionAttemptError>;
   readonly probe?: (attempt: number) => Effect.Effect<void, ConnectionAttemptError>;
 }) {
-  const networkStatus = yield* SubscriptionRef.make<NetworkStatus>(
+  const reportedNetworkStatus = yield* SubscriptionRef.make<NetworkStatus>(
     options?.networkStatus ?? "online",
   );
+  const liveNetworkStatus = yield* Ref.make<NetworkStatus>(options?.networkStatus ?? "online");
   const prepareCount = yield* Ref.make(0);
   const sessionCount = yield* Ref.make(0);
   const releaseCount = yield* Ref.make(0);
@@ -134,8 +135,8 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
   >([]);
 
   const connectivity = Connectivity.Connectivity.of({
-    status: SubscriptionRef.get(networkStatus),
-    changes: SubscriptionRef.changes(networkStatus),
+    status: Ref.get(liveNetworkStatus),
+    changes: SubscriptionRef.changes(reportedNetworkStatus),
   });
 
   const prepare = Effect.fn("TestConnectionDriver.prepare")(function* (target: ConnectionTarget) {
@@ -197,7 +198,11 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
     prepareCount,
     sessionCount,
     releaseCount,
-    setNetworkStatus: (status: NetworkStatus) => SubscriptionRef.set(networkStatus, status),
+    setNetworkStatus: (status: NetworkStatus) =>
+      Ref.set(liveNetworkStatus, status).pipe(
+        Effect.andThen(SubscriptionRef.set(reportedNetworkStatus, status)),
+      ),
+    setNetworkStatusWithoutNotifying: (status: NetworkStatus) => Ref.set(liveNetworkStatus, status),
     wake: (reason: ConnectionWakeups.ConnectionWakeup) =>
       SubscriptionRef.update(wakeups, (event) => ({
         sequence: event.sequence + 1,
@@ -305,6 +310,28 @@ describe("EnvironmentSupervisor", () => {
         phase: "connected",
         attempt: 1,
         generation: 1,
+        lastFailure: null,
+      });
+      expect(yield* Ref.get(harness.prepareCount)).toBe(1);
+    }),
+  );
+
+  it.effect("recovers a network transition missed while the application was suspended", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ networkStatus: "offline" });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "offline");
+      yield* harness.setNetworkStatusWithoutNotifying("online");
+      yield* harness.wake("application-active-reconnect");
+
+      const ready = yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      expect(ready).toMatchObject({
+        desired: true,
+        network: "online",
+        phase: "connected",
         lastFailure: null,
       });
       expect(yield* Ref.get(harness.prepareCount)).toBe(1);

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -10,7 +10,6 @@ import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Scope from "effect/Scope";
-import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import * as Tracer from "effect/Tracer";
 
@@ -224,7 +223,6 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
 
   const connectivity = yield* Connectivity.Connectivity;
   const driver = yield* ConnectionDriver.ConnectionDriver;
-  const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
   const initialIntent: SupervisorIntent = {
     desired: options?.initiallyDesired ?? false,
     network: yield* connectivity.status,
@@ -766,11 +764,8 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
 
   yield* Connectivity.followNetworkStatus({
     apply: applyNetworkStatus,
+    onWakeup: (reason) => signal({ _tag: "Wakeup", reason }),
   });
-  yield* wakeups.changes.pipe(
-    Stream.runForEach((reason) => signal({ _tag: "Wakeup", reason })),
-    Effect.forkScoped,
-  );
   yield* run().pipe(Effect.forkScoped);
 
   const connect = Ref.update(intent, (current) => ({

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -755,18 +755,18 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
     }
   });
 
-  yield* connectivity.changes.pipe(
-    Stream.runForEach((network) =>
-      Ref.modify(intent, (current) =>
-        current.network === network ? [false, current] : ([true, { ...current, network }] as const),
-      ).pipe(
-        Effect.flatMap((changed) =>
-          changed ? signal({ _tag: "NetworkChanged", network }) : Effect.void,
-        ),
-      ),
-    ),
-    Effect.forkScoped,
-  );
+  const applyNetworkStatus = Effect.fnUntraced(function* (network: NetworkStatus) {
+    const changed = yield* Ref.modify(intent, (current) =>
+      current.network === network ? [false, current] : ([true, { ...current, network }] as const),
+    );
+    if (changed) {
+      yield* signal({ _tag: "NetworkChanged", network });
+    }
+  });
+
+  yield* Connectivity.followNetworkStatus({
+    apply: applyNetworkStatus,
+  });
   yield* wakeups.changes.pipe(
     Stream.runForEach((reason) => signal({ _tag: "Wakeup", reason })),
     Effect.forkScoped,

--- a/packages/client-runtime/src/platform/persistence.ts
+++ b/packages/client-runtime/src/platform/persistence.ts
@@ -21,6 +21,9 @@ export class ConnectionPersistenceError extends Schema.TaggedErrorClass<Connecti
       "list-targets",
       "register-connection",
       "remove-connection",
+      "list-activation",
+      "set-activation",
+      "reconcile-activation",
       "load-shell",
       "save-shell",
       "load-thread",
@@ -50,10 +53,25 @@ export class ConnectionRegistrationStore extends Context.Service<
   {
     readonly register: (
       registration: ConnectionRegistration,
+      options: { readonly enabled: boolean },
     ) => Effect.Effect<void, ConnectionPersistenceError>;
     readonly remove: (target: ConnectionTarget) => Effect.Effect<void, ConnectionPersistenceError>;
   }
 >()("@t3tools/client-runtime/platform/persistence/ConnectionRegistrationStore") {}
+
+export class ConnectionActivationStore extends Context.Service<
+  ConnectionActivationStore,
+  {
+    readonly listDisabled: Effect.Effect<ReadonlySet<EnvironmentId>, ConnectionPersistenceError>;
+    readonly setEnabled: (
+      environmentId: EnvironmentId,
+      enabled: boolean,
+    ) => Effect.Effect<void, ConnectionPersistenceError>;
+    readonly reconcile: (
+      environmentIds: ReadonlySet<EnvironmentId>,
+    ) => Effect.Effect<void, ConnectionPersistenceError>;
+  }
+>()("@t3tools/client-runtime/platform/persistence/ConnectionActivationStore") {}
 
 export class EnvironmentCacheStore extends Context.Service<
   EnvironmentCacheStore,

--- a/packages/client-runtime/src/platform/storageDocument.test.ts
+++ b/packages/client-runtime/src/platform/storageDocument.test.ts
@@ -60,6 +60,7 @@ describe("ConnectionCatalogDocument", () => {
         profile: BEARER_PROFILE,
         credential: BEARER_CREDENTIAL,
       }),
+      { enabled: true },
     );
 
     expect(document.targets).toEqual([BEARER_TARGET]);
@@ -76,6 +77,7 @@ describe("ConnectionCatalogDocument", () => {
     const bearer = registerConnectionInCatalog(
       {
         ...EMPTY_CONNECTION_CATALOG_DOCUMENT,
+        disabledEnvironmentIds: [ENVIRONMENT_ID],
         remoteDpopTokens: [REMOTE_TOKEN],
       },
       new BearerConnectionRegistration({
@@ -83,6 +85,7 @@ describe("ConnectionCatalogDocument", () => {
         profile: BEARER_PROFILE,
         credential: BEARER_CREDENTIAL,
       }),
+      { enabled: false },
     );
     const relayTarget = new RelayConnectionTarget({
       environmentId: ENVIRONMENT_ID,
@@ -91,8 +94,11 @@ describe("ConnectionCatalogDocument", () => {
     const relay = registerConnectionInCatalog(
       bearer,
       new RelayConnectionRegistration({ target: relayTarget }),
+      { enabled: true },
     );
 
+    expect(bearer.disabledEnvironmentIds).toEqual([ENVIRONMENT_ID]);
+    expect(relay.disabledEnvironmentIds).toEqual([]);
     expect(relay.targets).toEqual([relayTarget]);
     expect(relay.profiles).toEqual([]);
     expect(relay.credentials).toEqual([]);
@@ -110,6 +116,7 @@ describe("ConnectionCatalogDocument", () => {
         profile: BEARER_PROFILE,
         credential: BEARER_CREDENTIAL,
       }),
+      { enabled: true },
     );
 
     expect(removeConnectionFromCatalog(registered, BEARER_TARGET)).toEqual(
@@ -137,6 +144,7 @@ describe("ConnectionCatalogDocument", () => {
     const document = registerConnectionInCatalog(
       EMPTY_CONNECTION_CATALOG_DOCUMENT,
       new SshConnectionRegistration({ target, profile }),
+      { enabled: true },
     );
 
     expect(document.targets).toEqual([target]);

--- a/packages/client-runtime/src/platform/storageDocument.ts
+++ b/packages/client-runtime/src/platform/storageDocument.ts
@@ -1,3 +1,5 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 import {
@@ -17,6 +19,9 @@ export type StoredConnectionCredential = typeof StoredConnectionCredential.Type;
 export const ConnectionCatalogDocument = Schema.Struct({
   schemaVersion: Schema.Literal(1),
   targets: Schema.Array(PersistedConnectionTarget),
+  disabledEnvironmentIds: Schema.Array(EnvironmentId).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
   profiles: Schema.Array(ConnectionProfile),
   credentials: Schema.Array(StoredConnectionCredential),
   remoteDpopTokens: Schema.Array(TokenStore.RemoteDpopAccessToken),
@@ -26,6 +31,7 @@ export type ConnectionCatalogDocument = typeof ConnectionCatalogDocument.Type;
 export const EMPTY_CONNECTION_CATALOG_DOCUMENT: ConnectionCatalogDocument = Object.freeze({
   schemaVersion: 1,
   targets: [],
+  disabledEnvironmentIds: [],
   profiles: [],
   credentials: [],
   remoteDpopTokens: [],
@@ -93,6 +99,7 @@ function removeConnectionMetadata(
 export function registerConnectionInCatalog(
   document: ConnectionCatalogDocument,
   registration: ConnectionRegistration,
+  options: { readonly enabled: boolean },
 ): ConnectionCatalogDocument {
   const target = registration.target;
   const previous = document.targets.find(
@@ -103,6 +110,11 @@ export function registerConnectionInCatalog(
   const next: ConnectionCatalogDocument = {
     ...cleaned,
     targets: replaceCatalogValue(cleaned.targets, (value) => value.environmentId, target),
+    disabledEnvironmentIds: options.enabled
+      ? cleaned.disabledEnvironmentIds.filter(
+          (environmentId) => environmentId !== target.environmentId,
+        )
+      : [...new Set([...cleaned.disabledEnvironmentIds, target.environmentId])],
   };
 
   switch (registration._tag) {
@@ -137,5 +149,10 @@ export function removeConnectionFromCatalog(
   document: ConnectionCatalogDocument,
   target: ConnectionTarget,
 ): ConnectionCatalogDocument {
-  return removeConnectionMetadata(document, target, true);
+  return {
+    ...removeConnectionMetadata(document, target, true),
+    disabledEnvironmentIds: document.disabledEnvironmentIds.filter(
+      (environmentId) => environmentId !== target.environmentId,
+    ),
+  };
 }

--- a/packages/client-runtime/src/relay/discovery.test.ts
+++ b/packages/client-runtime/src/relay/discovery.test.ts
@@ -59,6 +59,9 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
   initialNetworkStatus: NetworkStatus = "online",
 ) {
   const networkStatus = yield* SubscriptionRef.make<NetworkStatus>(initialNetworkStatus);
+  const pauseNextStatusRead = yield* Ref.make(false);
+  const pausedStatusRead = yield* Deferred.make<void>();
+  const resumeStatusRead = yield* Deferred.make<void>();
   const listCalls = yield* Ref.make(0);
   const listFailure = yield* Ref.make<ManagedRelay.ManagedRelayClientError | null>(null);
   const secondListCall = yield* Deferred.make<void>();
@@ -118,7 +121,14 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
     resetTokenCache: Effect.void,
   } satisfies ManagedRelay.ManagedRelayClient["Service"]);
   const connectivity = Connectivity.Connectivity.of({
-    status: SubscriptionRef.get(networkStatus),
+    status: Effect.gen(function* () {
+      const status = yield* SubscriptionRef.get(networkStatus);
+      if (yield* Ref.getAndSet(pauseNextStatusRead, false)) {
+        yield* Deferred.succeed(pausedStatusRead, undefined);
+        yield* Deferred.await(resumeStatusRead);
+      }
+      return status;
+    }),
     changes: SubscriptionRef.changes(networkStatus),
   });
   const layer = RelayEnvironmentDiscovery.layer.pipe(
@@ -162,6 +172,9 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
     listFailure,
     clerkToken,
     networkStatus,
+    pauseNextStatusRead,
+    pausedStatusRead,
+    resumeStatusRead,
     secondListCall,
     statusRequests,
     wake: (reason: "application-active" | "credentials-changed") =>
@@ -276,6 +289,44 @@ describe("RelayEnvironmentDiscovery", () => {
 
         expect((yield* SubscriptionRef.get(discovery.state)).offline).toBe(false);
         expect(yield* Ref.get(harness.listCalls)).toBe(0);
+      }).pipe(Effect.provide(harness.layer));
+    }),
+  );
+
+  it.effect("keeps the offline state when connectivity changes during a refresh status read", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      yield* Effect.gen(function* () {
+        const discovery = yield* RelayEnvironmentDiscovery.RelayEnvironmentDiscovery;
+        const requests = yield* Ref.get(harness.statusRequests);
+        for (const environment of environments) {
+          yield* Deferred.succeed(
+            requests.get(environment.environmentId)!,
+            status(environment, "online"),
+          );
+        }
+        yield* discovery.refresh;
+
+        yield* SubscriptionRef.set(harness.networkStatus, "offline");
+        yield* SubscriptionRef.changes(discovery.state).pipe(
+          Stream.filter((state) => state.offline),
+          Stream.runHead,
+        );
+
+        yield* Ref.set(harness.pauseNextStatusRead, true);
+        yield* SubscriptionRef.set(harness.networkStatus, "online");
+        yield* Deferred.await(harness.pausedStatusRead);
+        const offlineFiber = yield* SubscriptionRef.changes(discovery.state).pipe(
+          Stream.filter((state) => state.offline),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* SubscriptionRef.set(harness.networkStatus, "offline");
+        yield* Deferred.succeed(harness.resumeStatusRead, undefined);
+        yield* Fiber.join(offlineFiber);
+        yield* Deferred.await(harness.secondListCall);
+
+        expect((yield* SubscriptionRef.get(discovery.state)).offline).toBe(true);
       }).pipe(Effect.provide(harness.layer));
     }),
   );

--- a/packages/client-runtime/src/relay/discovery.test.ts
+++ b/packages/client-runtime/src/relay/discovery.test.ts
@@ -55,8 +55,10 @@ function status(
   };
 }
 
-const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
-  const networkStatus = yield* SubscriptionRef.make<NetworkStatus>("online");
+const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
+  initialNetworkStatus: NetworkStatus = "online",
+) {
+  const networkStatus = yield* SubscriptionRef.make<NetworkStatus>(initialNetworkStatus);
   const listCalls = yield* Ref.make(0);
   const listFailure = yield* Ref.make<ManagedRelay.ManagedRelayClientError | null>(null);
   const secondListCall = yield* Deferred.make<void>();
@@ -250,6 +252,32 @@ describe("RelayEnvironmentDiscovery", () => {
           expect(yield* Ref.get(harness.listCalls)).toBe(2);
         }).pipe(Effect.provide(harness.layer));
       }),
+  );
+
+  it.effect("clears an initial offline state on the first online transition", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness("offline");
+      yield* Effect.gen(function* () {
+        const discovery = yield* RelayEnvironmentDiscovery.RelayEnvironmentDiscovery;
+        const offline = yield* SubscriptionRef.changes(discovery.state).pipe(
+          Stream.filter((state) => state.offline),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* Fiber.join(offline);
+
+        const online = yield* SubscriptionRef.changes(discovery.state).pipe(
+          Stream.filter((state) => !state.offline),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* SubscriptionRef.set(harness.networkStatus, "online");
+        yield* Fiber.join(online);
+
+        expect((yield* SubscriptionRef.get(discovery.state)).offline).toBe(false);
+        expect(yield* Ref.get(harness.listCalls)).toBe(0);
+      }).pipe(Effect.provide(harness.layer));
+    }),
   );
 
   it.effect("publishes listing failures without rejecting the refresh command", () =>

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -107,6 +107,7 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
   const session = yield* ClientCapabilities.CloudSession;
   const connectivity = yield* Connectivity.Connectivity;
   const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
+  const scope = yield* Effect.scope;
   const state = yield* SubscriptionRef.make(EMPTY_RELAY_ENVIRONMENT_DISCOVERY_STATE);
   const refreshLock = yield* Semaphore.make(1);
   const hasRefreshed = yield* Ref.make(false);
@@ -309,21 +310,24 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
     ),
   );
 
-  yield* connectivity.changes.pipe(
-    Stream.changes,
-    Stream.runForEach((networkStatus) =>
+  yield* Connectivity.followNetworkStatus({
+    apply: (networkStatus) =>
       networkStatus === "offline"
         ? SubscriptionRef.update(state, (current) => ({
             ...current,
             refreshing: false,
             offline: true,
           }))
-        : Ref.get(hasRefreshed).pipe(
-            Effect.flatMap((shouldRefresh) => (shouldRefresh ? refresh : Effect.void)),
-          ),
-    ),
-    Effect.forkScoped,
-  );
+        : Effect.gen(function* () {
+            yield* SubscriptionRef.update(state, (current) => ({
+              ...current,
+              offline: false,
+            }));
+            if (yield* Ref.get(hasRefreshed)) {
+              yield* refresh.pipe(Effect.forkIn(scope));
+            }
+          }),
+  });
   yield* wakeups.changes.pipe(
     Stream.runForEach((reason) =>
       reason === "credentials-changed"

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -110,6 +110,7 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
   const scope = yield* Effect.scope;
   const state = yield* SubscriptionRef.make(EMPTY_RELAY_ENVIRONMENT_DISCOVERY_STATE);
   const refreshLock = yield* Semaphore.make(1);
+  const networkStateLock = yield* Semaphore.make(1);
   const hasRefreshed = yield* Ref.make(false);
   const accountGeneration = yield* Ref.make(0);
   const activeAccountId = yield* Ref.make<Option.Option<string>>(Option.none());
@@ -205,23 +206,32 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
   const refresh = refreshLock.withPermits(1)(
     Effect.gen(function* () {
       yield* Ref.set(hasRefreshed, true);
-      if ((yield* connectivity.status) === "offline") {
-        yield* SubscriptionRef.update(state, (current) => ({
-          ...current,
-          refreshing: false,
-          offline: true,
-        }));
+      const canRefresh = yield* networkStateLock.withPermits(1)(
+        Effect.gen(function* () {
+          if ((yield* connectivity.status) === "offline") {
+            yield* SubscriptionRef.update(state, (current) => ({
+              ...current,
+              refreshing: false,
+              offline: true,
+            }));
+            return false;
+          }
+
+          yield* SubscriptionRef.set(state, {
+            environments: new Map(),
+            refreshing: true,
+            offline: false,
+            error: Option.none(),
+          });
+          return true;
+        }),
+      );
+      if (!canRefresh) {
         return;
       }
 
       let generation = yield* Ref.get(accountGeneration);
       yield* Ref.set(refreshGeneration, generation);
-      yield* SubscriptionRef.set(state, {
-        environments: new Map(),
-        refreshing: true,
-        offline: false,
-        error: Option.none(),
-      });
 
       // Signed out is the idle state, not a failure: the proactive refresh on
       // credentials-changed also runs on sign-out and must settle back to a
@@ -312,21 +322,23 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
 
   yield* Connectivity.followNetworkStatus({
     apply: (networkStatus) =>
-      networkStatus === "offline"
-        ? SubscriptionRef.update(state, (current) => ({
-            ...current,
-            refreshing: false,
-            offline: true,
-          }))
-        : Effect.gen(function* () {
-            yield* SubscriptionRef.update(state, (current) => ({
+      networkStateLock.withPermits(1)(
+        networkStatus === "offline"
+          ? SubscriptionRef.update(state, (current) => ({
               ...current,
-              offline: false,
-            }));
-            if (yield* Ref.get(hasRefreshed)) {
-              yield* refresh.pipe(Effect.forkIn(scope));
-            }
-          }),
+              refreshing: false,
+              offline: true,
+            }))
+          : Effect.gen(function* () {
+              yield* SubscriptionRef.update(state, (current) => ({
+                ...current,
+                offline: false,
+              }));
+              if (yield* Ref.get(hasRefreshed)) {
+                yield* refresh.pipe(Effect.forkIn(scope));
+              }
+            }),
+      ),
   });
   yield* wakeups.changes.pipe(
     Stream.runForEach((reason) =>

--- a/packages/client-runtime/src/state/connections.ts
+++ b/packages/client-runtime/src/state/connections.ts
@@ -115,6 +115,15 @@ export function createEnvironmentCatalogAtoms<R, E>(
         Effect.flatMap((registry) => registry.retryNow(environmentId)),
       ),
   });
+  const setEnabled = createRuntimeCommand(runtime, {
+    label: "environment-catalog:set-enabled",
+    scheduler: commandScheduler,
+    concurrency: serial,
+    execute: (input: { readonly environmentId: EnvironmentIdType; readonly enabled: boolean }) =>
+      EnvironmentRegistry.EnvironmentRegistry.pipe(
+        Effect.flatMap((registry) => registry.setEnabled(input.environmentId, input.enabled)),
+      ),
+  });
 
   return {
     catalogAtom,
@@ -126,5 +135,6 @@ export function createEnvironmentCatalogAtoms<R, E>(
     remove,
     removeRelayEnvironments,
     retryNow,
+    setEnabled,
   };
 }


### PR DESCRIPTION
## Problem

Saved environments are always treated as desired connections. Users can remove an environment, but they cannot temporarily disable it while preserving its endpoint, credentials, cached data, and identity.

## Solution

Add persistent per-environment activation state to the shared connection runtime:

- extend the version-1 catalog document with a backward-compatible `disabledEnvironmentIds` default;
- add a platform `ConnectionActivationStore` implemented by web and mobile storage;
- initialize supervisors without connecting disabled environments;
- expose a serialized `setEnabled` runtime command;
- reconnect on enable and release the active session on disable;
- retain the catalog registration and environment-owned cached data;
- reconcile stale disabled IDs and remove activation state when an environment is deleted.

The supervisor remains the sole owner of desired state and connection lifecycle; UI clients only dispatch the typed activation command.

## Review feedback addressed

- startup remains retryable when activation reconciliation fails;
- reconciled disabled IDs are refreshed in memory before supervisors start;
- enable/disable and removal are serialized by the per-environment lease;
- activation state is reset before deleting the durable registration;
- activation persistence failures carry accurate list, set, and reconcile operation labels;
- platform environments still start enabled when cleanup of a shadowed persisted registration fails.

## User impact

An environment can be disabled and later re-enabled without pairing it again or losing its cached workspace data.

## Stack

This PR is **2/5**. Depends on [1/5, #5597](https://github.com/pingdotgg/t3code/pull/5597).

Please review and merge the upstream PRs in order from 1 through 5. Because this repository does not have native stacked PRs enabled and cross-fork branches cannot be upstream base refs, the upstream diffs are cumulative. The corresponding fork PRs use the true dependent bases and provide the clean per-layer diffs.

| Layer | Upstream PR | Clean stacked diff |
| --- | --- | --- |
| 1 | [#5597 — network-status recovery](https://github.com/pingdotgg/t3code/pull/5597) | [fork #1](https://github.com/DominicVonk/t3code/pull/1) |
| 2 | [#5600 — persistent environment activation](https://github.com/pingdotgg/t3code/pull/5600) | [fork #2](https://github.com/DominicVonk/t3code/pull/2) |
| 3 | [#5598 — environment-management UI](https://github.com/pingdotgg/t3code/pull/5598) | [fork #3](https://github.com/DominicVonk/t3code/pull/3) |
| 4 | [#5596 — pasted pairing-link parsing](https://github.com/pingdotgg/t3code/pull/5596) | [fork #4](https://github.com/DominicVonk/t3code/pull/4) |
| 5 | [#5599 — composer-pill activation](https://github.com/pingdotgg/t3code/pull/5599) | [fork #5](https://github.com/DominicVonk/t3code/pull/5) |

## Validation

```text
Focused activation tests
Test Files  4 passed (4)
Tests       34 passed (34)

Integrated stack tests
Test Files  14 passed (14)
Tests       124 passed (124)

Type checks
@t3tools/client-runtime  passed
@t3tools/web             passed
@t3tools/mobile          passed

Fallow (PR 2 scope)
No issues in 9 changed files; 25 inherited findings excluded
```

Regression coverage includes retrying startup after reconciliation failure, refreshing reconciled activation state, serializing enable/disable with removal, preserving durable registration when activation reset fails, reporting activation-specific persistence operations, and preserving platform-environment startup when shadow cleanup fails.

The repository Vite+ formatter/linter currently fails before inspecting changed files because it attempts to load `vite.config.ts` as an Oxlint/Oxfmt configuration. `git diff --check` passes; this infrastructure failure is recorded here rather than hidden.

## Final review pass

Registration and activation now persist in one catalog mutation. The global activation lock is released before supervisor construction, and registration updates can preserve the existing desired state without transiently connecting. Desktop legacy migration now initializes the activation field explicitly.

Latest verification: client-runtime 47 test files / 599 tests passed; desktop 58 test files / 447 tests passed; client-runtime, web, mobile, and desktop typechecks passed. `fallow audit --base codex/network-status-refresh` passed the new-only gate with inherited findings excluded.

Rebased onto upstream `main` at `5661c6116` on 2026-08-07. Post-rebase verification: client-runtime 47 test files / 603 tests passed; mobile 100 test files / 624 tests passed; desktop 58 test files / 447 tests passed; client-runtime, web, mobile, and desktop typechecks passed.

Model: GPT-5; harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection startup, supervisor desired state, and catalog persistence across platforms; incorrect activation or locking could leave environments stuck disconnected or briefly connected when disabled.
> 
> **Overview**
> Adds **persistent per-environment activation** so saved environments can stay registered but stay disconnected when disabled.
> 
> The connection catalog gains a backward-compatible **`disabledEnvironmentIds`** field, a **`ConnectionActivationStore`** on web/mobile storage, and registration now takes an **`enabled`** flag in one catalog mutation. **`EnvironmentRegistry`** loads disabled IDs at startup, reconciles stale entries, seeds supervisors with the right **desired** state (no auto-connect for disabled envs), and exposes **`setEnabled`** to connect or disconnect without removing credentials or cache.
> 
> **`Connectivity.followNetworkStatus`** centralizes network change + app-wakeup handling (revision/lock so in-flight reads don’t stomp newer reports); the registry, supervisor, and relay discovery switch to it. Mobile drops the extra AppState network probe on connectivity changes (wakeups still handle foreground refresh). Connection startup **retries** on activation reconciliation failure.
> 
> A serialized **`setEnabled`** command is wired through client state for UI callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1306054d822717e751a51c786b216574cd412f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist environment activation state across restarts in the connection registry
> - Adds a `ConnectionActivationStore` service (web and mobile storage layers) and extends `ConnectionCatalogDocument` with a `disabledEnvironmentIds` field to persist per-environment enabled/disabled state.
> - `EnvironmentRegistry` now loads activation state on `start`, reconciles it against current targets, and creates supervisors with `initiallyDesired` reflecting activation rather than always connecting eagerly.
> - Adds `EnvironmentRegistry.setEnabled` to toggle activation at runtime, immediately connecting or disconnecting the supervisor and persisting the choice.
> - Platform-managed environments are force-enabled in activation; removing an environment clears its disabled tracking both in-memory and in persistence.
> - Introduces `Connectivity.followNetworkStatus` helper (used by both the registry and `EnvironmentSupervisor`) that serializes status application, deduplicates in-flight refreshes, and handles wakeup-driven status recovery — fixing missed network transitions during app suspension.
> - Risk: `EnvironmentRegistry.start` now returns `ConnectionPersistenceError` on failure; callers that previously assumed infallible startup will need to handle this error type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1306054.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->



