### PR TITLE
fix(server): resolve Claude launcher shims from pnpm and space-containing Windows installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,46 @@ jobs:
       - name: Test resource monitor
         run: cargo test --locked --manifest-path native/resource-monitor/Cargo.toml
 
+  windows_claude_provider_tests:
+    name: Windows Claude/WSL Provider Tests
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !/.repos/
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: |
+            args:
+              - --filter=t3...
+              - --filter=@t3tools/desktop...
+
+      # Windows-only path resolution (npm/pnpm launcher shims, PATH/PATHEXT
+      # search) and the desktop WSL backend can't be exercised by the
+      # Ubuntu/macOS `test` job even though they're unit-tested with a mocked
+      # platform service everywhere. Running the real, Windows-specific
+      # subset here catches drift a mock can't. Scoped to Claude/WSL-owning
+      # files, not the full suite: e.g. Codex's shadow-home tests hit an
+      # unrelated Windows symlink-privilege wall on hosted runners.
+      - name: Test Claude and WSL provider code on Windows
+        run: >
+          vp test run
+          apps/server/src/provider/Drivers/ClaudeExecutable.test.ts
+          apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+          apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+          apps/desktop/src/wsl/DesktopWslBackend.test.ts
+          apps/desktop/src/wsl/DesktopWslEnvironment.test.ts
+          apps/desktop/src/wsl/wslPathParsing.test.ts
+
   mobile_native_static_analysis:
     name: Mobile Native Static Analysis
     runs-on: blacksmith-6vcpu-macos-26

--- a/apps/server/src/provider/Drivers/ClaudeExecutable.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeExecutable.test.ts
@@ -3,23 +3,68 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { SpawnExecutableResolution } from "@t3tools/shared/shell";
 import * as Effect from "effect/Effect";
 
-import { ClaudeExecutableFileCheck, resolveClaudeSdkExecutablePath } from "./ClaudeExecutable.ts";
+import {
+  ClaudeExecutableFileCheck,
+  ClaudeExecutableShimReader,
+  resolveClaudeSdkExecutablePath,
+} from "./ClaudeExecutable.ts";
 
 const NPM_DIR = "C:\\Users\\dev\\AppData\\Roaming\\npm";
 const NPM_SHIM = `${NPM_DIR}\\claude.cmd`;
 const NPM_PACKAGE_EXE = `${NPM_DIR}\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe`;
 const NPM_PACKAGE_CLI = `${NPM_DIR}\\node_modules\\@anthropic-ai\\claude-code\\cli.js`;
 
+// Real content captured from an npm-generated `claude.cmd` shim (Node's
+// documented cmd-shim convention: resolve own directory via %~dp0/%dp0%,
+// invoke the real entry relative to it).
+const npmCmdShimContent = (relativeTarget: string) => `@ECHO off
+GOTO start
+:find_dp0
+SET dp0=%~dp0
+EXIT /b
+:start
+SETLOCAL
+CALL :find_dp0
+"%dp0%\\${relativeTarget}"   %*
+`;
+
+// Real content captured from a pnpm global `.cmd` shim: the real entry lives
+// in a version-pinned pnpm store path, not under a fixed node_modules layout.
+const pnpmCmdShimContent = (relativeTarget: string) => `@SETLOCAL
+@IF EXIST "%~dp0\\node.exe" (
+  "%~dp0\\node.exe"  "%~dp0\\${relativeTarget}" %*
+) ELSE (
+  node  "%~dp0\\${relativeTarget}" %*
+)
+`;
+
+// Real content captured from a pnpm global `.ps1` shim.
+const pnpmPs1ShimContent = (relativeTarget: string) => `#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  $exe=".exe"
+}
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/${relativeTarget.replace(/\\/g, "/")}" $args
+} else {
+  & "node$exe"  "$basedir/${relativeTarget.replace(/\\/g, "/")}" $args
+}
+`;
+
 function withWindowsResolution(input: {
   readonly resolvedCommand: string | undefined;
   readonly existingFiles?: ReadonlyArray<string>;
+  readonly shimContents?: Readonly<Record<string, string>>;
 }) {
   const existing = new Set(input.existingFiles ?? []);
+  const shimContents = input.shimContents ?? {};
   return <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     effect.pipe(
       Effect.provideService(HostProcessPlatform, "win32"),
       Effect.provideService(SpawnExecutableResolution, () => input.resolvedCommand),
       Effect.provideService(ClaudeExecutableFileCheck, (filePath) => existing.has(filePath)),
+      Effect.provideService(ClaudeExecutableShimReader, (filePath) => shimContents[filePath]),
     );
 }
 
