### PR TITLE
fix(web): use themed confirmation dialogs

### DIFF
--- a/apps/desktop/src/electron/ElectronDialog.test.ts
+++ b/apps/desktop/src/electron/ElectronDialog.test.ts
@@ -28,70 +28,6 @@ describe("ElectronDialog", () => {
     showErrorBoxMock.mockReset();
   });
 
-  it.effect("returns false without opening a confirm dialog for empty messages", () =>
-    Effect.gen(function* () {
-      const dialog = yield* ElectronDialog.ElectronDialog;
-
-      const result = yield* dialog.confirm({
-        message: "   ",
-        owner: Option.none(),
-      });
-
-      assert.isFalse(result);
-      assert.equal(showMessageBoxMock.mock.calls.length, 0);
-    }).pipe(Effect.provide(ElectronDialog.layer)),
-  );
-
-  it.effect("opens a confirm dialog for the owner window", () =>
-    Effect.gen(function* () {
-      const owner = { id: 1 } as BrowserWindow;
-      showMessageBoxMock.mockResolvedValue({ response: 1 });
-      const dialog = yield* ElectronDialog.ElectronDialog;
-
-      const result = yield* dialog.confirm({
-        message: "Delete worktree?",
-        owner: Option.some(owner),
-      });
-
-      assert.isTrue(result);
-      assert.deepEqual(showMessageBoxMock.mock.calls[0], [
-        owner,
-        {
-          type: "question",
-          buttons: ["No", "Yes"],
-          defaultId: 0,
-          cancelId: 0,
-          noLink: true,
-          message: "Delete worktree?",
-        },
-      ]);
-    }).pipe(Effect.provide(ElectronDialog.layer)),
-  );
-
-  it.effect("opens an app-level confirm dialog when there is no owner window", () =>
-    Effect.gen(function* () {
-      showMessageBoxMock.mockResolvedValue({ response: 0 });
-      const dialog = yield* ElectronDialog.ElectronDialog;
-
-      const result = yield* dialog.confirm({
-        message: "Delete worktree?",
-        owner: Option.none(),
-      });
-
-      assert.isFalse(result);
-      assert.deepEqual(showMessageBoxMock.mock.calls[0], [
-        {
-          type: "question",
-          buttons: ["No", "Yes"],
-          defaultId: 0,
-          cancelId: 0,
-          noLink: true,
-          message: "Delete worktree?",
-        },
-      ]);
-    }).pipe(Effect.provide(ElectronDialog.layer)),
-  );
-
   it.effect("preserves folder picker request context and cause", () =>
     Effect.gen(function* () {
       const cause = new Error("folder picker failed");
@@ -113,31 +49,6 @@ describe("ElectronDialog", () => {
       assert.strictEqual(error.cause, cause);
       assert.include(error.message, "window 7");
       assert.include(error.message, "/workspace");
-      assert.notInclude(error.message, cause.message);
-    }).pipe(Effect.provide(ElectronDialog.layer)),
-  );
-
-  it.effect("preserves confirmation request context and cause", () =>
-    Effect.gen(function* () {
-      const cause = new Error("confirmation failed");
-      const owner = { id: 9 } as BrowserWindow;
-      showMessageBoxMock.mockRejectedValue(cause);
-      const dialog = yield* ElectronDialog.ElectronDialog;
-
-      const error = yield* Effect.flip(
-        dialog.confirm({
-          owner: Option.some(owner),
-          message: "  Confirm removal?  ",
-        }),
-      );
-
-      assert.instanceOf(error, ElectronDialog.ElectronDialogConfirmError);
-      assert.strictEqual(error.ownerWindowId, 9);
-      assert.strictEqual(error.promptLength, "Confirm removal?".length);
-      assert.notProperty(error, "promptMessage");
-      assert.strictEqual(error.cause, cause);
-      assert.include(error.message, "window 9");
-      assert.notInclude(error.message, "Confirm removal?");
       assert.notInclude(error.message, cause.message);
     }).pipe(Effect.provide(ElectronDialog.layer)),
   );

--- a/apps/desktop/src/electron/ElectronDialog.ts
+++ b/apps/desktop/src/electron/ElectronDialog.ts
@@ -6,8 +6,6 @@ import * as Schema from "effect/Schema";
 
 import * as Electron from "electron";
 
-const CONFIRM_BUTTON_INDEX = 1;
-
 export class ElectronDialogPickFolderError extends Schema.TaggedErrorClass<ElectronDialogPickFolderError>()(
   "ElectronDialogPickFolderError",
   {
@@ -35,20 +33,6 @@ export class ElectronDialogPickFilesError extends Schema.TaggedErrorClass<Electr
     const owner = this.ownerWindowId === null ? "the application" : `window ${this.ownerWindowId}`;
     const defaultPath = this.defaultPath === null ? "no default path" : this.defaultPath;
     return `Failed to open the Electron file picker for ${owner} with ${defaultPath}.`;
-  }
-}
-
-export class ElectronDialogConfirmError extends Schema.TaggedErrorClass<ElectronDialogConfirmError>()(
-  "ElectronDialogConfirmError",
-  {
-    ownerWindowId: Schema.NullOr(Schema.Number),
-    promptLength: Schema.Number,
-    cause: Schema.Defect(),
-  },
-) {
-  override get message(): string {
-    const owner = this.ownerWindowId === null ? "the application" : `window ${this.ownerWindowId}`;
-    return `Failed to open an Electron confirmation dialog for ${owner} with a ${this.promptLength}-character prompt.`;
   }
 }
 
@@ -85,7 +69,6 @@ export class ElectronDialogShowErrorBoxError extends Schema.TaggedErrorClass<Ele
 export const ElectronDialogError = Schema.Union([
   ElectronDialogPickFolderError,
   ElectronDialogPickFilesError,
-  ElectronDialogConfirmError,
   ElectronDialogShowMessageBoxError,
   ElectronDialogShowErrorBoxError,
 ]);
@@ -103,11 +86,6 @@ export interface ElectronDialogPickFilesInput {
   readonly filters: readonly Electron.FileFilter[];
 }
 
-export interface ElectronDialogConfirmInput {
-  readonly owner: Option.Option<Electron.BrowserWindow>;
-  readonly message: string;
-}
-
 export class ElectronDialog extends Context.Service<
   ElectronDialog,
   {
@@ -117,9 +95,6 @@ export class ElectronDialog extends Context.Service<
     readonly pickFiles: (
       input: ElectronDialogPickFilesInput,
     ) => Effect.Effect<readonly string[], ElectronDialogPickFilesError>;
-    readonly confirm: (
-      input: ElectronDialogConfirmInput,
-    ) => Effect.Effect<boolean, ElectronDialogConfirmError>;
     readonly showMessageBox: (
       options: Electron.MessageBoxOptions,
     ) => Effect.Effect<Electron.MessageBoxReturnValue, ElectronDialogShowMessageBoxError>;
@@ -187,39 +162,6 @@ export const make = ElectronDialog.of({
         }),
     });
     return result.canceled ? [] : result.filePaths;
-  }),
-  confirm: Effect.fn("desktop.electron.dialog.confirm")(function* (input) {
-    const normalizedMessage = input.message.trim();
-    if (normalizedMessage.length === 0) {
-      return false;
-    }
-
-    const options = {
-      type: "question" as const,
-      buttons: ["No", "Yes"],
-      defaultId: 0,
-      cancelId: 0,
-      noLink: true,
-      message: normalizedMessage,
-    };
-    const ownerWindowId = Option.match(input.owner, {
-      onNone: () => null,
-      onSome: (owner) => owner.id,
-    });
-    const result = yield* Effect.tryPromise({
-      try: () =>
-        Option.match(input.owner, {
-          onNone: () => Electron.dialog.showMessageBox(options),
-          onSome: (owner) => Electron.dialog.showMessageBox(owner, options),
-        }),
-      catch: (cause) =>
-        new ElectronDialogConfirmError({
-          ownerWindowId,
-          promptLength: normalizedMessage.length,
-          cause,
-        }),
-    });
-    return result.response === CONFIRM_BUTTON_INDEX;
   }),
   showMessageBox: (options) =>
     Effect.tryPromise({

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -31,7 +31,6 @@ import {
   setUpdateChannel,
 } from "./methods/updates.ts";
 import {
-  confirm,
   getAppBranding,
   getLocalEnvironmentBootstraps,
   getLocalEnvironmentBearerToken,
@@ -81,7 +80,6 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
 
   yield* ipc.handle(pickFolder);
   yield* ipc.handle(pickThemeFiles);
-  yield* ipc.handle(confirm);
   yield* ipc.handle(setTheme);
   yield* ipc.handle(showContextMenu);
   yield* ipc.handle(openExternal);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -1,6 +1,5 @@
 export const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 export const PICK_THEME_FILES_CHANNEL = "desktop:pick-theme-files";
-export const CONFIRM_CHANNEL = "desktop:confirm";
 export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -220,19 +220,6 @@ export const pickFolder = DesktopIpc.makeIpcMethod({
   }),
 });
 
-export const confirm = DesktopIpc.makeIpcMethod({
-  channel: IpcChannels.CONFIRM_CHANNEL,
-  payload: Schema.String,
-  result: Schema.Boolean,
-  handler: Effect.fn("desktop.ipc.window.confirm")(function* (message) {
-    const dialog = yield* ElectronDialog.ElectronDialog;
-    const electronWindow = yield* ElectronWindow.ElectronWindow;
-    return yield* electronWindow.focusedMainOrFirst.pipe(
-      Effect.flatMap((owner) => dialog.confirm({ owner, message })),
-    );
-  }),
-});
-
 export const setTheme = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.SET_THEME_CHANNEL,
   payload: DesktopThemeSchema,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -98,7 +98,6 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   setWslOnly: (enabled) => ipcRenderer.invoke(IpcChannels.SET_WSL_ONLY_CHANNEL, enabled),
   pickFolder: (options) => ipcRenderer.invoke(IpcChannels.PICK_FOLDER_CHANNEL, options),
   pickThemeFiles: () => ipcRenderer.invoke(IpcChannels.PICK_THEME_FILES_CHANNEL, undefined),
-  confirm: (message) => ipcRenderer.invoke(IpcChannels.CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(IpcChannels.SET_THEME_CHANNEL, theme),
   showContextMenu: (items, position) =>
     ipcRenderer.invoke(IpcChannels.CONTEXT_MENU_CHANNEL, {

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -53,7 +53,6 @@ const electronAppLayer = Layer.succeed(ElectronApp.ElectronApp, {
 const electronDialogLayer = Layer.succeed(ElectronDialog.ElectronDialog, {
   pickFolder: () => Effect.succeed(Option.none()),
   pickFiles: () => Effect.succeed([]),
-  confirm: () => Effect.succeed(false),
   showMessageBox: () => Effect.succeed({ response: 0, checkboxChecked: false }),
   showErrorBox: () => Effect.void,
 } satisfies ElectronDialog.ElectronDialog["Service"]);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4745,6 +4745,7 @@ function ChatViewContent(props: ChatViewProps) {
           "This will discard newer messages and turn diffs in this thread.",
           "This action cannot be undone.",
         ].join("\n"),
+        { variant: "destructive" },
       );
       if (!confirmed) {
         return;

--- a/apps/web/src/components/ConfirmDialogHost.tsx
+++ b/apps/web/src/components/ConfirmDialogHost.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useSyncExternalStore } from "react";
+
+import {
+  completeConfirmDialogClose,
+  readConfirmDialogState,
+  registerConfirmDialogHost,
+  respondToConfirmDialog,
+  subscribeConfirmDialog,
+} from "../confirmDialog";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
+import { Button } from "./ui/button";
+
+type ConfirmationCopy = {
+  readonly title: string;
+  readonly description: string;
+};
+
+export function resolveConfirmDialogCopy(message: string): ConfirmationCopy {
+  const normalizedMessage = message.trim();
+  const lines = normalizedMessage.split("\n");
+  const questionLineIndex = lines.findIndex((line) => line.trim().endsWith("?"));
+
+  if (questionLineIndex >= 0) {
+    const title = lines[questionLineIndex]!.trim();
+    const description = lines
+      .filter((_, index) => index !== questionLineIndex)
+      .join("\n")
+      .trim();
+    return { title, description };
+  }
+
+  const questionMarkIndex = normalizedMessage.indexOf("?");
+  if (questionMarkIndex >= 0) {
+    return {
+      title: normalizedMessage.slice(0, questionMarkIndex + 1).trim(),
+      description: normalizedMessage.slice(questionMarkIndex + 1).trim(),
+    };
+  }
+
+  return {
+    title: "Confirm action",
+    description: normalizedMessage || "This action requires your confirmation.",
+  };
+}
+
+export function ConfirmDialogHost() {
+  const state = useSyncExternalStore(
+    subscribeConfirmDialog,
+    readConfirmDialogState,
+    readConfirmDialogState,
+  );
+
+  useEffect(() => registerConfirmDialogHost(), []);
+
+  const copy = resolveConfirmDialogCopy(state.status === "idle" ? "" : state.message);
+  const onCancel = () => respondToConfirmDialog(false);
+  const onConfirm = () => respondToConfirmDialog(true);
+
+  return (
+    <AlertDialog
+      open={state.status === "confirming"}
+      onOpenChange={(open) => {
+        if (!open) onCancel();
+      }}
+      onOpenChangeComplete={(open) => {
+        if (!open) completeConfirmDialogClose();
+      }}
+    >
+      <AlertDialogPopup className="max-w-lg">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{copy.title}</AlertDialogTitle>
+          <AlertDialogDescription>{copy.description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+          <Button onClick={onConfirm}>Confirm</Button>
+        </AlertDialogFooter>
+      </AlertDialogPopup>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/ConfirmDialogHost.tsx
+++ b/apps/web/src/components/ConfirmDialogHost.tsx
@@ -61,6 +61,7 @@ export function ConfirmDialogHost() {
   useEffect(() => registerConfirmDialogHost(), []);
 
   const copy = resolveConfirmDialogCopy(state.status === "idle" ? "" : state.message);
+  const confirmVariant = state.status === "idle" ? "default" : state.variant;
   const onCancel = () => respondToConfirmDialog(false);
   const onConfirm = () => respondToConfirmDialog(true);
 
@@ -85,7 +86,9 @@ export function ConfirmDialogHost() {
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
-          <Button onClick={onConfirm}>Confirm</Button>
+          <Button variant={confirmVariant} onClick={onConfirm}>
+            Confirm
+          </Button>
         </AlertDialogFooter>
       </AlertDialogPopup>
     </AlertDialog>

--- a/apps/web/src/components/ConfirmDialogHost.tsx
+++ b/apps/web/src/components/ConfirmDialogHost.tsx
@@ -77,7 +77,9 @@ export function ConfirmDialogHost() {
       <AlertDialogPopup className="max-w-lg">
         <AlertDialogHeader>
           <AlertDialogTitle>{copy.title}</AlertDialogTitle>
-          <AlertDialogDescription>{copy.description}</AlertDialogDescription>
+          <AlertDialogDescription className="whitespace-pre-line">
+            {copy.description}
+          </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>

--- a/apps/web/src/components/ConfirmDialogHost.tsx
+++ b/apps/web/src/components/ConfirmDialogHost.tsx
@@ -20,7 +20,7 @@ import { Button } from "./ui/button";
 
 type ConfirmationCopy = {
   readonly title: string;
-  readonly description: string;
+  readonly description: string | null;
 };
 
 export function resolveConfirmDialogCopy(message: string): ConfirmationCopy {
@@ -34,14 +34,14 @@ export function resolveConfirmDialogCopy(message: string): ConfirmationCopy {
       .filter((_, index) => index !== questionLineIndex)
       .join("\n")
       .trim();
-    return { title, description };
+    return { title, description: description || null };
   }
 
   const questionMarkIndex = normalizedMessage.indexOf("?");
   if (questionMarkIndex >= 0) {
     return {
       title: normalizedMessage.slice(0, questionMarkIndex + 1).trim(),
-      description: normalizedMessage.slice(questionMarkIndex + 1).trim(),
+      description: normalizedMessage.slice(questionMarkIndex + 1).trim() || null,
     };
   }
 
@@ -77,9 +77,11 @@ export function ConfirmDialogHost() {
       <AlertDialogPopup className="max-w-lg">
         <AlertDialogHeader>
           <AlertDialogTitle>{copy.title}</AlertDialogTitle>
-          <AlertDialogDescription className="whitespace-pre-line">
-            {copy.description}
-          </AlertDialogDescription>
+          {copy.description ? (
+            <AlertDialogDescription className="whitespace-pre-line">
+              {copy.description}
+            </AlertDialogDescription>
+          ) : null}
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -104,7 +104,7 @@ import {
 } from "../keybindings";
 import { isModelPickerOpen } from "../modelPickerVisibility";
 import { useShortcutModifierState } from "../shortcutModifierState";
-import { readLocalApi } from "../localApi";
+import { ensureLocalApi, readLocalApi } from "../localApi";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { useDesktopUpdateState } from "../state/desktopUpdate";
@@ -2730,6 +2730,7 @@ interface SidebarProjectsContentProps {
   arm64IntelBuildWarningDescription: string | null;
   desktopUpdateButtonAction: "download" | "install" | "none";
   desktopUpdateButtonDisabled: boolean;
+  desktopUpdateActionPending: boolean;
   handleDesktopUpdateButtonClick: () => void;
   projectSortOrder: SidebarProjectSortOrder;
   threadSortOrder: SidebarThreadSortOrder;
@@ -2770,6 +2771,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     arm64IntelBuildWarningDescription,
     desktopUpdateButtonAction,
     desktopUpdateButtonDisabled,
+    desktopUpdateActionPending,
     handleDesktopUpdateButtonClick,
     projectSortOrder,
     threadSortOrder,
@@ -2862,7 +2864,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 <Button
                   size="xs"
                   variant="outline"
-                  disabled={desktopUpdateButtonDisabled}
+                  disabled={desktopUpdateButtonDisabled || desktopUpdateActionPending}
                   onClick={handleDesktopUpdateButtonClick}
                 >
                   {desktopUpdateButtonAction === "download"
@@ -3032,6 +3034,7 @@ export default function LegacySidebar() {
   const suppressProjectClickAfterDragRef = useRef(false);
   const suppressProjectClickForContextMenuRef = useRef(false);
   const desktopUpdateState = useDesktopUpdateState();
+  const [desktopUpdateActionPending, setDesktopUpdateActionPending] = useState(false);
   const clearSelection = useThreadSelectionStore((s) => s.clearSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
   const platform = navigator.platform;
@@ -3498,10 +3501,18 @@ export default function LegacySidebar() {
     "commandPalette.toggle",
     newThreadShortcutLabelOptions,
   );
-  const handleDesktopUpdateButtonClick = useCallback(() => {
+  const handleDesktopUpdateButtonClick = useCallback(async () => {
     const bridge = window.desktopBridge;
     if (!bridge || !desktopUpdateState) return;
-    if (desktopUpdateButtonDisabled || desktopUpdateButtonAction === "none") return;
+    if (
+      desktopUpdateButtonDisabled ||
+      desktopUpdateButtonAction === "none" ||
+      desktopUpdateActionPending
+    ) {
+      return;
+    }
+
+    setDesktopUpdateActionPending(true);
 
     if (desktopUpdateButtonAction === "download") {
       void bridge
@@ -3529,15 +3540,32 @@ export default function LegacySidebar() {
               description: error instanceof Error ? error.message : "An unexpected error occurred.",
             }),
           );
-        });
+        })
+        .finally(() => setDesktopUpdateActionPending(false));
       return;
     }
 
     if (desktopUpdateButtonAction === "install") {
-      const confirmed = window.confirm(
-        getDesktopUpdateInstallConfirmationMessage(desktopUpdateState, navigator.platform),
-      );
-      if (!confirmed) return;
+      let confirmed = false;
+      try {
+        confirmed = await ensureLocalApi().dialogs.confirm(
+          getDesktopUpdateInstallConfirmationMessage(desktopUpdateState, navigator.platform),
+        );
+      } catch (error) {
+        setDesktopUpdateActionPending(false);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not confirm update",
+            description: error instanceof Error ? error.message : "Update confirmation failed.",
+          }),
+        );
+        return;
+      }
+      if (!confirmed) {
+        setDesktopUpdateActionPending(false);
+        return;
+      }
       void bridge
         .installUpdate()
         .then((result) => {
@@ -3560,9 +3588,15 @@ export default function LegacySidebar() {
               description: error instanceof Error ? error.message : "An unexpected error occurred.",
             }),
           );
-        });
+        })
+        .finally(() => setDesktopUpdateActionPending(false));
     }
-  }, [desktopUpdateButtonAction, desktopUpdateButtonDisabled, desktopUpdateState]);
+  }, [
+    desktopUpdateActionPending,
+    desktopUpdateButtonAction,
+    desktopUpdateButtonDisabled,
+    desktopUpdateState,
+  ]);
 
   const expandThreadListForProject = useCallback((projectKey: string) => {
     setExpandedThreadListsByProject((current) => {
@@ -3594,6 +3628,7 @@ export default function LegacySidebar() {
         arm64IntelBuildWarningDescription={arm64IntelBuildWarningDescription}
         desktopUpdateButtonAction={desktopUpdateButtonAction}
         desktopUpdateButtonDisabled={desktopUpdateButtonDisabled}
+        desktopUpdateActionPending={desktopUpdateActionPending}
         handleDesktopUpdateButtonClick={handleDesktopUpdateButtonClick}
         projectSortOrder={sidebarProjectSortOrder}
         threadSortOrder={sidebarThreadSortOrder}

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -1499,6 +1499,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                             : []),
                           "This removes only this project entry.",
                         ].join("\n"),
+                    { variant: "destructive" },
                   );
                   if (!confirmed) {
                     return;
@@ -1547,7 +1548,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         ...(member.environmentLabel ? [`Environment: ${member.environmentLabel}`] : []),
         "This removes only this project entry.",
       ].join("\n");
-      const confirmed = await api.dialogs.confirm(message);
+      const confirmed = await api.dialogs.confirm(message, { variant: "destructive" });
       if (!confirmed) {
         return;
       }
@@ -1830,6 +1831,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
             `Delete ${count} thread${count === 1 ? "" : "s"}?`,
             "This permanently clears conversation history for these threads.",
           ].join("\n"),
+          { variant: "destructive" },
         );
         if (!confirmed) return;
       }
@@ -2180,6 +2182,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
             `Delete thread "${thread.title}"?`,
             "This permanently clears conversation history for this thread.",
           ].join("\n"),
+          { variant: "destructive" },
         );
         if (!confirmed) {
           return;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2808,6 +2808,7 @@ export default function Sidebar() {
               `Delete ${count} thread${count === 1 ? "" : "s"}?`,
               "This permanently clears conversation history for these threads.",
             ].join("\n"),
+            { variant: "destructive" },
           ),
         );
         if (confirmed._tag === "Failure" || !confirmed.value) return;
