### PR TITLE
feat(swift-ios): bring Ghostty to the terminal

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -62,11 +62,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     ] = [:]
     private var approvalRoutes: [String: PendingRequestRoute] = [:]
     private var inputRoutes: [String: PendingRequestRoute] = [:]
-    private var terminalIDs: [String: String] = [:]
-    private var terminalSnapshots: [String: FeatureTerminalSnapshot] = [:]
-    private var terminalContinuations: [
-        String: [UUID: AsyncStream<FeatureTerminalSnapshot>.Continuation]
-    ] = [:]
+    private struct TerminalKey: Hashable {
+        let threadID: String
+        let terminalID: String
+    }
+
+    private var terminalSnapshots: [TerminalKey: FeatureTerminalSnapshot] = [:]
     private var pollingTask: Task<Void, Never>?
     private var fallbackPollingTask: Task<Void, Never>?
     private var configurationTask: Task<Void, Never>?
@@ -399,8 +400,6 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         pendingTurnSubmissions.removeAll()
         approvalRoutes.removeAll()
         inputRoutes.removeAll()
-        finishTerminalStreams()
-        terminalIDs.removeAll()
         terminalSnapshots.removeAll()
     }
 
@@ -1569,35 +1568,52 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         )
     }
 
-    func terminalSnapshot(threadID: String) async throws -> FeatureTerminalSnapshot {
+    func terminalSnapshot(
+        threadID: String,
+        terminalID: String
+    ) async throws -> FeatureTerminalSnapshot {
         let route = try threadRoute(for: threadID)
-        if let snapshot = terminalSnapshots[route.uiID] {
+        let key = TerminalKey(threadID: route.uiID, terminalID: terminalID)
+        if let snapshot = terminalSnapshots[key] {
             return snapshot
         }
         let context = try workspaceContext(route: route)
         return FeatureTerminalSnapshot(
             threadID: route.uiID,
+            terminalID: terminalID,
             workingDirectory: context.cwd
         )
     }
 
-    func terminalEvents(threadID: String) -> AsyncStream<FeatureTerminalSnapshot> {
-        guard let route = try? threadRoute(for: threadID) else {
+    func terminalEvents(
+        threadID: String,
+        terminalID: String
+    ) -> AsyncStream<FeatureTerminalSnapshot> {
+        guard let route = try? threadRoute(for: threadID),
+              let context = try? workspaceContext(route: route) else {
             return AsyncStream { continuation in continuation.finish() }
         }
         let environmentID = route.environmentID
         let client = route.client
         let uiThreadID = route.uiID
+        let wireThreadID = route.wireID
+        let key = TerminalKey(threadID: uiThreadID, terminalID: terminalID)
         let generation = environmentGeneration
         return AsyncStream { continuation in
-            let subscriptionID = UUID()
-            terminalContinuations[uiThreadID, default: [:]][subscriptionID] = continuation
-            if let snapshot = terminalSnapshots[uiThreadID] {
+            if let snapshot = terminalSnapshots[key] {
                 continuation.yield(snapshot)
             }
             let task = Task { [weak self] in
                 do {
-                    for try await event in await client.terminalEvents() {
+                    let events = try await client.attachTerminal(
+                        threadID: wireThreadID,
+                        terminalID: terminalID,
+                        cwd: context.cwd,
+                        worktreePath: context.worktreePath,
+                        columns: 80,
+                        rows: 24
+                    )
+                    for try await event in events {
                         guard !Task.isCancelled else { break }
                         guard let self else { break }
                         guard self.isKnownClient(
@@ -1607,14 +1623,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                         ) else {
                             break
                         }
-                        guard event.threadId == route.wireID else { continue }
-                        if let terminalID = self.terminalIDs[uiThreadID],
-                           event.terminalId != nil,
-                           event.terminalId != terminalID {
-                            continue
-                        }
-                        let snapshot = self.consumeTerminalEvent(event, threadID: uiThreadID)
-                        self.publishTerminal(snapshot, threadID: uiThreadID)
+                        let snapshot = self.consumeTerminalEvent(
+                            event,
+                            threadID: uiThreadID,
+                            terminalID: terminalID
+                        )
+                        continuation.yield(snapshot)
                     }
                     continuation.finish()
                 } catch is CancellationError {
@@ -1632,35 +1646,99 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                         continuation.finish()
                         return
                     }
-                    var snapshot = self.terminalSnapshots[uiThreadID]
-                        ?? FeatureTerminalSnapshot(threadID: uiThreadID)
+                    var snapshot = self.terminalSnapshots[key]
+                        ?? FeatureTerminalSnapshot(
+                            threadID: uiThreadID,
+                            terminalID: terminalID,
+                            workingDirectory: context.cwd
+                        )
                     snapshot.state = .failed
                     snapshot.error = error.localizedDescription
-                    self.terminalSnapshots[uiThreadID] = snapshot
-                    self.publishTerminal(snapshot, threadID: uiThreadID)
+                    self.terminalSnapshots[key] = snapshot
+                    continuation.yield(snapshot)
                     continuation.finish()
                 }
             }
-            continuation.onTermination = { @Sendable [weak self] _ in
+            continuation.onTermination = { @Sendable _ in
                 task.cancel()
-                Task { @MainActor in
-                    self?.terminalContinuations[uiThreadID]?[subscriptionID] = nil
-                    if self?.terminalContinuations[uiThreadID]?.isEmpty == true {
-                        self?.terminalContinuations[uiThreadID] = nil
-                    }
-                }
             }
         }
     }
 
-    func openTerminal(threadID: String, columns: Int, rows: Int) async throws {
+    func terminalSessions(threadID: String) -> AsyncStream<[FeatureTerminalSnapshot]> {
+        guard let route = try? threadRoute(for: threadID) else {
+            return AsyncStream { continuation in continuation.finish() }
+        }
+        let environmentID = route.environmentID
+        let client = route.client
+        let uiThreadID = route.uiID
+        let wireThreadID = route.wireID
+        let generation = environmentGeneration
+        return AsyncStream { continuation in
+            let task = Task { [weak self] in
+                var summaries = [TerminalSummary]()
+                do {
+                    for try await event in await client.terminalMetadataEvents() {
+                        guard !Task.isCancelled else { break }
+                        guard let self else { break }
+                        guard self.isKnownClient(
+                            client,
+                            environmentID: environmentID,
+                            generation: generation
+                        ) else {
+                            break
+                        }
+
+                        switch event.type {
+                        case "snapshot":
+                            summaries = (event.terminals ?? []).filter {
+                                $0.threadId == wireThreadID
+                            }
+                        case "upsert":
+                            if let summary = event.terminal,
+                               summary.threadId == wireThreadID {
+                                summaries.removeAll { $0.terminalId == summary.terminalId }
+                                summaries.append(summary)
+                            }
+                        case "remove":
+                            if event.threadId == wireThreadID,
+                               let terminalID = event.terminalId {
+                                summaries.removeAll { $0.terminalId == terminalID }
+                            }
+                        default:
+                            break
+                        }
+
+                        let sessions = summaries
+                            .sorted {
+                                $0.terminalId.localizedStandardCompare($1.terminalId)
+                                    == .orderedAscending
+                            }
+                            .map { self.mergeTerminalSummary($0, threadID: uiThreadID) }
+                        continuation.yield(sessions)
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish()
+                } catch {
+                    continuation.finish()
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+
+    func openTerminal(
+        threadID: String,
+        terminalID: String,
+        columns: Int,
+        rows: Int
+    ) async throws {
         let route = try threadRoute(for: threadID)
         let client = route.client
         let environmentID = route.environmentID
         let generation = environmentGeneration
         let context = try workspaceContext(route: route)
-        let terminalID = terminalIDs[route.uiID] ?? UUID().uuidString
-        terminalIDs[route.uiID] = terminalID
         let snapshot = try await client.openTerminal(
             threadID: route.wireID,
             terminalID: terminalID,
@@ -1675,13 +1753,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let mapped = NativeWorkspaceMapper.terminal(snapshot)
         var scoped = mapped
         scoped.threadID = route.uiID
-        terminalSnapshots[route.uiID] = scoped
-        publishTerminal(scoped, threadID: route.uiID)
+        terminalSnapshots[TerminalKey(threadID: route.uiID, terminalID: terminalID)] = scoped
     }
 
-    func writeTerminal(threadID: String, data: String) async throws {
+    func writeTerminal(threadID: String, terminalID: String, data: String) async throws {
         let route = try threadRoute(for: threadID)
-        let terminalID = try requireTerminalID(threadID: route.uiID)
         try await route.client.writeTerminal(
             threadID: route.wireID,
             terminalID: terminalID,
@@ -1689,9 +1765,13 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         )
     }
 
-    func resizeTerminal(threadID: String, columns: Int, rows: Int) async throws {
+    func resizeTerminal(
+        threadID: String,
+        terminalID: String,
+        columns: Int,
+        rows: Int
+    ) async throws {
         let route = try threadRoute(for: threadID)
-        let terminalID = try requireTerminalID(threadID: route.uiID)
         try await route.client.resizeTerminal(
             threadID: route.wireID,
             terminalID: terminalID,
@@ -1700,20 +1780,30 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         )
     }
 
-    func closeTerminal(threadID: String) async throws {
+    func clearTerminal(threadID: String, terminalID: String) async throws {
+        let route = try threadRoute(for: threadID)
+        try await route.client.clearTerminal(
+            threadID: route.wireID,
+            terminalID: terminalID
+        )
+    }
+
+    func closeTerminal(threadID: String, terminalID: String) async throws {
         let route = try threadRoute(for: threadID)
         let client = route.client
         let environmentID = route.environmentID
         let generation = environmentGeneration
-        let terminalID = try requireTerminalID(threadID: route.uiID)
         try await client.closeTerminal(threadID: route.wireID, terminalID: terminalID)
         guard isKnownClient(client, environmentID: environmentID, generation: generation) else {
             throw CancellationError()
         }
-        terminalIDs[route.uiID] = nil
-        let snapshot = FeatureTerminalSnapshot(threadID: route.uiID)
-        terminalSnapshots[route.uiID] = snapshot
-        publishTerminal(snapshot, threadID: route.uiID)
+        let context = try workspaceContext(route: route)
+        terminalSnapshots[TerminalKey(threadID: route.uiID, terminalID: terminalID)] =
+            FeatureTerminalSnapshot(
+                threadID: route.uiID,
+                terminalID: terminalID,
+                workingDirectory: context.cwd
+            )
     }
 
     private func requireClient() throws -> T3Client {
@@ -1907,13 +1997,6 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         publish(detail, threadID: threadID)
     }
 
-    private func requireTerminalID(threadID: String) throws -> String {
-        guard let terminalID = terminalIDs[threadID] else {
-            throw NativeFeatureClientError.terminalNotOpen
-        }
-        return terminalID
-    }
-
     private func workspaceContext(route: NativeThreadRoute) throws -> (
         cwd: String,
         worktreePath: String?
@@ -1931,22 +2014,23 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func consumeTerminalEvent(
         _ event: TerminalEvent,
-        threadID: String
+        threadID: String,
+        terminalID: String
     ) -> FeatureTerminalSnapshot {
+        let key = TerminalKey(threadID: threadID, terminalID: terminalID)
         if let coreSnapshot = event.snapshot {
             var snapshot = NativeWorkspaceMapper.terminal(coreSnapshot)
             snapshot.threadID = threadID
             snapshot.buffer = Self.cappedTerminalBuffer(snapshot.buffer)
-            terminalIDs[threadID] = coreSnapshot.terminalId
-            terminalSnapshots[threadID] = snapshot
+            terminalSnapshots[key] = snapshot
             return snapshot
         }
 
-        var snapshot = terminalSnapshots[threadID]
-            ?? FeatureTerminalSnapshot(threadID: threadID)
+        var snapshot = terminalSnapshots[key]
+            ?? FeatureTerminalSnapshot(threadID: threadID, terminalID: terminalID)
         switch event.type {
         case "output":
-            snapshot.buffer.append(NativeWorkspaceMapper.terminalText(event.data ?? ""))
+            snapshot.buffer.append(event.data ?? "")
             snapshot.buffer = Self.cappedTerminalBuffer(snapshot.buffer)
         case "exited":
             snapshot.state = .exited
@@ -1960,16 +2044,33 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             snapshot.buffer = ""
         case "activity":
             snapshot.title = event.label ?? snapshot.title
+            snapshot.hasRunningSubprocess = event.hasRunningSubprocess
+                ?? snapshot.hasRunningSubprocess
         default:
             break
         }
-        terminalSnapshots[threadID] = snapshot
+        terminalSnapshots[key] = snapshot
+        return snapshot
+    }
+
+    private func mergeTerminalSummary(
+        _ summary: TerminalSummary,
+        threadID: String
+    ) -> FeatureTerminalSnapshot {
+        let key = TerminalKey(threadID: threadID, terminalID: summary.terminalId)
+        var snapshot = NativeWorkspaceMapper.terminal(summary)
+        snapshot.threadID = threadID
+        if let cached = terminalSnapshots[key] {
+            snapshot.buffer = cached.buffer
+            snapshot.error = cached.error
+        }
+        terminalSnapshots[key] = snapshot
         return snapshot
     }
 
     /// A verbose command can stream megabytes; the viewer only ever shows the
     /// tail, so cap retained history to keep layout and memory bounded.
-    private static let terminalBufferLimit = 256 * 1024
+    private static let terminalBufferLimit = 512 * 1024
 
     private static func cappedTerminalBuffer(_ buffer: String) -> String {
         let utf8 = buffer.utf8
@@ -1993,24 +2094,6 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             return String(tail[tail.index(after: newline)...])
         }
         return String(tail)
-    }
-
-    private func publishTerminal(
-        _ snapshot: FeatureTerminalSnapshot,
-        threadID: String
-    ) {
-        for continuation in terminalContinuations[threadID]?.values ?? [:].values {
-            continuation.yield(snapshot)
-        }
-    }
-
-    private func finishTerminalStreams() {
-        for continuations in terminalContinuations.values {
-            for continuation in continuations.values {
-                continuation.finish()
-            }
-        }
-        terminalContinuations.removeAll()
     }
 
     private func startPolling(_ activeClient: T3Client) {
@@ -5303,7 +5386,6 @@ private enum NativeFeatureClientError: LocalizedError {
     case inputRequestNotFound
     case invalidProjectPath
     case branchRequired
-    case terminalNotOpen
     case deviceSessionNotFound
     case missingScope(String)
     case tooManyAttachments
@@ -5319,7 +5401,6 @@ private enum NativeFeatureClientError: LocalizedError {
         case .inputRequestNotFound: "The input request is no longer active."
         case .invalidProjectPath: "Enter a workspace path on the connected environment."
         case .branchRequired: "Choose a base branch for the new worktree."
-        case .terminalNotOpen: "Open the terminal before sending input."
         case .deviceSessionNotFound: "That device session is no longer active."
         case .missingScope: "This connection does not have permission to manage devices."
         case .tooManyAttachments: "You can attach up to 8 images per message."

--- a/apps/swift-ios/App/NativeWorkspaceMapper.swift
+++ b/apps/swift-ios/App/NativeWorkspaceMapper.swift
@@ -106,11 +106,26 @@ enum NativeWorkspaceMapper {
     static func terminal(_ snapshot: TerminalSessionSnapshot) -> FeatureTerminalSnapshot {
         FeatureTerminalSnapshot(
             threadID: snapshot.threadId,
+            terminalID: snapshot.terminalId,
             state: terminalState(snapshot.status),
             title: snapshot.label,
             workingDirectory: snapshot.cwd,
-            buffer: terminalText(snapshot.history),
-            exitCode: snapshot.exitCode
+            buffer: snapshot.history,
+            exitCode: snapshot.exitCode,
+            updatedAt: snapshot.updatedAt
+        )
+    }
+
+    static func terminal(_ summary: TerminalSummary) -> FeatureTerminalSnapshot {
+        FeatureTerminalSnapshot(
+            threadID: summary.threadId,
+            terminalID: summary.terminalId,
+            state: terminalState(summary.status),
+            title: summary.label,
+            workingDirectory: summary.cwd,
+            exitCode: summary.exitCode,
+            hasRunningSubprocess: summary.hasRunningSubprocess,
+            updatedAt: summary.updatedAt
         )
     }
 
@@ -120,41 +135,6 @@ enum NativeWorkspaceMapper {
         case .running: .running
         case .exited: .exited
         case .error: .failed
-        }
-    }
-
-    /// This surface is a plain-text terminal viewer, not a VT100 emulator.
-    static func terminalText(_ value: String) -> String {
-        let withoutEscapes = value
-            .replacingOccurrences(
-                of: "\u{1B}\\][^\u{7}\u{1B}]*(?:\u{7}|\u{1B}\\\\)",
-                with: "",
-                options: .regularExpression
-            )
-            .replacingOccurrences(
-                of: "\u{1B}\\[[0-?]*[ -/]*[@-~]",
-                with: "",
-                options: .regularExpression
-            )
-            .replacingOccurrences(
-                of: "\u{1B}[@-_]",
-                with: "",
-                options: .regularExpression
-            )
-        return withoutEscapes.reduce(into: "") { output, character in
-            if character == "\u{8}" || character == "\u{7F}" {
-                if !output.isEmpty { output.removeLast() }
-                return
-            }
-            if character == "\r" { return }
-            if character.unicodeScalars.count == 1,
-               let scalar = character.unicodeScalars.first,
-               scalar.value < 32,
-               character != "\n",
-               character != "\t" {
-                return
-            }
-            output.append(character)
         }
     }
 

--- a/apps/swift-ios/Features/Shared/FeatureClient.swift
+++ b/apps/swift-ios/Features/Shared/FeatureClient.swift
@@ -108,12 +108,19 @@ public protocol FeatureClient: AnyObject {
         message: String?
     ) async throws -> FeatureSourceControlStatus
 
-    func terminalSnapshot(threadID: String) async throws -> FeatureTerminalSnapshot
-    func terminalEvents(threadID: String) -> AsyncStream<FeatureTerminalSnapshot>
-    func openTerminal(threadID: String, columns: Int, rows: Int) async throws
-    func writeTerminal(threadID: String, data: String) async throws
-    func resizeTerminal(threadID: String, columns: Int, rows: Int) async throws
-    func closeTerminal(threadID: String) async throws
+    func terminalSnapshot(threadID: String, terminalID: String) async throws -> FeatureTerminalSnapshot
+    func terminalEvents(threadID: String, terminalID: String) -> AsyncStream<FeatureTerminalSnapshot>
+    func terminalSessions(threadID: String) -> AsyncStream<[FeatureTerminalSnapshot]>
+    func openTerminal(threadID: String, terminalID: String, columns: Int, rows: Int) async throws
+    func writeTerminal(threadID: String, terminalID: String, data: String) async throws
+    func resizeTerminal(
+        threadID: String,
+        terminalID: String,
+        columns: Int,
+        rows: Int
+    ) async throws
+    func clearTerminal(threadID: String, terminalID: String) async throws
+    func closeTerminal(threadID: String, terminalID: String) async throws
 }
 
 public extension FeatureClient {
@@ -304,27 +311,45 @@ public extension FeatureClient {
         throw FeatureCapabilityUnavailable("Source control actions")
     }
 
-    func terminalSnapshot(threadID: String) async throws -> FeatureTerminalSnapshot {
+    func terminalSnapshot(threadID: String, terminalID _: String) async throws -> FeatureTerminalSnapshot {
         throw FeatureCapabilityUnavailable("Terminal")
     }
 
-    func terminalEvents(threadID: String) -> AsyncStream<FeatureTerminalSnapshot> {
+    func terminalEvents(threadID: String, terminalID _: String) -> AsyncStream<FeatureTerminalSnapshot> {
         AsyncStream { $0.finish() }
     }
 
-    func openTerminal(threadID: String, columns: Int, rows: Int) async throws {
+    func terminalSessions(threadID _: String) -> AsyncStream<[FeatureTerminalSnapshot]> {
+        AsyncStream { $0.finish() }
+    }
+
+    func openTerminal(
+        threadID: String,
+        terminalID _: String,
+        columns: Int,
+        rows: Int
+    ) async throws {
         throw FeatureCapabilityUnavailable("Terminal")
     }
 
-    func writeTerminal(threadID: String, data: String) async throws {
+    func writeTerminal(threadID: String, terminalID _: String, data: String) async throws {
         throw FeatureCapabilityUnavailable("Terminal")
     }
 
-    func resizeTerminal(threadID: String, columns: Int, rows: Int) async throws {
+    func resizeTerminal(
+        threadID: String,
+        terminalID _: String,
+        columns: Int,
+        rows: Int
+    ) async throws {
         throw FeatureCapabilityUnavailable("Terminal")
     }
 
-    func closeTerminal(threadID: String) async throws {
+    func clearTerminal(threadID: String, terminalID _: String) async throws {
+        throw FeatureCapabilityUnavailable("Terminal")
+    }
+
+    func closeTerminal(threadID: String, terminalID _: String) async throws {
         throw FeatureCapabilityUnavailable("Terminal")
     }
 }

--- a/apps/swift-ios/Features/Shared/FeatureToolModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureToolModels.swift
@@ -893,28 +893,37 @@ public enum FeatureTerminalState: String, Sendable, Codable {
 
 public struct FeatureTerminalSnapshot: Sendable, Equatable, Codable {
     public var threadID: String
+    public var terminalID: String
     public var state: FeatureTerminalState
     public var title: String
     public var workingDirectory: String?
     public var buffer: String
     public var exitCode: Int?
     public var error: String?
+    public var hasRunningSubprocess: Bool
+    public var updatedAt: String?
 
     public init(
         threadID: String,
+        terminalID: String = "default",
         state: FeatureTerminalState = .stopped,
         title: String = "Terminal",
         workingDirectory: String? = nil,
         buffer: String = "",
         exitCode: Int? = nil,
-        error: String? = nil
+        error: String? = nil,
+        hasRunningSubprocess: Bool = false,
+        updatedAt: String? = nil
     ) {
         self.threadID = threadID
+        self.terminalID = terminalID
         self.state = state
         self.title = title
         self.workingDirectory = workingDirectory
         self.buffer = buffer
         self.exitCode = exitCode
         self.error = error
+        self.hasRunningSubprocess = hasRunningSubprocess
+        self.updatedAt = updatedAt
     }
 }

--- a/apps/swift-ios/Features/Terminal/FeatureTerminalView.swift
+++ b/apps/swift-ios/Features/Terminal/FeatureTerminalView.swift
@@ -1,14 +1,77 @@
 import SwiftUI
 
+private enum TerminalFontSize {
+    static let minimum = 6.0
+    static let maximum = 14.0
+    static let step = 0.5
+    static let defaultValue = 10.5
+
+    static func normalized(_ value: Double) -> Double {
+        min(maximum, max(minimum, value))
+    }
+}
+
+enum TerminalSessionList {
+    static func initialID(in sessions: [FeatureTerminalSnapshot]) -> String {
+        let running = sessions.filter { $0.state == .running || $0.state == .starting }
+        return running.first(where: { $0.terminalID == "default" })?.terminalID
+            ?? running.first?.terminalID
+            ?? "default"
+    }
+
+    static func nextID(occupiedIDs: [String]) -> String {
+        let occupied = Set(occupiedIDs)
+        guard occupied.contains("default") else { return "default" }
+        var index = 2
+        while occupied.contains("term-\(index)") { index += 1 }
+        return "term-\(index)"
+    }
+
+    static func fallbackID(
+        in sessions: [FeatureTerminalSnapshot],
+        excluding terminalID: String
+    ) -> String? {
+        sessions.first {
+            $0.terminalID != terminalID && ($0.state == .running || $0.state == .starting)
+        }?.terminalID
+    }
+
+    static func displayTitle(for session: FeatureTerminalSnapshot) -> String {
+        let number: Int
+        if session.terminalID == "default" {
+            number = 1
+        } else if session.terminalID.hasPrefix("term-"),
+                  let parsed = Int(session.terminalID.dropFirst("term-".count)) {
+            number = parsed
+        } else {
+            return session.title
+        }
+
+        let shell = session.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !shell.isEmpty, shell.caseInsensitiveCompare("Terminal") != .orderedSame else {
+            return "Terminal \(number)"
+        }
+        return "Terminal \(number) · \(shell)"
+    }
+}
+
 public struct FeatureTerminalView: View {
     let client: any FeatureClient
     let threadID: String
 
+    @SwiftUI.Environment(\.dismiss) private var dismiss
+    @AppStorage("terminalFontSize") private var storedFontSize = TerminalFontSize.defaultValue
     @State private var terminal: FeatureTerminalSnapshot?
-    @State private var input = ""
+    @State private var sessions = [FeatureTerminalSnapshot]()
+    @State private var activeTerminalID = "default"
+    @State private var sessionsResolved = false
+    @State private var columns = 80
+    @State private var rows = 24
+    @State private var focusRequest = 0
+    @State private var surfaceGeneration = 0
     @State private var isLoading = true
+    @State private var isOpening = false
     @State private var errorMessage: String?
-    @FocusState private var inputFocused: Bool
 
     public init(client: any FeatureClient, threadID: String) {
         self.client = client
@@ -16,153 +79,326 @@ public struct FeatureTerminalView: View {
     }
 
     public var body: some View {
-        VStack(spacing: 0) {
+        ZStack {
+            Color.black
+
+            GhosttyTerminalSurface(
+                terminalKey: "\(threadID):\(activeTerminalID)",
+                buffer: terminal?.buffer ?? "",
+                fontSize: CGFloat(fontSize),
+                isRunning: isRunning,
+                focusRequest: focusRequest,
+                onInput: { data in
+                    Task { await write(data) }
+                },
+                onResize: { nextColumns, nextRows in
+                    updateGrid(columns: nextColumns, rows: nextRows)
+                },
+                onClear: {
+                    Task { await clear() }
+                },
+                onFontSizeStep: { direction in
+                    stepFontSize(direction)
+                }
+            )
+            .id("\(terminalTaskID):\(fontSize):\(surfaceGeneration)")
+            .padding(.top, 48)
+
+            if isLoading, terminal == nil {
+                ProgressView("Opening terminal…")
+                    .tint(.white)
+                    .foregroundStyle(.white)
+            } else if let errorMessage, terminal == nil {
+                ContentUnavailableView(
+                    "Terminal unavailable",
+                    systemImage: "terminal",
+                    description: Text(errorMessage)
+                )
+                .foregroundStyle(.white)
+            }
+
+            if let errorMessage, terminal != nil {
+                VStack {
+                    Spacer()
+                    Text(errorMessage)
+                        .font(T3Typography.supporting)
+                        .foregroundStyle(Color.white)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(Color.red.opacity(0.88))
+                        .accessibilityLabel("Terminal error: \(errorMessage)")
+                }
+            }
+
             terminalHeader
-            Divider()
-            terminalBuffer
-            terminalControls
         }
-        .background(Color.black)
-        .navigationTitle("Terminal")
-        .navigationBarTitleDisplayMode(.inline)
-        .task { await loadAndOpen() }
+        .background(Color.black.ignoresSafeArea())
+        .toolbar(.hidden, for: .navigationBar)
         .task {
-            for await update in client.terminalEvents(threadID: threadID) {
+            for await updates in client.terminalSessions(threadID: threadID) {
+                sessions = updates
+                if !sessionsResolved {
+                    activeTerminalID = TerminalSessionList.initialID(in: updates)
+                    sessionsResolved = true
+                }
+            }
+            sessionsResolved = true
+        }
+        .task(id: terminalTaskID) {
+            guard sessionsResolved else { return }
+            await loadAndOpen()
+        }
+        .task(id: terminalTaskID) {
+            guard sessionsResolved else { return }
+            let terminalID = activeTerminalID
+            for await update in client.terminalEvents(
+                threadID: threadID,
+                terminalID: terminalID
+            ) {
+                guard terminalID == activeTerminalID else { break }
+                let shouldSyncGrid = !isRunning
+                    && (update.state == .running || update.state == .starting)
+                if let currentBuffer = terminal?.buffer,
+                   !update.buffer.hasPrefix(currentBuffer) {
+                    surfaceGeneration += 1
+                }
                 terminal = update
+                if shouldSyncGrid {
+                    try? await client.resizeTerminal(
+                        threadID: threadID,
+                        terminalID: terminalID,
+                        columns: columns,
+                        rows: rows
+                    )
+                }
+                if update.state == .running {
+                    errorMessage = nil
+                } else if update.state == .failed, let error = update.error {
+                    errorMessage = error
+                }
             }
         }
     }
 
     private var terminalHeader: some View {
-        HStack(spacing: 9) {
-            Circle()
-                .fill(statusColor)
-                .frame(width: 7, height: 7)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(terminal?.title ?? "Terminal")
+        VStack(spacing: 0) {
+            ZStack {
+                Text("Terminal")
                     .font(T3Typography.navigationTitle)
-                Text(terminal?.workingDirectory ?? statusLabel)
-                    .font(T3Typography.tool)
-                    .foregroundStyle(T3Colors.textSecondary)
-                    .lineLimit(1)
-            }
-            Spacer()
-            if terminal?.state == .running {
-                Button("Stop", role: .destructive) {
-                    Task { await stop() }
-                }
-                .font(T3Typography.supportingStrong)
-            } else {
-                Button("Start") {
-                    Task { await open() }
-                }
-                .font(T3Typography.supportingStrong)
-                .disabled(isLoading)
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 9)
-    }
+                    .foregroundStyle(.white)
 
-    @ViewBuilder
-    private var terminalBuffer: some View {
-        if isLoading, terminal == nil {
-            ProgressView("Opening terminal…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let errorMessage, terminal == nil {
-            ContentUnavailableView(
-                "Terminal unavailable",
-                systemImage: "terminal",
-                description: Text(errorMessage)
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            ScrollViewReader { proxy in
-                ScrollView([.horizontal, .vertical]) {
-                    Text(terminal?.buffer.isEmpty == false ? terminal?.buffer ?? "" : " ")
-                        .font(T3Typography.code)
-                        .foregroundStyle(Color(white: 0.86))
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, minHeight: 300, alignment: .topLeading)
-                        .padding(14)
-                        .id("terminal-end")
-                }
-                .defaultScrollAnchor(.bottom)
-                .onChange(of: terminal?.buffer) {
-                    proxy.scrollTo("terminal-end", anchor: .bottom)
+                HStack {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .frame(width: 44, height: 44)
+                    }
+                    .foregroundStyle(.white)
+                    .accessibilityLabel("Close terminal")
+
+                    Spacer()
+
+                    terminalMenu
+                        .frame(width: 44, height: 44)
                 }
             }
+            .frame(height: 48)
+            .background(Color.black)
+
+            Spacer(minLength: 0)
         }
     }
 
-    private var terminalControls: some View {
-        VStack(spacing: 7) {
-            HStack(spacing: 7) {
-                terminalKey("ctrl-c", label: "^C", data: "\u{3}")
-                terminalKey("escape", label: "esc", data: "\u{1B}")
-                terminalKey("tab", label: "tab", data: "\t")
-                Spacer()
-            }
-            HStack(spacing: 8) {
-                TextField("Command", text: $input)
-                    .font(.system(.body, design: .monospaced))
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .focused($inputFocused)
-                    .submitLabel(.send)
-                    .onSubmit(sendCommand)
-                    .padding(.horizontal, 11)
-                    .frame(minHeight: 40)
-                    .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 9))
-                Button(action: sendCommand) {
-                    Image(systemName: "return")
-                        .frame(width: 40, height: 40)
+    private var terminalMenu: some View {
+        Menu {
+            Section {
+                Label(statusLabel, systemImage: statusSymbol)
+                if let workingDirectory = terminal?.workingDirectory {
+                    Text(workingDirectory)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.white)
-                .foregroundStyle(.black)
-                .disabled(!isRunning || input.isEmpty)
-                .accessibilityLabel("Send command")
             }
+
+            Section("Sessions") {
+                ForEach(menuSessions, id: \.terminalID) { session in
+                    Button {
+                        selectTerminal(session.terminalID)
+                    } label: {
+                        Label(
+                            TerminalSessionList.displayTitle(for: session),
+                            systemImage: session.terminalID == activeTerminalID
+                                ? "checkmark"
+                                : "terminal"
+                        )
+                    }
+                }
+
+                Button {
+                    openNewTerminal()
+                } label: {
+                    Label("Open new terminal", systemImage: "plus")
+                }
+            }
+
+            Section {
+                Menu {
+                    Button {
+                        stepFontSize(-1)
+                    } label: {
+                        Label(
+                            "Smaller · \(formattedFontSize(fontSize - TerminalFontSize.step)) pt",
+                            systemImage: "textformat.size.smaller"
+                        )
+                    }
+                    .disabled(fontSize <= TerminalFontSize.minimum)
+
+                    Button {
+                        stepFontSize(1)
+                    } label: {
+                        Label(
+                            "Larger · \(formattedFontSize(fontSize + TerminalFontSize.step)) pt",
+                            systemImage: "textformat.size.larger"
+                        )
+                    }
+                    .disabled(fontSize >= TerminalFontSize.maximum)
+                } label: {
+                    Label("Text size · \(formattedFontSize(fontSize)) pt", systemImage: "textformat.size")
+                }
+
+                Button {
+                    Task { await clear() }
+                } label: {
+                    Label("Clear", systemImage: "eraser")
+                }
+                .disabled(terminal == nil)
+            }
+
+            Section {
+                if isRunning {
+                    Button(role: .destructive) {
+                        Task { await stop() }
+                    } label: {
+                        Label("Stop terminal", systemImage: "stop.fill")
+                    }
+                } else {
+                    Button {
+                        Task { await open() }
+                    } label: {
+                        Label("Start terminal", systemImage: "play.fill")
+                    }
+                    .disabled(isLoading || isOpening)
+                }
+            }
+        } label: {
+            Image(systemName: "terminal")
         }
-        .padding(10)
-        .background(Color(white: 0.025))
-        .overlay(alignment: .top) { Divider() }
+        .accessibilityLabel("Terminal options")
     }
 
-    private func terminalKey(_ id: String, label: String, data: String) -> some View {
-        Button(label) {
-            Task { await write(data) }
-        }
-        .font(T3Typography.tool.weight(.medium))
-        .buttonStyle(.bordered)
-        .controlSize(.small)
-        .disabled(!isRunning)
-        .accessibilityIdentifier("terminal-\(id)")
+    private var fontSize: Double {
+        TerminalFontSize.normalized(storedFontSize)
     }
 
-    private var isRunning: Bool { terminal?.state == .running }
+    private var terminalTaskID: String {
+        "\(sessionsResolved):\(activeTerminalID)"
+    }
 
-    private var statusColor: Color {
-        switch terminal?.state {
-        case .running: .green
-        case .starting: .orange
-        case .failed: .red
-        case .exited, .stopped, nil: .gray
+    private var menuSessions: [FeatureTerminalSnapshot] {
+        var visible = sessions.filter {
+            $0.state == .running || $0.state == .starting || $0.terminalID == activeTerminalID
         }
+        if let terminal,
+           !visible.contains(where: { $0.terminalID == terminal.terminalID }) {
+            visible.append(terminal)
+        }
+        return visible.sorted {
+            $0.terminalID.localizedStandardCompare($1.terminalID) == .orderedAscending
+        }
+    }
+
+    private var isRunning: Bool {
+        terminal?.state == .running || terminal?.state == .starting
     }
 
     private var statusLabel: String {
-        terminal?.state.rawValue.capitalized ?? "Not connected"
+        switch terminal?.state {
+        case .running: terminal?.hasRunningSubprocess == true ? "Task running" : "Ready"
+        case .starting: "Starting"
+        case .failed: "Error"
+        case .exited: "Exited"
+        case .stopped, nil: "Not started"
+        }
+    }
+
+    private var statusSymbol: String {
+        switch terminal?.state {
+        case .running: "checkmark.circle.fill"
+        case .starting: "clock.fill"
+        case .failed: "exclamationmark.triangle.fill"
+        case .exited: "xmark.circle.fill"
+        case .stopped, nil: "circle"
+        }
+    }
+
+    private func formattedFontSize(_ value: Double) -> String {
+        String(format: "%.1f", TerminalFontSize.normalized(value))
+    }
+
+    private func stepFontSize(_ direction: Int) {
+        storedFontSize = TerminalFontSize.normalized(
+            fontSize + Double(direction) * TerminalFontSize.step
+        )
+    }
+
+    private func selectTerminal(_ terminalID: String) {
+        guard terminalID != activeTerminalID else { return }
+        terminal = nil
+        errorMessage = nil
+        activeTerminalID = terminalID
+    }
+
+    private func openNewTerminal() {
+        let nextID = TerminalSessionList.nextID(
+            occupiedIDs: sessions.map(\.terminalID) + [activeTerminalID]
+        )
+        terminal = nil
+        errorMessage = nil
+        activeTerminalID = nextID
+    }
+
+    private func updateGrid(columns nextColumns: Int, rows nextRows: Int) {
+        guard nextColumns != columns || nextRows != rows else { return }
+        columns = nextColumns
+        rows = nextRows
+        guard isRunning else { return }
+        Task {
+            do {
+                try await client.resizeTerminal(
+                    threadID: threadID,
+                    terminalID: activeTerminalID,
+                    columns: nextColumns,
+                    rows: nextRows
+                )
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
     }
 
     private func loadAndOpen() async {
+        let terminalID = activeTerminalID
         isLoading = true
         defer { isLoading = false }
         do {
-            terminal = try await client.terminalSnapshot(threadID: threadID)
-            if terminal?.state == .stopped || terminal?.state == .exited {
-                try await client.openTerminal(threadID: threadID, columns: 80, rows: 24)
+            let snapshot = try await client.terminalSnapshot(
+                threadID: threadID,
+                terminalID: terminalID
+            )
+            guard terminalID == activeTerminalID else { return }
+            terminal = snapshot
+            if snapshot.state == .stopped || snapshot.state == .exited {
+                try await openTerminal(terminalID: terminalID)
             }
             errorMessage = nil
         } catch {
@@ -171,43 +407,84 @@ public struct FeatureTerminalView: View {
     }
 
     private func open() async {
+        guard !isOpening else { return }
+        isOpening = true
+        defer { isOpening = false }
         do {
-            try await client.openTerminal(threadID: threadID, columns: 80, rows: 24)
-            terminal = try await client.terminalSnapshot(threadID: threadID)
+            try await openTerminal(terminalID: activeTerminalID)
+            focusRequest += 1
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
         }
     }
 
+    private func openTerminal(terminalID: String) async throws {
+        try await client.openTerminal(
+            threadID: threadID,
+            terminalID: terminalID,
+            columns: columns,
+            rows: rows
+        )
+        guard terminalID == activeTerminalID else { return }
+        terminal = try await client.terminalSnapshot(
+            threadID: threadID,
+            terminalID: terminalID
+        )
+    }
+
     private func stop() async {
+        let terminalID = activeTerminalID
+        let fallbackID = TerminalSessionList.fallbackID(
+            in: sessions,
+            excluding: terminalID
+        )
         do {
-            try await client.closeTerminal(threadID: threadID)
-            terminal = try? await client.terminalSnapshot(threadID: threadID)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func sendCommand() {
-        guard isRunning, !input.isEmpty else { return }
-        let command = input
-        Task {
-            if await write(command + "\r") {
-                input = ""
+            try await client.closeTerminal(threadID: threadID, terminalID: terminalID)
+            if let fallbackID {
+                selectTerminal(fallbackID)
+            } else {
+                terminal = try? await client.terminalSnapshot(
+                    threadID: threadID,
+                    terminalID: terminalID
+                )
             }
-            inputFocused = true
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
 
-    @discardableResult
-    private func write(_ data: String) async -> Bool {
+    private func clear() async {
         do {
-            try await client.writeTerminal(threadID: threadID, data: data)
-            return true
+            terminal?.buffer = ""
+            surfaceGeneration += 1
+            try await client.clearTerminal(
+                threadID: threadID,
+                terminalID: activeTerminalID
+            )
+            if isRunning {
+                try await client.writeTerminal(
+                    threadID: threadID,
+                    terminalID: activeTerminalID,
+                    data: "\u{0C}"
+                )
+            }
+            errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
-            return false
+        }
+    }
+
+    private func write(_ data: String) async {
+        do {
+            try await client.writeTerminal(
+                threadID: threadID,
+                terminalID: activeTerminalID,
+                data: data
+            )
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
 }

--- a/apps/swift-ios/Features/Terminal/TerminalSurfaceView.swift
+++ b/apps/swift-ios/Features/Terminal/TerminalSurfaceView.swift
@@ -1,0 +1,996 @@
+import GhosttyKit
+import QuartzCore
+import SwiftUI
+import UIKit
+
+struct GhosttyTerminalSurface: UIViewRepresentable {
+    let terminalKey: String
+    let buffer: String
+    let fontSize: CGFloat
+    let isRunning: Bool
+    let focusRequest: Int
+    let onInput: (String) -> Void
+    let onResize: (Int, Int) -> Void
+    let onClear: () -> Void
+    let onFontSizeStep: (Int) -> Void
+
+    func makeUIView(context _: Context) -> GhosttyTerminalView {
+        let view = GhosttyTerminalView()
+        configure(view)
+        return view
+    }
+
+    func updateUIView(_ view: GhosttyTerminalView, context _: Context) {
+        configure(view)
+    }
+
+    private func configure(_ view: GhosttyTerminalView) {
+        view.onInput = onInput
+        view.onResize = onResize
+        view.onClear = onClear
+        view.onFontSizeStep = onFontSizeStep
+        view.terminalKey = terminalKey
+        view.fontSize = fontSize
+        view.isRunning = isRunning
+        view.buffer = buffer
+        view.focusRequest = focusRequest
+    }
+}
+
+enum TerminalText {
+    static func plainText(from value: String) -> String {
+        let withoutEscapes = value
+            .replacingOccurrences(
+                of: "\u{1B}\\][^\u{7}\u{1B}]*(?:\u{7}|\u{1B}\\\\)",
+                with: "",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: "\u{1B}\\[[0-?]*[ -/]*[@-~]",
+                with: "",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: "\u{1B}[@-_]",
+                with: "",
+                options: .regularExpression
+            )
+
+        return withoutEscapes.reduce(into: "") { output, character in
+            if character == "\u{8}" || character == "\u{7F}" {
+                if !output.isEmpty { output.removeLast() }
+                return
+            }
+            if character == "\r" { return }
+            if character.unicodeScalars.count == 1,
+               let scalar = character.unicodeScalars.first,
+               scalar.value < 32,
+               character != "\n",
+               character != "\t" {
+                return
+            }
+            output.append(character)
+        }
+    }
+}
+
+private enum GhosttyRuntime {
+    private static let lock = NSLock()
+    private static var initialized = false
+
+    static func ensureInitialized() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if initialized { return true }
+        initialized = ghostty_init(0, nil) == GHOSTTY_SUCCESS
+        return initialized
+    }
+}
+
+private enum TerminalHardwareKeyEncoder {
+    private static let controlInputs = "abcdefghijklmnopqrstuvwxyz@[\\]^_-? "
+
+    static func makeKeyCommands(action: Selector) -> [UIKeyCommand] {
+        var commands = [UIKeyCommand]()
+        let specialInputs = [
+            UIKeyCommand.inputEscape,
+            UIKeyCommand.inputUpArrow,
+            UIKeyCommand.inputDownArrow,
+            UIKeyCommand.inputLeftArrow,
+            UIKeyCommand.inputRightArrow,
+            "\t",
+        ]
+
+        for input in specialInputs {
+            commands.append(makeCommand(input: input, modifierFlags: [], action: action))
+        }
+        commands.append(makeCommand(input: "\t", modifierFlags: .shift, action: action))
+
+        for character in controlInputs {
+            commands.append(
+                makeCommand(
+                    input: String(character),
+                    modifierFlags: .control,
+                    action: action
+                )
+            )
+            commands.append(
+                makeCommand(
+                    input: String(character),
+                    modifierFlags: [.control, .shift],
+                    action: action
+                )
+            )
+        }
+
+        commands.append(makeCommand(input: "c", modifierFlags: .command, action: action))
+        commands.append(makeCommand(input: "v", modifierFlags: .command, action: action))
+        return commands
+    }
+
+    private static func makeCommand(
+        input: String,
+        modifierFlags: UIKeyModifierFlags,
+        action: Selector
+    ) -> UIKeyCommand {
+        let command = UIKeyCommand(input: input, modifierFlags: modifierFlags, action: action)
+        command.wantsPriorityOverSystemBehavior = true
+        return command
+    }
+
+    static func sequence(input: String, modifiers: UIKeyModifierFlags) -> String? {
+        if modifiers == .command {
+            return input.lowercased() == "c" ? "copy" : input.lowercased() == "v" ? "paste" : nil
+        }
+
+        switch input {
+        case UIKeyCommand.inputEscape: return "\u{1B}"
+        case UIKeyCommand.inputUpArrow: return "\u{1B}[A"
+        case UIKeyCommand.inputDownArrow: return "\u{1B}[B"
+        case UIKeyCommand.inputRightArrow: return "\u{1B}[C"
+        case UIKeyCommand.inputLeftArrow: return "\u{1B}[D"
+        case "\t": return modifiers.contains(.shift) ? "\u{1B}[Z" : "\t"
+        default: break
+        }
+
+        guard modifiers.contains(.control),
+              let scalar = input.lowercased().unicodeScalars.first else {
+            return nil
+        }
+        return controlSequence(for: scalar)
+    }
+
+    static func applyingControl(to input: String) -> String {
+        guard let scalar = input.lowercased().unicodeScalars.first else { return input }
+        return controlSequence(for: scalar) ?? input
+    }
+
+    private static func controlSequence(for scalar: Unicode.Scalar) -> String? {
+        switch scalar {
+        case "a"..."z": return UnicodeScalar(scalar.value - 96).map(String.init)
+        case " ", "@": return "\u{00}"
+        case "[": return "\u{1B}"
+        case "\\": return "\u{1C}"
+        case "]": return "\u{1D}"
+        case "^": return "\u{1E}"
+        case "_", "-": return "\u{1F}"
+        case "?": return "\u{7F}"
+        default: return nil
+        }
+    }
+}
+
+private final class TerminalInputField: UITextField {
+    var onDeleteBackward: (() -> Void)?
+    var onInsert: ((String) -> Void)?
+    var onCopyOutput: (() -> Void)?
+    var onPasteText: (() -> Void)?
+
+    private static let terminalKeyCommands = TerminalHardwareKeyEncoder.makeKeyCommands(
+        action: #selector(handleHardwareKeyCommand(_:))
+    )
+
+    override var keyCommands: [UIKeyCommand]? { Self.terminalKeyCommands }
+
+    override func deleteBackward() {
+        onDeleteBackward?()
+        super.deleteBackward()
+    }
+
+    @objc private func handleHardwareKeyCommand(_ command: UIKeyCommand) {
+        guard let input = command.input,
+              let sequence = TerminalHardwareKeyEncoder.sequence(
+                input: input,
+                modifiers: command.modifierFlags
+              ) else {
+            return
+        }
+
+        if sequence == "copy" {
+            onCopyOutput?()
+        } else if sequence == "paste" {
+            onPasteText?()
+        } else {
+            onInsert?(sequence)
+        }
+    }
+}
+
+private enum TerminalAccessoryAction: String {
+    case escape
+    case command
+    case control
+    case tab
+    case clear
+    case up
+    case down
+    case left
+    case right
+    case tilde
+    case pipe
+    case slash
+    case dash
+    case dismiss
+
+    var label: String {
+        switch self {
+        case .escape: "esc"
+        case .command: "cmd"
+        case .control: "ctrl"
+        case .tab: "tab"
+        case .clear: "clear"
+        case .up: "↑"
+        case .down: "↓"
+        case .left: "←"
+        case .right: "→"
+        case .tilde: "~"
+        case .pipe: "|"
+        case .slash: "/"
+        case .dash: "-"
+        case .dismiss: ""
+        }
+    }
+
+    var sequence: String? {
+        switch self {
+        case .escape: "\u{1B}"
+        case .tab: "\t"
+        case .up: "\u{1B}[A"
+        case .down: "\u{1B}[B"
+        case .left: "\u{1B}[D"
+        case .right: "\u{1B}[C"
+        case .tilde: "~"
+        case .pipe: "|"
+        case .slash: "/"
+        case .dash: "-"
+        case .command, .control, .clear, .dismiss: nil
+        }
+    }
+
+    var width: CGFloat {
+        switch self {
+        case .escape, .tab: 44
+        case .command: 48
+        case .control, .clear: 50
+        case .up, .down, .left, .right, .tilde, .pipe, .slash, .dash: 38
+        case .dismiss: 36
+        }
+    }
+}
+
+private final class TerminalAccessoryButton: UIButton {
+    let terminalAction: TerminalAccessoryAction
+
+    init(action: TerminalAccessoryAction) {
+        terminalAction = action
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) { nil }
+}
+
+private final class TerminalAccessoryView: UIInputView {
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+    private let dismissButton = TerminalAccessoryButton(action: .dismiss)
+    private var actionButtons = [TerminalAccessoryAction: TerminalAccessoryButton]()
+    var onAction: ((TerminalAccessoryAction) -> Void)?
+
+    init() {
+        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: 50), inputViewStyle: .keyboard)
+        allowsSelfSizing = true
+        backgroundColor = .black
+
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.alwaysBounceHorizontal = true
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 7
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(scrollView)
+        addSubview(dismissButton)
+        scrollView.addSubview(stackView)
+
+        let actions: [TerminalAccessoryAction] = [
+            .escape, .command, .control, .tab, .clear,
+            .up, .down, .left, .right, .tilde, .pipe, .slash, .dash,
+        ]
+        for action in actions {
+            let button = TerminalAccessoryButton(action: action)
+            configure(button, label: action.label)
+            actionButtons[action] = button
+            stackView.addArrangedSubview(button)
+        }
+
+        var dismissConfiguration = UIButton.Configuration.plain()
+        dismissConfiguration.image = UIImage(systemName: "keyboard.chevron.compact.down")
+        dismissConfiguration.baseForegroundColor = UIColor(white: 0.82, alpha: 1)
+        dismissConfiguration.contentInsets = .zero
+        dismissButton.configuration = dismissConfiguration
+        dismissButton.accessibilityLabel = "Dismiss keyboard"
+        dismissButton.addTarget(self, action: #selector(handleButton(_:)), for: .touchUpInside)
+        dismissButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 50),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: dismissButton.leadingAnchor),
+            dismissButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
+            dismissButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            dismissButton.widthAnchor.constraint(equalToConstant: TerminalAccessoryAction.dismiss.width),
+            dismissButton.heightAnchor.constraint(equalToConstant: 42),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 8),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -8),
+            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            stackView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) { nil }
+
+    func setRunning(_ running: Bool) {
+        for (action, button) in actionButtons {
+            button.isEnabled = running || action == .clear
+        }
+    }
+
+    func setActiveModifier(_ action: TerminalAccessoryAction?) {
+        for modifier in [TerminalAccessoryAction.command, .control] {
+            guard let button = actionButtons[modifier] else { continue }
+            applyStyle(to: button, active: modifier == action)
+        }
+    }
+
+    private func configure(_ button: TerminalAccessoryButton, label: String) {
+        button.setTitle(label.uppercased(), for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 10, weight: .semibold)
+        button.accessibilityLabel = label
+        button.addTarget(self, action: #selector(handleButton(_:)), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.heightAnchor.constraint(equalToConstant: 34).isActive = true
+        button.widthAnchor.constraint(equalToConstant: button.terminalAction.width).isActive = true
+        applyStyle(to: button, active: false)
+    }
+
+    private func applyStyle(to button: UIButton, active: Bool) {
+        var configuration = UIButton.Configuration.plain()
+        if let terminalButton = button as? TerminalAccessoryButton,
+           terminalButton.terminalAction != .dismiss {
+            configuration.title = terminalButton.terminalAction.label.uppercased()
+        }
+        configuration.baseForegroundColor = active ? .black : UIColor(white: 0.88, alpha: 1)
+        configuration.background.backgroundColor = active
+            ? UIColor(white: 0.94, alpha: 1)
+            : UIColor(white: 0.08, alpha: 1)
+        configuration.background.cornerRadius = 7
+        configuration.background.strokeColor = UIColor(white: active ? 0.55 : 0.20, alpha: 1)
+        configuration.background.strokeWidth = 1
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
+            var attributes = $0
+            attributes.font = .systemFont(ofSize: 10, weight: .semibold)
+            return attributes
+        }
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 4,
+            bottom: 0,
+            trailing: 4
+        )
+        button.configuration = configuration
+    }
+
+    @objc private func handleButton(_ sender: TerminalAccessoryButton) {
+        onAction?(sender.terminalAction)
+    }
+}
+
+final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIContextMenuInteractionDelegate {
+    private static let minimumVerticalScrollStepPoints: CGFloat = 18
+    private static let verticalScrollStepMultiplier: CGFloat = 1.15
+    private static let themeConfig = """
+    background = #000000
+    foreground = #adadb1
+    cursor-color = #009fff
+    cursor-text = #000000
+    cursor-style-blink = false
+    palette = 0=#141415
+    palette = 1=#ff2e3f
+    palette = 2=#0dbe4e
+    palette = 3=#ffca00
+    palette = 4=#009fff
+    palette = 5=#c635e4
+    palette = 6=#08c0ef
+    palette = 7=#c6c6c8
+    palette = 8=#55555a
+    palette = 9=#ff2e3f
+    palette = 10=#0dbe4e
+    palette = 11=#ffca00
+    palette = 12=#009fff
+    palette = 13=#c635e4
+    palette = 14=#08c0ef
+    palette = 15=#ffffff
+    """
+
+    var onInput: ((String) -> Void)?
+    var onResize: ((Int, Int) -> Void)?
+    var onClear: (() -> Void)?
+    var onFontSizeStep: ((Int) -> Void)?
+
+    var terminalKey = "" {
+        didSet {
+            accessibilityIdentifier = "t3-terminal-\(terminalKey)"
+            inputField.accessibilityIdentifier = "t3-terminal-input-\(terminalKey)"
+            guard oldValue != terminalKey else { return }
+            pendingModifier = nil
+            resetSurface()
+        }
+    }
+
+    var buffer = "" {
+        didSet {
+            guard oldValue != buffer else { return }
+            applyRemoteBuffer(buffer)
+        }
+    }
+
+    var fontSize: CGFloat = 10.5 {
+        didSet {
+            guard oldValue != fontSize else { return }
+            inputField.font = .monospacedSystemFont(ofSize: max(fontSize, 13), weight: .regular)
+            refreshSurface()
+        }
+    }
+
+    var isRunning = false {
+        didSet {
+            guard oldValue != isRunning else { return }
+            inputField.isEnabled = isRunning
+            accessoryView.setRunning(isRunning)
+            keyboardButton.isHidden = !isRunning || inputField.isFirstResponder
+            if isRunning, window != nil, !hasAutoFocused {
+                hasAutoFocused = true
+                DispatchQueue.main.async { [weak self] in self?.requestKeyboardFocus() }
+            } else if !isRunning {
+                pendingModifier = nil
+            }
+        }
+    }
+
+    var focusRequest = 0 {
+        didSet {
+            guard oldValue != focusRequest else { return }
+            DispatchQueue.main.async { [weak self] in self?.requestKeyboardFocus() }
+        }
+    }
+
+    private let terminalViewport = UIView()
+    private let inputField = TerminalInputField()
+    private let accessoryView = TerminalAccessoryView()
+    private let keyboardButton = UIButton(type: .system)
+    private let focusTapGesture = UITapGestureRecognizer()
+    private let scrollPanGesture = UIPanGestureRecognizer()
+    private let fontPinchGesture = UIPinchGestureRecognizer()
+    private var pendingModifier: TerminalAccessoryAction? {
+        didSet { accessoryView.setActiveModifier(pendingModifier) }
+    }
+    private var lastViewportSize: CGSize = .zero
+    private var lastContentScale: CGFloat = 0
+    private var lastReportedGrid: (columns: Int, rows: Int)?
+    private var lastAppliedBuffer = ""
+    private var isReplayingBuffer = false
+    private var pendingVerticalScrollPoints: CGFloat = 0
+    private var hasAutoFocused = false
+    private var app: ghostty_app_t?
+    private var surface: ghostty_surface_t?
+    private var isCreatingSurface = false
+    private var surfaceCreationFailed = false
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .black
+        clipsToBounds = true
+        contentScaleFactor = UIScreen.main.scale
+        accessibilityLabel = "Terminal"
+
+        terminalViewport.backgroundColor = .black
+        terminalViewport.clipsToBounds = true
+        terminalViewport.contentScaleFactor = contentScaleFactor
+        terminalViewport.translatesAutoresizingMaskIntoConstraints = false
+        terminalViewport.isUserInteractionEnabled = true
+
+        inputField.delegate = self
+        inputField.inputAccessoryView = accessoryView
+        inputField.backgroundColor = .clear
+        inputField.textColor = .clear
+        inputField.tintColor = .clear
+        inputField.font = .monospacedSystemFont(ofSize: max(fontSize, 13), weight: .regular)
+        inputField.placeholder = ""
+        inputField.autocorrectionType = .no
+        inputField.autocapitalizationType = .none
+        inputField.spellCheckingType = .no
+        inputField.smartDashesType = .no
+        inputField.smartQuotesType = .no
+        inputField.returnKeyType = .send
+        inputField.keyboardType = .asciiCapable
+        inputField.enablesReturnKeyAutomatically = false
+        inputField.translatesAutoresizingMaskIntoConstraints = false
+        inputField.alpha = 0.02
+        inputField.isAccessibilityElement = true
+        inputField.accessibilityLabel = "Terminal input"
+        inputField.addTarget(self, action: #selector(inputDidBegin), for: .editingDidBegin)
+        inputField.addTarget(self, action: #selector(inputDidEnd), for: .editingDidEnd)
+        inputField.onDeleteBackward = { [weak self] in self?.sendInput("\u{7F}") }
+        inputField.onInsert = { [weak self] in self?.sendInput($0) }
+        inputField.onCopyOutput = { [weak self] in self?.copyOutput() }
+        inputField.onPasteText = { [weak self] in self?.pasteText() }
+
+        var keyboardConfiguration = UIButton.Configuration.filled()
+        keyboardConfiguration.image = UIImage(systemName: "keyboard")
+        keyboardConfiguration.baseForegroundColor = UIColor(white: 0.88, alpha: 1)
+        keyboardConfiguration.baseBackgroundColor = UIColor(white: 0.10, alpha: 0.96)
+        keyboardConfiguration.background.cornerRadius = 24
+        keyboardConfiguration.background.strokeColor = UIColor(white: 0.25, alpha: 1)
+        keyboardConfiguration.background.strokeWidth = 1
+        keyboardButton.configuration = keyboardConfiguration
+        keyboardButton.accessibilityLabel = "Show keyboard"
+        keyboardButton.isHidden = true
+        keyboardButton.translatesAutoresizingMaskIntoConstraints = false
+        keyboardButton.addTarget(self, action: #selector(showKeyboard), for: .touchUpInside)
+
+        accessoryView.onAction = { [weak self] in self?.handleAccessoryAction($0) }
+
+        focusTapGesture.addTarget(self, action: #selector(viewportTapped))
+        terminalViewport.addGestureRecognizer(focusTapGesture)
+
+        scrollPanGesture.addTarget(self, action: #selector(viewportPanned(_:)))
+        scrollPanGesture.maximumNumberOfTouches = 1
+        scrollPanGesture.cancelsTouchesInView = false
+        terminalViewport.addGestureRecognizer(scrollPanGesture)
+
+        fontPinchGesture.addTarget(self, action: #selector(viewportPinched(_:)))
+        terminalViewport.addGestureRecognizer(fontPinchGesture)
+        terminalViewport.addInteraction(UIContextMenuInteraction(delegate: self))
+
+        addSubview(terminalViewport)
+        addSubview(inputField)
+        addSubview(keyboardButton)
+
+        NSLayoutConstraint.activate([
+            terminalViewport.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            terminalViewport.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            terminalViewport.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            terminalViewport.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+            inputField.trailingAnchor.constraint(equalTo: trailingAnchor),
+            inputField.topAnchor.constraint(equalTo: bottomAnchor, constant: 8),
+            inputField.widthAnchor.constraint(equalToConstant: 1),
+            inputField.heightAnchor.constraint(equalToConstant: 1),
+            keyboardButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            keyboardButton.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -16),
+            keyboardButton.widthAnchor.constraint(equalToConstant: 48),
+            keyboardButton.heightAnchor.constraint(equalToConstant: 48),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) { nil }
+
+    deinit { destroySurface() }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateContentScale()
+        if surface == nil { createSurfaceIfPossible() }
+
+        let viewportSize = terminalViewport.bounds.size
+        guard viewportSize != lastViewportSize || contentScaleFactor != lastContentScale else {
+            return
+        }
+        lastViewportSize = viewportSize
+        lastContentScale = contentScaleFactor
+        resizeSurface()
+        inputField.accessibilityFrame = terminalViewport.convert(terminalViewport.bounds, to: nil)
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window != nil, isRunning, !hasAutoFocused else { return }
+        hasAutoFocused = true
+        DispatchQueue.main.async { [weak self] in self?.requestKeyboardFocus() }
+    }
+
+    func textField(
+        _: UITextField,
+        shouldChangeCharactersIn _: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        if !string.isEmpty {
+            sendInput(string == "\n" || string == "\r\n" ? "\r" : string)
+        }
+        return false
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        sendInput("\r")
+        textField.text = ""
+        return false
+    }
+
+    func contextMenuInteraction(
+        _: UIContextMenuInteraction,
+        configurationForMenuAtLocation _: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            guard let self else { return UIMenu() }
+            let copy = UIAction(title: "Copy output", image: UIImage(systemName: "doc.on.doc")) { [weak self] _ in
+                self?.copyOutput()
+            }
+            let paste = UIAction(
+                title: "Paste",
+                image: UIImage(systemName: "doc.on.clipboard"),
+                attributes: self.isRunning && UIPasteboard.general.hasStrings ? [] : .disabled
+            ) { [weak self] _ in
+                self?.pasteText()
+            }
+            let clear = UIAction(title: "Clear", image: UIImage(systemName: "eraser")) { [weak self] _ in
+                self?.onClear?()
+            }
+            return UIMenu(children: [copy, paste, clear])
+        }
+    }
+
+    private func createSurfaceIfPossible() {
+        guard surface == nil, app == nil, !isCreatingSurface, !surfaceCreationFailed else { return }
+        guard terminalViewport.bounds.width > 0, terminalViewport.bounds.height > 0 else { return }
+        guard GhosttyRuntime.ensureInitialized() else {
+            surfaceCreationFailed = true
+            return
+        }
+
+        isCreatingSurface = true
+        defer { isCreatingSurface = false }
+
+        var runtimeConfig = ghostty_runtime_config_s(
+            userdata: Unmanaged.passUnretained(self).toOpaque(),
+            supports_selection_clipboard: false,
+            wakeup_cb: { _ in },
+            action_cb: { _, _, _ in false },
+            read_clipboard_cb: { _, _, _ in false },
+            confirm_read_clipboard_cb: { _, _, _, _ in },
+            write_clipboard_cb: { _, _, _, _, _ in },
+            close_surface_cb: { _, _ in }
+        )
+
+        guard let config = ghostty_config_new() else {
+            surfaceCreationFailed = true
+            return
+        }
+        loadThemeConfig(into: config)
+        ghostty_config_finalize(config)
+        defer { ghostty_config_free(config) }
+
+        guard let createdApp = ghostty_app_new(&runtimeConfig, config) else {
+            surfaceCreationFailed = true
+            return
+        }
+
+        var surfaceConfig = ghostty_surface_config_new()
+        surfaceConfig.platform_tag = GHOSTTY_PLATFORM_IOS
+        surfaceConfig.platform.ios.uiview = Unmanaged.passUnretained(terminalViewport).toOpaque()
+        surfaceConfig.userdata = Unmanaged.passUnretained(self).toOpaque()
+        surfaceConfig.scale_factor = Double(contentScaleFactor)
+        surfaceConfig.font_size = Float(fontSize)
+        surfaceConfig.context = GHOSTTY_SURFACE_CONTEXT_WINDOW
+        surfaceConfig.use_custom_io = true
+
+        guard let createdSurface = ghostty_surface_new(createdApp, &surfaceConfig) else {
+            ghostty_app_free(createdApp)
+            surfaceCreationFailed = true
+            return
+        }
+
+        app = createdApp
+        surface = createdSurface
+        ghostty_app_set_color_scheme(createdApp, GHOSTTY_COLOR_SCHEME_DARK)
+        ghostty_surface_set_color_scheme(createdSurface, GHOSTTY_COLOR_SCHEME_DARK)
+        setupWriteCallback()
+        resizeSurface()
+        feedBuffer(buffer)
+    }
+
+    private func resetSurface() {
+        destroySurface()
+        lastAppliedBuffer = ""
+        lastViewportSize = .zero
+        lastContentScale = 0
+        lastReportedGrid = nil
+        surfaceCreationFailed = false
+        setNeedsLayout()
+    }
+
+    private func refreshSurface() {
+        resetSurface()
+        createSurfaceIfPossible()
+    }
+
+    private func destroySurface() {
+        if let surface {
+            ghostty_surface_set_write_callback(surface, nil, nil)
+            ghostty_surface_free(surface)
+        }
+        if let app { ghostty_app_free(app) }
+        terminalViewport.layer.sublayers?.forEach { $0.removeFromSuperlayer() }
+        surface = nil
+        app = nil
+    }
+
+    private func applyRemoteBuffer(_ newBuffer: String) {
+        guard surface != nil else {
+            createSurfaceIfPossible()
+            return
+        }
+        guard newBuffer != lastAppliedBuffer else { return }
+
+        if newBuffer.isEmpty {
+            feedData(Data("\u{1B}[2J\u{1B}[H".utf8))
+            lastAppliedBuffer = ""
+            return
+        }
+
+        if newBuffer.hasPrefix(lastAppliedBuffer) {
+            feedData(Data(newBuffer.dropFirst(lastAppliedBuffer.count).utf8))
+            lastAppliedBuffer = newBuffer
+            return
+        }
+
+        resetSurface()
+        createSurfaceIfPossible()
+    }
+
+    private func feedBuffer(_ value: String) {
+        guard !value.isEmpty else { return }
+        isReplayingBuffer = true
+        defer { isReplayingBuffer = false }
+        feedData(Data(value.utf8))
+        lastAppliedBuffer = value
+    }
+
+    private func feedData(_ data: Data) {
+        guard let surface, !data.isEmpty else { return }
+        data.withUnsafeBytes { bytes in
+            guard let pointer = bytes.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
+            ghostty_surface_feed_data(surface, pointer, bytes.count)
+        }
+        redrawSurface()
+    }
+
+    private func setupWriteCallback() {
+        guard let surface else { return }
+        let userdata = Unmanaged.passUnretained(self).toOpaque()
+        ghostty_surface_set_write_callback(surface, { userdata, data, length in
+            guard let userdata, let data, length > 0 else { return }
+            let view = Unmanaged<GhosttyTerminalView>.fromOpaque(userdata).takeUnretainedValue()
+            guard !view.isReplayingBuffer else { return }
+            let bytes = Data(bytes: data, count: length)
+            guard let input = String(data: bytes, encoding: .utf8), !input.isEmpty else { return }
+            DispatchQueue.main.async { view.onInput?(input) }
+        }, userdata)
+    }
+
+    private func resizeSurface() {
+        guard let surface else {
+            emitEstimatedResize()
+            return
+        }
+
+        let scale = contentScaleFactor
+        let width = UInt32(max(floor(terminalViewport.bounds.width * scale), 1))
+        let height = UInt32(max(floor(terminalViewport.bounds.height * scale), 1))
+        terminalViewport.contentScaleFactor = scale
+        ghostty_surface_set_content_scale(surface, Double(scale), Double(scale))
+        ghostty_surface_set_size(surface, width, height)
+        ghostty_surface_set_occlusion(surface, window != nil)
+        configureIOSurfaceLayers()
+        redrawSurface()
+        emitGhosttyResize()
+    }
+
+    private func redrawSurface() {
+        guard let surface else { return }
+        ghostty_surface_refresh(surface)
+        ghostty_surface_draw(surface)
+        markIOSurfaceLayersForDisplay()
+        emitGhosttyResize()
+    }
+
+    private func emitGhosttyResize() {
+        guard let surface else {
+            emitEstimatedResize()
+            return
+        }
+        let size = ghostty_surface_size(surface)
+        emitResize(columns: max(1, Int(size.columns)), rows: max(1, Int(size.rows)))
+    }
+
+    private func emitEstimatedResize() {
+        guard bounds.width > 0, bounds.height > 0 else { return }
+        let columns = max(20, min(400, Int(bounds.width / max(fontSize * 0.62, 1))))
+        let rows = max(5, min(200, Int(bounds.height / max(fontSize * 1.35, 1))))
+        emitResize(columns: columns, rows: rows)
+    }
+
+    private func emitResize(columns: Int, rows: Int) {
+        guard lastReportedGrid?.columns != columns || lastReportedGrid?.rows != rows else { return }
+        lastReportedGrid = (columns, rows)
+        onResize?(columns, rows)
+    }
+
+    private func updateContentScale() {
+        let scale = window?.screen.scale ?? UIScreen.main.scale
+        if contentScaleFactor != scale { contentScaleFactor = scale }
+    }
+
+    private func requestKeyboardFocus() {
+        guard window != nil, isRunning else { return }
+        inputField.becomeFirstResponder()
+        if let surface { ghostty_surface_set_focus(surface, true) }
+        if let app { ghostty_app_keyboard_changed(app) }
+    }
+
+    private func sendInput(_ data: String) {
+        guard isRunning, !data.isEmpty else { return }
+        let resolved: String
+        if pendingModifier == .control {
+            resolved = TerminalHardwareKeyEncoder.applyingControl(to: data)
+        } else if pendingModifier == .command {
+            resolved = "\u{1B}\(data)"
+        } else {
+            resolved = data
+        }
+        pendingModifier = nil
+        onInput?(resolved)
+    }
+
+    private func copyOutput() {
+        UIPasteboard.general.string = TerminalText.plainText(from: buffer)
+    }
+
+    private func pasteText() {
+        guard let value = UIPasteboard.general.string, !value.isEmpty else { return }
+        sendInput(value)
+    }
+
+    private func handleAccessoryAction(_ action: TerminalAccessoryAction) {
+        switch action {
+        case .command, .control:
+            pendingModifier = pendingModifier == action ? nil : action
+        case .clear:
+            pendingModifier = nil
+            onClear?()
+        case .dismiss:
+            pendingModifier = nil
+            inputField.resignFirstResponder()
+        default:
+            if let sequence = action.sequence { sendInput(sequence) }
+        }
+    }
+
+    private func configureIOSurfaceLayers() {
+        let targetBounds = CGRect(origin: .zero, size: terminalViewport.bounds.size)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        terminalViewport.layer.sublayers?.forEach { layer in
+            layer.frame = targetBounds
+            layer.contentsScale = contentScaleFactor
+        }
+        CATransaction.commit()
+    }
+
+    private func markIOSurfaceLayersForDisplay() {
+        terminalViewport.layer.setNeedsDisplay()
+        terminalViewport.layer.sublayers?.forEach { $0.setNeedsDisplay() }
+    }
+
+    private func loadThemeConfig(into config: ghostty_config_t) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-swiftui-terminal.ghostty")
+        do {
+            if (try? String(contentsOf: url, encoding: .utf8)) != Self.themeConfig {
+                try Self.themeConfig.write(to: url, atomically: true, encoding: .utf8)
+            }
+            url.path.withCString { ghostty_config_load_file(config, $0) }
+        } catch {
+            // The default Ghostty configuration is still usable if the theme file cannot be staged.
+        }
+    }
+
+    @objc private func viewportTapped() {
+        requestKeyboardFocus()
+    }
+
+    @objc private func viewportPanned(_ gesture: UIPanGestureRecognizer) {
+        guard let surface else { return }
+        let location = gesture.location(in: terminalViewport)
+        ghostty_surface_mouse_pos(
+            surface,
+            Double(location.x * contentScaleFactor),
+            Double(location.y * contentScaleFactor),
+            GHOSTTY_MODS_NONE
+        )
+
+        switch gesture.state {
+        case .began:
+            pendingVerticalScrollPoints = 0
+            gesture.setTranslation(.zero, in: terminalViewport)
+        case .changed:
+            let translation = gesture.translation(in: terminalViewport)
+            let stepSize = max(
+                fontSize * Self.verticalScrollStepMultiplier,
+                Self.minimumVerticalScrollStepPoints
+            )
+            let total = pendingVerticalScrollPoints + translation.y
+            let steps = Int(total / stepSize)
+            pendingVerticalScrollPoints = total - CGFloat(steps) * stepSize
+            if steps != 0 {
+                ghostty_surface_mouse_scroll(surface, 0, Double(steps), 0)
+                redrawSurface()
+            }
+            gesture.setTranslation(.zero, in: terminalViewport)
+        default:
+            pendingVerticalScrollPoints = 0
+            gesture.setTranslation(.zero, in: terminalViewport)
+        }
+    }
+
+    @objc private func viewportPinched(_ gesture: UIPinchGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+        if gesture.scale >= 1.08 {
+            onFontSizeStep?(1)
+        } else if gesture.scale <= 0.92 {
+            onFontSizeStep?(-1)
+        }
+    }
+
+    @objc private func inputDidBegin() {
+        keyboardButton.isHidden = true
+        if let surface { ghostty_surface_set_focus(surface, true) }
+        if let app { ghostty_app_keyboard_changed(app) }
+    }
+
+    @objc private func inputDidEnd() {
+        pendingModifier = nil
+        keyboardButton.isHidden = !isRunning
+        if let surface { ghostty_surface_set_focus(surface, false) }
+    }
+
+    @objc private func showKeyboard() {
+        requestKeyboardFocus()
+    }
+}

--- a/apps/swift-ios/README.md
+++ b/apps/swift-ios/README.md
@@ -49,7 +49,8 @@ the active selection are stored separately in Application Support.
   photo/camera/file image attachments, turn cancellation, approval decisions, and
   structured user-input requests.
 - Workspace files and previews, working-tree review, Git status and common actions,
-  plus an interactive terminal session scoped to each thread.
+  plus Ghostty-rendered terminal sessions with VT/ANSI output, scrollback, hardware
+  and software keyboard controls, and per-thread session switching.
 - Native settings with persisted appearance and behavior preferences, platform
   deep links, shortcuts, background refresh, and notification routing.
 - A Share extension that imports text, URLs, and images into persistent project

--- a/apps/swift-ios/T3Code.xcodeproj/project.pbxproj
+++ b/apps/swift-ios/T3Code.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		B10000000000000000000001 /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = B30000000000000000000001 /* ClerkKit */; };
 		B10000000000000000000002 /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = B30000000000000000000002 /* ClerkKitUI */; };
+		D10000000000000000000001 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D40000000000000000000001 /* GhosttyKit.xcframework */; };
 		C10000000000000000000001 /* AgentActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40000000000000000000001 /* AgentActivityAttributes.swift */; };
 		C10000000000000000000002 /* SharedContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40000000000000000000002 /* SharedContainer.swift */; };
 		C10000000000000000000003 /* TaskWidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40000000000000000000003 /* TaskWidgetSnapshot.swift */; };
@@ -96,6 +97,7 @@
 			files = (
 				B10000000000000000000001 /* ClerkKit in Frameworks */,
 				B10000000000000000000002 /* ClerkKitUI in Frameworks */,
+				D10000000000000000000001 /* GhosttyKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,6 +159,7 @@
 				A10000000000000000000005 /* Resources */,
 				A10000000000000000000006 /* Tests */,
 				C30000000000000000000001 /* Extensions */,
+				D40000000000000000000001 /* GhosttyKit.xcframework */,
 				A30000000000000000000002 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -636,6 +639,19 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-lz",
+					"-framework",
+					IOSurface,
+					"-framework",
+					Metal,
+					"-framework",
+					MetalKit,
+					"-framework",
+					QuartzCore,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.t3tools.t3code.swiftui.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -680,6 +696,19 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-lz",
+					"-framework",
+					IOSurface,
+					"-framework",
+					Metal,
+					"-framework",
+					MetalKit,
+					"-framework",
+					QuartzCore,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.t3tools.t3code.swiftui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -963,6 +992,7 @@
 		C4000000000000000000000F /* T3CodeWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = T3CodeWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		C40000000000000000000010 /* T3CodeShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = T3CodeShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		C40000000000000000000011 /* ExtensionContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionContractTests.swift; sourceTree = "<group>"; };
+		D40000000000000000000001 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = ../mobile/modules/t3-terminal/Vendor/libghostty/GhosttyKit.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 	};
 	rootObject = A90000000000000000000001 /* Project object */;

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -259,6 +259,57 @@ struct FeatureToolStateTests {
     @Test
     func terminalPlainTextDropsControlSequences() {
         let prompt = "\u{1B}]0;workspace\u{7}\u{1B}[38;5;221mx\u{8}repo\u{1B}[39m ❯ "
-        #expect(NativeWorkspaceMapper.terminalText(prompt) == "repo ❯ ")
+        #expect(TerminalText.plainText(from: prompt) == "repo ❯ ")
+    }
+
+    @Test
+    func terminalSessionSelectionPrefersAndAllocatesStableIDs() {
+        let sessions = [
+            FeatureTerminalSnapshot(
+                threadID: "thread",
+                terminalID: "term-2",
+                state: .running,
+                title: "Tests"
+            ),
+            FeatureTerminalSnapshot(
+                threadID: "thread",
+                terminalID: "default",
+                state: .running
+            ),
+            FeatureTerminalSnapshot(
+                threadID: "thread",
+                terminalID: "term-3",
+                state: .exited
+            ),
+        ]
+
+        #expect(TerminalSessionList.initialID(in: sessions) == "default")
+        #expect(TerminalSessionList.nextID(occupiedIDs: ["default", "term-2", "term-4"]) == "term-3")
+        #expect(TerminalSessionList.displayTitle(for: sessions[0]) == "Terminal 2 · Tests")
+        #expect(TerminalSessionList.displayTitle(for: sessions[1]) == "Terminal 1")
+        #expect(
+            TerminalSessionList.fallbackID(in: sessions, excluding: "default") == "term-2"
+        )
+    }
+
+    @Test
+    func terminalSnapshotPreservesVTDataForGhostty() {
+        let history = "\u{1B}[31mred\u{1B}[0m\r\n"
+        let snapshot = TerminalSessionSnapshot(
+            threadId: "thread",
+            terminalId: "default",
+            cwd: "/repo",
+            worktreePath: nil,
+            status: .running,
+            pid: 123,
+            history: history,
+            exitCode: nil,
+            exitSignal: nil,
+            label: "Terminal",
+            updatedAt: "2026-08-07T00:00:00Z",
+            sequence: 1
+        )
+
+        #expect(NativeWorkspaceMapper.terminal(snapshot).buffer == history)
     }
 }


### PR DESCRIPTION
The SwiftUI terminal was a plain-text command box, so ANSI output, TUIs, scrollback, keyboard workflows, and multiple shell sessions fell short of the React Native app.

This replaces it with a native Ghostty-backed full-canvas terminal, adds mobile and hardware keyboard controls, accurate resizing and scrollback, stable clear/reconnect behavior, and independent per-thread terminal sessions.

Stacks on #5178.

## Before / after

| Before | After |
| --- | --- |
| ![Before](https://files.tslop.org/2026/08/swiftui-terminal-before-2a2e1e4b.jpg) | ![After](https://files.tslop.org/2026/08/swiftui-terminal-after-fb2188e8.jpg) |

## Demo

![Terminal demo](https://files.tslop.org/2026/08/swiftui-terminal-preview-37aa4839.gif)

[Full-quality screen recording](https://files.tslop.org/2026/08/swiftui-terminal-demo-06706a29.mp4)

## Verification

- `T3CodeTests/FeatureToolStateTests`
- `T3CodeTests/NativeMultiEnvironmentTests`
- `T3CodeTests/CoreContractTests`
- 37 tests passed, 0 failed
- iPhone 17 Pro Simulator: ANSI colors, clear/reconnect, Ctrl-C, resize, and session create/switch/stop fallback

This PR was built by GPT-5.6-sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new native dependency and reworked terminal RPC/stream lifecycle; behavior is user-facing but scoped to the terminal feature with existing T3 RPC contracts.
> 
> **Overview**
> Replaces the **plain-text terminal** with a **GhosttyKit**-rendered surface so VT/ANSI output, TUIs, and scrollback work like the RN app. The UI is a full-screen canvas with pinch-to-zoom text size, a session menu (switch, open, stop), and software/hardware keyboard controls (accessory bar, Ctrl/Cmd modifiers, copy/paste/clear).
> 
> **Client and protocol:** Terminal APIs are now keyed by **`terminalID`** per thread instead of one implicit shell. `NativeFeatureClient` drops the shared `terminalEvents` fan-out and uses **`attachTerminal`** per session plus a new **`terminalSessions`** stream from **`terminalMetadataEvents`**. Snapshots keep raw escape sequences (stripping moved to `TerminalText` for copy-only). **`clearTerminal`** is added; buffer cap rises to 512KB.
> 
> **Build:** Xcode links **`GhosttyKit.xcframework`** with Metal/IOSurface/QuartzCore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9975f2f86de4a7e76c560a50b46aadc4b16116c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace text buffer terminal with Ghostty-rendered terminal surface in iOS app
> - Replaces the static `ScrollView`/`Text` buffer and `TextField` command input with a `GhosttyTerminalSurface` backed by [TerminalSurfaceView.swift](https://github.com/pingdotgg/t3code/pull/5602/files#diff-54979dce1a595d296518af7d256b0658fc60f08289ca37782a97cb3dac4df0e9), providing VT/ANSI rendering, scrollback, and native keyboard input via a UIKit layer.
> - Adds multi-session support: `FeatureClient` and `NativeFeatureClient` now manage terminals per `(threadID, terminalID)`, replacing the single implicit terminal per thread; users can open, switch, and close multiple terminal sessions per thread.
> - Adds a terminal menu (session list, font size control, clear, start/stop) replacing inline header buttons; font size is clamped between 6.0–14.0pt with 0.5pt steps.
> - Raw VT/ANSI output is now preserved in `FeatureTerminalSnapshot.buffer` and stripped only at copy time via `TerminalText.plainText`; `NativeWorkspaceMapper.terminalText` is removed.
> - Behavioral Change: terminal buffer cap doubles to 512 KiB; writes no longer return a success flag; stopping a terminal auto-selects a fallback running session if one exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9975f2f. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->