@@ -121,4 +166,128 @@ describe("resolveClaudeSdkExecutablePath", () => {
       ).toBe("claude");
     }),
   );
+
+  it.effect("follows an npm .cmd shim via shim-content parsing, not just the fixed fallback", () =>
+    Effect.gen(function* () {
+      const relativeTarget = "node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe";
+      expect(
+        yield* resolveClaudeSdkExecutablePath("claude", {}).pipe(
+          withWindowsResolution({
+            resolvedCommand: NPM_SHIM,
+            existingFiles: [NPM_PACKAGE_EXE],
+            shimContents: { [NPM_SHIM]: npmCmdShimContent(relativeTarget) },
+          }),
+        ),
+      ).toBe(NPM_PACKAGE_EXE);
+    }),
+  );
+
+  describe("pnpm and other cmd-shim-convention global installs", () => {
+    // pnpm keeps the real entry in a version-pinned store path
+    // (global/5/.pnpm/<pkg>@<version>/node_modules/<pkg>/...), which the
+    // fixed npm-layout candidate list cannot anticipate. The shim itself
+    // still resolves its own directory and references the real entry
+    // relative to it, so parsing the shim's source finds it.
+    const PNPM_DIR = "C:\\Users\\dev\\AppData\\Local\\pnpm";
+    const PNPM_SHIM_CMD = `${PNPM_DIR}\\claude.cmd`;
+    const PNPM_SHIM_PS1 = `${PNPM_DIR}\\claude.ps1`;
+    const PNPM_STORE_RELATIVE =
+      "global\\5\\.pnpm\\@anthropic-ai+claude-code@2.1.224\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe";
+    const PNPM_STORE_ABSOLUTE = `${PNPM_DIR}\\${PNPM_STORE_RELATIVE}`;
+
+    it.effect("follows a pnpm .cmd global shim to its version-pinned store entry", () =>
+      Effect.gen(function* () {
+        expect(
+          yield* resolveClaudeSdkExecutablePath("claude", {}).pipe(
+            withWindowsResolution({
+              resolvedCommand: PNPM_SHIM_CMD,
+              existingFiles: [PNPM_STORE_ABSOLUTE],
+              shimContents: { [PNPM_SHIM_CMD]: pnpmCmdShimContent(PNPM_STORE_RELATIVE) },
+            }),
+          ),
+        ).toBe(PNPM_STORE_ABSOLUTE);
+      }),
+    );
+
+    it.effect("skips the shim's own node.exe reference and finds the real target", () =>
+      Effect.gen(function* () {
+        // pnpmCmdShimContent references "%~dp0\node.exe" before the real
+        // target; a naive first-match parse would return the Node runtime
+        // itself instead of the package entry.
+        expect(
+          yield* resolveClaudeSdkExecutablePath("claude", {}).pipe(
+            withWindowsResolution({
+              resolvedCommand: PNPM_SHIM_CMD,
+              existingFiles: [`${PNPM_DIR}\\node.exe`, PNPM_STORE_ABSOLUTE],
+              shimContents: { [PNPM_SHIM_CMD]: pnpmCmdShimContent(PNPM_STORE_RELATIVE) },
+            }),
+          ),
+        ).toBe(PNPM_STORE_ABSOLUTE);
+      }),
+    );
+
+    it.effect("follows a pnpm .ps1 global shim via its $basedir reference", () =>
+      Effect.gen(function* () {
+        expect(
+          yield* resolveClaudeSdkExecutablePath("claude", {}).pipe(
+            withWindowsResolution({
+              resolvedCommand: PNPM_SHIM_PS1,
+              existingFiles: [PNPM_STORE_ABSOLUTE],
+              shimContents: { [PNPM_SHIM_PS1]: pnpmPs1ShimContent(PNPM_STORE_RELATIVE) },
+            }),
+          ),
+        ).toBe(PNPM_STORE_ABSOLUTE);
+      }),
+    );
+
+    it.effect("falls back to the fixed npm layout when shim parsing finds nothing usable", () =>
+      Effect.gen(function* () {
+        expect(
+          yield* resolveClaudeSdkExecutablePath("claude", {}).pipe(
+            withWindowsResolution({
+              resolvedCommand: NPM_SHIM,
+              existingFiles: [NPM_PACKAGE_EXE],
+              shimContents: { [NPM_SHIM]: "not a recognizable shim format" },
+            }),
+          ),
+        ).toBe(NPM_PACKAGE_EXE);
+      }),
+    );
+  });
+
+  describe("install directories containing spaces", () => {
+    const SPACED_DIR = "C:\\Users\\Jane Doe\\AppData\\Roaming\\npm";
+    const SPACED_SHIM = `${SPACED_DIR}\\claude.cmd`;
+    const SPACED_PACKAGE_EXE = `${SPACED_DIR}\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe`;
+
+    it.effect("resolves an npm shim under a directory with spaces", () =>
+      Effect.gen(function* () {
+        expect(
+          yield* resolveClaudeSdkExecutablePath("claude", {}).pipe(
+            withWindowsResolution({
+              resolvedCommand: SPACED_SHIM,
+              existingFiles: [SPACED_PACKAGE_EXE],
+            }),
+          ),
+        ).toBe(SPACED_PACKAGE_EXE);
+      }),
+    );
+
+    it.effect("resolves a pnpm-style shim referencing a store path with spaces", () =>
+      Effect.gen(function* () {
+        const relativeTarget =
+          "global\\5\\.pnpm\\@anthropic-ai+claude-code@2.1.224\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe";
+        const absoluteTarget = `${SPACED_DIR}\\${relativeTarget}`;
+        expect(
+          yield* resolveClaudeSdkExecutablePath("claude", {}).pipe(
+            withWindowsResolution({
+              resolvedCommand: SPACED_SHIM,
+              existingFiles: [absoluteTarget],
+              shimContents: { [SPACED_SHIM]: pnpmCmdShimContent(relativeTarget) },
+            }),
+          ),
+        ).toBe(absoluteTarget);
+      }),
+    );
+  });
 });

