### PR TITLE
feat(web): add a rebindable thread.interrupt keybinding

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -436,6 +436,29 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("replaces a rule whose stored key uses an alias spelling", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "escape", command: "script.run-tests.run" },
+      ]);
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        // The settings UI renders a stored "escape" rule as "esc", so the
+        // replace target arrives spelled differently than it was persisted.
+        return yield* keybindings.upsertKeybindingRule({
+          key: "mod+m",
+          command: "script.run-tests.run",
+          replace: { key: "esc", command: "script.run-tests.run" },
+        });
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedView = persisted.map(({ key, command }) => ({ key, command }));
+      assert.deepEqual(persistedView, [{ key: "mod+m", command: "script.run-tests.run" }]);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("removes only the targeted custom keybinding", () =>
     Effect.gen(function* () {
       const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -101,11 +101,21 @@ export const ResolvedKeybindingsFromConfig = Schema.Array(ResolvedKeybindingFrom
 );
 
 function isSameKeybindingRule(left: KeybindingRule, right: KeybindingRule): boolean {
-  return (
-    left.command === right.command &&
-    left.key === right.key &&
-    (left.when ?? undefined) === (right.when ?? undefined)
-  );
+  if (left.command !== right.command) return false;
+  if ((left.when ?? undefined) !== (right.when ?? undefined)) return false;
+  if (left.key === right.key) return true;
+  // A key can be spelled more than one way ("esc"/"escape", "space"/" "), and
+  // the settings UI renders a stored rule back as the alias. Comparing raw
+  // strings would then fail to match a rule against itself, so replacing that
+  // rule would leave the original behind instead of updating it.
+  const leftKey = canonicalKeybindingKey(left);
+  return leftKey !== null && leftKey === canonicalKeybindingKey(right);
+}
+
+function canonicalKeybindingKey(rule: KeybindingRule): string | null {
+  const parsed = parseKeybindingShortcut(rule.key);
+  if (!parsed) return null;
+  return encodeShortcut(parsed);
 }
 
 function keybindingShortcutContext(rule: KeybindingRule): string | null {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -22,6 +22,22 @@ import {
 } from "../lib/terminalContext";
 import type { DraftThreadEnvMode } from "../composerDraftStore";
 
+/**
+ * Matches any open floating layer: dialogs, menus, selects, popovers, and
+ * ad-hoc dialogs that only carry `role="dialog"` (like the expanded image
+ * viewer). Used to suppress global key behavior — type-to-focus and the
+ * thread.interrupt shortcut — while an overlay owns the keyboard.
+ */
+export const OPEN_FLOATING_LAYER_SELECTOR = [
+  '[data-slot="dialog"]',
+  '[data-slot="menu-popup"]',
+  '[data-slot="select-popup"]',
+  '[data-slot="popover-popup"]',
+  '[data-slot="combobox-popup"]',
+  '[data-slot="autocomplete-popup"]',
+  '[role="dialog"]',
+].join(",");
+
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
 export const MAX_HIDDEN_MOUNTED_TERMINAL_THREADS = 10;
 export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4570,7 +4570,17 @@ function ChatViewContent(props: ChatViewProps) {
         modelPickerOpen: composerRef.current?.isModelPickerOpen() ?? false,
       };
 
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: shortcutContext,
+      });
+
+      // Type-to-focus only claims keys that resolve to no binding: a user who
+      // explicitly bound a bare printable key (for example to
+      // thread.interrupt) means the command, and this handler runs in the
+      // capture phase, so consuming the key here would shadow bindings
+      // dispatched by bubble-phase listeners.
       if (
+        !command &&
         !shortcutContext.terminalFocus &&
         !shortcutContext.modelPickerOpen &&
         shouldTypeToFocusComposer(event)
@@ -4582,9 +4592,6 @@ function ChatViewContent(props: ChatViewProps) {
         }
       }
 
-      const command = resolveShortcutCommand(event, keybindings, {
-        context: shortcutContext,
-      });
       if (!command) return;
 
       if (command === "terminal.toggle") {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -293,6 +293,7 @@ import {
   PullRequestDialogState,
   cloneComposerImageForRetry,
   deriveLockedProvider,
+  OPEN_FLOATING_LAYER_SELECTOR,
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
@@ -436,14 +437,7 @@ const TYPE_TO_FOCUS_INTERACTIVE_SELECTOR = [
   '[role="switch"]',
   '[role="tab"]',
 ].join(",");
-const TYPE_TO_FOCUS_FLOATING_LAYER_SELECTOR = [
-  '[data-slot="dialog"]',
-  '[data-slot="menu-popup"]',
-  '[data-slot="select-popup"]',
-  '[data-slot="popover-popup"]',
-  '[data-slot="combobox-popup"]',
-  '[data-slot="autocomplete-popup"]',
-].join(",");
+const TYPE_TO_FOCUS_FLOATING_LAYER_SELECTOR = OPEN_FLOATING_LAYER_SELECTOR;
 
 type EnvironmentUnavailableState = {
   readonly environmentId: EnvironmentId;

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -42,7 +42,11 @@ import {
   shouldInterruptRunningThreadFromKeybinding,
   shouldSubmitComposerOnEnter,
 } from "../../composer-logic";
-import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
+import {
+  deriveComposerSendState,
+  OPEN_FLOATING_LAYER_SELECTOR,
+  readFileAsDataUrl,
+} from "../ChatView.logic";
 import {
   dataTransferHasComposerMention,
   makeComposerMentionDragHandlers,
@@ -2305,10 +2309,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       ) {
         return;
       }
-      // Belt and suspenders for overlays whose dismiss handlers do not mark
-      // the event consumed; the model picker is excluded via the default
-      // binding's when clause.
-      if (isCommandPaletteOpen() || isStashMenuOpen) {
+      // An open floating layer owns the keyboard even when its dismiss
+      // handler has not run yet — window bubble listeners fire in
+      // registration order, so a later-mounted overlay (the expanded image
+      // viewer) marks the event only after this handler has already seen it.
+      // Checking the DOM instead of the event answers "is an overlay open"
+      // regardless of listener ordering; the model picker is excluded via
+      // the default binding's when clause.
+      if (isCommandPaletteOpen() || document.querySelector(OPEN_FLOATING_LAYER_SELECTOR) !== null) {
         return;
       }
       event.preventDefault();
@@ -2316,7 +2324,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [isComposerModelPickerOpen, isStashMenuOpen, keybindings, onInterrupt, phase, terminalOpen]);
+  }, [isComposerModelPickerOpen, keybindings, onInterrupt, phase, terminalOpen]);
 
   // ------------------------------------------------------------------
   // Callbacks: images

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2279,11 +2279,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // Interrupting the running turn is a keybinding rather than a hard-coded key
   // so it shows up in Settings and can be rebound. It only claims the shortcut
   // while a turn is running; otherwise the key falls through untouched.
+  //
+  // Bubble phase, unlike the capture-phase composer.stash listener above:
+  // stash must beat the browser's save dialog, while interrupt must lose to
+  // any open overlay that dismisses on the same key. By the time the event
+  // bubbles to window every overlay handler has run, and a dismiss marks the
+  // event consumed via preventDefault.
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
       // Interrupt is one-shot: key auto-repeat would spray concurrent
       // interrupt requests that race each other for the same turn.
       if (event.repeat) return;
+      // An overlay (dialog, menu, select, command palette) already consumed
+      // this press to dismiss itself.
+      if (event.defaultPrevented) return;
       const command = resolveShortcutCommand(event, keybindings, {
         context: {
           terminalFocus: getTerminalFocusOwner() !== null,
@@ -2296,17 +2305,17 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       ) {
         return;
       }
-      // Overlays that dismiss on the same key keep their dismiss behavior;
-      // the model picker is excluded via the default binding's when clause.
+      // Belt and suspenders for overlays whose dismiss handlers do not mark
+      // the event consumed; the model picker is excluded via the default
+      // binding's when clause.
       if (isCommandPaletteOpen() || isStashMenuOpen) {
         return;
       }
       event.preventDefault();
-      event.stopPropagation();
       onInterrupt();
     };
-    window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
   }, [isComposerModelPickerOpen, isStashMenuOpen, keybindings, onInterrupt, phase, terminalOpen]);
 
   // ------------------------------------------------------------------

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2281,6 +2281,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // while a turn is running; otherwise the key falls through untouched.
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
+      // Interrupt is one-shot: key auto-repeat would spray concurrent
+      // interrupt requests that race each other for the same turn.
+      if (event.repeat) return;
       const command = resolveShortcutCommand(event, keybindings, {
         context: {
           terminalFocus: getTerminalFocusOwner() !== null,
@@ -2293,13 +2296,18 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       ) {
         return;
       }
+      // Overlays that dismiss on the same key keep their dismiss behavior;
+      // the model picker is excluded via the default binding's when clause.
+      if (isCommandPaletteOpen() || isStashMenuOpen) {
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
       onInterrupt();
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [isComposerModelPickerOpen, keybindings, onInterrupt, phase, terminalOpen]);
+  }, [isComposerModelPickerOpen, isStashMenuOpen, keybindings, onInterrupt, phase, terminalOpen]);
 
   // ------------------------------------------------------------------
   // Callbacks: images

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -39,6 +39,7 @@ import {
   detectComposerTrigger,
   expandCollapsedComposerCursor,
   replaceTextRange,
+  shouldInterruptRunningThreadFromKeybinding,
   shouldSubmitComposerOnEnter,
 } from "../../composer-logic";
 import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
@@ -2274,6 +2275,31 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     stashCurrentPrompt,
     terminalOpen,
   ]);
