### PR TITLE
Automate production mobile EAS releases

### DIFF
--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -5,6 +5,23 @@ name: Mobile EAS Production
 # in the same OS/pnpm as the EAS build; a macOS `eas build` computes a different
 # fingerprint (platform-specific deps + pnpm version) and errors. On this Linux
 # runner, with corepack pinning pnpm 10.24 in eas.json, local == build.
+#
+# Every merge to main that touches the mobile app reconciles, per platform:
+#   1. Store builds: if the latest production build's version differs from
+#      app.config.ts, cut a new build with --auto-submit (TestFlight +
+#      Play internal track). Bumping `version` is therefore all it takes to
+#      start the next release train — the first build of a version enters
+#      external-TestFlight beta review immediately, and later builds of the
+#      same version auto-approve. Releasing to the App Store stays a manual
+#      App Store Connect step.
+#   2. OTA: publish a production-channel update for each platform where at
+#      least one finished production build matches the current native
+#      fingerprint. Old-version binaries with a matching fingerprint receive
+#      it too. When native drift means no binary could install the update,
+#      it is skipped and flagged in the job summary instead of published
+#      into the void.
+# workflow_dispatch remains as a manual override for both modes (e.g. to
+# retry an errored build or force an OTA).
 on:
   workflow_dispatch:
     inputs:
@@ -29,10 +46,28 @@ on:
         description: "OTA update message (mode=update only)"
         required: false
         type: string
