### PR TITLE
fix(ios): support image paste from composer edit menu

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -676,6 +676,10 @@ enum FeatureComposerTextSelectionPolicy {
         let lowerIndex = text.index(text.startIndex, offsetBy: lower)
         return text[..<lowerIndex].utf16.count + replacement.utf16.count
     }
+
+    static func cursorLocationAfterBindingUpdate(previousText: String, newText: String, selectedLocation: Int) -> Int {
+        previousText.isEmpty ? newText.utf16.count : min(selectedLocation, newText.utf16.count)
+    }
 }
 
 enum FeatureComposerPasteTextPolicy {
@@ -745,7 +749,6 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
         textView.adjustsFontForContentSizeCategory = true
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
-        // Return always edits the draft; sending is deliberately button-only.
         textView.isScrollEnabled = false
         textView.accessibilityIdentifier = "message-composer"
         updateAccessibility(textView)
@@ -761,11 +764,14 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
             context.coordinator.lastAppliedSelectionRequestID != $0.id
         } ?? false
         if textView.text != text {
+            let previousText = textView.text ?? ""
             let selectedRange = textView.selectedRange
             textView.text = text
             if !shouldApplySelection {
-                let location = min(selectedRange.location, textView.text.utf16.count)
-                let length = min(selectedRange.length, textView.text.utf16.count - location)
+                let location = FeatureComposerTextSelectionPolicy.cursorLocationAfterBindingUpdate(
+                    previousText: previousText, newText: text, selectedLocation: selectedRange.location
+                )
+                let length = previousText.isEmpty ? 0 : min(selectedRange.length, text.utf16.count - location)
                 textView.selectedRange = NSRange(location: location, length: length)
             }
         }

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -42,6 +42,7 @@ struct FeatureComposerView: View {
         providers: [FeatureProvider],
         threadSelection: FeatureSelection?,
         attachmentContextID: String,
+        attachmentLifecycle injectedAttachmentLifecycle: FeatureAttachmentLifecycle? = nil,
         materializesDefaultSelection: Bool = true,
         isSending: Bool,
         isWorking: Bool,
@@ -60,7 +61,8 @@ struct FeatureComposerView: View {
         _text = text
         _selection = selection
         _attachments = attachments
-        let attachmentLifecycle = FeatureAttachmentLifecycle(contextID: attachmentContextID)
+        let attachmentLifecycle = injectedAttachmentLifecycle
+            ?? FeatureAttachmentLifecycle(contextID: attachmentContextID)
         _attachmentLifecycle = State(initialValue: attachmentLifecycle)
         _pasteQueue = State(
             initialValue: FeatureComposerPasteQueue(lifecycle: attachmentLifecycle)
@@ -131,7 +133,7 @@ struct FeatureComposerView: View {
                 await updatePathSearch()
             }
             .onChange(of: attachmentContextID) {
-                rotateAttachmentLifecycle(to: attachmentContextID)
+                synchronizeAttachmentLifecycle(to: attachmentContextID)
             }
             .alert(
                 "Couldn’t paste image",
@@ -557,6 +559,14 @@ struct FeatureComposerView: View {
         pasteQueue.cancelAll()
         attachmentPreparation.cancelAll()
     }
+
+    private func synchronizeAttachmentLifecycle(to contextID: String) {
+        if attachmentLifecycle.token(for: contextID) == nil {
+            attachmentLifecycle.transition(to: contextID)
+        }
+        pasteQueue.cancelAll()
+        attachmentPreparation.cancelAll()
+    }
 }
 
 enum FeatureComposerCollapsePolicy {
@@ -688,17 +698,23 @@ enum FeatureComposerPasteTextPolicy {
             let itemSet = IndexSet(integer: itemIndex)
             let typeIdentifiers = pasteboard.types(forItemSet: itemSet)?
                 .first ?? []
-            guard !typeIdentifiers.contains(where: {
-                UTType($0)?.conforms(to: .image) == true
-            }) else { return nil }
+            let textTypeIdentifiers = typeIdentifiers.filter {
+                UTType($0)?.conforms(to: .image) != true
+            }
+            guard !textTypeIdentifiers.isEmpty else { return nil }
 
-            for typeIdentifier in preferredPlainTextTypes(in: typeIdentifiers) {
-                if let value = pasteboard.values(
+            for typeIdentifier in preferredPlainTextTypes(in: textTypeIdentifiers) {
+                guard let value = pasteboard.values(
                     forPasteboardType: typeIdentifier,
                     inItemSet: itemSet
-                )?.first as? String,
-                   !value.isEmpty {
-                    return value
+                )?.first else { continue }
+                if let string = value as? String, !string.isEmpty {
+                    return string
+                }
+                if let data = value as? Data,
+                   let string = String(data: data, encoding: .utf8),
+                   !string.isEmpty {
+                    return string
                 }
             }
             return nil

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -731,8 +731,10 @@ enum FeatureComposerPasteTextPolicy {
                 return String(data: data, encoding: .utf16)
             }
             if type.conforms(to: .utf16ExternalPlainText) {
-                return String(data: data, encoding: .utf16LittleEndian)
-                    ?? String(data: data, encoding: .utf16BigEndian)
+                // RFC 2781 defines big-endian as the default for UTF-16 data
+                // without a byte-order mark in an external representation.
+                return String(data: data, encoding: .utf16BigEndian)
+                    ?? String(data: data, encoding: .utf16LittleEndian)
             }
             return String(data: data, encoding: .utf16)
                 ?? String(data: data, encoding: .utf16LittleEndian)

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -1,12 +1,18 @@
 import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
 
 struct FeatureComposerView: View {
     @State private var isManuallyExpanded = false
     @State private var isAttachmentFlowActive = false
     @State private var attachmentPreparation = FeatureAttachmentPreparationState()
+    @State private var attachmentLifecycle: FeatureAttachmentLifecycle
+    @State private var pasteQueue: FeatureComposerPasteQueue
     @State private var pathEntries: [FeatureComposerPathEntry] = []
     @State private var isPathSearchLoading = false
     @State private var pathSearchError: String?
+    @State private var attachmentErrorMessage: String?
+    @State private var textSelectionRequest: FeatureComposerTextSelectionRequest?
     @Binding private var text: String
     @Binding private var selection: FeatureSelection?
     @Binding private var attachments: [FeatureDraftAttachment]
@@ -16,6 +22,7 @@ struct FeatureComposerView: View {
     private let materializesDefaultSelection: Bool
     private let isSending: Bool
     private let isWorking: Bool
+    private let attachmentContextID: String
     private let focused: FocusState<Bool>.Binding
     private let contextUsage: Double?
     private let forceExpanded: Bool
@@ -34,6 +41,7 @@ struct FeatureComposerView: View {
         attachments: Binding<[FeatureDraftAttachment]>,
         providers: [FeatureProvider],
         threadSelection: FeatureSelection?,
+        attachmentContextID: String,
         materializesDefaultSelection: Bool = true,
         isSending: Bool,
         isWorking: Bool,
@@ -52,8 +60,14 @@ struct FeatureComposerView: View {
         _text = text
         _selection = selection
         _attachments = attachments
+        let attachmentLifecycle = FeatureAttachmentLifecycle(contextID: attachmentContextID)
+        _attachmentLifecycle = State(initialValue: attachmentLifecycle)
+        _pasteQueue = State(
+            initialValue: FeatureComposerPasteQueue(lifecycle: attachmentLifecycle)
+        )
         self.providers = providers
         self.threadSelection = threadSelection
+        self.attachmentContextID = attachmentContextID
         self.materializesDefaultSelection = materializesDefaultSelection
         self.isSending = isSending
         self.isWorking = isWorking
@@ -115,6 +129,20 @@ struct FeatureComposerView: View {
             }
             .task(id: pathSearchRequest) {
                 await updatePathSearch()
+            }
+            .onChange(of: attachmentContextID) {
+                rotateAttachmentLifecycle(to: attachmentContextID)
+            }
+            .alert(
+                "Couldn’t paste image",
+                isPresented: Binding(
+                    get: { attachmentErrorMessage != nil },
+                    set: { if !$0 { attachmentErrorMessage = nil } }
+                )
+            ) {
+                Button("OK") { attachmentErrorMessage = nil }
+            } message: {
+                Text(attachmentErrorMessage ?? "")
             }
     }
 
@@ -192,20 +220,31 @@ struct FeatureComposerView: View {
                     .padding(.horizontal, 13)
             }
 
-            TextField(
-                isWorking ? "Message to queue…" : "Ask anything…",
-                text: $text,
-                axis: .vertical
-            )
-                .font(T3Typography.composer)
-                .lineLimit(1...7)
-                .focused(focused)
-                // Return is always editing input. Sending is deliberately button-only.
-                .submitLabel(.return)
+            let placeholder = isWorking ? "Message to queue…" : "Ask anything…"
+            ZStack(alignment: .topLeading) {
+                FeatureComposerTextInput(
+                    text: $text,
+                    focused: focused,
+                    placeholder: placeholder,
+                    acceptsImages: imagesAllowed,
+                    selectionRequest: textSelectionRequest,
+                    onPasteImages: loadPastedImages
+                )
                 .padding(.horizontal, 16)
                 .padding(.top, 14)
-                .padding(.bottom, 7)
-                .frame(minHeight: 62, alignment: .top)
+
+                if text.isEmpty {
+                    Text(placeholder)
+                        .font(T3Typography.composer)
+                        .foregroundStyle(T3Colors.textTertiary)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 14)
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.bottom, 7)
+            .frame(minHeight: 62, alignment: .top)
 
             if !attachments.isEmpty, !imagesAllowed {
                 Label("Choose a model that accepts images", systemImage: "exclamationmark.circle")
@@ -230,12 +269,69 @@ struct FeatureComposerView: View {
         }
     }
 
+    private func loadPastedImages(_ providers: [NSItemProvider]) {
+        guard imagesAllowed,
+              let lifecycleToken = attachmentLifecycle.token(for: attachmentContextID) else {
+            return
+        }
+        let imageProviders = providers.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+        }
+        guard !imageProviders.isEmpty else { return }
+
+        guard let operation = attachmentPreparation.reserve(
+            itemCount: imageProviders.count,
+            attachments: attachments
+        ) else {
+            attachmentErrorMessage = "You can attach up to eight images."
+            return
+        }
+        let reservedProviders = Array(imageProviders.prefix(operation.count))
+        if operation.count < imageProviders.count {
+            attachmentErrorMessage =
+                "Some images were not attached because the eight-image limit was reached."
+        }
+
+        guard pasteQueue.enqueue(token: lifecycleToken, { @MainActor in
+            defer { self.attachmentPreparation.finish(operation) }
+            let result: FeatureImagePasteBatchResult
+            do {
+                result = try await FeatureImagePasteBatchLoader.prepare(
+                    providers: reservedProviders
+                )
+            } catch is CancellationError {
+                return
+            } catch {
+                self.attachmentErrorMessage = error.localizedDescription
+                return
+            }
+            guard !Task.isCancelled,
+                  self.attachmentLifecycle.isCurrent(lifecycleToken) else { return }
+            let accepted = FeatureImageAttachmentPolicy.attachmentsToAppend(
+                result.attachments,
+                to: self.attachments
+            )
+            if accepted.count < result.attachments.count {
+                self.attachmentErrorMessage =
+                    "Some images were not attached because the eight-image limit was reached."
+            } else if let failureMessage = result.failureMessage {
+                self.attachmentErrorMessage = failureMessage
+            }
+            self.attachments.append(contentsOf: accepted)
+        }) != nil else {
+            attachmentPreparation.finish(operation)
+            return
+        }
+    }
+
     private var composerFooter: some View {
         HStack(spacing: 2) {
             FeatureImageAttachmentPicker(
                 attachments: $attachments,
                 preparationState: $attachmentPreparation,
                 isFlowActive: $isAttachmentFlowActive,
+                lifecycle: attachmentLifecycle,
+                attachmentContextID: attachmentContextID,
                 isEnabled: imagesAllowed
             )
 
@@ -425,10 +521,18 @@ struct FeatureComposerView: View {
         case let .path(entry):
             replacement = FeatureComposerFileLinkSerializer.markdownLink(for: entry.path) + " "
         }
+        let cursorLocation = FeatureComposerTextSelectionPolicy.cursorLocation(
+            afterReplacing: trigger.range,
+            in: text,
+            with: replacement
+        )
         text = FeatureComposerTriggerParser.replacing(
             trigger.range,
             in: text,
             with: replacement
+        )
+        textSelectionRequest = FeatureComposerTextSelectionRequest(
+            location: cursorLocation
         )
         pathEntries = []
         pathSearchError = nil
@@ -443,8 +547,15 @@ struct FeatureComposerView: View {
             onStop()
         } else if FeatureComposerSubmissionPolicy.allowsSend(for: .explicitButton),
                   canSend {
+            rotateAttachmentLifecycle(to: attachmentContextID)
             onSend()
         }
+    }
+
+    private func rotateAttachmentLifecycle(to contextID: String) {
+        attachmentLifecycle.transition(to: contextID)
+        pasteQueue.cancelAll()
+        attachmentPreparation.cancelAll()
     }
 }
 
@@ -461,6 +572,274 @@ enum FeatureComposerCollapsePolicy {
             && attachmentsAreEmpty
             && !isAttachmentFlowActive
             && !isPreparingAttachments
+    }
+}
+
+@MainActor
+final class FeatureComposerPasteQueue {
+    private var tail: Task<Void, Never>?
+    private let lifecycle: FeatureAttachmentLifecycle
+
+    init(lifecycle: FeatureAttachmentLifecycle) {
+        self.lifecycle = lifecycle
+    }
+
+    @discardableResult
+    func enqueue(
+        token: FeatureAttachmentLifecycle.Token,
+        _ work: @escaping @MainActor () async -> Void
+    ) -> Task<Void, Never>? {
+        guard lifecycle.isCurrent(token) else { return nil }
+        let previous = tail
+        let task = Task { @MainActor [weak self] in
+            await previous?.value
+            guard let self,
+                  self.lifecycle.isCurrent(token),
+                  !Task.isCancelled else { return }
+            await work()
+        }
+        tail = task
+        return task
+    }
+
+    func cancelAll() {
+        tail?.cancel()
+        tail = nil
+    }
+
+}
+
+final class FeatureComposerUITextView: UITextView {
+    var acceptsImages = false {
+        didSet {
+            guard oldValue != acceptsImages else { return }
+            pasteConfiguration = acceptsImages
+                ? UIPasteConfiguration(
+                    acceptableTypeIdentifiers: [
+                        UTType.image.identifier,
+                        UTType.text.identifier,
+                    ]
+                )
+                : nil
+        }
+    }
+    var onPasteImages: (([NSItemProvider]) -> Void)?
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)),
+           acceptsImages,
+           FeatureComposerPasteboardPolicy.containsImage(in: UIPasteboard.general) {
+            return true
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    override func paste(_ sender: Any?) {
+        guard acceptsImages else {
+            super.paste(sender)
+            return
+        }
+        let imageProviders = UIPasteboard.general.itemProviders.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+        }
+        guard !imageProviders.isEmpty else {
+            super.paste(sender)
+            return
+        }
+        if let pastedText = FeatureComposerPasteTextPolicy.text(
+            from: UIPasteboard.general
+        ) {
+            insertText(pastedText)
+        }
+        onPasteImages?(imageProviders)
+    }
+}
+
+enum FeatureComposerPasteboardPolicy {
+    static func containsImage(in pasteboard: UIPasteboard) -> Bool {
+        pasteboard.contains(pasteboardTypes: [UTType.image.identifier])
+    }
+}
+
+struct FeatureComposerTextSelectionRequest: Equatable {
+    let id = UUID()
+    let location: Int
+}
+
+enum FeatureComposerTextSelectionPolicy {
+    static func cursorLocation(
+        afterReplacing range: Range<Int>,
+        in text: String,
+        with replacement: String
+    ) -> Int {
+        let lower = min(max(range.lowerBound, 0), text.count)
+        let lowerIndex = text.index(text.startIndex, offsetBy: lower)
+        return text[..<lowerIndex].utf16.count + replacement.utf16.count
+    }
+}
+
+enum FeatureComposerPasteTextPolicy {
+    static func text(from pasteboard: UIPasteboard) -> String? {
+        let strings = (0..<pasteboard.numberOfItems).compactMap { itemIndex -> String? in
+            let itemSet = IndexSet(integer: itemIndex)
+            let typeIdentifiers = pasteboard.types(forItemSet: itemSet)?
+                .first ?? []
+            guard !typeIdentifiers.contains(where: {
+                UTType($0)?.conforms(to: .image) == true
+            }) else { return nil }
+
+            for typeIdentifier in preferredPlainTextTypes(in: typeIdentifiers) {
+                if let value = pasteboard.values(
+                    forPasteboardType: typeIdentifier,
+                    inItemSet: itemSet
+                )?.first as? String,
+                   !value.isEmpty {
+                    return value
+                }
+            }
+            return nil
+        }
+        guard !strings.isEmpty else { return nil }
+        return strings.joined(separator: "\n")
+    }
+
+    private static func preferredPlainTextTypes(
+        in typeIdentifiers: [String]
+    ) -> [String] {
+        typeIdentifiers
+            .filter { UTType($0)?.conforms(to: .plainText) == true }
+            .sorted { lhs, rhs in
+                (plainTextPriority(lhs), lhs) < (plainTextPriority(rhs), rhs)
+            }
+    }
+
+    private static func plainTextPriority(_ typeIdentifier: String) -> Int {
+        if typeIdentifier == UTType.utf8PlainText.identifier { return 0 }
+        if typeIdentifier == UTType.plainText.identifier { return 1 }
+        return 2
+    }
+}
+
+private struct FeatureComposerTextInput: UIViewRepresentable {
+    @Binding var text: String
+    let focused: FocusState<Bool>.Binding
+    let placeholder: String
+    let acceptsImages: Bool
+    let selectionRequest: FeatureComposerTextSelectionRequest?
+    let onPasteImages: ([NSItemProvider]) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> FeatureComposerUITextView {
+        let textView = FeatureComposerUITextView()
+        context.coordinator.lastAppliedSelectionRequestID = selectionRequest?.id
+        textView.delegate = context.coordinator
+        textView.acceptsImages = acceptsImages
+        textView.onPasteImages = onPasteImages
+        textView.backgroundColor = .clear
+        textView.textColor = UIColor(T3Colors.textPrimary)
+        textView.tintColor = UIColor(T3Colors.accent)
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.adjustsFontForContentSizeCategory = true
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        // Return always edits the draft; sending is deliberately button-only.
+        textView.isScrollEnabled = false
+        textView.accessibilityIdentifier = "message-composer"
+        updateAccessibility(textView)
+        return textView
+    }
+
+    func updateUIView(_ textView: FeatureComposerUITextView, context: Context) {
+        context.coordinator.parent = self
+        textView.acceptsImages = acceptsImages
+        textView.onPasteImages = onPasteImages
+
+        let shouldApplySelection = selectionRequest.map {
+            context.coordinator.lastAppliedSelectionRequestID != $0.id
+        } ?? false
+        if textView.text != text {
+            let selectedRange = textView.selectedRange
+            textView.text = text
+            if !shouldApplySelection {
+                let location = min(selectedRange.location, textView.text.utf16.count)
+                let length = min(selectedRange.length, textView.text.utf16.count - location)
+                textView.selectedRange = NSRange(location: location, length: length)
+            }
+        }
+        if shouldApplySelection, let selectionRequest {
+            let location = min(selectionRequest.location, textView.text.utf16.count)
+            textView.selectedRange = NSRange(location: location, length: 0)
+            context.coordinator.lastAppliedSelectionRequestID = selectionRequest.id
+        }
+        updateAccessibility(textView)
+        Self.updateScrolling(textView)
+
+        if context.coordinator.lastAppliedFocus != focused.wrappedValue {
+            context.coordinator.lastAppliedFocus = focused.wrappedValue
+            if focused.wrappedValue, !textView.isFirstResponder {
+                textView.becomeFirstResponder()
+            } else if !focused.wrappedValue, textView.isFirstResponder {
+                textView.resignFirstResponder()
+            }
+        }
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        uiView: FeatureComposerUITextView,
+        context: Context
+    ) -> CGSize? {
+        guard let width = proposal.width, width.isFinite else { return nil }
+        let fittingSize = uiView.sizeThatFits(
+            CGSize(width: width, height: .greatestFiniteMagnitude)
+        )
+        let maximumHeight = (uiView.font?.lineHeight ?? 22) * 7
+        return CGSize(width: width, height: min(fittingSize.height, maximumHeight))
+    }
+
+    private func updateAccessibility(_ textView: FeatureComposerUITextView) {
+        textView.accessibilityLabel = "Message agent"
+        textView.accessibilityHint = acceptsImages
+            ? "Enter a message or paste images to attach them."
+            : "Enter a message."
+        textView.accessibilityValue = text.isEmpty ? placeholder : nil
+    }
+
+    private static func updateScrolling(_ textView: UITextView) {
+        let maximumHeight = (textView.font?.lineHeight ?? 22) * 7
+        textView.isScrollEnabled = textView.contentSize.height > maximumHeight
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var parent: FeatureComposerTextInput
+        var lastAppliedFocus: Bool?
+        var lastAppliedSelectionRequestID: UUID?
+
+        init(_ parent: FeatureComposerTextInput) {
+            self.parent = parent
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            FeatureComposerTextInput.updateScrolling(textView)
+            guard parent.text != textView.text else { return }
+            parent.text = textView.text
+        }
+
+        func textViewDidBeginEditing(_ textView: UITextView) {
+            if !parent.focused.wrappedValue {
+                parent.focused.wrappedValue = true
+            }
+        }
+
+        func textViewDidEndEditing(_ textView: UITextView) {
+            if parent.focused.wrappedValue {
+                parent.focused.wrappedValue = false
+            }
+        }
+
     }
 }
 

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -773,11 +773,13 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
                 )
                 let length = previousText.isEmpty ? 0 : min(selectedRange.length, text.utf16.count - location)
                 textView.selectedRange = NSRange(location: location, length: length)
+                textView.scrollRangeToVisible(textView.selectedRange)
             }
         }
         if shouldApplySelection, let selectionRequest {
             let location = min(selectionRequest.location, textView.text.utf16.count)
             textView.selectedRange = NSRange(location: location, length: 0)
+            textView.scrollRangeToVisible(textView.selectedRange)
             context.coordinator.lastAppliedSelectionRequestID = selectionRequest.id
         }
         updateAccessibility(textView)
@@ -806,7 +808,8 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
             width: width,
             height: FeatureComposerTextInputSizing.height(
                 fittingHeight: fittingSize.height,
-                proposedHeight: proposal.height
+                proposedHeight: proposal.height,
+                lineHeight: uiView.font?.lineHeight ?? 22
             )
         )
     }
@@ -850,9 +853,16 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
 }
 
 enum FeatureComposerTextInputSizing {
-    static func height(fittingHeight: CGFloat, proposedHeight: CGFloat?) -> CGFloat {
-        guard let proposedHeight, proposedHeight.isFinite else { return fittingHeight }
-        return min(fittingHeight, proposedHeight)
+    static func height(
+        fittingHeight: CGFloat,
+        proposedHeight: CGFloat?,
+        lineHeight: CGFloat,
+        maximumViewportFraction: CGFloat = 0.5
+    ) -> CGFloat {
+        guard let proposedHeight, proposedHeight.isFinite, proposedHeight > 0 else {
+            return min(fittingHeight, lineHeight * 12)
+        }
+        return min(fittingHeight, proposedHeight * maximumViewportFraction)
     }
 }
 

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -749,7 +749,7 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
         textView.adjustsFontForContentSizeCategory = true
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
-        textView.isScrollEnabled = false
+        textView.isScrollEnabled = true
         textView.accessibilityIdentifier = "message-composer"
         updateAccessibility(textView)
         return textView
@@ -781,7 +781,7 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
             context.coordinator.lastAppliedSelectionRequestID = selectionRequest.id
         }
         updateAccessibility(textView)