+
+  // Interrupting the running turn is a keybinding rather than a hard-coded key
+  // so it shows up in Settings and can be rebound. It only claims the shortcut
+  // while a turn is running; otherwise the key falls through untouched.
+  useEffect(() => {
+    const handler = (event: globalThis.KeyboardEvent) => {
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: {
+          terminalFocus: getTerminalFocusOwner() !== null,
+          terminalOpen,
+          modelPickerOpen: isComposerModelPickerOpen,
+        },
+      });
+      if (
+        !shouldInterruptRunningThreadFromKeybinding({ command, isRunning: phase === "running" })
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      onInterrupt();
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [isComposerModelPickerOpen, keybindings, onInterrupt, phase, terminalOpen]);
 
   // ------------------------------------------------------------------
   // Callbacks: images

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -8,6 +8,7 @@ import {
   isCollapsedCursorAdjacentToInlineToken,
   parseStandaloneComposerSlashCommand,
   replaceTextRange,
+  shouldInterruptRunningThreadFromKeybinding,
   shouldSubmitComposerOnEnter,
 } from "./composer-logic";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
@@ -24,6 +25,27 @@ describe("shouldSubmitComposerOnEnter", () => {
   it("inserts a newline for Shift+Enter", () => {
     expect(shouldSubmitComposerOnEnter({ isMobileViewport: false, shiftKey: true })).toBe(false);
   });
+});
+
+describe("shouldInterruptRunningThreadFromKeybinding", () => {
+  it("interrupts a running thread", () => {
+    expect(
+      shouldInterruptRunningThreadFromKeybinding({ command: "thread.interrupt", isRunning: true }),
+    ).toBe(true);
+  });
+
+  it("leaves the shortcut alone when the thread is not running", () => {
+    expect(
+      shouldInterruptRunningThreadFromKeybinding({ command: "thread.interrupt", isRunning: false }),
+    ).toBe(false);
+  });
+
+  it.each(["composer.stash", "thread.next", null] as const)(
+    "ignores the unrelated command %s",
+    (command) => {
+      expect(shouldInterruptRunningThreadFromKeybinding({ command, isRunning: true })).toBe(false);
+    },
+  );
 });
 
 describe("detectComposerTrigger", () => {

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -18,6 +18,16 @@ export function shouldSubmitComposerOnEnter(input: {
   return !input.isMobileViewport && !input.shiftKey;
 }
 
+// The interrupt shortcut is only ours while a turn is actually running. When
+// the thread is idle the key stays free for whatever else claims it, so the
+// default Escape binding does not swallow dismiss behavior.
+export function shouldInterruptRunningThreadFromKeybinding(input: {
+  command: string | null;
+  isRunning: boolean;
+}): boolean {
+  return input.command === "thread.interrupt" && input.isRunning;
+}
+
 const isInlineTokenSegment = (
   segment:
     | { type: "text"; text: string }

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -37,6 +37,7 @@ export type ModelPickerJumpKeybindingCommand =
 export const THREAD_KEYBINDING_COMMANDS = [
   "thread.previous",
   "thread.next",
+  "thread.interrupt",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,
 ] as const;
 export type ThreadKeybindingCommand = (typeof THREAD_KEYBINDING_COMMANDS)[number];

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -46,6 +46,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "escape", command: "thread.interrupt", when: "!terminalFocus" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -46,7 +46,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
-  { key: "escape", command: "thread.interrupt", when: "!terminalFocus" },
+  { key: "escape", command: "thread.interrupt", when: "!terminalFocus && !modelPickerOpen" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,


### PR DESCRIPTION
Closes #5667. Stacked on #5668 — rebinding the default Escape shortcut duplicates the rule without that fix, so this branch contains that commit too. Reviewing #5668 first leaves this diff at just the feature (5 files, +60).

## What changed

`thread.interrupt` is registered as a keybinding command, defaulting to Escape. It appears in Settings → Keybindings as "Thread: Interrupt" and can be rebound like any other shortcut.

## Why

Stopping a running turn required clicking the square stop button — there was no keyboard path, and no command to bind. Codex and Claude Code both stop on Escape, so the reflex already exists.

#4298 did this as a hard-coded Escape in the composer and was closed. This registers a command instead, so the key is configurable rather than baked in.

## Behavior

- The shortcut is only claimed while a turn is running. When the thread is idle the key falls through untouched, so Escape keeps its existing behavior everywhere else.
- The default is scoped to `!terminalFocus`, so Escape still reaches the terminal.
- The decision is a pure function (`shouldInterruptRunningThreadFromKeybinding`) with unit tests; the listener follows the existing `composer.stash` pattern in `ChatComposer`.
- `commandLabel` derives "Thread: Interrupt" from the command id, so no label map changes were needed.

## Rebinding back to Escape

The recorder uses bare Escape as its cancel action (`KeybindingsSettings.tsx:807`), matching how Codex behaves, so Escape is not recordable as a shortcut. Reset-to-default is the way back to it after rebinding, which works because Escape ships as this command's default.

## Verification

- `apps/web` composer-logic: 43 pass, including 3 new cases
- `packages/shared` + settings suites: 422 pass
- `apps/server` keybindings: 23 pass
- `vp lint` clean, typecheck clean across `web`, `contracts`, `shared`, `server`

note: video here is for this fix + the fix on #5668 as if not when you change the stop thread keybind from escape to something else it duplicates which is an unrelated bug that #5668 fixes. 

https://github.com/user-attachments/assets/10f8e6ae-40f2-4824-8f78-fb25e5612428

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Video of the interaction

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global keyboard routing (capture vs bubble) and default Escape behavior during active turns; changes are scoped with overlay checks and idle-thread fall-through, plus a server-side keybinding persistence fix.
> 
> **Overview**
> Introduces **`thread.interrupt`** as a first-class keybinding (default **`escape`**, when `!terminalFocus && !modelPickerOpen`) so users can stop a running turn from the keyboard and rebind it in Settings.
> 
> **`ChatComposer`** listens on window `keydown` (bubble phase), resolves the binding, and calls **`onInterrupt`** only while the thread phase is **`running`**—ignoring repeat events, consumed keys, the command palette, and any open floating layer via shared **`OPEN_FLOATING_LAYER_SELECTOR`** (dialogs, menus, `[role="dialog"]`, etc.).
> 
> **`ChatView`** type-to-focus now runs only when the key resolves to **no** command, so printable keys explicitly bound (e.g. to interrupt) are not swallowed in capture phase.
> 
> Server **`isSameKeybindingRule`** compares keys through parsed/canonical encoding so alias spellings (`esc`/`escape`) match when replacing rules from the settings UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3b6923f4720bdc448e4d350ebf380e59b10232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add rebindable `thread.interrupt` keybinding defaulting to Escape
> - Adds `thread.interrupt` to the keybinding contracts and sets a default binding of `Escape` (when terminal and model picker are not focused) in [`packages/shared/src/keybindings.ts`](https://github.com/pingdotgg/t3code/pull/5669/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06).
> - Wires the interrupt shortcut in [`ChatComposer`](https://github.com/pingdotgg/t3code/pull/5669/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) via a window `keydown` bubble-phase handler that calls `onInterrupt` when the thread is running, guarded against floating layers and command palette.
> - Fixes type-to-focus in `ChatView` so it no longer intercepts keys that have an explicit keybinding — commands are resolved first and type-to-focus only activates when none match.
> - Fixes `isSameKeybindingRule` in [`keybindings.ts`](https://github.com/pingdotgg/t3code/pull/5669/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e) to canonicalize keys before comparison, treating alias spellings like `esc`/`escape` as equivalent.
> - Behavioral Change: Pressing Escape while a thread is running now triggers an interrupt unless a dialog, menu, select, popover, or command palette is open.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c3b692.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->