### PR TITLE
fix(server): allow install scripts in npm-global provider updates

### DIFF
--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -176,7 +176,8 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       status: "behind_latest",
       currentVersion: "2.1.110",
       latestVersion: "2.1.117",
-      updateCommand: "npm install -g @example/native-package-tool@latest",
+      updateCommand:
+        "npm install -g --allow-scripts=@example/native-package-tool @example/native-package-tool@latest",
       canUpdate: true,
       message: "Install the update now or review provider settings.",
     });
@@ -482,11 +483,17 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         provider: driver("packageTool"),
         packageName: "@example/package-tool",
         update: {
-          command: "npm install -g @example/package-tool@latest",
+          command:
+            "npm install -g --allow-scripts=@example/package-tool @example/package-tool@latest",
 
           executable: "npm",
 
-          args: ["install", "-g", "@example/package-tool@latest"],
+          args: [
+            "install",
+            "-g",
+            "--allow-scripts=@example/package-tool",
+            "@example/package-tool@latest",
+          ],
 
           lockKey: "npm-global",
         },
@@ -540,6 +547,40 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       });
     }),
   );
+
+  it("allows the package's own install scripts in npm global updates", () => {
+    const claudeUpdate = makePackageManagedProviderMaintenanceResolver({
+      provider: driver("claudeAgent"),
+      npmPackageName: "@anthropic-ai/claude-code",
+      homebrewFormula: "claude-code",
+      nativeUpdate: {
+        executable: "claude",
+        args: ["update"],
+        lockKey: "claude-native",
+        isCommandPath: isNativeTestCommandPath("/.local/bin/claude"),
+      },
+    });
+
+    expect(claudeUpdate.resolve()).toEqual({
+      provider: driver("claudeAgent"),
+      packageName: "@anthropic-ai/claude-code",
+      update: {
+        command:
+          "npm install -g --allow-scripts=@anthropic-ai/claude-code @anthropic-ai/claude-code@latest",
+
+        executable: "npm",
+
+        args: [
+          "install",
+          "-g",
+          "--allow-scripts=@anthropic-ai/claude-code",
+          "@anthropic-ai/claude-code@latest",
+        ],
+
+        lockKey: "npm-global",
+      },
+    });
+  });
 
   it("disables one-click updates for explicit custom binary paths it cannot safely map", () => {
     expect(

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -137,7 +137,17 @@ function makeNpmGlobalProviderMaintenanceCapabilities(
     provider: definition.provider,
     packageName: definition.npmPackageName,
     updateExecutable: "npm",
-    updateArgs: ["install", "-g", `${definition.npmPackageName}@latest`],
+    // npm 12 blocks install scripts by default (empty allow-scripts allowlist)
+    // and still exits 0, so a package whose postinstall finishes the install
+    // (claude copies its native binary over a placeholder stub) is left broken
+    // while the update reports success. Allow this one package's scripts.
+    // Older npm warns about the unknown config and continues.
+    updateArgs: [
+      "install",
+      "-g",
+      `--allow-scripts=${definition.npmPackageName}`,
+      `${definition.npmPackageName}@latest`,
+    ],
     updateLockKey: "npm-global",
   });
 }


### PR DESCRIPTION
Fixes #5627.

## What changed

`makeNpmGlobalProviderMaintenanceCapabilities` now adds
`--allow-scripts=<packageName>` to the npm-global update args, scoped to
exactly the package being updated. A new test pins the exact argv for
`@anthropic-ai/claude-code`, and two existing expectations pick up the flag.
No other update path is touched.

## Why

npm 12 blocks install scripts by default. The `allow-scripts` allowlist ships
empty, a blocked script produces only a warning, and the install exits 0. The
one-click provider update runs `npm install -g <package>@latest`, so on npm 12
it replaces a working global `claude` with a broken one and reports success. The
package's postinstall is what copies the platform-native binary over the
`bin/claude` stub. With the script blocked, the stub stays in place and every
`claude` invocation fails with `claude native binary not installed`. The full
diagnosis and the npm debug log from the failing update are in #5627.

## Compatibility

npm 11 ships `allow-scripts` as a known config key and accepts the flag, which
I verified on 11.17.0. Older npm treats it as unknown config, warns, and
continues with exit 0.

## Verification

On npm 12.0.2 the update completes with the postinstall run and `claude`
launches afterward. The touched test file passes.

The pnpm-global and bun-global paths may carry the same class of exposure, as
noted in #5627, but both managers already block install scripts by default, so
any breakage there is pre-existing rather than new with npm 12. This PR fixes
only the reproduced npm path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to npm-global update argv only; older npm may warn on unknown config but continues, and script allowance is limited to the package being updated.
> 
> **Overview**
> **npm-global one-click provider updates** now pass `--allow-scripts=<packageName>` so npm 12 can run that package’s install scripts during `npm install -g …@latest`.
> 
> Without this, npm 12’s default empty script allowlist can block postinstall (e.g. copying the native `claude` binary) while still exiting 0, leaving a broken global CLI after a “successful” update.
> 
> Tests were updated for advisory/update command strings and npm symlink resolution, and a new case pins argv for `@anthropic-ai/claude-code`. **pnpm, bun, Homebrew, and native update paths are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e999f378eda7e56ef15263bf67cbc5d840cb76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--allow-scripts` flag to npm-global provider update commands
> In [providerMaintenance.ts](https://github.com/pingdotgg/t3code/pull/5646/files#diff-e29fae218a488cafd27faaeea37f0b7c1dccd03ba4a994975736ddf89e3bde14), the npm global update command now includes `--allow-scripts=<packageName>` between `-g` and `<package>@latest`, scoping install script execution to only the package being updated. This works around npm 12's default behavior of blocking install scripts. Behavioral Change: packages updated via the npm-global provider will now have their own install scripts permitted to run, where previously they were blocked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70e999f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->