### PR TITLE
fix(mobile): stop Android user bubbles with code blocks from overlapping

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -49,6 +49,7 @@ import Animated, { FadeIn, FadeInUp, type SharedValue } from "react-native-reani
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useFontFamily } from "../../lib/useFontFamily";
 import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
+import { hasWideMarkdownBlock } from "../../lib/wideMarkdownBlocks";
 import {
   hasNativeSelectableMarkdownText,
   SelectableMarkdownText,
@@ -876,6 +877,12 @@ function renderFeedEntry(
     const timestampLabel = formatMessageTime(isUser ? message.createdAt : message.updatedAt);
     const attachments = message.attachments ?? [];
     const hasReviewCommentContext = message.text.includes("<review_comment");
+    // A bubble that sizes itself from its content cannot lay out a block whose
+    // intrinsic width overflows `maxWidth`: Android positions the bubble's
+    // children during the unclamped pass and never moves them once the width
+    // is clamped, so the paragraphs around the block end up drawn on top of
+    // each other. Pinning the width removes that pass.
+    const hasWideBlock = hasWideMarkdownBlock(message.text);
     const assistantTurnStillInProgress =
       message.role === "assistant" &&
       props.unsettledTurnId !== null &&
@@ -898,7 +905,11 @@ function renderFeedEntry(
             style={{
               backgroundColor: userBubbleColor,
               maxWidth: props.userBubbleMaxWidth,
-              ...(hasReviewCommentContext ? { width: props.reviewCommentBubbleWidth } : null),
+              ...(hasReviewCommentContext
+                ? { width: props.reviewCommentBubbleWidth }
+                : hasWideBlock
+                  ? { width: props.userBubbleMaxWidth }
+                  : null),
             }}
           >
             {message.text.trim().length > 0 ? (

--- a/apps/mobile/src/lib/wideMarkdownBlocks.test.ts
+++ b/apps/mobile/src/lib/wideMarkdownBlocks.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { hasWideMarkdownBlock } from "./wideMarkdownBlocks";
+
+describe("hasWideMarkdownBlock", () => {
+  it("ignores prose, inline code, and emphasis", () => {
+    expect(hasWideMarkdownBlock("just a message")).toBe(false);
+    expect(hasWideMarkdownBlock("I found it in `secteurs_intervention` earlier")).toBe(false);
+    expect(hasWideMarkdownBlock("a | b in a sentence")).toBe(false);
+    expect(hasWideMarkdownBlock("an em dash — and a rule\n\n---\n")).toBe(false);
+  });
+
+  it("detects fenced code blocks", () => {
+    expect(hasWideMarkdownBlock("before\n```\ncode\n```\nafter")).toBe(true);
+    expect(hasWideMarkdownBlock("before\n```ts\ncode\n```")).toBe(true);
+    expect(hasWideMarkdownBlock("before\n~~~\ncode\n~~~")).toBe(true);
+    expect(hasWideMarkdownBlock("   ```\ncode\n```")).toBe(true);
+  });
+
+  it("detects GFM tables", () => {
+    expect(hasWideMarkdownBlock("| a | b |\n| --- | --- |\n| 1 | 2 |")).toBe(true);
+    expect(hasWideMarkdownBlock("a | b\n:-- | --:\n1 | 2")).toBe(true);
+  });
+});

--- a/apps/mobile/src/lib/wideMarkdownBlocks.ts
+++ b/apps/mobile/src/lib/wideMarkdownBlocks.ts
@@ -1,0 +1,38 @@
+/**
+ * Detects markdown that the JS renderer draws as a standalone block View
+ * wrapping a horizontal ScrollView — fenced code blocks and GFM tables.
+ *
+ * Those blocks report an intrinsic width equal to their widest line, which is
+ * effectively unbounded. A user bubble sizes itself from its content
+ * (`maxWidth` with no `width`), so Android lays the bubble's children out
+ * during the unclamped intrinsic pass — where the surrounding paragraphs
+ * collapse to a single line — and never repositions them once the width is
+ * clamped back to `maxWidth`. The result is siblings drawn on top of each
+ * other inside an over-tall bubble. Pinning the bubble's width removes the
+ * intrinsic pass entirely, which is the same reason review-comment bubbles
+ * already carry an explicit width.
+ *
+ * Indented (four-space) code blocks are deliberately not detected: they are
+ * vanishingly rare in chat input and the check would fire on ordinary nested
+ * list continuations.
+ */
+
+const FENCED_CODE_BLOCK = /^ {0,3}(?:```|~~~)/m;
+
+function isTableDelimiterRow(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.includes("|") || !trimmed.includes("-")) {
+    return false;
+  }
+  return /^[|\-: \t]+$/.test(trimmed);
+}
+
+export function hasWideMarkdownBlock(text: string): boolean {
+  if (FENCED_CODE_BLOCK.test(text)) {
+    return true;
+  }
+  if (!text.includes("|")) {
+    return false;
+  }
+  return text.split("\n").some(isTableDelimiterRow);
+}


### PR DESCRIPTION
## The bug

On Android, a user message that contains a fenced code block renders its paragraphs stacked on top of one another inside a hugely over-tall bubble, and the overflow paints over the rows that follow it in the feed. It is fully deterministic — scrolling away and back reproduces it at the same message.

Reproduced on the current Play Store release (1.0.2, versionCode 14) on a Pixel 8 / Android 16, and again from a clean checkout of `main`.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Brechard/t3code/pr-assets/android-bubble-overlap/before.png" width="330"> | <img src="https://raw.githubusercontent.com/Brechard/t3code/pr-assets/android-bubble-overlap/after.png" width="330"> |

Same seeded thread, same entry point, Pixel 8 / Android 16. A user message containing a fenced TypeScript block: before, the paragraphs are drawn on top of each other, the code block sits over the opening paragraph, and the trailing prose overflows the bubble and paints over the assistant reply below. After, the blocks are laid out in order and nothing overlaps.

## Root cause

The user bubble sizes itself from its content — `maxWidth: userBubbleMaxWidth` with no `width` (`ThreadFeed.tsx`). `MarkdownCodeBlock` wraps its body in a horizontal `ScrollView`, so its intrinsic width is the width of its widest line, which is effectively unbounded. That forces the bubble's width to be clamped.

Android lays the bubble's children out during the *unclamped* intrinsic pass — where the surrounding paragraphs collapse to a single line — and never repositions them once the width is clamped back to `maxWidth`.

Actual view bounds from `uiautomator dump` on the broken bubble:

```
ViewGroup [191,1570][1038,2400]   <- bubble
  TextView [223,1593][1005,2205]  <- paragraph, 612px tall
  ViewGroup [223,1621][1005,2400] <- code block, placed 28px below the paragraph's TOP
```

The paragraph is laid out 612px tall, but its next sibling starts 28px after the paragraph's top — a 584px overlap. The bubble still reserves the full stacked height, which is the large empty region.

An **assistant** message with the identical code block renders correctly, because assistant rows are full width and never hit the clamp:

```
TextView  [51,487][1028,691]    paragraph
ViewGroup [51,745][1029,1011]   code block   <- starts after the paragraph
TextView  [51,1037][1028,1173]  next paragraph
```

iOS is unaffected: `hasNativeSelectableMarkdownText()` is `true` there, so markdown goes through the native `T3SelectableMarkdownText` view and there are no nested block children to mis-position. Android has no `.android.tsx` variant, so it falls back to the JS `react-native-nitro-markdown` renderer.

## The fix

Pin the bubble's width when the message contains a block that renders as a horizontally scrollable View. This removes the intrinsic-width pass entirely, and is the same reason review-comment bubbles already carry an explicit `width`. The resulting width matches what the clamp would have produced, so nothing looks different other than being laid out correctly.

Covers fenced code blocks and GFM tables (same renderer shape). Bubbles without such a block are untouched and still hug their content.

## Verification

A/B on a physical Pixel 8 against a disposable seeded environment with four message shapes:

| Message | Before | After |
| --- | --- | --- |
| Plain prose (control) | correct | correct, still hugs content |
| User + fenced code block | **broken** | correct |
| User + narrow table | correct | correct |
| Assistant + code block (control) | correct | correct |

After the fix, child bounds are strictly sequential (paragraph → code block `298..614` → trailing paragraph `641..981`).

Also verified on a real, long production thread where the bug was originally reported: the previously broken message now renders correctly, as do the rows around it.

`vp lint`, `tsc --noEmit`, and the mobile suite (618 tests) pass. The helper ships with unit tests.

## Known limits

- The narrow-table case never actually broke at that width, so table detection is preventive — same mechanism, just untriggered until the table is wider than the bubble.
- Indented (four-space) code blocks are deliberately not detected; the check would fire on ordinary nested list continuations, and they are vanishingly rare in chat input.
- iOS was not rebuilt. The change is very likely a no-op there (the native view almost certainly already reports a wide intrinsic size, so those bubbles sit at max width already), but I did not confirm it on a simulator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow mobile UI/layout change with unit-tested detection; no auth, data, or API impact.
> 
> **Overview**
> Fixes **Android** layout where user messages with fenced code blocks (or wide GFM tables) stacked paragraphs on top of each other inside an over-tall bubble.
> 
> Adds **`hasWideMarkdownBlock`** to detect fenced code and GFM table delimiter rows (not inline code or prose with `|`). In **`ThreadFeed`**, when a user message contains such content, the bubble gets an explicit **`width: userBubbleMaxWidth`**—the same approach already used for review-comment bubbles—so Android skips the broken intrinsic-width layout pass. Plain prose bubbles still size from content only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b44d8448065f83e653ec8bfe8f481051fd38696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android user message bubbles with code blocks or tables overlapping
> On Android, user message bubbles containing fenced code blocks or GFM tables were sizing intrinsically, causing paragraph layout to overlap. The fix introduces [`hasWideMarkdownBlock`](https://github.com/pingdotgg/t3code/pull/5659/files#diff-9aff26e3a6e595c30414365d8b3df55c671704b0aa46f2d105b41a0a249143e3), which detects fenced code blocks (``` or `~~~`) and GFM table delimiter rows via regex, then applies a fixed `userBubbleMaxWidth` to affected bubbles in [`ThreadFeed.tsx`](https://github.com/pingdotgg/t3code/pull/5659/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b44d84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