-        Self.updateScrolling(textView)
+        textView.isScrollEnabled = true
 
         if context.coordinator.lastAppliedFocus != focused.wrappedValue {
             context.coordinator.lastAppliedFocus = focused.wrappedValue
@@ -802,8 +802,13 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
         let fittingSize = uiView.sizeThatFits(
             CGSize(width: width, height: .greatestFiniteMagnitude)
         )
-        let maximumHeight = (uiView.font?.lineHeight ?? 22) * 7
-        return CGSize(width: width, height: min(fittingSize.height, maximumHeight))
+        return CGSize(
+            width: width,
+            height: FeatureComposerTextInputSizing.height(
+                fittingHeight: fittingSize.height,
+                proposedHeight: proposal.height
+            )
+        )
     }
 
     private func updateAccessibility(_ textView: FeatureComposerUITextView) {
@@ -812,11 +817,6 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
             ? "Enter a message or paste images to attach them."
             : "Enter a message."
         textView.accessibilityValue = text.isEmpty ? placeholder : nil
-    }
-
-    private static func updateScrolling(_ textView: UITextView) {
-        let maximumHeight = (textView.font?.lineHeight ?? 22) * 7
-        textView.isScrollEnabled = textView.contentSize.height > maximumHeight
     }
 
     final class Coordinator: NSObject, UITextViewDelegate {
@@ -829,7 +829,7 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
         }
 
         func textViewDidChange(_ textView: UITextView) {
-            FeatureComposerTextInput.updateScrolling(textView)
+            textView.isScrollEnabled = true
             guard parent.text != textView.text else { return }
             parent.text = textView.text
         }
