### PR TITLE
fix(mobile): keep keyboard out of model picker

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1,7 +1,7 @@
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, usePreventRemove } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Alert, InteractionManager, Keyboard, Platform, View, useColorScheme } from "react-native";
+import { Alert, InteractionManager, Platform, View, useColorScheme } from "react-native";
 import { KeyboardAvoidingView, useKeyboardState } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
@@ -26,6 +26,7 @@ import { ControlPill, ControlPillMenu } from "../../components/ControlPill";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import { ComposerSurface } from "./ThreadComposer";
 import { ThreadSettingsSheet, threadSettingsSummaryLabel } from "./ThreadSettingsSheet";
+import { useThreadSettingsSheetPresentation } from "./use-thread-settings-sheet-presentation";
 
 import { makeTurnCommandMetadata } from "../../lib/commandMetadata";
 import { convertPastedImagesToAttachments, pickComposerImages } from "../../lib/composerImages";
@@ -99,9 +100,10 @@ export function NewTaskDraftScreen(props: {
   const promptInputRef = useRef<ComposerEditorHandle>(null);
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
-  const [isSettingsSheetVisible, setIsSettingsSheetVisible] = useState(false);
-  const isSettingsSheetVisibleRef = useRef(false);
-  isSettingsSheetVisibleRef.current = isSettingsSheetVisible;
+  const settingsSheetPresentation = useThreadSettingsSheetPresentation({
+    editorRef: promptInputRef,
+    isEditorFocused: isComposerFocused,
+  });
   const [importingShareKey, setImportingShareKey] = useState<string | null>(null);
   const [isCancellingShareImport, setIsCancellingShareImport] = useState(false);
   const [cancelledIncomingShareId, setCancelledIncomingShareId] = useState<string | null>(null);
@@ -523,8 +525,10 @@ export function NewTaskDraftScreen(props: {
       focusFrame = requestAnimationFrame(() => {
         // The delayed focus can land after the settings sheet opened, which
         // would pop the keyboard underneath its modal.
-        if (!isSettingsSheetVisibleRef.current) {
+        if (!settingsSheetPresentation.isActiveRef.current) {
           promptInputRef.current?.focus();
+        } else {
+          settingsSheetPresentation.restoreFocusAfterSave();
         }
       });
     });
@@ -535,7 +539,11 @@ export function NewTaskDraftScreen(props: {
         cancelAnimationFrame(focusFrame);
       }
     };
-  }, [selectedProject]);
+  }, [
+    selectedProject,
+    settingsSheetPresentation.isActiveRef,
+    settingsSheetPresentation.restoreFocusAfterSave,
+  ]);
 
   const environmentMenuActions = useMemo(
     () =>
@@ -643,24 +651,6 @@ export function NewTaskDraftScreen(props: {
       }),
     [currentBranchName, flow.selectedBranchName, flow.workspaceMode],
   );
