### PR TITLE
fix(ios): add compact header menu clearance

### DIFF
--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -187,6 +187,8 @@ public struct ThreadDetailView: View {
             .font(T3Typography.navigationMetadata)
             .foregroundStyle(T3Colors.textTertiary)
         }
+        // Leave compact-width clearance for the trailing thread menu.
+        .padding(.trailing, horizontalSizeClass == .compact ? 10 : 0)
         .frame(maxWidth: horizontalSizeClass == .compact ? 260 : 460, alignment: .leading)
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isHeader)


### PR DESCRIPTION
## What Changed

- Add 10 points of trailing clearance to the existing thread header only at compact width.
- Keep the regular-width header and the 44-point thread-actions menu unchanged.

## Why

On a compact iPhone, a long thread title and live status metadata can run visually into the trailing actions menu. The header already owns both rows, so applying the clearance there keeps their leading/trailing alignment together without changing menu behavior or wider layouts.

This remains a two-line layout fix, separate from the live-duration work in #5611 and stacked on #5178.

## UI Changes

| Before | After |
| --- | --- |
| ![Before: long compact header crowds the trailing menu](https://raw.githubusercontent.com/saphid/t3code/0a411f22c/header-spacing/spacing-before.jpg) | ![After: long compact header has menu clearance](https://raw.githubusercontent.com/saphid/t3code/0a411f22c/header-spacing/spacing-after.jpg) |

This is a static spacing change. It does not alter motion, timing, transitions, or interaction, so the navigation-only video was removed.

## Verification

- `git diff --check upstream/t3code/rebuild-mobile-app-swift...HEAD` — exit 0.
- SwiftUI Debug build on iPhone 17e / iOS 26.5 — succeeded.
- Focused `HomeThreadMetadataTests` Simulator run — 5 passed, 0 failed.
- Integrated compact-width pass on iPhone 17e: long title, branch/environment metadata, and live working status remained clear of the menu; the independently exposed “Thread actions” target opened its full menu.
- Integrated regular-width pass on iPad Pro 11-inch / iOS 26.5: existing split-view header layout and 44-point menu target remained unchanged.

## Scope

SwiftUI mobile only. No web, desktop, React Native mobile, provider, contract, connection-mode, or documentation behavior changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included clear before/after screenshots
- [x] Video is not applicable because animation and interaction behavior are unchanged
- [x] The branch contains no unrelated, generated, personal, or private files

PR refresh and Simulator verification used GPT-5.6 Sol in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compact-width thread layouts by adding clearance between the thread header content and its trailing menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SwiftUI layout-only tweak on compact iPhone; no logic, API, or interaction changes.
> 
> **Overview**
> Adds **10pt trailing padding** to the thread navigation header (`threadHeaderTitle`) when `horizontalSizeClass` is **compact**, so long titles and metadata no longer sit under the trailing **Thread actions** menu.
> 
> Regular-width layouts are unchanged (0 padding); the menu’s 44pt tap target and behavior are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca9ced31f4f45bbb234748f4735a98e5e2013c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 10pt trailing padding to compact header menu in `ThreadDetailView`
> Fixes header menu clipping in compact width by adding 10pt of trailing padding when `horizontalSizeClass` is `.compact`. No padding is added in regular width. The fix is applied in [ThreadDetailView.swift](https://github.com/pingdotgg/t3code/pull/5663/files#diff-c987f84bf3746c99e23dc49057c113592bca2c0bce299b9dd80fe73c9495af30) before the existing frame modifier.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fca9ced.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->