### PR TITLE
feat(voice): add Codex subscription transcription

### DIFF
--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -41,12 +41,14 @@ import {
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import { browserApiCorsAllowedHeaders, browserApiCorsAllowedMethods } from "./httpCors.ts";
 import {
+  codexTranscriptionAuthStatus,
   forwardVoiceTranscription,
   listVoiceTranscriptionModels,
   MAX_TRANSCRIPTION_AUDIO_BYTES,
   readTranscriptionAudio,
   resolveTranscriptionProvider,
   transcriptionEnvironmentApiKeyStatus,
+  TranscriptionCodexAuthError,
   TranscriptionProviderUnsupportedError,
 } from "./transcription.ts";
 
@@ -267,7 +269,8 @@ const transcriptionConfigRouteLayer = HttpRouter.add(
       transcriptionEnvironmentApiKeyStatus("openai"),
       transcriptionEnvironmentApiKeyStatus("groq"),
     ]);
-    return HttpServerResponse.jsonUnsafe({ openai, groq });
+    const codex = yield* codexTranscriptionAuthStatus;
+    return HttpServerResponse.jsonUnsafe({ codex, openai, groq });
   }).pipe(
     Effect.catchTags({
       EnvironmentAuthInvalidError: HttpServerRespondable.toResponse,
@@ -317,6 +320,8 @@ const transcriptionUploadRouteLayer = HttpRouter.add(
       TranscriptionApiKeyMissingError: (error) =>
         Effect.succeed(HttpServerResponse.jsonUnsafe({ error: error.message }, { status: 400 })),
       TranscriptionBodyReadError: (error) =>
+        Effect.succeed(HttpServerResponse.jsonUnsafe({ error: error.message }, { status: 400 })),
+      TranscriptionCodexAuthError: (error) =>
         Effect.succeed(HttpServerResponse.jsonUnsafe({ error: error.message }, { status: 400 })),
       TranscriptionEmptyAudioError: (error) =>
         Effect.succeed(HttpServerResponse.jsonUnsafe({ error: error.message }, { status: 400 })),

--- a/apps/server/src/transcription.test.ts
+++ b/apps/server/src/transcription.test.ts
@@ -1,9 +1,14 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as Stream from "effect/Stream";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 import { describe } from "vite-plus/test";
+
+import { ServerSettingsService } from "./serverSettings.ts";
 
 import {
   forwardVoiceTranscription,
@@ -17,6 +22,7 @@ import {
 
 describe("transcription providers", () => {
   it("uses fixed OpenAI and Groq configurations", () => {
+    expect(resolveTranscriptionProvider("codex")).toBe("codex");
     expect(resolveTranscriptionProvider("openai")).toBe("openai");
     expect(transcriptionProviderConfig("openai")).toEqual({
       endpoint: "https://api.openai.com/v1/audio/transcriptions",
@@ -96,6 +102,58 @@ describe("transcription providers", () => {
         ConfigProvider.layer(ConfigProvider.fromEnv({ env: { GROQ_API_KEY: "env-groq-key" } })),
       ),
     ),
+  );
+});
+
+it.layer(NodeServices.layer)("Codex subscription transcription", (it) => {
+  it.effect("keeps OAuth credentials host-side and forwards audio with Codex headers", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const codexHome = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-codex-transcription-",
+      });
+      yield* fileSystem.writeFileString(
+        path.join(codexHome, "auth.json"),
+        JSON.stringify({
+          tokens: { access_token: "codex-access-token", account_id: "account-123" },
+        }),
+      );
+
+      let capturedRequest: HttpClientRequest.HttpClientRequest | undefined;
+      const client = HttpClient.make((request) =>
+        Effect.sync(() => {
+          capturedRequest = request;
+          return HttpClientResponse.fromWeb(
+            request,
+            Response.json({ text: " subscription transcript " }),
+          );
+        }),
+      );
+
+      const transcript = yield* forwardVoiceTranscription({
+        audio: new Uint8Array([1, 2, 3]),
+        audioMimeType: "audio/webm;codecs=opus",
+        provider: "codex",
+        apiKey: "",
+        model: "",
+      }).pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+        Effect.provide(
+          ServerSettingsService.layerTest({ providers: { codex: { homePath: codexHome } } }),
+        ),
+      );
+
+      expect(transcript).toBe("subscription transcript");
+      expect(capturedRequest?.url).toBe("https://chatgpt.com/backend-api/transcribe");
+      expect(capturedRequest?.headers.authorization).toBe("Bearer codex-access-token");
+      expect(capturedRequest?.headers["chatgpt-account-id"]).toBe("account-123");
+      expect(capturedRequest?.body._tag).toBe("FormData");
+      if (capturedRequest?.body._tag === "FormData") {
+        expect(capturedRequest.body.formData.get("file")).toBeInstanceOf(Blob);
+        expect(capturedRequest.body.formData.has("model")).toBe(false);
+      }
+    }),
   );
 });
 

--- a/apps/server/src/transcription.ts
+++ b/apps/server/src/transcription.ts
@@ -1,13 +1,21 @@
-import type { VoiceTranscriptionProvider } from "@t3tools/contracts";
+import { CodexSettings, type VoiceTranscriptionProvider } from "@t3tools/contracts";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 
+import { resolveCodexHomeLayout } from "./provider/Drivers/CodexHomeLayout.ts";
+import { deriveProviderInstanceConfigMap } from "./provider/Layers/ProviderInstanceRegistryHydration.ts";
+import { ServerSettingsService } from "./serverSettings.ts";
+
 export const MAX_TRANSCRIPTION_AUDIO_BYTES = 25 * 1024 * 1024;
 
-const PROVIDERS = {
+type ApiKeyVoiceTranscriptionProvider = Exclude<VoiceTranscriptionProvider, "codex">;
+
+const API_KEY_PROVIDERS = {
   openai: {
     endpoint: "https://api.openai.com/v1/audio/transcriptions",
     modelsEndpoint: "https://api.openai.com/v1/models",
@@ -19,9 +27,11 @@ const PROVIDERS = {
     apiKeyEnvironmentVariable: "GROQ_API_KEY",
   },
 } as const satisfies Record<
-  VoiceTranscriptionProvider,
+  ApiKeyVoiceTranscriptionProvider,
   { endpoint: string; modelsEndpoint: string; apiKeyEnvironmentVariable: string }
 >;
+
+const CODEX_TRANSCRIPTION_ENDPOINT = "https://chatgpt.com/backend-api/transcribe";
 
 export interface VoiceTranscriptionInput {
   readonly audio: Uint8Array;
@@ -68,7 +78,7 @@ export class TranscriptionProviderUnsupportedError extends Schema.TaggedErrorCla
   {},
 ) {
   override get message(): string {
-    return "Select OpenAI or Groq for transcription.";
+    return "Select Codex subscription, OpenAI, or Groq for transcription.";
   }
 }
 
@@ -78,6 +88,15 @@ export class TranscriptionApiKeyMissingError extends Schema.TaggedErrorClass<Tra
 ) {
   override get message(): string {
     return "Add an API key or configure the provider's API key environment variable.";
+  }
+}
+
+export class TranscriptionCodexAuthError extends Schema.TaggedErrorClass<TranscriptionCodexAuthError>()(
+  "TranscriptionCodexAuthError",
+  {},
+) {
+  override get message(): string {
+    return "Voice transcription requires file-based Codex credentials signed in with ChatGPT.";
   }
 }
 
@@ -127,28 +146,74 @@ export class TranscriptionResponseError extends Schema.TaggedErrorClass<Transcri
 }
 
 const TranscriptionResponse = Schema.Struct({ text: Schema.String });
+const CodexVoiceAuth = Schema.Struct({
+  tokens: Schema.Struct({
+    access_token: Schema.NonEmptyString,
+    account_id: Schema.NonEmptyString,
+  }),
+});
 const ModelsResponse = Schema.Struct({
   data: Schema.Array(Schema.Struct({ id: Schema.String })),
 });
 const TRANSCRIPTION_MODEL_ID_PATTERN = /(?:transcri|whisper|speech[-_ ]?to[-_ ]?text)/i;
+const decodeCodexSettings = Schema.decodeUnknownEffect(CodexSettings);
+const decodeCodexVoiceAuth = Schema.decodeEffect(Schema.fromJsonString(CodexVoiceAuth));
 
 export function resolveTranscriptionProvider(provider: string): VoiceTranscriptionProvider | null {
-  return provider === "openai" || provider === "groq" ? provider : null;
+  return provider === "codex" || provider === "openai" || provider === "groq" ? provider : null;
 }
 
-export function transcriptionProviderConfig(provider: VoiceTranscriptionProvider) {
-  return PROVIDERS[provider];
+export function transcriptionProviderConfig(provider: ApiKeyVoiceTranscriptionProvider) {
+  return API_KEY_PROVIDERS[provider];
 }
 
 export const transcriptionEnvironmentApiKeyStatus = Effect.fn(
   "transcriptionEnvironmentApiKeyStatus",
-)(function* (provider: VoiceTranscriptionProvider) {
+)(function* (provider: ApiKeyVoiceTranscriptionProvider) {
   const providerConfig = transcriptionProviderConfig(provider);
   const value = yield* Config.string(providerConfig.apiKeyEnvironmentVariable).pipe(
     Config.withDefault(""),
   );
   return value.trim().length > 0;
 });
+
+const resolveCodexVoiceCredentials = Effect.fn("voiceTranscription.resolveCodexCredentials")(
+  function* () {
+    const settingsService = yield* ServerSettingsService;
+    const settings = yield* settingsService.getSettings.pipe(
+      Effect.mapError(() => new TranscriptionCodexAuthError()),
+    );
+    const instance = Object.values(deriveProviderInstanceConfigMap(settings)).find(
+      (candidate) => candidate.driver === "codex",
+    );
+    if (!instance) {
+      return yield* new TranscriptionCodexAuthError();
+    }
+
+    const config = yield* decodeCodexSettings(instance.config ?? {}).pipe(
+      Effect.mapError(() => new TranscriptionCodexAuthError()),
+    );
+    const layout = yield* resolveCodexHomeLayout(config);
+    const path = yield* Path.Path;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const authPath = path.join(layout.effectiveHomePath ?? layout.sharedHomePath, "auth.json");
+    const encoded = yield* fileSystem.readFileString(authPath).pipe(
+      Effect.mapError(() => new TranscriptionCodexAuthError()),
+    );
+    const auth = yield* decodeCodexVoiceAuth(encoded).pipe(
+      Effect.mapError(() => new TranscriptionCodexAuthError()),
+    );
+    return {
+      accessToken: auth.tokens.access_token,
+      accountId: auth.tokens.account_id,
+    };
+  },
+);
+
+export const codexTranscriptionAuthStatus = resolveCodexVoiceCredentials().pipe(
+  Effect.as(true),
+  Effect.catchTag("TranscriptionCodexAuthError", () => Effect.succeed(false)),
+);
 
 const resolveTranscriptionApiKey = Effect.fn("voiceTranscription.resolveApiKey")(function* (
   input: VoiceTranscriptionModelsInput,
@@ -168,6 +233,7 @@ const resolveTranscriptionApiKey = Effect.fn("voiceTranscription.resolveApiKey")
 export const listVoiceTranscriptionModels = Effect.fn("voiceTranscription.listModels")(function* (
   input: VoiceTranscriptionModelsInput,
 ) {
+  if (input.provider === "codex") return [];
   const providerConfig = transcriptionProviderConfig(input.provider);
   const apiKey = yield* resolveTranscriptionApiKey(input);
   const httpClient = yield* HttpClient.HttpClient;
@@ -178,6 +244,9 @@ export const listVoiceTranscriptionModels = Effect.fn("voiceTranscription.listMo
     Effect.flatMap((response) =>
       Effect.gen(function* () {
         if (response.status < 200 || response.status >= 300) {
+          if (response.status === 401 || response.status === 403) {
+            return yield* new TranscriptionCodexAuthError();
+          }
           return yield* new TranscriptionProviderError({
             provider: input.provider,
             providerStatus: response.status,
@@ -234,6 +303,50 @@ function audioFileExtension(mimeType: string): string {
   return "webm";
 }
 
+const forwardCodexVoiceTranscription = Effect.fn("voiceTranscription.forwardCodex")(function* (
+  input: Pick<VoiceTranscriptionInput, "audio" | "audioMimeType">,
+) {
+  const credentials = yield* resolveCodexVoiceCredentials();
+  const mimeType = input.audioMimeType.split(";", 1)[0]?.trim() || "audio/webm";
+  const form = new FormData();
+  form.set(
+    "file",
+    new Blob([input.audio], { type: mimeType }),
+    `recording.${audioFileExtension(mimeType)}`,
+  );
+
+  const httpClient = yield* HttpClient.HttpClient;
+  const payload = yield* HttpClientRequest.post(CODEX_TRANSCRIPTION_ENDPOINT).pipe(
+    HttpClientRequest.bearerToken(credentials.accessToken),
+    HttpClientRequest.setHeader("ChatGPT-Account-Id", credentials.accountId),
+    HttpClientRequest.setHeader("OAI-Product-Sku", "CODEX"),
+    HttpClientRequest.setHeader("originator", "Codex Desktop"),
+    HttpClientRequest.setHeader("User-Agent", "Codex Desktop/0.1.0"),
+    HttpClientRequest.bodyFormData(form),
+    httpClient.execute,
+    Effect.mapError((cause) => new TranscriptionRequestError({ provider: "codex", cause })),
+    Effect.flatMap((response) =>
+      Effect.gen(function* () {
+        if (response.status < 200 || response.status >= 300) {
+          return yield* new TranscriptionProviderError({
+            provider: "codex",
+            providerStatus: response.status,
+          });
+        }
+        return yield* HttpClientResponse.schemaBodyJson(TranscriptionResponse)(response).pipe(
+          Effect.mapError((cause) => new TranscriptionResponseError({ provider: "codex", cause })),
+        );
+      }),
+    ),
+    Effect.timeout("2 minutes"),
+    Effect.catchTags({
+      TimeoutError: (cause) =>
+        Effect.fail(new TranscriptionRequestError({ provider: "codex", cause })),
+    }),
+  );
+  return payload.text.trim();
+});
+
 export const forwardVoiceTranscription = Effect.fn("voiceTranscription.forward")(function* (
   input: VoiceTranscriptionInput,
 ) {
@@ -244,6 +357,9 @@ export const forwardVoiceTranscription = Effect.fn("voiceTranscription.forward")
     return yield* new TranscriptionAudioTooLargeError({
       receivedBytes: input.audio.byteLength,
     });
+  }
+  if (input.provider === "codex") {
+    return yield* forwardCodexVoiceTranscription(input);
   }
   const providerConfig = transcriptionProviderConfig(input.provider);
   const model = input.model.trim();

--- a/apps/web/src/components/settings/BetaSettingsPanel.tsx
+++ b/apps/web/src/components/settings/BetaSettingsPanel.tsx
@@ -23,6 +23,11 @@ const TRANSCRIPTION_API_KEY_ENV = {
   openai: "OPENAI_API_KEY",
   groq: "GROQ_API_KEY",
 } as const;
+const TRANSCRIPTION_PROVIDER_LABEL = {
+  codex: "Codex subscription",
+  openai: "OpenAI",
+  groq: "Groq",
+} as const;
 
 function AutoSettleDaysInput({
   value,
@@ -81,6 +86,7 @@ export function BetaSettingsPanel() {
   );
   const voiceTranscriptionModel = useClientSettings((settings) => settings.voiceTranscriptionModel);
   const [environmentApiKeys, setEnvironmentApiKeys] = useState({
+    codex: false,
     openai: false,
     groq: false,
   });
@@ -102,14 +108,20 @@ export function BetaSettingsPanel() {
     };
   }, [voiceTranscriptionEnabled]);
 
-  const transcriptionProviderLabel = voiceTranscriptionProvider === "openai" ? "OpenAI" : "Groq";
+  const transcriptionProviderLabel = TRANSCRIPTION_PROVIDER_LABEL[voiceTranscriptionProvider];
+  const isCodexSubscription = voiceTranscriptionProvider === "codex";
   const transcriptionApiKeyEnvironmentVariable =
-    TRANSCRIPTION_API_KEY_ENV[voiceTranscriptionProvider];
+    voiceTranscriptionProvider === "openai"
+      ? TRANSCRIPTION_API_KEY_ENV.openai
+      : voiceTranscriptionProvider === "groq"
+        ? TRANSCRIPTION_API_KEY_ENV.groq
+        : null;
   const hasEnvironmentApiKey = environmentApiKeys[voiceTranscriptionProvider];
-  const hasTranscriptionApiKey = voiceTranscriptionApiKey.trim().length > 0 || hasEnvironmentApiKey;
+  const hasTranscriptionApiKey =
+    isCodexSubscription || voiceTranscriptionApiKey.trim().length > 0 || hasEnvironmentApiKey;
 
   useEffect(() => {
-    if (!voiceTranscriptionEnabled || !hasTranscriptionApiKey) {
+    if (!voiceTranscriptionEnabled || !hasTranscriptionApiKey || isCodexSubscription) {
       setTranscriptionModels([]);
       setTranscriptionModelsLoading(false);
       setTranscriptionModelsError(null);
@@ -148,6 +160,7 @@ export function BetaSettingsPanel() {
     };
   }, [
     hasTranscriptionApiKey,
+    isCodexSubscription,
     voiceTranscriptionApiKey,
     voiceTranscriptionEnabled,
     voiceTranscriptionProvider,
@@ -242,7 +255,7 @@ export function BetaSettingsPanel() {
           <>
             <SettingsRow
               title="Transcription provider"
-              description="Use OpenAI or Groq. T3 loads the models available to the configured API key."
+              description="Use your Codex subscription, OpenAI, or Groq."
               control={
                 <Select
                   value={voiceTranscriptionProvider}
@@ -258,6 +271,9 @@ export function BetaSettingsPanel() {
                     <SelectValue>{transcriptionProviderLabel}</SelectValue>
                   </SelectTrigger>
                   <SelectPopup align="end" alignItemWithTrigger={false}>
+                    <SelectItem hideIndicator value="codex">
+                      Codex subscription
+                    </SelectItem>
                     <SelectItem hideIndicator value="openai">
                       OpenAI
                     </SelectItem>
@@ -268,61 +284,79 @@ export function BetaSettingsPanel() {
                 </Select>
               }
             />
-            <SettingsRow
-              title={`${transcriptionProviderLabel} API key`}
-              description={
-                hasEnvironmentApiKey
-                  ? `${transcriptionApiKeyEnvironmentVariable} is configured on the connected T3 server. Enter a key here to override it for this client.`
-                  : `Stored only in this client's local settings. You can also set ${transcriptionApiKeyEnvironmentVariable} on the connected T3 server.`
-              }
-              control={
-                <Input
-                  type="password"
-                  autoComplete="off"
-                  className="w-full sm:w-64"
-                  value={voiceTranscriptionApiKey}
-                  onChange={(event) =>
-                    updateSettings({
-                      voiceTranscriptionApiKey: event.target.value,
-                      voiceTranscriptionModel: "",
-                    })
-                  }
-                  placeholder={
+            {isCodexSubscription ? (
+              <SettingsRow
+                title="Codex authentication"
+                description={
+                  hasEnvironmentApiKey
+                    ? "Uses the first configured Codex provider with file-based ChatGPT credentials on the connected T3 server."
+                    : "No file-based Codex ChatGPT login was found on the connected T3 server. Run codex login first."
+                }
+                control={
+                  <span className="text-sm text-muted-foreground">
+                    {hasEnvironmentApiKey ? "Connected" : "Unavailable"}
+                  </span>
+                }
+              />
+            ) : (
+              <>
+                <SettingsRow
+                  title={`${transcriptionProviderLabel} API key`}
+                  description={
                     hasEnvironmentApiKey
-                      ? `Using ${transcriptionApiKeyEnvironmentVariable}`
-                      : "Required"
+                      ? `${transcriptionApiKeyEnvironmentVariable} is configured on the connected T3 server. Enter a key here to override it for this client.`
+                      : `Stored only in this client's local settings. You can also set ${transcriptionApiKeyEnvironmentVariable} on the connected T3 server.`
                   }
-                  aria-label={`${transcriptionProviderLabel} transcription API key`}
+                  control={
+                    <Input
+                      type="password"
+                      autoComplete="off"
+                      className="w-full sm:w-64"
+                      value={voiceTranscriptionApiKey}
+                      onChange={(event) =>
+                        updateSettings({
+                          voiceTranscriptionApiKey: event.target.value,
+                          voiceTranscriptionModel: "",
+                        })
+                      }
+                      placeholder={
+                        hasEnvironmentApiKey
+                          ? `Using ${transcriptionApiKeyEnvironmentVariable}`
+                          : "Required"
+                      }
+                      aria-label={`${transcriptionProviderLabel} transcription API key`}
+                    />
+                  }
                 />
-              }
-            />
-            <SettingsRow
-              title="Transcription model"
-              description={transcriptionModelDescription}
-              control={
-                <Select
-                  value={voiceTranscriptionModel}
-                  disabled={transcriptionModelsLoading || transcriptionModels.length === 0}
-                  onValueChange={(value) => {
-                    if (value !== null) updateSettings({ voiceTranscriptionModel: value });
-                  }}
-                >
-                  <SelectTrigger className="w-full sm:w-64" aria-label="Transcription model">
-                    <SelectValue>
-                      {voiceTranscriptionModel ||
-                        (transcriptionModelsLoading ? "Loading models…" : "Select model")}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectPopup align="end" alignItemWithTrigger={false}>
-                    {transcriptionModels.map((model) => (
-                      <SelectItem hideIndicator key={model} value={model}>
-                        {model}
-                      </SelectItem>
-                    ))}
-                  </SelectPopup>
-                </Select>
-              }
-            />
+                <SettingsRow
+                  title="Transcription model"
+                  description={transcriptionModelDescription}
+                  control={
+                    <Select
+                      value={voiceTranscriptionModel}
+                      disabled={transcriptionModelsLoading || transcriptionModels.length === 0}
+                      onValueChange={(value) => {
+                        if (value !== null) updateSettings({ voiceTranscriptionModel: value });
+                      }}
+                    >
+                      <SelectTrigger className="w-full sm:w-64" aria-label="Transcription model">
+                        <SelectValue>
+                          {voiceTranscriptionModel ||
+                            (transcriptionModelsLoading ? "Loading models…" : "Select model")}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectPopup align="end" alignItemWithTrigger={false}>
+                        {transcriptionModels.map((model) => (
+                          <SelectItem hideIndicator key={model} value={model}>
+                            {model}
+                          </SelectItem>
+                        ))}
+                      </SelectPopup>
+                    </Select>
+                  }
+                />
+              </>
+            )}
           </>
         ) : null}
       </SettingsSection>

--- a/apps/web/src/lib/voiceTranscription.test.ts
+++ b/apps/web/src/lib/voiceTranscription.test.ts
@@ -38,6 +38,20 @@ describe("voiceTranscriptionRequestHeaders", () => {
       "x-t3-transcription-model": "whisper-large-v3",
     });
   });
+
+  it("selects Codex subscription without sending credentials from the client", () => {
+    expect(
+      voiceTranscriptionRequestHeaders("audio/webm", {
+        provider: "codex",
+        apiKey: "",
+        model: "",
+      }),
+    ).toEqual({
+      "content-type": "audio/webm",
+      "x-t3-transcription-provider": "codex",
+      "x-t3-transcription-model": "",
+    });
+  });
 });
 
 describe("listVoiceTranscriptionModels", () => {

--- a/apps/web/src/lib/voiceTranscription.ts
+++ b/apps/web/src/lib/voiceTranscription.ts
@@ -12,6 +12,7 @@ export interface VoiceTranscriptionConfig {
 export type VoiceTranscriptionProviderConfig = Omit<VoiceTranscriptionConfig, "model">;
 
 export interface VoiceTranscriptionEnvironmentStatus {
+  readonly codex: boolean;
   readonly openai: boolean;
   readonly groq: boolean;
 }
@@ -48,8 +49,13 @@ export async function readVoiceTranscriptionEnvironmentStatus(): Promise<VoiceTr
   });
   if (!response.ok) throw new Error("Could not read transcription provider settings.");
 
-  const payload = (await response.json()) as { readonly openai?: unknown; readonly groq?: unknown };
+  const payload = (await response.json()) as {
+    readonly codex?: unknown;
+    readonly openai?: unknown;
+    readonly groq?: unknown;
+  };
   return {
+    codex: payload.codex === true,
     openai: payload.openai === true,
     groq: payload.groq === true,
   };

--- a/docs/user/voice-dictation.md
+++ b/docs/user/voice-dictation.md
@@ -7,9 +7,15 @@ Enable it in **Settings** → **Beta features** → **Voice dictation**. The com
 microphone action. Select it to start recording and stop it when you are finished. Recordings stop
 automatically after five minutes.
 
-## Providers and API Keys
+## Providers and Authentication
 
-Choose **OpenAI** or **Groq**. T3 Code supplies the provider's transcription endpoint. After an
+Choose **Codex subscription**, **OpenAI**, or **Groq**. Codex subscription is experimental and
+reuses the first configured Codex provider with file-based ChatGPT credentials on the connected T3
+server. It does not require a separate API key. This integration uses the same private transcription
+endpoint as Codex Desktop, which is not a documented public OpenAI API and may change without
+notice.
+
+For OpenAI or Groq, T3 Code supplies the provider's transcription endpoint. After an
 API key is available, T3 Code loads the models that key can access from the provider and lets you
 select the transcription model. Model IDs are not bundled into T3 Code, so newly available models
 can appear without an app update.

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -112,11 +112,15 @@ describe("ClientSettings sidebar v2", () => {
 });
 
 describe("ClientSettings voice transcription", () => {
-  it("defaults to OpenAI and accepts Groq", () => {
+  it("defaults to OpenAI and accepts Codex or Groq", () => {
     const settings = decodeClientSettings({});
 
     expect(settings.voiceTranscriptionProvider).toBe("openai");
     expect(settings.voiceTranscriptionModel).toBe("");
+    expect(
+      decodeClientSettingsPatch({ voiceTranscriptionProvider: "codex" })
+        .voiceTranscriptionProvider,
+    ).toBe("codex");
     expect(
       decodeClientSettingsPatch({ voiceTranscriptionProvider: "groq" }).voiceTranscriptionProvider,
     ).toBe("groq");

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -62,7 +62,7 @@ export const EnvironmentIdentificationMode = Schema.Literals(["artwork", "pill",
 export type EnvironmentIdentificationMode = typeof EnvironmentIdentificationMode.Type;
 export const DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE: EnvironmentIdentificationMode = "artwork";
 
-export const VoiceTranscriptionProvider = Schema.Literals(["openai", "groq"]);
+export const VoiceTranscriptionProvider = Schema.Literals(["codex", "openai", "groq"]);
 export type VoiceTranscriptionProvider = typeof VoiceTranscriptionProvider.Type;
 
 export const ClientSettingsSchema = Schema.Struct({


### PR DESCRIPTION
## Problem

The voice dictation beta in #5213 supports OpenAI and Groq API keys, but users already signed in to Codex with ChatGPT cannot reuse that subscription for transcription.

## What changed

- add `Codex subscription` to the existing transcription provider interface
- resolve the first configured Codex home, including shadow-home layouts, and read its file-based ChatGPT credentials on the server
- send recorded audio to the Codex Desktop transcription endpoint with credentials kept entirely host-side
- show Codex authentication availability in Beta settings without exposing token material to the client
- preserve the existing 25 MB limit, authenticated server route, recording flow, and OpenAI/Groq adapters
- document that the Codex endpoint is private and experimental

This is intentionally stacked on #5213 so the change stays at its existing transcription seam instead of duplicating the composer, recording, settings, and HTTP work in that PR.

## User impact

Users with file-based Codex ChatGPT credentials can select **Codex subscription** for dictation without configuring a separate speech-to-text API key. A missing or rejected login produces a bounded error and suggests signing in with `codex login`.

## Checks

Focused server, web, and contract tests were added. They were not run on this limited VPS per its workspace instructions; CI should run validation.

## UI

Adds a **Codex subscription** provider option and a host authentication status row in **Settings → Beta features → Voice dictation**. Screenshots are pending because browser/computer-use validation was not authorized for this run.

Built with GPT-5.6 Sol via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Codex subscription as a voice transcription provider
> - Adds `'codex'` as a valid `VoiceTranscriptionProvider`, routed through a new `forwardCodexVoiceTranscription` effect that posts audio to the Codex Desktop transcription endpoint using file-based ChatGPT OAuth credentials from the server.
> - Reads credentials via a new `resolveCodexVoiceCredentials` effect that locates the Codex provider config, reads `auth.json`, and extracts `access_token` and `account_id`.
> - Exposes a `codexTranscriptionAuthStatus` boolean on `GET /api/transcription` and surfaces it in the settings UI, which shows a server-side auth status row instead of API key/model inputs when Codex is selected.
> - Model listing returns an empty list for Codex; no API key or model is sent in transcription requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6ddfeec. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->