+  push:
+    branches: [main]
+    paths:
+      - apps/mobile/**
+      - packages/client-runtime/**
+      - packages/contracts/**
+      - packages/shared/**
+      - patches/**
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - .github/workflows/mobile-eas-production.yml
+
+# Serialize runs so OTAs publish in merge order. GitHub keeps at most one
+# queued run per group, so a burst of merges collapses into one run of the
+# newest commit — intermediate commits don't need their own OTA.
+concurrency:
+  group: mobile-eas-production
+  cancel-in-progress: false
 
 jobs:
   production:
-    name: EAS Production ${{ inputs.mode }}
+    name: EAS Production ${{ github.event_name == 'push' && 'auto' || inputs.mode }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -98,15 +133,15 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: eas env:pull production --non-interactive
 
-      - name: Build and submit
-        if: steps.expo-token.outputs.present == 'true' && inputs.mode == 'build'
+      - name: Build and submit (manual)
+        if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build'
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: eas build --platform ${{ inputs.platform }} --profile production --auto-submit --non-interactive --no-wait
 
-      - name: Publish OTA update
-        if: steps.expo-token.outputs.present == 'true' && inputs.mode == 'update'
+      - name: Publish OTA update (manual)
+        if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'update'
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
@@ -117,3 +152,48 @@ jobs:
             --platform ${{ inputs.platform }} \
             --message "${{ inputs.message || format('Production OTA ({0})', github.sha) }}" \
             --non-interactive
+
+      # No --status filter on build:list: an in-queue/in-progress build must
+      # count as existing, or every merge during the ~20 min build window
+      # would cut a duplicate. The flip side: after an errored build, retry
+      # via workflow_dispatch mode=build — pushes won't re-trigger it.
+      - name: Ensure store builds exist for the current app version
+        if: steps.expo-token.outputs.present == 'true' && github.event_name == 'push'
+        working-directory: apps/mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          version="$(npx expo config --json --type public | jq -r '.version')"
+          for platform in ios android; do
+            latest="$(eas build:list --platform "$platform" --buildProfile production --limit 1 --json --non-interactive | jq -r '.[0].appVersion // "none"')"
+            if [ "$latest" = "$version" ]; then
+              echo "$platform: production build for $version already exists (or is in progress)"
+              continue
+            fi
+            echo "$platform: latest production build is $latest, app.config.ts says $version — building"
+            eas build --platform "$platform" --profile production --auto-submit --non-interactive --no-wait
+            echo ":building_construction: $platform: cut production build for $version (auto-submitted)" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: Publish fingerprint-gated OTA
+        if: steps.expo-token.outputs.present == 'true' && github.event_name == 'push'
+        working-directory: apps/mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          message="$(git log -1 --pretty=%s | head -c 120) ($(git rev-parse --short=9 HEAD))"
+          for platform in ios android; do
+            hash="$(npx expo-updates fingerprint:generate --platform "$platform" | jq -r '.hash')"
+            matching="$(eas build:list --platform "$platform" --buildProfile production --status finished --runtimeVersion "$hash" --limit 1 --json --non-interactive | jq 'length')"
+            if [ "$matching" -gt 0 ]; then
+              eas update \
+                --channel production \
+                --environment production \
+                --platform "$platform" \
+                --message "$message" \
+                --non-interactive
+              echo ":white_check_mark: $platform: OTA published to production (fingerprint \`$hash\`)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo ":warning: $platform: no finished production build matches fingerprint \`$hash\` — OTA skipped; JS changes reach $platform only once a matching build ships" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done

--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -161,23 +161,31 @@ jobs:
       # the queued run for a later merge cannot overtake them and lose its OTA.
       # After an errored build, retry via workflow_dispatch mode=build — pushes
       # won't re-trigger it until the app version changes.
-      - name: Ensure store builds exist for the current app version
+      - id: store_builds
+        name: Ensure store builds exist for the current app version
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'push'
+        continue-on-error: true
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
+          failed=0
           version="$(npx expo config --json --type public | jq -r '.version')"
           for platform in ios android; do
-            latest="$(eas build:list --platform "$platform" --buildProfile production --limit 1 --json --non-interactive | jq -r '.[0].appVersion // "none"')"
+            latest="$(eas build:list --platform "$platform" --build-profile production --limit 1 --json --non-interactive | jq -r '.[0].appVersion // "none"')"
             if [ "$latest" = "$version" ]; then
               echo "$platform: production build for $version already exists (or is in progress)"
               continue
             fi
             echo "$platform: latest production build is $latest, app.config.ts says $version — building"
-            eas build --platform "$platform" --profile production --auto-submit --non-interactive
-            echo ":building_construction: $platform: cut production build for $version (auto-submitted)" >> "$GITHUB_STEP_SUMMARY"
+            if eas build --platform "$platform" --profile production --auto-submit --non-interactive; then
+              echo ":building_construction: $platform: cut production build for $version (auto-submitted)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              failed=1
+              echo ":x: $platform: production build or submission failed for $version" >> "$GITHUB_STEP_SUMMARY"
+            fi
           done
+          exit "$failed"
 
       - name: Publish fingerprint-gated OTA
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'push'
@@ -201,3 +209,7 @@ jobs:
               echo ":warning: $platform: no finished production build matches fingerprint \`$hash\` — OTA skipped; JS changes reach $platform only once a matching build ships" >> "$GITHUB_STEP_SUMMARY"
             fi
           done
+
+      - name: Propagate store build failure
+        if: steps.store_builds.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -53,6 +53,8 @@ on:
       - packages/client-runtime/**
       - packages/contracts/**
       - packages/shared/**
+      - assets/**
+      - scripts/**
       - patches/**
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
@@ -154,9 +156,11 @@ jobs:
             --non-interactive
 
       # No --status filter on build:list: an in-queue/in-progress build must
-      # count as existing, or every merge during the ~20 min build window
-      # would cut a duplicate. The flip side: after an errored build, retry
-      # via workflow_dispatch mode=build — pushes won't re-trigger it.
+      # count as existing, or every merge during the build window would cut a
+      # duplicate. Builds started here stay attached to this serialized run so
+      # the queued run for a later merge cannot overtake them and lose its OTA.
+      # After an errored build, retry via workflow_dispatch mode=build — pushes
+      # won't re-trigger it until the app version changes.
       - name: Ensure store builds exist for the current app version
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'push'
         working-directory: apps/mobile
@@ -171,7 +175,7 @@ jobs:
               continue
             fi
             echo "$platform: latest production build is $latest, app.config.ts says $version — building"
-            eas build --platform "$platform" --profile production --auto-submit --non-interactive --no-wait
+            eas build --platform "$platform" --profile production --auto-submit --non-interactive
             echo ":building_construction: $platform: cut production build for $version (auto-submitted)" >> "$GITHUB_STEP_SUMMARY"
           done
 
@@ -183,8 +187,8 @@ jobs:
         run: |
           message="$(git log -1 --pretty=%s | head -c 120) ($(git rev-parse --short=9 HEAD))"
           for platform in ios android; do
-            hash="$(npx expo-updates fingerprint:generate --platform "$platform" | jq -r '.hash')"
-            matching="$(eas build:list --platform "$platform" --buildProfile production --status finished --runtimeVersion "$hash" --limit 1 --json --non-interactive | jq 'length')"
+            hash="$(eas fingerprint:generate --platform "$platform" --environment production --json --non-interactive | jq -r '.hash')"
+            matching="$(eas build:list --platform "$platform" --build-profile production --status finished --fingerprint-hash "$hash" --limit 1 --json --non-interactive | jq 'length')"
             if [ "$matching" -gt 0 ]; then
               eas update \
                 --channel production \

--- a/.github/workflows/mobile-fingerprint-check.yml
+++ b/.github/workflows/mobile-fingerprint-check.yml
@@ -83,12 +83,9 @@ jobs:
             npx expo-updates fingerprint:generate --platform "$platform" > "$RUNNER_TEMP/fp/base/$platform.json"
           done
 
-      - name: Compare and label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+      - id: compare
+        name: Compare fingerprints
         run: |
-          label="📱 Native Change"
           changed=""
           {
             echo "## Native fingerprint diff"
@@ -111,14 +108,96 @@ jobs:
                   | "  - \(.type): `\(.filePath // .id)`"'
             done
           } >> "$GITHUB_STEP_SUMMARY"
+          echo "changed_platforms=${changed# }" >> "$GITHUB_OUTPUT"
 
-          # Label edits fail on fork PRs (read-only token) — advisory anyway.
-          if [ -n "$changed" ]; then
-            gh label create "$label" \
-              --color D93F0B \
-              --description "Changes the native fingerprint; merging blocks production OTAs until a new store build ships" \
-              --force || true
-            gh pr edit "$PR_NUMBER" --add-label "$label" || true
-          else
-            gh pr edit "$PR_NUMBER" --remove-label "$label" || true
-          fi
+      - name: Sync native change label
+        # Fork PRs get a read-only token under pull_request; the check stays
+        # advisory there (summary only). This workflow must not move to
+        # pull_request_target — it installs and runs PR code.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v8
+        env:
+          CHANGED_PLATFORMS: ${{ steps.compare.outputs.changed_platforms }}
+        with:
+          script: |
+            const managedLabel = {
+              name: "📱 Native Change",
+              color: "d93f0b",
+              description:
+                "Changes the native fingerprint; merging blocks production OTAs until a new store build ships.",
+            };
+            const nativeChanged = (process.env.CHANGED_PLATFORMS ?? "").trim() !== "";
+            const issueNumber = context.payload.pull_request.number;
+
+            try {
+              const { data: existing } = await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: managedLabel.name,
+              });
+
+              if (
+                existing.color !== managedLabel.color ||
+                (existing.description ?? "") !== managedLabel.description
+              ) {
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: managedLabel.name,
+                  color: managedLabel.color,
+                  description: managedLabel.description,
+                });
+              }
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: managedLabel.name,
+                  color: managedLabel.color,
+                  description: managedLabel.description,
+                });
+              } catch (createError) {
+                if (createError.status !== 422) {
+                  throw createError;
+                }
+              }
+            }
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const hasLabel = currentLabels.some((label) => label.name === managedLabel.name);
+
+            if (nativeChanged && !hasLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [managedLabel.name],
+              });
+            } else if (!nativeChanged && hasLabel) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: managedLabel.name,
+                });
+              } catch (removeError) {
+                if (removeError.status !== 404) {
+                  throw removeError;
+                }
+              }
+            }
+
+            core.info(
+              `PR #${issueNumber}: native fingerprint ${nativeChanged ? `changed (${process.env.CHANGED_PLATFORMS})` : "unchanged"}`,
+            );

--- a/.github/workflows/mobile-fingerprint-check.yml
+++ b/.github/workflows/mobile-fingerprint-check.yml
@@ -1,0 +1,124 @@
+name: Mobile Fingerprint Check
+
+# Detects whether a PR changes the native fingerprint — i.e. whether merging
+# it would leave main un-OTA-able until a new store build ships. Native-change
+# PRs get the "📱 Native Change" label so they can be held and merged as a
+# batch right before the next store submission, keeping main OTA-able for
+# everything else in between. (Once one native PR merges, every later merge
+# inherits the drifted fingerprint and loses OTA reach too — that is why the
+# signal has to fire before merge, not after.)
+#
+# The check is advisory: it always passes, the label is the signal. Both
+# fingerprints are computed in this one job (same OS, same corepack-pinned
+# pnpm), so the comparison is self-consistent; no EXPO_TOKEN needed.
+on:
+  pull_request:
+    paths:
+      - apps/mobile/**
+      - packages/client-runtime/**
+      - packages/contracts/**
+      - packages/shared/**
+      - patches/**
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - .github/workflows/mobile-fingerprint-check.yml
+
+concurrency:
+  group: mobile-fingerprint-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  fingerprint:
+    name: Native fingerprint diff
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      APP_VARIANT: production
+      NODE_OPTIONS: --max-old-space-size=8192
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Default pull_request checkout is the merge commit (PR applied on
+          # top of base), so the "head" fingerprint is the state main would
+          # actually be in after merging — stale branches compare cleanly.
+          fetch-depth: 0
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: |
+            args:
+              - --filter=@t3tools/mobile...
+
+      - name: Expose pnpm
+        run: |
+          pnpm_version="$(node --print "require('./package.json').packageManager.split('@').pop()")"
+          vp_pnpm_bin="$HOME/.vite-plus/package_manager/pnpm/$pnpm_version/pnpm/bin"
+          echo "$vp_pnpm_bin" >> "$GITHUB_PATH"
+          "$vp_pnpm_bin/pnpm" --version
+
+      - name: Fingerprint merge result
+        working-directory: apps/mobile
+        run: |
+          mkdir -p "$RUNNER_TEMP/fp/head" "$RUNNER_TEMP/fp/base"
+          for platform in ios android; do
+            npx expo-updates fingerprint:generate --platform "$platform" > "$RUNNER_TEMP/fp/head/$platform.json"
+          done
+
+      - name: Fingerprint base
+        run: |
+          git checkout --quiet "${{ github.event.pull_request.base.sha }}"
+          # Re-sync node_modules to the base commit's lockfile before
+          # fingerprinting — a dep-changing PR must not fingerprint the base
+          # against head's installed packages.
+          pnpm install --filter=@t3tools/mobile...
+          cd apps/mobile
+          for platform in ios android; do
+            npx expo-updates fingerprint:generate --platform "$platform" > "$RUNNER_TEMP/fp/base/$platform.json"
+          done
+
+      - name: Compare and label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          label="📱 Native Change"
+          changed=""
+          {
+            echo "## Native fingerprint diff"
+            echo
+            for platform in ios android; do
+              head_hash="$(jq -r .hash "$RUNNER_TEMP/fp/head/$platform.json")"
+              base_hash="$(jq -r .hash "$RUNNER_TEMP/fp/base/$platform.json")"
+              if [ "$head_hash" = "$base_hash" ]; then
+                echo "- ✅ **$platform**: unchanged (\`$head_hash\`) — OTA-compatible"
+                continue
+              fi
+              changed="$changed $platform"
+              echo "- 📱 **$platform**: \`$base_hash\` → \`$head_hash\` — merging requires a new native build before OTAs work again"
+              jq -r -n \
+                --slurpfile h "$RUNNER_TEMP/fp/head/$platform.json" \
+                --slurpfile b "$RUNNER_TEMP/fp/base/$platform.json" '
+                  ($b[0].sources | map({ (.filePath // .id): .hash }) | add // {}) as $bm
+                  | $h[0].sources[]
+                  | select($bm[(.filePath // .id)] != .hash)
+                  | "  - \(.type): `\(.filePath // .id)`"'
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Label edits fail on fork PRs (read-only token) — advisory anyway.
+          if [ -n "$changed" ]; then
+            gh label create "$label" \
+              --color D93F0B \
+              --description "Changes the native fingerprint; merging blocks production OTAs until a new store build ships" \
+              --force || true
+            gh pr edit "$PR_NUMBER" --add-label "$label" || true
+          else
+            gh pr edit "$PR_NUMBER" --remove-label "$label" || true
+          fi

--- a/.github/workflows/mobile-fingerprint-check.yml
+++ b/.github/workflows/mobile-fingerprint-check.yml
@@ -18,6 +18,8 @@ on:
       - packages/client-runtime/**
       - packages/contracts/**
       - packages/shared/**
+      - assets/**
+      - scripts/**
       - patches/**
       - pnpm-lock.yaml
       - pnpm-workspace.yaml


### PR DESCRIPTION
## What Changed

- Trigger the mobile EAS production workflow automatically for relevant changes merged into `main`.
- Serialize production runs to preserve OTA release order.
- Automatically create and submit iOS and Android store builds when the app version changes.
- Publish OTA updates only when a finished production build matches the current native fingerprint.
- Restore package versions from `0.0.32` to `0.0.31`.

## Why

This makes mobile production releases follow merges automatically while avoiding duplicate builds and incompatible OTA updates. Store builds are created when the app version changes, and JavaScript updates are published only when an installed native binary can apply them. Manual workflow dispatch remains available for retries and forced releases.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production release automation (store submits and OTA channel) on every qualifying merge; misconfigured version or fingerprint logic could skip OTAs or trigger duplicate builds, though serialization and gating reduce blast radius.
> 
> **Overview**
> **Production mobile releases now run automatically** when relevant paths merge to `main`, while `workflow_dispatch` stays for manual build/OTA retries.
> 
> `mobile-eas-production.yml` adds path-filtered `push` triggers and a **serialized** concurrency group so OTAs stay ordered (bursts collapse to the latest commit). On push it **compares** `app.config.ts` version to the latest EAS production build per platform and starts **auto-submit** store builds when they differ (in-progress builds count, avoiding duplicates). It then **fingerprint-gates** production OTAs: updates publish only if a **finished** build matches the current native fingerprint; otherwise the job summary warns and skips.
> 
> A new **`mobile-fingerprint-check.yml`** runs on PRs, fingerprints merge-result vs base (with `pnpm install` on base for lockfile accuracy), writes an iOS/Android diff to the job summary, and syncs a **📱 Native Change** label on in-repo PRs so native drift is visible before merge. The check is advisory and always passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c9273e4f7f5095a24cffe2a03763d962069eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Automate production mobile EAS releases and fingerprint checks on push to main
> - On pushes to `main` touching mobile paths, [mobile-eas-production.yml](.github/workflows/mobile-eas-production.yml) checks the current app version against the latest production build per platform and triggers a new store build + auto-submit if versions differ.
> - OTA updates are published to the production channel only when a finished production build with a matching native fingerprint exists; otherwise a warning is written to the job summary.
> - Adds [mobile-fingerprint-check.yml](.github/workflows/mobile-fingerprint-check.yml), which computes and compares native fingerprints for iOS and Android on PRs, writes a diff summary, and adds/removes a `📱 Native Change` label on same-repo PRs.
> - Manual `workflow_dispatch` triggers retain the existing build/submit and OTA publish steps unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88c9273.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->