### PR TITLE
feat(mobile): unarchive from the archived-thread row menu

### DIFF
--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -387,6 +387,13 @@ function ProjectGroupLabel(props: {
   );
 }
 
+// Long-press menu for archived rows, mirroring the active list's row menu so
+// Unarchive/Delete are reachable without discovering the swipe gesture.
+const ARCHIVED_ROW_MENU_ACTIONS: MenuAction[] = [
+  { id: "unarchive", title: "Unarchive", image: "arrow.uturn.backward" },
+  { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
+];
+
 function ArchivedThreadRow(props: {
   readonly environmentLabel: string | null;
   readonly isFirst: boolean;
@@ -400,7 +407,15 @@ function ArchivedThreadRow(props: {
   readonly onUnarchive: () => void;
   readonly thread: EnvironmentThreadShell;
 }) {
+  const { onDelete, onUnarchive } = props;
   const { width: windowWidth } = useWindowDimensions();
+  const handleMenuAction = useCallback(
+    ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
+      if (nativeEvent.event === "unarchive") onUnarchive();
+      if (nativeEvent.event === "delete") onDelete();
+    },
+    [onDelete, onUnarchive],
+  );
   const cardColor = useThemeColor("--color-card");
   const iconColor = useThemeColor("--color-icon-subtle");
   const separatorColor = useThemeColor("--color-separator");
@@ -434,47 +449,62 @@ function ArchivedThreadRow(props: {
       threadTitle={props.thread.title}
     >
       {() => (
-        <View
-          className="flex-row items-center gap-3 bg-card px-4 py-3"
-          style={{
-            borderBottomColor: separatorColor,
-            borderBottomWidth: props.isLast ? 0 : 1,
-          }}
+        // Messages-style long-press menu, matching the active list's rows:
+        // iOS gets a native UIContextMenuInteraction, Android the token-styled
+        // dropdown (ControlPillMenu injects onLongPress into the child, so the
+        // row must be a Pressable). Swipe actions are untouched.
+        <ControlPillMenu
+          actions={ARCHIVED_ROW_MENU_ACTIONS}
+          onPressAction={handleMenuAction}
+          shouldOpenOnLongPress
         >
-          <View className="h-[34px] w-[34px] items-center justify-center rounded-[11px] bg-subtle">
-            <SymbolView name="archivebox.fill" size={15} tintColor={iconColor} type="monochrome" />
-          </View>
-
-          <View className="min-w-0 flex-1 gap-1">
-            <View className="flex-row items-center gap-2">
-              <Text
-                className="min-w-0 flex-1 text-base font-t3-bold leading-snug text-foreground"
-                numberOfLines={1}
-              >
-                {props.thread.title}
-              </Text>
-              <Text className="min-w-[30px] text-right text-xs tabular-nums text-foreground-tertiary">
-                {timestamp}
-              </Text>
+          <Pressable
+            className="flex-row items-center gap-3 bg-card px-4 py-3"
+            style={{
+              borderBottomColor: separatorColor,
+              borderBottomWidth: props.isLast ? 0 : 1,
+            }}
+          >
+            <View className="h-[34px] w-[34px] items-center justify-center rounded-[11px] bg-subtle">
+              <SymbolView
+                name="archivebox.fill"
+                size={15}
+                tintColor={iconColor}
+                type="monochrome"
+              />
             </View>
-            {subtitle.length > 0 ? (
-              <View className="flex-row items-center gap-1.5">
-                <SymbolView
-                  name="arrow.triangle.branch"
-                  size={10}
-                  tintColor={iconColor}
-                  type="monochrome"
-                />
+
+            <View className="min-w-0 flex-1 gap-1">
+              <View className="flex-row items-center gap-2">
                 <Text
-                  className="min-w-0 flex-1 font-mono text-2xs text-foreground-tertiary"
+                  className="min-w-0 flex-1 text-base font-t3-bold leading-snug text-foreground"
                   numberOfLines={1}
                 >
-                  {subtitle.join(" · ")}
+                  {props.thread.title}
+                </Text>
+                <Text className="min-w-[30px] text-right text-xs tabular-nums text-foreground-tertiary">
+                  {timestamp}
                 </Text>
               </View>
-            ) : null}
-          </View>
-        </View>
+              {subtitle.length > 0 ? (
+                <View className="flex-row items-center gap-1.5">
+                  <SymbolView
+                    name="arrow.triangle.branch"
+                    size={10}
+                    tintColor={iconColor}
+                    type="monochrome"
+                  />
+                  <Text
+                    className="min-w-0 flex-1 font-mono text-2xs text-foreground-tertiary"
+                    numberOfLines={1}
+                  >
+                    {subtitle.join(" · ")}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+          </Pressable>
+        </ControlPillMenu>
       )}
     </ThreadSwipeable>
   );


### PR DESCRIPTION
## What changed

Archived-thread rows previously exposed **Unarchive** / **Delete** only via a left swipe. This gives them the same **long-press context menu** the active thread rows already have, so both actions are discoverable without knowing the swipe gesture.

## Why

The archive screen's only affordance for restoring or deleting a thread was a swipe, which isn't discoverable. Active thread rows have long offered a long-press menu; this brings archived rows to parity.

## How

- Add `ARCHIVED_ROW_MENU_ACTIONS` (`[Unarchive, Delete]`) and wire it through the shared `ControlPillMenu` with `shouldOpenOnLongPress`, reusing the row's existing `onUnarchive` / `onDelete` handlers.
- The row content becomes a `Pressable` so `ControlPillMenu`'s `onLongPress` injection works on Android (iOS hosts the native context menu directly). The existing swipe actions are unchanged.

No server, contract, or shared-runtime changes.

## Scope

Split out per request. Sibling PRs: **Rename** (#5648) and **Regenerate title**.

## Testing

- `tsc --noEmit`, `vp fmt --check`, `vp lint`: clean
- Mobile unit suite: **617 tests / 99 files pass**

## Screenshots

No Android device/emulator available here for before/after images (per `CONTRIBUTING.md`) — happy to add. The change adds a long-press menu (Unarchive / Delete) to rows on the Archived screen; the diff is mostly reindentation from the added wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only UI parity in the archive list; no API or data-layer changes, and delete/unarchive still use existing callbacks.
> 
> **Overview**
> Archived threads on **ArchivedThreadsScreen** now match active list rows: **long-press** opens **Unarchive** and **Delete** via `ControlPillMenu` with `shouldOpenOnLongPress`, reusing the same handlers as swipe actions.
> 
> Row content is wrapped in a **`Pressable`** so Android can receive the menu’s injected `onLongPress`; **left-swipe** unarchive/delete behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49846abfc1482f592bdbcacf7848a321d413961a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unarchive option to archived thread row long-press context menu
> Wraps `ArchivedThreadRow` in a `ControlPillMenu` that appears on long-press, offering 'Unarchive' and 'Delete' actions. Selecting an action invokes the existing `onUnarchive` or `onDelete` handlers. Regular tap behavior and swipe actions are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49846ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->