### PR TITLE
fix(web): inherit terminal size in simple typography

### DIFF
--- a/apps/web/src/appearanceFonts.test.ts
+++ b/apps/web/src/appearanceFonts.test.ts
@@ -11,6 +11,7 @@ import {
   cssFontFamilies,
   resolveDefaultFamilyLabel,
   resolveTerminalFontPreference,
+  resolveTerminalFontSizePreference,
 } from "./appearanceFonts";
 
 describe("areFontAdvancesMonospace", () => {
@@ -94,6 +95,16 @@ describe("resolveTerminalFontPreference", () => {
         terminal: "Berkeley Mono",
       }),
     ).toBe("Berkeley Mono");
+  });
+});
+
+describe("resolveTerminalFontSizePreference", () => {
+  it("inherits the code font size in simple mode", () => {
+    expect(resolveTerminalFontSizePreference({ advanced: false, code: 15, terminal: 12 })).toBe(15);
+  });
+
+  it("keeps code and terminal font sizes independent in advanced mode", () => {
+    expect(resolveTerminalFontSizePreference({ advanced: true, code: 15, terminal: 12 })).toBe(12);
   });
 });
 

--- a/apps/web/src/appearanceFonts.ts
+++ b/apps/web/src/appearanceFonts.ts
@@ -41,6 +41,15 @@ export function resolveTerminalFontPreference(input: {
   return input.code;
 }
 
+export function resolveTerminalFontSizePreference(input: {
+  readonly advanced: boolean;
+  readonly code: number;
+  readonly terminal: number;
+}): number {
+  if (input.advanced) return input.terminal;
+  return input.code;
+}
+
 function quoteFontFamilyName(name: string): string {
   const bare = name.trim();
   if (bare.length === 0) return "";

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -66,7 +66,11 @@ import { terminalEnvironment } from "../state/terminal";
 import { openTerminalLinkInPreview } from "./preview/openTerminalLinkInPreview";
 import { useAtomCommand } from "../state/use-atom-command";
 import { preventTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
-import { resolveTerminalFontPreference, TYPOGRAPHY_ADVANCED_STORAGE_KEY } from "../appearanceFonts";
+import {
+  resolveTerminalFontPreference,
+  resolveTerminalFontSizePreference,
+  TYPOGRAPHY_ADVANCED_STORAGE_KEY,
+} from "../appearanceFonts";
 
 const MIN_DRAWER_HEIGHT = 180;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
@@ -341,7 +345,13 @@ export function TerminalViewport({
       terminal: settings.fontFamilyTerminal,
     }),
   );
-  const terminalFontSize = useClientSettings((settings) => settings.fontSizeTerminal);
+  const terminalFontSize = useClientSettings((settings) =>
+    resolveTerminalFontSizePreference({
+      advanced: advancedTypography,
+      code: settings.fontSizeCode,
+      terminal: settings.fontSizeTerminal,
+    }),
+  );
   const terminalFontRef = useRef({ family: terminalFontFamily, size: terminalFontSize });
   const terminalSession = useAttachedTerminalSession({
     environmentId,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -100,6 +100,7 @@ import {
   isMonospaceFamily,
   resolveDefaultFamilyLabel,
   resolveTerminalFontPreference,
+  resolveTerminalFontSizePreference,
   TYPOGRAPHY_ADVANCED_STORAGE_KEY,
 } from "../../appearanceFonts";
 import { CodeFontPreview, PromptFontPreview, TerminalFontPreview } from "./SettingsFontPreviews";
@@ -1272,7 +1273,11 @@ function SimpleFontRows() {
                 code: settings.fontFamilyCode,
                 terminal: settings.fontFamilyTerminal,
               })}
-              size={settings.fontSizeTerminal}
+              size={resolveTerminalFontSizePreference({
+                advanced: false,
+                code: settings.fontSizeCode,
+                terminal: settings.fontSizeTerminal,
+              })}
             />
           </>
         }


### PR DESCRIPTION
## What Changed

In basic typography mode, the terminal now inherits the monospace font size, matching its existing font-family behavior. Advanced mode keeps its separate terminal size.

## Why

The Monospace font setting says it covers the terminal, but only the family changed it. The size continued using the hidden Advanced value.

## UI Changes

| Before | After |
| --- | --- |
| Terminal remains small at 18 px | Terminal follows the 18 px monospace size |
| <img width="896" height="420" alt="terminal-font-size-before" src="https://github.com/user-attachments/assets/9322dd9d-539d-4f76-ad3e-d4ad1569ad57" /> | <img width="896" height="420" alt="terminal-font-size-after" src="https://github.com/user-attachments/assets/49c819f2-de03-4d9b-9a16-20dd5c6da48d" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes — not applicable


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Inherit code font size for terminal in simple typography mode
> In simple typography mode, the terminal now uses the code font size instead of its own independent font size setting. This applies to both the terminal viewport in `ThreadTerminalDrawer` and the terminal preview in the simple settings panel. A new `resolveTerminalFontSizePreference` utility in [appearanceFonts.ts](https://github.com/pingdotgg/t3code/pull/5628/files#diff-264bfa08697508c4e4be1fd9398b44b8de2f8f8150ef75cec70f510e1e42f250) centralizes this logic, returning the terminal font size only when advanced typography is enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d22990.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized appearance logic with tests; no auth, data, or API changes.
> 
> **Overview**
> **Simple typography** now applies the **code (monospace) font size** to the terminal, matching how terminal font family already follows code in that mode. **Advanced typography** still uses the dedicated terminal size.
> 
> A new `resolveTerminalFontSizePreference` helper in `appearanceFonts.ts` mirrors `resolveTerminalFontPreference`. It is wired into the thread terminal drawer and the simple-settings `TerminalFontPreview`, with unit tests for both modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d2299004f4297e17c4c5f133a61503188d80515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->