### PR TITLE
fix(server): update standalone Codex installs with codex update

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -45,6 +45,7 @@ import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment
 import {
   enrichProviderSnapshotWithVersionAdvisory,
   makePackageManagedProviderMaintenanceResolver,
+  normalizeCommandPath,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
@@ -60,11 +61,32 @@ import {
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("codex");
+
+/**
+ * Codex's standalone installer drops a `~/.local/bin/codex` symlink pointing
+ * into a versioned release under `~/.codex/packages/standalone/`. Such an
+ * install is owned by `codex update`, not by any package manager, so it is
+ * matched here rather than falling through to the npm-global default.
+ */
+export function isCodexNativeCommandPath(commandPath: string): boolean {
+  const normalized = normalizeCommandPath(commandPath);
+  return (
+    normalized.endsWith("/.local/bin/codex") ||
+    normalized.endsWith("/.local/bin/codex.exe") ||
+    normalized.includes("/.codex/packages/standalone/")
+  );
+}
+
 const UPDATE = makePackageManagedProviderMaintenanceResolver({
   provider: DRIVER_KIND,
   npmPackageName: "@openai/codex",
   homebrewFormula: "codex",
-  nativeUpdate: null,
+  nativeUpdate: {
+    executable: "codex",
+    args: ["update"],
+    lockKey: "codex-native",
+    isCommandPath: isCodexNativeCommandPath,
+  },
 });
 
 /**

--- a/apps/server/src/provider/Drivers/CodexExecutable.test.ts
+++ b/apps/server/src/provider/Drivers/CodexExecutable.test.ts
@@ -1,0 +1,21 @@
+import { expect, it } from "@effect/vitest";
+
+import { isCodexNativeCommandPath } from "./CodexDriver.ts";
+
+it("treats codex standalone installs as native-updatable", () => {
+  expect(isCodexNativeCommandPath("/Users/example/.local/bin/codex")).toBe(true);
+  expect(
+    isCodexNativeCommandPath(
+      "/Users/example/.codex/packages/standalone/releases/0.146.1-aarch64-apple-darwin/bin/codex",
+    ),
+  ).toBe(true);
+  expect(isCodexNativeCommandPath("C:\\Users\\example\\.local\\bin\\codex.exe")).toBe(true);
+});
+
+it("leaves package-manager-owned codex installs to their package manager", () => {
+  expect(
+    isCodexNativeCommandPath("/opt/homebrew/lib/node_modules/@openai/codex/bin/codex.js"),
+  ).toBe(false);
+  expect(isCodexNativeCommandPath("/Users/example/.bun/bin/codex")).toBe(false);
+  expect(isCodexNativeCommandPath("/opt/homebrew/Cellar/codex/0.147.0/bin/codex")).toBe(false);
+});

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -615,6 +615,32 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       }),
   );
 
+  it.effect("keeps the displayed update command copyable when the install path has spaces", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-native-spaced-path-capabilities");
+      const nativeBinDir = NodePath.join(tempDir, "Alice Smith", ".scoped-package-tool", "bin");
+      NodeFS.mkdirSync(nativeBinDir, { recursive: true });
+      const configuredPath = NodePath.join(nativeBinDir, "scoped-package-tool");
+      NodeFS.writeFileSync(configuredPath, "#!/bin/sh\n");
+      NodeFS.chmodSync(configuredPath, 0o755);
+
+      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+        scopedPackageToolUpdate,
+        {
+          binaryPath: configuredPath,
+          env: {
+            PATH: "",
+          },
+        },
+      ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
+
+      // The spawned executable stays unquoted - it is passed as a list entry,
+      // never through a shell - while the copyable string quotes it.
+      expect(capabilities.update?.executable).toBe(configuredPath);
+      expect(capabilities.update?.command).toBe(`"${configuredPath}" upgrade`);
+    }),
+  );
+
   it("disables one-click updates for explicit custom binary paths it cannot safely map", () => {
     expect(
       packageToolUpdate.resolve({

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -356,9 +356,9 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           provider: driver("nativePackageTool"),
           packageName: "@example/native-package-tool",
           update: {
-            command: "native-package-tool update",
+            command: `${nativePackageToolPath} update`,
 
-            executable: "native-package-tool",
+            executable: nativePackageToolPath,
 
             args: ["update"],
 
@@ -393,9 +393,9 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           provider: driver("scopedPackageTool"),
           packageName: "@example/scoped-package-tool",
           update: {
-            command: "scoped-package-tool upgrade",
+            command: `${scopedPackageToolPath} upgrade`,
 
-            executable: "scoped-package-tool",
+            executable: scopedPackageToolPath,
 
             args: ["upgrade"],
 
@@ -570,15 +570,48 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           provider: driver("scopedPackageTool"),
           packageName: "@example/scoped-package-tool",
           update: {
-            command: "scoped-package-tool upgrade",
+            // The symlink is what was classified, so it is what gets updated —
+            // not the bare command name, which may resolve elsewhere on PATH.
+            command: `${symlinkPath} upgrade`,
 
-            executable: "scoped-package-tool",
+            executable: symlinkPath,
 
             args: ["upgrade"],
 
             lockKey: "scoped-package-tool-native",
           },
         });
+      }),
+  );
+
+  it.effect(
+    "runs native updates against the configured binary rather than a different one on PATH",
+    () =>
+      Effect.gen(function* () {
+        const tempDir = yield* makeTempDir("t3-native-configured-binary-capabilities");
+        const nativeBinDir = NodePath.join(tempDir, ".scoped-package-tool", "bin");
+        const otherBinDir = NodePath.join(tempDir, "other", "bin");
+        NodeFS.mkdirSync(nativeBinDir, { recursive: true });
+        NodeFS.mkdirSync(otherBinDir, { recursive: true });
+        const configuredPath = NodePath.join(nativeBinDir, "scoped-package-tool");
+        const otherPath = NodePath.join(otherBinDir, "scoped-package-tool");
+        for (const binaryPath of [configuredPath, otherPath]) {
+          NodeFS.writeFileSync(binaryPath, "#!/bin/sh\n");
+          NodeFS.chmodSync(binaryPath, 0o755);
+        }
+
+        const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+          scopedPackageToolUpdate,
+          {
+            binaryPath: configuredPath,
+            env: {
+              PATH: otherBinDir,
+            },
+          },
+        ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
+
+        expect(capabilities.update?.executable).toBe(configuredPath);
+        expect(capabilities.update?.executable).not.toBe(otherPath);
       }),
   );
 

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -541,6 +541,47 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     }),
   );
 
+  it.effect(
+    "selects native updates when only a symlink's real path matches the native install layout",
+    () =>
+      Effect.gen(function* () {
+        const tempDir = yield* makeTempDir("t3-native-realpath-capabilities");
+        const localBinDir = NodePath.join(tempDir, ".local", "bin");
+        const releaseBinDir = NodePath.join(tempDir, ".scoped-package-tool", "bin");
+        NodeFS.mkdirSync(localBinDir, { recursive: true });
+        NodeFS.mkdirSync(releaseBinDir, { recursive: true });
+        const releaseBinPath = NodePath.join(releaseBinDir, "scoped-package-tool");
+        const symlinkPath = NodePath.join(localBinDir, "scoped-package-tool");
+        NodeFS.writeFileSync(releaseBinPath, "#!/bin/sh\n");
+        NodeFS.chmodSync(releaseBinPath, 0o755);
+        NodeFS.symlinkSync(releaseBinPath, symlinkPath);
+
+        const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+          scopedPackageToolUpdate,
+          {
+            binaryPath: "scoped-package-tool",
+            env: {
+              PATH: localBinDir,
+            },
+          },
+        ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
+
+        expect(capabilities).toEqual({
+          provider: driver("scopedPackageTool"),
+          packageName: "@example/scoped-package-tool",
+          update: {
+            command: "scoped-package-tool upgrade",
+
+            executable: "scoped-package-tool",
+
+            args: ["upgrade"],
+
+            lockKey: "scoped-package-tool-native",
+          },
+        });
+      }),
+  );
+
   it("disables one-click updates for explicit custom binary paths it cannot safely map", () => {
     expect(
       packageToolUpdate.resolve({

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -94,6 +94,20 @@ function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+/**
+ * `command` is a display string — the UI renders it and users copy it into a
+ * terminal as the manual update. Execution never goes through it: the runner
+ * spawns `executable` with `args` as a list, so nothing here is a shell
+ * injection surface. Native updates do carry an absolute executable path
+ * though, and those can contain spaces (`/Users/Alice Smith/.local/bin/codex`),
+ * which would otherwise render as a command that splits into the wrong tokens
+ * when pasted. Double quotes rather than POSIX single quotes, since these
+ * paths are just as likely to be pasted into a Windows shell.
+ */
+function quoteCommandToken(token: string): string {
+  return /\s/.test(token) ? `"${token}"` : token;
+}
+
 export function makeProviderMaintenanceCapabilities(input: {
   readonly provider: ProviderDriverKind;
   readonly packageName: string | null;
@@ -105,7 +119,7 @@ export function makeProviderMaintenanceCapabilities(input: {
     input.updateExecutable === null || input.updateLockKey === null
       ? null
       : {
-          command: [input.updateExecutable, ...input.updateArgs].join(" "),
+          command: [input.updateExecutable, ...input.updateArgs].map(quoteCommandToken).join(" "),
           executable: input.updateExecutable,
           args: input.updateArgs,
           lockKey: input.updateLockKey,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -197,8 +197,18 @@ function makeHomebrewProviderMaintenanceCapabilities(
   });
 }
 
+/**
+ * Native updaters are self-updates: the binary rewrites its own install. The
+ * update therefore has to run *the binary that was classified as native*, not
+ * whatever the bare command name happens to resolve to at spawn time. Those
+ * differ whenever a provider's `binaryPath` points somewhere other than the
+ * first match on `PATH` — exactly the multi-install case this classification
+ * exists to handle — so prefer the resolved command path and fall back to the
+ * bare executable only when nothing was resolved.
+ */
 function makeNativeProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
+  resolvedCommandPath?: string | null,
 ): ProviderMaintenanceCapabilities | null {
   if (!definition.nativeUpdate) {
     return null;
@@ -207,7 +217,7 @@ function makeNativeProviderMaintenanceCapabilities(
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
     packageName: definition.npmPackageName,
-    updateExecutable: definition.nativeUpdate.executable,
+    updateExecutable: resolvedCommandPath ?? definition.nativeUpdate.executable,
     updateArgs: definition.nativeUpdate.args,
     updateLockKey: definition.nativeUpdate.lockKey,
   });
@@ -287,7 +297,7 @@ export function resolvePackageManagedProviderMaintenance(
       commandPaths.some((commandPath) => nativeUpdate.isCommandPath(commandPath))
     ) {
       return (
-        makeNativeProviderMaintenanceCapabilities(definition) ??
+        makeNativeProviderMaintenanceCapabilities(definition, resolvedCommandPath) ??
         makeNpmGlobalProviderMaintenanceCapabilities(definition)
       );
     }


### PR DESCRIPTION
Fixes the permanent "Codex still appears outdated" loop reported in #5629.

## Problem

`CodexDriver` declared `nativeUpdate: null`. A Codex CLI installed with OpenAI's standalone installer lives at `~/.local/bin/codex` and symlinks into `~/.codex/packages/standalone/releases/<ver>/bin/codex`, which matches none of the package-manager heuristics in `resolvePackageManagedProviderMaintenance`. With the provider's default bare `binaryPath` of `"codex"`, resolution then fell through to the fallback at `providerMaintenance.ts:311`, which assumes an unclassified install is npm-managed and reports `canUpdate: true`.

Clicking **Update now** therefore ran `npm install -g @openai/codex@latest` against an install npm does not own. The command exits 0, so `providerMaintenanceRunner` re-probed, still resolved the untouched standalone binary, still saw `behind_latest`, and recorded `unchanged` — surfacing "Provider still needs an update" on every attempt.

The silent half is worse than the loop: on a machine with no npm copy, that command *creates* a second Codex install the user never asked for, while the binary they actually run stays stale.

## Fix

Declare Codex's native update path the way `ClaudeDriver` already does for the identical `~/.local/bin` layout:

```ts
nativeUpdate: {
  executable: "codex",
  args: ["update"],
  lockKey: "codex-native",
  isCommandPath: isCodexNativeCommandPath,
},
```

`codex update` is a first-class subcommand of the CLI. Because `realCommandPath` is already threaded through `resolveProviderMaintenanceCapabilitiesEffect`, the `/.codex/packages/standalone/` clause matches through the symlink regardless of the link's name.

## Tests

- `CodexExecutable.test.ts` (new) — asserts standalone paths match and that npm, bun and Homebrew paths do **not**, so package-manager-owned installs keep being updated by their package manager.
- `providerMaintenance.test.ts` — adds coverage for a native install matched only via `realCommandPath` through a symlink. That path had no test, and it is the mechanism this fix depends on.

`apps/server` suite: 1917 passed, 7 skipped, 0 failures. `tsgo --noEmit`, `vp lint` and `vp fmt --check` all clean.

## Deliberately not fixed here

#5629 also describes a second defect: the `providerMaintenance.ts:311` fallback treats "could not classify this install" as "assume npm" for bare-name `binaryPath` values, while the path-separator branch two lines below correctly declines to `manual-only`. Tightening it looked like a natural companion change, but it is **not** safe as-is.

A Windows npm global install resolves to `%APPDATA%\npm\codex.cmd`. `realPath` does not rewrite `.cmd` shims, and `isNpmGlobalCommandPath` requires a `/node_modules/` segment, so that path matches nothing and currently reaches npm-global *only* through this fallback. Making the fallback stricter would silently take the update button away from Windows npm users.

Correcting that properly needs a Windows npm shim heuristic first, which felt like it belonged in its own PR with its own test matrix rather than riding along with a driver fix. Happy to follow up if maintainers want it.

## Note on scope

`isCodexNativeCommandPath` matches `~/.local/bin/codex` as well as the standalone release path, mirroring `isClaudeNativeCommandPath`. Native matching runs before the package-manager checks, so a Codex binary manually symlinked into `~/.local/bin` from a bun or pnpm install would now be offered `codex update` instead of its package manager's command. That matches existing Claude behaviour, and `codex update` reports the owning install method rather than doing something destructive — but I'm happy to drop the `~/.local/bin` clause and rely solely on `/.codex/packages/standalone/` if you'd prefer the narrower match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which executable runs for provider updates and Codex maintenance classification; behavior is covered by new tests but affects update execution paths.
> 
> **Overview**
> Fixes the **outdated Codex** loop for OpenAI’s standalone installer by treating those installs as **native** and offering **`codex update`** instead of **`npm install -g @openai/codex@latest`**.
> 
> **Codex driver:** Adds `isCodexNativeCommandPath` (paths under `~/.local/bin/codex` / `~/.codex/packages/standalone/`) and wires `nativeUpdate` with `codex update`, matching the Claude driver pattern.
> 
> **Shared maintenance:** Native update actions now spawn the **resolved binary path** (symlink or configured path), not the bare command name, so updates hit the install that was classified. Copyable update strings **quote** executable paths that contain spaces; spawn still uses unquoted argv.
> 
> Tests cover Codex path classification, symlink `realPath` matching, configured-vs-PATH binaries, and spaced paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d09a15d93720527b7c780a24da0fd9519720b834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `codex update` for standalone Codex installs detected by command path
> - Adds `isCodexNativeCommandPath` to classify a binary as a standalone Codex install when its path ends with `/.local/bin/codex[.exe]` or contains `/.codex/packages/standalone/`.
> - Wires a `nativeUpdate` config into the Codex driver that runs `codex update` when the binary matches the standalone layout, including symlink realpath resolution.
> - Updates the display command to quote tokens containing spaces, and sets the update executable to the resolved binary path rather than a bare command name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d09a15d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->