### PR TITLE
fix(web): add copying terminal selection with ctrl+c in the web app

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -685,8 +685,11 @@ export function TerminalViewport({
         }
         clearSelectionAction();
         // A copy shortcut that clears the selection (Ctrl+C) must also close
-        // the context menu that appears with the selection.
-        void localApi?.contextMenu.close();
+        // the context menu that appears with the selection, but a clear that
+        // never opened a menu must not dismiss an unrelated one.
+        if (selectionActionMenuOpenRef.current) {
+          void localApi?.contextMenu.close();
+        }
       }
 
       const handleMouseUp = (event: MouseEvent) => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -684,6 +684,9 @@ export function TerminalViewport({
           return;
         }
         clearSelectionAction();
+        // A copy shortcut that clears the selection (Ctrl+C) must also close
+        // the context menu that appears with the selection.
+        void localApi?.contextMenu.close();
       }
 
       const handleMouseUp = (event: MouseEvent) => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -440,7 +440,6 @@ export function TerminalViewport({
         onData: (data) => handleData(data),
         onResize: (cols, rows) => void resizeTerminal(cols, rows),
         onSelectionChange: () => handleSelectionChange(),
-        onCopy: (text) => handleCopy(text),
         beforeKey: (event) => handleBeforeKey(event),
         onLinkActivate: (text, event) => handleLinkActivate(text, event),
       };
@@ -666,17 +665,6 @@ export function TerminalViewport({
             error instanceof Error ? error.message : "Unable to open path",
           );
         })();