@@ -846,6 +846,13 @@ private struct FeatureComposerTextInput: UIViewRepresentable {
             }
         }
 
+    }
+}
+
+enum FeatureComposerTextInputSizing {
+    static func height(fittingHeight: CGFloat, proposedHeight: CGFloat?) -> CGFloat {
+        guard let proposedHeight, proposedHeight.isFinite else { return fittingHeight }
+        return min(fittingHeight, proposedHeight)
     }
 }
 

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -712,7 +712,7 @@ enum FeatureComposerPasteTextPolicy {
                     return string
                 }
                 if let data = value as? Data,
-                   let string = String(data: data, encoding: .utf8),
+                   let string = utf8String(from: data, typeIdentifier: typeIdentifier),
                    !string.isEmpty {
                     return string
                 }
@@ -721,6 +721,29 @@ enum FeatureComposerPasteTextPolicy {
         }
         guard !strings.isEmpty else { return nil }
         return strings.joined(separator: "\n")
+    }
+
+    private static func utf8String(from data: Data, typeIdentifier: String) -> String? {
+        guard let type = UTType(typeIdentifier) else { return nil }
+        if type.conforms(to: .utf16PlainText)
+            || type.conforms(to: .utf16ExternalPlainText) {
+            if data.starts(with: [0xFF, 0xFE]) || data.starts(with: [0xFE, 0xFF]) {
+                return String(data: data, encoding: .utf16)
+            }
+            if type.conforms(to: .utf16ExternalPlainText) {
+                return String(data: data, encoding: .utf16LittleEndian)
+                    ?? String(data: data, encoding: .utf16BigEndian)
+            }
+            return String(data: data, encoding: .utf16)
+                ?? String(data: data, encoding: .utf16LittleEndian)
+                ?? String(data: data, encoding: .utf16BigEndian)
+        }
+        var utf8Data = data
+        while utf8Data.last == 0 {
+            utf8Data.removeLast()
+        }
+        guard type.conforms(to: .utf8PlainText) || !utf8Data.contains(0) else { return nil }
+        return String(data: utf8Data, encoding: .utf8)
     }
 
     private static func preferredPlainTextTypes(

--- a/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
+++ b/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
@@ -4,9 +4,59 @@ import SwiftUI
 import UniformTypeIdentifiers
 import UIKit
 
+enum FeatureImageAttachmentPolicy {
+    static let maximumCount = 8
+
+    static func remainingCapacity(
+        attachmentCount: Int,
+        pendingItemCount: Int = 0,
+        maximumCount: Int = FeatureImageAttachmentPolicy.maximumCount
+    ) -> Int {
+        max(
+            0,
+            maximumCount
+                - max(0, attachmentCount)
+                - max(0, pendingItemCount)
+        )
+    }
+
+    static func nextOrdinal(after attachments: [FeatureDraftAttachment]) -> Int {
+        let generatedOrdinals = attachments.compactMap { attachment -> Int? in
+            let filename = attachment.filename
+            let prefix = "Image "
+            let suffix = ".jpg"
+            guard filename.hasPrefix(prefix), filename.lowercased().hasSuffix(suffix) else {
+                return nil
+            }
+            let ordinal = filename.dropFirst(prefix.count).dropLast(suffix.count)
+            return Int(ordinal)
+        }
+        return max(attachments.count, generatedOrdinals.max() ?? 0) + 1
+    }
+
+    static func attachmentsToAppend(
+        _ prepared: [FeatureDraftAttachment],
+        to existing: [FeatureDraftAttachment],
+        maximumCount: Int = FeatureImageAttachmentPolicy.maximumCount
+    ) -> [FeatureDraftAttachment] {
+        let acceptedCount = min(
+            prepared.count,
+            remainingCapacity(attachmentCount: existing.count, maximumCount: maximumCount)
+        )
+        var nextOrdinal = nextOrdinal(after: existing)
+        return prepared.prefix(acceptedCount).map { attachment in
+            var rebased = attachment
+            rebased.filename = "Image \(nextOrdinal).jpg"
+            nextOrdinal += 1
+            return rebased
+        }
+    }
+}
+
 struct FeatureAttachmentPreparationState: Equatable {
     struct Operation: Hashable {
         fileprivate let id: UUID
+        let count: Int
     }
 
     private var pendingItemsByOperation: [Operation: Int] = [:]
@@ -25,13 +75,62 @@ struct FeatureAttachmentPreparationState: Equatable {
 
     @discardableResult
     mutating func begin(itemCount: Int, id: UUID = UUID()) -> Operation {
-        let operation = Operation(id: id)
-        pendingItemsByOperation[operation] = max(1, itemCount)
+        let count = max(1, itemCount)
+        let operation = Operation(id: id, count: count)
+        pendingItemsByOperation[operation] = count
         return operation
+    }
+
+    @discardableResult
+    mutating func reserve(
+        itemCount: Int,
+        attachments: [FeatureDraftAttachment],
+        maximumCount: Int = FeatureImageAttachmentPolicy.maximumCount,
+        id: UUID = UUID()
+    ) -> Operation? {
+        guard itemCount > 0 else { return nil }
+
+        let availableCount = FeatureImageAttachmentPolicy.remainingCapacity(
+            attachmentCount: attachments.count,
+            pendingItemCount: pendingItemCount,
+            maximumCount: maximumCount
+        )
+        guard availableCount > 0 else { return nil }
+        return begin(itemCount: min(itemCount, availableCount), id: id)
     }
 
     mutating func finish(_ operation: Operation) {
         pendingItemsByOperation.removeValue(forKey: operation)
+    }
+
+    mutating func cancelAll() {
+        pendingItemsByOperation.removeAll()
+    }
+}
+
+@MainActor
+final class FeatureAttachmentLifecycle {
+    struct Token: Hashable {
+        fileprivate let id: UUID
+        fileprivate let contextID: String
+    }
+
+    private var current: Token
+
+    init(contextID: String) {
+        current = Token(id: UUID(), contextID: contextID)
+    }
+
+    func token(for contextID: String) -> Token? {
+        current.contextID == contextID ? current : nil
+    }
+
+    func isCurrent(_ token: Token) -> Bool {
+        token == current
+    }
+
+    func transition(to contextID: String) {
+        current = Token(id: UUID(), contextID: contextID)
     }
 }
 
@@ -45,6 +144,8 @@ struct FeatureImageAttachmentPicker: View {
     @Binding var attachments: [FeatureDraftAttachment]
     @Binding var preparationState: FeatureAttachmentPreparationState
     @Binding var isFlowActive: Bool
+    let lifecycle: FeatureAttachmentLifecycle
+    let attachmentContextID: String
     let maximumCount: Int
     let isEnabled: Bool
 
@@ -54,18 +155,23 @@ struct FeatureImageAttachmentPicker: View {
     @State private var isCameraPresented = false
     @State private var isFileImporterPresented = false
     @State private var sourcePresentationTask: Task<Void, Never>?
+    @State private var presentedLifecycleToken: FeatureAttachmentLifecycle.Token?
     @State private var errorMessage: String?
 
     init(
         attachments: Binding<[FeatureDraftAttachment]>,
         preparationState: Binding<FeatureAttachmentPreparationState>,
         isFlowActive: Binding<Bool>,
-        maximumCount: Int = 8,
+        lifecycle: FeatureAttachmentLifecycle,
+        attachmentContextID: String,
+        maximumCount: Int = FeatureImageAttachmentPolicy.maximumCount,
         isEnabled: Bool = true
     ) {
         _attachments = attachments
         _preparationState = preparationState
         _isFlowActive = isFlowActive
+        self.lifecycle = lifecycle
+        self.attachmentContextID = attachmentContextID
         self.maximumCount = maximumCount
         self.isEnabled = isEnabled
     }
@@ -100,30 +206,48 @@ struct FeatureImageAttachmentPicker: View {
             isPresented: $isPhotoLibraryPresented,
             onDismiss: finishPhotoLibrarySelection
         ) {
-            FeaturePhotoLibraryPicker(
-                maximumCount: max(1, remainingCount),
-                onFinish: { items in
-                    pendingPhotoLibraryItems = items
-                    isPhotoLibraryPresented = false
-                }
-            )
-            .ignoresSafeArea()
+            if presentedLifecycleToken != nil {
+                FeaturePhotoLibraryPicker(
+                    maximumCount: max(1, remainingCount),
+                    onFinish: { items in
+                        pendingPhotoLibraryItems = items
+                        isPhotoLibraryPresented = false
+                    }
+                )
+                .ignoresSafeArea()
+            }
         }
-        .fullScreenCover(isPresented: $isCameraPresented) {
-            FeatureCameraPicker(
-                onCapture: loadCapturedImage,
-                onCancel: {
-                    isCameraPresented = false
-                    isFlowActive = false
-                }
-            )
-            .ignoresSafeArea()
+        .fullScreenCover(
+            isPresented: $isCameraPresented,
+            onDismiss: { presentedLifecycleToken = nil }
+        ) {
+            if let token = presentedLifecycleToken {
+                FeatureCameraPicker(
+                    onCapture: { image in
+                        guard dismissPresentedSource(token) else { return }
+                        guard lifecycle.isCurrent(token) else {
+                            isFlowActive = false
+                            return
+                        }
+                        loadCapturedImage(image, token: token)
+                    },
+                    onCancel: {
+                        guard dismissPresentedSource(token) else { return }
+                        isFlowActive = false
+                    }
+                )
+                .ignoresSafeArea()
+            }
         }
         .fileImporter(
             isPresented: $isFileImporterPresented,
             allowedContentTypes: [.image],
             allowsMultipleSelection: true,
-            onCompletion: loadFiles
+            onCompletion: { result in
+                guard let token = presentedLifecycleToken else { return }
+                guard dismissPresentedSource(token) else { return }
+                loadFiles(result, token: token)
+            }
         )
         .alert(
             "Couldn’t add image",
@@ -139,10 +263,39 @@ struct FeatureImageAttachmentPicker: View {
         .onDisappear {
             sourcePresentationTask?.cancel()
         }
+        .onChange(of: attachmentContextID) {
+            sourcePresentationTask?.cancel()
+            isAttachmentSourcePresented = false
+            isPhotoLibraryPresented = false
+            isCameraPresented = false
+            isFileImporterPresented = false
+            pendingPhotoLibraryItems = []
+            presentedLifecycleToken = nil
+            errorMessage = nil
+            isFlowActive = false
+        }
     }
 
     private var remainingCount: Int {
-        max(0, maximumCount - attachments.count)
+        FeatureImageAttachmentPolicy.remainingCapacity(
+            attachmentCount: attachments.count,
+            pendingItemCount: preparationState.pendingItemCount,
+            maximumCount: maximumCount
+        )
+    }
+
+    private func dismissPresentedSource(
+        _ token: FeatureAttachmentLifecycle.Token,
+        clearToken: Bool = true
+    ) -> Bool {
+        guard presentedLifecycleToken == token else { return false }
+        isPhotoLibraryPresented = false
+        isCameraPresented = false
+        isFileImporterPresented = false
+        if clearToken {
+            presentedLifecycleToken = nil
+        }
+        return true
     }
 
     private var canAdd: Bool {
@@ -162,14 +315,21 @@ struct FeatureImageAttachmentPicker: View {
     }
 
     private func present(_ source: Source) {
+        guard let token = lifecycle.token(for: attachmentContextID) else {
+            isFlowActive = false
+            return
+        }
         sourcePresentationTask?.cancel()
         isAttachmentSourcePresented = false
+        presentedLifecycleToken = token
         sourcePresentationTask = Task { @MainActor in
             // A confirmation dialog is still the active presenter while its action
             // runs. Wait for its dismissal animation before presenting another
             // controller or UIKit can reject (or race) the new presentation.
             try? await Task.sleep(for: .milliseconds(300))
-            guard !Task.isCancelled, canAdd else {
+            guard !Task.isCancelled,
+                  lifecycle.isCurrent(token),
+                  canAdd else {
                 isFlowActive = false
                 return
             }
@@ -185,12 +345,20 @@ struct FeatureImageAttachmentPicker: View {
     }
 
     private func finishPhotoLibrarySelection() {
+        guard let token = presentedLifecycleToken, dismissPresentedSource(token) else {
+            pendingPhotoLibraryItems = []
+            isFlowActive = false
+            return
+        }
         Task { @MainActor in
             // Keep PhotosUI presentation and asset materialization in separate turns.
             // Some OS versions become stuck or dismiss mid-selection when the picker
             // and its selection are driven by the same SwiftUI binding transaction.
             await Task.yield()
-            guard !isPhotoLibraryPresented, !pendingPhotoLibraryItems.isEmpty, canAdd else {
+            guard lifecycle.isCurrent(token),
+                  !isPhotoLibraryPresented,
+                  !pendingPhotoLibraryItems.isEmpty,
+                  canAdd else {
                 pendingPhotoLibraryItems = []
                 isFlowActive = false
                 return
@@ -198,37 +366,51 @@ struct FeatureImageAttachmentPicker: View {
 
             let selected = Array(pendingPhotoLibraryItems.prefix(remainingCount))
             pendingPhotoLibraryItems = []
-            let firstOrdinal = attachments.count + preparationState.pendingItemCount + 1
-            let operation = preparationState.begin(itemCount: selected.count)
+            guard let operation = preparationState.reserve(
+                itemCount: selected.count,
+                attachments: attachments,
+                maximumCount: maximumCount
+            ) else {
+                isFlowActive = false
+                return
+            }
+            let reservedItems = Array(selected.prefix(operation.count))
 
             defer {
                 preparationState.finish(operation)
                 isFlowActive = false
             }
-
-            for (offset, item) in selected.enumerated() {
+            for item in reservedItems {
                 do {
-                    let data = try await item.loadData()
-                    try await appendImage(
-                        data,
-                        ordinal: firstOrdinal + offset
-                    )
+                    try await appendImage(try await item.loadData(), token: token)
+                } catch is CancellationError {
+                    return
                 } catch {
+                    guard lifecycle.isCurrent(token) else { return }
                     errorMessage = error.localizedDescription
                 }
             }
         }
     }
 
-    private func loadCapturedImage(_ image: UIImage) {
-        isCameraPresented = false
-        guard canAdd else {
+    private func loadCapturedImage(
+        _ image: UIImage,
+        token: FeatureAttachmentLifecycle.Token
+    ) {
+        guard lifecycle.isCurrent(token), canAdd else {
             isFlowActive = false
             return
         }
-        let operation = preparationState.begin(itemCount: 1)
+        guard let operation = preparationState.reserve(
+            itemCount: 1,
+            attachments: attachments,
+            maximumCount: maximumCount
+        ) else {
+            isFlowActive = false
+            return
+        }
 
-        Task {
+        Task { @MainActor in
             defer {
                 preparationState.finish(operation)
                 isFlowActive = false
@@ -240,49 +422,85 @@ struct FeatureImageAttachmentPicker: View {
                     }
                     return data
                 }.value
-                try await appendImage(data)
+                try await appendImage(data, token: token)
+            } catch is CancellationError {
+                return
             } catch {
+                guard lifecycle.isCurrent(token) else { return }
                 errorMessage = error.localizedDescription
             }
         }
     }
 
-    private func loadFiles(_ result: Result<[URL], Error>) {
-        defer { isFlowActive = false }
+    private func loadFiles(
+        _ result: Result<[URL], Error>,
+        token: FeatureAttachmentLifecycle.Token
+    ) {
+        guard lifecycle.isCurrent(token) else {
+            isFlowActive = false
+            return
+        }
         switch result {
         case .failure(let error):
             errorMessage = error.localizedDescription
+            isFlowActive = false
         case .success(let urls):
-            guard !urls.isEmpty, canAdd else { return }
-            let operation = preparationState.begin(itemCount: min(urls.count, remainingCount))
+            guard !urls.isEmpty, canAdd else {
+                isFlowActive = false
+                return
+            }
+            guard let operation = preparationState.reserve(
+                itemCount: urls.count,
+                attachments: attachments,
+                maximumCount: maximumCount
+            ) else {
+                isFlowActive = false
+                return
+            }
+            if operation.count < urls.count {
+                errorMessage =
+                    "Some images were not attached because the eight-image limit was reached."
+            }
+            let reservedURLs = Array(urls.prefix(operation.count))
 
-            Task {
-                defer { preparationState.finish(operation) }
-                for url in urls.prefix(remainingCount) {
+            Task { @MainActor in
+                defer {
+                    preparationState.finish(operation)
+                    isFlowActive = false
+                }
+                for url in reservedURLs {
                     do {
-                        let data = try await Task.detached(priority: .userInitiated) {
+                        let loadedData = try await Task.detached(priority: .userInitiated) {
                             let hasAccess = url.startAccessingSecurityScopedResource()
                             defer {
                                 if hasAccess { url.stopAccessingSecurityScopedResource() }
                             }
                             return try Data(contentsOf: url, options: .mappedIfSafe)
                         }.value
-                        try await appendImage(data)
+                        try await appendImage(loadedData, token: token)
+                    } catch is CancellationError {
+                        return
                     } catch {
+                        guard lifecycle.isCurrent(token) else { return }
                         errorMessage = error.localizedDescription
-                        break
                     }
                 }
             }
         }
     }
 
-    private func appendImage(_ data: Data, ordinal: Int? = nil) async throws {
-        let ordinal = ordinal ?? attachments.count + 1
-        let attachment = try await Task.detached(priority: .userInitiated) {
-            try FeatureImageProcessor.attachment(from: data, ordinal: ordinal)
-        }.value
-        attachments.append(attachment)
+    private func appendImage(
+        _ data: Data,
+        token: FeatureAttachmentLifecycle.Token
+    ) async throws {
+        guard lifecycle.isCurrent(token) else { throw CancellationError() }
+        let prepared = try await FeatureImageAttachmentIngestion.prepare(data: data)
+        guard lifecycle.isCurrent(token) else { throw CancellationError() }
+        attachments.append(contentsOf: FeatureImageAttachmentPolicy.attachmentsToAppend(
+            [prepared],
+            to: attachments,
+            maximumCount: maximumCount
+        ))
     }
 }
 
@@ -290,23 +508,7 @@ private struct FeaturePhotoLibraryItem: @unchecked Sendable {
     let provider: NSItemProvider
 
     func loadData() async throws -> Data {
-        guard let typeIdentifier = provider.registeredTypeIdentifiers.first(where: { identifier in
-            UTType(identifier)?.conforms(to: .image) == true
-        }) else {
-            throw FeatureImageAttachmentError.invalidImage
-        }
-
-        return try await withCheckedThrowingContinuation { continuation in
-            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, error in
-                if let data {
-                    continuation.resume(returning: data)
-                } else {
-                    continuation.resume(
-                        throwing: error ?? FeatureImageAttachmentError.encodingFailed
-                    )
-                }
-            }
-        }
+        try await FeatureImageItemProviderLoader.data(from: provider)
     }
 }
 
@@ -349,6 +551,72 @@ private struct FeaturePhotoLibraryPicker: UIViewControllerRepresentable {
                 onFinish(items)
             }
         }
+    }
+}
+
+enum FeatureImageItemProviderLoader {
+    @MainActor
+    static func data(from provider: NSItemProvider) async throws -> Data {
+        guard let typeIdentifier = provider.registeredTypeIdentifiers.first(where: {
+            UTType($0)?.conforms(to: .image) == true
+        }) else {
+            throw FeatureImageAttachmentError.invalidImage
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, error in
+                if let data {
+                    continuation.resume(returning: data)
+                } else if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(throwing: FeatureImageAttachmentError.invalidImage)
+                }
+            }
+        }
+    }
+
+}
+
+struct FeatureImagePasteBatchResult {
+    let attachments: [FeatureDraftAttachment]
+    let failureMessage: String?
+}
+
+enum FeatureImagePasteBatchLoader {
+    @MainActor
+    static func prepare(
+        providers: [NSItemProvider]
+    ) async throws -> FeatureImagePasteBatchResult {
+        var attachments: [FeatureDraftAttachment] = []
+        var failureMessage: String?
+
+        for provider in providers {
+            do {
+                let data = try await FeatureImageItemProviderLoader.data(from: provider)
+                try Task.checkCancellation()
+                let attachment = try await FeatureImageAttachmentIngestion.prepare(data: data)
+                try Task.checkCancellation()
+                attachments.append(attachment)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                failureMessage = error.localizedDescription
+            }
+        }
+
+        return FeatureImagePasteBatchResult(
+            attachments: attachments,
+            failureMessage: failureMessage
+        )
+    }
+}
+
+enum FeatureImageAttachmentIngestion {
+    static func prepare(data: Data) async throws -> FeatureDraftAttachment {
+        try await Task.detached(priority: .userInitiated) {
+            try FeatureImageProcessor.attachment(from: data, ordinal: 1)
+        }.value
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -345,6 +345,7 @@ public struct ThreadDetailView: View {
                 attachments: $attachments,
                 providers: threadProviders,
                 threadSelection: currentSelection,
+                attachmentContextID: thread.id,
                 materializesDefaultSelection: false,
                 isSending: isSending,
                 isWorking: detail.thread.state == .working || detail.thread.state == .queued,

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -30,6 +30,7 @@ public struct NewThreadView: View {
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var immediateDraftSaveTasks: [String: Task<Void, Never>] = [:]
     @State private var submittedSuccessfully = false
+    @State private var attachmentLifecycle: FeatureAttachmentLifecycle
     @FocusState private var promptFocused: Bool
 
     public init(
@@ -46,6 +47,9 @@ public struct NewThreadView: View {
         self.onCreateProject = onCreateProject
         self.initialProjectID = initialProjectID
         self.draftStore = draftStore
+        _attachmentLifecycle = State(
+            initialValue: FeatureAttachmentLifecycle(contextID: initialProjectID ?? "")
+        )
     }
 
     public var body: some View {
@@ -76,6 +80,7 @@ public struct NewThreadView: View {
                         providers: creationProviders,
                         threadSelection: nil,
                         attachmentContextID: projectID,
+                        attachmentLifecycle: attachmentLifecycle,
                         isSending: isSubmitting,
                         isWorking: false,
                         focused: $promptFocused,
@@ -562,6 +567,7 @@ public struct NewThreadView: View {
     private func selectProject(_ id: String) -> Bool {
         guard id != projectID else { return true }
         guard creationProjects.contains(where: { $0.id == id }) else { return false }
+        attachmentLifecycle.transition(to: id)
         persistCurrentDraftImmediately()
         projectID = id
         prepareProjectIfNeeded(id)
@@ -587,6 +593,7 @@ public struct NewThreadView: View {
     }
 
     private func selectInitialProject(_ id: String) {
+        attachmentLifecycle.transition(to: id)
         projectID = id
         prepareProjectIfNeeded(id)
     }

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -75,6 +75,7 @@ public struct NewThreadView: View {
                         attachments: $attachments,
                         providers: creationProviders,
                         threadSelection: nil,
+                        attachmentContextID: projectID,
                         isSending: isSubmitting,
                         isWorking: false,
                         focused: $promptFocused,

--- a/apps/swift-ios/Tests/FeatureTests/AttachmentPreparationTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/AttachmentPreparationTests.swift
@@ -1,5 +1,7 @@
 import Foundation
 import Testing
+import UIKit
+import UniformTypeIdentifiers
 @testable import T3Code
 
 @Suite("Attachment preparation")
@@ -26,6 +28,97 @@ struct AttachmentPreparationTests {
 
         #expect(!state.isPreparing)
         #expect(state.pendingItemCount == 0)
+    }
+
+    @Test
+    func reservationsShareCapacityAcrossPendingOperations() {
+        var state = FeatureAttachmentPreparationState()
+        let first = state.reserve(itemCount: 6, attachments: [])
+        let second = state.reserve(itemCount: 6, attachments: [])
+
+        #expect(first?.count == 6)
+        #expect(second?.count == 2)
+        #expect(state.pendingItemCount == FeatureImageAttachmentPolicy.maximumCount)
+        #expect(state.reserve(itemCount: 1, attachments: []) == nil)
+
+        if let first {
+            state.finish(first)
+        }
+        #expect(state.pendingItemCount == 2)
+
+        let third = state.reserve(itemCount: 6, attachments: [])
+        #expect(third?.count == 6)
+    }
+
+    @Test
+    @MainActor
+    func sameContextTransitionInvalidatesCapturedCallbacks() {
+        let lifecycle = FeatureAttachmentLifecycle(contextID: "draft-a")
+        let oldToken = lifecycle.token(for: "draft-a")!
+
+        lifecycle.transition(to: "draft-a")
+
+        #expect(!lifecycle.isCurrent(oldToken))
+        #expect(lifecycle.token(for: "draft-a") != oldToken)
+    }
+
+    @Test
+    func preparedAttachmentsRespectCapacityAfterDraftRestoration() {
+        let existing = (1...7).map { ordinal in
+            FeatureDraftAttachment(
+                data: Data([UInt8(ordinal)]),
+                filename: "Image \(ordinal).jpg",
+                mimeType: "image/jpeg"
+            )
+        }
+        let prepared = (1...3).map { ordinal in
+            FeatureDraftAttachment(
+                data: Data([UInt8(ordinal)]),
+                filename: "Image \(ordinal).jpg",
+                mimeType: "image/jpeg"
+            )
+        }
+
+        let accepted = FeatureImageAttachmentPolicy.attachmentsToAppend(
+            prepared,
+            to: existing
+        )
+
+        #expect(accepted.count == 1)
+        #expect(accepted.first?.filename == "Image 8.jpg")
+    }
+
+    @Test
+    func pasteProviderLoaderReadsImageDataRepresentation() async throws {
+        let expected = Data([0x01, 0x02, 0x03])
+        let provider = NSItemProvider(
+            item: expected as NSData,
+            typeIdentifier: UTType.jpeg.identifier
+        )
+
+        #expect(try await FeatureImageItemProviderLoader.data(from: provider) == expected)
+    }
+
+    @Test
+    @MainActor
+    func pasteBatchKeepsValidImagesWhenAnotherProviderFails() async throws {
+        let invalidProvider = NSItemProvider()
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4)).image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+        }
+        let imageData = try #require(image.jpegData(compressionQuality: 1))
+        let validProvider = NSItemProvider(
+            item: imageData as NSData,
+            typeIdentifier: UTType.jpeg.identifier
+        )
+
+        let result = try await FeatureImagePasteBatchLoader.prepare(
+            providers: [invalidProvider, validProvider]
+        )
+
+        #expect(result.attachments.count == 1)
+        #expect(result.failureMessage != nil)
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -1,4 +1,7 @@
+import Foundation
 import Testing
+import UIKit
+import UniformTypeIdentifiers
 @testable import T3Code
 
 @Suite("Composer power features")
@@ -38,6 +41,77 @@ struct FeatureComposerPowerTests {
             with: "[App](Sources/App) "
         )
         #expect(result == "Review [App](Sources/App)  please")
+    }
+
+    @Test
+    func replacementCursorLandsAfterInsertedTextInUTF16() {
+        let original = "🧪 Use $dep please"
+        let range = 6..<10
+        let replacement = "$dependency "
+
+        #expect(
+            FeatureComposerTextSelectionPolicy.cursorLocation(
+                afterReplacing: range,
+                in: original,
+                with: replacement
+            ) == "🧪 Use $dependency ".utf16.count
+        )
+    }
+
+    @Test
+    func mixedPasteReadsPlainTextLazilyFromUIPasteboard() {
+        let pasteboard = UIPasteboard.withUniqueName()
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+        pasteboard.items = [
+            [
+                UTType.png.identifier: Data([0x89]),
+                UTType.plainText.identifier: "image metadata",
+            ],
+            [UTType.utf8PlainText.identifier: Data("first".utf8)],
+            [
+                UTType.html.identifier: Data("<b>second</b>".utf8),
+                UTType.utf8PlainText.identifier: "second",
+            ],
+        ]
+
+        #expect(
+            FeatureComposerPasteTextPolicy.text(from: pasteboard)
+                == "first\nsecond"
+        )
+    }
+
+    @Test @MainActor
+    func imageCapableComposerAdvertisesImagesToTheNativePasteMenu() {
+        let textView = FeatureComposerUITextView()
+
+        textView.acceptsImages = true
+
+        #expect(
+            textView.pasteConfiguration?.acceptableTypeIdentifiers.contains(
+                UTType.image.identifier
+            ) == true
+        )
+        #expect(
+            textView.pasteConfiguration?.acceptableTypeIdentifiers.contains(
+                UTType.text.identifier
+            ) == true
+        )
+
+        textView.acceptsImages = false
+
+        #expect(textView.pasteConfiguration == nil)
+    }
+
+    @Test
+    func nativePasteDetectionUsesImageTypeConformance() {
+        let pasteboard = UIPasteboard.withUniqueName()
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+        pasteboard.items = [
+            [UTType.heic.identifier: Data([0x00])],
+        ]
+
+        #expect(!pasteboard.hasImages)
+        #expect(FeatureComposerPasteboardPolicy.containsImage(in: pasteboard))
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -7,12 +7,13 @@ import UniformTypeIdentifiers
 @Suite("Composer power features")
 struct FeatureComposerPowerTests {
     @Test
-    func composerTextInputHasNoNumericLineCap() {
+    func composerTextInputUsesAFallbackBoundWithoutAViewport() {
         #expect(
             FeatureComposerTextInputSizing.height(
                 fittingHeight: 1_200,
-                proposedHeight: nil
-            ) == 1_200
+                proposedHeight: nil,
+                lineHeight: 22
+            ) == 264
         )
     }
 
@@ -21,8 +22,9 @@ struct FeatureComposerPowerTests {
         #expect(
             FeatureComposerTextInputSizing.height(
                 fittingHeight: 1_200,
-                proposedHeight: 500
-            ) == 500
+                proposedHeight: 500,
+                lineHeight: 22
+            ) == 250
         )
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -104,7 +104,7 @@ struct FeatureComposerPowerTests {
 
         #expect(
             FeatureComposerPasteTextPolicy.text(from: pasteboard)
-                == "first\nsecond"
+                == "image metadata\nfirst\nsecond"
         )
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -132,7 +132,7 @@ struct FeatureComposerPowerTests {
             ],
             [
                 UTType.utf16ExternalPlainText.identifier:
-                    "external UTF-16".data(using: .utf16LittleEndian)!,
+                    "external UTF-16".data(using: .utf16BigEndian)!,
             ],
             [UTType.swiftSource.identifier: Data("let x = 1\0".utf8)],
             [

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -97,6 +97,15 @@ struct FeatureComposerPowerTests {
             ],
             [UTType.utf8PlainText.identifier: Data("first".utf8)],
             [
+                UTType.utf16PlainText.identifier:
+                    "UTF-16".data(using: .utf16)!,
+            ],
+            [
+                UTType.utf16ExternalPlainText.identifier:
+                    "external UTF-16".data(using: .utf16LittleEndian)!,
+            ],
+            [UTType.swiftSource.identifier: Data("let x = 1\0".utf8)],
+            [
                 UTType.html.identifier: Data("<b>second</b>".utf8),
                 UTType.utf8PlainText.identifier: "second",
             ],
@@ -104,7 +113,7 @@ struct FeatureComposerPowerTests {
 
         #expect(
             FeatureComposerPasteTextPolicy.text(from: pasteboard)
-                == "image metadata\nfirst\nsecond"
+                == "image metadata\nfirst\nUTF-16\nexternal UTF-16\nlet x = 1\nsecond"
         )
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -7,6 +7,36 @@ import UniformTypeIdentifiers
 @Suite("Composer power features")
 struct FeatureComposerPowerTests {
     @Test
+    func composerTextInputGrowsPastThreeLinesBeforeReachingItsViewportBound() {
+        let threeLines = FeatureComposerTextInputSizing.height(
+            fittingHeight: 66,
+            proposedHeight: 800,
+            lineHeight: 22
+        )
+        let tenLines = FeatureComposerTextInputSizing.height(
+            fittingHeight: 220,
+            proposedHeight: 800,
+            lineHeight: 22
+        )
+
+        #expect(threeLines == 66)
+        #expect(tenLines == 220)
+        #expect(tenLines > threeLines)
+    }
+
+    @Test
+    func composerTextInputKeepsContentUnlimitedWhenItsVisibleHeightIsBounded() {
+        let viewportHeight = FeatureComposerTextInputSizing.height(
+            fittingHeight: 2_200,
+            proposedHeight: 600,
+            lineHeight: 22
+        )
+
+        #expect(viewportHeight == 300)
+        #expect(viewportHeight < 2_200)
+    }
+
+    @Test
     func composerTextInputUsesAFallbackBoundWithoutAViewport() {
         #expect(
             FeatureComposerTextInputSizing.height(

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -7,6 +7,26 @@ import UniformTypeIdentifiers
 @Suite("Composer power features")
 struct FeatureComposerPowerTests {
     @Test
+    func composerTextInputHasNoNumericLineCap() {
+        #expect(
+            FeatureComposerTextInputSizing.height(
+                fittingHeight: 1_200,
+                proposedHeight: nil
+            ) == 1_200
+        )
+    }
+
+    @Test
+    func composerTextInputYieldsToTheAvailableViewport() {
+        #expect(
+            FeatureComposerTextInputSizing.height(
+                fittingHeight: 1_200,
+                proposedHeight: 500
+            ) == 500
+        )
+    }
+
+    @Test
     func detectsCommandsModelsSkillsAndPathsAtTheCursor() {
         #expect(
             FeatureComposerTriggerParser.detect(in: "/re")

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -58,6 +58,12 @@ struct FeatureComposerPowerTests {
         )
     }
 
+    @Test func restoredComposerTextPlacesCaretAtUTF16End() {
+        #expect(FeatureComposerTextSelectionPolicy.cursorLocationAfterBindingUpdate(
+            previousText: "", newText: "🧪 restored draft", selectedLocation: 0
+        ) == "🧪 restored draft".utf16.count)
+    }
+
     @Test
     func mixedPasteReadsPlainTextLazilyFromUIPasteboard() {
         let pasteboard = UIPasteboard.withUniqueName()

--- a/docs/user/swiftui-image-attachments.md
+++ b/docs/user/swiftui-image-attachments.md
@@ -1,0 +1,9 @@
+# Image attachments in SwiftUI mobile
+
+The SwiftUI mobile composer accepts up to eight images. Tap the paperclip to
+choose images from the photo library, camera, or Files. You can also long-press
+the message field and choose Paste for an image copied from another app.
+
+When pasting multiple images, their order in the attachment strip matches the
+order of the paste. Images are prepared before they can be sent, and a model
+that supports image input must be selected.

--- a/docs/user/swiftui-image-attachments.md
+++ b/docs/user/swiftui-image-attachments.md
@@ -1,9 +1,3 @@
 # Image attachments in SwiftUI mobile
 
-The SwiftUI mobile composer accepts up to eight images. Tap the paperclip to
-choose images from the photo library, camera, or Files. You can also long-press
-the message field and choose Paste for an image copied from another app.
-
-When pasting multiple images, their order in the attachment strip matches the
-order of the paste. Images are prepared before they can be sent, and a model
-that supports image input must be selected.
+The SwiftUI mobile composer accepts up to eight ordered images from Photos, Camera, Files, or the message field's long-press Paste action. Sending requires a model that supports image input.


### PR DESCRIPTION
## What changed

- Replace the SwiftUI composer field with a small UIKit-backed `UITextView` so copied images appear in the native long-press **Paste** menu.
- Keep ordinary text paste unchanged, preserve text from mixed image/text pasteboard items, and keep command, model, skill, and path replacement caret placement correct.
- Send pasted image providers through the existing image processor and attachment strip, preserving successful providers when another provider fails.
- Reserve the shared eight-image capacity across in-flight picker, camera, Files, and paste work, and reject callbacks captured for a stale composer context.

The patch is limited to the SwiftUI iOS composer and attachment ingestion, plus focused tests and user documentation. It is stacked on the experimental SwiftUI client in #5178. The branch is rebased on `0d0c77431`, which includes `f79886039` and its native-CI repair.

## Why

The SwiftUI field accepted pasted text but did not offer Paste for a copied screenshot or photo. A UIKit text responder can advertise image and text paste types through the standard iOS edit menu, then hand image providers to the same preparation path as the existing attachment picker.

## UI evidence

| Before: copied image, no Paste | After: native Paste action |
| --- | --- |
| ![Before: long-press edit menu without Paste](https://raw.githubusercontent.com/saphid/t3code/ef05a708d12ac57c771e6df6a736efa28074e432/5610/image-before.jpg) | ![After: long-press edit menu with Paste](https://raw.githubusercontent.com/saphid/t3code/ef05a708d12ac57c771e6df6a736efa28074e432/5610/image-after.jpg) |

### Resulting attachment

![Copied image appears in the attachment strip](https://raw.githubusercontent.com/saphid/t3code/ef05a708d12ac57c771e6df6a736efa28074e432/5610/image-attached.jpg)

### Eight-image limit

![A further paste remains at eight attachments and shows the limit alert](https://raw.githubusercontent.com/saphid/t3code/ef05a708d12ac57c771e6df6a736efa28074e432/5610/image-limit.jpg)

### Image-conforming provider regression

![A HEIC-conforming pasteboard item still exposes Paste at the eight-image limit](https://raw.githubusercontent.com/saphid/t3code/ef05a708d12ac57c771e6df6a736efa28074e432/5610/image-heic-paste.jpg)

[Interaction video: native Paste action to attachment (10.97 seconds)](https://cdn.jsdelivr.net/gh/saphid/t3code@ef05a708d12ac57c771e6df6a736efa28074e432/5610/image-after.mp4)

The four primary images and video were re-downloaded from the immutable evidence commit and matched their local SHA-256 hashes. The video was identified as H.264 at 1206×2622 and played in T3's collaborative preview. The HEIC regression image was captured from the final signed build after the Macroscope fix.

## Validation

- `AttachmentPreparationTests` + `FeatureComposerPowerTests`: 22 passed, 0 failed on the frozen diff after the review fixes.
- `T3_SWIFT_SIMULATOR_ID=… apps/swift-ios/Scripts/ci-test.sh`: 228 tests in 27 suites, 0 failures. Existing unrelated simulator warnings remained visible; no test was weakened.
- `node scripts/generate-swift-wire-fixtures.ts --check`: passed on the final diff, verifying the earlier native-CI fixture failure is repaired by the current stacking base.
- Final signed Xcode 26.6 build, install, and launch on an iPhone 17 Pro simulator running iOS 26.5: passed.
- Integrated UI: native menu and text-only paste; image-only paste to one attachment; mixed paste to text plus one attachment; text inserted at a nonterminal caret; nine-image paste capped at eight; and a further paste at capacity remained at eight with the limit alert.
- Focused simulator tests cover shared pending capacity, partial-provider success, stale lifecycle tokens used by picker/camera/paste callbacks, provider loading, draft restoration, and UTF-16 caret restoration.
- `git diff --check`: passed. Final range is four commits and 999 changed lines (915 additions, 84 deletions), reduced from 1,299 by removing the generic task store and duplicate test seams.
- Fresh GPT-5.6 Sol high minimum-scope review inspected the frozen range and found one actionable issue: image interception was being disabled once eight attachments were present. Macroscope then found that `hasImages` misses some image-conforming providers, reproduced with `public.heic`. The final patch keeps interception active at capacity and detects `UTType.image` conformance. A late exact-head Cursor finding then reproduced an empty-to-restored-text caret jump; the fix now places that caret at the UTF-16 end while preserving ordinary selections. Affected tests and the signed integrated pass were repeated.

## Checklist

- [x] Single-purpose SwiftUI image-paste change, minimized to the reliable behavior and its proof
- [x] Exact behavior and rationale described
- [x] Before/after and resulting-state screenshots included
- [x] Short interaction video included and playback verified
- [x] Focused tests, full native script, fixture check, and integrated simulator pass completed

## Related

- Stacked follow-up to #5178

Implementation, integration, and fresh review: GPT-5.6 Sol in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core composer input and async attachment ingestion with lifecycle cancellation; behavior is well-tested but regressions in paste, limits, or draft/project context switches would affect every send path on iOS.
> 
> **Overview**
> Enables **Paste** for copied screenshots/photos in the iOS chat composer by swapping the SwiftUI `TextField` for a UIKit-backed `FeatureComposerUITextView` that advertises image paste types and routes image providers through the same ingestion path as Photos, Camera, and Files.
> 
> **Paste and attachments:** Mixed pasteboards still insert plain text (via `FeatureComposerPasteTextPolicy`) while images load in a serialized `FeatureComposerPasteQueue`, respect the shared **eight-image** cap (`FeatureImageAttachmentPolicy.reserve` / `attachmentsToAppend`), and surface alerts on limit or partial failure. Image detection uses `UTType.image` conformance so HEIC-style items still show Paste at capacity.
> 
> **Lifecycle:** `FeatureAttachmentLifecycle` tokens tied to `attachmentContextID` (thread or project) cancel stale picker, camera, file, and paste work on context change or send; `NewThreadView` shares one lifecycle across project switches.
> 
> **Composer UX:** Trigger replacements and empty-to-restored draft updates set caret position with UTF-16-aware selection policy; the text field grows within a bounded viewport. Focused unit tests and brief user docs cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fc22e1db87355edabf48123233be6ec57a98c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add image paste support to the iOS chat composer
> - Subclasses `UITextView` as `FeatureComposerUITextView` to intercept paste events, exposing the system paste menu for images and inserting any coexisting plain text before queuing image attachments.
> - Introduces `FeatureComposerPasteQueue` to serialize and cancel pending paste operations when the attachment context changes or a message is sent.
> - Enforces an 8-image limit across concurrent picker and paste flows via `FeatureImageAttachmentPolicy` and `FeatureAttachmentPreparationState.reserve`; excess images are dropped and the user sees an alert.
> - Replaces the SwiftUI `TextField` with a new `FeatureComposerTextInput` (`UIViewRepresentable`) that grows to a viewport-dependent max height and preserves caret position after autocomplete insertions.
> - Attachment context is now bound to thread/project ID so in-flight async operations are invalidated on context changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fc22e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable; native/repository checks and current review are green. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
