### PR TITLE
fix(server): stop PR status lookups amplifying GitHub rate limits

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -5,6 +5,7 @@ import * as NodeChildProcess from "node:child_process";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -947,6 +948,73 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(1);
     }),
   );
+
+  it.effect("status skips the provider lookup for a branch that was never pushed", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/never-pushed"]);
+
+      const { manager, ghCalls } = yield* makeManager();
+
+      const status = yield* manager.status({ cwd: repoDir });
+
+      expect(status.refName).toBe("feature/never-pushed");
+      expect(status.pr).toBeNull();
+      expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(0);
+    }),
+  );
+
+  it.effect("status still looks up PRs for a branch pushed without --set-upstream", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/pushed-no-upstream"]);
+      // No `-u`, so the remote-tracking ref exists but branch.<name>.merge does
+      // not. Most terminal and agent pushes land this way, and they can still
+      // have a PR, so the skip must not trigger here.
+      yield* runGit(repoDir, ["push", "origin", "feature/pushed-no-upstream"]);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 214,
+                title: "Pushed without upstream",
+                url: "https://github.com/pingdotgg/t3code/pull/214",
+                baseRefName: "main",
+                headRefName: "feature/pushed-no-upstream",
+                state: "OPEN",
+                updatedAt: "2026-04-01T15:00:00Z",
+              },
+            ]),
+          ],
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+
+      expect(status.pr?.number).toBe(214);
+      expect(ghCalls.filter((call) => call.startsWith("pr list ")).length).toBeGreaterThan(0);
+    }),
+  );
+
+  it("backs off repeated PR lookup failures past the healthy refresh cadence", () => {
+    expect(Duration.toMillis(GitManager.prLookupFailureTtl(1))).toBe(20_000);
+    expect(Duration.toMillis(GitManager.prLookupFailureTtl(2))).toBe(40_000);
+    // The point of the backoff: by the third retry a failing branch must not be
+    // asking more often than a healthy one, which refreshes every 2 minutes.
+    expect(Duration.toMillis(GitManager.prLookupFailureTtl(4))).toBeGreaterThan(120_000);
+    expect(Duration.toMillis(GitManager.prLookupFailureTtl(20))).toBe(900_000);
+  });
 
   it.effect(
     "status ignores unrelated fork PRs when the current branch tracks the same repository",

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -110,8 +110,25 @@ const TOAST_DESCRIPTION_MAX = 72;
 const STATUS_RESULT_CACHE_TTL = Duration.seconds(1);
 const STATUS_RESULT_CACHE_CAPACITY = 2_048;
 const PR_LOOKUP_CACHE_TTL = Duration.minutes(2);
-const PR_LOOKUP_FAILURE_TTL = Duration.seconds(20);
+const PR_LOOKUP_FAILURE_BASE_TTL = Duration.seconds(20);
+const PR_LOOKUP_FAILURE_MAX_TTL = Duration.minutes(15);
 const PR_LOOKUP_CACHE_CAPACITY = 2_048;
+
+/**
+ * How long a failed PR lookup is cached, given the number of consecutive
+ * failures for that branch.
+ *
+ * A hosting provider rejects a throttled request immediately, so caching every
+ * failure for a flat 20s made a rate-limited poller re-ask *faster* than a
+ * healthy one does (which waits PR_LOOKUP_CACHE_TTL), turning a transient 429
+ * into sustained pressure. Backing off per branch keeps the retry rate below
+ * the healthy rate once a branch has failed more than a couple of times.
+ */
+export function prLookupFailureTtl(consecutiveFailures: number): Duration.Duration {
+  const exponent = Math.max(0, consecutiveFailures - 1);
+  const backoffMs = Duration.toMillis(PR_LOOKUP_FAILURE_BASE_TTL) * Math.pow(2, exponent);
+  return Duration.min(Duration.millis(backoffMs), PR_LOOKUP_FAILURE_MAX_TTL);
+}
 type StripProgressContext<T> = T extends any ? Omit<T, "actionId" | "cwd" | "action"> : never;
 type GitActionProgressPayload = StripProgressContext<GitActionProgressEvent>;
 type GitActionProgressEmitter = (event: GitActionProgressPayload) => Effect.Effect<void, never>;
@@ -889,6 +906,23 @@ export const make = Effect.gen(function* () {
   // back to a null upstreamRef.
   const prLookupCacheKey = (cwd: string, details: { branch: string; upstreamRef: string | null }) =>
     [cwd, details.branch, details.upstreamRef ?? "", String(prLookupEpoch(cwd))].join("\u0000");
+  // Consecutive failures per cache key, so a branch that keeps failing waits
+  // longer before the next attempt. Cleared as soon as a lookup succeeds.
+  const prLookupFailureStreakByKey = new Map<string, number>();
+  const nextPrLookupFailureTtl = (key: string) => {
+    if (
+      !prLookupFailureStreakByKey.has(key) &&
+      prLookupFailureStreakByKey.size >= PR_LOOKUP_CACHE_CAPACITY
+    ) {
+      const oldestKey = prLookupFailureStreakByKey.keys().next().value;
+      if (oldestKey !== undefined) {
+        prLookupFailureStreakByKey.delete(oldestKey);
+      }
+    }
+    const streak = (prLookupFailureStreakByKey.get(key) ?? 0) + 1;
+    prLookupFailureStreakByKey.set(key, streak);
+    return prLookupFailureTtl(streak);
+  };
   const prLookupCache = yield* Cache.makeWith(
     (key: string) => {
       const [cwd = "", branch = "", upstreamRef = ""] = key.split("\u0000");
@@ -896,17 +930,26 @@ export const make = Effect.gen(function* () {
         branch,
         upstreamRef: upstreamRef.length > 0 ? upstreamRef : null,
       };
-      return resolveBranchHeadContext(cwd, details).pipe(
-        Effect.flatMap((headContext) =>
-          findLatestPrForHeadContext(cwd, headContext).pipe(
-            Effect.map((latest) => ({ latest, headContext })),
-          ),
-        ),
-      );
+      return Effect.gen(function* () {
+        const headContext = yield* resolveBranchHeadContext(cwd, details);
+        // Only skip when the branch is untracked as well: anything carrying an
+        // upstream keeps the old behaviour.
+        if (details.upstreamRef === null && (yield* isUnpublishedBranch(cwd, headContext))) {
+          return { latest: null, headContext };
+        }
+        const latest = yield* findLatestPrForHeadContext(cwd, headContext);
+        return { latest, headContext };
+      });
     },
     {
       capacity: PR_LOOKUP_CACHE_CAPACITY,
-      timeToLive: (exit) => (Exit.isSuccess(exit) ? PR_LOOKUP_CACHE_TTL : PR_LOOKUP_FAILURE_TTL),
+      timeToLive: (exit, key) => {
+        if (Exit.isSuccess(exit)) {
+          prLookupFailureStreakByKey.delete(key);
+          return PR_LOOKUP_CACHE_TTL;
+        }
+        return nextPrLookupFailureTtl(key);
+      },
     },
   );
   // A transient lookup failure (rate limit, network blip) must not clear an
@@ -1167,6 +1210,43 @@ export const make = Effect.gen(function* () {
       headRepositoryOwnerLogin: remoteRepository.ownerLogin,
       isCrossRepository,
     } satisfies BranchHeadContext;
+  });
+
+  /**
+   * Whether git has no record of this branch on any remote, so a change request
+   * cannot exist for it and asking the provider is a guaranteed-empty API call.
+   *
+   * `git push` writes the remote-tracking ref even without `-u` (how most
+   * terminal and agent pushes land), which makes this a safer "did it ever
+   * reach the host" test than looking for upstream config, and the glob spans
+   * every remote so a fork branch still counts. A repository that tracks no
+   * remotes at all cannot answer the question, because then every branch looks
+   * unpublished; it, and any failed probe, keeps the lookup.
+   */
+  const isUnpublishedBranch = Effect.fn("isUnpublishedBranch")(function* (
+    cwd: string,
+    headContext: Pick<BranchHeadContext, "headBranch">,
+  ) {
+    if (headContext.headBranch.length === 0) {
+      return false;
+    }
+    const matchesRef = (pattern: string) =>
+      gitCore
+        .execute({
+          operation: "GitManager.isUnpublishedBranch",
+          cwd,
+          args: ["for-each-ref", "--count=1", "--format=%(refname)", pattern],
+          timeoutMs: 5_000,
+        })
+        .pipe(Effect.map((result) => result.stdout.trim().length > 0));
+
+    return yield* Effect.all(
+      [matchesRef("refs/remotes"), matchesRef(`refs/remotes/*/${headContext.headBranch}`)],
+      { concurrency: "unbounded" },
+    ).pipe(
+      Effect.map(([tracksAnyRemote, tracksThisBranch]) => tracksAnyRemote && !tracksThisBranch),
+      Effect.orElseSucceed(() => false),
+    );
   });
 
   const findOpenPr = Effect.fn("findOpenPr")(function* (


### PR DESCRIPTION
## Problem

I keep getting throttled on the GitHub API. Digging through logs, most of it is
my own agents running `gh` in bursts, but T3 Code makes it worse in two ways.

The PR status badge caches a **successful** lookup for 2 minutes and a **failed**
one for 20 seconds. GitHub rejects a throttled request instantly, so once you're
rate limited the poller starts asking six times faster than it does when
everything is healthy. On top of that, `lookupStatusPr` catches the failure and
returns the last known PR, so the poll reports success and
`VcsStatusBroadcaster`'s exponential backoff never engages. Nothing ever slows
down, and a transient 429 turns into a sustained one.

Separately, the badge asks the provider about every branch, including branches
that were never pushed anywhere. Those queries cannot match a PR. On this machine
66% of sampled t3code worktrees are in that state, so two thirds of the baseline
API spend was guaranteed-empty.

## Solution

Failed lookups now back off per branch (20s, 40s, 80s, ... capped at 15 min)
instead of retrying on a flat 20s timer, so a failing branch drops below the
healthy refresh rate after a couple of attempts rather than above it.

Branches git has no record of on any remote skip the provider call entirely. The
check looks for a remote-tracking ref rather than upstream config, because
`git push` writes that ref even without `-u`, which is how most terminal and
agent pushes land. Repositories that track no remotes at all can't answer the
question, so they keep the old behaviour, as does any failed probe: hiding a PR
badge is worse than spending the lookup.

Tests cover the backoff curve, the skip, and the case that makes the naive
version wrong (a branch pushed without `--set-upstream` still gets looked up).

## Not in this PR

Two bigger wins from the same investigation, kept separate because they change
lookup semantics and deserve their own review:

- Batch the sidebar into one `gh pr list` per repo matched locally by branch,
  instead of one call per branch. Caps the worst case (expanded thread list,
  262 distinct cwds here) at a few calls instead of thousands.
- Stop worktree dev servers from polling GitHub at all. Four servers were live
  during the investigation, each with independent pollers and caches against the
  same token.

---

Made by Claude Opus 5 (1M context) in Claude Code, on T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR badge lookup timing and when GitHub is contacted; incorrect unpublished detection could hide a PR badge, though failures fall back to the old lookup path.
> 
> **Overview**
> **Reduces GitHub API load** from VCS PR status polling by changing how failed lookups are cached and when provider calls run.
> 
> Failed PR lookups no longer use a flat 20s cache TTL. They use **per-branch exponential backoff** (20s → 40s → … capped at 15 minutes), with streak tracking cleared on success, so rate-limited branches retry **less often** than the healthy 2-minute refresh instead of more often.
> 
> For branches **without upstream config**, `status` can **skip `gh pr list`** when git shows remotes exist but no `refs/remotes/*/<branch>` for the current head—treating never-pushed local branches as having no PR. Branches that were pushed without `-u` still get looked up because remote-tracking refs exist. Ambiguous cases (no remotes, or probe failure) still call the provider.
> 
> Tests cover the backoff curve, the never-pushed skip, and push-without-upstream still querying GitHub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76cbc6376373f3a17458b31105988a6161edb89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PR status lookups amplifying GitHub rate limits via exponential backoff and branch skip logic
> - Repeated PR lookup failures now back off exponentially per branch (base 20s, max 15min) using a new `prLookupFailureTtl(consecutiveFailures)` function, resetting on success.
> - Branches that have never been pushed to any remote skip the provider PR lookup entirely, using a new `isUnpublishedBranch` check via `git for-each-ref`.
> - Branches pushed without `--set-upstream` still perform the provider lookup as before.
> - Behavioral Change: branches with no remote-tracking ref and no push history return no PR without making any GitHub API calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a76cbc6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->