### PR TITLE
feat(mobile): one sheet for model and thread settings

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1,7 +1,7 @@
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, usePreventRemove } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Alert, InteractionManager, Keyboard, Platform, View, useColorScheme } from "react-native";
+import { Alert, InteractionManager, Platform, View, useColorScheme } from "react-native";
 import { KeyboardAvoidingView, useKeyboardState } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
@@ -26,6 +26,7 @@ import { ControlPill, ControlPillMenu } from "../../components/ControlPill";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import { ComposerSurface } from "./ThreadComposer";
 import { ThreadSettingsSheet, threadSettingsSummaryLabel } from "./ThreadSettingsSheet";
+import { useThreadSettingsSheetPresentation } from "./use-thread-settings-sheet-presentation";
 
 import { makeTurnCommandMetadata } from "../../lib/commandMetadata";
 import { convertPastedImagesToAttachments, pickComposerImages } from "../../lib/composerImages";
@@ -99,9 +100,10 @@ export function NewTaskDraftScreen(props: {
   const promptInputRef = useRef<ComposerEditorHandle>(null);
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
-  const [isSettingsSheetVisible, setIsSettingsSheetVisible] = useState(false);
-  const isSettingsSheetVisibleRef = useRef(false);
-  isSettingsSheetVisibleRef.current = isSettingsSheetVisible;
+  const settingsSheetPresentation = useThreadSettingsSheetPresentation({
+    editorRef: promptInputRef,
+    isEditorFocused: isComposerFocused,
+  });
   const [importingShareKey, setImportingShareKey] = useState<string | null>(null);
   const [isCancellingShareImport, setIsCancellingShareImport] = useState(false);
   const [cancelledIncomingShareId, setCancelledIncomingShareId] = useState<string | null>(null);
@@ -523,8 +525,10 @@ export function NewTaskDraftScreen(props: {
       focusFrame = requestAnimationFrame(() => {
         // The delayed focus can land after the settings sheet opened, which
         // would pop the keyboard underneath its modal.
-        if (!isSettingsSheetVisibleRef.current) {
+        if (!settingsSheetPresentation.isActiveRef.current) {
           promptInputRef.current?.focus();
+        } else {
+          settingsSheetPresentation.restoreFocusAfterSave();
         }
       });
     });
@@ -535,7 +539,11 @@ export function NewTaskDraftScreen(props: {
         cancelAnimationFrame(focusFrame);
       }
     };
-  }, [selectedProject]);
+  }, [
+    selectedProject,
+    settingsSheetPresentation.isActiveRef,
+    settingsSheetPresentation.restoreFocusAfterSave,
+  ]);
 
   const environmentMenuActions = useMemo(
     () =>
@@ -643,24 +651,6 @@ export function NewTaskDraftScreen(props: {
       }),
     [currentBranchName, flow.selectedBranchName, flow.workspaceMode],
   );