@@ -3010,6 +3011,7 @@ export default function Sidebar() {
                     `Delete thread "${thread.title}"?`,
                     "This permanently clears conversation history for this thread.",
                   ].join("\n"),
+                  { variant: "destructive" },
                 ),
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -22,6 +22,7 @@ import * as DateTime from "effect/DateTime";
 import * as Option from "effect/Option";
 
 import { cn } from "../../lib/utils";
+import { ensureLocalApi } from "../../localApi";
 import { resolveAndPersistPreferredEditor } from "../../editorPreferences";
 import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFormat";
 import { useEnvironmentQuery } from "../../state/query";
@@ -895,12 +896,14 @@ export function DiagnosticsSettingsPanel() {
   const isInitialLoading = isPending && data === null;
   const isProcessInitialLoading = isProcessPending && processData === null;
   const signalProcess = useCallback(
-    (pid: number, signal: ServerProcessSignal) => {
-      if (
-        signal === "SIGKILL" &&
-        !window.confirm(`Send SIGKILL to process ${pid}? This cannot be handled by the process.`)
-      ) {
-        return;
+    async (pid: number, signal: ServerProcessSignal) => {
+      if (signal === "SIGKILL") {
+        const confirmed = await ensureLocalApi().dialogs.confirm(
+          `Send SIGKILL to process ${pid}? This cannot be handled by the process.`,
+        );
+        if (!confirmed) {
+          return;
+        }
       }
       if (environmentId === null) {
         return;

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -914,6 +914,7 @@ export function DiagnosticsSettingsPanel() {
         try {
           confirmed = await ensureLocalApi().dialogs.confirm(
             `Send SIGKILL to process ${pid}? This cannot be handled by the process.`,
+            { variant: "destructive" },
           );
         } catch (error) {
           clearSignaling();

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -902,7 +902,7 @@ export function DiagnosticsSettingsPanel() {
   const isProcessInitialLoading = isProcessPending && processData === null;
   const signalProcess = useCallback(
     async (pid: number, signal: ServerProcessSignal) => {
-      if (signalingPidRef.current === pid) return;
+      if (signalingPidRef.current !== null) return;
       signalingPidRef.current = pid;
       setSignalingPid(pid);
       if (signal === "SIGKILL") {
@@ -914,7 +914,12 @@ export function DiagnosticsSettingsPanel() {
         } catch (error) {
           signalingPidRef.current = null;
           setSignalingPid(null);
-          throw error;
+          toastManager.add({
+            type: "error",
+            title: "Could not confirm signal",
+            description: error instanceof Error ? error.message : `Failed to send ${signal}.`,
+          });
+          return;
         }
         if (!confirmed) {
           signalingPidRef.current = null;

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -12,7 +12,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 import type {
   ServerProcessDiagnosticsEntry,
   ServerProcessResourceHistorySummary,
@@ -858,6 +858,11 @@ export function DiagnosticsSettingsPanel() {
   const [isOpeningLogsDirectory, setIsOpeningLogsDirectory] = useState(false);
   const [openLogsDirectoryError, setOpenLogsDirectoryError] = useState<string | null>(null);
   const [signalingPid, setSignalingPid] = useState<number | null>(null);
+  const signalingPidRef = useRef<number | null>(null);
+  const environmentIdRef = useRef(environmentId);
+  const processDataRef = useRef(processData);
+  environmentIdRef.current = environmentId;
+  processDataRef.current = processData;
 
   const openLogsDirectory = useCallback(() => {
     const logsDirectoryPath = observability?.logsDirectoryPath ?? null;
@@ -897,28 +902,45 @@ export function DiagnosticsSettingsPanel() {
   const isProcessInitialLoading = isProcessPending && processData === null;
   const signalProcess = useCallback(
     async (pid: number, signal: ServerProcessSignal) => {
+      if (signalingPidRef.current === pid) return;
+      signalingPidRef.current = pid;
+      setSignalingPid(pid);
       if (signal === "SIGKILL") {
-        const confirmed = await ensureLocalApi().dialogs.confirm(
-          `Send SIGKILL to process ${pid}? This cannot be handled by the process.`,
-        );
+        let confirmed = false;
+        try {
+          confirmed = await ensureLocalApi().dialogs.confirm(
+            `Send SIGKILL to process ${pid}? This cannot be handled by the process.`,
+          );
+        } catch (error) {
+          signalingPidRef.current = null;
+          setSignalingPid(null);
+          throw error;
+        }
         if (!confirmed) {
+          signalingPidRef.current = null;
+          setSignalingPid(null);
           return;
         }
       }
-      if (environmentId === null) {
+      const currentEnvironmentId = environmentIdRef.current;
+      if (currentEnvironmentId === null) {
+        signalingPidRef.current = null;
+        setSignalingPid(null);
         return;
       }
-      const process = processData?.processes.find((entry) => entry.pid === pid);
+      const process = processDataRef.current?.processes.find((entry) => entry.pid === pid);
       if (process === undefined) {
+        signalingPidRef.current = null;
+        setSignalingPid(null);
         return;
       }
 
-      setSignalingPid(pid);
       void (async () => {
         const result = await signalServerProcess({
-          environmentId,
+          environmentId: currentEnvironmentId,
           input: { pid, startTimeMs: process.startTimeMs, signal },
         });
+        signalingPidRef.current = null;
         setSignalingPid(null);
         if (result._tag === "Failure") {
           if (!isAtomCommandInterrupted(result)) {

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -905,6 +905,10 @@ export function DiagnosticsSettingsPanel() {
       if (signalingPidRef.current !== null) return;
       signalingPidRef.current = pid;
       setSignalingPid(pid);
+      const clearSignaling = () => {
+        signalingPidRef.current = null;
+        setSignalingPid(null);
+      };
       if (signal === "SIGKILL") {
         let confirmed = false;
         try {
@@ -912,8 +916,7 @@ export function DiagnosticsSettingsPanel() {
             `Send SIGKILL to process ${pid}? This cannot be handled by the process.`,
           );
         } catch (error) {
-          signalingPidRef.current = null;
-          setSignalingPid(null);
+          clearSignaling();
           toastManager.add({
             type: "error",
             title: "Could not confirm signal",
@@ -922,31 +925,26 @@ export function DiagnosticsSettingsPanel() {
           return;
         }
         if (!confirmed) {
-          signalingPidRef.current = null;
-          setSignalingPid(null);
+          clearSignaling();
           return;
         }
       }
       const currentEnvironmentId = environmentIdRef.current;
       if (currentEnvironmentId === null) {
-        signalingPidRef.current = null;
-        setSignalingPid(null);
+        clearSignaling();
         return;
       }
       const process = processDataRef.current?.processes.find((entry) => entry.pid === pid);
       if (process === undefined) {
-        signalingPidRef.current = null;
-        setSignalingPid(null);
+        clearSignaling();
         return;
       }
 
-      void (async () => {
+      try {
         const result = await signalServerProcess({
           environmentId: currentEnvironmentId,
           input: { pid, startTimeMs: process.startTimeMs, signal },
         });
-        signalingPidRef.current = null;
-        setSignalingPid(null);
         if (result._tag === "Failure") {
           if (!isAtomCommandInterrupted(result)) {
             const error = squashAtomCommandFailure(result);
@@ -979,9 +977,11 @@ export function DiagnosticsSettingsPanel() {
           return;
         }
         refreshProcesses();
-      })();
+      } finally {
+        clearSignaling();
+      }
     },
-    [environmentId, processData?.processes, refreshProcesses, signalServerProcess],
+    [refreshProcesses, signalServerProcess],
   );
 
   const processDiagnosticsError = processData ? Option.getOrNull(processData.error) : null;

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -657,6 +657,7 @@ function ProjectDetail({
               : "Other entries in this grouped project are unaffected.",
             "This action cannot be undone.",
           ].join("\n"),
+          { variant: "destructive" },
         ),
       );
       if (confirmed._tag === "Failure" || !confirmed.value) return;

--- a/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
+++ b/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
@@ -873,6 +873,7 @@ export function ResourceTelemetryDiagnostics() {
         try {
           confirmed = await ensureLocalApi().dialogs.confirm(
             `Send SIGKILL to process ${process.identity.pid}? This cannot be handled by the process.`,
+            { variant: "destructive" },
           );
         } catch (error) {
           clearSignaling();

--- a/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
+++ b/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
@@ -27,7 +27,7 @@ import type {
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
 import * as Option from "effect/Option";
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -846,26 +846,49 @@ export function ResourceTelemetryDiagnostics() {
     reportFailure: false,
   });
   const [signalingKeys, setSignalingKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const signalingKeysRef = useRef<ReadonlySet<string>>(new Set());
+  signalingKeysRef.current = signalingKeys;
   const [isRetrying, setIsRetrying] = useState(false);
   const snapshot = telemetry.data;
   const allT3 = snapshot?.groups.allT3;
 
   const signalProcess = useCallback(
     async (process: ResourceTelemetryProcess, signal: ServerProcessSignal) => {
+      const identityKey = processIdentityKey(process);
+      if (signalingKeysRef.current.has(identityKey)) return;
+      const nextSignalingKeys = new Set(signalingKeysRef.current).add(identityKey);
+      signalingKeysRef.current = nextSignalingKeys;
+      setSignalingKeys(nextSignalingKeys);
+
       if (signal === "SIGKILL") {
-        const confirmed = await ensureLocalApi().dialogs.confirm(
-          `Send SIGKILL to process ${process.identity.pid}? This cannot be handled by the process.`,
-        );
+        let confirmed = false;
+        try {
+          confirmed = await ensureLocalApi().dialogs.confirm(
+            `Send SIGKILL to process ${process.identity.pid}? This cannot be handled by the process.`,
+          );
+        } catch (error) {
+          signalingKeysRef.current = new Set(
+            [...signalingKeysRef.current].filter((key) => key !== identityKey),
+          );
+          setSignalingKeys(signalingKeysRef.current);
+          throw error;
+        }
         if (!confirmed) {
+          signalingKeysRef.current = new Set(
+            [...signalingKeysRef.current].filter((key) => key !== identityKey),
+          );
+          setSignalingKeys(signalingKeysRef.current);
           return;
         }
       }
-      const identityKey = processIdentityKey(process);
       const environmentId = primaryEnvironment?.environmentId;
       if (environmentId === undefined) {
+        signalingKeysRef.current = new Set(
+          [...signalingKeysRef.current].filter((key) => key !== identityKey),
+        );
+        setSignalingKeys(signalingKeysRef.current);
         return;
       }
-      setSignalingKeys((current) => new Set(current).add(identityKey));
       void signalServerProcess({
         environmentId,
         input: {
@@ -897,12 +920,10 @@ export function ResourceTelemetryDiagnostics() {
           });
         })
         .finally(() => {
-          setSignalingKeys((current) => {
-            if (!current.has(identityKey)) return current;
-            const next = new Set(current);
-            next.delete(identityKey);
-            return next;
-          });
+          signalingKeysRef.current = new Set(
+            [...signalingKeysRef.current].filter((key) => key !== identityKey),
+          );
+          setSignalingKeys(signalingKeysRef.current);
         });
     },
     [primaryEnvironment?.environmentId, signalServerProcess],

--- a/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
+++ b/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
@@ -848,6 +848,8 @@ export function ResourceTelemetryDiagnostics() {
   const [signalingKeys, setSignalingKeys] = useState<ReadonlySet<string>>(() => new Set());
   const signalingKeysRef = useRef<ReadonlySet<string>>(new Set());
   signalingKeysRef.current = signalingKeys;
+  const primaryEnvironmentIdRef = useRef(primaryEnvironment?.environmentId);
+  primaryEnvironmentIdRef.current = primaryEnvironment?.environmentId;
   const [isRetrying, setIsRetrying] = useState(false);
   const snapshot = telemetry.data;
   const allT3 = snapshot?.groups.allT3;
@@ -859,6 +861,12 @@ export function ResourceTelemetryDiagnostics() {
       const nextSignalingKeys = new Set(signalingKeysRef.current).add(identityKey);
       signalingKeysRef.current = nextSignalingKeys;
       setSignalingKeys(nextSignalingKeys);
+      const clearSignaling = () => {
+        const next = new Set(signalingKeysRef.current);
+        next.delete(identityKey);
+        signalingKeysRef.current = next;
+        setSignalingKeys(next);
+      };
 
       if (signal === "SIGKILL") {
         let confirmed = false;
@@ -867,26 +875,22 @@ export function ResourceTelemetryDiagnostics() {
             `Send SIGKILL to process ${process.identity.pid}? This cannot be handled by the process.`,
           );
         } catch (error) {
-          signalingKeysRef.current = new Set(
-            [...signalingKeysRef.current].filter((key) => key !== identityKey),
-          );
-          setSignalingKeys(signalingKeysRef.current);
-          throw error;
+          clearSignaling();
+          toastManager.add({
+            type: "error",
+            title: "Could not confirm signal",
+            description: error instanceof Error ? error.message : `Failed to send ${signal}.`,
+          });
+          return;
         }
         if (!confirmed) {
-          signalingKeysRef.current = new Set(
-            [...signalingKeysRef.current].filter((key) => key !== identityKey),
-          );
-          setSignalingKeys(signalingKeysRef.current);
+          clearSignaling();
           return;
         }
       }
-      const environmentId = primaryEnvironment?.environmentId;
+      const environmentId = primaryEnvironmentIdRef.current;
       if (environmentId === undefined) {
-        signalingKeysRef.current = new Set(
-          [...signalingKeysRef.current].filter((key) => key !== identityKey),
-        );
-        setSignalingKeys(signalingKeysRef.current);
+        clearSignaling();
         return;
       }
       void signalServerProcess({
@@ -920,13 +924,10 @@ export function ResourceTelemetryDiagnostics() {
           });
         })
         .finally(() => {
-          signalingKeysRef.current = new Set(
-            [...signalingKeysRef.current].filter((key) => key !== identityKey),
-          );
-          setSignalingKeys(signalingKeysRef.current);
+          clearSignaling();
         });
     },
-    [primaryEnvironment?.environmentId, signalServerProcess],
+    [signalServerProcess],
   );
 
   const retryCollector = useCallback(() => {

--- a/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
+++ b/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
@@ -38,6 +38,7 @@ import {
   useResourceTelemetryHistory,
 } from "../../lib/resourceTelemetryState";
 import { cn } from "../../lib/utils";
+import { ensureLocalApi } from "../../localApi";
 import { usePrimaryEnvironment } from "../../state/environments";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
@@ -850,14 +851,14 @@ export function ResourceTelemetryDiagnostics() {
   const allT3 = snapshot?.groups.allT3;
 
   const signalProcess = useCallback(
-    (process: ResourceTelemetryProcess, signal: ServerProcessSignal) => {
-      if (
-        signal === "SIGKILL" &&
-        !window.confirm(
+    async (process: ResourceTelemetryProcess, signal: ServerProcessSignal) => {
+      if (signal === "SIGKILL") {
+        const confirmed = await ensureLocalApi().dialogs.confirm(
           `Send SIGKILL to process ${process.identity.pid}? This cannot be handled by the process.`,
-        )
-      ) {
-        return;
+        );
+        if (!confirmed) {
+          return;
+        }
       }
       const identityKey = processIdentityKey(process);
       const environmentId = primaryEnvironment?.environmentId;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -255,7 +255,7 @@ function AboutVersionSection() {
     [selectedUpdateChannel],
   );
 
-  const handleButtonClick = useCallback(() => {
+  const handleButtonClick = useCallback(async () => {
     const bridge = window.desktopBridge;
     if (!bridge) return;
 
@@ -275,7 +275,7 @@ function AboutVersionSection() {
     }
 
     if (action === "install") {
-      const confirmed = window.confirm(
+      const confirmed = await ensureLocalApi().dialogs.confirm(
         getDesktopUpdateInstallConfirmationMessage(
           updateState ?? { availableVersion: null, downloadedVersion: null },
           navigator.platform,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -220,6 +220,7 @@ function AboutVersionTitle() {
 function AboutVersionSection() {
   const updateState = useDesktopUpdateState();
   const [isChangingUpdateChannel, setIsChangingUpdateChannel] = useState(false);
+  const [isUpdateActionPending, setIsUpdateActionPending] = useState(false);
 
   const hasDesktopBridge = typeof window !== "undefined" && Boolean(window.desktopBridge);
   const selectedUpdateChannel = updateState?.channel ?? "latest";
@@ -275,22 +276,36 @@ function AboutVersionSection() {
     }
 
     if (action === "install") {
-      const confirmed = await ensureLocalApi().dialogs.confirm(
-        getDesktopUpdateInstallConfirmationMessage(
-          updateState ?? { availableVersion: null, downloadedVersion: null },
-          navigator.platform,
-        ),
-      );
-      if (!confirmed) return;
-      void bridge.installUpdate().catch((error: unknown) => {
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Could not install update",
-            description: error instanceof Error ? error.message : "Install failed.",
-          }),
+      if (isUpdateActionPending) return;
+      setIsUpdateActionPending(true);
+      let confirmed = false;
+      try {
+        confirmed = await ensureLocalApi().dialogs.confirm(
+          getDesktopUpdateInstallConfirmationMessage(
+            updateState ?? { availableVersion: null, downloadedVersion: null },
+            navigator.platform,
+          ),
         );
-      });
+      } catch (error) {
+        setIsUpdateActionPending(false);
+        throw error;
+      }
+      if (!confirmed) {
+        setIsUpdateActionPending(false);
+        return;
+      }
+      void bridge
+        .installUpdate()
+        .catch((error: unknown) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not install update",
+              description: error instanceof Error ? error.message : "Install failed.",
+            }),
+          );
+        })
+        .finally(() => setIsUpdateActionPending(false));
       return;
     }
 
@@ -318,7 +333,7 @@ function AboutVersionSection() {
           }),
         );
       });
-  }, [updateState]);
+  }, [isUpdateActionPending, updateState]);
 
   const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
   const buttonTooltip = updateState ? getDesktopUpdateButtonTooltip(updateState) : null;
@@ -352,7 +367,7 @@ function AboutVersionSection() {
                 <Button
                   size="xs"
                   variant={action === "install" ? "default" : "outline"}
-                  disabled={buttonDisabled}
+                  disabled={buttonDisabled || isUpdateActionPending}
                   onClick={handleButtonClick}
                 >
                   {buttonLabel}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -288,7 +288,14 @@ function AboutVersionSection() {
         );
       } catch (error) {
         setIsUpdateActionPending(false);
-        throw error;
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not confirm update",
+            description: error instanceof Error ? error.message : "Update confirmation failed.",
+          }),
+        );
+        return;
       }
       if (!confirmed) {
         setIsUpdateActionPending(false);

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -571,6 +571,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       ["Restore default settings?", `This will reset: ${changedSettingLabels.join(", ")}.`].join(
         "\n",
       ),
+      { variant: "destructive" },
     );
     if (!confirmed) return;
 

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -128,7 +128,14 @@ export function SidebarUpdatePill() {
         );
       } catch (error) {
         setIsActionPending(false);
-        throw error;
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not confirm update",
+            description: error instanceof Error ? error.message : "Update confirmation failed.",
+          }),
+        );
+        return;
       }
       if (!confirmed) {
         setIsActionPending(false);

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -71,6 +71,7 @@ function SidebarUpdateReleaseNotesTooltip({
 export function SidebarUpdatePill() {
   const state = useDesktopUpdateState();
   const [dismissed, setDismissed] = useState(false);
+  const [isActionPending, setIsActionPending] = useState(false);
 
   const visible = isElectron && shouldShowDesktopUpdateButton(state) && !dismissed;
   const tooltip = state ? getDesktopUpdateButtonTooltip(state) : "Update available";
@@ -84,7 +85,9 @@ export function SidebarUpdatePill() {
   const handleAction = useCallback(async () => {
     const bridge = window.desktopBridge;
     if (!bridge || !state) return;
-    if (disabled || action === "none") return;
+    if (disabled || action === "none" || isActionPending) return;
+
+    setIsActionPending(true);
 
     if (action === "download") {
       void bridge
@@ -112,15 +115,25 @@ export function SidebarUpdatePill() {
               description: error instanceof Error ? error.message : "An unexpected error occurred.",
             }),
           );
-        });
+        })
+        .finally(() => setIsActionPending(false));
       return;
     }
 
     if (action === "install") {
-      const confirmed = await ensureLocalApi().dialogs.confirm(
-        getDesktopUpdateInstallConfirmationMessage(state, navigator.platform),
-      );
-      if (!confirmed) return;
+      let confirmed = false;
+      try {
+        confirmed = await ensureLocalApi().dialogs.confirm(
+          getDesktopUpdateInstallConfirmationMessage(state, navigator.platform),
+        );
+      } catch (error) {
+        setIsActionPending(false);
+        throw error;
+      }
+      if (!confirmed) {
+        setIsActionPending(false);
+        return;
+      }
       void bridge
         .installUpdate()
         .then((result) => {
@@ -143,9 +156,10 @@ export function SidebarUpdatePill() {
               description: error instanceof Error ? error.message : "An unexpected error occurred.",
             }),
           );
-        });
+        })
+        .finally(() => setIsActionPending(false));
     }
-  }, [action, disabled, state]);
+  }, [action, disabled, isActionPending, state]);
 
   if (!visible && !showArm64Warning) return null;
 
@@ -171,8 +185,8 @@ export function SidebarUpdatePill() {
                 <button
                   type="button"
                   aria-label={tooltip}
-                  aria-disabled={disabled || undefined}
-                  disabled={disabled}
+                  aria-disabled={disabled || isActionPending || undefined}
+                  disabled={disabled || isActionPending}
                   className="update-main relative flex h-full flex-1 items-center gap-2 px-2 enabled:cursor-pointer"
                   onClick={handleAction}
                 >

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -1,6 +1,7 @@
 import { DownloadIcon, RotateCwIcon, TriangleAlertIcon, XIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { isElectron } from "../../env";
+import { ensureLocalApi } from "../../localApi";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import {
@@ -80,7 +81,7 @@ export function SidebarUpdatePill() {
   const arm64Description =
     state && showArm64Warning ? getArm64IntelBuildWarningDescription(state) : null;
 
-  const handleAction = useCallback(() => {
+  const handleAction = useCallback(async () => {
     const bridge = window.desktopBridge;
     if (!bridge || !state) return;
     if (disabled || action === "none") return;
@@ -116,7 +117,7 @@ export function SidebarUpdatePill() {
     }
 
     if (action === "install") {
-      const confirmed = window.confirm(
+      const confirmed = await ensureLocalApi().dialogs.confirm(
         getDesktopUpdateInstallConfirmationMessage(state, navigator.platform),
       );
       if (!confirmed) return;

--- a/apps/web/src/confirmDialog.test.ts
+++ b/apps/web/src/confirmDialog.test.ts
@@ -28,11 +28,14 @@ describe("confirm dialog coordinator", () => {
 
   it("resolves a displayed confirmation and waits for its close transition", async () => {
     const unregister = registerConfirmDialogHost();
-    const confirmation = requireConfirmation(requestConfirmDialog("Delete this thread?"));
+    const confirmation = requireConfirmation(
+      requestConfirmDialog("Delete this thread?", { variant: "destructive" }),
+    );
 
     expect(readConfirmDialogState()).toEqual({
       status: "confirming",
       message: "Delete this thread?",
+      variant: "destructive",
     });
 
     respondToConfirmDialog(true);
@@ -40,6 +43,7 @@ describe("confirm dialog coordinator", () => {
     expect(readConfirmDialogState()).toEqual({
       status: "closing",
       message: "Delete this thread?",
+      variant: "destructive",
     });
 
     completeConfirmDialogClose();
@@ -57,12 +61,14 @@ describe("confirm dialog coordinator", () => {
     expect(readConfirmDialogState()).toEqual({
       status: "closing",
       message: "Delete the project?",
+      variant: "default",
     });
 
     completeConfirmDialogClose();
     expect(readConfirmDialogState()).toEqual({
       status: "confirming",
       message: "Delete the worktree too?",
+      variant: "default",
     });
 
     respondToConfirmDialog(true);

--- a/apps/web/src/confirmDialog.test.ts
+++ b/apps/web/src/confirmDialog.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  completeConfirmDialogClose,
+  readConfirmDialogState,
+  registerConfirmDialogHost,
+  requestConfirmDialog,
+  resetConfirmDialogForTests,
+  respondToConfirmDialog,
+} from "./confirmDialog";
+
+function requireConfirmation(confirmation: Promise<boolean> | undefined): Promise<boolean> {
+  if (!confirmation) {
+    throw new Error("Expected a registered confirmation host.");
+  }
+  return confirmation;
+}
+
+describe("confirm dialog coordinator", () => {
+  beforeEach(() => {
+    resetConfirmDialogForTests();
+  });
+
+  it("returns undefined until a themed host is mounted", () => {
+    expect(requestConfirmDialog("Confirm this action?")).toBeUndefined();
+    expect(readConfirmDialogState()).toEqual({ status: "idle" });
+  });
+
+  it("resolves a displayed confirmation and waits for its close transition", async () => {
+    const unregister = registerConfirmDialogHost();
+    const confirmation = requireConfirmation(requestConfirmDialog("Delete this thread?"));
+
+    expect(readConfirmDialogState()).toEqual({
+      status: "confirming",
+      message: "Delete this thread?",
+    });
+
+    respondToConfirmDialog(true);
+    await expect(confirmation).resolves.toBe(true);
+    expect(readConfirmDialogState()).toEqual({
+      status: "closing",
+      message: "Delete this thread?",
+    });
+
+    completeConfirmDialogClose();
+    expect(readConfirmDialogState()).toEqual({ status: "idle" });
+    unregister();
+  });
+
+  it("serializes concurrent confirmations", async () => {
+    const unregister = registerConfirmDialogHost();
+    const first = requireConfirmation(requestConfirmDialog("Delete the project?"));
+    const second = requireConfirmation(requestConfirmDialog("Delete the worktree too?"));
+
+    respondToConfirmDialog(false);
+    await expect(first).resolves.toBe(false);
+    expect(readConfirmDialogState()).toEqual({
+      status: "closing",
+      message: "Delete the project?",
+    });
+
+    completeConfirmDialogClose();
+    expect(readConfirmDialogState()).toEqual({
+      status: "confirming",
+      message: "Delete the worktree too?",
+    });
+
+    respondToConfirmDialog(true);
+    await expect(second).resolves.toBe(true);
+    completeConfirmDialogClose();
+    expect(readConfirmDialogState()).toEqual({ status: "idle" });
+    unregister();
+  });
+
+  it("cancels active and queued confirmations if the last host unmounts", async () => {
+    const unregister = registerConfirmDialogHost();
+    const active = requireConfirmation(requestConfirmDialog("Delete the thread?"));
+    const queued = requireConfirmation(requestConfirmDialog("Delete the worktree too?"));
+
+    unregister();
+
+    await expect(Promise.all([active, queued])).resolves.toEqual([false, false]);
+    expect(readConfirmDialogState()).toEqual({ status: "idle" });
+  });
+
+  it("ignores responses after the active dialog has been closed", () => {
+    const unregister = registerConfirmDialogHost();
+    const confirmation = requireConfirmation(requestConfirmDialog("Continue?"));
+
+    respondToConfirmDialog(true);
+    respondToConfirmDialog(false);
+    completeConfirmDialogClose();
+
+    expect(readConfirmDialogState()).toEqual({ status: "idle" });
+    unregister();
+    return expect(confirmation).resolves.toBe(true);
+  });
+});

--- a/apps/web/src/confirmDialog.ts
+++ b/apps/web/src/confirmDialog.ts
@@ -43,8 +43,8 @@ export function subscribeConfirmDialog(listener: () => void): () => void {
 }
 
 /**
- * Registers the renderer host that can present themed confirmations. Returning
- * an unavailable result lets the local API retain a host-specific fallback.
+ * Registers the renderer host that can present themed confirmations. The
+ * returned cleanup function also cancels any request left without a host.
  */
 export function registerConfirmDialogHost(): () => void {
   registeredHostCount += 1;
@@ -64,7 +64,7 @@ export function registerConfirmDialogHost(): () => void {
 
 /**
  * Requests a themed confirmation when a host is mounted. An undefined result
- * means the caller should use its environment-specific fallback.
+ * means no themed host is currently available.
  */
 export function requestConfirmDialog(message: string): Promise<boolean> | undefined {
   if (registeredHostCount === 0) return undefined;

--- a/apps/web/src/confirmDialog.ts
+++ b/apps/web/src/confirmDialog.ts
@@ -1,0 +1,113 @@
+export type ConfirmDialogState =
+  | { readonly status: "idle" }
+  | { readonly status: "confirming"; readonly message: string }
+  | { readonly status: "closing"; readonly message: string };
+
+type PendingConfirmation = {
+  readonly message: string;
+  readonly resolve: (confirmed: boolean) => void;
+};
+
+const idleState: ConfirmDialogState = { status: "idle" };
+let state: ConfirmDialogState = idleState;
+let activeConfirmation: PendingConfirmation | null = null;
+let queuedConfirmations: PendingConfirmation[] = [];
+let registeredHostCount = 0;
+const listeners = new Set<() => void>();
+
+function publish(next: ConfirmDialogState): void {
+  state = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function resolvePendingConfirmations(confirmed: boolean): void {
+  activeConfirmation?.resolve(confirmed);
+  for (const confirmation of queuedConfirmations) {
+    confirmation.resolve(confirmed);
+  }
+  activeConfirmation = null;
+  queuedConfirmations = [];
+}
+
+export function readConfirmDialogState(): ConfirmDialogState {
+  return state;
+}
+
+export function subscribeConfirmDialog(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Registers the renderer host that can present themed confirmations. Returning
+ * an unavailable result lets the local API retain a host-specific fallback.
+ */
+export function registerConfirmDialogHost(): () => void {
+  registeredHostCount += 1;
+  let registered = true;
+
+  return () => {
+    if (!registered) return;
+    registered = false;
+    registeredHostCount = Math.max(0, registeredHostCount - 1);
+
+    if (registeredHostCount === 0) {
+      resolvePendingConfirmations(false);
+      publish(idleState);
+    }
+  };
+}
+
+/**
+ * Requests a themed confirmation when a host is mounted. An undefined result
+ * means the caller should use its environment-specific fallback.
+ */
+export function requestConfirmDialog(message: string): Promise<boolean> | undefined {
+  if (registeredHostCount === 0) return undefined;
+
+  const confirmation = new Promise<boolean>((resolve) => {
+    const pending = { message, resolve } satisfies PendingConfirmation;
+    if (activeConfirmation || state.status === "closing") {
+      queuedConfirmations.push(pending);
+      return;
+    }
+
+    activeConfirmation = pending;
+    publish({ status: "confirming", message });
+  });
+
+  return confirmation;
+}
+
+export function respondToConfirmDialog(confirmed: boolean): void {
+  if (state.status !== "confirming" || !activeConfirmation) return;
+
+  const confirmation = activeConfirmation;
+  activeConfirmation = null;
+  confirmation.resolve(confirmed);
+  publish({ status: "closing", message: state.message });
+}
+
+export function completeConfirmDialogClose(): void {
+  if (state.status !== "closing") return;
+
+  const next = queuedConfirmations.shift();
+  if (!next) {
+    publish(idleState);
+    return;
+  }
+
+  activeConfirmation = next;
+  publish({ status: "confirming", message: next.message });
+}
+
+export function resetConfirmDialogForTests(): void {
+  resolvePendingConfirmations(false);
+  registeredHostCount = 0;
+  publish(idleState);
+  listeners.clear();
+}

--- a/apps/web/src/confirmDialog.ts
+++ b/apps/web/src/confirmDialog.ts
@@ -1,10 +1,21 @@
+import type { ConfirmDialogOptions, ConfirmDialogVariant } from "@t3tools/contracts";
+
 export type ConfirmDialogState =
   | { readonly status: "idle" }
-  | { readonly status: "confirming"; readonly message: string }
-  | { readonly status: "closing"; readonly message: string };
+  | {
+      readonly status: "confirming";
+      readonly message: string;
+      readonly variant: ConfirmDialogVariant;
+    }
+  | {
+      readonly status: "closing";
+      readonly message: string;
+      readonly variant: ConfirmDialogVariant;
+    };
 
 type PendingConfirmation = {
   readonly message: string;
+  readonly variant: ConfirmDialogVariant;
   readonly resolve: (confirmed: boolean) => void;
 };
 
@@ -66,18 +77,25 @@ export function registerConfirmDialogHost(): () => void {
  * Requests a themed confirmation when a host is mounted. An undefined result
  * means no themed host is currently available.
  */
-export function requestConfirmDialog(message: string): Promise<boolean> | undefined {
+export function requestConfirmDialog(
+  message: string,
+  options?: ConfirmDialogOptions,
+): Promise<boolean> | undefined {
   if (registeredHostCount === 0) return undefined;
 
   const confirmation = new Promise<boolean>((resolve) => {
-    const pending = { message, resolve } satisfies PendingConfirmation;
+    const pending = {
+      message,
+      variant: options?.variant ?? "default",
+      resolve,
+    } satisfies PendingConfirmation;
     if (activeConfirmation || state.status === "closing") {
       queuedConfirmations.push(pending);
       return;
     }
 
     activeConfirmation = pending;
-    publish({ status: "confirming", message });
+    publish({ status: "confirming", message, variant: pending.variant });
   });
 
   return confirmation;
@@ -89,7 +107,7 @@ export function respondToConfirmDialog(confirmed: boolean): void {
   const confirmation = activeConfirmation;
   activeConfirmation = null;
   confirmation.resolve(confirmed);
-  publish({ status: "closing", message: state.message });
+  publish({ status: "closing", message: state.message, variant: state.variant });
 }
 
 export function completeConfirmDialogClose(): void {
@@ -102,7 +120,7 @@ export function completeConfirmDialogClose(): void {
   }
 
   activeConfirmation = next;
-  publish({ status: "confirming", message: next.message });
+  publish({ status: "confirming", message: next.message, variant: next.variant });
 }
 
 export function resetConfirmDialogForTests(): void {

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -250,6 +250,7 @@ export function useThreadActionMenu(input: {
                     `Delete thread "${thread.title}"?`,
                     "This permanently clears conversation history for this thread.",
                   ].join("\n"),
+                  { variant: "destructive" },
                 ),
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -324,6 +324,7 @@ export function useThreadActions() {
               "",
               "Delete the worktree too?",
             ].join("\n"),
+            { variant: "destructive" },
           ),
         );
         if (confirmationResult._tag === "Failure") {
@@ -678,6 +679,7 @@ export function useThreadActions() {
               `Delete thread "${title}"?`,
               "This permanently clears conversation history for this thread.",
             ].join("\n"),
+            { variant: "destructive" },
           ),
         );
         if (confirmationResult._tag === "Failure") {

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -13,8 +13,14 @@ const showContextMenuFallbackMock =
     ) => Promise<T | null>
   >();
 
+const requestConfirmDialogMock = vi.fn<(message: string) => Promise<boolean> | undefined>();
+
 vi.mock("./contextMenuFallback", () => ({
   showContextMenuFallback: showContextMenuFallbackMock,
+}));
+
+vi.mock("./confirmDialog", () => ({
+  requestConfirmDialog: requestConfirmDialogMock,
 }));
 
 function createLocalStorageStub(): Storage {
@@ -77,13 +83,30 @@ describe("LocalApi", () => {
     expect(showContextMenuFallbackMock).toHaveBeenCalledWith(items, { x: 4, y: 5 });
   });
 
+  it("uses the themed confirmation host when it is available", async () => {
+    requestConfirmDialogMock.mockResolvedValue(true);
+    const { createLocalApi } = await import("./localApi");
+
+    await expect(createLocalApi().dialogs.confirm("Delete this thread?")).resolves.toBe(true);
+    expect(requestConfirmDialogMock).toHaveBeenCalledWith("Delete this thread?");
+  });
+
+  it("fails closed in a browser when no themed host is available", async () => {
+    requestConfirmDialogMock.mockReturnValue(undefined);
+    const { createLocalApi } = await import("./localApi");
+
+    await expect(createLocalApi().dialogs.confirm("Delete this thread?")).resolves.toBe(false);
+  });
+
   it("delegates host capabilities and persistence to the desktop bridge", async () => {
     const showContextMenu = vi.fn().mockResolvedValue("delete");
+    const confirm = vi.fn().mockResolvedValue(true);
     const pickFolder = vi.fn().mockResolvedValue("/tmp/project");
     const getClientSettings = vi.fn().mockResolvedValue(DEFAULT_CLIENT_SETTINGS);
     const setClientSettings = vi.fn().mockResolvedValue(undefined);
     testWindow().desktopBridge = {
       showContextMenu,
+      confirm,
       pickFolder,
       getClientSettings,
       setClientSettings,
@@ -94,11 +117,14 @@ describe("LocalApi", () => {
     const items = [{ id: "delete", label: "Delete" }] as const;
 
     await expect(api.contextMenu.show(items)).resolves.toBe("delete");
+    requestConfirmDialogMock.mockReturnValue(undefined);
+    await expect(api.dialogs.confirm("Install update?")).resolves.toBe(true);
     await expect(api.dialogs.pickFolder({ initialPath: "/tmp" })).resolves.toBe("/tmp/project");
     await expect(api.persistence.getClientSettings()).resolves.toEqual(DEFAULT_CLIENT_SETTINGS);
     await api.persistence.setClientSettings(DEFAULT_CLIENT_SETTINGS);
 
     expect(showContextMenu).toHaveBeenCalledWith(items, undefined);
+    expect(confirm).toHaveBeenCalledWith("Install update?");
     expect(pickFolder).toHaveBeenCalledWith({ initialPath: "/tmp" });
     expect(getClientSettings).toHaveBeenCalledTimes(1);
     expect(setClientSettings).toHaveBeenCalledWith(DEFAULT_CLIENT_SETTINGS);

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -100,13 +100,11 @@ describe("LocalApi", () => {
 
   it("delegates host capabilities and persistence to the desktop bridge", async () => {
     const showContextMenu = vi.fn().mockResolvedValue("delete");
-    const confirm = vi.fn().mockResolvedValue(true);
     const pickFolder = vi.fn().mockResolvedValue("/tmp/project");
     const getClientSettings = vi.fn().mockResolvedValue(DEFAULT_CLIENT_SETTINGS);
     const setClientSettings = vi.fn().mockResolvedValue(undefined);
     testWindow().desktopBridge = {
       showContextMenu,
-      confirm,
       pickFolder,
       getClientSettings,
       setClientSettings,
@@ -118,13 +116,12 @@ describe("LocalApi", () => {
 
     await expect(api.contextMenu.show(items)).resolves.toBe("delete");
     requestConfirmDialogMock.mockReturnValue(undefined);
-    await expect(api.dialogs.confirm("Install update?")).resolves.toBe(true);
+    await expect(api.dialogs.confirm("Install update?")).resolves.toBe(false);
     await expect(api.dialogs.pickFolder({ initialPath: "/tmp" })).resolves.toBe("/tmp/project");
     await expect(api.persistence.getClientSettings()).resolves.toEqual(DEFAULT_CLIENT_SETTINGS);
     await api.persistence.setClientSettings(DEFAULT_CLIENT_SETTINGS);
 
     expect(showContextMenu).toHaveBeenCalledWith(items, undefined);
-    expect(confirm).toHaveBeenCalledWith("Install update?");
     expect(pickFolder).toHaveBeenCalledWith({ initialPath: "/tmp" });
     expect(getClientSettings).toHaveBeenCalledTimes(1);
     expect(setClientSettings).toHaveBeenCalledWith(DEFAULT_CLIENT_SETTINGS);

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_CLIENT_SETTINGS,
+  type ConfirmDialogOptions,
   type ContextMenuItem,
   type DesktopBridge,
 } from "@t3tools/contracts";
@@ -13,7 +14,8 @@ const showContextMenuFallbackMock =
     ) => Promise<T | null>
   >();
 
-const requestConfirmDialogMock = vi.fn<(message: string) => Promise<boolean> | undefined>();
+const requestConfirmDialogMock =
+  vi.fn<(message: string, options?: ConfirmDialogOptions) => Promise<boolean> | undefined>();
 
 vi.mock("./contextMenuFallback", () => ({
   showContextMenuFallback: showContextMenuFallbackMock,
@@ -86,9 +88,12 @@ describe("LocalApi", () => {
   it("uses the themed confirmation host when it is available", async () => {
     requestConfirmDialogMock.mockResolvedValue(true);
     const { createLocalApi } = await import("./localApi");
+    const options = { variant: "destructive" } as const;
 
-    await expect(createLocalApi().dialogs.confirm("Delete this thread?")).resolves.toBe(true);
-    expect(requestConfirmDialogMock).toHaveBeenCalledWith("Delete this thread?");
+    await expect(createLocalApi().dialogs.confirm("Delete this thread?", options)).resolves.toBe(
+      true,
+    );
+    expect(requestConfirmDialogMock).toHaveBeenCalledWith("Delete this thread?", options);
   });
 
   it("fails closed in a browser when no themed host is available", async () => {

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -16,9 +16,7 @@ function createBrowserLocalApi(): LocalApi {
       },
       confirm: async (message) => {
         const themedConfirmation = requestConfirmDialog(message);
-        if (themedConfirmation !== undefined) return themedConfirmation;
-        if (window.desktopBridge) return window.desktopBridge.confirm(message);
-        return false;
+        return themedConfirmation ?? false;
       },
     },
     shell: {

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -1,8 +1,9 @@
 import type { ContextMenuItem, LocalApi } from "@t3tools/contracts";
 
-import { resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
+import { requestConfirmDialog } from "./confirmDialog";
 import { showContextMenuFallback } from "./contextMenuFallback";
 import { readBrowserClientSettings, writeBrowserClientSettings } from "./clientPersistenceStorage";
+import { resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
 
 let cachedApi: LocalApi | undefined;
 
@@ -14,10 +15,10 @@ function createBrowserLocalApi(): LocalApi {
         return window.desktopBridge.pickFolder(options);
       },
       confirm: async (message) => {
-        if (window.desktopBridge) {
-          return window.desktopBridge.confirm(message);
-        }
-        return window.confirm(message);
+        const themedConfirmation = requestConfirmDialog(message);
+        if (themedConfirmation !== undefined) return themedConfirmation;
+        if (window.desktopBridge) return window.desktopBridge.confirm(message);
+        return false;
       },
     },
     shell: {

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -1,4 +1,4 @@
-import type { ContextMenuItem, LocalApi } from "@t3tools/contracts";
+import type { ConfirmDialogOptions, ContextMenuItem, LocalApi } from "@t3tools/contracts";
 
 import { requestConfirmDialog } from "./confirmDialog";
 import { showContextMenuFallback } from "./contextMenuFallback";
@@ -14,8 +14,8 @@ function createBrowserLocalApi(): LocalApi {
         if (!window.desktopBridge) return null;
         return window.desktopBridge.pickFolder(options);
       },
-      confirm: async (message) => {
-        return requestConfirmDialog(message) ?? false;
+      confirm: async (message, options?: ConfirmDialogOptions) => {
+        return requestConfirmDialog(message, options) ?? false;
       },
     },
     shell: {

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -15,8 +15,7 @@ function createBrowserLocalApi(): LocalApi {
         return window.desktopBridge.pickFolder(options);
       },
       confirm: async (message) => {
-        const themedConfirmation = requestConfirmDialog(message);
-        return themedConfirmation ?? false;
+        return requestConfirmDialog(message) ?? false;
       },
     },
     shell: {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -14,6 +14,7 @@ import { APP_BASE_NAME, APP_DISPLAY_NAME, APP_STAGE_LABEL } from "../branding";
 import { resolveServerBackedAppDisplayName } from "../branding.logic";
 import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
+import { ConfirmDialogHost } from "../components/ConfirmDialogHost";
 import { ConnectOnboardingDialog } from "../components/cloud/ConnectOnboardingDialog";
 import { RelayClientInstallDialog } from "../components/cloud/RelayClientInstallDialog";
 import { SshPasswordPromptDialog } from "../components/desktop/SshPasswordPromptDialog";
@@ -135,6 +136,7 @@ function RootRouteView() {
         <RelayClientInstallDialog />
         <ConnectOnboardingDialog />
         <SshPasswordPromptDialog />
+        <ConfirmDialogHost />
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1136,6 +1136,12 @@ export interface DesktopPreviewBridge {
   onPointerEvent: (listener: (event: DesktopPreviewPointerEvent) => void) => () => void;
 }
 
+export type ConfirmDialogVariant = "default" | "destructive";
+
+export interface ConfirmDialogOptions {
+  readonly variant?: ConfirmDialogVariant;
+}
+
 /**
  * APIs bound to the local app shell, not to any particular backend environment.
  *
@@ -1149,7 +1155,7 @@ export interface DesktopPreviewBridge {
 export interface LocalApi {
   dialogs: {
     pickFolder: (options?: PickFolderOptions) => Promise<string | null>;
-    confirm: (message: string) => Promise<boolean>;
+    confirm: (message: string, options?: ConfirmDialogOptions) => Promise<boolean>;
   };
   shell: {
     openExternal: (url: string) => Promise<void>;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1042,7 +1042,6 @@ export interface DesktopBridge {
    * web callers fall back to a plain file input.
    */
   pickThemeFiles?: () => Promise<readonly PickedThemeFile[] | null>;
-  confirm: (message: string) => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;
   showContextMenu: <T extends string>(
     items: readonly ContextMenuItem<T>[],


### PR DESCRIPTION
## Summary

Rebased onto the newest `upstream/main` (`1a003e383ac6`) and addressed the review feedback. The shared themed confirmation coordinator now carries an explicit confirmation intent: destructive actions render the existing T3 destructive/red button variant, while normal confirmations keep the standard primary button.

Deletion, worktree removal, project removal, checkpoint revert, settings reset, and SIGKILL confirmations are destructive. Archive, update/install, and informational confirmations remain normal. Native macOS context menus remain unchanged.

## Verification

- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/desktop typecheck`
- targeted Oxlint on all changed confirmation files
- `vp fmt --check`
- `git diff --check`
- focused Vitest invocations retried after `vp i`; both still fail before test execution because of the repository's runner/configuration bootstrap errors (zero test bodies run)
- CI will re-run the full test job for the new head
- before/after deletion confirmation evidence is inline below
![Before: native Electron confirmation (pre-PR)](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/bc7c9799-40e7-4b62-8735-ea2e92ca91d7/pre-pr-native-electron-confirmation.png)
![After: destructive delete-thread dialog](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/ca56928d-e966-4593-bb7a-e3dcb9ba94e9/destructive-delete-confirmation.png)



## Scope

Mobile native alerts, CLI prompts, Electron message/error boxes, and native macOS context-menu behavior remain unchanged. The renderer confirmation path fails closed when no themed host is mounted.

Model/harness: gpt-5.6-luna via Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how destructive actions (updates, SIGKILL, deletes via LocalApi) are confirmed; fail-closed behavior when no host is mounted could block actions in edge cases.
> 
> **Overview**
> Replaces native browser and Electron confirmation flows with a **shared in-app `AlertDialog`** so destructive prompts match the rest of the UI on web and desktop.
> 
> A new **`confirmDialog` coordinator** queues requests, handles close transitions, and exposes **`ConfirmDialogHost`** from the root route. **`LocalApi.dialogs.confirm`** now goes through `requestConfirmDialog` when a host is mounted; if none is registered it **returns `false`** instead of calling `window.confirm` or the desktop bridge.
> 
> The **Electron `confirm` IPC path** is removed (`ElectronDialog.confirm`, `CONFIRM_CHANNEL`, preload `confirm`, and `DesktopBridge.confirm` in contracts). Call sites that used **`window.confirm`** (update install, SIGKILL in diagnostics/telemetry) now **`await ensureLocalApi().dialogs.confirm`**, with **pending-state guards** to avoid double submissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01be733f4df3f366f48421434c2b98384f599d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace native `window.confirm` with themed in-app confirmation dialogs
> - Introduces a `confirmDialog` coordinator module ([confirmDialog.ts](https://github.com/pingdotgg/t3code/pull/5624/files#diff-e0cc9fb1c5e0cbd404f2509322458b723c901fd7270c2992e4d05a4a178cfa98)) with a pub/sub state machine that serializes confirmation requests, supports a `destructive` visual variant, and resolves pending dialogs when the host unmounts.
> - Adds [ConfirmDialogHost.tsx](https://github.com/pingdotgg/t3code/pull/5624/files#diff-52d90696c07b53aa80d629a3c61477a642ef21d981580d50ff00390fa417a8c2), mounted in the app root, which renders an `AlertDialog` driven by the coordinator state and handles confirm/cancel/close lifecycle callbacks.
> - Updates `LocalApi.dialogs.confirm` to route exclusively through the coordinator, returning `false` when no host is registered, and removes the previous `window.confirm` and desktop bridge fallback paths.
> - Removes the Electron `confirm` IPC handler, `ElectronDialog.confirm`, `CONFIRM_CHANNEL`, and `desktopBridge.confirm` from the desktop layer entirely.
> - All destructive actions (delete thread, remove project, SIGKILL, install update) now pass `{ variant: 'destructive' }` to `dialogs.confirm` for consistent styling.
> - Risk: `window.desktopBridge.confirm` is permanently removed; any external caller relying on it will receive no response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e4424a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->







