### PR TITLE
fix(web): reconnect the composer seam for remote non-Git projects

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -126,7 +126,7 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
 
   if (isLocked) {
     return (
-      <span className="inline-flex min-w-0 max-w-[48%] flex-1 items-center justify-start gap-1 rounded-md border border-transparent px-[calc(--spacing(2)-1px)] text-sm font-medium text-muted-foreground/70 md:hidden">
+      <span className="inline-flex h-7 min-w-0 max-w-[48%] flex-1 items-center justify-start gap-1 rounded-md border border-transparent px-[calc(--spacing(2)-1px)] text-sm font-medium text-muted-foreground/70 sm:h-6 md:hidden">
         {triggerContent}
       </span>
     );

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -50,7 +50,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
 
   if (envLocked) {
     return (
-      <span className="inline-flex shrink-0 items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
+      <span className="inline-flex h-7 shrink-0 items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:h-6 sm:text-xs">
         {activeWorktreePath ? (
           <>
             <FolderGitIcon className="size-3" />

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -41,9 +41,14 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
     [availableEnvironments],
   );
 
+  // The static label carries the xs control's height (h-7 sm:h-6) as well as
+  // its padding: the composer context strip has no min-height of its own, and
+  // the glass seam joining it to the composer assumes a fixed strip height, so
+  // a shorter label would drag the seam out of line whenever this label is the
+  // only thing in the strip.
   if (envLocked || onEnvironmentChange === undefined) {
     return (
-      <span className="inline-flex min-w-0 max-w-full items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
+      <span className="inline-flex h-7 min-w-0 max-w-full items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:h-6 sm:text-xs">
         {activeEnvironment?.isPrimary ? (
           <MonitorIcon className="size-3 shrink-0" />
         ) : (


### PR DESCRIPTION
On a remote environment whose project isn't a Git repo, the composer's rounded corners step out past the context strip instead of flowing into it, so the seam between the two reads as a broken double border. Local Git projects look correct.

#5555 started rendering the context strip for remote non-Git projects and gated the Git controls behind `showGitControls`. Before it, the strip only ever appeared for Git repos, which meant it always held at least one `size="xs"` control (`h-7 sm:h-6`). Now the only child left in that case is the static environment label, and the three locked label variants copied the xs control's padding and border but not its height, so they render 18px instead of 24px. `.chat-composer-glass-shell-with-context` hardcodes `--chat-composer-context-extension: 2rem` and its `clip-path: shape(...)` uses that value to decide where the composer narrows into the strip, so a 42px strip instead of 48px puts the shoulder 6px above the composer's real bottom edge.

Measured in the app on a remote non-Git project, before and after:

| | strip height | label height | composer→shell gap | CSS extension |
| --- | --- | --- | --- | --- |
| before | 42px | 18px | 26px | 32px |
| after | 48px | 24px | 32px | 32px |

The fix gives the three locked labels the xs control height they already borrow padding from, so the strip keeps a fixed height whatever it contains, rather than hardcoding a second magic number in the CSS. The mobile locked label had the same 6px gap against its `2.25rem` extension and is fixed the same way.

**Before**

![before](https://raw.githubusercontent.com/caezium/t3code/pr-assets-composer-seam/composer-seam-before.png)

**After**

![after](https://raw.githubusercontent.com/caezium/t3code/pr-assets-composer-seam/composer-seam-after.png)

Surfaces walked: **web** (the reported surface, verified in a browser against two local environments — a primary one plus a paired remote holding a non-Git project); **mobile** shares the locked-label markup through `MobileRunContextSelector` and gets the same height, though its own strip only collapses when every control is locked; **desktop** wraps web, so it follows. No contract, provider, or server behavior changes, and no user-visible behavior to document — this is geometry only.

Verified with `vp test run apps/web/src/components/BranchToolbar.logic.test.ts` (56 passed) plus the measurements above; the change is className-only.

Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ClassName-only layout fix in web toolbar components; no logic, API, or data changes.
> 
> **Overview**
> Fixes a **misaligned composer “glass” seam** when the context strip only shows static locked labels (e.g. remote non-Git projects with Git controls hidden). Those labels copied xs padding but not height, so the strip shrank ~6px while CSS still assumed the full xs strip height.
> 
> Adds **`h-7 sm:h-6`** to the locked read-only spans in `BranchToolbarEnvironmentSelector`, `BranchToolbarEnvModeSelector`, and the mobile locked branch in `BranchToolbar` so strip height stays consistent with interactive `size="xs"` controls. A short comment in the environment selector documents why the static label must carry that height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf5a91fa51db05dd3b47570fe5bca8585e2f0e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix height of locked selector spans in the branch toolbar for remote non-Git projects
> Adds explicit height classes (`h-7`, `sm:h-6`) to the static `<span>` elements rendered in the locked/disabled state of [`BranchToolbar`](https://github.com/pingdotgg/t3code/pull/5633/files#diff-698af5019ef8a26d8e1653085b9e61762e35f389e79e62d402760255625b0a10), [`BranchToolbarEnvModeSelector`](https://github.com/pingdotgg/t3code/pull/5633/files#diff-f6e603d70ca6bba6f4bb6ec0c74ab245223570c8a33c292fb1d25529770f3f67), and [`BranchToolbarEnvironmentSelector`](https://github.com/pingdotgg/t3code/pull/5633/files#diff-3759c9280378eadf1bb9c4b0f2e904767a2ba23386070a9a38f60a6ae124278a). This restores visual alignment between the locked labels and the interactive controls they replace, which was broken for remote non-Git projects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cf5a91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->