-  // Order matters: mark the sheet open before dismissing the keyboard so the
-  // Android draft layout (expanded only while focused) doesn't collapse.
-  // The keyboard only comes back on close if it was up when the sheet opened.
-  const wasFocusedBeforeSheetRef = useRef(false);
-  const openSettingsSheet = useCallback(() => {
-    wasFocusedBeforeSheetRef.current = isComposerFocused;
-    setIsSettingsSheetVisible(true);
-    Keyboard.dismiss();
-  }, [isComposerFocused]);
-  const closeSettingsSheet = useCallback((reason: "save" | "dismiss") => {
-    setIsSettingsSheetVisible(false);
-    // Only Save/Done restores the keyboard: a dismissal (backdrop or
-    // grabber, including stray taps near the sheet's edge) closes quietly.
-    if (reason === "save" && wasFocusedBeforeSheetRef.current) {
-      promptInputRef.current?.focus();
-    }
-  }, []);
-
   function handleEnvironmentMenuAction(event: string) {
     if (isIncomingShareTransferPending || !event.startsWith("environment:")) {
       return;
@@ -876,7 +866,7 @@ export function NewTaskDraftScreen(props: {
   // the touch gesture that opens the keyboard.
   // The settings sheet dismisses the keyboard, so its flag keeps the Android
   // draft composer expanded through the blur (mirrors ThreadComposer).
-  const isExpanded = !isAndroid || isComposerFocused || isSettingsSheetVisible;
+  const isExpanded = !isAndroid || isComposerFocused || settingsSheetPresentation.isActive;
   const canStart =
     Boolean(flow.selectedProject) &&
     Boolean(flow.selectedModel) &&
@@ -936,7 +926,7 @@ export function NewTaskDraftScreen(props: {
         iconNode={<ProviderIcon provider={flow.selectedModelOption?.providerDriver} size={16} />}
         label={settingsSummaryLabel}
         maxWidth={320}
-        onPress={openSettingsSheet}
+        onPress={settingsSheetPresentation.open}
       />
       <ControlPillMenu
         actions={environmentMenuActions}
@@ -965,8 +955,9 @@ export function NewTaskDraftScreen(props: {
 
   const settingsSheet = (
     <ThreadSettingsSheet
-      visible={isSettingsSheetVisible}
-      onClose={closeSettingsSheet}
+      visible={settingsSheetPresentation.isVisible}
+      onClose={settingsSheetPresentation.close}
+      onDismissed={settingsSheetPresentation.onDismissed}
       providerGroups={flow.providerGroups}
       selectedModel={flow.selectedModel}
       onSelectModel={(option) => flow.setSelectedModelKey(option.key, option.selection.options)}

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -652,9 +652,11 @@ export function NewTaskDraftScreen(props: {
     setIsSettingsSheetVisible(true);
     Keyboard.dismiss();
   }, [isComposerFocused]);
-  const closeSettingsSheet = useCallback(() => {
+  const closeSettingsSheet = useCallback((reason: "save" | "dismiss") => {
     setIsSettingsSheetVisible(false);
-    if (wasFocusedBeforeSheetRef.current) {
+    // Only Save/Done restores the keyboard: a dismissal (backdrop or
+    // grabber, including stray taps near the sheet's edge) closes quietly.
+    if (reason === "save" && wasFocusedBeforeSheetRef.current) {
       promptInputRef.current?.focus();
     }
   }, []);

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -100,6 +100,8 @@ export function NewTaskDraftScreen(props: {
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
   const [isSettingsSheetVisible, setIsSettingsSheetVisible] = useState(false);
+  const isSettingsSheetVisibleRef = useRef(false);
+  isSettingsSheetVisibleRef.current = isSettingsSheetVisible;
   const [importingShareKey, setImportingShareKey] = useState<string | null>(null);
   const [isCancellingShareImport, setIsCancellingShareImport] = useState(false);
   const [cancelledIncomingShareId, setCancelledIncomingShareId] = useState<string | null>(null);
@@ -518,7 +520,13 @@ export function NewTaskDraftScreen(props: {
 
     let focusFrame: ReturnType<typeof requestAnimationFrame> | null = null;
     const interaction = InteractionManager.runAfterInteractions(() => {
-      focusFrame = requestAnimationFrame(() => promptInputRef.current?.focus());
+      focusFrame = requestAnimationFrame(() => {
+        // The delayed focus can land after the settings sheet opened, which
+        // would pop the keyboard underneath its modal.
+        if (!isSettingsSheetVisibleRef.current) {
+          promptInputRef.current?.focus();
+        }
+      });
     });
 
     return () => {
@@ -637,13 +645,18 @@ export function NewTaskDraftScreen(props: {
   );
   // Order matters: mark the sheet open before dismissing the keyboard so the
   // Android draft layout (expanded only while focused) doesn't collapse.
+  // The keyboard only comes back on close if it was up when the sheet opened.
+  const wasFocusedBeforeSheetRef = useRef(false);
   const openSettingsSheet = useCallback(() => {
+    wasFocusedBeforeSheetRef.current = isComposerFocused;
     setIsSettingsSheetVisible(true);
     Keyboard.dismiss();
-  }, []);
+  }, [isComposerFocused]);
   const closeSettingsSheet = useCallback(() => {
     setIsSettingsSheetVisible(false);
-    promptInputRef.current?.focus();
+    if (wasFocusedBeforeSheetRef.current) {
+      promptInputRef.current?.focus();
+    }
   }, []);
 
   function handleEnvironmentMenuAction(event: string) {

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -954,7 +954,7 @@ export function NewTaskDraftScreen(props: {
       onClose={closeSettingsSheet}
       providerGroups={flow.providerGroups}
       selectedModel={flow.selectedModel}
-      onSelectModel={(option) => flow.setSelectedModelKey(option.key)}
+      onSelectModel={(option) => flow.setSelectedModelKey(option.key, option.selection.options)}
       optionDescriptors={providerOptionDescriptors}
       onUpdateOptionSelections={flow.setSelectedModelOptions}
       runtimeMode={flow.runtimeMode}

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -959,8 +959,6 @@ export function NewTaskDraftScreen(props: {
       onUpdateOptionSelections={flow.setSelectedModelOptions}
       runtimeMode={flow.runtimeMode}
       onUpdateRuntimeMode={flow.setRuntimeMode}
-      interactionMode={flow.interactionMode}
-      onUpdateInteractionMode={flow.setInteractionMode}
     />
   );
 

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1,7 +1,7 @@
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, usePreventRemove } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Alert, InteractionManager, Platform, View, useColorScheme } from "react-native";
+import { Alert, InteractionManager, Keyboard, Platform, View, useColorScheme } from "react-native";
 import { KeyboardAvoidingView, useKeyboardState } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
@@ -25,15 +25,11 @@ import { ComposerAttachmentStrip } from "../../components/ComposerAttachmentStri
 import { ControlPill, ControlPillMenu } from "../../components/ControlPill";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import { ComposerSurface } from "./ThreadComposer";
+import { ThreadSettingsSheet, threadSettingsSummaryLabel } from "./ThreadSettingsSheet";
 
 import { makeTurnCommandMetadata } from "../../lib/commandMetadata";
 import { convertPastedImagesToAttachments, pickComposerImages } from "../../lib/composerImages";
-import {
-  applyProviderOptionMenuEvent,
-  buildProviderOptionMenuActions,
-  providerOptionsConfigurationLabel,
-  resolveProviderOptionDescriptors,
-} from "../../lib/providerOptions";
+import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
 import { useScaledTextRole } from "../settings/appearance/useScaledTextRole";
 import {
   clearComposerDraftContent,
@@ -43,7 +39,7 @@ import {
   type ComposerDraft,
 } from "../../state/use-composer-drafts";
 import { useEnvironmentServerConfig, useProjects } from "../../state/entities";
-import { buildModelMenuActions, resolveSelectableModelSelection } from "../../lib/modelOptions";
+import { resolveSelectableModelSelection } from "../../lib/modelOptions";
 import { deriveThreadTitleFromPrompt } from "../../lib/projectThreadStartTurn";
 import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/remoteRegistration";
 import { enqueueThreadOutboxMessage, removeThreadOutboxMessage } from "../../state/thread-outbox";
@@ -103,6 +99,7 @@ export function NewTaskDraftScreen(props: {
   const promptInputRef = useRef<ComposerEditorHandle>(null);
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
+  const [isSettingsSheetVisible, setIsSettingsSheetVisible] = useState(false);
   const [importingShareKey, setImportingShareKey] = useState<string | null>(null);
   const [isCancellingShareImport, setIsCancellingShareImport] = useState(false);
   const [cancelledIncomingShareId, setCancelledIncomingShareId] = useState<string | null>(null);
@@ -544,10 +541,6 @@ export function NewTaskDraftScreen(props: {
     [flow.environments, flow.selectedEnvironmentId, isIncomingShareTransferPending],
   );
 
-  const modelMenuActions = useMemo(
-    () => buildModelMenuActions(flow.providerGroups, flow.selectedModel),
-    [flow.providerGroups, flow.selectedModel],
-  );
   const providerOptionDescriptors = useMemo(
     () =>
       resolveProviderOptionDescriptors({
@@ -555,54 +548,6 @@ export function NewTaskDraftScreen(props: {
         selections: flow.selectedModel?.options,
       }),
     [flow.selectedModel?.options, flow.selectedModelOption?.capabilities],
-  );
-
-  const optionsMenuActions = useMemo(
-    () => [
-      ...buildProviderOptionMenuActions(providerOptionDescriptors),
-      {
-        id: "options-runtime",
-        title: "Runtime",
-        subtitle:
-          flow.runtimeMode === "approval-required"
-            ? "Approve actions"
-            : flow.runtimeMode === "auto-accept-edits"
-              ? "Auto-accept edits"
-              : flow.runtimeMode === "auto"
-                ? "Auto"
-                : "Full access",
-        subactions: [
-          { id: "options:runtime:approval-required", title: "Approve actions" },
-          { id: "options:runtime:auto-accept-edits", title: "Auto-accept edits" },
-          { id: "options:runtime:auto", title: "Auto" },
-          { id: "options:runtime:full-access", title: "Full access" },
-        ].map((option) => {
-          const value = option.id.replace("options:runtime:", "");
-          return {
-            id: option.id,
-            title: option.title,
-            state: flow.runtimeMode === value ? ("on" as const) : undefined,
-          };
-        }),
-      },
-      {
-        id: "options-interaction",
-        title: "Interaction",
-        subtitle: flow.interactionMode === "plan" ? "Plan" : "Default",
-        subactions: [
-          { id: "options:interaction:default", title: "Default" },
-          { id: "options:interaction:plan", title: "Plan" },
-        ].map((option) => {
-          const value = option.id.replace("options:interaction:", "");
-          return {
-            id: option.id,
-            title: option.title,
-            state: flow.interactionMode === value ? ("on" as const) : undefined,
-          };
-        }),
-      },
-    ],
-    [flow.interactionMode, flow.runtimeMode, providerOptionDescriptors],
   );
 
   const workspaceMenuActions = useMemo(() => {
@@ -675,10 +620,12 @@ export function NewTaskDraftScreen(props: {
     flow.availableBranches.find((branch) => branch.current)?.name ??
     flow.availableBranches.find((branch) => branch.isDefault)?.name ??
     null;
-  const configurationLabel = useMemo(
-    () => providerOptionsConfigurationLabel(providerOptionDescriptors),
-    [providerOptionDescriptors],
-  );
+  const settingsSummaryLabel = threadSettingsSummaryLabel({
+    modelLabel: flow.selectedModelOption?.label ?? "Model",
+    optionDescriptors: providerOptionDescriptors,
+    runtimeMode: flow.runtimeMode,
+    interactionMode: flow.interactionMode,
+  });
   const workspaceLabel = useMemo(
     () =>
       formatWorkspaceLabel({
@@ -688,40 +635,22 @@ export function NewTaskDraftScreen(props: {
       }),
     [currentBranchName, flow.selectedBranchName, flow.workspaceMode],
   );
-  function handleModelMenuAction(event: string) {
-    if (isIncomingShareTransferPending || !event.startsWith("model:")) {
-      return;
-    }
-    flow.setSelectedModelKey(event.slice("model:".length));
-  }
+  // Order matters: mark the sheet open before dismissing the keyboard so the
+  // Android draft layout (expanded only while focused) doesn't collapse.
+  const openSettingsSheet = useCallback(() => {
+    setIsSettingsSheetVisible(true);
+    Keyboard.dismiss();
+  }, []);
+  const closeSettingsSheet = useCallback(() => {
+    setIsSettingsSheetVisible(false);
+    promptInputRef.current?.focus();
+  }, []);
 
   function handleEnvironmentMenuAction(event: string) {
     if (isIncomingShareTransferPending || !event.startsWith("environment:")) {
       return;
     }
     flow.selectEnvironment(EnvironmentId.make(event.slice("environment:".length)));
-  }
-
-  function handleOptionsMenuAction(event: string) {
-    if (isIncomingShareTransferPending) {
-      return;
-    }
-    const providerOptions = applyProviderOptionMenuEvent(providerOptionDescriptors, event);
-    if (providerOptions) {
-      flow.setSelectedModelOptions(providerOptions);
-      return;
-    }
-    if (event.startsWith("options:runtime:")) {
-      flow.setRuntimeMode(
-        event.slice("options:runtime:".length) as Parameters<typeof flow.setRuntimeMode>[0],
-      );
-      return;
-    }
-    if (event.startsWith("options:interaction:")) {
-      flow.setInteractionMode(
-        event.slice("options:interaction:".length) as Parameters<typeof flow.setInteractionMode>[0],
-      );
-    }
   }
 
   function handleWorkspaceMenuAction(event: string) {
@@ -930,7 +859,9 @@ export function NewTaskDraftScreen(props: {
   const isDarkMode = colorScheme === "dark";
   // Android expansion follows native editor focus so relayout cannot race
   // the touch gesture that opens the keyboard.
-  const isExpanded = !isAndroid || isComposerFocused;
+  // The settings sheet dismisses the keyboard, so its flag keeps the Android
+  // draft composer expanded through the blur (mirrors ThreadComposer).
+  const isExpanded = !isAndroid || isComposerFocused || isSettingsSheetVisible;
   const canStart =
     Boolean(flow.selectedProject) &&
     Boolean(flow.selectedModel) &&
@@ -984,28 +915,14 @@ export function NewTaskDraftScreen(props: {
         showChevron={false}
         disabled={isIncomingShareTransferPending}
       />
-      <ControlPillMenu
-        actions={modelMenuActions}
-        onPressAction={({ nativeEvent }) => handleModelMenuAction(nativeEvent.event)}
-      >
-        <ComposerToolbarTrigger
-          accessibilityLabel="Model"
-          disabled={isIncomingShareTransferPending}
-          iconNode={<ProviderIcon provider={flow.selectedModelOption?.providerDriver} size={16} />}
-          label={flow.selectedModelOption?.label ?? "Model"}
-        />
-      </ControlPillMenu>
-      <ControlPillMenu
-        actions={optionsMenuActions}
-        onPressAction={({ nativeEvent }) => handleOptionsMenuAction(nativeEvent.event)}
-      >
-        <ComposerToolbarTrigger
-          accessibilityLabel="Configuration"
-          disabled={isIncomingShareTransferPending}
-          icon="slider.horizontal.3"
-          label={configurationLabel}
-        />
-      </ControlPillMenu>
+      <ComposerToolbarTrigger
+        accessibilityLabel="Thread settings"
+        disabled={isIncomingShareTransferPending}
+        iconNode={<ProviderIcon provider={flow.selectedModelOption?.providerDriver} size={16} />}
+        label={settingsSummaryLabel}
+        maxWidth={320}
+        onPress={openSettingsSheet}
+      />
       <ControlPillMenu
         actions={environmentMenuActions}
         onPressAction={({ nativeEvent }) => handleEnvironmentMenuAction(nativeEvent.event)}
@@ -1029,6 +946,22 @@ export function NewTaskDraftScreen(props: {
         />
       </ControlPillMenu>
     </>
+  );
+
+  const settingsSheet = (
+    <ThreadSettingsSheet
+      visible={isSettingsSheetVisible}
+      onClose={closeSettingsSheet}
+      providerGroups={flow.providerGroups}
+      selectedModel={flow.selectedModel}
+      onSelectModel={(option) => flow.setSelectedModelKey(option.key)}
+      optionDescriptors={providerOptionDescriptors}
+      onUpdateOptionSelections={flow.setSelectedModelOptions}
+      runtimeMode={flow.runtimeMode}
+      onUpdateRuntimeMode={flow.setRuntimeMode}
+      interactionMode={flow.interactionMode}
+      onUpdateInteractionMode={flow.setInteractionMode}
+    />
   );
 
   const startButton = (
@@ -1120,6 +1053,7 @@ export function NewTaskDraftScreen(props: {
             ) : null}
           </View>
         </KeyboardAvoidingView>
+        {settingsSheet}
       </View>
     );
   }
@@ -1153,6 +1087,7 @@ export function NewTaskDraftScreen(props: {
           </ComposerToolbarRow>
         </View>
       </KeyboardAvoidingView>
+      {settingsSheet}
     </View>
   );
 }

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -622,13 +622,18 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
 
   // Order matters: mark the sheet open before dismissing the keyboard so
   // isExpanded stays true through the blur and the composer doesn't collapse.
+  // The keyboard only comes back on close if it was up when the sheet opened.
+  const wasFocusedBeforeSheetRef = useRef(false);
   const openSettingsSheet = useCallback(() => {
+    wasFocusedBeforeSheetRef.current = isFocused;
     setIsSettingsSheetVisible(true);
     Keyboard.dismiss();
-  }, []);
+  }, [isFocused]);
   const closeSettingsSheet = useCallback(() => {
     setIsSettingsSheetVisible(false);
-    inputRef.current?.focus();
+    if (wasFocusedBeforeSheetRef.current) {
+      inputRef.current?.focus();
+    }
   }, [inputRef]);
 
   return (

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -19,7 +19,6 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject
 import {
   ActivityIndicator,
   Image,
-  Keyboard,
   Platform,
   Pressable,
   StyleSheet,
@@ -67,6 +66,7 @@ import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
 import { useComposerPathSearch } from "../../state/use-composer-path-search";
 import { ComposerCommandPopover, type ComposerCommandItem } from "./ComposerCommandPopover";
 import { ThreadSettingsSheet, threadSettingsSummaryLabel } from "./ThreadSettingsSheet";
+import { useThreadSettingsSheetPresentation } from "./use-thread-settings-sheet-presentation";
 
 /**
  * Height of the collapsed composer (pill + vertical padding, excluding safe-area inset).
@@ -270,16 +270,19 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const fallbackInputRef = useRef<ComposerEditorHandle>(null);
   const inputRef = props.editorRef ?? fallbackInputRef;
   const [isFocused, setIsFocused] = useState(false);
+  const settingsSheetPresentation = useThreadSettingsSheetPresentation({
+    editorRef: inputRef,
+    isEditorFocused: isFocused,
+  });
   const wasExpandedBeforePreviewRef = useRef(false);
   const inFlightThreadIdsRef = useRef(new Set<string>());
   const { onExpandedChange } = props;
 
   const [previewImageUri, setPreviewImageUri] = useState<string | null>(null);
-  const [isSettingsSheetVisible, setIsSettingsSheetVisible] = useState(false);
   const hasContent = props.draftMessage.trim().length > 0 || props.draftAttachments.length > 0;
-  // The settings sheet dismisses the keyboard (it would cover the sheet), so
-  // the sheet flag keeps the composer expanded through that blur.
-  const isExpanded = isFocused || isSettingsSheetVisible;
+  // Opening and closing count as active so the composer stays expanded while
+  // focus moves between its native editor and the settings modal.
+  const isExpanded = isFocused || settingsSheetPresentation.isActive;
   const canSend = hasContent;
 
   // Notify the parent from the derived value, not focus events: the parent
@@ -620,27 +623,6 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     interactionMode: currentInteractionMode,
   });
 
-  // Order matters: mark the sheet open before dismissing the keyboard so
-  // isExpanded stays true through the blur and the composer doesn't collapse.
-  // The keyboard only comes back on close if it was up when the sheet opened.
-  const wasFocusedBeforeSheetRef = useRef(false);
-  const openSettingsSheet = useCallback(() => {
-    wasFocusedBeforeSheetRef.current = isFocused;
-    setIsSettingsSheetVisible(true);
-    Keyboard.dismiss();
-  }, [isFocused]);
-  const closeSettingsSheet = useCallback(
-    (reason: "save" | "dismiss") => {
-      setIsSettingsSheetVisible(false);
-      // Only Save/Done restores the keyboard: a dismissal (backdrop or
-      // grabber, including stray taps near the sheet's edge) closes quietly.
-      if (reason === "save" && wasFocusedBeforeSheetRef.current) {
-        inputRef.current?.focus();
-      }
-    },
-    [inputRef],
-  );
-
   return (
     <Animated.View
       className="px-4"
@@ -817,7 +799,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                   }
                   label={settingsSummaryLabel}
                   maxWidth={320}
-                  onPress={openSettingsSheet}
+                  onPress={settingsSheetPresentation.open}
                 />
                 {showStopAction ? (
                   <ComposerToolbarButton
@@ -853,8 +835,9 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       </Animated.View>
 
       <ThreadSettingsSheet
-        visible={isSettingsSheetVisible}
-        onClose={closeSettingsSheet}
+        visible={settingsSheetPresentation.isVisible}
+        onClose={settingsSheetPresentation.close}
+        onDismissed={settingsSheetPresentation.onDismissed}
         providerGroups={threadProviderGroups}
         selectedModel={currentModelSelection}
         onSelectModel={(option) => props.onUpdateModelSelection(option.selection)}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -629,12 +629,17 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     setIsSettingsSheetVisible(true);
     Keyboard.dismiss();
   }, [isFocused]);
-  const closeSettingsSheet = useCallback(() => {
-    setIsSettingsSheetVisible(false);
-    if (wasFocusedBeforeSheetRef.current) {
-      inputRef.current?.focus();
-    }
-  }, [inputRef]);
+  const closeSettingsSheet = useCallback(
+    (reason: "save" | "dismiss") => {
+      setIsSettingsSheetVisible(false);
+      // Only Save/Done restores the keyboard: a dismissal (backdrop or
+      // grabber, including stray taps near the sheet's edge) closes quietly.
+      if (reason === "save" && wasFocusedBeforeSheetRef.current) {
+        inputRef.current?.focus();
+      }
+    },
+    [inputRef],
+  );
 
   return (
     <Animated.View

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -593,6 +593,12 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     [props.serverConfig, currentModelSelection],
   );
   const providerGroups = useMemo(() => groupByProvider(modelOptions), [modelOptions]);
+  // An existing thread is bound to its harness: sessions can't move between
+  // provider instances, so the picker only offers the thread's own group.
+  const threadProviderGroups = useMemo(
+    () => providerGroups.filter((group) => group.providerKey === currentModelSelection.instanceId),
+    [providerGroups, currentModelSelection.instanceId],
+  );
   const currentModelOption =
     modelOptions.find(
       (option) =>
@@ -839,7 +845,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       <ThreadSettingsSheet
         visible={isSettingsSheetVisible}
         onClose={closeSettingsSheet}
-        providerGroups={providerGroups}
+        providerGroups={threadProviderGroups}
         selectedModel={currentModelSelection}
         onSelectModel={(option) => props.onUpdateModelSelection(option.selection)}
         optionDescriptors={providerOptionDescriptors}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -19,6 +19,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject
 import {
   ActivityIndicator,
   Image,
+  Keyboard,
   Platform,
   Pressable,
   StyleSheet,
@@ -51,10 +52,10 @@ import {
   ComposerToolbarScroller,
   ComposerToolbarTrigger,
 } from "../../components/ComposerToolbarTrigger";
-import { ControlPill, ControlPillMenu } from "../../components/ControlPill";
+import { ControlPill } from "../../components/ControlPill";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
-import { buildModelMenuActions, buildModelOptions, groupByProvider } from "../../lib/modelOptions";
+import { buildModelOptions, groupByProvider } from "../../lib/modelOptions";
 import { useScaledTextRole } from "../settings/appearance/useScaledTextRole";
 import type { RemoteClientConnectionState } from "../../lib/connection";
 import {
@@ -62,14 +63,10 @@ import {
   normalizeSearchQuery,
   scoreQueryMatch,
 } from "@t3tools/shared/searchRanking";
-import {
-  applyProviderOptionMenuEvent,
-  buildProviderOptionMenuActions,
-  providerOptionsConfigurationLabel,
-  resolveProviderOptionDescriptors,
-} from "../../lib/providerOptions";
+import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
 import { useComposerPathSearch } from "../../state/use-composer-path-search";
 import { ComposerCommandPopover, type ComposerCommandItem } from "./ComposerCommandPopover";
+import { ThreadSettingsSheet, threadSettingsSummaryLabel } from "./ThreadSettingsSheet";
 
 /**
  * Height of the collapsed composer (pill + vertical padding, excluding safe-area inset).
@@ -278,8 +275,11 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const { onExpandedChange } = props;
 
   const [previewImageUri, setPreviewImageUri] = useState<string | null>(null);
+  const [isSettingsSheetVisible, setIsSettingsSheetVisible] = useState(false);
   const hasContent = props.draftMessage.trim().length > 0 || props.draftAttachments.length > 0;
-  const isExpanded = isFocused;
+  // The settings sheet dismisses the keyboard (it would cover the sheet), so
+  // the sheet flag keeps the composer expanded through that blur.
+  const isExpanded = isFocused || isSettingsSheetVisible;
   const canSend = hasContent;
 
   const onPressImage = useCallback(
@@ -602,95 +602,23 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       }),
     [currentModelOption?.capabilities, currentModelSelection.options],
   );
-  const configurationLabel = useMemo(
-    () => providerOptionsConfigurationLabel(providerOptionDescriptors),
-    [providerOptionDescriptors],
-  );
-  const modelMenuActions = useMemo(
-    () => buildModelMenuActions(providerGroups, currentModelSelection),
-    [providerGroups, currentModelSelection],
-  );
+  const settingsSummaryLabel = threadSettingsSummaryLabel({
+    modelLabel: currentModelOption?.label ?? currentModelSelection.model,
+    optionDescriptors: providerOptionDescriptors,
+    runtimeMode: currentRuntimeMode,
+    interactionMode: currentInteractionMode,
+  });
 
-  // ── Options menu ─────────────────────────────────────────
-  const optionsMenuActions = useMemo(
-    () => [
-      ...buildProviderOptionMenuActions(providerOptionDescriptors),
-      {
-        id: "options-runtime",
-        title: "Runtime",
-        subtitle:
-          currentRuntimeMode === "approval-required"
-            ? "Approve actions"
-            : currentRuntimeMode === "auto-accept-edits"
-              ? "Auto-accept edits"
-              : currentRuntimeMode === "auto"
-                ? "Auto"
-                : "Full access",
-        subactions: [
-          { id: "options:runtime:approval-required", title: "Approve actions" },
-          { id: "options:runtime:auto-accept-edits", title: "Auto-accept edits" },
-          { id: "options:runtime:auto", title: "Auto" },
-          { id: "options:runtime:full-access", title: "Full access" },
-        ].map((option) => {
-          const value = option.id.replace("options:runtime:", "");
-          return {
-            id: option.id,
-            title: option.title,
-            state: currentRuntimeMode === value ? ("on" as const) : undefined,
-          };
-        }),
-      },
-      {
-        id: "options-interaction",
-        title: "Interaction",
-        subtitle: currentInteractionMode === "plan" ? "Plan" : "Default",
-        subactions: [
-          { id: "options:interaction:default", title: "Default" },
-          { id: "options:interaction:plan", title: "Plan" },
-        ].map((option) => {
-          const value = option.id.replace("options:interaction:", "");
-          return {
-            id: option.id,
-            title: option.title,
-            state: currentInteractionMode === value ? ("on" as const) : undefined,
-          };
-        }),
-      },
-    ],
-    [currentInteractionMode, currentRuntimeMode, providerOptionDescriptors],
-  );
-
-  // ── Menu handlers ────────────────────────────────────────
-  function handleModelMenuAction(event: string) {
-    if (!event.startsWith("model:")) {
-      return;
-    }
-    const modelKey = event.slice("model:".length);
-    const option = modelOptions.find((o) => o.key === modelKey);
-    if (option) {
-      props.onUpdateModelSelection(option.selection);
-    }
-  }
-
-  function handleOptionsMenuAction(event: string) {
-    const providerOptions = applyProviderOptionMenuEvent(providerOptionDescriptors, event);
-    if (providerOptions) {
-      props.onUpdateModelSelection({
-        ...currentModelSelection,
-        options: providerOptions,
-      });
-      return;
-    }
-    if (event.startsWith("options:runtime:")) {
-      const runtimeMode = event.slice("options:runtime:".length) as RuntimeMode;
-      props.onUpdateRuntimeMode(runtimeMode);
-      return;
-    }
-    if (event.startsWith("options:interaction:")) {
-      const interactionMode = event.slice("options:interaction:".length) as ProviderInteractionMode;
-      props.onUpdateInteractionMode(interactionMode);
-    }
-  }
+  // Order matters: mark the sheet open before dismissing the keyboard so
+  // isExpanded stays true through the blur and the composer doesn't collapse.
+  const openSettingsSheet = useCallback(() => {
+    setIsSettingsSheetVisible(true);
+    Keyboard.dismiss();
+  }, []);
+  const closeSettingsSheet = useCallback(() => {
+    setIsSettingsSheetVisible(false);
+    inputRef.current?.focus();
+  }, [inputRef]);
 
   return (
     <Animated.View
@@ -861,28 +789,15 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                   onPress={() => void props.onPickDraftImages()}
                   showChevron={false}
                 />
-                <ControlPillMenu
-                  actions={modelMenuActions}
-                  onPressAction={({ nativeEvent }) => handleModelMenuAction(nativeEvent.event)}
-                >
-                  <ComposerToolbarTrigger
-                    accessibilityLabel="Model"
-                    iconNode={
-                      <ProviderIcon provider={currentModelOption?.providerDriver} size={16} />
-                    }
-                    label={currentModelOption?.label ?? currentModelSelection.model}
-                  />
-                </ControlPillMenu>
-                <ControlPillMenu
-                  actions={optionsMenuActions}
-                  onPressAction={({ nativeEvent }) => handleOptionsMenuAction(nativeEvent.event)}
-                >
-                  <ComposerToolbarTrigger
-                    accessibilityLabel="Configuration"
-                    icon="slider.horizontal.3"
-                    label={configurationLabel}
-                  />
-                </ControlPillMenu>
+                <ComposerToolbarTrigger
+                  accessibilityLabel="Thread settings"
+                  iconNode={
+                    <ProviderIcon provider={currentModelOption?.providerDriver} size={16} />
+                  }
+                  label={settingsSummaryLabel}
+                  maxWidth={320}
+                  onPress={openSettingsSheet}
+                />
                 {showStopAction ? (
                   <ComposerToolbarButton
                     accessibilityLabel="Stop"
@@ -915,6 +830,22 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
           </Animated.View>
         ) : null}
       </Animated.View>
+
+      <ThreadSettingsSheet
+        visible={isSettingsSheetVisible}
+        onClose={closeSettingsSheet}
+        providerGroups={providerGroups}
+        selectedModel={currentModelSelection}
+        onSelectModel={(option) => props.onUpdateModelSelection(option.selection)}
+        optionDescriptors={providerOptionDescriptors}
+        onUpdateOptionSelections={(options) =>
+          props.onUpdateModelSelection({ ...currentModelSelection, options })
+        }
+        runtimeMode={currentRuntimeMode}
+        onUpdateRuntimeMode={props.onUpdateRuntimeMode}
+        interactionMode={currentInteractionMode}
+        onUpdateInteractionMode={props.onUpdateInteractionMode}
+      />
 
       <ImageViewing
         images={previewImageUri ? [{ uri: previewImageUri }] : []}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -282,6 +282,13 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const isExpanded = isFocused || isSettingsSheetVisible;
   const canSend = hasContent;
 
+  // Notify the parent from the derived value, not focus events: the parent
+  // sizes the feed inset from this, and blur-during-sheet would otherwise
+  // report collapsed while the composer still renders expanded.
+  useEffect(() => {
+    onExpandedChange?.(isExpanded);
+  }, [isExpanded, onExpandedChange]);
+
   const onPressImage = useCallback(
     (uri: string) => {
       wasExpandedBeforePreviewRef.current = isFocused;
@@ -299,13 +306,11 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
 
   const handleFocus = useCallback(() => {
     setIsFocused(true);
-    onExpandedChange?.(true);
-  }, [onExpandedChange]);
+  }, []);
 
   const handleBlur = useCallback(() => {
     setIsFocused(false);
-    onExpandedChange?.(false);
-  }, [onExpandedChange]);
+  }, []);
   const showStopAction =
     props.selectedThread.session?.status === "running" ||
     props.selectedThread.session?.status === "starting";

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -843,8 +843,6 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         }
         runtimeMode={currentRuntimeMode}
         onUpdateRuntimeMode={props.onUpdateRuntimeMode}
-        interactionMode={currentInteractionMode}
-        onUpdateInteractionMode={props.onUpdateInteractionMode}
       />
 
       <ImageViewing

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -462,11 +462,17 @@ export function ThreadSettingsSheet(props: {
                   <Pressable
                     accessibilityRole="button"
                     accessibilityState={{ selected: showLegacy }}
+                    // Forced on while the highlighted model is legacy: hiding
+                    // it would strand the checkmark, so don't offer a no-op.
+                    disabled={displayedIsLegacy}
                     onPress={() => {
                       void Haptics.selectionAsync();
                       setShowLegacyToggle(!showLegacy);
                     }}
-                    className="rounded-full border border-border bg-subtle px-3 py-1.5 active:opacity-70"
+                    className={cn(
+                      "rounded-full border border-border bg-subtle px-3 py-1.5 active:opacity-70",
+                      displayedIsLegacy && "opacity-40",
+                    )}
                   >
                     <Text className="text-2xs font-t3-medium text-foreground-muted">
                       {showLegacy ? "Hide legacy models" : "Show legacy models"}

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -179,14 +179,19 @@ function ProviderHeader(props: {
 function DisclosureRow(props: {
   readonly label: string;
   readonly value: string | undefined;
+  readonly disabled?: boolean;
   readonly onPress: () => void;
 }) {
   const iconSubtle = useThemeColor("--color-icon-subtle");
   return (
     <Pressable
       accessibilityRole="button"
+      disabled={props.disabled}
       onPress={props.onPress}
-      className="flex-row items-center gap-2 px-5 py-3 active:opacity-70"
+      className={cn(
+        "flex-row items-center gap-2 px-5 py-3 active:opacity-70",
+        props.disabled && "opacity-40",
+      )}
     >
       <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
       <View className="flex-1" />
@@ -236,14 +241,21 @@ function ChoiceRow(props: {
 function SwitchRow(props: {
   readonly label: string;
   readonly value: boolean;
+  readonly disabled?: boolean;
   readonly onValueChange: (value: boolean) => void;
 }) {
   const activeTrack = String(useThemeColor("--color-switch-active"));
   const track = String(useThemeColor("--color-secondary-border"));
   return (
-    <View className="flex-row items-center justify-between px-5 py-2.5">
+    <View
+      className={cn(
+        "flex-row items-center justify-between px-5 py-2.5",
+        props.disabled && "opacity-40",
+      )}
+    >
       <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
       <Switch
+        disabled={props.disabled}
         ios_backgroundColor={track}
         onValueChange={props.onValueChange}
         trackColor={{ false: track, true: activeTrack }}
@@ -326,12 +338,41 @@ export function ThreadSettingsSheet(props: {
   const hasLegacyModels = props.providerGroups.some((group) =>
     group.models.some((model) => model.isLegacy),
   );
-  // A legacy selection forces the toggle on: hiding the highlighted model
-  // would strand the checkmark somewhere invisible.
-  const displayedIsLegacy = props.providerGroups.some((group) =>
-    group.models.some((model) => model.isLegacy && isDisplayed(model)),
-  );
-  const showLegacy = showLegacyToggle || displayedIsLegacy;
+  // Legacy stays hidden unless the pill is toggled this open; a highlighted
+  // legacy model is exempted from the filter instead of forcing the whole
+  // legacy list visible.
+  const showLegacy = showLegacyToggle;
+
+  // Stable settings rows: the union of descriptors across the primary
+  // harnesses' current models (plus whatever the displayed model advertises)
+  // always renders, with unsupported rows disabled instead of vanishing when
+  // the selection changes. Keyed by label, not id — Claude and Codex use
+  // different ids for the same "Reasoning" concept.
+  const descriptorTemplate = (() => {
+    const seen = new Map<string, { type: "select" | "boolean" }>();
+    for (const group of props.providerGroups) {
+      const driver = group.models[0]?.providerDriver;
+      if (driver === undefined || !PRIMARY_PROVIDER_DRIVERS.has(driver)) {
+        continue;
+      }
+      for (const model of group.models) {
+        if (model.isLegacy) {
+          continue;
+        }
+        for (const descriptor of model.capabilities?.optionDescriptors ?? []) {
+          if (!seen.has(descriptor.label)) {
+            seen.set(descriptor.label, { type: descriptor.type });
+          }
+        }
+      }
+    }
+    for (const descriptor of displayedDescriptors) {
+      if (!seen.has(descriptor.label)) {
+        seen.set(descriptor.label, { type: descriptor.type });
+      }
+    }
+    return [...seen.entries()].map(([label, entry]) => ({ label, ...entry }));
+  })();
 
   const handleSave = () => {
     if (pendingModel) {
@@ -439,17 +480,11 @@ export function ThreadSettingsSheet(props: {
               <Pressable
                 accessibilityRole="button"
                 accessibilityState={{ selected: showLegacy }}
-                // Forced on while the highlighted model is legacy: hiding it
-                // would strand the checkmark, so don't offer a no-op.
-                disabled={displayedIsLegacy}
                 onPress={() => {
                   void Haptics.selectionAsync();
                   setShowLegacyToggle(!showLegacy);
                 }}
-                className={cn(
-                  "rounded-full border border-border bg-subtle px-3 py-1.5 active:opacity-70",
-                  displayedIsLegacy && "opacity-40",
-                )}
+                className="rounded-full border border-border bg-subtle px-3 py-1.5 active:opacity-70"
               >
                 <Text className="text-2xs font-t3-medium text-foreground-muted">
                   {showLegacy ? "Hide legacy models" : "Show legacy models"}
@@ -470,7 +505,7 @@ export function ThreadSettingsSheet(props: {
               const isPrimary = driver !== undefined && PRIMARY_PROVIDER_DRIVERS.has(driver);
               const visibleModels = showLegacy
                 ? group.models
-                : group.models.filter((model) => !model.isLegacy);
+                : group.models.filter((model) => !model.isLegacy || isDisplayed(model));
               if (visibleModels.length === 0) {
                 return null;
               }
@@ -509,23 +544,39 @@ export function ThreadSettingsSheet(props: {
           <View className="mx-5 h-px bg-border" />
 
           <View style={{ paddingBottom: insets.bottom + 12 }}>
-            {displayedDescriptors.map((descriptor) =>
-              descriptor.type === "select" ? (
-                <DisclosureRow
-                  key={descriptor.id}
-                  label={descriptor.label}
-                  value={getProviderOptionCurrentLabel(descriptor)}
-                  onPress={() => setSubmenu({ kind: "descriptor", id: descriptor.id })}
-                />
-              ) : (
+            {descriptorTemplate.map((entry) => {
+              const live = displayedDescriptors.find(
+                (descriptor) => descriptor.label === entry.label,
+              );
+              if ((live?.type ?? entry.type) === "select") {
+                return (
+                  <DisclosureRow
+                    key={entry.label}
+                    label={entry.label}
+                    value={live ? getProviderOptionCurrentLabel(live) : undefined}
+                    disabled={!live}
+                    onPress={() => {
+                      if (live) {
+                        setSubmenu({ kind: "descriptor", id: live.id });
+                      }
+                    }}
+                  />
+                );
+              }
+              return (
                 <SwitchRow
-                  key={descriptor.id}
-                  label={descriptor.label}
-                  value={descriptor.currentValue ?? false}
-                  onValueChange={(value) => handleOptionChange(descriptor.id, value)}
+                  key={entry.label}
+                  label={entry.label}
+                  value={live?.type === "boolean" ? (live.currentValue ?? false) : false}
+                  disabled={!live}
+                  onValueChange={(value) => {
+                    if (live) {
+                      handleOptionChange(live.id, value);
+                    }
+                  }}
                 />
-              ),
-            )}
+              );
+            })}
             <DisclosureRow
               label="Runtime"
               value={

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -8,6 +8,7 @@ import type {
 import {
   getProviderOptionCurrentLabel,
   getProviderOptionCurrentValue,
+  getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
 import * as Haptics from "expo-haptics";
 import { useEffect, useState } from "react";
@@ -174,23 +175,18 @@ function ProviderHeader(props: {
   );
 }
 
-/** Compact row that drills into a single-choice submenu page. */
+/** Compact row that opens a single-choice submenu panel. */
 function DisclosureRow(props: {
   readonly label: string;
   readonly value: string | undefined;
-  readonly disabled?: boolean;
   readonly onPress: () => void;
 }) {
   const iconSubtle = useThemeColor("--color-icon-subtle");
   return (
     <Pressable
       accessibilityRole="button"
-      disabled={props.disabled}
       onPress={props.onPress}
-      className={cn(
-        "flex-row items-center gap-2 px-5 py-3 active:opacity-70",
-        props.disabled && "opacity-40",
-      )}
+      className="flex-row items-center gap-2 px-5 py-3 active:opacity-70"
     >
       <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
       <View className="flex-1" />
@@ -204,7 +200,7 @@ function DisclosureRow(props: {
   );
 }
 
-/** Single option inside a submenu page. */
+/** Single option inside a submenu panel. */
 function ChoiceRow(props: {
   readonly label: string;
   readonly selected: boolean;
@@ -240,21 +236,14 @@ function ChoiceRow(props: {
 function SwitchRow(props: {
   readonly label: string;
   readonly value: boolean;
-  readonly disabled?: boolean;
   readonly onValueChange: (value: boolean) => void;
 }) {
   const activeTrack = String(useThemeColor("--color-switch-active"));
   const track = String(useThemeColor("--color-secondary-border"));
   return (
-    <View
-      className={cn(
-        "flex-row items-center justify-between px-5 py-2.5",
-        props.disabled && "opacity-40",
-      )}
-    >
+    <View className="flex-row items-center justify-between px-5 py-2.5">
       <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
       <Switch
-        disabled={props.disabled}
         ios_backgroundColor={track}
         onValueChange={props.onValueChange}
         trackColor={{ false: track, true: activeTrack }}
@@ -264,18 +253,17 @@ function SwitchRow(props: {
   );
 }
 
-type SheetPage =
-  | { readonly kind: "models" }
+type SubmenuPage =
   | { readonly kind: "descriptor"; readonly id: string }
   | { readonly kind: "runtime" };
 
 /**
  * Unified thread settings: the sheet is the provider-grouped model list
  * (primary harnesses expanded, other providers folded, legacy behind the
- * top-right pill) with a Save button, plus compact disclosure rows that
- * drill into single-choice submenus for reasoning / provider options and
- * runtime mode. Model changes stage until Save; submenu choices apply on
- * tap.
+ * top-right pill) with a Save button, plus compact disclosure rows whose
+ * single-choice submenus stack in a small panel over the sheet so it never
+ * changes size. Model changes stage until Save — while staged, the settings
+ * rows edit the staged model's options and Save applies everything together.
  *
  * Callers control which harnesses are offered via providerGroups: an
  * existing thread must pass only its own provider's group, since a session
@@ -299,21 +287,20 @@ export function ThreadSettingsSheet(props: {
 }) {
   const insets = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
-  const iconColor = useThemeColor("--color-icon");
   const [showLegacyToggle, setShowLegacyToggle] = useState(false);
   const [expandedProviders, setExpandedProviders] = useState<ReadonlySet<string>>(() => new Set());
   const [pendingModel, setPendingModel] = useState<ModelOption | null>(null);
-  const [page, setPage] = useState<SheetPage>({ kind: "models" });
+  const [submenu, setSubmenu] = useState<SubmenuPage | null>(null);
 
-  // Every open starts fresh: model list page, no staged model, legacy
-  // hidden, secondary providers folded. The sheet stays mounted between
-  // opens, so state would otherwise stick around.
+  // Every open starts fresh: no staged model, no submenu, legacy hidden,
+  // secondary providers folded. The sheet stays mounted between opens, so
+  // state would otherwise stick around.
   useEffect(() => {
     if (props.visible) {
       setShowLegacyToggle(false);
       setExpandedProviders(new Set());
       setPendingModel(null);
-      setPage({ kind: "models" });
+      setSubmenu(null);
     }
   }, [props.visible]);
 
@@ -323,7 +310,18 @@ export function ThreadSettingsSheet(props: {
   // The list highlights the staged pick; Save turns it into the applied one.
   const isDisplayed = (option: ModelOption) =>
     pendingModel ? option.key === pendingModel.key : isApplied(option);
-  const hasPendingModelChange = pendingModel !== null && !isApplied(pendingModel);
+
+  // While a model is staged, the settings rows describe and edit the staged
+  // model's options (kept on its pending selection); Save applies model and
+  // options together. Otherwise they edit the applied selection directly.
+  const displayedDescriptors = pendingModel
+    ? pendingModel.capabilities
+      ? getProviderOptionDescriptors({
+          caps: pendingModel.capabilities,
+          selections: pendingModel.selection.options,
+        })
+      : []
+    : props.optionDescriptors;
 
   const hasLegacyModels = props.providerGroups.some((group) =>
     group.models.some((model) => model.isLegacy),
@@ -336,7 +334,7 @@ export function ThreadSettingsSheet(props: {
   const showLegacy = showLegacyToggle || displayedIsLegacy;
 
   const handleSave = () => {
-    if (hasPendingModelChange && pendingModel) {
+    if (pendingModel) {
       void Haptics.selectionAsync();
       props.onSelectModel(pendingModel);
     }
@@ -344,8 +342,16 @@ export function ThreadSettingsSheet(props: {
   };
 
   const handleOptionChange = (id: string, value: string | boolean) => {
-    const next = applyProviderOptionSelection(props.optionDescriptors, { id, value });
-    if (next) {
+    const next = applyProviderOptionSelection(displayedDescriptors, { id, value });
+    if (!next) {
+      return;
+    }
+    if (pendingModel) {
+      setPendingModel({
+        ...pendingModel,
+        selection: { ...pendingModel.selection, options: next },
+      });
+    } else {
       props.onUpdateOptionSelections(next);
     }
   };
@@ -361,14 +367,14 @@ export function ThreadSettingsSheet(props: {
   };
 
   const activeDescriptor =
-    page.kind === "descriptor"
-      ? props.optionDescriptors.find(
-          (descriptor) => descriptor.type === "select" && descriptor.id === page.id,
+    submenu?.kind === "descriptor"
+      ? displayedDescriptors.find(
+          (descriptor) => descriptor.type === "select" && descriptor.id === submenu.id,
         )
       : undefined;
 
-  const subpage =
-    page.kind === "runtime"
+  const submenuContent =
+    submenu?.kind === "runtime"
       ? {
           title: "Runtime",
           rows: RUNTIME_MODE_CHOICES.map((choice) => ({
@@ -378,7 +384,7 @@ export function ThreadSettingsSheet(props: {
             onPress: () => {
               void Haptics.selectionAsync();
               props.onUpdateRuntimeMode(choice.mode);
-              setPage({ kind: "models" });
+              setSubmenu(null);
             },
           })),
         }
@@ -392,7 +398,7 @@ export function ThreadSettingsSheet(props: {
               onPress: () => {
                 void Haptics.selectionAsync();
                 handleOptionChange(activeDescriptor.id, choice.id);
-                setPage({ kind: "models" });
+                setSubmenu(null);
               },
             })),
           }
@@ -405,7 +411,7 @@ export function ThreadSettingsSheet(props: {
       navigationBarTranslucent
       animationType="fade"
       visible={props.visible}
-      onRequestClose={props.onClose}
+      onRequestClose={submenuContent ? () => setSubmenu(null) : props.onClose}
     >
       <View className="flex-1 justify-end">
         <Pressable
@@ -428,24 +434,145 @@ export function ThreadSettingsSheet(props: {
           >
             <View className="h-1 w-9 rounded-full bg-subtle-strong" />
           </Pressable>
-
-          {subpage ? (
-            <>
+          {hasLegacyModels ? (
+            <View className="flex-row justify-end px-4 pb-1.5">
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel="Back"
-                onPress={() => setPage({ kind: "models" })}
-                className="flex-row items-center gap-1.5 px-4 pb-2 pt-1 active:opacity-70"
+                accessibilityState={{ selected: showLegacy }}
+                // Forced on while the highlighted model is legacy: hiding it
+                // would strand the checkmark, so don't offer a no-op.
+                disabled={displayedIsLegacy}
+                onPress={() => {
+                  void Haptics.selectionAsync();
+                  setShowLegacyToggle(!showLegacy);
+                }}
+                className={cn(
+                  "rounded-full border border-border bg-subtle px-3 py-1.5 active:opacity-70",
+                  displayedIsLegacy && "opacity-40",
+                )}
               >
-                <SymbolView name="chevron.left" size={13} tintColor={iconColor} type="monochrome" />
-                <Text className="text-sm font-t3-bold text-foreground">{subpage.title}</Text>
+                <Text className="text-2xs font-t3-medium text-foreground-muted">
+                  {showLegacy ? "Hide legacy models" : "Show legacy models"}
+                </Text>
               </Pressable>
+            </View>
+          ) : null}
+          {/* Only the model list scrolls. Provider catalogs can run to
+              hundreds of models (OpenRouter), so the rows below stay pinned
+              and reachable instead of living at the end of that scroll. */}
+          <ScrollView
+            style={{ flexShrink: 1 }}
+            contentContainerStyle={{ paddingBottom: 8 }}
+            showsVerticalScrollIndicator={false}
+          >
+            {props.providerGroups.map((group) => {
+              const driver = group.models[0]?.providerDriver;
+              const isPrimary = driver !== undefined && PRIMARY_PROVIDER_DRIVERS.has(driver);
+              const visibleModels = showLegacy
+                ? group.models
+                : group.models.filter((model) => !model.isLegacy);
+              if (visibleModels.length === 0) {
+                return null;
+              }
+              const containsSelection = group.models.some(isDisplayed);
+              const collapsible = !isPrimary && !containsSelection;
+              const collapsed = collapsible && !expandedProviders.has(group.providerKey);
+              return (
+                <View key={group.providerKey}>
+                  <ProviderHeader
+                    driver={driver}
+                    label={group.providerLabel}
+                    collapsible={collapsible}
+                    collapsed={collapsed}
+                    modelCount={visibleModels.length}
+                    onToggle={() => toggleProvider(group.providerKey)}
+                  />
+                  {collapsed
+                    ? null
+                    : visibleModels.map((option) => (
+                        <ModelRow
+                          key={option.key}
+                          option={option}
+                          selected={isDisplayed(option)}
+                          onPress={() => {
+                            void Haptics.selectionAsync();
+                            // Re-tapping the applied model cancels staging.
+                            setPendingModel(isApplied(option) ? null : option);
+                          }}
+                        />
+                      ))}
+                </View>
+              );
+            })}
+          </ScrollView>
+
+          <View className="mx-5 h-px bg-border" />
+
+          <View style={{ paddingBottom: insets.bottom + 12 }}>
+            {displayedDescriptors.map((descriptor) =>
+              descriptor.type === "select" ? (
+                <DisclosureRow
+                  key={descriptor.id}
+                  label={descriptor.label}
+                  value={getProviderOptionCurrentLabel(descriptor)}
+                  onPress={() => setSubmenu({ kind: "descriptor", id: descriptor.id })}
+                />
+              ) : (
+                <SwitchRow
+                  key={descriptor.id}
+                  label={descriptor.label}
+                  value={descriptor.currentValue ?? false}
+                  onValueChange={(value) => handleOptionChange(descriptor.id, value)}
+                />
+              ),
+            )}
+            <DisclosureRow
+              label="Runtime"
+              value={
+                RUNTIME_MODE_CHOICES.find((choice) => choice.mode === props.runtimeMode)?.label
+              }
+              onPress={() => setSubmenu({ kind: "runtime" })}
+            />
+            <Pressable
+              accessibilityRole="button"
+              onPress={handleSave}
+              className="mx-4 mt-2 h-12 items-center justify-center rounded-full bg-primary active:opacity-80"
+            >
+              <Text className="text-sm font-t3-bold text-primary-foreground">
+                {pendingModel ? "Save" : "Done"}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {/* Submenus stack over the sheet instead of replacing its content,
+            so the main sheet keeps its size while drilling in and out. */}
+        {submenuContent ? (
+          <View className="absolute inset-0 justify-end">
+            <Pressable
+              accessibilityLabel={`Close ${submenuContent.title}`}
+              className="absolute inset-0 bg-backdrop"
+              onPress={() => setSubmenu(null)}
+            />
+            <View className="overflow-hidden rounded-t-[24px] border border-b-0 border-border bg-sheet">
+              <Pressable
+                accessibilityLabel={`Close ${submenuContent.title}`}
+                accessibilityRole="button"
+                onPress={() => setSubmenu(null)}
+                className="items-center pb-1 pt-2.5"
+              >
+                <View className="h-1 w-9 rounded-full bg-subtle-strong" />
+              </Pressable>
+              <Text className="px-5 pb-1.5 text-2xs font-t3-bold uppercase tracking-widest text-foreground-muted">
+                {submenuContent.title}
+              </Text>
               <ScrollView
-                style={{ flexShrink: 1 }}
+                style={{ maxHeight: windowHeight * 0.5 }}
                 contentContainerStyle={{ paddingBottom: insets.bottom + 12 }}
                 showsVerticalScrollIndicator={false}
+                bounces={false}
               >
-                {subpage.rows.map((row) => (
+                {submenuContent.rows.map((row) => (
                   <ChoiceRow
                     key={row.id}
                     label={row.label}
@@ -454,126 +581,9 @@ export function ThreadSettingsSheet(props: {
                   />
                 ))}
               </ScrollView>
-            </>
-          ) : (
-            <>
-              {hasLegacyModels ? (
-                <View className="flex-row justify-end px-4 pb-1.5">
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityState={{ selected: showLegacy }}
-                    // Forced on while the highlighted model is legacy: hiding
-                    // it would strand the checkmark, so don't offer a no-op.
-                    disabled={displayedIsLegacy}
-                    onPress={() => {
-                      void Haptics.selectionAsync();
-                      setShowLegacyToggle(!showLegacy);
-                    }}
-                    className={cn(
-                      "rounded-full border border-border bg-subtle px-3 py-1.5 active:opacity-70",
-                      displayedIsLegacy && "opacity-40",
-                    )}
-                  >
-                    <Text className="text-2xs font-t3-medium text-foreground-muted">
-                      {showLegacy ? "Hide legacy models" : "Show legacy models"}
-                    </Text>
-                  </Pressable>
-                </View>
-              ) : null}
-              {/* Only the model list scrolls. Provider catalogs can run to
-                  hundreds of models (OpenRouter), so the rows below stay
-                  pinned and reachable instead of living at the end of that
-                  scroll. */}
-              <ScrollView
-                style={{ flexShrink: 1 }}
-                contentContainerStyle={{ paddingBottom: 8 }}
-                showsVerticalScrollIndicator={false}
-              >
-                {props.providerGroups.map((group) => {
-                  const driver = group.models[0]?.providerDriver;
-                  const isPrimary = driver !== undefined && PRIMARY_PROVIDER_DRIVERS.has(driver);
-                  const visibleModels = showLegacy
-                    ? group.models
-                    : group.models.filter((model) => !model.isLegacy);
-                  if (visibleModels.length === 0) {
-                    return null;
-                  }
-                  const containsSelection = group.models.some(isDisplayed);
-                  const collapsible = !isPrimary && !containsSelection;
-                  const collapsed = collapsible && !expandedProviders.has(group.providerKey);
-                  return (
-                    <View key={group.providerKey}>
-                      <ProviderHeader
-                        driver={driver}
-                        label={group.providerLabel}
-                        collapsible={collapsible}
-                        collapsed={collapsed}
-                        modelCount={visibleModels.length}
-                        onToggle={() => toggleProvider(group.providerKey)}
-                      />
-                      {collapsed
-                        ? null
-                        : visibleModels.map((option) => (
-                            <ModelRow
-                              key={option.key}
-                              option={option}
-                              selected={isDisplayed(option)}
-                              onPress={() => {
-                                void Haptics.selectionAsync();
-                                setPendingModel(option);
-                              }}
-                            />
-                          ))}
-                    </View>
-                  );
-                })}
-              </ScrollView>
-
-              <View className="mx-5 h-px bg-border" />
-
-              {/* Settings rows configure the applied model, so they pause
-                  while a different model is staged; Save applies it first. */}
-              <View style={{ paddingBottom: insets.bottom + 12 }}>
-                {props.optionDescriptors.map((descriptor) =>
-                  descriptor.type === "select" ? (
-                    <DisclosureRow
-                      key={descriptor.id}
-                      label={descriptor.label}
-                      value={getProviderOptionCurrentLabel(descriptor)}
-                      disabled={hasPendingModelChange}
-                      onPress={() => setPage({ kind: "descriptor", id: descriptor.id })}
-                    />
-                  ) : (
-                    <SwitchRow
-                      key={descriptor.id}
-                      label={descriptor.label}
-                      value={descriptor.currentValue ?? false}
-                      disabled={hasPendingModelChange}
-                      onValueChange={(value) => handleOptionChange(descriptor.id, value)}
-                    />
-                  ),
-                )}
-                <DisclosureRow
-                  label="Runtime"
-                  value={
-                    RUNTIME_MODE_CHOICES.find((choice) => choice.mode === props.runtimeMode)?.label
-                  }
-                  disabled={hasPendingModelChange}
-                  onPress={() => setPage({ kind: "runtime" })}
-                />
-                <Pressable
-                  accessibilityRole="button"
-                  onPress={handleSave}
-                  className="mx-4 mt-2 h-12 items-center justify-center rounded-full bg-primary active:opacity-80"
-                >
-                  <Text className="text-sm font-t3-bold text-primary-foreground">
-                    {hasPendingModelChange ? "Save" : "Done"}
-                  </Text>
-                </Pressable>
-              </View>
-            </>
-          )}
-        </View>
+            </View>
+          </View>
+        ) : null}
       </View>
     </Modal>
   );

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -7,7 +7,7 @@ import type {
 } from "@t3tools/contracts";
 import { getProviderOptionCurrentValue } from "@t3tools/shared/model";
 import * as Haptics from "expo-haptics";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Modal, Pressable, ScrollView, Switch, useWindowDimensions, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -227,9 +227,9 @@ function SwitchRow(props: {
 /**
  * Unified thread settings: one bottom sheet holding the provider-grouped
  * model list (primary harnesses expanded, other providers folded, legacy
- * models behind a top toggle), the selected model's provider options, runtime
- * mode, and plan mode. Picking a model dismisses the sheet; every other
- * control keeps it open.
+ * models behind the top-right pill), the selected model's provider options,
+ * and runtime mode. Picking a model dismisses the sheet; every other control
+ * keeps it open.
  *
  * Rendered through an RN Modal (not the root OverlayPortal) so it also
  * presents above natively-presented form sheets like the new-task draft.
@@ -246,13 +246,21 @@ export function ThreadSettingsSheet(props: {
   readonly onUpdateOptionSelections: (selections: ReadonlyArray<ProviderOptionSelection>) => void;
   readonly runtimeMode: RuntimeMode;
   readonly onUpdateRuntimeMode: (mode: RuntimeMode) => void;
-  readonly interactionMode: ProviderInteractionMode;
-  readonly onUpdateInteractionMode: (mode: ProviderInteractionMode) => void;
 }) {
   const insets = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
   const [showLegacyToggle, setShowLegacyToggle] = useState(false);
   const [expandedProviders, setExpandedProviders] = useState<ReadonlySet<string>>(() => new Set());
+
+  // Every open starts from the compact view: legacy hidden, secondary
+  // providers folded. The sheet stays mounted between opens, so state would
+  // otherwise stick around.
+  useEffect(() => {
+    if (props.visible) {
+      setShowLegacyToggle(false);
+      setExpandedProviders(new Set());
+    }
+  }, [props.visible]);
 
   const isSelected = (option: ModelOption) =>
     option.selection.instanceId === props.selectedModel?.instanceId &&
@@ -321,6 +329,23 @@ export function ThreadSettingsSheet(props: {
           >
             <View className="h-1 w-9 rounded-full bg-subtle-strong" />
           </Pressable>
+          {hasLegacyModels ? (
+            <View className="flex-row justify-end px-4 pb-1.5">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityState={{ selected: showLegacy }}
+                onPress={() => {
+                  void Haptics.selectionAsync();
+                  setShowLegacyToggle(!showLegacy);
+                }}
+                className="rounded-full border border-border bg-subtle px-3 py-1.5 active:opacity-70"
+              >
+                <Text className="text-2xs font-t3-medium text-foreground-muted">
+                  {showLegacy ? "Hide legacy models" : "Show legacy models"}
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
           {/* Only the model list scrolls. Provider catalogs can run to hundreds
               of models (OpenRouter), so the settings below stay pinned and
               reachable instead of living at the end of that scroll. */}
@@ -410,21 +435,6 @@ export function ThreadSettingsSheet(props: {
               selectedId={props.runtimeMode}
               onSelect={props.onUpdateRuntimeMode}
             />
-
-            <View className="pt-2">
-              <SwitchRow
-                label="Plan mode"
-                value={props.interactionMode === "plan"}
-                onValueChange={(value) => props.onUpdateInteractionMode(value ? "plan" : "default")}
-              />
-              {hasLegacyModels ? (
-                <SwitchRow
-                  label="Show legacy models"
-                  value={showLegacy}
-                  onValueChange={setShowLegacyToggle}
-                />
-              ) : null}
-            </View>
           </ScrollView>
         </View>
       </View>

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -1,0 +1,429 @@
+import type {
+  ModelSelection,
+  ProviderInteractionMode,
+  ProviderOptionDescriptor,
+  ProviderOptionSelection,
+  RuntimeMode,
+} from "@t3tools/contracts";
+import { getProviderOptionCurrentValue } from "@t3tools/shared/model";
+import * as Haptics from "expo-haptics";
+import { useState } from "react";
+import { Modal, Pressable, ScrollView, Switch, useWindowDimensions, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { SymbolView } from "../../components/AppSymbol";
+import { AppText as Text } from "../../components/AppText";
+import { ProviderIcon } from "../../components/ProviderIcon";
+import { cn } from "../../lib/cn";
+import type { ModelOption, ProviderGroup } from "../../lib/modelOptions";
+import { applyProviderOptionSelection, providerOptionValueLabels } from "../../lib/providerOptions";
+import { useThemeColor } from "../../lib/useThemeColor";
+
+/**
+ * The everyday harnesses stay expanded; every other provider (OpenRouter
+ * catalogs and friends) folds behind its header so a 300-model catalog can't
+ * bury the list.
+ */
+const PRIMARY_PROVIDER_DRIVERS: ReadonlySet<string> = new Set(["claudeAgent", "codex"]);
+
+const RUNTIME_MODE_CHOICES: ReadonlyArray<{
+  readonly mode: RuntimeMode;
+  readonly label: string;
+  readonly shortLabel: string;
+}> = [
+  { mode: "approval-required", label: "Approve actions", shortLabel: "Approve" },
+  { mode: "auto-accept-edits", label: "Auto-accept edits", shortLabel: "Edits" },
+  { mode: "auto", label: "Auto", shortLabel: "Auto" },
+  { mode: "full-access", label: "Full access", shortLabel: "Full" },
+];
+
+/**
+ * Compact "Fable 5 · Max · Auto" style summary for the composer trigger pill,
+ * covering model, provider options, runtime mode, and plan mode in one label.
+ */
+export function threadSettingsSummaryLabel(input: {
+  readonly modelLabel: string;
+  readonly optionDescriptors: ReadonlyArray<ProviderOptionDescriptor>;
+  readonly runtimeMode: RuntimeMode;
+  readonly interactionMode: ProviderInteractionMode;
+}): string {
+  const runtime = RUNTIME_MODE_CHOICES.find((choice) => choice.mode === input.runtimeMode);
+  return [
+    input.modelLabel,
+    ...providerOptionValueLabels(input.optionDescriptors),
+    ...(runtime ? [runtime.shortLabel] : []),
+    ...(input.interactionMode === "plan" ? ["Plan"] : []),
+  ].join(" · ");
+}
+
+function SectionHeader(props: { readonly label: string }) {
+  return (
+    <Text className="px-5 pb-1.5 pt-4 text-2xs font-t3-bold uppercase tracking-widest text-foreground-muted">
+      {props.label}
+    </Text>
+  );
+}
+
+function ModelRow(props: {
+  readonly option: ModelOption;
+  readonly selected: boolean;
+  readonly onPress: () => void;
+}) {
+  const primaryFg = useThemeColor("--color-primary-foreground");
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected: props.selected }}
+      onPress={props.onPress}
+      // Selected rows get the same primary treatment as the selected chips
+      // below. Subtle backgrounds (bg-subtle-strong) get overridden by the
+      // OS selection chrome on iOS 26, so use the explicit high-contrast
+      // style everywhere instead.
+      className={cn(
+        "mx-2.5 flex-row items-center gap-2 rounded-xl px-3 py-3.5 active:opacity-70",
+        props.selected ? "bg-primary" : "bg-transparent",
+      )}
+    >
+      <Text
+        className={cn(
+          "shrink text-sm font-t3-medium",
+          props.selected ? "text-primary-foreground" : "text-foreground",
+        )}
+        numberOfLines={1}
+      >
+        {props.option.label}
+      </Text>
+      {props.option.isDefault ? (
+        <View className="rounded-md bg-subtle-strong px-1.5 py-0.5">
+          <Text className="text-3xs font-t3-bold text-foreground-muted">Default</Text>
+        </View>
+      ) : null}
+      {props.option.isLegacy ? (
+        <View className="rounded-md bg-subtle px-1.5 py-0.5">
+          <Text className="text-3xs font-t3-bold text-foreground-muted">Legacy</Text>
+        </View>
+      ) : null}
+      <View className="flex-1" />
+      {props.selected ? (
+        <SymbolView name="checkmark" size={14} tintColor={primaryFg} type="monochrome" />
+      ) : null}
+    </Pressable>
+  );
+}
+
+/**
+ * Provider section header with the harness logo. Secondary providers render
+ * as a tappable fold (count + chevron while collapsed); primary providers
+ * and the group holding the current selection are static headers.
+ */
+function ProviderHeader(props: {
+  readonly driver: string | undefined;
+  readonly label: string;
+  readonly collapsible: boolean;
+  readonly collapsed: boolean;
+  readonly modelCount: number;
+  readonly onToggle: () => void;
+}) {
+  const iconSubtle = useThemeColor("--color-icon-subtle");
+  return (
+    <Pressable
+      accessibilityRole={props.collapsible ? "button" : "header"}
+      accessibilityState={props.collapsible ? { expanded: !props.collapsed } : undefined}
+      accessibilityLabel={
+        props.collapsible ? `${props.label}, ${props.modelCount} models` : props.label
+      }
+      disabled={!props.collapsible}
+      onPress={props.onToggle}
+      className={cn(
+        "mx-2.5 flex-row items-center gap-2 rounded-xl px-3",
+        props.collapsible ? "py-3.5 active:opacity-70" : "pb-2 pt-4",
+      )}
+    >
+      <ProviderIcon provider={props.driver} size={15} />
+      <Text className="text-2xs font-t3-bold uppercase tracking-widest text-foreground-muted">
+        {props.label}
+      </Text>
+      {props.collapsible ? (
+        <>
+          <View className="flex-1" />
+          {props.collapsed ? (
+            <Text className="text-2xs font-t3-medium text-foreground-muted">
+              {props.modelCount}
+            </Text>
+          ) : null}
+          <SymbolView
+            name={props.collapsed ? "chevron.down" : "chevron.up"}
+            size={11}
+            tintColor={iconSubtle}
+            type="monochrome"
+          />
+        </>
+      ) : null}
+    </Pressable>
+  );
+}
+
+function ChoiceChips<Id extends string>(props: {
+  readonly choices: ReadonlyArray<{ readonly id: Id; readonly label: string }>;
+  readonly selectedId: Id | undefined;
+  readonly onSelect: (id: Id) => void;
+}) {
+  return (
+    <View className="flex-row flex-wrap gap-1.5 px-4">
+      {props.choices.map((choice) => {
+        const selected = choice.id === props.selectedId;
+        return (
+          <Pressable
+            key={choice.id}
+            accessibilityRole="button"
+            accessibilityState={{ selected }}
+            onPress={() => {
+              if (!selected) {
+                void Haptics.selectionAsync();
+                props.onSelect(choice.id);
+              }
+            }}
+            className={cn(
+              "rounded-full border px-3.5 py-2 active:opacity-70",
+              selected ? "border-transparent bg-primary" : "border-border bg-subtle",
+            )}
+          >
+            <Text
+              className={
+                selected
+                  ? "text-xs font-t3-bold text-primary-foreground"
+                  : "text-xs font-t3-medium text-foreground"
+              }
+            >
+              {choice.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function SwitchRow(props: {
+  readonly label: string;
+  readonly value: boolean;
+  readonly onValueChange: (value: boolean) => void;
+}) {
+  const activeTrack = String(useThemeColor("--color-switch-active"));
+  const track = String(useThemeColor("--color-secondary-border"));
+  return (
+    <View className="flex-row items-center justify-between px-5 py-2.5">
+      <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
+      <Switch
+        ios_backgroundColor={track}
+        onValueChange={props.onValueChange}
+        trackColor={{ false: track, true: activeTrack }}
+        value={props.value}
+      />
+    </View>
+  );
+}
+
+/**
+ * Unified thread settings: one bottom sheet holding the provider-grouped
+ * model list (primary harnesses expanded, other providers folded, legacy
+ * models behind a top toggle), the selected model's provider options, runtime
+ * mode, and plan mode. Picking a model dismisses the sheet; every other
+ * control keeps it open.
+ *
+ * Rendered through an RN Modal (not the root OverlayPortal) so it also
+ * presents above natively-presented form sheets like the new-task draft.
+ * Callers must dismiss the keyboard when opening — the iOS keyboard window
+ * would otherwise cover the lower half of the sheet.
+ */
+export function ThreadSettingsSheet(props: {
+  readonly visible: boolean;
+  readonly onClose: () => void;
+  readonly providerGroups: ReadonlyArray<ProviderGroup>;
+  readonly selectedModel: ModelSelection | null;
+  readonly onSelectModel: (option: ModelOption) => void;
+  readonly optionDescriptors: ReadonlyArray<ProviderOptionDescriptor>;
+  readonly onUpdateOptionSelections: (
+    selections: ReadonlyArray<ProviderOptionSelection>,
+  ) => void;
+  readonly runtimeMode: RuntimeMode;
+  readonly onUpdateRuntimeMode: (mode: RuntimeMode) => void;
+  readonly interactionMode: ProviderInteractionMode;
+  readonly onUpdateInteractionMode: (mode: ProviderInteractionMode) => void;
+}) {
+  const insets = useSafeAreaInsets();
+  const { height: windowHeight } = useWindowDimensions();
+  const [showLegacyToggle, setShowLegacyToggle] = useState(false);
+  const [expandedProviders, setExpandedProviders] = useState<ReadonlySet<string>>(() => new Set());
+
+  const isSelected = (option: ModelOption) =>
+    option.selection.instanceId === props.selectedModel?.instanceId &&
+    option.selection.model === props.selectedModel.model;
+
+  const hasLegacyModels = props.providerGroups.some((group) =>
+    group.models.some((model) => model.isLegacy),
+  );
+  // A legacy selection forces the toggle on: hiding the current model would
+  // strand the checkmark somewhere invisible.
+  const selectedIsLegacy = props.providerGroups.some((group) =>
+    group.models.some((model) => model.isLegacy && isSelected(model)),
+  );
+  const showLegacy = showLegacyToggle || selectedIsLegacy;
+
+  const handleSelectModel = (option: ModelOption) => {
+    void Haptics.selectionAsync();
+    props.onSelectModel(option);
+    props.onClose();
+  };
+
+  const handleOptionChange = (id: string, value: string | boolean) => {
+    const next = applyProviderOptionSelection(props.optionDescriptors, { id, value });
+    if (next) {
+      props.onUpdateOptionSelections(next);
+    }
+  };
+
+  const toggleProvider = (providerKey: string) => {
+    setExpandedProviders((current) => {
+      const next = new Set(current);
+      if (!next.delete(providerKey)) {
+        next.add(providerKey);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <Modal
+      transparent
+      statusBarTranslucent
+      navigationBarTranslucent
+      animationType="fade"
+      visible={props.visible}
+      onRequestClose={props.onClose}
+    >
+      <View className="flex-1 justify-end">
+        <Pressable
+          accessibilityLabel="Close thread settings"
+          className="absolute inset-0 bg-backdrop"
+          onPress={props.onClose}
+        />
+        <View
+          className="overflow-hidden rounded-t-[24px] border border-b-0 border-border bg-sheet"
+          style={{ maxHeight: windowHeight * 0.85 }}
+        >
+          {/* The grabber doubles as the accessible close control: the dim
+              backdrop above a tall sheet is a sliver, and VoiceOver can't
+              reach it at all. */}
+          <Pressable
+            accessibilityLabel="Close thread settings"
+            accessibilityRole="button"
+            onPress={props.onClose}
+            className="items-center pb-1 pt-2.5"
+          >
+            <View className="h-1 w-9 rounded-full bg-subtle-strong" />
+          </Pressable>
+          {/* Only the model list scrolls. Provider catalogs can run to hundreds
+              of models (OpenRouter), so the settings below stay pinned and
+              reachable instead of living at the end of that scroll. */}
+          <ScrollView
+            style={{ flexShrink: 1 }}
+            contentContainerStyle={{ paddingBottom: 8 }}
+            showsVerticalScrollIndicator={false}
+          >
+            {props.providerGroups.map((group) => {
+              const driver = group.models[0]?.providerDriver;
+              const isPrimary = driver !== undefined && PRIMARY_PROVIDER_DRIVERS.has(driver);
+              const visibleModels = showLegacy
+                ? group.models
+                : group.models.filter((model) => !model.isLegacy);
+              if (visibleModels.length === 0) {
+                return null;
+              }
+              const containsSelection = group.models.some(isSelected);
+              const collapsible = !isPrimary && !containsSelection;
+              const collapsed = collapsible && !expandedProviders.has(group.providerKey);
+              return (
+                <View key={group.providerKey}>
+                  <ProviderHeader
+                    driver={driver}
+                    label={group.providerLabel}
+                    collapsible={collapsible}
+                    collapsed={collapsed}
+                    modelCount={visibleModels.length}
+                    onToggle={() => toggleProvider(group.providerKey)}
+                  />
+                  {collapsed
+                    ? null
+                    : visibleModels.map((option) => (
+                        <ModelRow
+                          key={option.key}
+                          option={option}
+                          selected={isSelected(option)}
+                          onPress={() => handleSelectModel(option)}
+                        />
+                      ))}
+                </View>
+              );
+            })}
+          </ScrollView>
+
+          <View className="mx-5 h-px bg-border" />
+
+          <View style={{ paddingBottom: insets.bottom + 12 }}>
+            {props.optionDescriptors.map((descriptor) => {
+              if (descriptor.type === "select") {
+                const currentValue = getProviderOptionCurrentValue(descriptor);
+                return (
+                  <View key={descriptor.id}>
+                    <SectionHeader label={descriptor.label} />
+                    <ChoiceChips
+                      choices={descriptor.options}
+                      selectedId={typeof currentValue === "string" ? currentValue : undefined}
+                      onSelect={(id) => handleOptionChange(descriptor.id, id)}
+                    />
+                  </View>
+                );
+              }
+              return (
+                <SwitchRow
+                  key={descriptor.id}
+                  label={descriptor.label}
+                  value={descriptor.currentValue ?? false}
+                  onValueChange={(value) => handleOptionChange(descriptor.id, value)}
+                />
+              );
+            })}
+
+            <SectionHeader label="Runtime" />
+            <ChoiceChips
+              choices={RUNTIME_MODE_CHOICES.map((choice) => ({
+                id: choice.mode,
+                label: choice.label,
+              }))}
+              selectedId={props.runtimeMode}
+              onSelect={props.onUpdateRuntimeMode}
+            />
+
+            <View className="pt-2">
+              <SwitchRow
+                label="Plan mode"
+                value={props.interactionMode === "plan"}
+                onValueChange={(value) =>
+                  props.onUpdateInteractionMode(value ? "plan" : "default")
+                }
+              />
+              {hasLegacyModels ? (
+                <SwitchRow
+                  label="Show legacy models"
+                  value={showLegacy}
+                  onValueChange={setShowLegacyToggle}
+                />
+              ) : null}
+            </View>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -288,7 +288,12 @@ type SubmenuPage =
  */
 export function ThreadSettingsSheet(props: {
   readonly visible: boolean;
-  readonly onClose: () => void;
+  /**
+   * "save" = the Save/Done button (the user is finished configuring);
+   * "dismiss" = backdrop, grabber, or system back. Hosts only restore the
+   * keyboard for "save" so a stray tap outside a control never pops it.
+   */
+  readonly onClose: (reason: "save" | "dismiss") => void;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly selectedModel: ModelSelection | null;
   readonly onSelectModel: (option: ModelOption) => void;
@@ -379,7 +384,7 @@ export function ThreadSettingsSheet(props: {
       void Haptics.selectionAsync();
       props.onSelectModel(pendingModel);
     }
-    props.onClose();
+    props.onClose("save");
   };
 
   const handleOptionChange = (id: string, value: string | boolean) => {
@@ -452,13 +457,13 @@ export function ThreadSettingsSheet(props: {
       navigationBarTranslucent
       animationType="fade"
       visible={props.visible}
-      onRequestClose={submenuContent ? () => setSubmenu(null) : props.onClose}
+      onRequestClose={submenuContent ? () => setSubmenu(null) : () => props.onClose("dismiss")}
     >
       <View className="flex-1 justify-end">
         <Pressable
           accessibilityLabel="Close thread settings"
           className="absolute inset-0 bg-backdrop"
-          onPress={props.onClose}
+          onPress={() => props.onClose("dismiss")}
         />
         <View
           className="overflow-hidden rounded-t-[24px] border border-b-0 border-border bg-sheet"
@@ -470,7 +475,7 @@ export function ThreadSettingsSheet(props: {
           <Pressable
             accessibilityLabel="Close thread settings"
             accessibilityRole="button"
-            onPress={props.onClose}
+            onPress={() => props.onClose("dismiss")}
             className="items-center pb-1 pt-2.5"
           >
             <View className="h-1 w-9 rounded-full bg-subtle-strong" />
@@ -480,6 +485,7 @@ export function ThreadSettingsSheet(props: {
               <Pressable
                 accessibilityRole="button"
                 accessibilityState={{ selected: showLegacy }}
+                hitSlop={8}
                 onPress={() => {
                   void Haptics.selectionAsync();
                   setShowLegacyToggle(!showLegacy);

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -243,9 +243,7 @@ export function ThreadSettingsSheet(props: {
   readonly selectedModel: ModelSelection | null;
   readonly onSelectModel: (option: ModelOption) => void;
   readonly optionDescriptors: ReadonlyArray<ProviderOptionDescriptor>;
-  readonly onUpdateOptionSelections: (
-    selections: ReadonlyArray<ProviderOptionSelection>,
-  ) => void;
+  readonly onUpdateOptionSelections: (selections: ReadonlyArray<ProviderOptionSelection>) => void;
   readonly runtimeMode: RuntimeMode;
   readonly onUpdateRuntimeMode: (mode: RuntimeMode) => void;
   readonly interactionMode: ProviderInteractionMode;
@@ -370,7 +368,15 @@ export function ThreadSettingsSheet(props: {
 
           <View className="mx-5 h-px bg-border" />
 
-          <View style={{ paddingBottom: insets.bottom + 12 }}>
+          {/* Normally fits without scrolling, but a model advertising many
+              option descriptors could outgrow the sheet; the smaller
+              flexShrink keeps the model list absorbing most of the squeeze. */}
+          <ScrollView
+            style={{ flexShrink: 0.25 }}
+            contentContainerStyle={{ paddingBottom: insets.bottom + 12 }}
+            bounces={false}
+            showsVerticalScrollIndicator={false}
+          >
             {props.optionDescriptors.map((descriptor) => {
               if (descriptor.type === "select") {
                 const currentValue = getProviderOptionCurrentValue(descriptor);
@@ -409,9 +415,7 @@ export function ThreadSettingsSheet(props: {
               <SwitchRow
                 label="Plan mode"
                 value={props.interactionMode === "plan"}
-                onValueChange={(value) =>
-                  props.onUpdateInteractionMode(value ? "plan" : "default")
-                }
+                onValueChange={(value) => props.onUpdateInteractionMode(value ? "plan" : "default")}
               />
               {hasLegacyModels ? (
                 <SwitchRow
@@ -421,7 +425,7 @@ export function ThreadSettingsSheet(props: {
                 />
               ) : null}
             </View>
-          </View>
+          </ScrollView>
         </View>
       </View>
     </Modal>

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -11,8 +11,16 @@ import {
   getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
 import * as Haptics from "expo-haptics";
-import { useEffect, useState } from "react";
-import { Modal, Pressable, ScrollView, Switch, useWindowDimensions, View } from "react-native";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  Switch,
+  useWindowDimensions,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { SymbolView } from "../../components/AppSymbol";
@@ -22,6 +30,8 @@ import { cn } from "../../lib/cn";
 import type { ModelOption, ProviderGroup } from "../../lib/modelOptions";
 import { applyProviderOptionSelection, providerOptionValueLabels } from "../../lib/providerOptions";
 import { useThemeColor } from "../../lib/useThemeColor";
+import { pendingModelAfterPress } from "./thread-settings-sheet-state";
+import type { ThreadSettingsSheetCloseReason } from "./use-thread-settings-sheet-presentation";
 
 /**
  * The everyday harnesses stay expanded; every other provider (OpenRouter
@@ -293,7 +303,8 @@ export function ThreadSettingsSheet(props: {
    * "dismiss" = backdrop, grabber, or system back. Hosts only restore the
    * keyboard for "save" so a stray tap outside a control never pops it.
    */
-  readonly onClose: (reason: "save" | "dismiss") => void;
+  readonly onClose: (reason: ThreadSettingsSheetCloseReason) => void;
+  readonly onDismissed: () => void;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly selectedModel: ModelSelection | null;
   readonly onSelectModel: (option: ModelOption) => void;
@@ -308,18 +319,31 @@ export function ThreadSettingsSheet(props: {
   const [expandedProviders, setExpandedProviders] = useState<ReadonlySet<string>>(() => new Set());
   const [pendingModel, setPendingModel] = useState<ModelOption | null>(null);
   const [submenu, setSubmenu] = useState<SubmenuPage | null>(null);
+  const wasPresentedRef = useRef(false);
+  const notifyDismissed = useCallback(() => {
+    if (!wasPresentedRef.current) {
+      return;
+    }
+    wasPresentedRef.current = false;
+    props.onDismissed();
+  }, [props.onDismissed]);
 
   // Every open starts fresh: no staged model, no submenu, legacy hidden,
   // secondary providers folded. The sheet stays mounted between opens, so
   // state would otherwise stick around.
   useEffect(() => {
     if (props.visible) {
+      wasPresentedRef.current = true;
       setShowLegacyToggle(false);
       setExpandedProviders(new Set());
       setPendingModel(null);
       setSubmenu(null);
+    } else if (Platform.OS === "android" && wasPresentedRef.current) {
+      // React Native only emits Modal.onDismiss on iOS. Android uses no exit
+      // animation below, so the post-commit effect is its dismissal boundary.
+      notifyDismissed();
     }
-  }, [props.visible]);
+  }, [notifyDismissed, props.visible]);
 
   const isApplied = (option: ModelOption) =>
     option.selection.instanceId === props.selectedModel?.instanceId &&
@@ -455,8 +479,9 @@ export function ThreadSettingsSheet(props: {
       transparent
       statusBarTranslucent
       navigationBarTranslucent
-      animationType="fade"
+      animationType={Platform.OS === "ios" ? "fade" : "none"}
       visible={props.visible}
+      onDismiss={notifyDismissed}
       onRequestClose={submenuContent ? () => setSubmenu(null) : () => props.onClose("dismiss")}
     >
       <View className="flex-1 justify-end">
@@ -538,7 +563,13 @@ export function ThreadSettingsSheet(props: {
                           onPress={() => {
                             void Haptics.selectionAsync();
                             // Re-tapping the applied model cancels staging.
-                            setPendingModel(isApplied(option) ? null : option);
+                            setPendingModel((current) =>
+                              pendingModelAfterPress({
+                                current,
+                                pressed: option,
+                                pressedIsApplied: isApplied(option),
+                              }),
+                            );
                           }}
                         />
                       ))}

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -5,7 +5,10 @@ import type {
   ProviderOptionSelection,
   RuntimeMode,
 } from "@t3tools/contracts";
-import { getProviderOptionCurrentValue } from "@t3tools/shared/model";
+import {
+  getProviderOptionCurrentLabel,
+  getProviderOptionCurrentValue,
+} from "@t3tools/shared/model";
 import * as Haptics from "expo-haptics";
 import { useEffect, useState } from "react";
 import { Modal, Pressable, ScrollView, Switch, useWindowDimensions, View } from "react-native";
@@ -25,6 +28,15 @@ import { useThemeColor } from "../../lib/useThemeColor";
  * bury the list.
  */
 const PRIMARY_PROVIDER_DRIVERS: ReadonlySet<string> = new Set(["claudeAgent", "codex"]);
+
+/**
+ * Desktop-oriented effort keywords that don't belong in the phone picker.
+ * Prompt-injected values (ultrathink and friends) are filtered from the
+ * descriptor metadata; ultracode is a real option but a workflow trigger, not
+ * a reasoning level. A value set elsewhere still displays, it just isn't
+ * offered.
+ */
+const HIDDEN_EFFORT_OPTION_IDS: ReadonlySet<string> = new Set(["ultracode"]);
 
 const RUNTIME_MODE_CHOICES: ReadonlyArray<{
   readonly mode: RuntimeMode;
@@ -56,11 +68,10 @@ export function threadSettingsSummaryLabel(input: {
   ].join(" · ");
 }
 
-function SectionHeader(props: { readonly label: string }) {
-  return (
-    <Text className="px-5 pb-1.5 pt-4 text-2xs font-t3-bold uppercase tracking-widest text-foreground-muted">
-      {props.label}
-    </Text>
+function selectableChoices(descriptor: Extract<ProviderOptionDescriptor, { type: "select" }>) {
+  const injected = new Set(descriptor.promptInjectedValues ?? []);
+  return descriptor.options.filter(
+    (option) => !injected.has(option.id) && !HIDDEN_EFFORT_OPTION_IDS.has(option.id),
   );
 }
 
@@ -75,10 +86,10 @@ function ModelRow(props: {
       accessibilityRole="button"
       accessibilityState={{ selected: props.selected }}
       onPress={props.onPress}
-      // Selected rows get the same primary treatment as the selected chips
-      // below. Subtle backgrounds (bg-subtle-strong) get overridden by the
-      // OS selection chrome on iOS 26, so use the explicit high-contrast
-      // style everywhere instead.
+      // Selected rows get the same primary treatment as the submenu rows.
+      // Subtle backgrounds (bg-subtle-strong) get overridden by the OS
+      // selection chrome on iOS 26, so use the explicit high-contrast style
+      // everywhere instead.
       className={cn(
         "mx-2.5 flex-row items-center gap-2 rounded-xl px-3 py-3.5 active:opacity-70",
         props.selected ? "bg-primary" : "bg-transparent",
@@ -163,58 +174,87 @@ function ProviderHeader(props: {
   );
 }
 
-function ChoiceChips<Id extends string>(props: {
-  readonly choices: ReadonlyArray<{ readonly id: Id; readonly label: string }>;
-  readonly selectedId: Id | undefined;
-  readonly onSelect: (id: Id) => void;
+/** Compact row that drills into a single-choice submenu page. */
+function DisclosureRow(props: {
+  readonly label: string;
+  readonly value: string | undefined;
+  readonly disabled?: boolean;
+  readonly onPress: () => void;
 }) {
+  const iconSubtle = useThemeColor("--color-icon-subtle");
   return (
-    <View className="flex-row flex-wrap gap-1.5 px-4">
-      {props.choices.map((choice) => {
-        const selected = choice.id === props.selectedId;
-        return (
-          <Pressable
-            key={choice.id}
-            accessibilityRole="button"
-            accessibilityState={{ selected }}
-            onPress={() => {
-              if (!selected) {
-                void Haptics.selectionAsync();
-                props.onSelect(choice.id);
-              }
-            }}
-            className={cn(
-              "rounded-full border px-3.5 py-2 active:opacity-70",
-              selected ? "border-transparent bg-primary" : "border-border bg-subtle",
-            )}
-          >
-            <Text
-              className={
-                selected
-                  ? "text-xs font-t3-bold text-primary-foreground"
-                  : "text-xs font-t3-medium text-foreground"
-              }
-            >
-              {choice.label}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </View>
+    <Pressable
+      accessibilityRole="button"
+      disabled={props.disabled}
+      onPress={props.onPress}
+      className={cn(
+        "flex-row items-center gap-2 px-5 py-3 active:opacity-70",
+        props.disabled && "opacity-40",
+      )}
+    >
+      <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
+      <View className="flex-1" />
+      {props.value ? (
+        <Text className="text-sm text-foreground-muted" numberOfLines={1}>
+          {props.value}
+        </Text>
+      ) : null}
+      <SymbolView name="chevron.right" size={12} tintColor={iconSubtle} type="monochrome" />
+    </Pressable>
+  );
+}
+
+/** Single option inside a submenu page. */
+function ChoiceRow(props: {
+  readonly label: string;
+  readonly selected: boolean;
+  readonly onPress: () => void;
+}) {
+  const primaryFg = useThemeColor("--color-primary-foreground");
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected: props.selected }}
+      onPress={props.onPress}
+      className={cn(
+        "mx-2.5 flex-row items-center rounded-xl px-3 py-3.5 active:opacity-70",
+        props.selected ? "bg-primary" : "bg-transparent",
+      )}
+    >
+      <Text
+        className={cn(
+          "shrink text-sm font-t3-medium",
+          props.selected ? "text-primary-foreground" : "text-foreground",
+        )}
+      >
+        {props.label}
+      </Text>
+      <View className="flex-1" />
+      {props.selected ? (
+        <SymbolView name="checkmark" size={14} tintColor={primaryFg} type="monochrome" />
+      ) : null}
+    </Pressable>
   );
 }
 
 function SwitchRow(props: {
   readonly label: string;
   readonly value: boolean;
+  readonly disabled?: boolean;
   readonly onValueChange: (value: boolean) => void;
 }) {
   const activeTrack = String(useThemeColor("--color-switch-active"));
   const track = String(useThemeColor("--color-secondary-border"));
   return (
-    <View className="flex-row items-center justify-between px-5 py-2.5">
+    <View
+      className={cn(
+        "flex-row items-center justify-between px-5 py-2.5",
+        props.disabled && "opacity-40",
+      )}
+    >
       <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
       <Switch
+        disabled={props.disabled}
         ios_backgroundColor={track}
         onValueChange={props.onValueChange}
         trackColor={{ false: track, true: activeTrack }}
@@ -224,12 +264,22 @@ function SwitchRow(props: {
   );
 }
 
+type SheetPage =
+  | { readonly kind: "models" }
+  | { readonly kind: "descriptor"; readonly id: string }
+  | { readonly kind: "runtime" };
+
 /**
- * Unified thread settings: one bottom sheet holding the provider-grouped
- * model list (primary harnesses expanded, other providers folded, legacy
- * models behind the top-right pill), the selected model's provider options,
- * and runtime mode. Picking a model dismisses the sheet; every other control
- * keeps it open.
+ * Unified thread settings: the sheet is the provider-grouped model list
+ * (primary harnesses expanded, other providers folded, legacy behind the
+ * top-right pill) with a Save button, plus compact disclosure rows that
+ * drill into single-choice submenus for reasoning / provider options and
+ * runtime mode. Model changes stage until Save; submenu choices apply on
+ * tap.
+ *
+ * Callers control which harnesses are offered via providerGroups: an
+ * existing thread must pass only its own provider's group, since a session
+ * can't switch harness mid-thread.
  *
  * Rendered through an RN Modal (not the root OverlayPortal) so it also
  * presents above natively-presented form sheets like the new-task draft.
@@ -249,36 +299,47 @@ export function ThreadSettingsSheet(props: {
 }) {
   const insets = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
+  const iconColor = useThemeColor("--color-icon");
   const [showLegacyToggle, setShowLegacyToggle] = useState(false);
   const [expandedProviders, setExpandedProviders] = useState<ReadonlySet<string>>(() => new Set());
+  const [pendingModel, setPendingModel] = useState<ModelOption | null>(null);
+  const [page, setPage] = useState<SheetPage>({ kind: "models" });
 
-  // Every open starts from the compact view: legacy hidden, secondary
-  // providers folded. The sheet stays mounted between opens, so state would
-  // otherwise stick around.
+  // Every open starts fresh: model list page, no staged model, legacy
+  // hidden, secondary providers folded. The sheet stays mounted between
+  // opens, so state would otherwise stick around.
   useEffect(() => {
     if (props.visible) {
       setShowLegacyToggle(false);
       setExpandedProviders(new Set());
+      setPendingModel(null);
+      setPage({ kind: "models" });
     }
   }, [props.visible]);
 
-  const isSelected = (option: ModelOption) =>
+  const isApplied = (option: ModelOption) =>
     option.selection.instanceId === props.selectedModel?.instanceId &&
     option.selection.model === props.selectedModel.model;
+  // The list highlights the staged pick; Save turns it into the applied one.
+  const isDisplayed = (option: ModelOption) =>
+    pendingModel ? option.key === pendingModel.key : isApplied(option);
+  const hasPendingModelChange = pendingModel !== null && !isApplied(pendingModel);
 
   const hasLegacyModels = props.providerGroups.some((group) =>
     group.models.some((model) => model.isLegacy),
   );
-  // A legacy selection forces the toggle on: hiding the current model would
-  // strand the checkmark somewhere invisible.
-  const selectedIsLegacy = props.providerGroups.some((group) =>
-    group.models.some((model) => model.isLegacy && isSelected(model)),
+  // A legacy selection forces the toggle on: hiding the highlighted model
+  // would strand the checkmark somewhere invisible.
+  const displayedIsLegacy = props.providerGroups.some((group) =>
+    group.models.some((model) => model.isLegacy && isDisplayed(model)),
   );
-  const showLegacy = showLegacyToggle || selectedIsLegacy;
+  const showLegacy = showLegacyToggle || displayedIsLegacy;
 
-  const handleSelectModel = (option: ModelOption) => {
-    void Haptics.selectionAsync();
-    props.onSelectModel(option);
+  const handleSave = () => {
+    if (hasPendingModelChange && pendingModel) {
+      void Haptics.selectionAsync();
+      props.onSelectModel(pendingModel);
+    }
     props.onClose();
   };
 
@@ -298,6 +359,44 @@ export function ThreadSettingsSheet(props: {
       return next;
     });
   };
+
+  const activeDescriptor =
+    page.kind === "descriptor"
+      ? props.optionDescriptors.find(
+          (descriptor) => descriptor.type === "select" && descriptor.id === page.id,
+        )
+      : undefined;
+
+  const subpage =
+    page.kind === "runtime"
+      ? {
+          title: "Runtime",
+          rows: RUNTIME_MODE_CHOICES.map((choice) => ({
+            id: choice.mode,
+            label: choice.label,
+            selected: choice.mode === props.runtimeMode,
+            onPress: () => {
+              void Haptics.selectionAsync();
+              props.onUpdateRuntimeMode(choice.mode);
+              setPage({ kind: "models" });
+            },
+          })),
+        }
+      : activeDescriptor?.type === "select"
+        ? {
+            title: activeDescriptor.label,
+            rows: selectableChoices(activeDescriptor).map((choice) => ({
+              id: choice.id,
+              label: choice.label,
+              selected: choice.id === getProviderOptionCurrentValue(activeDescriptor),
+              onPress: () => {
+                void Haptics.selectionAsync();
+                handleOptionChange(activeDescriptor.id, choice.id);
+                setPage({ kind: "models" });
+              },
+            })),
+          }
+        : null;
 
   return (
     <Modal
@@ -329,113 +428,145 @@ export function ThreadSettingsSheet(props: {
           >
             <View className="h-1 w-9 rounded-full bg-subtle-strong" />
           </Pressable>
-          {hasLegacyModels ? (
-            <View className="flex-row justify-end px-4 pb-1.5">
+
+          {subpage ? (
+            <>
               <Pressable
                 accessibilityRole="button"
-                accessibilityState={{ selected: showLegacy }}
-                onPress={() => {
-                  void Haptics.selectionAsync();
-                  setShowLegacyToggle(!showLegacy);
-                }}
-                className="rounded-full border border-border bg-subtle px-3 py-1.5 active:opacity-70"
+                accessibilityLabel="Back"
+                onPress={() => setPage({ kind: "models" })}
+                className="flex-row items-center gap-1.5 px-4 pb-2 pt-1 active:opacity-70"
               >
-                <Text className="text-2xs font-t3-medium text-foreground-muted">
-                  {showLegacy ? "Hide legacy models" : "Show legacy models"}
-                </Text>
+                <SymbolView name="chevron.left" size={13} tintColor={iconColor} type="monochrome" />
+                <Text className="text-sm font-t3-bold text-foreground">{subpage.title}</Text>
               </Pressable>
-            </View>
-          ) : null}
-          {/* Only the model list scrolls. Provider catalogs can run to hundreds
-              of models (OpenRouter), so the settings below stay pinned and
-              reachable instead of living at the end of that scroll. */}
-          <ScrollView
-            style={{ flexShrink: 1 }}
-            contentContainerStyle={{ paddingBottom: 8 }}
-            showsVerticalScrollIndicator={false}
-          >
-            {props.providerGroups.map((group) => {
-              const driver = group.models[0]?.providerDriver;
-              const isPrimary = driver !== undefined && PRIMARY_PROVIDER_DRIVERS.has(driver);
-              const visibleModels = showLegacy
-                ? group.models
-                : group.models.filter((model) => !model.isLegacy);
-              if (visibleModels.length === 0) {
-                return null;
-              }
-              const containsSelection = group.models.some(isSelected);
-              const collapsible = !isPrimary && !containsSelection;
-              const collapsed = collapsible && !expandedProviders.has(group.providerKey);
-              return (
-                <View key={group.providerKey}>
-                  <ProviderHeader
-                    driver={driver}
-                    label={group.providerLabel}
-                    collapsible={collapsible}
-                    collapsed={collapsed}
-                    modelCount={visibleModels.length}
-                    onToggle={() => toggleProvider(group.providerKey)}
+              <ScrollView
+                style={{ flexShrink: 1 }}
+                contentContainerStyle={{ paddingBottom: insets.bottom + 12 }}
+                showsVerticalScrollIndicator={false}
+              >
+                {subpage.rows.map((row) => (
+                  <ChoiceRow
+                    key={row.id}
+                    label={row.label}
+                    selected={row.selected}
+                    onPress={row.onPress}
                   />
-                  {collapsed
-                    ? null
-                    : visibleModels.map((option) => (
-                        <ModelRow
-                          key={option.key}
-                          option={option}
-                          selected={isSelected(option)}
-                          onPress={() => handleSelectModel(option)}
-                        />
-                      ))}
+                ))}
+              </ScrollView>
+            </>
+          ) : (
+            <>
+              {hasLegacyModels ? (
+                <View className="flex-row justify-end px-4 pb-1.5">
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: showLegacy }}
+                    onPress={() => {
+                      void Haptics.selectionAsync();
+                      setShowLegacyToggle(!showLegacy);
+                    }}
+                    className="rounded-full border border-border bg-subtle px-3 py-1.5 active:opacity-70"
+                  >
+                    <Text className="text-2xs font-t3-medium text-foreground-muted">
+                      {showLegacy ? "Hide legacy models" : "Show legacy models"}
+                    </Text>
+                  </Pressable>
                 </View>
-              );
-            })}
-          </ScrollView>
+              ) : null}
+              {/* Only the model list scrolls. Provider catalogs can run to
+                  hundreds of models (OpenRouter), so the rows below stay
+                  pinned and reachable instead of living at the end of that
+                  scroll. */}
+              <ScrollView
+                style={{ flexShrink: 1 }}
+                contentContainerStyle={{ paddingBottom: 8 }}
+                showsVerticalScrollIndicator={false}
+              >
+                {props.providerGroups.map((group) => {
+                  const driver = group.models[0]?.providerDriver;
+                  const isPrimary = driver !== undefined && PRIMARY_PROVIDER_DRIVERS.has(driver);
+                  const visibleModels = showLegacy
+                    ? group.models
+                    : group.models.filter((model) => !model.isLegacy);
+                  if (visibleModels.length === 0) {
+                    return null;
+                  }
+                  const containsSelection = group.models.some(isDisplayed);
+                  const collapsible = !isPrimary && !containsSelection;
+                  const collapsed = collapsible && !expandedProviders.has(group.providerKey);
+                  return (
+                    <View key={group.providerKey}>
+                      <ProviderHeader
+                        driver={driver}
+                        label={group.providerLabel}
+                        collapsible={collapsible}
+                        collapsed={collapsed}
+                        modelCount={visibleModels.length}
+                        onToggle={() => toggleProvider(group.providerKey)}
+                      />
+                      {collapsed
+                        ? null
+                        : visibleModels.map((option) => (
+                            <ModelRow
+                              key={option.key}
+                              option={option}
+                              selected={isDisplayed(option)}
+                              onPress={() => {
+                                void Haptics.selectionAsync();
+                                setPendingModel(option);
+                              }}
+                            />
+                          ))}
+                    </View>
+                  );
+                })}
+              </ScrollView>
 
-          <View className="mx-5 h-px bg-border" />
+              <View className="mx-5 h-px bg-border" />
 
-          {/* Normally fits without scrolling, but a model advertising many
-              option descriptors could outgrow the sheet; the smaller
-              flexShrink keeps the model list absorbing most of the squeeze. */}
-          <ScrollView
-            style={{ flexShrink: 0.25 }}
-            contentContainerStyle={{ paddingBottom: insets.bottom + 12 }}
-            bounces={false}
-            showsVerticalScrollIndicator={false}
-          >
-            {props.optionDescriptors.map((descriptor) => {
-              if (descriptor.type === "select") {
-                const currentValue = getProviderOptionCurrentValue(descriptor);
-                return (
-                  <View key={descriptor.id}>
-                    <SectionHeader label={descriptor.label} />
-                    <ChoiceChips
-                      choices={descriptor.options}
-                      selectedId={typeof currentValue === "string" ? currentValue : undefined}
-                      onSelect={(id) => handleOptionChange(descriptor.id, id)}
+              {/* Settings rows configure the applied model, so they pause
+                  while a different model is staged; Save applies it first. */}
+              <View style={{ paddingBottom: insets.bottom + 12 }}>
+                {props.optionDescriptors.map((descriptor) =>
+                  descriptor.type === "select" ? (
+                    <DisclosureRow
+                      key={descriptor.id}
+                      label={descriptor.label}
+                      value={getProviderOptionCurrentLabel(descriptor)}
+                      disabled={hasPendingModelChange}
+                      onPress={() => setPage({ kind: "descriptor", id: descriptor.id })}
                     />
-                  </View>
-                );
-              }
-              return (
-                <SwitchRow
-                  key={descriptor.id}
-                  label={descriptor.label}
-                  value={descriptor.currentValue ?? false}
-                  onValueChange={(value) => handleOptionChange(descriptor.id, value)}
+                  ) : (
+                    <SwitchRow
+                      key={descriptor.id}
+                      label={descriptor.label}
+                      value={descriptor.currentValue ?? false}
+                      disabled={hasPendingModelChange}
+                      onValueChange={(value) => handleOptionChange(descriptor.id, value)}
+                    />
+                  ),
+                )}
+                <DisclosureRow
+                  label="Runtime"
+                  value={
+                    RUNTIME_MODE_CHOICES.find((choice) => choice.mode === props.runtimeMode)?.label
+                  }
+                  disabled={hasPendingModelChange}
+                  onPress={() => setPage({ kind: "runtime" })}
                 />
-              );
-            })}
-
-            <SectionHeader label="Runtime" />
-            <ChoiceChips
-              choices={RUNTIME_MODE_CHOICES.map((choice) => ({
-                id: choice.mode,
-                label: choice.label,
-              }))}
-              selectedId={props.runtimeMode}
-              onSelect={props.onUpdateRuntimeMode}
-            />
-          </ScrollView>
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={handleSave}
+                  className="mx-4 mt-2 h-12 items-center justify-center rounded-full bg-primary active:opacity-80"
+                >
+                  <Text className="text-sm font-t3-bold text-primary-foreground">
+                    {hasPendingModelChange ? "Save" : "Done"}
+                  </Text>
+                </Pressable>
+              </View>
+            </>
+          )}
         </View>
       </View>
     </Modal>

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -25,6 +25,7 @@ import type { ModelOption, ProviderGroup } from "../../lib/modelOptions";
 import {
   buildModelOptions,
   groupByProvider,
+  resolveDefaultableModelSelection,
   resolveSelectableModelSelection,
 } from "../../lib/modelOptions";
 import { scopedProjectKey } from "../../lib/scopedEntities";
@@ -362,14 +363,16 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const runtimeMode = selectedProjectDraft.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const interactionMode = selectedProjectDraft.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE;
 
-  // Stored selections (draft and project default) only count while their
-  // provider is usable on the server; otherwise the server's default model
-  // wins instead of silently targeting a disabled provider.
+  // Stored selections only count while their provider is usable on the
+  // server; otherwise the server's default model wins instead of silently
+  // targeting a disabled provider. The draft selection is an explicit pick
+  // and passes through as-is; the project default (last used, possibly from
+  // desktop) is implicit and additionally never resolves to a legacy model.
   const draftModelSelection = resolveSelectableModelSelection(
     selectedEnvironmentServerConfig,
     selectedProjectDraft.modelSelection ?? null,
   );
-  const projectDefaultModelSelection = resolveSelectableModelSelection(
+  const projectDefaultModelSelection = resolveDefaultableModelSelection(
     selectedEnvironmentServerConfig,
     selectedProject?.defaultModelSelection ?? null,
   );

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -147,7 +147,10 @@ type NewTaskFlowContextValue = {
   readonly reset: () => void;
   readonly setProject: (project: EnvironmentProject) => void;
   readonly selectEnvironment: (environmentId: EnvironmentId) => void;
-  readonly setSelectedModelKey: (key: string | null) => void;
+  readonly setSelectedModelKey: (
+    key: string | null,
+    options?: ReadonlyArray<ProviderOptionSelection>,
+  ) => void;
   readonly setWorkspaceMode: (mode: WorkspaceMode) => void;
   readonly selectBranch: (branch: VcsRef) => void;
   readonly setStartFromOrigin: (value: boolean) => void;
@@ -404,7 +407,9 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     [selectedEnvironmentServerConfig, selectedModel?.instanceId],
   );
   const setSelectedModelKey = useCallback(
-    (key: string | null) => {
+    // Options ride along in the same write: a follow-up setSelectedModelOptions
+    // call would rebuild the selection from the stale pre-switch model.
+    (key: string | null, options?: ReadonlyArray<ProviderOptionSelection>) => {
       if (!key || !selectedProjectDraftKey) {
         return;
       }
@@ -413,7 +418,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         return;
       }
       updateComposerDraftSettings(selectedProjectDraftKey, {
-        modelSelection: option.selection,
+        modelSelection: options ? { ...option.selection, options } : option.selection,
       });
     },
     [modelOptions, selectedProjectDraftKey],

--- a/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
+++ b/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { ProviderInstanceId, type ProviderOptionSelection } from "@t3tools/contracts";
+
+import type { ModelOption } from "../../lib/modelOptions";
+import { pendingModelAfterPress } from "./thread-settings-sheet-state";
+
+function modelOption(
+  model: string,
+  options: ReadonlyArray<ProviderOptionSelection> = [],
+): ModelOption {
+  return {
+    key: `codex:${model}`,
+    label: model,
+    subtitle: "Codex",
+    providerKey: "codex",
+    providerLabel: "Codex",
+    providerDriver: "codex",
+    isDefault: false,
+    isLegacy: false,
+    capabilities: null,
+    selection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model,
+      options,
+    },
+  };
+}
+
+describe("thread settings sheet state", () => {
+  it("clears staging when the applied model is pressed", () => {
+    expect(
+      pendingModelAfterPress({
+        current: modelOption("gpt-next"),
+        pressed: modelOption("gpt-current"),
+        pressedIsApplied: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("preserves staged options when the highlighted model is pressed again", () => {
+    const pending = modelOption("gpt-next", [{ id: "effort", value: "high" }]);
+
+    expect(
+      pendingModelAfterPress({
+        current: pending,
+        pressed: modelOption("gpt-next"),
+        pressedIsApplied: false,
+      }),
+    ).toBe(pending);
+  });
+
+  it("stages a different model", () => {
+    const pressed = modelOption("gpt-other");
+
+    expect(
+      pendingModelAfterPress({
+        current: modelOption("gpt-next"),
+        pressed,
+        pressedIsApplied: false,
+      }),
+    ).toBe(pressed);
+  });
+});

--- a/apps/mobile/src/features/threads/thread-settings-sheet-state.ts
+++ b/apps/mobile/src/features/threads/thread-settings-sheet-state.ts
@@ -1,0 +1,13 @@
+import type { ModelOption } from "../../lib/modelOptions";
+
+/** Preserve staged provider options when the highlighted model is tapped again. */
+export function pendingModelAfterPress(input: {
+  readonly current: ModelOption | null;
+  readonly pressed: ModelOption;
+  readonly pressedIsApplied: boolean;
+}): ModelOption | null {
+  if (input.pressedIsApplied) {
+    return null;
+  }
+  return input.current?.key === input.pressed.key ? input.current : input.pressed;
+}

--- a/apps/mobile/src/features/threads/use-thread-settings-sheet-presentation.ts
+++ b/apps/mobile/src/features/threads/use-thread-settings-sheet-presentation.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { KeyboardController } from "react-native-keyboard-controller";
+
+import type { ComposerEditorHandle } from "../../components/ComposerEditor";
+
+export type ThreadSettingsSheetCloseReason = "save" | "dismiss";
+
+type PresentationPhase = "closed" | "opening" | "visible" | "closing";
+
+/**
+ * Keeps the custom native composer and the settings modal from owning focus at
+ * the same time. Opening waits for the keyboard dismissal to finish, while
+ * focus restoration waits for the modal's dismissal callback.
+ */
+export function useThreadSettingsSheetPresentation(input: {
+  readonly editorRef: RefObject<ComposerEditorHandle | null>;
+  readonly isEditorFocused: boolean;
+}) {
+  const [phase, setPhase] = useState<PresentationPhase>("closed");
+  const isActiveRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const openingIdRef = useRef(0);
+  const restoreFocusOnSaveRef = useRef(false);
+  const shouldRestoreAfterDismissRef = useRef(false);
+
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+      isActiveRef.current = false;
+      openingIdRef.current += 1;
+    },
+    [],
+  );
+
+  const open = useCallback(() => {
+    if (isActiveRef.current) {
+      return;
+    }
+
+    isActiveRef.current = true;
+    restoreFocusOnSaveRef.current = input.isEditorFocused || KeyboardController.isVisible();
+    shouldRestoreAfterDismissRef.current = false;
+    setPhase("opening");
+
+    const openingId = openingIdRef.current + 1;
+    openingIdRef.current = openingId;
+
+    // Keyboard.dismiss() only tracks React Native TextInputs. The composer is
+    // a custom native text view, so explicitly resign its first responder too.
+    input.editorRef.current?.blur();
+    void KeyboardController.dismiss().then(() => {
+      if (!isMountedRef.current || !isActiveRef.current || openingIdRef.current !== openingId) {
+        return;
+      }
+      setPhase("visible");
+    });
+  }, [input.editorRef, input.isEditorFocused]);
+
+  const close = useCallback((reason: ThreadSettingsSheetCloseReason) => {
+    if (!isActiveRef.current) {
+      return;
+    }
+
+    openingIdRef.current += 1;
+    shouldRestoreAfterDismissRef.current = reason === "save" && restoreFocusOnSaveRef.current;
+    setPhase("closing");
+  }, []);
+
+  const onDismissed = useCallback(() => {
+    const shouldRestoreFocus = shouldRestoreAfterDismissRef.current;
+    shouldRestoreAfterDismissRef.current = false;
+    restoreFocusOnSaveRef.current = false;
+    isActiveRef.current = false;
+    setPhase("closed");
+
+    if (shouldRestoreFocus) {
+      input.editorRef.current?.focus();
+    }
+  }, [input.editorRef]);
+
+  // The new-task screen can have an autofocus queued before the sheet opens.
+  // Preserve that intent for Save without allowing it to focus under the modal.
+  const restoreFocusAfterSave = useCallback(() => {
+    if (isActiveRef.current) {
+      restoreFocusOnSaveRef.current = true;
+    }
+  }, []);
+
+  return {
+    isActive: phase !== "closed",
+    isActiveRef,
+    isVisible: phase === "visible",
+    open,
+    close,
+    onDismissed,
+    restoreFocusAfterSave,
+  } as const;
+}

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -2,15 +2,10 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { ProviderInstanceId, type ServerConfig } from "@t3tools/contracts";
 
-import {
-  buildModelMenuActions,
-  buildModelOptions,
-  groupByProvider,
-  resolveSelectableModelSelection,
-} from "./modelOptions";
+import { buildModelOptions, groupByProvider, resolveSelectableModelSelection } from "./modelOptions";
 
 describe("mobile model options", () => {
-  it("folds legacy models into a provider-scoped menu", () => {
+  it("groups models by provider and flags legacy entries", () => {
     const config = {
       providers: [
         {
@@ -39,51 +34,14 @@ describe("mobile model options", () => {
       ],
     } as unknown as ServerConfig;
 
-    const actions = buildModelMenuActions(groupByProvider(buildModelOptions(config, null)), null);
-
-    expect(actions).toMatchObject([
+    expect(groupByProvider(buildModelOptions(config, null))).toMatchObject([
       {
-        title: "Codex",
-        subactions: [{ id: "model:codex:gpt-5.6-sol", title: "GPT-5.6 Sol" }],
-      },
-      {
-        id: "legacy-models:codex",
-        title: "Codex legacy models",
-        subactions: [{ id: "model:codex:gpt-5.4", title: "GPT-5.4" }],
-      },
-    ]);
-  });
-
-  it("omits an empty provider menu when every model is legacy", () => {
-    const config = {
-      providers: [
-        {
-          instanceId: "codex",
-          driver: "codex",
-          displayName: "Codex",
-          enabled: true,
-          installed: true,
-          auth: { status: "authenticated" },
-          models: [
-            {
-              slug: "gpt-5.4",
-              name: "GPT-5.4",
-              isCustom: false,
-              isLegacy: true,
-              capabilities: null,
-            },
-          ],
-        },
-      ],
-    } as unknown as ServerConfig;
-
-    expect(
-      buildModelMenuActions(groupByProvider(buildModelOptions(config, null)), null),
-    ).toMatchObject([
-      {
-        id: "legacy-models:codex",
-        title: "Codex legacy models",
-        subactions: [{ id: "model:codex:gpt-5.4" }],
+        providerKey: "codex",
+        providerLabel: "Codex",
+        models: [
+          { key: "codex:gpt-5.6-sol", label: "GPT-5.6 Sol", isLegacy: false },
+          { key: "codex:gpt-5.4", label: "GPT-5.4", isLegacy: true },
+        ],
       },
     ]);
   });

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -5,6 +5,7 @@ import { ProviderInstanceId, type ServerConfig } from "@t3tools/contracts";
 import {
   buildModelOptions,
   groupByProvider,
+  resolveDefaultableModelSelection,
   resolveSelectableModelSelection,
 } from "./modelOptions";
 
@@ -135,5 +136,39 @@ describe("mobile model options", () => {
     expect(resolveSelectableModelSelection(config, removed)).toBeNull();
     // No config (environment offline) — nothing to validate against.
     expect(resolveSelectableModelSelection(null, disabled)).toBe(disabled);
+  });
+
+  it("keeps legacy models out of implicit defaults", () => {
+    const config = {
+      providers: [
+        {
+          instanceId: "codex",
+          driver: "codex",
+          displayName: "Codex",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          models: [
+            { slug: "gpt-5.6-sol", name: "GPT-5.6 Sol", isCustom: false, capabilities: null },
+            {
+              slug: "gpt-5.4",
+              name: "GPT-5.4",
+              isCustom: false,
+              isLegacy: true,
+              capabilities: null,
+            },
+          ],
+        },
+      ],
+    } as unknown as ServerConfig;
+
+    const current = { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.6-sol" };
+    const legacy = { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" };
+
+    expect(resolveDefaultableModelSelection(config, current)).toBe(current);
+    // A legacy last-used selection falls through to the provider default.
+    expect(resolveDefaultableModelSelection(config, legacy)).toBeNull();
+    // Offline: nothing to validate against, selection passes through.
+    expect(resolveDefaultableModelSelection(null, legacy)).toBe(legacy);
   });
 });

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { ProviderInstanceId, type ServerConfig } from "@t3tools/contracts";
 
-import { buildModelOptions, groupByProvider, resolveSelectableModelSelection } from "./modelOptions";
+import {
+  buildModelOptions,
+  groupByProvider,
+  resolveSelectableModelSelection,
+} from "./modelOptions";
 
 describe("mobile model options", () => {
   it("groups models by provider and flags legacy entries", () => {

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -3,7 +3,6 @@ import type {
   ModelSelection,
   ServerConfig as T3ServerConfig,
 } from "@t3tools/contracts";
-import type { MenuAction } from "@react-native-menu/menu";
 import {
   buildProviderOptionSelectionsFromDescriptors,
   getProviderOptionDescriptors,
@@ -167,54 +166,4 @@ export function groupByProvider(options: ReadonlyArray<ModelOption>): ReadonlyAr
     providerLabel: group.providerLabel,
     models: group.models,
   }));
-}
-
-function modelMenuAction(option: ModelOption, selectedModel: ModelSelection | null): MenuAction {
-  return {
-    id: `model:${option.key}`,
-    title: option.label,
-    state:
-      option.selection.instanceId === selectedModel?.instanceId &&
-      option.selection.model === selectedModel.model
-        ? "on"
-        : undefined,
-  };
-}
-
-export function buildModelMenuActions(
-  groups: ReadonlyArray<ProviderGroup>,
-  selectedModel: ModelSelection | null,
-): MenuAction[] {
-  return groups.flatMap((group) => {
-    const currentModels = group.models.filter((model) => !model.isLegacy);
-    const legacyModels = group.models.filter((model) => model.isLegacy);
-    const selected = group.models.find(
-      (model) =>
-        model.selection.instanceId === selectedModel?.instanceId &&
-        model.selection.model === selectedModel.model,
-    );
-
-    return [
-      ...(currentModels.length > 0
-        ? [
-            {
-              id: `provider:${group.providerKey}`,
-              title: group.providerLabel,
-              subtitle: selected && !selected.isLegacy ? selected.label : undefined,
-              subactions: currentModels.map((option) => modelMenuAction(option, selectedModel)),
-            },
-          ]
-        : []),
-      ...(legacyModels.length > 0
-        ? [
-            {
-              id: `legacy-models:${group.providerKey}`,
-              title: `${group.providerLabel} legacy models`,
-              subtitle: selected?.isLegacy ? selected.label : undefined,
-              subactions: legacyModels.map((option) => modelMenuAction(option, selectedModel)),
-            },
-          ]
-        : []),
-    ];
-  });
 }

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -84,6 +84,26 @@ export function resolveSelectableModelSelection(
     : null;
 }
 
+/**
+ * Like resolveSelectableModelSelection, but additionally rejects legacy
+ * models. Used for implicit defaults (stored draft, project last-used): a
+ * new thread should never quietly start on a legacy model, so those fall
+ * through to the provider's default instead. Explicit picks in the settings
+ * sheet are unaffected.
+ */
+export function resolveDefaultableModelSelection(
+  config: T3ServerConfig | null | undefined,
+  selection: ModelSelection | null,
+): ModelSelection | null {
+  const usable = resolveSelectableModelSelection(config, selection);
+  if (!usable || !config) {
+    return usable;
+  }
+  const provider = config.providers.find((candidate) => candidate.instanceId === usable.instanceId);
+  const model = provider?.models.find((candidate) => candidate.slug === usable.model);
+  return model?.isLegacy === true ? null : usable;
+}
+
 export function buildModelOptions(
   config: T3ServerConfig | null | undefined,
   fallbackModelSelection: ModelSelection | null,

--- a/apps/mobile/src/lib/providerOptions.test.ts
+++ b/apps/mobile/src/lib/providerOptions.test.ts
@@ -3,9 +3,8 @@ import { describe, expect, it } from "vite-plus/test";
 import type { ModelCapabilities } from "@t3tools/contracts";
 
 import {
-  applyProviderOptionMenuEvent,
-  buildProviderOptionMenuActions,
-  providerOptionsConfigurationLabel,
+  applyProviderOptionSelection,
+  providerOptionValueLabels,
   resolveProviderOptionDescriptors,
 } from "./providerOptions";
 
@@ -35,31 +34,13 @@ const CODEX_CAPABILITIES: ModelCapabilities = {
 };
 
 describe("mobile provider options", () => {
-  it("renders the option descriptors advertised by the selected model", () => {
+  it("summarizes the option values currently in effect", () => {
     const descriptors = resolveProviderOptionDescriptors({
       capabilities: CODEX_CAPABILITIES,
       selections: undefined,
     });
 
-    expect(buildProviderOptionMenuActions(descriptors)).toMatchObject([
-      {
-        title: "Reasoning",
-        subtitle: "Medium",
-        subactions: [
-          { title: "Medium (default)", state: "on" },
-          { title: "High", state: undefined },
-        ],
-      },
-      {
-        title: "Service Tier",
-        subtitle: "Standard",
-        subactions: [
-          { title: "Standard (default)", state: "on" },
-          { title: "Fast", state: undefined },
-        ],
-      },
-    ]);
-    expect(providerOptionsConfigurationLabel(descriptors)).toBe("Medium · Standard");
+    expect(providerOptionValueLabels(descriptors)).toEqual(["Medium", "Standard"]);
   });
 
   it("updates generic select options without knowing provider-specific ids", () => {
@@ -67,14 +48,14 @@ describe("mobile provider options", () => {
       capabilities: CODEX_CAPABILITIES,
       selections: undefined,
     });
-    const actions = buildProviderOptionMenuActions(descriptors);
-    const fastEvent = actions[1]?.subactions?.[1]?.id;
 
-    expect(fastEvent).toBeDefined();
-    expect(applyProviderOptionMenuEvent(descriptors, fastEvent!)).toEqual([
+    expect(applyProviderOptionSelection(descriptors, { id: "serviceTier", value: "priority" })).toEqual([
       { id: "reasoningEffort", value: "medium" },
       { id: "serviceTier", value: "priority" },
     ]);
+    // Choices the model doesn't advertise are rejected, not stored.
+    expect(applyProviderOptionSelection(descriptors, { id: "serviceTier", value: "turbo" })).toBeNull();
+    expect(applyProviderOptionSelection(descriptors, { id: "unknown", value: "high" })).toBeNull();
   });
 
   it("treats an unspecified boolean capability as off", () => {
@@ -85,16 +66,9 @@ describe("mobile provider options", () => {
       selections: undefined,
     });
 
-    expect(buildProviderOptionMenuActions(descriptors)).toMatchObject([
-      {
-        title: "Fast Mode",
-        subtitle: "Off",
-        subactions: [
-          { title: "Off", state: "on" },
-          { title: "On", state: undefined },
-        ],
-      },
+    expect(providerOptionValueLabels(descriptors)).toEqual([]);
+    expect(applyProviderOptionSelection(descriptors, { id: "fastMode", value: true })).toEqual([
+      { id: "fastMode", value: true },
     ]);
-    expect(providerOptionsConfigurationLabel(descriptors)).toBe("Configuration");
   });
 });

--- a/apps/mobile/src/lib/providerOptions.test.ts
+++ b/apps/mobile/src/lib/providerOptions.test.ts
@@ -49,12 +49,16 @@ describe("mobile provider options", () => {
       selections: undefined,
     });
 
-    expect(applyProviderOptionSelection(descriptors, { id: "serviceTier", value: "priority" })).toEqual([
+    expect(
+      applyProviderOptionSelection(descriptors, { id: "serviceTier", value: "priority" }),
+    ).toEqual([
       { id: "reasoningEffort", value: "medium" },
       { id: "serviceTier", value: "priority" },
     ]);
     // Choices the model doesn't advertise are rejected, not stored.
-    expect(applyProviderOptionSelection(descriptors, { id: "serviceTier", value: "turbo" })).toBeNull();
+    expect(
+      applyProviderOptionSelection(descriptors, { id: "serviceTier", value: "turbo" }),
+    ).toBeNull();
     expect(applyProviderOptionSelection(descriptors, { id: "unknown", value: "high" })).toBeNull();
   });
 

--- a/apps/mobile/src/lib/providerOptions.ts
+++ b/apps/mobile/src/lib/providerOptions.ts
@@ -3,47 +3,11 @@ import type {
   ProviderOptionDescriptor,
   ProviderOptionSelection,
 } from "@t3tools/contracts";
-import type { MenuAction } from "@react-native-menu/menu";
 import {
   buildProviderOptionSelectionsFromDescriptors,
   getProviderOptionCurrentLabel,
-  getProviderOptionCurrentValue,
   getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
-
-const PROVIDER_OPTION_EVENT_PREFIX = "provider-option:";
-
-function providerOptionEvent(id: string, value: string | boolean): string {
-  return `${PROVIDER_OPTION_EVENT_PREFIX}${encodeURIComponent(JSON.stringify({ id, value }))}`;
-}
-
-function parseProviderOptionEvent(
-  event: string,
-): { readonly id: string; readonly value: string | boolean } | null {
-  if (!event.startsWith(PROVIDER_OPTION_EVENT_PREFIX)) {
-    return null;
-  }
-
-  try {
-    const parsed: unknown = JSON.parse(
-      decodeURIComponent(event.slice(PROVIDER_OPTION_EVENT_PREFIX.length)),
-    );
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "id" in parsed &&
-      typeof parsed.id === "string" &&
-      "value" in parsed &&
-      (typeof parsed.value === "string" || typeof parsed.value === "boolean")
-    ) {
-      return { id: parsed.id, value: parsed.value };
-    }
-  } catch {
-    return null;
-  }
-
-  return null;
-}
 
 export function resolveProviderOptionDescriptors(input: {
   readonly capabilities: ModelCapabilities | null | undefined;
@@ -58,72 +22,41 @@ export function resolveProviderOptionDescriptors(input: {
   });
 }
 
-export function buildProviderOptionMenuActions(
+/**
+ * Labels for the option values currently in effect (select values plus
+ * enabled booleans), used to summarize the thread configuration in the
+ * composer trigger pill.
+ */
+export function providerOptionValueLabels(
   descriptors: ReadonlyArray<ProviderOptionDescriptor>,
-): ReadonlyArray<MenuAction> {
-  return descriptors.map((descriptor) => {
-    const currentValue =
-      descriptor.type === "boolean"
-        ? (descriptor.currentValue ?? false)
-        : getProviderOptionCurrentValue(descriptor);
-    const choices =
-      descriptor.type === "select"
-        ? descriptor.options.map((option) => ({
-            id: providerOptionEvent(descriptor.id, option.id),
-            title: `${option.label}${option.isDefault ? " (default)" : ""}`,
-            state: currentValue === option.id ? ("on" as const) : undefined,
-          }))
-        : ([false, true] as const).map((value) => ({
-            id: providerOptionEvent(descriptor.id, value),
-            title: value ? "On" : "Off",
-            state: currentValue === value ? ("on" as const) : undefined,
-          }));
-
-    return {
-      id: `provider-option-menu:${descriptor.id}`,
-      title: descriptor.label,
-      subtitle:
-        descriptor.type === "boolean"
-          ? currentValue
-            ? "On"
-            : "Off"
-          : getProviderOptionCurrentLabel(descriptor),
-      subactions: choices,
-    };
-  });
-}
-
-export function providerOptionsConfigurationLabel(
-  descriptors: ReadonlyArray<ProviderOptionDescriptor>,
-): string {
-  const labels = descriptors.flatMap((descriptor) => {
+): ReadonlyArray<string> {
+  return descriptors.flatMap((descriptor) => {
     if (descriptor.type === "boolean") {
       return descriptor.currentValue ? [descriptor.label] : [];
     }
     const label = getProviderOptionCurrentLabel(descriptor);
     return label ? [label] : [];
   });
-  return labels.length > 0 ? labels.join(" · ") : "Configuration";
 }
 
-export function applyProviderOptionMenuEvent(
+/**
+ * Applies one option change (by descriptor id) and returns the full selection
+ * list to store on the model selection, or null when the change doesn't match
+ * an advertised descriptor / choice.
+ */
+export function applyProviderOptionSelection(
   descriptors: ReadonlyArray<ProviderOptionDescriptor>,
-  event: string,
+  change: ProviderOptionSelection,
 ): ReadonlyArray<ProviderOptionSelection> | null {
-  const selection = parseProviderOptionEvent(event);
-  if (!selection) {
-    return null;
-  }
-
-  const descriptor = descriptors.find((candidate) => candidate.id === selection.id);
+  const descriptor = descriptors.find((candidate) => candidate.id === change.id);
   if (!descriptor) {
     return null;
   }
   if (
-    (descriptor.type === "boolean" && typeof selection.value !== "boolean") ||
+    (descriptor.type === "boolean" && typeof change.value !== "boolean") ||
     (descriptor.type === "select" &&
-      (typeof selection.value !== "string" ||
-        !descriptor.options.some((option) => option.id === selection.value)))
+      (typeof change.value !== "string" ||
+        !descriptor.options.some((option) => option.id === change.value)))
   ) {
     return null;
   }
@@ -132,7 +65,7 @@ export function applyProviderOptionMenuEvent(
     candidate.id === descriptor.id
       ? {
           ...candidate,
-          currentValue: selection.value,
+          currentValue: change.value,
         }
       : candidate,
   ) as ReadonlyArray<ProviderOptionDescriptor>;


### PR DESCRIPTION
Changing the model on mobile meant drilling through nested native context menus: provider submenu, then model, with effort and runtime hiding in a second menu. No search, no overview, and every provider doubled its menu length with a "legacy models" submenu.

Now the composer has one pill that shows the whole thread setup ("Claude Fable 5 · Max · 1M · Auto") and opens a single bottom sheet:

- Model list grouped by provider with harness logos. Claude and Codex stay expanded; other providers (OpenCode's 438-model OpenRouter catalog...) fold behind their header with a count. Legacy models hide behind a pill and get a badge when shown.
- Model changes stage until an explicit Save; re-tapping the applied model cancels. While staged, the settings rows edit the staged model's options and Save applies everything in one write.
- Reasoning, context window, and runtime each live behind a compact disclosure row whose submenu stacks in a small panel over the sheet, so the sheet never changes size. Ultracode/ultrathink pseudo-efforts aren't offered on mobile.
- Existing threads only list their own harness's models; picking a harness happens on the new-task draft, which shares the same sheet.
- Plan mode has no toggle here: threads build by default (the /plan command path is unchanged).

| Light | Staged model | Submenu | Dark | Dark submenu |
| --- | --- | --- | --- | --- |
| ![light](https://files.tslop.org/2026/08/sheet-v3-light-818c2ab9.jpg) | ![staged](https://files.tslop.org/2026/08/sheet-v4-staged-stable-rows-bc4abd18.jpg) | ![submenu](https://files.tslop.org/2026/08/sheet-v3-submenu-light-8d24fa23.jpg) | ![dark](https://files.tslop.org/2026/08/sheet-v3-dark-4e5b909d.jpg) | ![dark submenu](https://files.tslop.org/2026/08/sheet-v3-submenu-dark-d19a473d.jpg) |

Verified end to end on the iOS Simulator and on-device: model staging and save (with staged option edits carried through), folds, legacy pill, submenu apply, runtime changes, summary pill updates, light and dark.

Built by Claude Fable 5 running in Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate model and thread settings into a single sheet in the mobile composer
> - Replaces separate Model and Options menu pills in [`NewTaskDraftScreen`](https://github.com/pingdotgg/t3code/pull/5625/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2) and [`ThreadComposer`](https://github.com/pingdotgg/t3code/pull/5625/files#diff-4c62d895b68dd46f4d2858321c8942fde0d3ddd37c5e4253cba04c18c21a6024) with a single 'Thread settings' toolbar trigger that opens a unified [`ThreadSettingsSheet`](https://github.com/pingdotgg/t3code/pull/5625/files#diff-c7889046e38baae09b395b2fe1b43d588c686f9827763c7b5ff624f88481d6ea) modal.
> - The sheet groups models by provider with collapsible sections, hides legacy models by default, and stages model + option changes together until Save is tapped.
> - A new `threadSettingsSummaryLabel` utility composes a compact summary string (model, options, runtime mode) displayed on the trigger pill.
> - [`useThreadSettingsSheetPresentation`](https://github.com/pingdotgg/t3code/pull/5625/files#diff-ca81d99fee6867ac0dda1210735bb2a2384f797d9e4a8301063abb554c721b04) coordinates keyboard dismissal on open and restores editor focus only when the sheet is closed via Save, not on dismiss.
> - `resolveDefaultableModelSelection` prevents implicit defaults from resolving to legacy models; `applyProviderOptionSelection` replaces menu-event-string parsing with typed, validated selection updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a056b34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core composer model/runtime selection and draft default resolution; staging and keyboard/focus timing add UX edge cases but changes are localized to mobile thread UI.
> 
> **Overview**
> **Replaces nested native model/configuration menus** in the new-task draft and thread composer with **one toolbar pill** (summary like `Model · Max · Auto`) that opens a **`ThreadSettingsSheet` modal**.
> 
> The sheet adds a **scrollable, provider-grouped model list** (primary harnesses expanded, large catalogs foldable, legacy behind a toggle), **staged model picks applied on Save/Done**, and **disclosure submenus** for provider options and runtime. **Open threads only see models from their current harness**; new tasks still get all providers. **Plan/interaction mode** is no longer in the sheet—only reflected in the summary when already in plan mode (`/plan` unchanged).
> 
> **Presentation plumbing:** `useThreadSettingsSheetPresentation` dismisses the custom composer keyboard before showing the modal, keeps Android/iOS composer **expanded while the sheet is open**, and **restores focus only after Save**, not backdrop dismiss.
> 
> **Selection defaults:** `resolveDefaultableModelSelection` stops **implicit** project last-used defaults from landing on **legacy** models; draft picks stay explicit. `setSelectedModelKey` can apply **model + options in one write** when saving a staged change.
> 
> **Cleanup:** Removes `buildModelMenuActions` and menu-event provider option helpers in favor of direct selection APIs and tests for staging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a056b34e505b5b3268752ea0c1c3c42738e3c788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

