### PR TITLE
fix(server): match keybinding rules whose key uses an alias spelling

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -436,6 +436,29 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("replaces a rule whose stored key uses an alias spelling", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "escape", command: "script.run-tests.run" },
+      ]);
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        // The settings UI renders a stored "escape" rule as "esc", so the
+        // replace target arrives spelled differently than it was persisted.
+        return yield* keybindings.upsertKeybindingRule({
+          key: "mod+m",
+          command: "script.run-tests.run",
+          replace: { key: "esc", command: "script.run-tests.run" },
+        });
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedView = persisted.map(({ key, command }) => ({ key, command }));
+      assert.deepEqual(persistedView, [{ key: "mod+m", command: "script.run-tests.run" }]);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("removes only the targeted custom keybinding", () =>
     Effect.gen(function* () {
       const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -101,11 +101,21 @@ export const ResolvedKeybindingsFromConfig = Schema.Array(ResolvedKeybindingFrom
 );
 
 function isSameKeybindingRule(left: KeybindingRule, right: KeybindingRule): boolean {
-  return (
-    left.command === right.command &&
-    left.key === right.key &&
-    (left.when ?? undefined) === (right.when ?? undefined)
-  );
+  if (left.command !== right.command) return false;
+  if ((left.when ?? undefined) !== (right.when ?? undefined)) return false;
+  if (left.key === right.key) return true;
+  // A key can be spelled more than one way ("esc"/"escape", "space"/" "), and
+  // the settings UI renders a stored rule back as the alias. Comparing raw
+  // strings would then fail to match a rule against itself, so replacing that
+  // rule would leave the original behind instead of updating it.
+  const leftKey = canonicalKeybindingKey(left);
+  return leftKey !== null && leftKey === canonicalKeybindingKey(right);
+}
+
+function canonicalKeybindingKey(rule: KeybindingRule): string | null {
+  const parsed = parseKeybindingShortcut(rule.key);
+  if (!parsed) return null;
+  return encodeShortcut(parsed);
 }
 
 function keybindingShortcutContext(rule: KeybindingRule): string | null {


### PR DESCRIPTION
## What changed

Keybinding rule comparison now falls back to comparing the parsed shortcut when two rules spell their key differently.

## Why

A key can be written more than one way. `parseKeybindingShortcut` normalizes `"esc"` → `"escape"` and `"space"` → `" "`, while the settings UI renders a stored shortcut back using the alias:

```ts
// apps/web/src/components/settings/KeybindingsSettings.logic.ts:52
parts.push(shortcut.key === " " ? "space" : shortcut.key === "escape" ? "esc" : shortcut.key);
```

So editing a rule bound to Escape sends a replace target of `"esc"` for a rule persisted as `"escape"`. Comparison used raw string equality:

```ts
// apps/server/src/keybindings.ts
left.command === right.command && left.key === right.key && ...
```

`"esc" !== "escape"`, so the replace target never matches, the original rule survives alongside the new one, and the command ends up bound twice.

No default binding currently uses an aliased key, which is why this has gone unnoticed — every shipped default is a `mod+…` combination whose stored and rendered spellings are identical.

## How to reproduce

Note that the recorder cannot capture bare Escape: it uses Escape to cancel recording (`KeybindingsSettings.tsx:807`), which is the behavior you want. So reaching this state today means writing the rule to disk directly:

1. In `keybindings.json`, bind any command to `escape` (or `space` — the other aliased key).
2. In Settings → Keybindings, edit that row and record a different shortcut.
3. Reopen Settings → Keybindings.

The command now appears twice: once on the original Escape and once on the new shortcut.

This is reachable without hand-editing anything as soon as a *default* binding uses one of those keys — see #5669, which is how I ran into it.

## Test

Added a case that persists a rule as `escape` and replaces it targeting `esc`. It fails on `main` and passes with this change.

before (keybind duplicates after trying to change off of escape): 
<img width="720" height="81" alt="image" src="https://github.com/user-attachments/assets/f6626624-79b0-402f-b66f-f82bb435521f" />

after: (doesnt duplicate as is desired) 
<img width="953" height="132" alt="image" src="https://github.com/user-attachments/assets/81b57e08-cd7c-4b88-984d-dc8f55351ca6" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Regression test that fails without the fix