--- a/apps/server/src/provider/Drivers/ClaudeExecutable.ts
+++ b/apps/server/src/provider/Drivers/ClaudeExecutable.ts
@@ -19,19 +19,47 @@ const WINDOWS_SHIM_EXTENSIONS: ReadonlySet<string> = new Set([".cmd", ".bat", ".
  * global `node_modules` directory that sits next to the npm launcher shim.
  * Newer package versions ship a native `bin/claude.exe`; older versions only
  * ship `cli.js`, which the SDK runs with a JavaScript runtime.
+ *
+ * Kept as a fallback after {@link extractShimRelativeTargets} — that parser
+ * covers this layout too, but this list is cheap, exactly matches npm's
+ * documented layout, and protects against a shim format the parser doesn't
+ * anticipate.
  */
 const NPM_PACKAGE_ENTRY_CANDIDATES = [
   ["node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe"],
   ["node_modules", "@anthropic-ai", "claude-code", "cli.js"],
 ] as const;
 
+/**
+ * Matches the launcher's own directory reference in `.cmd`/`.bat` shims
+ * (`%~dp0\...` or `%dp0%\...`), capturing everything up to the closing quote
+ * or line end.
+ */
+const CMD_DP0_REFERENCE_PATTERN = /%~?dp0%?[\\/]([^"'\r\n]+)/gi;
+
+/**
+ * Matches the launcher's own directory reference in `.ps1` shims
+ * (`$basedir/...`), capturing everything up to the closing quote, a `$`
+ * (variable interpolation, e.g. `$basedir/node$exe`), or line end.
+ */
+const PS1_BASEDIR_REFERENCE_PATTERN = /\$basedir[\\/]([^"'\r\n$]+)/gi;
+
 export type ExecutableFileCheck = (filePath: string) => boolean;
+export type ShimScriptReader = (filePath: string) => string | undefined;
 
 function isExistingFile(filePath: string): boolean {
   try {
     return NodeFS.statSync(filePath).isFile();
   } catch {
     return false;
+  }
+}
+
+function readShimScript(filePath: string): string | undefined {
+  try {
+    return NodeFS.readFileSync(filePath, "utf8");
+  } catch {
+    return undefined;
   }
 }
 
@@ -42,6 +70,45 @@ export const ClaudeExecutableFileCheck = Context.Reference<ExecutableFileCheck>(
     defaultValue: () => isExistingFile,
   },
 );
+
+/** Injectable shim-script reader so tests can run against fake shim contents. */
+export const ClaudeExecutableShimReader = Context.Reference<ShimScriptReader>(
+  "server/provider/Drivers/ClaudeExecutableShimReader",
+  {
+    defaultValue: () => readShimScript,
+  },
+);
+
+function isNodeExecutableTarget(relativeTarget: string): boolean {
+  const base = NodePath.win32.basename(relativeTarget).toLowerCase();
+  return base === "node.exe" || base === "node";
+}
+
+/**
+ * Extracts candidate real-target paths (relative to the shim's own
+ * directory) from a launcher shim's source text.
+ *
+ * Both npm and pnpm generate `.cmd`/`.bat`/`.ps1` launcher shims from the
+ * same underlying convention (`cmd-shim`): the script resolves its own
+ * directory (`%~dp0` / `$basedir`) and invokes the real entry point via a
+ * path relative to it. npm keeps that target at a fixed
+ * `node_modules/<pkg>/...` layout, but pnpm's global shims point into a
+ * version-pinned pnpm store path instead
+ * (`global/5/.pnpm/<pkg>@<version>/node_modules/<pkg>/...`), which no fixed
+ * candidate list can anticipate. Parsing the shim's own reference works for
+ * both, and for any other tool built on the same convention (e.g. corepack).
+ */
+function extractShimRelativeTargets(shimContent: string, extension: string): ReadonlyArray<string> {
+  const pattern = extension === ".ps1" ? PS1_BASEDIR_REFERENCE_PATTERN : CMD_DP0_REFERENCE_PATTERN;
+  const targets: Array<string> = [];
+  for (const match of shimContent.matchAll(pattern)) {
+    const relative = match[1]?.trim();
+    if (relative && relative.length > 0) {
+      targets.push(relative.replace(/\//g, "\\"));
+    }
+  }
+  return targets;
+}
 
 /**
  * Resolves the configured Claude binary path into a value the Claude Agent
@@ -67,6 +134,7 @@ export const resolveClaudeSdkExecutablePath = Effect.fn("resolveClaudeSdkExecuta
 
     const resolveExecutable = yield* SpawnExecutableResolution;
     const isFile = yield* ClaudeExecutableFileCheck;
+    const readShim = yield* ClaudeExecutableShimReader;
     const resolved = resolveExecutable(binaryPath, platform, environment) ?? binaryPath;
     const extension = NodePath.win32.extname(resolved).toLowerCase();
     if (!WINDOWS_SHIM_EXTENSIONS.has(extension)) {
@@ -74,6 +142,19 @@ export const resolveClaudeSdkExecutablePath = Effect.fn("resolveClaudeSdkExecuta
     }
 
     const shimDirectory = NodePath.win32.dirname(resolved);
+    const shimContent = readShim(resolved);
+    if (shimContent) {
+      for (const relativeTarget of extractShimRelativeTargets(shimContent, extension)) {
+        if (isNodeExecutableTarget(relativeTarget)) {
+          continue;
+        }
+        const candidate = NodePath.win32.join(shimDirectory, relativeTarget);
+        if (isFile(candidate)) {
+          return candidate;
+        }
+      }
+    }
+
     for (const entrySegments of NPM_PACKAGE_ENTRY_CANDIDATES) {
       const candidate = NodePath.win32.join(shimDirectory, ...entrySegments);
       if (isFile(candidate)) {

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -10,6 +10,36 @@ Common reasons:
 - run Claude through a router such as Claude Code Router
 - use external providers exposed through a Claude-compatible workflow
 
+## Windows: Native Vs WSL
+
+Claude Code runs two ways on a Windows T3 Code server: natively, or inside WSL.
+
+### Native Windows
+
+T3 Code finds `claude` on Windows the same way it finds any provider binary: it searches `PATH`
+using `PATHEXT`, or uses the explicit **Binary path** you set in Settings. Node cannot spawn a
+`.cmd`/`.bat`/`.ps1` launcher script directly, so when that search lands on one of those (the
+normal result for a global `npm install -g @anthropic-ai/claude-code`, or an equivalent global
+install with pnpm, Yarn, or corepack), T3 Code reads the shim and follows it to the real
+`claude.exe` or `cli.js` next to it before handing the path to the Claude Agent SDK. This covers
+the common global-install layouts without needing WSL.
+
+If T3 Code can't work out the real target from an unusual install layout, it falls back to the
+shim path itself, which will fail to start a session. Set an explicit **Binary path** pointing at
+the real executable (for example `...\node_modules\@anthropic-ai\claude-code\bin\claude.exe`) to
+work around it, and consider filing an issue with your install layout.
+
+### WSL
+
+T3 Code Desktop can also run the whole server inside a WSL distro instead of natively on Windows
+(Settings → Connections → WSL backend, or WSL-only mode). When it does, Claude Code runs exactly
+like it does on Linux — no shim-following, no Windows-specific resolution — because the server
+process itself is a WSL process. Use this if you'd rather manage Claude Code (and other providers)
+inside your existing WSL setup, or if native resolution isn't working for your install.
+
+Either mode uses the same Claude provider configuration (config directory, environment variables,
+etc.) described below; only where the CLI itself runs changes.
+
 ## I Only Use One Claude Account
 
 Use the default provider.


### PR DESCRIPTION
## What was broken or under-supported

Claude was already a fully-built provider (`ClaudeAdapter`, `ClaudeExecutable`, etc.), and native Windows launch support existed (#3740) for the common case: an npm global install (`npm install -g @anthropic-ai/claude-code`), where Node can't spawn the resulting `.cmd`/`.bat`/`.ps1` launcher shim directly (`spawn EINVAL`), so `resolveClaudeSdkExecutablePath` followed the shim to npm's fixed `node_modules/@anthropic-ai/claude-code/{bin/claude.exe,cli.js}` layout.

That fixed-layout assumption breaks for other common Windows Node package managers. Verified on a real Windows machine: a **pnpm** global install's shim points at a version-pinned pnpm store path instead (`global/5/.pnpm/<pkg>@<version>/node_modules/<pkg>/...`), which the npm-shaped candidate list can never match — the resolver silently fell back to the unspawnable shim path itself, and session start would fail.

Also verified: Windows CI never actually ran this code. `.github/workflows/ci.yml` only tests on Ubuntu/macOS runners; the Windows-specific logic was exercised solely with a mocked platform service.

## What changed

`apps/server/src/provider/Drivers/ClaudeExecutable.ts`: instead of guessing a fixed relative layout, parse the shim script's *own* self-reference. Windows launcher shims (npm, pnpm, and anything else built on the same `cmd-shim` convention, e.g. corepack) resolve their own directory (`%~dp0`/`%dp0%` in `.cmd`/`.bat`, `$basedir` in `.ps1`) and invoke the real entry relative to it — parsing that reference works regardless of which package manager generated the shim or how deep/versioned its target path is. The original fixed npm candidate list is kept as a fallback in case a shim format doesn't match the parser.

### Native Windows behavior

- `claude` resolves via PATH/PATHEXT (or an explicit Binary path setting) as before.
- If that lands on a `.cmd`/`.bat`/`.ps1` shim, T3 Code now reads the shim's source and follows its own relative reference to the real executable/script, rather than assuming npm's specific `node_modules` layout.
- Falls back to the previous fixed-candidate check, then to the shim path itself (existing warning-and-continue behavior) if nothing resolves.
- Handles install directories containing spaces (e.g. `C:\Users\Jane Doe\...`) — verified with a regression test; nothing in the resolution path goes through shell parsing, so this was already safe once the right path is found.

### WSL fallback behavior

Unchanged and unaffected — T3 Code Desktop's existing dual-mode WSL backend (`DesktopWslBackend`) runs the whole server inside WSL when enabled, at which point Claude Code runs like it does on Linux with no Windows-specific resolution involved. Documented this alongside native behavior in `docs/user/providers-claude.md` since it wasn't written down anywhere before.

### macOS verification

No code path here executes on macOS (`resolveClaudeSdkExecutablePath` early-returns the input unchanged for any non-`win32` platform), so this change can't affect macOS behavior. Reviewed the macOS desktop build/signing config for anything that could interfere with Claude Code's subprocess (Keychain access, sandboxing): no `com.apple.security.app-sandbox` entitlement is applied, and the only entitlements added (`allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`) are permissive, not restrictive, toward spawned child processes. Attempted to run the test suite on a physical Mac for extra confidence; the machine was unreachable (see Remaining limitations).

### Windows CI coverage

Added a `windows_claude_provider_tests` job (`windows-latest`) running the Claude- and WSL-owning test files directly: `ClaudeExecutable.test.ts`, `ClaudeAdapter.test.ts`, `ProviderAdapterRegistry.test.ts`, and the three `apps/desktop/src/wsl` test files. Scoped deliberately, not the full suite — see limitations below.

### Tests/builds run

All run locally on real Windows (not just CI-mocked):
- `ClaudeExecutable.test.ts`: 15/15 passing (8 pre-existing + 7 new: pnpm `.cmd`, pnpm `.ps1`, node.exe-self-reference skip, garbage-shim fallback, npm-shim-content parsing, spaced npm path, spaced pnpm path)
- Full Claude/WSL suite (`ClaudeAdapter.test.ts`, `ProviderAdapterRegistry.test.ts`, `apps/desktop/src/wsl/*`): 137/137 passing
- Typecheck (`tsgo --noEmit`) for `t3` and `@t3tools/desktop`: clean (only pre-existing `suggestion`-level oxlint hints in untouched files)
- Lint (`vp lint`) on touched files: clean
- Format check (`vp fmt --check`): clean
- Server bundle build (`vp pack`): succeeds
- Manually verified end-to-end against two real installs on this machine before writing the fix: a real npm global `claude-code` install (resolves correctly, as before) and a real pnpm global install of an equivalent-shaped package (previously unresolvable, now resolves correctly to the real `.pnpm` store target)

## Remaining limitations

- Live macOS runtime verification (`claude auth login` + a full desktop session) wasn't performed — the physical Mac used for this kind of check was unreachable during this work. Not expected to matter given this PR's code never executes on macOS, but flagging it as unverified rather than claiming it.
- The new Windows CI job intentionally excludes `CodexHomeLayout.test.ts` and the rest of `apps/server/src/provider/Drivers`: those hit an unrelated, pre-existing `EPERM: symlink not permitted` failure on Windows (symlink creation needs elevated privileges/Developer Mode, which hosted `windows-latest` runners don't have by default). That's a Codex-specific gap, out of scope here.
- Shim parsing covers the `cmd-shim` convention (npm, pnpm, corepack). A package manager using a fundamentally different shim mechanism could still fall through to the existing warn-and-return-original-path behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only run on Windows when resolving Claude binaries; incorrect shim parsing could break session start for some install layouts, but behavior is covered by new tests and falls back to the previous npm layout.
> 
> **Overview**
> Fixes **native Windows Claude** sessions failing when `claude` resolves to a global **pnpm** (or other cmd-shim) launcher: resolution no longer assumes npm’s fixed `node_modules` layout next to the shim.
> 
> `resolveClaudeSdkExecutablePath` now **reads `.cmd`/`.bat`/`.ps1` shim source**, parses `%~dp0` / `$basedir` relative targets, skips `node.exe` self-references, and follows the first existing real entry—then keeps the prior npm candidate list as fallback. Tests cover pnpm `.cmd`/`.ps1`, garbage shims, and paths under directories with spaces.
> 
> CI adds a **`windows-latest` job** scoped to Claude executable/adapter and desktop WSL tests so Windows-specific logic runs on a real runner. User docs add a **Native vs WSL** section describing shim-following and when to set an explicit binary path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a880430d41e9ff9af4bff29a7610c1a7b82ee2ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude executable resolution for pnpm shims and Windows paths with spaces
> - On Windows, `resolveClaudeSdkExecutablePath` now reads `.cmd`/`.bat`/`.ps1` launcher shims and parses relative targets to locate the real Claude executable (e.g., `claude.exe` or `cli.js`), skipping `node.exe` references.
> - Adds support for pnpm shim format in addition to the existing npm layout, and handles install paths containing spaces.
> - Falls back to the previous fixed npm package entry candidates if shim parsing yields no valid result.
> - Adds a new CI job running Claude/WSL-specific tests on `windows-latest` to cover these paths.
> - Adds a [providers-claude.md](https://github.com/pingdotgg/t3code/pull/5678/files#diff-f3b54bb573c78b526a8c1181ccd8146c7df38119b974038b08aff6f4e5a3819d) section documenting Windows native vs. WSL resolution behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a880430.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->