### PR TITLE
fix(mobile): add long-press unarchive menu to archived thread rows

### DIFF
--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -387,6 +387,14 @@ function ProjectGroupLabel(props: {
   );
 }
 
+// Long-press row menu, mirroring the home/sidebar thread rows. On Android this
+// is the reliable action affordance (swipe-then-tap on the narrow action button
+// is fiddly), and it is the only non-swipe way to unarchive a thread.
+const ARCHIVED_THREAD_ROW_MENU_ACTIONS: MenuAction[] = [
+  { id: "unarchive", title: "Unarchive", image: "arrow.uturn.backward" },
+  { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
+];
+
 function ArchivedThreadRow(props: {
   readonly environmentLabel: string | null;
   readonly isFirst: boolean;
@@ -407,6 +415,14 @@ function ArchivedThreadRow(props: {
   const timestamp = relativeTime(props.thread.archivedAt ?? props.thread.updatedAt);
   const subtitle = [props.environmentLabel, props.thread.branch].filter((part): part is string =>
     Boolean(part),
+  );
+  const { onDelete, onUnarchive } = props;
+  const handleMenuAction = useCallback(
+    ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
+      if (nativeEvent.event === "unarchive") onUnarchive();
+      if (nativeEvent.event === "delete") onDelete();
+    },
+    [onDelete, onUnarchive],
   );
   return (
     <ThreadSwipeable
@@ -430,51 +446,67 @@ function ArchivedThreadRow(props: {
         label: "Unarchive",
         onPress: props.onUnarchive,
       }}
+      resetKey={`${props.thread.environmentId}:${props.thread.id}`}
       simultaneousWithExternalGesture={props.simultaneousSwipeGesture}
       threadTitle={props.thread.title}
     >
       {() => (
-        <View
-          className="flex-row items-center gap-3 bg-card px-4 py-3"
-          style={{
-            borderBottomColor: separatorColor,
-            borderBottomWidth: props.isLast ? 0 : 1,
-          }}
+        // Messages-style long-press actions, matching the home/sidebar rows.
+        // On Android ControlPillMenu injects onLongPress into the row (so the
+        // native dropdown anchors to it); on iOS it renders a context menu.
+        // This is the dependable way to unarchive without the swipe gesture.
+        <ControlPillMenu
+          actions={ARCHIVED_THREAD_ROW_MENU_ACTIONS}
+          onPressAction={handleMenuAction}
+          shouldOpenOnLongPress
         >
-          <View className="h-[34px] w-[34px] items-center justify-center rounded-[11px] bg-subtle">
-            <SymbolView name="archivebox.fill" size={15} tintColor={iconColor} type="monochrome" />
-          </View>
-
-          <View className="min-w-0 flex-1 gap-1">
-            <View className="flex-row items-center gap-2">
-              <Text
-                className="min-w-0 flex-1 text-base font-t3-bold leading-snug text-foreground"
-                numberOfLines={1}
-              >
-                {props.thread.title}
-              </Text>
-              <Text className="min-w-[30px] text-right text-xs tabular-nums text-foreground-tertiary">
-                {timestamp}
-              </Text>
+          <Pressable
+            className="flex-row items-center gap-3 bg-card px-4 py-3"
+            style={{
+              borderBottomColor: separatorColor,
+              borderBottomWidth: props.isLast ? 0 : 1,
+            }}
+          >
+            <View className="h-[34px] w-[34px] items-center justify-center rounded-[11px] bg-subtle">
+              <SymbolView
+                name="archivebox.fill"
+                size={15}
+                tintColor={iconColor}
+                type="monochrome"
+              />
             </View>
-            {subtitle.length > 0 ? (
-              <View className="flex-row items-center gap-1.5">
-                <SymbolView
-                  name="arrow.triangle.branch"
-                  size={10}
-                  tintColor={iconColor}
-                  type="monochrome"
-                />
+
+            <View className="min-w-0 flex-1 gap-1">
+              <View className="flex-row items-center gap-2">
                 <Text
-                  className="min-w-0 flex-1 font-mono text-2xs text-foreground-tertiary"
+                  className="min-w-0 flex-1 text-base font-t3-bold leading-snug text-foreground"
                   numberOfLines={1}
                 >
-                  {subtitle.join(" · ")}
+                  {props.thread.title}
+                </Text>
+                <Text className="min-w-[30px] text-right text-xs tabular-nums text-foreground-tertiary">
+                  {timestamp}
                 </Text>
               </View>
-            ) : null}
-          </View>
-        </View>
+              {subtitle.length > 0 ? (
+                <View className="flex-row items-center gap-1.5">
+                  <SymbolView
+                    name="arrow.triangle.branch"
+                    size={10}
+                    tintColor={iconColor}
+                    type="monochrome"
+                  />
+                  <Text
+                    className="min-w-0 flex-1 font-mono text-2xs text-foreground-tertiary"
+                    numberOfLines={1}
+                  >
+                    {subtitle.join(" · ")}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+          </Pressable>
+        </ControlPillMenu>
       )}
     </ThreadSwipeable>
   );


### PR DESCRIPTION
## Problem

On Android, archived threads can't be reliably unarchived. The archived-threads screen's rows are the **only** thread list in the app without a long-press action menu — every other row (home, sidebar) got a `ControlPillMenu` in the Android support work (#3579), but the archived rows were missed.

That leaves the swipe action as the sole unarchive affordance: swipe a row open, then tap the narrow "Unarchive" button. On Android this is fiddly, and worse — a **full** swipe on the row triggers **Delete**, so a slightly-too-far swipe permanently deletes the thread instead of unarchiving it.

The underlying command/decider/projector/reducer path for unarchive is correct and symmetric with archive; this is purely a missing Android-friendly UI affordance.

## Fix

Wrap the archived thread row in a `ControlPillMenu` long-press menu exposing **Unarchive** and **Delete**, mirroring the home/sidebar rows:

- **Android** — anchors a native dropdown to the row (via the injected `onLongPress`), giving a dependable, non-swipe way to unarchive.
- **iOS** — renders the standard context menu, consistent with the other thread lists.

Swipe actions are left untouched. Also passes `resetKey` to the row's `ThreadSwipeable` so recycled `LegendList` rows reset their swipe state, matching the home/sidebar lists.

## Testing

- `tsc --noEmit` (mobile) — clean
- `vp check` (format + lint) — clean
- `vp test` for `features/archive` + `features/home` — 38 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only affordance on the archive screen; reuses existing `ControlPillMenu` and existing unarchive/delete callbacks with no backend or auth changes.
> 
> **Overview**
> Archived threads were the only list rows without long-press actions, so on Android unarchive depended on a narrow swipe button and a full swipe could delete instead.
> 
> **Archived thread rows** are wrapped in `ControlPillMenu` with `shouldOpenOnLongPress`, exposing **Unarchive** and **Delete** the same way as home/sidebar thread rows (native dropdown on Android, context menu on iOS). Swipe-to-unarchive/delete is unchanged.
> 
> `ThreadSwipeable` also gets a `resetKey` of `environmentId:threadId` so recycled `LegendList` rows don’t keep a stale open swipe state, consistent with other thread lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571cc9094edb02329314b0bdfa34ec2d4af4d7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->