### PR TITLE
feat(web): add Poimandres as a built-in Appearance theme

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -120,6 +120,14 @@
               chrome: "#1d1929",
             },
           },
+          poimandres: {
+            dark: {
+              background: "#1b1e28",
+              foreground: "#a6accd",
+              accent: "#5de4c7",
+              chrome: "#1b1e28",
+            },
+          },
         };
         // Keep the built-in mode list in sync with the runtime so the selected
         // T3 Chat palette is visible before React has mounted.
@@ -138,6 +146,7 @@
           "ocean",
           "ember",
           "iris",
+          "poimandres",
           "t3-chat-dark",
           "t3-grove",
           "t3-ocean",
@@ -232,7 +241,13 @@
             themeModes !== null;
           const theme = isKnownTheme && storedTheme ? storedTheme : "system";
           const isThemed = isKnownTheme && themeModes !== null;
-          const baseAppearance = customTheme ? customTheme.appearance : "light";
+          // Dual-mode built-ins are light-based; a single-mode built-in uses
+          // that mode as its base (mirrors ThemeDefinition.appearance).
+          const baseAppearance = customTheme
+            ? customTheme.appearance
+            : builtInModes?.length === 1
+              ? builtInModes[0]
+              : "light";
           const systemMode = prefersDark ? "dark" : "light";
           const storedAppearanceMode = window.localStorage.getItem(
             THEME_APPEARANCE_MODE_STORAGE_KEY,

--- a/apps/web/src/components/settings/ThemeSettings.tsx
+++ b/apps/web/src/components/settings/ThemeSettings.tsx
@@ -21,6 +21,7 @@ import {
   GROVE_THEME,
   IRIS_THEME,
   OCEAN_THEME,
+  POIMANDRES_THEME,
 } from "../../themePalette";
 import {
   AlertDialog,
@@ -52,6 +53,7 @@ const MAINTAINER_THEMES: ReadonlyArray<ThemeDefinition> = [
   OCEAN_THEME,
   EMBER_THEME,
   IRIS_THEME,
+  POIMANDRES_THEME,
 ];
 
 function downloadThemeFile(filename: string, contents: string): void {

--- a/apps/web/src/themeBoot.test.ts
+++ b/apps/web/src/themeBoot.test.ts
@@ -13,6 +13,7 @@ import {
   GROVE_THEME,
   IRIS_THEME,
   OCEAN_THEME,
+  POIMANDRES_THEME,
   THEME_APPEARANCE_MODE_STORAGE_KEY,
   THEME_FOLLOW_SYSTEM_STORAGE_KEY,
 } from "./themePalette";
@@ -184,6 +185,11 @@ describe("index.html boot script", () => {
       prefersDark: true,
     },
     {
+      name: "Poimandres stays dark on a light OS",
+      storage: { [THEME_STORAGE_KEY]: "poimandres", [THEME_FOLLOW_SYSTEM_STORAGE_KEY]: "true" },
+      prefersDark: false,
+    },
+    {
       name: "a legacy t3-grove preference resolves through the alias",
       storage: { [THEME_STORAGE_KEY]: "t3-grove", [THEME_FOLLOW_SYSTEM_STORAGE_KEY]: "true" },
       prefersDark: true,
@@ -280,7 +286,7 @@ describe("index.html boot script", () => {
   // palette change breaks this test until the copy in index.html is updated.
   it("keeps every built-in boot splash in sync with the real palettes", () => {
     for (const theme of [T3_CHAT_THEME, GROVE_THEME, OCEAN_THEME, EMBER_THEME, IRIS_THEME]) {
-      // The boot script resolves every built-in from a light base appearance.
+      // The boot script resolves every dual-mode built-in from a light base appearance.
       expect(theme.appearance).toBe("light");
       for (const mode of ["light", "dark"] as const) {
         const colors = getThemeColorsForMode(theme, mode);
@@ -300,6 +306,25 @@ describe("index.html boot script", () => {
         expect(boot.backgroundColor).toBe(colors!.chrome);
         expect(boot.metaContent).toBe(colors!.chrome);
       }
+    }
+
+    expect(POIMANDRES_THEME.appearance).toBe("dark");
+    const poimandresColors = getThemeColorsForMode(POIMANDRES_THEME, "dark")!;
+    for (const appearanceMode of ["light", "dark", "system"] as const) {
+      const boot = runBootScript({
+        storage: {
+          [THEME_STORAGE_KEY]: POIMANDRES_THEME.id,
+          [THEME_APPEARANCE_MODE_STORAGE_KEY]: appearanceMode,
+        },
+        prefersDark: false,
+      });
+      expect(boot.themeId).toBe(POIMANDRES_THEME.id);
+      expect(boot.isDark).toBe(true);
+      expect(boot.bootVariables["--boot-background"]).toBe(poimandresColors.canvas);
+      expect(boot.bootVariables["--boot-foreground"]).toBe(poimandresColors.text);
+      expect(boot.bootVariables["--boot-accent"]).toBe(poimandresColors.accent);
+      expect(boot.backgroundColor).toBe(poimandresColors.chrome);
+      expect(boot.metaContent).toBe(poimandresColors.chrome);
     }
   });
 

--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -25,6 +25,7 @@ import {
   GROVE_THEME,
   IRIS_THEME,
   OCEAN_THEME,
+  POIMANDRES_THEME,
   updateCustomTheme,
   CUSTOM_THEMES_STORAGE_KEY,
   createManagedThemeColors,
@@ -354,6 +355,21 @@ describe("theme files", () => {
         ).toBeGreaterThanOrEqual(theme === T3_CHAT_THEME ? 3 : 4.5);
       }
     }
+  });
+
+  it("includes the dark-only Poimandres maintainer theme", () => {
+    expect(getThemeDefinition(POIMANDRES_THEME.id)).toBe(POIMANDRES_THEME);
+    expect(getThemeModes(POIMANDRES_THEME)).toEqual(["dark"]);
+    expect(getThemeColorsForMode(POIMANDRES_THEME, "light")).toBeNull();
+
+    const colors = getThemeColorsForMode(POIMANDRES_THEME, "dark")!;
+    expect(colors.canvas).toBe("#1b1e28");
+    expect(colors.accent).toBe("#5de4c7");
+    expect(contrastRatio(colors.text, colors.canvas)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.accentForeground, colors.accent)).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrastRatio(colors.messageActionForeground, colors.messageAction),
+    ).toBeGreaterThanOrEqual(4.5);
   });
 
   it("rejects a variant that repeats the base appearance", () => {

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -10,6 +10,8 @@ export const EMBER_THEME_ID = "ember" as const;
 export const EMBER_THEME_LABEL = "Ember";
 export const IRIS_THEME_ID = "iris" as const;
 export const IRIS_THEME_LABEL = "Iris";
+export const POIMANDRES_THEME_ID = "poimandres" as const;
+export const POIMANDRES_THEME_LABEL = "Poimandres";
 export const THEME_FILE_VERSION = 1 as const;
 export const CUSTOM_THEMES_STORAGE_KEY = "t3code:themes:v1";
 export const THEME_FOLLOW_SYSTEM_STORAGE_KEY = "t3code:theme-follow-system";
@@ -122,6 +124,7 @@ const RESERVED_THEME_IDS = new Set([
   OCEAN_THEME_ID,
   EMBER_THEME_ID,
   IRIS_THEME_ID,
+  POIMANDRES_THEME_ID,
   LEGACY_T3_CHAT_DARK_THEME_ID,
   "t3-grove",
   "t3-ocean",
@@ -1384,12 +1387,79 @@ export const IRIS_THEME: ThemeDefinition = {
   },
 };
 
+/** Dark-only port of pmndrs/poimandres (https://github.com/gsimone/poimandres-t3code). */
+export const POIMANDRES_THEME: ThemeDefinition = {
+  id: POIMANDRES_THEME_ID,
+  label: POIMANDRES_THEME_LABEL,
+  appearance: "dark",
+  colors: {
+    canvas: "#1b1e28",
+    chrome: "#1b1e28",
+    toolbar: "#1b1e28",
+    toolbarForeground: "#a6accd",
+    toolbarBorder: "#161820",
+    toolbarControl: "#262934",
+    toolbarControlForeground: "#e4f0fb",
+    toolbarControlHover: "#303340",
+    surface: "#21242f",
+    surfaceRaised: "#262934",
+    surfaceOverlay: "#2b2e3a",
+    text: "#a6accd",
+    textMuted: "#767c9d",
+    border: "#262934",
+    input: "#292c35",
+    focus: "#5de4c7",
+    accent: "#5de4c7",
+    accentForeground: "#1b1e28",
+    secondary: "#303340",
+    secondaryForeground: "#e4f0fb",
+    muted: "#21242f",
+    mutedForeground: "#767c9d",
+    placeholder: "#767c9d",
+    secondaryLabel: "#767c9d",
+    iconMuted: "#767c9d",
+    error: "#d0679d",
+    errorForeground: "#f087bd",
+    errorSurface: "#36293a",
+    warning: "#fffac2",
+    warningForeground: "#fffac2",
+    warningSurface: "#33301f",
+    update: "#89ddff",
+    updateForeground: "#89ddff",
+    updateSurface: "#253647",
+    accentSurface: "#303340",
+    accentSurfaceForeground: "#e4f0fb",
+    messageSurface: "#21242f",
+    messageForeground: "#a6accd",
+    messageAction: "#5de4c7",
+    messageActionForeground: "#1b1e28",
+    messageActionHover: "#5ecbb4",
+    codeBackground: "#12151b",
+    codeForeground: "#a6accd",
+    sidebar: "#1b1e28",
+    sidebarForeground: "#a6accd",
+    sidebarMutedForeground: "#767c9d",
+    sidebarControlSurface: "#21242f",
+    sidebarRowHover: "#20232e",
+    sidebarRowActive: "#232631",
+    sidebarRowSelected: "#2b2e3a",
+    sidebarBorder: "#161820",
+    terminalBackground: "#1b1e28",
+    terminalForeground: "#a6accd",
+    terminalCursor: "#5de4c7",
+    terminalSelection: "#30354b",
+    terminalScrollbar: "#262934",
+    terminalScrollbarHover: "#303340",
+  },
+};
+
 const BUILT_IN_THEME_DEFINITIONS: ReadonlyArray<ThemeDefinition> = [
   T3_CHAT_THEME,
   GROVE_THEME,
   OCEAN_THEME,
   EMBER_THEME,
   IRIS_THEME,
+  POIMANDRES_THEME,
 ];
 
 export function getThemeDefinition(theme: ThemePreference): ThemeDefinition | null {


### PR DESCRIPTION
## Summary
- Adds **Poimandres** as a dark-only built-in theme in Settings → Appearance (from [gsimone/poimandres-t3code](https://github.com/gsimone/poimandres-t3code))
- Keeps the boot splash palette in sync, including single-mode built-in appearance handling
- Covers the new theme in palette/boot tests

## Test plan
- [ ] Open Settings → Appearance and confirm Poimandres appears with the other maintainer themes
- [ ] Select Poimandres and verify canvas `#1b1e28` / accent `#5de4c7`
- [ ] Confirm it stays dark when the OS/appearance mode is light
- [ ] Reload and confirm no wrong-color flash before React mounts


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Poimandres as a built-in dark-only appearance theme
> - Adds a new `poimandres` built-in theme to [themePalette.ts](https://github.com/pingdotgg/t3code/pull/5650/files#diff-064fba647ceaa3b988839d538985299275f3a7ab7bd18e98ad03158fa06d31ad) with a full dark-only color map (canvas, chrome, text, accent, terminal, sidebar) and reserves the ID from custom theme use.
> - Adds the theme to the settings UI via `MAINTAINER_THEMES` in [ThemeSettings.tsx](https://github.com/pingdotgg/t3code/pull/5650/files#diff-4cc84a2ea71f7b5fef270e04a72f0110c8530ee83377e432642907950560b408).
> - Behavioral Change: the boot script in [index.html](https://github.com/pingdotgg/t3code/pull/5650/files#diff-6954645055c39fbf3050b489306101f727465101a1172683088448035dc8463f) now uses a single-mode built-in's sole mode as the base appearance, so dark-only themes like Poimandres render correctly (dark splash/meta theme-color) even on a light OS. Previously all built-ins defaulted to a light base.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 54877e5. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->