-      }
-
-      function handleCopy(text: string): void {
-        void writeTextToClipboard(text, "terminal selection").catch((error: unknown) => {
-          const activeTerminal = terminalRef.current;
-          if (!activeTerminal) return;
-          writeSystemMessage(
-            activeTerminal,
-            error instanceof Error ? error.message : "Unable to copy terminal selection",
-          );
-        });
       }
 
       function handleData(data: string): void {

--- a/apps/web/src/components/settings/SettingsFontPreviews.tsx
+++ b/apps/web/src/components/settings/SettingsFontPreviews.tsx
@@ -238,7 +238,6 @@ export function TerminalFontPreview({ family, size }: { family: string; size: nu
       onData: echo,
       onResize: noop,
       onSelectionChange: noop,
-      onCopy: (text) => void navigator.clipboard?.writeText(text).catch(noop),
       // Tab keeps walking the settings page instead of feeding the echo loop.
       beforeKey: (event) => event.key !== "Tab",
       onLinkActivate: noop,

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { showContextMenuFallback } from "./contextMenuFallback";
+import { dismissContextMenu, showContextMenuFallback } from "./contextMenuFallback";
 
 type FakeListener = (event: FakeDomEvent) => void;
 
@@ -234,5 +234,25 @@ describe("showContextMenuFallback", () => {
     childButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     await expect(selectionPromise).resolves.toBe("rename:project-b");
+  });
+});
+
+describe("dismissContextMenu", () => {
+  it("resolves an open menu with null", async () => {
+    const selectionPromise = showContextMenuFallback([
+      { id: "rename", label: "Rename" },
+      { id: "delete", label: "Delete" },
+    ]);
+    expect(findButton("Rename")).toBeTruthy();
+
+    dismissContextMenu();
+
+    await expect(selectionPromise).resolves.toBeNull();
+    expect(findButton("Rename")).toBeUndefined();
+  });
+
+  it("is a no-op when no menu is open", async () => {
+    dismissContextMenu();
+    expect(findButton("Rename")).toBeUndefined();
   });
 });

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -255,4 +255,18 @@ describe("dismissContextMenu", () => {
     dismissContextMenu();
     expect(findButton("Rename")).toBeUndefined();
   });
+
+  it("dismisses the prior menu when a new one opens", async () => {
+    const firstPromise = showContextMenuFallback([{ id: "first", label: "First" }]);
+    expect(findButton("First")).toBeTruthy();
+
+    const secondPromise = showContextMenuFallback([{ id: "second", label: "Second" }]);
+
+    await expect(firstPromise).resolves.toBeNull();
+    expect(findButton("First")).toBeUndefined();
+    expect(findButton("Second")).toBeTruthy();
+
+    dismissContextMenu();
+    await expect(secondPromise).resolves.toBeNull();
+  });
 });

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -319,6 +319,12 @@ export function showContextMenuFallback<T extends string>(
     document.addEventListener("pointerdown", onPointerDown, true);
     document.addEventListener("contextmenu", onContextMenu, true);
     openMenu(items, position?.x ?? 0, position?.y ?? 0, 0);
+    // Only one fallback menu can be open at a time: a new show must dismiss
+    // any prior one, or its DOM and listeners leak and close() can only ever
+    // reach the newest menu.
+    if (activeContextMenuDismiss) {
+      activeContextMenuDismiss();
+    }
     activeContextMenuDismiss = dismiss;
 
     requestAnimationFrame(() => {

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -101,6 +101,21 @@ function isNodeWithinMenuStack(target: EventTarget | null, menuStack: readonly H
   return false;
 }
 
+// Only one fallback menu exists at a time in the renderer; the active one is
+// tracked so a state change (for example a terminal selection clearing) can
+// dismiss it with the same result as an outside click or Escape.
+let activeContextMenuDismiss: (() => void) | null = null;
+
+/**
+ * Closes the currently open fallback context menu, resolving its show() with
+ * null (the same result as dismissing by outside click or Escape). No-op when
+ * no fallback menu is open.
+ */
+export function dismissContextMenu(): void {
+  activeContextMenuDismiss?.();
+  activeContextMenuDismiss = null;
+}
+
 /**
  * Imperative DOM-based context menu for non-Electron environments.
  * Supports nested submenus and resolves with the clicked leaf item id.
@@ -114,11 +129,16 @@ export function showContextMenuFallback<T extends string>(
     let isDisposed = false;
     let canDismissFromPointer = false;
 
+    const dismiss = () => cleanup(null);
+
     const cleanup = (result: T | null) => {
       if (isDisposed) {
         return;
       }
       isDisposed = true;
+      if (activeContextMenuDismiss === dismiss) {
+        activeContextMenuDismiss = null;
+      }
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("pointerdown", onPointerDown, true);
       document.removeEventListener("contextmenu", onContextMenu, true);
@@ -299,6 +319,7 @@ export function showContextMenuFallback<T extends string>(
     document.addEventListener("pointerdown", onPointerDown, true);
     document.addEventListener("contextmenu", onContextMenu, true);
     openMenu(items, position?.x ?? 0, position?.y ?? 0, 0);
+    activeContextMenuDismiss = dismiss;
 
     requestAnimationFrame(() => {
       canDismissFromPointer = true;

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -13,12 +13,14 @@ const showContextMenuFallbackMock =
       position?: { x: number; y: number },
     ) => Promise<T | null>
   >();
+const dismissContextMenuMock = vi.fn<() => void>();
 
 const requestConfirmDialogMock =
   vi.fn<(message: string, options?: ConfirmDialogOptions) => Promise<boolean> | undefined>();
 
 vi.mock("./contextMenuFallback", () => ({
   showContextMenuFallback: showContextMenuFallbackMock,
+  dismissContextMenu: dismissContextMenuMock,
 }));
 
 vi.mock("./confirmDialog", () => ({
@@ -83,6 +85,14 @@ describe("LocalApi", () => {
 
     await expect(createLocalApi().contextMenu.show(items, { x: 4, y: 5 })).resolves.toBe("rename");
     expect(showContextMenuFallbackMock).toHaveBeenCalledWith(items, { x: 4, y: 5 });
+  });
+
+  it("dismisses an open browser context menu without a desktop bridge", async () => {
+    const { createLocalApi } = await import("./localApi");
+
+    await createLocalApi().contextMenu.close();
+
+    expect(dismissContextMenuMock).toHaveBeenCalledOnce();
   });
 
   it("uses the themed confirmation host when it is available", async () => {

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -1,7 +1,7 @@
 import type { ConfirmDialogOptions, ContextMenuItem, LocalApi } from "@t3tools/contracts";
 
 import { requestConfirmDialog } from "./confirmDialog";
-import { showContextMenuFallback } from "./contextMenuFallback";
+import { dismissContextMenu, showContextMenuFallback } from "./contextMenuFallback";
 import { readBrowserClientSettings, writeBrowserClientSettings } from "./clientPersistenceStorage";
 import { resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
 
@@ -40,6 +40,14 @@ function createBrowserLocalApi(): LocalApi {
           return window.desktopBridge.showContextMenu(items, position) as Promise<T | null>;
         }
         return showContextMenuFallback(items, position);
+      },
+      // A native desktop menu blocks keyboard input and closes on outside
+      // interaction, so nothing to do there; the DOM fallback needs an explicit
+      // dismiss when the state behind it goes away.
+      close: async () => {
+        if (!window.desktopBridge) {
+          dismissContextMenu();
+        }
       },
     },
     persistence: {

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -219,11 +219,12 @@ describe("isTerminalCopyShortcut", () => {
     expect(isTerminalCopyShortcut(event({ metaKey: true }), "MacIntel")).toBe(true);
   });
 
-  it("uses the conventional Ctrl+Shift+C shortcut elsewhere", () => {
-    expect(isTerminalCopyShortcut(event({ ctrlKey: true }), "Linux x86_64")).toBe(false);
+  it("copies with Ctrl+C and Ctrl+Shift+C elsewhere", () => {
+    expect(isTerminalCopyShortcut(event({ ctrlKey: true }), "Linux x86_64")).toBe(true);
     expect(isTerminalCopyShortcut(event({ ctrlKey: true, shiftKey: true }), "Linux x86_64")).toBe(
       true,
     );
+    expect(isTerminalCopyShortcut(event({}), "Linux x86_64")).toBe(false);
   });
 
   it("uses the produced character instead of the physical key position", () => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -942,8 +942,12 @@ export class GhosttyTerminalSurface {
               },
               () => {
                 // The write failed and the native event has already had its
-                // chance, so nothing copied and no clear is owed.
-                this.clearSelectionAfterCopy = false;
+                // chance, so nothing copied and no clear is owed by this
+                // gesture; a newer one may have just set the flag, so only
+                // drop it if this gesture still owns the token.
+                if (this.copyShortcutToken === token) {
+                  this.clearSelectionAfterCopy = false;
+                }
               },
             );
           });

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -913,9 +913,11 @@ export class GhosttyTerminalSurface {
         document.execCommand("copy");
       } else {
         // A plain Ctrl+C is also SIGINT on non-mac: clear the selection once
-        // it copies so the next Ctrl+C reaches the shell. Cmd+C on mac and the
-        // Shift chord are copy-only, so they keep the selection.
-        this.clearSelectionAfterCopy = !isMacPlatform(navigator.platform);
+        // it copies so the next Ctrl+C reaches the shell. The Shift chord and
+        // Cmd+C are copy-only, so they keep the selection; resetting the flag
+        // up front also drops any clear owed by an earlier gesture that never
+        // completed.
+        this.clearSelectionAfterCopy = !event.shiftKey && !isMacPlatform(navigator.platform);
         const clipboard = navigator.clipboard;
         if (typeof clipboard?.writeText === "function") {
           // Defer the write past the default action: the native copy event
@@ -930,13 +932,18 @@ export class GhosttyTerminalSurface {
             if (this.disposed || this.copyShortcutToken !== token) return;
             void clipboard.writeText(selection).then(
               () => {
+                // The write may have been superseded while in flight; only
+                // touch the selection if this gesture still owns the token.
+                if (this.disposed || this.copyShortcutToken !== token) return;
                 if (this.clearSelectionAfterCopy) {
                   this.clearSelectionAfterCopy = false;
                   this.clearSelection();
                 }
               },
               () => {
-                // Clipboard write denied; the native copy event remains the path.
+                // The write failed and the native event has already had its
+                // chance, so nothing copied and no clear is owed.
+                this.clearSelectionAfterCopy = false;
               },
             );
           });

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -531,6 +531,7 @@ export class GhosttyTerminalSurface {
   private readonly suppressedKeyCodes = new Set<string>();
   private pasteShortcutToken = 0;
   private copyShortcutToken = 0;
+  private clearSelectionAfterCopy = false;
   private wheelRemainder = 0;
   private dprMedia: MediaQueryList | null = null;
   // Read live on every blink decision, and watched so that dropping the
@@ -911,6 +912,10 @@ export class GhosttyTerminalSurface {
         event.preventDefault();
         document.execCommand("copy");
       } else {
+        // A plain Ctrl+C is also SIGINT on non-mac: clear the selection once
+        // it copies so the next Ctrl+C reaches the shell. Cmd+C on mac and the
+        // Shift chord are copy-only, so they keep the selection.
+        this.clearSelectionAfterCopy = !isMacPlatform(navigator.platform);
         const clipboard = navigator.clipboard;
         if (typeof clipboard?.writeText === "function") {
           // Defer the write past the default action: the native copy event
@@ -923,9 +928,17 @@ export class GhosttyTerminalSurface {
           const selection = this.getSelection();
           void Promise.resolve().then(() => {
             if (this.disposed || this.copyShortcutToken !== token) return;
-            void clipboard.writeText(selection).catch(() => {
-              // Clipboard write denied; the native copy event remains the path.
-            });
+            void clipboard.writeText(selection).then(
+              () => {
+                if (this.clearSelectionAfterCopy) {
+                  this.clearSelectionAfterCopy = false;
+                  this.clearSelection();
+                }
+              },
+              () => {
+                // Clipboard write denied; the native copy event remains the path.
+              },
+            );
           });
         }
       }
@@ -1021,6 +1034,10 @@ export class GhosttyTerminalSurface {
     event.clipboardData?.setData("text/plain", this.getSelection());
     // The native event beat any deferred write; drop the in-flight fallback.
     this.copyShortcutToken += 1;
+    if (this.clearSelectionAfterCopy) {
+      this.clearSelectionAfterCopy = false;
+      this.clearSelection();
+    }
   };
 
   private readonly onPaste = (event: ClipboardEvent) => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -901,12 +901,24 @@ export class GhosttyTerminalSurface {
     }
     if (isTerminalCopyShortcut(event) && this.hasSelection()) {
       // A plain Ctrl+C/Cmd+C fires the browser's native copy event, caught in
-      // onCopyEvent; not preventing the default keeps that path alive. The
+      // onCopyEvent; not preventing the default keeps that path alive. WebKit
+      // omits the keyboard copy event without a DOM selection, so race the
+      // clipboard write against it the same way paste races its read. The
       // Shift variant has no native event (Chrome binds Ctrl+Shift+C to
       // inspect), so synthesize one with execCommand("copy").
       if (event.shiftKey) {
         event.preventDefault();
         document.execCommand("copy");
+      } else {
+        const clipboard = navigator.clipboard;
+        if (typeof clipboard?.writeText === "function") {
+          // The native copy event (dispatched with the default action) always
+          // wins when it fires; the write covers browsers whose shortcut
+          // produces no copy event.
+          void clipboard.writeText(this.getSelection()).catch(() => {
+            // Clipboard write denied; the native copy event remains the path.
+          });
+        }
       }
       this.suppressedKeyCodes.add(event.code);
       return;

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -530,6 +530,7 @@ export class GhosttyTerminalSurface {
   private theme: GhosttyTheme;
   private readonly suppressedKeyCodes = new Set<string>();
   private pasteShortcutToken = 0;
+  private copyShortcutToken = 0;
   private wheelRemainder = 0;
   private dprMedia: MediaQueryList | null = null;
   // Read live on every blink decision, and watched so that dropping the
@@ -912,11 +913,19 @@ export class GhosttyTerminalSurface {
       } else {
         const clipboard = navigator.clipboard;
         if (typeof clipboard?.writeText === "function") {
-          // The native copy event (dispatched with the default action) always
-          // wins when it fires; the write covers browsers whose shortcut
-          // produces no copy event.
-          void clipboard.writeText(this.getSelection()).catch(() => {
-            // Clipboard write denied; the native copy event remains the path.
+          // Defer the write past the default action: the native copy event
+          // (dispatched synchronously with the default action) claims the
+          // token first when it fires, and the write covers browsers whose
+          // shortcut produces no copy event. Skipping a write the native
+          // event already handled stops a stale resolution from clobbering a
+          // clipboard the user filled after this copy.
+          const token = ++this.copyShortcutToken;
+          const selection = this.getSelection();
+          void Promise.resolve().then(() => {
+            if (this.disposed || this.copyShortcutToken !== token) return;
+            void clipboard.writeText(selection).catch(() => {
+              // Clipboard write denied; the native copy event remains the path.
+            });
           });
         }
       }
@@ -1010,6 +1019,8 @@ export class GhosttyTerminalSurface {
     if (!this.hasSelection()) return;
     event.preventDefault();
     event.clipboardData?.setData("text/plain", this.getSelection());
+    // The native event beat any deferred write; drop the in-flight fallback.
+    this.copyShortcutToken += 1;
   };
 
   private readonly onPaste = (event: ClipboardEvent) => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -333,7 +333,7 @@ export function isTerminalCopyShortcut(
   platform = navigator.platform,
 ) {
   if (event.key.toLowerCase() !== "c") return false;
-  return isMacPlatform(platform) ? event.metaKey : event.ctrlKey && event.shiftKey;
+  return isMacPlatform(platform) ? event.metaKey : event.ctrlKey;
 }
 
 export function isTerminalPasteShortcut(
@@ -463,7 +463,6 @@ export interface GhosttyTerminalSurfaceOptions {
   readonly onData: (data: string) => void;
   readonly onResize: (cols: number, rows: number) => void;
   readonly onSelectionChange: () => void;
-  readonly onCopy: (text: string) => void;
   readonly beforeKey: (event: KeyboardEvent) => boolean;
   readonly onLinkActivate: (text: string, event: MouseEvent) => void;
 }
@@ -901,9 +900,15 @@ export class GhosttyTerminalSurface {
       return;
     }
     if (isTerminalCopyShortcut(event) && this.hasSelection()) {
-      event.preventDefault();
+      // A plain Ctrl+C/Cmd+C fires the browser's native copy event, caught in
+      // onCopyEvent; not preventing the default keeps that path alive. The
+      // Shift variant has no native event (Chrome binds Ctrl+Shift+C to
+      // inspect), so synthesize one with execCommand("copy").
+      if (event.shiftKey) {
+        event.preventDefault();
+        document.execCommand("copy");
+      }
       this.suppressedKeyCodes.add(event.code);
-      this.options.onCopy(this.getSelection());
       return;
     }
     if (isTerminalPasteShortcut(event)) {
@@ -988,6 +993,12 @@ export class GhosttyTerminalSurface {
     this.dprMedia = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
     this.dprMedia.addEventListener("change", this.onDevicePixelRatioChange);
   }
+
+  private readonly onCopyEvent = (event: ClipboardEvent) => {
+    if (!this.hasSelection()) return;
+    event.preventDefault();
+    event.clipboardData?.setData("text/plain", this.getSelection());
+  };
 
   private readonly onPaste = (event: ClipboardEvent) => {
     // Always suppress the browser's default insertion: content the textarea
@@ -1384,6 +1395,7 @@ export class GhosttyTerminalSurface {
     this.input.addEventListener("blur", this.onBlur);
     this.input.addEventListener("input", this.onInput);
     this.input.addEventListener("paste", this.onPaste);
+    this.input.addEventListener("copy", this.onCopyEvent);
     this.input.addEventListener("compositionstart", this.onCompositionStart);
     this.input.addEventListener("compositionend", this.onCompositionEnd);
     this.canvas.addEventListener("pointerdown", this.onPointerDown);
@@ -1408,6 +1420,7 @@ export class GhosttyTerminalSurface {
     this.input.removeEventListener("blur", this.onBlur);
     this.input.removeEventListener("input", this.onInput);
     this.input.removeEventListener("paste", this.onPaste);
+    this.input.removeEventListener("copy", this.onCopyEvent);
     this.input.removeEventListener("compositionstart", this.onCompositionStart);
     this.input.removeEventListener("compositionend", this.onCompositionEnd);
     this.canvas.removeEventListener("pointerdown", this.onPointerDown);

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1189,6 +1189,7 @@ export interface LocalApi {
       items: readonly ContextMenuItem<T>[],
       position?: { x: number; y: number },
     ) => Promise<T | null>;
+    close: () => Promise<void>;
   };
   persistence: {
     getClientSettings: () => Promise<ClientSettings | null>;


### PR DESCRIPTION
## What Changed

When text is selected in a terminal in the web app on Windows, Ctrl+C now copies the selected text instead of sending a ctrl+c into the shell. Ctrl+Shift+C still copies as before.

Copy no longer routes through navigator.clipboard.writeText; instead the surface writes the selection into the native copy event's clipboardData (mirroring the existing paste path), with execCommand synthesizing the event for Ctrl+Shift+C since that key fires no native one. Drops the dead onCopy option and its drawer handler.

## Why

Pressing Ctrl+C on a selection used to pass through to the terminal as input even when text was selected, so the shortcut never copied. It now copies on Windows.

## Video Demo

https://github.com/user-attachments/assets/bd3150f8-f7b4-4848-91aa-8ee8ff27efd8

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal keyboard semantics (Ctrl+C with selection) and clipboard handling across browsers; scope is localized to the web terminal and DOM context-menu fallback.
> 
> **Overview**
> **Web terminal copy** now treats **plain `Ctrl+C`** (and `Ctrl+Shift+C`) as copy when text is selected on non-macOS platforms, instead of requiring `Ctrl+Shift+C` only. **macOS** still uses **Cmd+C** for copy and leaves **Ctrl+C** for SIGINT when nothing is selected.
> 
> Copy moves into **`GhosttyTerminalSurface`**: it handles the native **`copy`** event via `clipboardData`, races **`navigator.clipboard.writeText`** as a fallback (like paste), uses **`execCommand('copy')`** for **Ctrl+Shift+C**, and on Linux/Windows clears the selection after a plain **Ctrl+C** copy so the next **Ctrl+C** can interrupt the shell. The **`onCopy`** option and drawer clipboard handler are removed.
> 
> **Browser context menus** gain **`dismissContextMenu`**, single-menu tracking (new menus dismiss the prior one), **`LocalApi.contextMenu.close()`**, and the terminal drawer calls **close** when a copy-driven selection clear dismisses the selection action menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0d12c657e18745621e0fbfced0b7eddcdb09a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Ctrl+C copy support in the web terminal surface
> - On non-mac platforms, `Ctrl+C` now copies the current terminal selection (previously required `Ctrl+Shift+C`); after copying, the selection is cleared so subsequent `Ctrl+C` reaches the shell.
> - Copy handling moves into `GhosttyTerminalSurface` internally: it intercepts the native copy event to set clipboard data, with a `navigator.clipboard.writeText` fallback when no native event fires. The `onCopy` callback option is removed from `GhosttyTerminalSurfaceOptions`.
> - Adds `dismissContextMenu` to [`contextMenuFallback.ts`](https://github.com/pingdotgg/t3code/pull/5638/files#diff-032cd4155f179490fdc876b54fb96f2609ab2552587ed8b42b9963c1d250a3be) and exposes `LocalApi.contextMenu.close()` in the browser fallback so that copying (which clears a selection) also closes any open selection context menu.
> - Behavioral Change: `Ctrl+C` in the web terminal no longer sends the interrupt signal when text is selected; it copies instead and clears the selection.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a0d12c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->