### PR TITLE
fix(ios): preserve project picker scroll during refresh

### DIFF
--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -271,6 +271,15 @@ enum DailyUXProjectGrouping {
         groups.first { $0.memberProjectIDs.contains(projectID) }
     }
 
+    static func selectionTarget(
+        groupID: String,
+        preferredEnvironmentID: String?,
+        in groups: [DailyUXProjectGroup]
+    ) -> FeatureProject? {
+        groups.first { $0.id == groupID }?
+            .preferredProject(environmentID: preferredEnvironmentID)
+    }
+
     private static func physicalKey(_ project: FeatureProject) -> String {
         "\(project.environmentID):\(normalizedPath(project.path))"
     }

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -938,6 +938,7 @@ private struct NewTaskProjectPicker: View {
                                 }
                             }
                             .frame(minHeight: 34)
+                            .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
                         .accessibilityAddTraits(

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -22,7 +22,7 @@ public struct NewThreadView: View {
     @State private var startFromOrigin = true
     @State private var branchesLoading = false
     @State private var branchLoadFailed = false
-    @State private var showingBranchPicker = false
+    @State private var activePicker: NewTaskPicker?
     @State private var isSubmitting = false
     @State private var submissionFailed = false
     @State private var restoredDraftProjectID: String?
@@ -126,19 +126,32 @@ public struct NewThreadView: View {
             guard !submittedSuccessfully else { return }
             persistCurrentDraftImmediately()
         }
-        .sheet(isPresented: $showingBranchPicker) {
-            NewTaskBranchPicker(
-                branches: branches,
-                selection: selectedBranch,
-                isLoading: branchesLoading,
-                loadFailed: branchLoadFailed,
-                onSelect: { branch in
-                    workspaceSelectionIsExplicit = true
-                    selectedBranch = branch
-                    showingBranchPicker = false
-                },
-                onRefresh: { Task { await loadBranches(refresh: true) } }
-            )
+        .sheet(item: $activePicker) { picker in
+            switch picker {
+            case .project:
+                NewTaskProjectPicker(
+                    groups: creationProjectGroups,
+                    selectionID: selectedProjectGroup?.id,
+                    onSelect: { group in
+                        if selectProjectGroup(group) {
+                            activePicker = nil
+                        }
+                    }
+                )
+            case .branch:
+                NewTaskBranchPicker(
+                    branches: branches,
+                    selection: selectedBranch,
+                    isLoading: branchesLoading,
+                    loadFailed: branchLoadFailed,
+                    onSelect: { branch in
+                        workspaceSelectionIsExplicit = true
+                        selectedBranch = branch
+                        activePicker = nil
+                    },
+                    onRefresh: { Task { await loadBranches(refresh: true) } }
+                )
+            }
         }
         .alert("Couldn’t start task", isPresented: $submissionFailed) {
             Button("OK") {}
@@ -167,18 +180,8 @@ public struct NewThreadView: View {
             Text("What should we build")
             HStack(spacing: 0) {
                 Text("in")
-                Menu {
-                    ForEach(creationProjectGroups) { group in
-                        Button {
-                            selectProjectGroup(group)
-                        } label: {
-                            if group.id == selectedProjectGroup?.id {
-                                Label(group.name, systemImage: "checkmark")
-                            } else {
-                                Text(group.name)
-                            }
-                        }
-                    }
+                Button {
+                    activePicker = .project
                 } label: {
                     Text(selectedProjectGroup?.name ?? selectedProject?.name ?? "a project")
                         .foregroundStyle(T3Colors.textPrimary)
@@ -195,6 +198,10 @@ public struct NewThreadView: View {
                 .buttonStyle(.plain)
                 .disabled(isSubmitting)
                 .padding(.leading, 5)
+                .accessibilityLabel("Choose project")
+                .accessibilityValue(
+                    selectedProjectGroup?.name ?? selectedProject?.name ?? "a project"
+                )
                 Text("?")
             }
         }
@@ -311,7 +318,7 @@ public struct NewThreadView: View {
 
             if workspaceMode == .worktree {
                 Button {
-                    showingBranchPicker = true
+                    activePicker = .branch
                 } label: {
                     workspaceControlLabel(
                         selectedBranch?.name
@@ -550,19 +557,25 @@ public struct NewThreadView: View {
         }
     }
 
-    private func selectProject(_ id: String) {
-        guard id != projectID else { return }
+    @discardableResult
+    private func selectProject(_ id: String) -> Bool {
+        guard id != projectID else { return true }
+        guard creationProjects.contains(where: { $0.id == id }) else { return false }
         persistCurrentDraftImmediately()
         projectID = id
         prepareProjectIfNeeded(id)
+        return true
     }
 
-    private func selectProjectGroup(_ group: DailyUXProjectGroup) {
-        guard group.id != selectedProjectGroup?.id else { return }
-        let target = group.preferredProject(environmentID: selectedProject?.environmentID)
-            ?? group.projects.first
-        guard let target else { return }
-        selectProject(target.id)
+    @discardableResult
+    private func selectProjectGroup(_ group: DailyUXProjectGroup) -> Bool {
+        guard let target = DailyUXProjectGrouping.selectionTarget(
+            groupID: group.id,
+            preferredEnvironmentID: selectedProject?.environmentID,
+            in: creationProjectGroups
+        ) else { return false }
+        guard group.id != selectedProjectGroup?.id else { return true }
+        return selectProject(target.id)
     }
 
     private func selectEnvironment(_ id: String) {
@@ -882,6 +895,71 @@ private struct DottedUnderline: Shape {
         path.move(to: CGPoint(x: rect.minX, y: rect.midY))
         path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
         return path
+    }
+}
+
+private enum NewTaskPicker: String, Identifiable {
+    case project
+    case branch
+
+    var id: String { rawValue }
+}
+
+private struct NewTaskProjectPicker: View {
+    @SwiftUI.Environment(\.dismiss) private var dismiss
+    let groups: [DailyUXProjectGroup]
+    let selectionID: String?
+    let onSelect: (DailyUXProjectGroup) -> Void
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if groups.isEmpty {
+                    ContentUnavailableView(
+                        "No projects available",
+                        systemImage: "folder",
+                        description: Text("Reconnect an environment or add a project to continue.")
+                    )
+                } else {
+                    List(groups) { group in
+                        Button {
+                            onSelect(group)
+                        } label: {
+                            HStack(spacing: 12) {
+                                Text(group.name)
+                                    .foregroundStyle(T3Colors.textPrimary)
+
+                                Spacer(minLength: 10)
+
+                                if group.id == selectionID {
+                                    Image(systemName: "checkmark")
+                                        .font(.system(size: 13, weight: .semibold))
+                                        .foregroundStyle(T3Colors.accent)
+                                }
+                            }
+                            .frame(minHeight: 34)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityAddTraits(
+                            group.id == selectionID ? .isSelected : []
+                        )
+                        .listRowBackground(T3Colors.background)
+                    }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                }
+            }
+            .background(T3Colors.background)
+            .navigationTitle("Project")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationBackground(T3Colors.background)
     }
 }
 

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -267,6 +267,56 @@ struct DailyUXNewTaskTests {
     }
 
     @Test
+    func projectSelectionResolvesAgainstCurrentGroups() throws {
+        let identity = FeatureRepositoryIdentity(
+            canonicalKey: "github.com/t3/example",
+            displayName: "Example"
+        )
+        let staleStudio = FeatureProject(
+            id: "stale-studio",
+            environmentID: "studio",
+            name: "example",
+            path: "/code/example",
+            repositoryIdentity: identity
+        )
+        let currentStudio = FeatureProject(
+            id: "current-studio",
+            environmentID: "studio",
+            name: "example",
+            path: "/code/example",
+            repositoryIdentity: identity
+        )
+        let laptop = FeatureProject(
+            id: "current-laptop",
+            environmentID: "laptop",
+            name: "example",
+            path: "/Users/test/example",
+            repositoryIdentity: identity
+        )
+        let staleGroup = try #require(
+            DailyUXProjectGrouping.groups(projects: [staleStudio]).first
+        )
+        let currentGroups = DailyUXProjectGrouping.groups(
+            projects: [currentStudio, laptop]
+        )
+
+        #expect(
+            DailyUXProjectGrouping.selectionTarget(
+                groupID: staleGroup.id,
+                preferredEnvironmentID: laptop.environmentID,
+                in: currentGroups
+            )?.id == laptop.id
+        )
+        #expect(
+            DailyUXProjectGrouping.selectionTarget(
+                groupID: "removed-project",
+                preferredEnvironmentID: nil,
+                in: currentGroups
+            ) == nil
+        )
+    }
+
+    @Test
     func projectsWithoutRepositoryIdentityNeverGroupAcrossComputers() {
         let studio = FeatureProject(
             id: "studio",


### PR DESCRIPTION
## What Changed

- Replace the New Task project `Menu` with a sheet-backed SwiftUI `List` whose logical row identities survive live refreshes without resetting the picker viewport.
- Re-resolve a tapped group against the latest project snapshot before selecting it, so stale rows cannot choose a vanished project or dismiss the sheet.
- Share one typed sheet route with the existing branch picker, keep environment choice separate, show an empty live-update state, and make each plain-styled project row fully tappable.

## Why

The SwiftUI client continuously receives project snapshots. Rebuilding the old `Menu` while someone was browsing it reset the viewport to the top. A `List` updates stable rows in place, so an incoming project can appear without interrupting the user's position.

This is a focused follow-up to the experimental SwiftUI client in #5178 and targets `t3code/rebuild-mobile-app-swift`, where that client currently lives.

## UI Changes

| Before: live refresh resets the menu | After: live refresh preserves the list position |
| --- | --- |
| ![Before refresh, scrolled](https://raw.githubusercontent.com/saphid/t3code/pr-media/swiftui-project-picker-scroll/bug-before-refresh.jpg) | ![Fixed picker before refresh, anchored at project 10](https://raw.githubusercontent.com/saphid/t3code/pr-media/swiftui-project-picker-scroll/fixed-before-refresh.jpg) |
| ![After refresh, reset to top](https://raw.githubusercontent.com/saphid/t3code/pr-media/swiftui-project-picker-scroll/bug-after-refresh-reset.jpg) | ![After refresh, still anchored at project 10 with project 23 visible](https://raw.githubusercontent.com/saphid/t3code/pr-media/swiftui-project-picker-scroll/fixed-after-refresh.jpg) |

[9-second interaction proof: project 23 arrives while the picker remains anchored (MP4)](https://cdn.jsdelivr.net/gh/saphid/t3code@pr-media/swiftui-project-picker-scroll/preserved-scroll.mp4)

## Validation

- `T3CodeTests/DailyUXNewTaskTests`: 14 passed, 0 failed, 0 skipped on the final reviewed head.
- Debug build, install, and launch passed on iPhone 17 Pro Max, iOS 26.5.
- Integrated live-refresh proof: project 10 remained the visual anchor while project 23 arrived and became visible.
- Integrated final-build interaction: the project sheet opened, selecting project 02 dismissed it, and the composer updated to project 02.
- Controlled branch-picker comparison: branch search, refresh, Cancel, and visible rows matched the untouched stacking base; the same row-tap automation limitation reproduced on both builds.
- Stale rows, empty state, environment preference, and stable identities were rechecked in the focused model test and source audit.
- `git diff --check`: passed.
- Direct Claude Opus 5 High review found one project-row hit-area issue; commit `827aae58e` fixed it. A fresh post-fix review exited 0 with no actionable findings.
- Theo merged the reviewed head as `65e66ee51`; the three PR-owned files are byte-for-byte identical to `827aae58e`, and `git range-diff` shows the hit-area follow-up folded into the squash while the CI repair remains a separate base commit.
- Post-merge stacking-head verification: CI passed, and SwiftUI iOS run [31290353405](https://github.com/pingdotgg/t3code/actions/runs/31290353405) passed fixture verification plus the full native test job.

## Scope

This is one SwiftUI-only bug fix: three files, 208 changed lines, no wire contract, server, web, desktop, or React Native mobile changes. The `size:L` label reflects the extracted sheet view and focused regression test, not additional product scope.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implementation and verification used GPT-5.6 Sol High in T3 Code with the Codex harness. Independent review used Claude Opus 5 High in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused SwiftUI UX and selection-validation changes in the new-thread flow; no auth, networking, or data-model changes beyond grouping helper usage.
> 
> **Overview**
> Replaces the New Task **project** `Menu` with a sheet-backed **`List`** so live project snapshot updates no longer jump scroll position to the top. Project and branch pickers now share a single `activePicker` sheet route (`NewTaskPicker`).
> 
> **`NewTaskProjectPicker`** shows grouped projects with checkmarks, empty state, and accessibility on the hero control; the sheet dismisses only when **`selectProject` / `selectProjectGroup`** succeed (`Bool` return). Group picks resolve via new **`DailyUXProjectGrouping.selectionTarget`** against the **current** groups (handles stale IDs after refresh); tests cover that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 827aae58e20578b6897fc9ddf6360db2b4ae877b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve project picker scroll position during refresh in iOS new thread view
> - Replaces the inline `Menu` for project selection in [`NewThreadView`](https://github.com/pingdotgg/t3code/pull/5660/files#diff-b6ba9c0744007ccd1dd2c30b31fc66ec800d601a0a3153404e3ee2917cda96c5) with a dedicated sheet (`NewTaskProjectPicker`) driven by a new `NewTaskPicker` enum, fixing scroll position loss on refresh.
> - Adds `DailyUXProjectGrouping.selectionTarget` to resolve a project group against the current live groups, so stale or removed group IDs fail gracefully without mutating state.
> - `selectProject` now validates that the provided project ID exists in `creationProjects` before applying changes, returning a `Bool` to indicate success.
> - Behavioral Change: project selection no longer uses a popover menu — it opens a modal sheet with medium/large detents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 827aae5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a project picker that groups projects and indicates the current selection.
  * Added clear empty-state handling when no projects are available.
  * Improved project and branch selection with a consistent picker experience.
  * Added accessibility labels and values to the project selector.

* **Bug Fixes**
  * Project selection now safely handles outdated or removed project groups and selects the appropriate available project when possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->