-  // Order matters: mark the sheet open before dismissing the keyboard so the
-  // Android draft layout (expanded only while focused) doesn't collapse.
-  // The keyboard only comes back on close if it was up when the sheet opened.
-  const wasFocusedBeforeSheetRef = useRef(false);
-  const openSettingsSheet = useCallback(() => {
-    wasFocusedBeforeSheetRef.current = isComposerFocused;
-    setIsSettingsSheetVisible(true);
-    Keyboard.dismiss();
-  }, [isComposerFocused]);
-  const closeSettingsSheet = useCallback((reason: "save" | "dismiss") => {
-    setIsSettingsSheetVisible(false);
-    // Only Save/Done restores the keyboard: a dismissal (backdrop or
-    // grabber, including stray taps near the sheet's edge) closes quietly.
-    if (reason === "save" && wasFocusedBeforeSheetRef.current) {
-      promptInputRef.current?.focus();
-    }
-  }, []);
-
   function handleEnvironmentMenuAction(event: string) {
     if (isIncomingShareTransferPending || !event.startsWith("environment:")) {
       return;
@@ -876,7 +866,7 @@ export function NewTaskDraftScreen(props: {
   // the touch gesture that opens the keyboard.
   // The settings sheet dismisses the keyboard, so its flag keeps the Android
   // draft composer expanded through the blur (mirrors ThreadComposer).
-  const isExpanded = !isAndroid || isComposerFocused || isSettingsSheetVisible;
+  const isExpanded = !isAndroid || isComposerFocused || settingsSheetPresentation.isActive;
   const canStart =
     Boolean(flow.selectedProject) &&
     Boolean(flow.selectedModel) &&
@@ -936,7 +926,7 @@ export function NewTaskDraftScreen(props: {
         iconNode={<ProviderIcon provider={flow.selectedModelOption?.providerDriver} size={16} />}
         label={settingsSummaryLabel}
         maxWidth={320}
-        onPress={openSettingsSheet}
+        onPress={settingsSheetPresentation.open}
       />
       <ControlPillMenu
         actions={environmentMenuActions}
@@ -965,8 +955,9 @@ export function NewTaskDraftScreen(props: {
 
   const settingsSheet = (
     <ThreadSettingsSheet
-      visible={isSettingsSheetVisible}
-      onClose={closeSettingsSheet}
+      visible={settingsSheetPresentation.isVisible}
+      onClose={settingsSheetPresentation.close}
+      onDismissed={settingsSheetPresentation.onDismissed}
       providerGroups={flow.providerGroups}
       selectedModel={flow.selectedModel}
       onSelectModel={(option) => flow.setSelectedModelKey(option.key, option.selection.options)}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -19,7 +19,6 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject
 import {
   ActivityIndicator,
   Image,
-  Keyboard,
   Platform,
   Pressable,
   StyleSheet,
@@ -67,6 +66,7 @@ import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
 import { useComposerPathSearch } from "../../state/use-composer-path-search";
 import { ComposerCommandPopover, type ComposerCommandItem } from "./ComposerCommandPopover";
 import { ThreadSettingsSheet, threadSettingsSummaryLabel } from "./ThreadSettingsSheet";
+import { useThreadSettingsSheetPresentation } from "./use-thread-settings-sheet-presentation";
 
 /**
  * Height of the collapsed composer (pill + vertical padding, excluding safe-area inset).
@@ -270,16 +270,19 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const fallbackInputRef = useRef<ComposerEditorHandle>(null);
   const inputRef = props.editorRef ?? fallbackInputRef;
   const [isFocused, setIsFocused] = useState(false);
+  const settingsSheetPresentation = useThreadSettingsSheetPresentation({
+    editorRef: inputRef,
+    isEditorFocused: isFocused,
+  });
   const wasExpandedBeforePreviewRef = useRef(false);
   const inFlightThreadIdsRef = useRef(new Set<string>());
   const { onExpandedChange } = props;
 
   const [previewImageUri, setPreviewImageUri] = useState<string | null>(null);
-  const [isSettingsSheetVisible, setIsSettingsSheetVisible] = useState(false);
   const hasContent = props.draftMessage.trim().length > 0 || props.draftAttachments.length > 0;
-  // The settings sheet dismisses the keyboard (it would cover the sheet), so
-  // the sheet flag keeps the composer expanded through that blur.
-  const isExpanded = isFocused || isSettingsSheetVisible;
+  // Opening and closing count as active so the composer stays expanded while
+  // focus moves between its native editor and the settings modal.
+  const isExpanded = isFocused || settingsSheetPresentation.isActive;
   const canSend = hasContent;
 
   // Notify the parent from the derived value, not focus events: the parent
@@ -620,27 +623,6 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     interactionMode: currentInteractionMode,
   });
 
-  // Order matters: mark the sheet open before dismissing the keyboard so
-  // isExpanded stays true through the blur and the composer doesn't collapse.
-  // The keyboard only comes back on close if it was up when the sheet opened.
-  const wasFocusedBeforeSheetRef = useRef(false);
-  const openSettingsSheet = useCallback(() => {
-    wasFocusedBeforeSheetRef.current = isFocused;
-    setIsSettingsSheetVisible(true);
-    Keyboard.dismiss();
-  }, [isFocused]);
-  const closeSettingsSheet = useCallback(
-    (reason: "save" | "dismiss") => {
-      setIsSettingsSheetVisible(false);
-      // Only Save/Done restores the keyboard: a dismissal (backdrop or
-      // grabber, including stray taps near the sheet's edge) closes quietly.
-      if (reason === "save" && wasFocusedBeforeSheetRef.current) {
-        inputRef.current?.focus();
-      }
-    },
-    [inputRef],
-  );
-
   return (
     <Animated.View
       className="px-4"
@@ -817,7 +799,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                   }
                   label={settingsSummaryLabel}
                   maxWidth={320}
-                  onPress={openSettingsSheet}
+                  onPress={settingsSheetPresentation.open}
                 />
                 {showStopAction ? (
                   <ComposerToolbarButton
@@ -853,8 +835,9 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       </Animated.View>
 
       <ThreadSettingsSheet
-        visible={isSettingsSheetVisible}
-        onClose={closeSettingsSheet}
+        visible={settingsSheetPresentation.isVisible}
+        onClose={settingsSheetPresentation.close}
+        onDismissed={settingsSheetPresentation.onDismissed}
         providerGroups={threadProviderGroups}
         selectedModel={currentModelSelection}
         onSelectModel={(option) => props.onUpdateModelSelection(option.selection)}

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -11,8 +11,16 @@ import {
   getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
 import * as Haptics from "expo-haptics";
-import { useEffect, useState } from "react";
-import { Modal, Pressable, ScrollView, Switch, useWindowDimensions, View } from "react-native";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  Switch,
+  useWindowDimensions,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { SymbolView } from "../../components/AppSymbol";
@@ -22,6 +30,8 @@ import { cn } from "../../lib/cn";
 import type { ModelOption, ProviderGroup } from "../../lib/modelOptions";
 import { applyProviderOptionSelection, providerOptionValueLabels } from "../../lib/providerOptions";
 import { useThemeColor } from "../../lib/useThemeColor";
+import { pendingModelAfterPress } from "./thread-settings-sheet-state";
+import type { ThreadSettingsSheetCloseReason } from "./use-thread-settings-sheet-presentation";
 
 /**
  * The everyday harnesses stay expanded; every other provider (OpenRouter
@@ -293,7 +303,8 @@ export function ThreadSettingsSheet(props: {
    * "dismiss" = backdrop, grabber, or system back. Hosts only restore the
    * keyboard for "save" so a stray tap outside a control never pops it.
    */
-  readonly onClose: (reason: "save" | "dismiss") => void;
+  readonly onClose: (reason: ThreadSettingsSheetCloseReason) => void;
+  readonly onDismissed: () => void;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly selectedModel: ModelSelection | null;
   readonly onSelectModel: (option: ModelOption) => void;
@@ -308,18 +319,31 @@ export function ThreadSettingsSheet(props: {
   const [expandedProviders, setExpandedProviders] = useState<ReadonlySet<string>>(() => new Set());
   const [pendingModel, setPendingModel] = useState<ModelOption | null>(null);
   const [submenu, setSubmenu] = useState<SubmenuPage | null>(null);
+  const wasPresentedRef = useRef(false);
+  const notifyDismissed = useCallback(() => {
+    if (!wasPresentedRef.current) {
+      return;
+    }
+    wasPresentedRef.current = false;
+    props.onDismissed();
+  }, [props.onDismissed]);
 
   // Every open starts fresh: no staged model, no submenu, legacy hidden,
   // secondary providers folded. The sheet stays mounted between opens, so
   // state would otherwise stick around.
   useEffect(() => {
     if (props.visible) {
+      wasPresentedRef.current = true;
       setShowLegacyToggle(false);
       setExpandedProviders(new Set());
       setPendingModel(null);
       setSubmenu(null);
+    } else if (Platform.OS === "android" && wasPresentedRef.current) {
+      // React Native only emits Modal.onDismiss on iOS. Android uses no exit
+      // animation below, so the post-commit effect is its dismissal boundary.
+      notifyDismissed();
     }
-  }, [props.visible]);
+  }, [notifyDismissed, props.visible]);
 
   const isApplied = (option: ModelOption) =>
     option.selection.instanceId === props.selectedModel?.instanceId &&
@@ -455,8 +479,9 @@ export function ThreadSettingsSheet(props: {
       transparent
       statusBarTranslucent
       navigationBarTranslucent
-      animationType="fade"
+      animationType={Platform.OS === "ios" ? "fade" : "none"}
       visible={props.visible}
+      onDismiss={notifyDismissed}
       onRequestClose={submenuContent ? () => setSubmenu(null) : () => props.onClose("dismiss")}
     >
       <View className="flex-1 justify-end">
@@ -538,7 +563,13 @@ export function ThreadSettingsSheet(props: {
                           onPress={() => {
                             void Haptics.selectionAsync();
                             // Re-tapping the applied model cancels staging.
-                            setPendingModel(isApplied(option) ? null : option);
+                            setPendingModel((current) =>
+                              pendingModelAfterPress({
+                                current,
+                                pressed: option,
+                                pressedIsApplied: isApplied(option),
+                              }),
+                            );
                           }}
                         />
                       ))}

--- a/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
+++ b/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { ProviderInstanceId, type ProviderOptionSelection } from "@t3tools/contracts";
+
+import type { ModelOption } from "../../lib/modelOptions";
+import { pendingModelAfterPress } from "./thread-settings-sheet-state";
+
+function modelOption(
+  model: string,
+  options: ReadonlyArray<ProviderOptionSelection> = [],
+): ModelOption {
+  return {
+    key: `codex:${model}`,
+    label: model,
+    subtitle: "Codex",
+    providerKey: "codex",
+    providerLabel: "Codex",
+    providerDriver: "codex",
+    isDefault: false,
+    isLegacy: false,
+    capabilities: null,
+    selection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model,
+      options,
+    },
+  };
+}
+
+describe("thread settings sheet state", () => {
+  it("clears staging when the applied model is pressed", () => {
+    expect(
+      pendingModelAfterPress({
+        current: modelOption("gpt-next"),
+        pressed: modelOption("gpt-current"),
+        pressedIsApplied: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("preserves staged options when the highlighted model is pressed again", () => {
+    const pending = modelOption("gpt-next", [{ id: "effort", value: "high" }]);
+
+    expect(
+      pendingModelAfterPress({
+        current: pending,
+        pressed: modelOption("gpt-next"),
+        pressedIsApplied: false,
+      }),
+    ).toBe(pending);
+  });
+
+  it("stages a different model", () => {
+    const pressed = modelOption("gpt-other");
+
+    expect(
+      pendingModelAfterPress({
+        current: modelOption("gpt-next"),
+        pressed,
+        pressedIsApplied: false,
+      }),
+    ).toBe(pressed);
+  });
+});

--- a/apps/mobile/src/features/threads/thread-settings-sheet-state.ts
+++ b/apps/mobile/src/features/threads/thread-settings-sheet-state.ts
@@ -1,0 +1,13 @@
+import type { ModelOption } from "../../lib/modelOptions";
+
+/** Preserve staged provider options when the highlighted model is tapped again. */
+export function pendingModelAfterPress(input: {
+  readonly current: ModelOption | null;
+  readonly pressed: ModelOption;
+  readonly pressedIsApplied: boolean;
+}): ModelOption | null {
+  if (input.pressedIsApplied) {
+    return null;
+  }
+  return input.current?.key === input.pressed.key ? input.current : input.pressed;
+}

--- a/apps/mobile/src/features/threads/use-thread-settings-sheet-presentation.ts
+++ b/apps/mobile/src/features/threads/use-thread-settings-sheet-presentation.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { KeyboardController } from "react-native-keyboard-controller";
+
+import type { ComposerEditorHandle } from "../../components/ComposerEditor";
+
+export type ThreadSettingsSheetCloseReason = "save" | "dismiss";
+
+type PresentationPhase = "closed" | "opening" | "visible" | "closing";
+
+/**
+ * Keeps the custom native composer and the settings modal from owning focus at
+ * the same time. Opening waits for the keyboard dismissal to finish, while
+ * focus restoration waits for the modal's dismissal callback.
+ */
+export function useThreadSettingsSheetPresentation(input: {
+  readonly editorRef: RefObject<ComposerEditorHandle | null>;
+  readonly isEditorFocused: boolean;
+}) {
+  const [phase, setPhase] = useState<PresentationPhase>("closed");
+  const isActiveRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const openingIdRef = useRef(0);
+  const restoreFocusOnSaveRef = useRef(false);
+  const shouldRestoreAfterDismissRef = useRef(false);
+
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+      isActiveRef.current = false;
+      openingIdRef.current += 1;
+    },
+    [],
+  );
+
+  const open = useCallback(() => {
+    if (isActiveRef.current) {
+      return;
+    }
+
+    isActiveRef.current = true;
+    restoreFocusOnSaveRef.current = input.isEditorFocused || KeyboardController.isVisible();
+    shouldRestoreAfterDismissRef.current = false;
+    setPhase("opening");
+
+    const openingId = openingIdRef.current + 1;
+    openingIdRef.current = openingId;
+
+    // Keyboard.dismiss() only tracks React Native TextInputs. The composer is
+    // a custom native text view, so explicitly resign its first responder too.
+    input.editorRef.current?.blur();
+    void KeyboardController.dismiss().then(() => {
+      if (!isMountedRef.current || !isActiveRef.current || openingIdRef.current !== openingId) {
+        return;
+      }
+      setPhase("visible");
+    });
+  }, [input.editorRef, input.isEditorFocused]);
+
+  const close = useCallback((reason: ThreadSettingsSheetCloseReason) => {
+    if (!isActiveRef.current) {
+      return;
+    }
+
+    openingIdRef.current += 1;
+    shouldRestoreAfterDismissRef.current = reason === "save" && restoreFocusOnSaveRef.current;
+    setPhase("closing");
+  }, []);
+
+  const onDismissed = useCallback(() => {
+    const shouldRestoreFocus = shouldRestoreAfterDismissRef.current;
+    shouldRestoreAfterDismissRef.current = false;
+    restoreFocusOnSaveRef.current = false;
+    isActiveRef.current = false;
+    setPhase("closed");
+
+    if (shouldRestoreFocus) {
+      input.editorRef.current?.focus();
+    }
+  }, [input.editorRef]);
+
+  // The new-task screen can have an autofocus queued before the sheet opens.
+  // Preserve that intent for Save without allowing it to focus under the modal.
+  const restoreFocusAfterSave = useCallback(() => {
+    if (isActiveRef.current) {
+      restoreFocusOnSaveRef.current = true;
+    }
+  }, []);
+
+  return {
+    isActive: phase !== "closed",
+    isActiveRef,
+    isVisible: phase === "visible",
+    open,
+    close,
+    onDismissed,
+    restoreFocusAfterSave,
+  } as const;
+}


### PR DESCRIPTION
The model settings sheet could race the custom native composer. The keyboard could survive underneath the picker, delayed new-task autofocus could land after presentation started, and Save could refocus before the modal finished dismissing. Re-tapping a staged model could also discard its edited provider options.

The picker now uses one shared presentation lifecycle that latches opening synchronously, explicitly blurs the native editor, waits for keyboard dismissal before presenting, and restores focus only after modal dismissal. Re-tapping the highlighted staged model preserves its pending options.

Stacked on #5625.

Tests:
- `vp lint` on the six touched mobile files
- `vp test run apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts apps/mobile/src/lib/modelOptions.test.ts apps/mobile/src/lib/providerOptions.test.ts`
- `vp run --filter @t3tools/mobile typecheck`

Built by GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes focus/keyboard timing for the main composer and model picker on iOS and Android; behavior is localized to mobile UI but easy to regress in edge cases (autofocus, Save vs dismiss).
> 
> **Overview**
> Fixes keyboard and focus races between the **custom native composer** and the **thread settings / model picker** modal on mobile.
> 
> **Thread settings presentation** is centralized in `useThreadSettingsSheetPresentation`, used by both `ThreadComposer` and `NewTaskDraftScreen` instead of duplicated local state. Opening **latches active immediately** (so the composer stays expanded), **blurs the native editor**, and waits for `KeyboardController.dismiss()` before the modal becomes visible. Closing moves through a **closing** phase; **keyboard/focus is restored only after** `ThreadSettingsSheet` reports dismissal via new `onDismissed` (iOS `Modal.onDismiss`, Android when `visible` goes false with no exit animation). **Save** restores focus only if the keyboard was up when the sheet opened; dismiss does not.
> 
> `NewTaskDraftScreen` delayed autofocus respects an active sheet via `isActiveRef` and can call `restoreFocusAfterSave` so Save still brings the keyboard back after a queued focus.
> 
> **Model staging:** re-tapping the already-highlighted staged model no longer resets pending provider options—logic extracted to `pendingModelAfterPress` with unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e132c951d58af7888299265da6be6b4a6550a65d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keyboard interference with model picker in thread settings sheet
> - Introduces [`useThreadSettingsSheetPresentation`](https://github.com/pingdotgg/t3code/pull/5686/files#diff-ca81d99fee6867ac0dda1210735bb2a2384f797d9e4a8301063abb554c721b04) to manage modal presentation phases (closed/opening/visible/closing), ensuring the keyboard fully dismisses before the settings modal appears.
> - Prevents the editor from stealing focus while the settings sheet is active, and restores focus only after the modal fully dismisses when closed via Save.
> - Adds [`pendingModelAfterPress`](https://github.com/pingdotgg/t3code/pull/5686/files#diff-e6e1364e445dc8dfcac2ff7decfedbaa497c0fdf75f230be2e5ac56ca994e3c1) to fix model selection staging: re-tapping the highlighted model preserves staged options, while tapping the already-applied model clears staging.
> - The composer remains visually expanded while the settings modal is opening or closing.
> - Behavioral Change: Android settings modal now uses no animation; iOS retains a fade animation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e132c95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->