### PR TITLE
fix(server): bound Codex subagent progress events

### DIFF
--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -34,6 +34,30 @@ const [CHILD_A, CHILD_B] = wireFixture.childThreadIds as [string, string];
  */
 function buildScript() {
   const captured = wireFixture.notifications;
+  const progressBurst = captured.flatMap((entry) => {
+    const item = (entry.params as { item?: { type?: string } }).item;
+    const threadId = (entry.params as { threadId?: string }).threadId;
+    if (entry.method === "thread/tokenUsage/updated" && threadId === CHILD_A) {
+      return [entry, entry, entry];
+    }
+    if (
+      (entry.method === "item/started" || entry.method === "item/completed") &&
+      item?.type === "collabAgentToolCall"
+    ) {
+      return [
+        entry,
+        {
+          ...entry,
+          params: {
+            ...entry.params,
+            threadId: CHILD_A,
+            turnId: `${CHILD_A}-turn-1`,
+          },
+        },
+      ];
+    }
+    return [entry];
+  });
   const extras = [
     {
       method: "item/completed",
@@ -66,7 +90,10 @@ function buildScript() {
   ];
   return {
     rootThreadId: ROOT,
-    notifications: [...captured.filter((entry) => entry.method !== "turn/completed"), ...extras],
+    notifications: [
+      ...progressBurst.filter((entry) => entry.method !== "turn/completed"),
+      ...extras,
+    ],
   };
 }
 
@@ -74,7 +101,7 @@ const scriptPath = NodePath.join(import.meta.dirname, "../testFixtures/.collab-s
 const peerPath = NodePath.join(import.meta.dirname, "../testFixtures/codexCollabMockPeer.sh");
 
 describe("CodexSessionRuntime collab integration", () => {
-  it.effect("replays the captured fan-out into synthetic agent events without child leaks", () =>
+  it.live("replays bounded child progress before terminal lifecycle without child leaks", () =>
     Effect.gen(function* () {
       // @effect-diagnostics-next-line preferSchemaOverJson:off
       NodeFS.writeFileSync(scriptPath, JSON.stringify(buildScript()), "utf8");
@@ -115,6 +142,47 @@ describe("CodexSessionRuntime collab integration", () => {
           (event.payload as { agentThreadId?: string }).agentThreadId === CHILD_A,
       );
       assert.isDefined(childTurnCompleted, "child A's turn completion becomes an agent event");
+
+      const childAProgress = events.filter(
+        (event) =>
+          (event.method === "collabAgent/item" || event.method === "collabAgent/tokenUsage") &&
+          (event.payload as { agentThreadId?: string }).agentThreadId === CHILD_A,
+      );
+      const childAItems = childAProgress.filter((event) => event.method === "collabAgent/item");
+      const childAUsage = childAProgress.filter(
+        (event) => event.method === "collabAgent/tokenUsage",
+      );
+      assert.isAtLeast(childAItems.length, 1, "the child item lane survives coalescing");
+      assert.isBelow(childAItems.length, 2, "the two child item updates coalesce");
+      assert.isAtLeast(childAUsage.length, 1, "the child usage lane survives coalescing");
+      assert.isBelow(childAUsage.length, 6, "the six cumulative child usage updates coalesce");
+      const latestItem = childAItems.findLast(() => true);
+      assert.isDefined(latestItem);
+      assert.equal(
+        (latestItem.payload as { item?: { status?: string } }).item?.status,
+        "completed",
+        "the latest child item survives coalescing",
+      );
+      const latestUsage = childAUsage.findLast(() => true);
+      assert.isDefined(latestUsage);
+      assert.equal(
+        (latestUsage.payload as { tokenUsage?: { total?: { totalTokens?: number } } }).tokenUsage
+          ?.total?.totalTokens,
+        41_529,
+        "the latest cumulative child usage survives coalescing",
+      );
+      const childAIdleIndex = events.findIndex(
+        (event) =>
+          event.method === "collabAgent/statusChanged" &&
+          (event.payload as { agentThreadId?: string; status?: { type?: string } })
+            .agentThreadId === CHILD_A &&
+          (event.payload as { status?: { type?: string } }).status?.type === "idle",
+      );
+      assert.isAtLeast(childAIdleIndex, 0, "child A's terminal idle status becomes an agent event");
+      assert.isTrue(
+        childAProgress.every((event) => events.indexOf(event) < childAIdleIndex),
+        "latest child progress must be emitted before terminal lifecycle",
+      );
 
       const childClosed = events.find(
         (event) =>

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -1,8 +1,10 @@
 import * as NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
 import { describe } from "vite-plus/test";
 import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
@@ -16,11 +18,44 @@ import {
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
+  emitCodexCollabProgressBatch,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
   openCodexThread,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+
+describe("emitCodexCollabProgressBatch", () => {
+  it.effect("emits the leading batch before cooldown and keeps flushes delay-free", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const normalEmitted = yield* Deferred.make<void>();
+        const normalCompleted = yield* Deferred.make<void>();
+        yield* emitCodexCollabProgressBatch(
+          Deferred.succeed(normalEmitted, undefined).pipe(Effect.orDie),
+          false,
+        ).pipe(
+          Effect.andThen(Deferred.succeed(normalCompleted, undefined).pipe(Effect.orDie)),
+          Effect.forkChild,
+        );
+
+        yield* Effect.yieldNow;
+        NodeAssert.equal(yield* Deferred.isDone(normalEmitted), true);
+        NodeAssert.equal(yield* Deferred.isDone(normalCompleted), false);
+
+        yield* TestClock.adjust("250 millis");
+        yield* Deferred.await(normalCompleted);
+
+        const flushEmitted = yield* Deferred.make<void>();
+        yield* emitCodexCollabProgressBatch(
+          Deferred.succeed(flushEmitted, undefined).pipe(Effect.orDie),
+          true,
+        );
+        NodeAssert.equal(yield* Deferred.isDone(flushEmitted), true);
+      }),
+    ),
+  );
+});
 
 describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   it("retains identifier purpose and the random source failure", () => {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -1,10 +1,8 @@
 import * as NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
-import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
-import * as TestClock from "effect/testing/TestClock";
 import { describe } from "vite-plus/test";
 import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
@@ -18,44 +16,11 @@ import {
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
-  emitCodexCollabProgressBatch,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
   openCodexThread,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
-
-describe("emitCodexCollabProgressBatch", () => {
-  it.effect("emits the leading batch before cooldown and keeps flushes delay-free", () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const normalEmitted = yield* Deferred.make<void>();
-        const normalCompleted = yield* Deferred.make<void>();
-        yield* emitCodexCollabProgressBatch(
-          Deferred.succeed(normalEmitted, undefined).pipe(Effect.orDie),
-          false,
-        ).pipe(
-          Effect.andThen(Deferred.succeed(normalCompleted, undefined).pipe(Effect.orDie)),
-          Effect.forkChild,
-        );
-
-        yield* Effect.yieldNow;
-        NodeAssert.equal(yield* Deferred.isDone(normalEmitted), true);
-        NodeAssert.equal(yield* Deferred.isDone(normalCompleted), false);
-
-        yield* TestClock.adjust("250 millis");
-        yield* Deferred.await(normalCompleted);
-
-        const flushEmitted = yield* Deferred.make<void>();
-        yield* emitCodexCollabProgressBatch(
-          Deferred.succeed(flushEmitted, undefined).pipe(Effect.orDie),
-          true,
-        );
-        NodeAssert.equal(yield* Deferred.isDone(flushEmitted), true);
-      }),
-    ),
-  );
-});
 
 describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   it("retains identifier purpose and the random source failure", () => {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -16,6 +16,7 @@ import {
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
+import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { normalizeModelSlug } from "@t3tools/shared/model";
 import * as Crypto from "effect/Crypto";
@@ -52,6 +53,7 @@ const BENIGN_ERROR_LOG_SNIPPETS = [
   "state db record_discrepancy: find_thread_path_by_id_str_in_subdir, falling_back",
 ];
 const CODEX_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
+const CODEX_COLLAB_PROGRESS_DEBOUNCE = "250 millis" as const;
 const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "not found",
   "missing thread",
@@ -949,6 +951,46 @@ export const makeCodexSessionRuntime = (
         message,
       });
 
+    type CollabProgressEvent = Parameters<typeof emitEvent>[0];
+    interface PendingCollabProgress {
+      readonly item?: CollabProgressEvent;
+      readonly tokenUsage?: CollabProgressEvent;
+    }
+    const collabProgressWorker = yield* makeKeyedCoalescingWorker<
+      string,
+      PendingCollabProgress,
+      never,
+      never
+    >({
+      merge: (current, next) => ({
+        ...current,
+        ...(next.item ? { item: next.item } : {}),
+        ...(next.tokenUsage ? { tokenUsage: next.tokenUsage } : {}),
+      }),
+      process: (agentThreadId, progress, context) =>
+        Effect.gen(function* () {
+          // One scoped processor throttles normal progress across this
+          // session while per-child pending lanes merge. Terminal flushes
+          // bypass the delay so lifecycle events are never stuck behind it.
+          if (!context.flush) {
+            yield* Effect.sleep(CODEX_COLLAB_PROGRESS_DEBOUNCE);
+          }
+          if (progress.item) {
+            yield* emitEvent(progress.item);
+          }
+          if (progress.tokenUsage) {
+            yield* emitEvent(progress.tokenUsage);
+          }
+        }).pipe(
+          Effect.catch((cause) =>
+            Effect.logWarning("Failed to emit coalesced Codex subagent progress.", {
+              agentThreadId,
+              cause,
+            }),
+          ),
+        ),
+    }).pipe(Effect.provideService(Scope.Scope, runtimeScope));
+
     const settlePendingApprovals = (decision: ProviderApprovalDecision) =>
       Ref.get(pendingApprovalsRef).pipe(
         Effect.flatMap((pendingApprovals) =>
@@ -1138,6 +1180,7 @@ export const makeCodexSessionRuntime = (
             return true;
           }
           case "turn/completed":
+            yield* collabProgressWorker.flushKey(child.agentThreadId);
             yield* Ref.update(collabChildLiveTurnsRef, (current) => {
               const next = new Map(current);
               next.delete(child.agentThreadId);
@@ -1155,6 +1198,9 @@ export const makeCodexSessionRuntime = (
             });
             return true;
           case "thread/status/changed":
+            if (notification.params.status.type !== "active") {
+              yield* collabProgressWorker.flushKey(child.agentThreadId);
+            }
             yield* emitEvent({
               kind: "notification",
               threadId: options.threadId,
@@ -1167,27 +1213,31 @@ export const makeCodexSessionRuntime = (
             });
             return true;
           case "thread/tokenUsage/updated":
-            yield* emitEvent({
-              kind: "notification",
-              threadId: options.threadId,
-              ...(child.spawnTurnId ? { turnId: child.spawnTurnId } : {}),
-              method: "collabAgent/tokenUsage",
-              payload: {
-                ...childIdentity,
-                tokenUsage: notification.params.tokenUsage,
+            yield* collabProgressWorker.enqueue(child.agentThreadId, {
+              tokenUsage: {
+                kind: "notification",
+                threadId: options.threadId,
+                ...(child.spawnTurnId ? { turnId: child.spawnTurnId } : {}),
+                method: "collabAgent/tokenUsage",
+                payload: {
+                  ...childIdentity,
+                  tokenUsage: notification.params.tokenUsage,
+                },
               },
             });
             return true;
           case "item/started":
           case "item/completed":
-            yield* emitEvent({
-              kind: "notification",
-              threadId: options.threadId,
-              ...(child.spawnTurnId ? { turnId: child.spawnTurnId } : {}),
-              method: "collabAgent/item",
-              payload: {
-                ...childIdentity,
-                item: notification.params.item,
+            yield* collabProgressWorker.enqueue(child.agentThreadId, {
+              item: {
+                kind: "notification",
+                threadId: options.threadId,
+                ...(child.spawnTurnId ? { turnId: child.spawnTurnId } : {}),
+                method: "collabAgent/item",
+                payload: {
+                  ...childIdentity,
+                  item: notification.params.item,
+                },
               },
             });
             return true;
@@ -1195,6 +1245,7 @@ export const makeCodexSessionRuntime = (
             // The child is gone: drop its live-turn entry so a later Stop
             // doesn't waste a turn/interrupt RPC on a closed thread before
             // reaching the parent (review finding).
+            yield* collabProgressWorker.flushKey(child.agentThreadId);
             yield* Ref.update(collabChildLiveTurnsRef, (current) => {
               const next = new Map(current);
               next.delete(child.agentThreadId);
@@ -1221,6 +1272,7 @@ export const makeCodexSessionRuntime = (
             if (willRetry) {
               return true;
             }
+            yield* collabProgressWorker.flushKey(child.agentThreadId);
             yield* Ref.update(collabChildLiveTurnsRef, (current) => {
               const next = new Map(current);
               next.delete(child.agentThreadId);
@@ -1733,12 +1785,16 @@ export const makeCodexSessionRuntime = (
         status: "closed",
         activeTurnId: undefined,
       });
+      // Runtime close cancels pending best-effort progress before publishing
+      // the terminal session event. The worker shares this scope with the
+      // notification consumer, so neither can offer after the event queue is
+      // shut down below.
+      yield* Scope.close(runtimeScope, Exit.void);
       yield* emitSessionEvent("session/closed", "Session stopped").pipe(
         Effect.catch((cause) =>
           Effect.logError("Failed to emit Codex session closed event.", { cause }),
         ),
       );
-      yield* Scope.close(runtimeScope, Exit.void);
       yield* Queue.shutdown(serverNotifications);
       yield* Queue.shutdown(events);
     });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -62,6 +62,21 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "does not exist",
 ];
 
+export const emitCodexCollabProgressBatch = Effect.fn("emitCodexCollabProgressBatch")(function* <
+  A,
+  E,
+  R,
+>(emission: Effect.Effect<A, E, R>, flush: boolean): Effect.fn.Return<A, E, R> {
+  // Leading-edge emission keeps a newly active child responsive. The
+  // cooldown follows the batch so updates arriving during it collapse into
+  // the next latest-state snapshot instead of delaying the first one.
+  const result = yield* emission;
+  if (!flush) {
+    yield* Effect.sleep(CODEX_COLLAB_PROGRESS_DEBOUNCE);
+  }
+  return result;
+});
+
 export function hasConfiguredMcpServer(appServerArgs: ReadonlyArray<string> | undefined): boolean {
   return appServerArgs?.some((argument) => argument.includes("mcp_servers.")) === true;
 }
@@ -968,20 +983,17 @@ export const makeCodexSessionRuntime = (
         ...(next.tokenUsage ? { tokenUsage: next.tokenUsage } : {}),
       }),
       process: (agentThreadId, progress, context) =>
-        Effect.gen(function* () {
-          // One scoped processor throttles normal progress across this
-          // session while per-child pending lanes merge. Terminal flushes
-          // bypass the delay so lifecycle events are never stuck behind it.
-          if (!context.flush) {
-            yield* Effect.sleep(CODEX_COLLAB_PROGRESS_DEBOUNCE);
-          }
-          if (progress.item) {
-            yield* emitEvent(progress.item);
-          }
-          if (progress.tokenUsage) {
-            yield* emitEvent(progress.tokenUsage);
-          }
-        }).pipe(
+        emitCodexCollabProgressBatch(
+          Effect.gen(function* () {
+            if (progress.item) {
+              yield* emitEvent(progress.item);
+            }
+            if (progress.tokenUsage) {
+              yield* emitEvent(progress.tokenUsage);
+            }
+          }),
+          context.flush,
+        ).pipe(
           Effect.catch((cause) =>
             Effect.logWarning("Failed to emit coalesced Codex subagent progress.", {
               agentThreadId,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -62,21 +62,6 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "does not exist",
 ];
 
-export const emitCodexCollabProgressBatch = Effect.fn("emitCodexCollabProgressBatch")(function* <
-  A,
-  E,
-  R,
->(emission: Effect.Effect<A, E, R>, flush: boolean): Effect.fn.Return<A, E, R> {
-  // Leading-edge emission keeps a newly active child responsive. The
-  // cooldown follows the batch so updates arriving during it collapse into
-  // the next latest-state snapshot instead of delaying the first one.
-  const result = yield* emission;
-  if (!flush) {
-    yield* Effect.sleep(CODEX_COLLAB_PROGRESS_DEBOUNCE);
-  }
-  return result;
-});
-
 export function hasConfiguredMcpServer(appServerArgs: ReadonlyArray<string> | undefined): boolean {
   return appServerArgs?.some((argument) => argument.includes("mcp_servers.")) === true;
 }
@@ -977,23 +962,21 @@ export const makeCodexSessionRuntime = (
       never,
       never
     >({
+      cooldown: CODEX_COLLAB_PROGRESS_DEBOUNCE,
       merge: (current, next) => ({
         ...current,
         ...(next.item ? { item: next.item } : {}),
         ...(next.tokenUsage ? { tokenUsage: next.tokenUsage } : {}),
       }),
-      process: (agentThreadId, progress, context) =>
-        emitCodexCollabProgressBatch(
-          Effect.gen(function* () {
-            if (progress.item) {
-              yield* emitEvent(progress.item);
-            }
-            if (progress.tokenUsage) {
-              yield* emitEvent(progress.tokenUsage);
-            }
-          }),
-          context.flush,
-        ).pipe(
+      process: (agentThreadId, progress) =>
+        Effect.gen(function* () {
+          if (progress.item) {
+            yield* emitEvent(progress.item);
+          }
+          if (progress.tokenUsage) {
+            yield* emitEvent(progress.tokenUsage);
+          }
+        }).pipe(
           Effect.catch((cause) =>
             Effect.logWarning("Failed to emit coalesced Codex subagent progress.", {
               agentThreadId,

--- a/packages/shared/src/KeyedCoalescingWorker.test.ts
+++ b/packages/shared/src/KeyedCoalescingWorker.test.ts
@@ -1,5 +1,6 @@
 import { it } from "@effect/vitest";
 import { describe, expect } from "vite-plus/test";
+import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -140,6 +141,137 @@ describe("makeKeyedCoalescingWorker", () => {
           "urgent:terminal:flush",
           "queued:second:normal",
         ]);
+      }),
+    ),
+  );
+
+  it.live("does not process the same key concurrently when flushing queued work", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const blockerStarted = yield* Deferred.make<void>();
+        const releaseBlocker = yield* Deferred.make<void>();
+        const firstFlushStarted = yield* Deferred.make<void>();
+        const releaseFirstFlush = yield* Deferred.make<void>();
+        const secondFlushStarted = yield* Deferred.make<void>();
+        const afterStarted = yield* Deferred.make<void>();
+
+        const worker = yield* makeKeyedCoalescingWorker<string, string, never, never>({
+          merge: (_current, next) => next,
+          process: (key, value) =>
+            Effect.gen(function* () {
+              if (key === "blocker") {
+                yield* Deferred.succeed(blockerStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseBlocker);
+              }
+
+              if (key === "target" && value === "first") {
+                yield* Deferred.succeed(firstFlushStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseFirstFlush);
+              }
+
+              if (key === "target" && value === "second") {
+                yield* Deferred.succeed(secondFlushStarted, undefined).pipe(Effect.orDie);
+              }
+
+              if (key === "after") {
+                yield* Deferred.succeed(afterStarted, undefined).pipe(Effect.orDie);
+              }
+            }),
+        });
+
+        yield* worker.enqueue("blocker", "first");
+        yield* Deferred.await(blockerStarted);
+        yield* worker.enqueue("target", "first");
+
+        const flushed = yield* Effect.forkChild(worker.flushKey("target"));
+        yield* Deferred.await(firstFlushStarted);
+        yield* worker.enqueue("target", "second");
+        yield* worker.enqueue("after", "only");
+
+        yield* Deferred.succeed(releaseBlocker, undefined);
+        yield* Deferred.await(afterStarted);
+
+        expect(yield* Deferred.isDone(secondFlushStarted)).toBe(false);
+
+        yield* Deferred.succeed(releaseFirstFlush, undefined);
+        yield* Fiber.join(flushed);
+        expect(yield* Deferred.isDone(secondFlushStarted)).toBe(true);
+      }),
+    ),
+  );
+
+  it.live("requeues normal follow-up work behind other queued keys", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const processed: string[] = [];
+        const firstStarted = yield* Deferred.make<void>();
+        const releaseFirst = yield* Deferred.make<void>();
+
+        const worker = yield* makeKeyedCoalescingWorker<string, string, never, never>({
+          merge: (_current, next) => next,
+          process: (key, value) =>
+            Effect.gen(function* () {
+              processed.push(`${key}:${value}`);
+              if (key === "hot" && value === "first") {
+                yield* Deferred.succeed(firstStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseFirst);
+              }
+            }),
+        });
+
+        yield* worker.enqueue("hot", "first");
+        yield* Deferred.await(firstStarted);
+        yield* worker.enqueue("hot", "second");
+        yield* worker.enqueue("other", "only");
+
+        yield* Deferred.succeed(releaseFirst, undefined);
+        yield* worker.drainKey("hot");
+        yield* worker.drainKey("other");
+
+        expect(processed).toEqual(["hot:first", "other:only", "hot:second"]);
+      }),
+    ),
+  );
+
+  it.live("preserves interruption when direct flush processing is interrupted", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const blockerStarted = yield* Deferred.make<void>();
+        const releaseBlocker = yield* Deferred.make<void>();
+        const flushStarted = yield* Deferred.make<void>();
+        const neverReleaseFlush = yield* Deferred.make<void>();
+
+        const worker = yield* makeKeyedCoalescingWorker<string, string, never, never>({
+          merge: (_current, next) => next,
+          process: (key) =>
+            Effect.gen(function* () {
+              if (key === "blocker") {
+                yield* Deferred.succeed(blockerStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseBlocker);
+              }
+
+              if (key === "target") {
+                yield* Deferred.succeed(flushStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(neverReleaseFlush);
+              }
+            }),
+        });
+
+        yield* worker.enqueue("blocker", "first");
+        yield* Deferred.await(blockerStarted);
+        yield* worker.enqueue("target", "terminal");
+
+        const flushed = yield* Effect.forkChild(worker.flushKey("target"));
+        yield* Deferred.await(flushStarted);
+        yield* Fiber.interrupt(flushed);
+        const flushExit = yield* Fiber.await(flushed);
+
+        expect(Exit.isFailure(flushExit)).toBe(true);
+        if (Exit.isFailure(flushExit)) {
+          expect(Cause.hasInterruptsOnly(flushExit.cause)).toBe(true);
+        }
+
+        yield* Deferred.succeed(releaseBlocker, undefined);
       }),
     ),
   );

--- a/packages/shared/src/KeyedCoalescingWorker.test.ts
+++ b/packages/shared/src/KeyedCoalescingWorker.test.ts
@@ -6,10 +6,53 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Scope from "effect/Scope";
+import * as TestClock from "effect/testing/TestClock";
 
 import { makeKeyedCoalescingWorker } from "./KeyedCoalescingWorker.ts";
 
 describe("makeKeyedCoalescingWorker", () => {
+  it.effect("flushes during cooldown while the next normal dequeue remains rate-limited", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const firstProcessed = yield* Deferred.make<void>();
+        const flushedProcessed = yield* Deferred.make<void>();
+        const secondProcessed = yield* Deferred.make<void>();
+
+        const worker = yield* makeKeyedCoalescingWorker<string, string, never, never>({
+          cooldown: "250 millis",
+          merge: (_current, next) => next,
+          process: (key, value) =>
+            Effect.gen(function* () {
+              if (key === "first" && value === "initial") {
+                yield* Deferred.succeed(firstProcessed, undefined).pipe(Effect.orDie);
+                return;
+              }
+              if (key === "first") {
+                yield* Deferred.succeed(flushedProcessed, undefined).pipe(Effect.orDie);
+                return;
+              }
+              yield* Deferred.succeed(secondProcessed, undefined).pipe(Effect.orDie);
+            }),
+        });
+
+        yield* worker.enqueue("first", "initial");
+        yield* Deferred.await(firstProcessed);
+        yield* Effect.yieldNow;
+
+        yield* worker.enqueue("first", "terminal-snapshot");
+        yield* worker.enqueue("second", "queued-during-cooldown");
+        yield* worker.flushKey("first");
+
+        expect(yield* Deferred.isDone(flushedProcessed)).toBe(true);
+        expect(yield* Deferred.isDone(secondProcessed)).toBe(false);
+        yield* TestClock.adjust("249 millis");
+        expect(yield* Deferred.isDone(secondProcessed)).toBe(false);
+        yield* TestClock.adjust("1 millis");
+        yield* Deferred.await(secondProcessed);
+      }),
+    ),
+  );
+
   it.live("waits for latest work enqueued during active processing before draining the key", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/shared/src/KeyedCoalescingWorker.test.ts
+++ b/packages/shared/src/KeyedCoalescingWorker.test.ts
@@ -2,6 +2,9 @@ import { it } from "@effect/vitest";
 import { describe, expect } from "vite-plus/test";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Scope from "effect/Scope";
 
 import { makeKeyedCoalescingWorker } from "./KeyedCoalescingWorker.ts";
 
@@ -93,5 +96,77 @@ describe("makeKeyedCoalescingWorker", () => {
         expect(processed).toEqual(["terminal-1:first", "terminal-1:second"]);
       }),
     ),
+  );
+
+  it.live("flushes one key without waiting behind unrelated queued work", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const processed: string[] = [];
+        const slowStarted = yield* Deferred.make<void>();
+        const releaseSlow = yield* Deferred.make<void>();
+        const urgentStarted = yield* Deferred.make<void>();
+
+        const worker = yield* makeKeyedCoalescingWorker<string, string, never, never>({
+          merge: (_current, next) => next,
+          process: (key, value, context) =>
+            Effect.gen(function* () {
+              processed.push(`${key}:${value}:${context.flush ? "flush" : "normal"}`);
+              if (key === "slow") {
+                yield* Deferred.succeed(slowStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseSlow);
+              }
+              if (key === "urgent") {
+                yield* Deferred.succeed(urgentStarted, undefined).pipe(Effect.orDie);
+              }
+            }),
+        });
+
+        yield* worker.enqueue("slow", "first");
+        yield* Deferred.await(slowStarted);
+        yield* worker.enqueue("queued", "second");
+        yield* worker.enqueue("urgent", "terminal");
+
+        const flushed = yield* Effect.forkChild(worker.flushKey("urgent"));
+        yield* Deferred.await(urgentStarted);
+
+        expect(processed).toEqual(["slow:first:normal", "urgent:terminal:flush"]);
+
+        yield* Fiber.join(flushed);
+        yield* Deferred.succeed(releaseSlow, undefined);
+        yield* worker.drainKey("queued");
+
+        expect(processed).toEqual([
+          "slow:first:normal",
+          "urgent:terminal:flush",
+          "queued:second:normal",
+        ]);
+      }),
+    ),
+  );
+
+  it.live("stops active processing when its owning scope closes", () =>
+    Effect.gen(function* () {
+      const workerScope = yield* Scope.make();
+      const started = yield* Deferred.make<void>();
+      const interrupted = yield* Deferred.make<void>();
+      const neverRelease = yield* Deferred.make<void>();
+
+      const worker = yield* makeKeyedCoalescingWorker<string, string, never, never>({
+        merge: (_current, next) => next,
+        process: () =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(started, undefined).pipe(Effect.orDie);
+            yield* Deferred.await(neverRelease);
+          }).pipe(
+            Effect.onInterrupt(() => Deferred.succeed(interrupted, undefined).pipe(Effect.orDie)),
+          ),
+      }).pipe(Effect.provideService(Scope.Scope, workerScope));
+
+      yield* worker.enqueue("child", "progress");
+      yield* Deferred.await(started);
+      yield* Scope.close(workerScope, Exit.void);
+
+      expect(yield* Deferred.isDone(interrupted)).toBe(true);
+    }),
   );
 });

--- a/packages/shared/src/KeyedCoalescingWorker.ts
+++ b/packages/shared/src/KeyedCoalescingWorker.ts
@@ -8,8 +8,9 @@
  *
  * @module KeyedCoalescingWorker
  */
-import * as Scope from "effect/Scope";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Scope from "effect/Scope";
 import * as TxQueue from "effect/TxQueue";
 import * as TxRef from "effect/TxRef";
 
@@ -29,6 +30,11 @@ interface KeyedCoalescingWorkerState<K, V> {
   readonly activeKeys: Set<K>;
   readonly flushRequestedKeys: Set<K>;
 }
+
+type ProcessKeyNext<V> =
+  | { readonly _tag: "Process"; readonly value: V }
+  | { readonly _tag: "Requeue" }
+  | null;
 
 export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
   readonly merge: (current: V, next: V) => V;
@@ -52,29 +58,47 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
       options.process(key, value, { flush }).pipe(
         Effect.provide(processContext),
         Effect.flatMap(() =>
-          TxRef.modify(stateRef, (state) => {
-            const nextValue = state.latestByKey.get(key);
-            if (nextValue === undefined) {
-              const activeKeys = new Set(state.activeKeys);
-              activeKeys.delete(key);
-              const flushRequestedKeys = new Set(state.flushRequestedKeys);
-              flushRequestedKeys.delete(key);
-              return [null, { ...state, activeKeys, flushRequestedKeys }] as const;
-            }
+          Effect.gen(function* () {
+            const next = yield* TxRef.modify(
+              stateRef,
+              (state): [ProcessKeyNext<V>, KeyedCoalescingWorkerState<K, V>] => {
+                const nextValue = state.latestByKey.get(key);
+                if (nextValue === undefined) {
+                  const activeKeys = new Set(state.activeKeys);
+                  activeKeys.delete(key);
+                  const flushRequestedKeys = new Set(state.flushRequestedKeys);
+                  flushRequestedKeys.delete(key);
+                  return [null, { ...state, activeKeys, flushRequestedKeys }];
+                }
 
-            const latestByKey = new Map(state.latestByKey);
-            latestByKey.delete(key);
-            return [
-              {
-                value: nextValue,
-                flush: state.flushRequestedKeys.has(key),
+                if (!state.flushRequestedKeys.has(key)) {
+                  const queuedKeys = new Set(state.queuedKeys);
+                  queuedKeys.add(key);
+                  const activeKeys = new Set(state.activeKeys);
+                  activeKeys.delete(key);
+                  return [{ _tag: "Requeue" }, { ...state, queuedKeys, activeKeys }];
+                }
+
+                const latestByKey = new Map(state.latestByKey);
+                latestByKey.delete(key);
+                return [
+                  { _tag: "Process", value: nextValue },
+                  { ...state, latestByKey },
+                ];
               },
-              { ...state, latestByKey },
-            ] as const;
+            );
+            if (next?._tag === "Requeue") {
+              yield* TxQueue.offer(queue, key);
+            }
+            return next;
           }).pipe(Effect.tx),
         ),
         Effect.flatMap((next) =>
-          next === null ? Effect.void : processKey(key, next.value, next.flush),
+          next === null
+            ? Effect.void
+            : next._tag === "Requeue"
+              ? Effect.void
+              : processKey(key, next.value, true),
         ),
       );
 
@@ -99,9 +123,18 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
         ),
       );
 
+    const cleanupProcessFailure = (key: K, cause: Cause.Cause<E>): Effect.Effect<void> =>
+      cleanupFailedKey(key).pipe(
+        Effect.andThen(Cause.hasInterrupts(cause) ? Effect.interrupt : Effect.void),
+      );
+
     yield* TxQueue.take(queue).pipe(
       Effect.flatMap((key) =>
         TxRef.modify(stateRef, (state) => {
+          if (state.activeKeys.has(key)) {
+            return [null, state] as const;
+          }
+
           const queuedKeys = new Set(state.queuedKeys);
           queuedKeys.delete(key);
 
@@ -125,7 +158,7 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
         item === null
           ? Effect.void
           : processKey(item.key, item.value, item.flush).pipe(
-              Effect.catchCause(() => cleanupFailedKey(item.key)),
+              Effect.catchCause((cause) => cleanupProcessFailure(item.key, cause)),
             ),
       ),
       Effect.forever,
@@ -199,7 +232,7 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
           item === null
             ? Effect.void
             : processKey(key, item.value, true).pipe(
-                Effect.catchCause(() => cleanupFailedKey(key)),
+                Effect.catchCause((cause) => cleanupProcessFailure(key, cause)),
               ),
         ),
         Effect.andThen(drainKey(key)),

--- a/packages/shared/src/KeyedCoalescingWorker.ts
+++ b/packages/shared/src/KeyedCoalescingWorker.ts
@@ -4,11 +4,14 @@
  * Enqueues for an active or already-queued key are merged atomically instead of
  * creating duplicate queued items. `flushKey()` promotes pending work for one
  * key and processes it without waiting behind unrelated keys, while
- * `drainKey()` only waits for work already in flight.
+ * `drainKey()` only waits for work already in flight. An optional cooldown
+ * rate-limits the normal background consumer after it releases the active key,
+ * so direct flushes remain delay-free.
  *
  * @module KeyedCoalescingWorker
  */
 import * as Cause from "effect/Cause";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Scope from "effect/Scope";
 import * as TxQueue from "effect/TxQueue";
@@ -37,6 +40,7 @@ type ProcessKeyNext<V> =
   | null;
 
 export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
+  readonly cooldown?: Duration.Input;
   readonly merge: (current: V, next: V) => V;
   readonly process: (
     key: K,
@@ -53,6 +57,7 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
       activeKeys: new Set(),
       flushRequestedKeys: new Set(),
     });
+    const cooldown = options.cooldown === undefined ? Effect.void : Effect.sleep(options.cooldown);
 
     const processKey = (key: K, value: V, flush: boolean): Effect.Effect<void, E> =>
       options.process(key, value, { flush }).pipe(
@@ -159,6 +164,7 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
           ? Effect.void
           : processKey(item.key, item.value, item.flush).pipe(
               Effect.catchCause((cause) => cleanupProcessFailure(item.key, cause)),
+              Effect.andThen(cooldown),
             ),
       ),
       Effect.forever,

--- a/packages/shared/src/KeyedCoalescingWorker.ts
+++ b/packages/shared/src/KeyedCoalescingWorker.ts
@@ -2,8 +2,9 @@
  * KeyedCoalescingWorker - A keyed worker that keeps only the latest value per key.
  *
  * Enqueues for an active or already-queued key are merged atomically instead of
- * creating duplicate queued items. `drainKey()` resolves only when that key has
- * no queued, pending, or active work left.
+ * creating duplicate queued items. `flushKey()` promotes pending work for one
+ * key and processes it without waiting behind unrelated keys, while
+ * `drainKey()` only waits for work already in flight.
  *
  * @module KeyedCoalescingWorker
  */
@@ -14,45 +15,66 @@ import * as TxRef from "effect/TxRef";
 
 export interface KeyedCoalescingWorker<K, V> {
   readonly enqueue: (key: K, value: V) => Effect.Effect<void>;
+  readonly flushKey: (key: K) => Effect.Effect<void>;
   readonly drainKey: (key: K) => Effect.Effect<void>;
+}
+
+export interface KeyedCoalescingWorkerProcessContext {
+  readonly flush: boolean;
 }
 
 interface KeyedCoalescingWorkerState<K, V> {
   readonly latestByKey: Map<K, V>;
   readonly queuedKeys: Set<K>;
   readonly activeKeys: Set<K>;
+  readonly flushRequestedKeys: Set<K>;
 }
 
 export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
   readonly merge: (current: V, next: V) => V;
-  readonly process: (key: K, value: V) => Effect.Effect<void, E, R>;
+  readonly process: (
+    key: K,
+    value: V,
+    context: KeyedCoalescingWorkerProcessContext,
+  ) => Effect.Effect<void, E, R>;
 }): Effect.Effect<KeyedCoalescingWorker<K, V>, never, Scope.Scope | R> =>
   Effect.gen(function* () {
+    const processContext = yield* Effect.context<R>();
     const queue = yield* Effect.acquireRelease(TxQueue.unbounded<K>(), TxQueue.shutdown);
     const stateRef = yield* TxRef.make<KeyedCoalescingWorkerState<K, V>>({
       latestByKey: new Map(),
       queuedKeys: new Set(),
       activeKeys: new Set(),
+      flushRequestedKeys: new Set(),
     });
 
-    const processKey = (key: K, value: V): Effect.Effect<void, E, R> =>
-      options.process(key, value).pipe(
+    const processKey = (key: K, value: V, flush: boolean): Effect.Effect<void, E> =>
+      options.process(key, value, { flush }).pipe(
+        Effect.provide(processContext),
         Effect.flatMap(() =>
           TxRef.modify(stateRef, (state) => {
             const nextValue = state.latestByKey.get(key);
             if (nextValue === undefined) {
               const activeKeys = new Set(state.activeKeys);
               activeKeys.delete(key);
-              return [null, { ...state, activeKeys }] as const;
+              const flushRequestedKeys = new Set(state.flushRequestedKeys);
+              flushRequestedKeys.delete(key);
+              return [null, { ...state, activeKeys, flushRequestedKeys }] as const;
             }
 
             const latestByKey = new Map(state.latestByKey);
             latestByKey.delete(key);
-            return [nextValue, { ...state, latestByKey }] as const;
+            return [
+              {
+                value: nextValue,
+                flush: state.flushRequestedKeys.has(key),
+              },
+              { ...state, latestByKey },
+            ] as const;
           }).pipe(Effect.tx),
         ),
-        Effect.flatMap((nextValue) =>
-          nextValue === null ? Effect.void : processKey(key, nextValue),
+        Effect.flatMap((next) =>
+          next === null ? Effect.void : processKey(key, next.value, next.flush),
         ),
       );
 
@@ -67,7 +89,9 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
           return [true, { ...state, activeKeys, queuedKeys }] as const;
         }
 
-        return [false, { ...state, activeKeys }] as const;
+        const flushRequestedKeys = new Set(state.flushRequestedKeys);
+        flushRequestedKeys.delete(key);
+        return [false, { ...state, activeKeys, flushRequestedKeys }] as const;
       }).pipe(
         Effect.tx,
         Effect.flatMap((shouldRequeue) =>
@@ -92,7 +116,7 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
           activeKeys.add(key);
 
           return [
-            { key, value } as const,
+            { key, value, flush: state.flushRequestedKeys.has(key) } as const,
             { ...state, latestByKey, queuedKeys, activeKeys },
           ] as const;
         }).pipe(Effect.tx),
@@ -100,7 +124,7 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
       Effect.flatMap((item) =>
         item === null
           ? Effect.void
-          : processKey(item.key, item.value).pipe(
+          : processKey(item.key, item.value, item.flush).pipe(
               Effect.catchCause(() => cleanupFailedKey(item.key)),
             ),
       ),
@@ -138,5 +162,48 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
         Effect.tx,
       );
 
-    return { enqueue, drainKey } satisfies KeyedCoalescingWorker<K, V>;
+    const flushKey: KeyedCoalescingWorker<K, V>["flushKey"] = (key) =>
+      TxRef.modify(stateRef, (state) => {
+        const hasWork =
+          state.latestByKey.has(key) || state.queuedKeys.has(key) || state.activeKeys.has(key);
+        if (!hasWork) {
+          return [null, state] as const;
+        }
+
+        const flushRequestedKeys = new Set(state.flushRequestedKeys);
+        flushRequestedKeys.add(key);
+        const value = state.latestByKey.get(key);
+        if (state.activeKeys.has(key) || value === undefined) {
+          return [null, { ...state, flushRequestedKeys }] as const;
+        }
+
+        const latestByKey = new Map(state.latestByKey);
+        latestByKey.delete(key);
+        const queuedKeys = new Set(state.queuedKeys);
+        queuedKeys.delete(key);
+        const activeKeys = new Set(state.activeKeys);
+        activeKeys.add(key);
+        return [
+          { value },
+          {
+            ...state,
+            latestByKey,
+            queuedKeys,
+            activeKeys,
+            flushRequestedKeys,
+          },
+        ] as const;
+      }).pipe(
+        Effect.tx,
+        Effect.flatMap((item) =>
+          item === null
+            ? Effect.void
+            : processKey(key, item.value, true).pipe(
+                Effect.catchCause(() => cleanupFailedKey(key)),
+              ),
+        ),
+        Effect.andThen(drainKey(key)),
+      );
+
+    return { enqueue, flushKey, drainKey } satisfies KeyedCoalescingWorker<K, V>;
   });


### PR DESCRIPTION
Closes #5681 

## What Changed

- Coalesce normal Codex child item and cumulative token-usage progress at the provider runtime boundary.
- Preserve independent latest-item and latest-usage lanes per child thread.
- Throttle normal progress through the shared keyed worker, while allowing a terminal child lifecycle event to flush that child's latest progress immediately.
- Add priority-flush and scope-ownership semantics to `KeyedCoalescingWorker` without changing existing `drainKey` behavior.
- Bind the progress worker to the Codex runtime scope so explicit close cancels pending best-effort progress before event queues shut down.
- Add focused coverage for burst coalescing, latest-value preservation, progress-before-terminal ordering, cross-key priority flush, and scope-close interruption.

## Why

Native Codex subagent observability currently emits every child `item/started`, `item/completed`, and cumulative token-usage snapshot as a separate provider event. The adapter maps each event to `task.progress`, and provider ingestion persists every update as a durable activity append.

Stable task activity IDs keep projected row count small, but do not reduce event-store or command-processing work. A busy subagent fleet can therefore fill the serial ingestion path with redundant progress snapshots and delay unrelated threads.

Coalescing belongs at the provider boundary because these events are latest-state snapshots: the UI needs the newest item summary and cumulative usage, not every intermediate value. Terminal lifecycle events still flush the latest pending values first, so task state cannot overtake its final progress.

Normal progress is throttled per Codex session. Terminal flushes intentionally bypass the debounce and may emit up to the latest item and usage snapshots immediately; this avoids cross-child head-of-line blocking without claiming an absolute rate cap over lifecycle flushes.

## Validation

- `node_modules/vite-plus/bin/vp test run packages/shared/src/KeyedCoalescingWorker.test.ts apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts`
  - 2 test files passed
  - 6 tests passed
- Targeted `vp lint --type-aware --type-check --report-unused-disable-directives` on all four changed files passed.
- Targeted `vp fmt --check` on all four changed files passed.
- `git diff --check` passed.

## UI Changes

None.

## Scope

This PR does not change raw assistant streaming, global orchestration scheduling, projectors, SQLite cleanup, or UI behavior. It addresses only Codex child progress amplification and the worker semantics required for correct terminal flushing.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I added focused regression coverage
- [x] No UI screenshots or interaction video are needed

## Related

- Proposed issue: #5681 
- Native subagent observability: [PR #5219](https://github.com/pingdotgg/t3code/pull/5219)
- Related assistant-stream persistence amplification: [issue #5110](https://github.com/pingdotgg/t3code/issues/5110)
- Regression-introducing commit: [`a2ca89aa`](https://github.com/pingdotgg/t3code/commit/a2ca89aa10f13a2222e08afd98c66285121d5ba2)

Prepared with Codex CLI (GPT-5.6-sol).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider event ordering and ingestion volume for collab children; terminal flush ordering is correctness-sensitive but scoped to Codex runtime and covered by integration tests.
> 
> **Overview**
> **Codex collab child progress** (`collabAgent/item`, `collabAgent/tokenUsage`) is no longer emitted on every wire notification. Updates are merged per child thread into separate **latest-item** and **latest-usage** lanes, debounced (~250ms) through a session-scoped `KeyedCoalescingWorker`, then emitted as provider events.
> 
> **Terminal lifecycle** (`turn/completed`, non-active `thread/status/changed`, `thread/closed`, terminal child `error`) calls **`flushKey`** so the newest pending progress is delivered **before** idle/complete/close events, without waiting behind other children. Normal flushes skip the debounce sleep.
> 
> **`KeyedCoalescingWorker`** gains **`flushKey`** (priority processing for one key, `context.flush` on `process`) and documents that **`drainKey`** behavior is unchanged. Closing the worker’s scope interrupts in-flight work.
> 
> **Session `close`** now **`Scope.close(runtimeScope)`** before `session/closed` and queue shutdown so coalesced progress cannot enqueue after teardown.
> 
> Integration and unit tests cover burst coalescing, latest-value retention, progress-before-terminal ordering, cross-key flush, and scope-close interruption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c74ae215156452ba8de454ad2f179949c4ff6be8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound Codex subagent progress events with coalescing and flush-before-terminal semantics
> - Collab child progress notifications (`collabAgent/item` and `collabAgent/tokenUsage`) are now coalesced via a keyed worker with a 250ms cooldown, emitting only the latest item and token usage per child within each window.
> - Before emitting terminal child lifecycle events (turn completed, status changed to non-active, thread closed, terminal errors), the latest coalesced progress is flushed synchronously to preserve ordering.
> - Extends `KeyedCoalescingWorker` in [KeyedCoalescingWorker.ts](https://github.com/pingdotgg/t3code/pull/5682/files#diff-3fd0fe720a2d3805cc6315c91490c028cf8304928b19b3c0c17dba21f6a521e7) with a `flushKey` method that bypasses the queue and cooldown for a specific key, passing a flush-context flag to the process callback.
> - Session close now shuts down the runtime scope before emitting `session/closed`, cancelling any pending best-effort progress emissions.
> - Behavioral Change: child progress events may be delayed up to ~250ms and burst updates are collapsed to a single emit; consumers will see fewer, coalesced events rather than every individual update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d765754.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->