### PR TITLE
fix(threads): make completed-PR auto-settle configurable

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -32,6 +32,7 @@ const clientSettings: ClientSettings = {
   planModeEnabled: false,
   providerModelPreferences: {},
   sidebarAutoSettleAfterDays: 3,
+  sidebarAutoSettleCompletedChangeRequests: true,
   sidebarProjectGroupingMode: "repository_path",
   sidebarProjectGroupingOverrides: {
     "environment-1:/tmp/project-a": "separate",

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -34,6 +34,7 @@ import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
 import { useThreadSearch } from "../../state/queries";
 import { useThreadListV2Enabled } from "../threads/use-thread-list-v2-enabled";
+import { useAutoSettleCompletedChangeRequests } from "../threads/use-auto-settle-completed-change-requests";
 import { environmentServerConfigsAtom } from "../../state/server";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 import {
@@ -206,6 +207,7 @@ export function HomeScreen(props: HomeScreenProps) {
   >(() => new Map());
   const preferencesResult = useAtomValue(mobilePreferencesAtom);
   const threadListV2Enabled = useThreadListV2Enabled();
+  const autoSettleCompletedChangeRequests = useAutoSettleCompletedChangeRequests();
   const savePreferences = useAtomSet(updateMobilePreferencesAtom);
   const openSwipeableRef = useRef<SwipeableMethods | null>(null);
   const listRef = useRef<LegendListRef | null>(null);
@@ -651,6 +653,7 @@ export function HomeScreen(props: HomeScreenProps) {
       changeRequestStateByKey,
       settlementEnvironmentIds,
       snoozeEnvironmentIds,
+      autoSettleCompletedChangeRequests,
       settledLimit: settledVisibleCount,
       now: `${nowMinute}:00.000Z`,
       snoozeNow: new Date().toISOString(),
@@ -659,6 +662,7 @@ export function HomeScreen(props: HomeScreenProps) {
       selectedThreadKey: null,
     });
   }, [
+    autoSettleCompletedChangeRequests,
     changeRequestStateByKey,
     nowMinute,
     snoozeWakeTick,

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -38,6 +38,7 @@ import { runtime } from "../../lib/runtime";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
 import { useThreadListV2Enabled } from "../threads/use-thread-list-v2-enabled";
+import { useAutoSettleCompletedChangeRequests } from "../threads/use-auto-settle-completed-change-requests";
 import {
   type AppUpdateCheckState,
   registerHiddenUpdateTap,
@@ -544,6 +545,7 @@ function GeneralSettingsSection() {
 function BetaSettingsSection() {
   const savePreferences = useAtomSet(updateMobilePreferencesAtom);
   const threadListV2Enabled = useThreadListV2Enabled();
+  const autoSettleCompletedChangeRequests = useAutoSettleCompletedChangeRequests();
 
   return (
     <View className="gap-3">
@@ -554,11 +556,26 @@ function BetaSettingsSection() {
           value={threadListV2Enabled}
           onValueChange={(value) => savePreferences({ threadListV2Enabled: value })}
         />
+        {threadListV2Enabled ? (
+          <SettingsSwitchRow
+            icon="checkmark.circle"
+            label="Auto-settle completed pull requests"
+            value={autoSettleCompletedChangeRequests}
+            onValueChange={(value) => savePreferences({ autoSettleCompletedChangeRequests: value })}
+          />
+        ) : null}
       </SettingsSection>
       <Text className="px-2 text-sm text-foreground-muted">
         One flat thread list in creation order. Active work renders as cards; settled threads
         collapse to compact rows. Switch back any time.
       </Text>
+      {threadListV2Enabled ? (
+        <Text className="px-2 text-sm text-foreground-muted">
+          Completed pull-request settle is independent of the three-day inactivity window. Turn it
+          off to keep merged or closed PR threads active until inactivity settle applies, or until
+          you settle them yourself. A manual Un-settle stays active until you settle again.
+        </Text>
+      ) : null}
     </View>
   );
 }

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -31,6 +31,7 @@ import { useThemeColor } from "../../lib/useThemeColor";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { useThreadSearch } from "../../state/queries";
 import { useThreadListV2Enabled } from "./use-thread-list-v2-enabled";
+import { useAutoSettleCompletedChangeRequests } from "./use-auto-settle-completed-change-requests";
 import { environmentServerConfigsAtom } from "../../state/server";
 import { usePendingNewTasks } from "../../state/use-pending-new-tasks";
 import { useWorkspaceState } from "../../state/workspace";
@@ -213,6 +214,7 @@ function ThreadNavigationSidebarPane(
     movePinnedThread,
   } = useThreadListActions();
   const threadListV2Enabled = useThreadListV2Enabled();
+  const autoSettleCompletedChangeRequests = useAutoSettleCompletedChangeRequests();
   const pendingTasks = usePendingNewTasks();
   const { openPendingTask, confirmDeletePendingTask } = usePendingTaskListActions();
   const environments = useMemo(
@@ -538,6 +540,7 @@ function ThreadNavigationSidebarPane(
       changeRequestStateByKey,
       settlementEnvironmentIds,
       snoozeEnvironmentIds,
+      autoSettleCompletedChangeRequests,
       settledLimit: settledVisibleCount,
       now: `${nowMinute}:00.000Z`,
       snoozeNow: new Date().toISOString(),
@@ -546,6 +549,7 @@ function ThreadNavigationSidebarPane(
       selectedThreadKey: props.selectedThreadKey ?? null,
     });
   }, [
+    autoSettleCompletedChangeRequests,
     changeRequestStateByKey,
     nowMinute,
     snoozeWakeTick,

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -16,6 +16,7 @@ import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 import {
   buildThreadListV2Items,
   buildThreadListV2ListItems,
+  resolveAutoSettleCompletedChangeRequests,
   resolveThreadListV2Enabled,
   resolveThreadListV2SnoozeMenuSelection,
   resolveThreadListV2SnoozeGateExpiryMs,
@@ -118,6 +119,41 @@ describe("resolveThreadListV2Enabled", () => {
     expect(resolveThreadListV2Enabled({ preference: undefined, preferencesLoaded: false })).toBe(
       true,
     );
+  });
+});
+
+describe("resolveAutoSettleCompletedChangeRequests", () => {
+  it("defaults on when the device has never chosen", () => {
+    expect(
+      resolveAutoSettleCompletedChangeRequests({
+        preference: undefined,
+        preferencesLoaded: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("honors an explicit device opt-out", () => {
+    expect(
+      resolveAutoSettleCompletedChangeRequests({
+        preference: false,
+        preferencesLoaded: true,
+      }),
+    ).toBe(false);
+    expect(
+      resolveAutoSettleCompletedChangeRequests({
+        preference: true,
+        preferencesLoaded: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("holds the default while preferences are still loading", () => {
+    expect(
+      resolveAutoSettleCompletedChangeRequests({
+        preference: undefined,
+        preferencesLoaded: false,
+      }),
+    ).toBe(true);
   });
 });
 
@@ -286,6 +322,38 @@ describe("buildThreadListV2Items", () => {
     // thread is BACK in the card block and the snoozed one is gone.
     expect(layout.items.map((item) => item.thread.id)).toEqual(["active", "woken"]);
     expect(layout.snoozedCount).toBe(1);
+  });
+
+  it("settles merged PRs by default and keeps them active when completed-PR settle is off", () => {
+    const mergedThread = makeThread({
+      id: ThreadId.make("merged"),
+      title: "Merged",
+      latestUserMessageAt: "2026-06-01T20:00:00.000Z",
+    });
+    const changeRequestStateByKey = new Map([[`${environmentId}:merged`, "merged" as const]]);
+
+    const defaultLayout = buildThreadListV2Items({
+      threads: [mergedThread],
+      environmentId: null,
+      searchQuery: "",
+      changeRequestStateByKey,
+      now: NOW,
+    });
+    expect(defaultLayout.items.map((item) => item.thread.id)).toEqual(["merged"]);
+    expect(defaultLayout.settledCount).toBe(1);
+    expect(defaultLayout.items[0]?.variant).toBe("slim");
+
+    const optedOut = buildThreadListV2Items({
+      threads: [mergedThread],
+      environmentId: null,
+      searchQuery: "",
+      changeRequestStateByKey,
+      autoSettleCompletedChangeRequests: false,
+      now: NOW,
+    });
+    expect(optedOut.settledCount).toBe(0);
+    expect(optedOut.items.map((item) => item.thread.id)).toEqual(["merged"]);
+    expect(optedOut.items[0]?.variant).toBe("card");
   });
 
   it("renders pinned threads first and exempts them from auto-settle — parity with web", () => {

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -122,6 +122,20 @@ export function resolveThreadListV2Enabled(input: {
   return input.preference ?? true;
 }
 
+/**
+ * Device-local completed-PR auto-settle preference. Defaults on (matching web
+ * ClientSettings) so older installs keep historical always-settle behavior.
+ */
+export function resolveAutoSettleCompletedChangeRequests(input: {
+  readonly preference: boolean | undefined;
+  readonly preferencesLoaded: boolean;
+}): boolean {
+  if (!input.preferencesLoaded) {
+    return true;
+  }
+  return input.preference ?? true;
+}
+
 export function resolveThreadListV2Status(
   thread: Pick<EnvironmentThreadShell, "hasPendingApprovals" | "hasPendingUserInput" | "session">,
 ): ThreadListV2Status {
@@ -307,8 +321,9 @@ export function buildThreadListV2ListItems(input: {
 /**
  * Partitions visible threads into the active card block (creation order) and
  * the settled recency tail, matching the web v2 list. `autoSettleAfterDays`
- * mirrors the web default of 3 — mobile has no client-settings sync yet, so
- * the default is fixed here rather than user-configurable.
+ * mirrors the web default of 3 — mobile has no synced inactivity setting yet,
+ * so that default is fixed here. Completed-PR auto-settle is a separate
+ * device-local preference.
  */
 export function buildThreadListV2Items(input: {
   readonly threads: ReadonlyArray<EnvironmentThreadShell>;
@@ -329,6 +344,8 @@ export function buildThreadListV2Items(input: {
       contract as settlementEnvironmentIds. */
   readonly snoozeEnvironmentIds?: ReadonlySet<EnvironmentId>;
   readonly autoSettleAfterDays?: number;
+  /** Defaults to true so callers that omit it keep historical behavior. */
+  readonly autoSettleCompletedChangeRequests?: boolean;
   /** Max settled rows to render; the rest are counted, not built. */
   readonly settledLimit?: number;
   /** Injectable for tests; defaults to now. */
@@ -349,6 +366,7 @@ export function buildThreadListV2Items(input: {
   const now = input.now ?? new Date().toISOString();
   const snoozeNow = input.snoozeNow ?? now;
   const autoSettleAfterDays = input.autoSettleAfterDays ?? 3;
+  const autoSettleCompletedChangeRequests = input.autoSettleCompletedChangeRequests !== false;
   const query = input.searchQuery.trim().toLocaleLowerCase();
   const projectKeys = input.projectRefs
     ? new Set(input.projectRefs.map((ref) => `${ref.environmentId}:${ref.projectId}`))
@@ -405,7 +423,12 @@ export function buildThreadListV2Items(input: {
     }
     if (
       supportsSettlement &&
-      effectiveSettled(thread, { now, autoSettleAfterDays, changeRequestState })
+      effectiveSettled(thread, {
+        now,
+        autoSettleAfterDays,
+        autoSettleCompletedChangeRequests,
+        changeRequestState,
+      })
     ) {
       settled.push(thread);
     } else {

--- a/apps/mobile/src/features/threads/use-auto-settle-completed-change-requests.ts
+++ b/apps/mobile/src/features/threads/use-auto-settle-completed-change-requests.ts
@@ -1,0 +1,18 @@
+import { useAtomValue } from "@effect/atom-react";
+import { AsyncResult } from "effect/unstable/reactivity";
+
+import { mobilePreferencesAtom } from "../../state/preferences";
+import { resolveAutoSettleCompletedChangeRequests } from "./threadListV2";
+
+/**
+ * Resolved completed-PR auto-settle preference: the device-local choice if
+ * set, otherwise the default (on). Matches web ClientSettings semantics.
+ */
+export function useAutoSettleCompletedChangeRequests(): boolean {
+  const preferencesResult = useAtomValue(mobilePreferencesAtom);
+  const loaded = AsyncResult.isSuccess(preferencesResult);
+  return resolveAutoSettleCompletedChangeRequests({
+    preference: loaded ? preferencesResult.value.autoSettleCompletedChangeRequests : undefined,
+    preferencesLoaded: loaded,
+  });
+}

--- a/apps/mobile/src/persistence/mobile-preferences.test.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("expo-secure-store", () => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+}));
+
+vi.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+
+import { sanitizePreferences } from "./mobile-preferences";
+
+describe("sanitizePreferences completed-PR auto-settle", () => {
+  it("drops an absent preference so resolvers can default on", () => {
+    expect(sanitizePreferences({}).autoSettleCompletedChangeRequests).toBeUndefined();
+  });
+
+  it.each([true, false])("keeps an explicit completed-PR auto-settle choice: %s", (value) => {
+    expect(
+      sanitizePreferences({
+        autoSettleCompletedChangeRequests: value,
+        threadListV2Enabled: true,
+      }),
+    ).toEqual({
+      autoSettleCompletedChangeRequests: value,
+      threadListV2Enabled: true,
+    });
+  });
+
+  it("ignores non-boolean completed-PR auto-settle values", () => {
+    expect(
+      sanitizePreferences({
+        autoSettleCompletedChangeRequests: "yes" as unknown as boolean,
+      }).autoSettleCompletedChangeRequests,
+    ).toBeUndefined();
+  });
+});

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -33,6 +33,11 @@ export interface Preferences {
    * see `resolveThreadListV2Enabled`.
    */
   readonly threadListV2Enabled?: boolean;
+  /**
+   * Device-local mirror of web's `sidebarAutoSettleCompletedChangeRequests`.
+   * Undefined means never chosen, which resolves to on (historical default).
+   */
+  readonly autoSettleCompletedChangeRequests?: boolean;
 }
 
 export class MobilePreferencesLoadError extends Schema.TaggedErrorClass<MobilePreferencesLoadError>()(
@@ -72,7 +77,7 @@ export class MobilePreferencesStore extends Context.Service<
   }
 >()("@t3tools/mobile/persistence/MobilePreferencesStore") {}
 
-function sanitizePreferences(parsed: Preferences): Preferences {
+export function sanitizePreferences(parsed: Preferences): Preferences {
   const preferences: {
     liveActivitiesEnabled?: boolean;
     baseFontSize?: number;
@@ -85,6 +90,7 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     projectGroupingEnabled?: boolean;
     projectGroupingMode?: SidebarProjectGroupingMode;
     threadListV2Enabled?: boolean;
+    autoSettleCompletedChangeRequests?: boolean;
   } = {};
 
   if (typeof parsed.liveActivitiesEnabled === "boolean") {
@@ -123,6 +129,9 @@ function sanitizePreferences(parsed: Preferences): Preferences {
   }
   if (typeof parsed.threadListV2Enabled === "boolean") {
     preferences.threadListV2Enabled = parsed.threadListV2Enabled;
+  }
+  if (typeof parsed.autoSettleCompletedChangeRequests === "boolean") {
+    preferences.autoSettleCompletedChangeRequests = parsed.autoSettleCompletedChangeRequests;
   }
   return preferences;
 }

--- a/apps/server/src/orchestration/decider.settled.test.ts
+++ b/apps/server/src/orchestration/decider.settled.test.ts
@@ -385,9 +385,7 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
           session: makeSession("running"),
           createdAt: NOW,
         },
-        // A keep-active pin is also an override: real activity clears it
-        // back to neutral so auto-settle can apply again later.
-        readModel: makeReadModel("active"),
+        readModel: makeReadModel("settled"),
       });
       const sessionEvents = Array.isArray(sessionResult) ? sessionResult : [sessionResult];
       expect(sessionEvents.map((event) => event.type)).toEqual([
@@ -397,7 +395,7 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
     }),
   );
 
-  it.effect("clears a keep-active pin on real activity", () =>
+  it.effect("keeps a manual Un-settle pin across messages, sessions, and approvals", () =>
     Effect.gen(function* () {
       const turnResult = yield* decideOrchestrationCommand({
         command: {
@@ -417,13 +415,26 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
         readModel: makeReadModel("active"),
       });
       const turnEvents = Array.isArray(turnResult) ? turnResult : [turnResult];
-      // The pin exists to suppress AUTO-settle, not to survive real work:
-      // activity resets it to neutral, restoring the default lifecycle.
+      // Manual Un-settle is an explicit keep-active choice: later activity
+      // must not clear it back to neutral (which would re-qualify the thread
+      // for completed-PR auto-settle).
       expect(turnEvents.map((event) => event.type)).toEqual([
-        "thread.unsettled",
         "thread.message-sent",
         "thread.turn-start-requested",
       ]);
+
+      const sessionResult = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-active-session"),
+          threadId: ThreadId.make("thread-1"),
+          session: makeSession("running"),
+          createdAt: NOW,
+        },
+        readModel: makeReadModel("active"),
+      });
+      const sessionEvents = Array.isArray(sessionResult) ? sessionResult : [sessionResult];
+      expect(sessionEvents.map((event) => event.type)).toEqual(["thread.session-set"]);
 
       const activityResult = yield* decideOrchestrationCommand({
         command: {
@@ -444,10 +455,28 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
         readModel: makeReadModel("active"),
       });
       const activityEvents = Array.isArray(activityResult) ? activityResult : [activityResult];
-      expect(activityEvents.map((event) => event.type)).toEqual([
-        "thread.unsettled",
-        "thread.activity-appended",
-      ]);
+      expect(activityEvents.map((event) => event.type)).toEqual(["thread.activity-appended"]);
+
+      const inputResult = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.activity.append",
+          commandId: CommandId.make("cmd-active-input"),
+          threadId: ThreadId.make("thread-1"),
+          activity: {
+            id: EventId.make("activity-active-input"),
+            tone: "approval",
+            kind: "user-input.requested",
+            summary: "User input requested",
+            payload: null,
+            turnId: null,
+            createdAt: NOW,
+          },
+          createdAt: NOW,
+        },
+        readModel: makeReadModel("active"),
+      });
+      const inputEvents = Array.isArray(inputResult) ? inputResult : [inputResult];
+      expect(inputEvents.map((event) => event.type)).toEqual(["thread.activity-appended"]);
     }),
   );
 

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -978,13 +978,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           createdAt: command.createdAt,
         },
       };
-      // Real activity resets ANY override: it wakes an explicitly settled
-      // thread, and it clears a keep-active pin back to neutral so the
-      // thread can auto-settle again after this burst of work goes stale.
-      // A snooze clears the same way — sending a message to a snoozed
-      // thread is the user re-engaging, so the return ticket is spent.
+      // Real activity wakes an explicitly settled thread. A manual Un-settle
+      // ("active") pin is sticky across messages until the user settles again.
+      // A snooze clears the same way as a settled override — sending a message
+      // to a snoozed thread is the user re-engaging, so the return ticket is spent.
       const lifecycleResetEvents: Array<Omit<OrchestrationEvent, "sequence">> = [];
-      if (targetThread.settledOverride !== null) {
+      if (targetThread.settledOverride === "settled") {
         lifecycleResetEvents.push({
           ...(yield* withEventBase({
             aggregateKind: "thread",
@@ -1166,8 +1165,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       // as snoozed, without spending the return ticket.
       const isSessionActivity =
         command.session.status === "starting" || command.session.status === "running";
-      // Real activity resets ANY override (settled wakes, active unpins).
-      if (thread.settledOverride === null || !isSessionActivity) {
+      // Wake settled threads only. Manual Un-settle ("active") stays pinned.
+      if (thread.settledOverride !== "settled" || !isSessionActivity) {
         return sessionSetEvent;
       }
       const unsettledEvent: Omit<OrchestrationEvent, "sequence"> = {
@@ -1343,8 +1342,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       const wakesSettledThread =
         command.activity.kind === "approval.requested" ||
         command.activity.kind === "user-input.requested";
-      // Real activity resets ANY override (settled wakes, active unpins).
-      if (thread.settledOverride === null || !wakesSettledThread) {
+      // Wake settled threads only. Manual Un-settle ("active") stays pinned;
+      // effectiveSettled still refuses to classify blocked work as settled.
+      if (thread.settledOverride !== "settled" || !wakesSettledThread) {
         return activityAppendedEvent;
       }
       const unsettledEvent: Omit<OrchestrationEvent, "sequence"> = {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4003,6 +4003,9 @@ function ChatViewContent(props: ChatViewProps) {
   // so the banner and the sidebar row never disagree.
   const activeThreadShell = useThreadShell(isServerThread ? activeThreadRef : null);
   const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
+  const autoSettleCompletedChangeRequests = useClientSettings(
+    (settings) => settings.sidebarAutoSettleCompletedChangeRequests,
+  );
   const activeThreadPr = resolveThreadPr({
     threadBranch: activeThread?.branch ?? null,
     gitStatus: gitStatusQuery.data ?? null,
@@ -4071,12 +4074,14 @@ function ChatViewContent(props: ChatViewProps) {
     return effectiveSettled(activeThreadShell, {
       now: `${nowMinute}:00.000Z`,
       autoSettleAfterDays,
+      autoSettleCompletedChangeRequests,
       changeRequestState: activeThreadPr?.state ?? null,
     });
   }, [
     activeThreadPr?.state,
     activeThreadShell,
     autoSettleAfterDays,
+    autoSettleCompletedChangeRequests,
     nowMinute,
     supportsSettlement,
   ]);

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1362,6 +1362,9 @@ export default function SidebarV2() {
   const { isMobile, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
+  const autoSettleCompletedChangeRequests = useClientSettings(
+    (s) => s.sidebarAutoSettleCompletedChangeRequests,
+  );
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
@@ -1811,7 +1814,12 @@ export default function SidebarV2() {
         pinned.push(thread);
       } else if (
         supportsSettlement &&
-        effectiveSettled(thread, { now, autoSettleAfterDays, changeRequestState })
+        effectiveSettled(thread, {
+          now,
+          autoSettleAfterDays,
+          autoSettleCompletedChangeRequests,
+          changeRequestState,
+        })
       ) {
         settled.push(thread);
       } else {
@@ -1846,6 +1854,7 @@ export default function SidebarV2() {
     };
   }, [
     autoSettleAfterDays,
+    autoSettleCompletedChangeRequests,
     changeRequestStateByKey,
     nowMinute,
     scopedProjectKeys,

--- a/apps/web/src/components/settings/BetaSettingsPanel.tsx
+++ b/apps/web/src/components/settings/BetaSettingsPanel.tsx
@@ -60,6 +60,9 @@ export function BetaSettingsPanel() {
   const sidebarAutoSettleAfterDays = useClientSettings(
     (settings) => settings.sidebarAutoSettleAfterDays,
   );
+  const sidebarAutoSettleCompletedChangeRequests = useClientSettings(
+    (settings) => settings.sidebarAutoSettleCompletedChangeRequests,
+  );
   const planModeEnabled = useClientSettings((settings) => settings.planModeEnabled);
   const updateSettings = useUpdateClientSettings();
 
@@ -88,7 +91,7 @@ export function BetaSettingsPanel() {
           <>
             <SettingsRow
               title={searchableSetting("auto-settle-inactive-threads").title}
-              description="Threads with no activity for this long settle automatically. Threads on merged or closed PRs always settle."
+              description="Threads with no activity for this long settle automatically. Independent of merged or closed pull requests."
               control={
                 <Switch
                   checked={sidebarAutoSettleAfterDays !== null}
@@ -104,7 +107,7 @@ export function BetaSettingsPanel() {
             {sidebarAutoSettleAfterDays !== null ? (
               <SettingsRow
                 title="Days of inactivity before auto-settle"
-                description="Any new activity un-settles a thread automatically."
+                description="Any new activity un-settles a thread that settled from inactivity. A manual Un-settle stays active until you settle again."
                 control={
                   <AutoSettleDaysInput
                     value={sidebarAutoSettleAfterDays}
@@ -113,6 +116,21 @@ export function BetaSettingsPanel() {
                 }
               />
             ) : null}
+            <SettingsRow
+              {...searchableSetting("auto-settle-completed-pull-requests")}
+              description="Settle threads as soon as their linked pull request is merged or closed. Turn this off to keep those threads active until inactivity settle applies, or until you settle them yourself."
+              control={
+                <Switch
+                  checked={sidebarAutoSettleCompletedChangeRequests}
+                  onCheckedChange={(checked) =>
+                    updateSettings({
+                      sidebarAutoSettleCompletedChangeRequests: Boolean(checked),
+                    })
+                  }
+                  aria-label="Auto-settle completed pull requests"
+                />
+              }
+            />
           </>
         ) : null}
         <SettingsRow

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -67,6 +67,10 @@ describe("searchSettings", () => {
   it("serves anchor props to panels from the catalog", () => {
     expect(searchableSetting("word-wrap")).toEqual({ id: "word-wrap", title: "Word wrap" });
     expect(searchableSetting("archive")).toEqual({ id: "archive", title: "Archived threads" });
+    expect(searchableSetting("auto-settle-completed-pull-requests")).toEqual({
+      id: "auto-settle-completed-pull-requests",
+      title: "Auto-settle completed pull requests",
+    });
   });
 
   it("routes appearance settings to their current section", () => {

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -188,6 +188,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     targetId: "sidebar-v2",
   },
   {
+    id: "auto-settle-completed-pull-requests",
+    title: "Auto-settle completed pull requests",
+    to: "/settings/beta",
+    targetId: "sidebar-v2",
+  },
+  {
     id: "restore-plan-mode",
     title: "Restore plan mode (legacy)",
     to: "/settings/beta",

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -80,6 +80,9 @@ export function useThreadActionMenu(input: {
   const handleNewThread = useNewThreadHandler();
   const markThreadUnread = useUiStateStore((s) => s.markThreadUnread);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
+  const autoSettleCompletedChangeRequests = useClientSettings(
+    (s) => s.sidebarAutoSettleCompletedChangeRequests,
+  );
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const { copyToClipboard: copyPathToClipboard } = useCopyToClipboard<{ path: string }>({
@@ -126,6 +129,7 @@ export function useThreadActionMenu(input: {
               // parked-thread banner within the same minute.
               now: `${now.toISOString().slice(0, 16)}:00.000Z`,
               autoSettleAfterDays,
+              autoSettleCompletedChangeRequests,
               changeRequestState,
             }),
           isSnoozed: supports.snooze && effectiveSnoozed(thread, { now: now.toISOString() }),
@@ -274,6 +278,7 @@ export function useThreadActionMenu(input: {
     },
     [
       autoSettleAfterDays,
+      autoSettleCompletedChangeRequests,
       changeRequestState,
       confirmThreadDelete,
       copyBranchToClipboard,

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -11,3 +11,25 @@ other connected devices.
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.
+
+## Settling threads
+
+With Sidebar v2 / Thread List v2, finished work moves into a compact settled shelf so active cards
+stay focused.
+
+Two independent auto-settle controls decide when a neutral thread settles on its own:
+
+1. **Inactive threads** — settle after a chosen number of quiet days (default: 3). Turn this off to
+   keep quiet threads active forever unless you settle them yourself. An open pull request never
+   settles from inactivity alone; review can take longer than the window.
+2. **Completed pull requests** — settle as soon as a linked pull request is merged or closed
+   (default: on). Turn this off to leave those threads on the ordinary inactivity path instead.
+
+On web and desktop these live under Settings → Beta (with Sidebar v2 enabled). On mobile they are
+device-local preferences under Settings → Beta (with Thread List v2 enabled), because mobile does
+not sync Client Settings.
+
+You can always settle or un-settle a thread from its menu. **Un-settle** is a keep-active choice:
+it stays active across later messages and provider activity until you settle that thread again.
+Settled threads still wake when real work arrives (a new message, a live session, or an approval /
+user-input request).

--- a/packages/client-runtime/src/state/threadSettled.test.ts
+++ b/packages/client-runtime/src/state/threadSettled.test.ts
@@ -178,6 +178,50 @@ describe("effectiveSettled", () => {
     }
   });
 
+  it("leaves merged or closed threads on the inactivity path when completed-PR auto-settle is off", () => {
+    const fresh = makeShell({ activityAt: FRESH });
+    const stale = makeShell({ activityAt: STALE });
+    for (const changeRequestState of ["merged", "closed"] as const) {
+      expect(
+        effectiveSettled(fresh, {
+          now: NOW,
+          autoSettleAfterDays: 3,
+          autoSettleCompletedChangeRequests: false,
+          changeRequestState,
+        }),
+      ).toBe(false);
+      expect(
+        effectiveSettled(stale, {
+          now: NOW,
+          autoSettleAfterDays: 3,
+          autoSettleCompletedChangeRequests: false,
+          changeRequestState,
+        }),
+      ).toBe(true);
+      // Inactivity settle remains independently controllable.
+      expect(
+        effectiveSettled(stale, {
+          now: NOW,
+          autoSettleAfterDays: null,
+          autoSettleCompletedChangeRequests: false,
+          changeRequestState,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("still blocks inactivity settle for an open PR when completed-PR auto-settle is off", () => {
+    const stale = makeShell({ activityAt: STALE });
+    expect(
+      effectiveSettled(stale, {
+        now: NOW,
+        autoSettleAfterDays: 3,
+        autoSettleCompletedChangeRequests: false,
+        changeRequestState: "open",
+      }),
+    ).toBe(false);
+  });
+
   it("never auto-settles a stale thread with an open change request", () => {
     const stale = makeShell({ activityAt: STALE });
     expect(

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -221,17 +221,19 @@ export function threadWokeAt(
  * queued turn) are checked first and hold a thread active regardless of any
  * override. Past the blockers, the explicit user override (thread.settle /
  * thread.unsettle commands, projected into settledOverride + settledAt)
- * wins in both directions; without one, a thread auto-settles on a
- * merged/closed PR immediately or on inactivity past the window — except
- * that an open PR blocks the inactivity path entirely. The server
- * un-settles on real activity (user message, session start, approval/
- * user-input request), so an override never goes stale silently.
+ * wins in both directions; without one, a thread can auto-settle on a
+ * merged/closed PR (when that setting is enabled) or on inactivity past the
+ * window — except that an open PR blocks the inactivity path entirely. The
+ * server wakes an explicitly settled thread on real activity; a manual
+ * Un-settle ("active") pin is sticky until the user settles again.
  */
 export function effectiveSettled(
   shell: OrchestrationThreadShell,
   options: {
     readonly now: string;
     readonly autoSettleAfterDays: number | null;
+    /** Defaults to true so callers that omit it keep historical behavior. */
+    readonly autoSettleCompletedChangeRequests?: boolean;
     readonly changeRequestState?: ChangeRequestStateLike | null;
   },
 ): boolean {
@@ -256,15 +258,19 @@ export function effectiveSettled(
   }
   if (shell.settledOverride === "settled") return true;
   // "active" is the explicit keep-active pin: it suppresses auto-settle
-  // until real activity clears it server-side.
+  // until the user settles again.
   if (shell.settledOverride === "active") return false;
-  if (options.changeRequestState === "merged" || options.changeRequestState === "closed") {
+  const autoSettleCompletedChangeRequests = options.autoSettleCompletedChangeRequests !== false;
+  if (
+    autoSettleCompletedChangeRequests &&
+    (options.changeRequestState === "merged" || options.changeRequestState === "closed")
+  ) {
     return true;
   }
   // An open PR is unfinished business regardless of how long the thread has
   // been quiet: review can take days, and hiding the thread would bury the
-  // work waiting on it. Only merge/close (above) or an explicit user settle
-  // resolves it.
+  // work waiting on it. Only merge/close (above, when enabled) or an explicit
+  // user settle resolves it.
   if (options.changeRequestState === "open") return false;
   if (options.autoSettleAfterDays === null) return false;
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -72,6 +72,7 @@ describe("ClientSettings sidebar v2", () => {
     const settings = decodeClientSettings({});
     expect(settings.sidebarV2Enabled).toBe(false);
     expect(settings.sidebarAutoSettleAfterDays).toBe(3);
+    expect(settings.sidebarAutoSettleCompletedChangeRequests).toBe(true);
   });
 
   it("treats settings written before the beta had a per-channel default as unconfigured", () => {
@@ -104,6 +105,27 @@ describe("ClientSettings sidebar v2", () => {
       decodeClientSettings({ sidebarAutoSettleAfterDays: null }).sidebarAutoSettleAfterDays,
     ).toBeNull();
   });
+
+  it("defaults completed-PR auto-settle on for older stored settings", () => {
+    // Blobs written before this field existed must keep the historical always-on
+    // completed-PR settle behavior.
+    expect(
+      decodeClientSettings({ sidebarAutoSettleAfterDays: 3 })
+        .sidebarAutoSettleCompletedChangeRequests,
+    ).toBe(true);
+  });
+
+  it.each([true, false])(
+    "accepts completed-PR auto-settle patches without changing unrelated settings: %s",
+    (value) => {
+      const patch = decodeClientSettingsPatch({
+        sidebarAutoSettleCompletedChangeRequests: value,
+      });
+      expect(patch.sidebarAutoSettleCompletedChangeRequests).toBe(value);
+      expect(patch).not.toHaveProperty("sidebarAutoSettleAfterDays");
+      expect(patch).not.toHaveProperty("sidebarV2Enabled");
+    },
+  );
 
   it.each([-1, 0, 91])("rejects an auto-settle threshold outside 1..90: %s", (value) => {
     expect(() => decodeClientSettings({ sidebarAutoSettleAfterDays: value })).toThrow();

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -52,6 +52,8 @@ export const SidebarAutoSettleAfterDays = Schema.Number.check(
 );
 export type SidebarAutoSettleAfterDays = typeof SidebarAutoSettleAfterDays.Type;
 export const DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS: SidebarAutoSettleAfterDays = 3;
+/** When true, merged or closed change requests settle immediately. */
+export const DEFAULT_SIDEBAR_AUTO_SETTLE_COMPLETED_CHANGE_REQUESTS = true;
 export const MIN_GLASS_OPACITY = 40;
 export const MAX_GLASS_OPACITY = 100;
 export const GlassOpacity = Schema.Int.check(
@@ -173,6 +175,14 @@ export const ClientSettingsSchema = Schema.Struct({
   planModeEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
+  ),
+  // Independent of inactivity auto-settle: merged or closed PRs settle as soon
+  // as their state is known. Off means those threads stay on the ordinary
+  // inactivity path (or stay active if inactivity settle is also off).
+  sidebarAutoSettleCompletedChangeRequests: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(
+      Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_COMPLETED_CHANGE_REQUESTS),
+    ),
   ),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
@@ -787,6 +797,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
+  sidebarAutoSettleCompletedChangeRequests: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),


### PR DESCRIPTION
## What Changed

Adds an independent **Auto-settle completed pull requests** setting for Sidebar v2. It defaults on for compatibility, but users can turn it off so merged or closed PR threads follow the ordinary inactivity rule instead.

Manual **Un-settle** is now a sticky keep-active choice. Later messages, sessions, approvals, and user-input activity no longer clear that choice; explicitly settled threads still wake when real work resumes.

The shared classification logic covers web and desktop. Mobile gets the same default and semantics through a device-local preference because it does not currently sync Client Settings.

## Why

The existing inactivity auto-settle switch did not control completed PRs: merged or closed PR threads always settled. Activity also cleared a manual Un-settle override, so a thread linked to a completed PR could settle again immediately after every message.

This keeps the two automatic rules independent and makes the explicit user override durable.

## UI Changes

| Before | After |
| --- | --- |
| ![Before: merged or closed PRs always settle](https://raw.githubusercontent.com/joshfcc/t3code/07f57adf9ba7e06ebc38e6f1d1d886bf9e7df815/.github/pr-assets/configurable-pr-auto-settle/before-beta-settings.png) | ![After: separate completed pull-request auto-settle switch](https://raw.githubusercontent.com/joshfcc/t3code/07f57adf9ba7e06ebc38e6f1d1d886bf9e7df815/.github/pr-assets/configurable-pr-auto-settle/after-beta-settings.png) |

No motion or timing behavior changed, so a video is not applicable.

## Verification

- 7 focused test files: 286 tests passed
- Targeted typechecks passed for contracts, client-runtime, server, web, desktop, and mobile
- Integrated web settings pass completed against isolated worktree state
- Pre-land adversarial review passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] Video is not applicable because there is no animation, motion, or timing change

Model: GPT-5.6 via the Codex desktop harness, with Cursor Grok 4.5 as the builder and Claude Fable as the adversarial reviewer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration lifecycle (sticky unsettle) and shared settled classification across web, mobile, and server; behavior changes are user-visible but covered by tests and default-on for compatibility.
> 
> **Overview**
> Adds a separate **Auto-settle completed pull requests** control (default on) so merged/closed PR threads no longer always auto-settle when users turn it off—they follow the inactivity rule instead.
> 
> **Manual Un-settle** is now sticky: later messages, sessions, and approval/input activity no longer clear the `"active"` override on the server; only explicit settle or waking an explicitly `"settled"` thread still applies.
> 
> Web/desktop read the new `sidebarAutoSettleCompletedChangeRequests` client setting everywhere thread settled state is computed (sidebar, chat, context menu). Mobile mirrors the same behavior via a device-local preference and wires it through Thread List v2. Shared `effectiveSettled` gates PR-based auto-settle on the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca0ebbd4b04177c1f4bcdb80d903111d6989a80f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->