### PR TITLE
feat(web): add a Clear all action to the settled shelf

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -126,6 +126,7 @@ import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
 import {
+  archiveSelectedThreadEntries,
   buildBulkTitleRegenerationContextMenuItem,
   formatWorkingDurationLabel,
   firstValidTimestampMs,
@@ -1935,39 +1936,8 @@ export default function Sidebar() {
   );
   const [settledShelfExpanded, setSettledShelfExpanded] = useState(true);
   const toggleSettledShelf = useCallback(() => setSettledShelfExpanded((value) => !value), []);
-  // Empties the whole shelf in one action. Archive, not delete: "clear" is
-  // about the sidebar, so every row stays recoverable from Settings → Archived.
-  const clearSettledThreads = useCallback(async () => {
-    const count = settledThreads.length;
-    if (count === 0) return;
-    const api = readLocalApi();
-    if (!api) return;
-    const confirmed = await settlePromise(() =>
-      api.dialogs.confirm(
-        [
-          `Clear ${count} settled thread${count === 1 ? "" : "s"} from the sidebar?`,
-          "They move to Archived and can be restored from Settings.",
-        ].join("\n"),
-      ),
-    );
-    if (confirmed._tag === "Failure" || !confirmed.value) return;
-    for (const thread of settledThreads) {
-      const result = await archiveThread(scopeThreadRef(thread.environmentId, thread.id));
-      if (result._tag === "Failure") {
-        if (!isAtomCommandInterrupted(result)) {
-          const error = squashAtomCommandFailure(result);
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Failed to clear settled threads",
-              description: error instanceof Error ? error.message : "An error occurred.",
-            }),
-          );
-        }
-        return;
-      }
-    }
-  }, [archiveThread, settledThreads]);
+  const settledThreadsRef = useRef(settledThreads);
+  settledThreadsRef.current = settledThreads;
   const renderedSettledThreads = useMemo(() => {
     if (settledShelfExpanded) return visibleSettledThreads;
     if (routeThreadKey === null) return [];
@@ -2530,6 +2500,67 @@ export default function Sidebar() {
   );
 
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
+  // Empties the whole shelf in one action. Archive, not delete: "clear" is
+  // about the sidebar, so every row stays recoverable from Settings → Archived.
+  const clearSettledThreads = useCallback(async () => {
+    const confirmedTargets = settledThreadsRef.current;
+    const count = confirmedTargets.length;
+    if (count === 0) return;
+    const api = readLocalApi();
+    if (!api) return;
+    const confirmed = await settlePromise(() =>
+      api.dialogs.confirm(
+        [
+          `Clear ${count} settled thread${count === 1 ? "" : "s"} from the sidebar?`,
+          "They move to Archived and can be restored from Settings.",
+        ].join("\n"),
+      ),
+    );
+    if (confirmed._tag === "Failure" || !confirmed.value) return;
+    // The dialog stays open as long as the user takes, so re-read the shelf:
+    // a thread that stopped being settled meanwhile is no longer part of what
+    // was agreed to, and archiving it anyway would be a surprise.
+    const stillSettled = new Set(
+      settledThreadsRef.current.map((thread) =>
+        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      ),
+    );
+    const entries = confirmedTargets
+      .map((thread) => {
+        const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+        return { threadRef, threadKey: scopedThreadKey(threadRef) };
+      })
+      .filter((entry) => stillSettled.has(entry.threadKey));
+    const outcome = await archiveSelectedThreadEntries({
+      entries,
+      archive: ({ threadRef }, onArchived) => archiveThread(threadRef, { onArchived }),
+    });
+    // Archiving the open thread navigates away afterwards; that followup can
+    // fail on its own without undoing the archive, so it must not abort the
+    // rest of the batch.
+    for (const failure of outcome.followupFailures) {
+      if (isAtomCommandInterrupted(failure)) continue;
+      const error = squashAtomCommandFailure(failure);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Thread archived, but navigation failed",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    }
+    removeFromSelection(outcome.archivedThreadKeys);
+    if (outcome.mutationFailure && !isAtomCommandInterrupted(outcome.mutationFailure)) {
+      const error = squashAtomCommandFailure(outcome.mutationFailure);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Failed to clear settled threads",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    }
+  }, [archiveThread, removeFromSelection]);
   const handleMultiSelectContextMenu = useCallback(
     async (position: { x: number; y: number }) => {
       const api = readLocalApi();

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1375,6 +1375,7 @@ export default function Sidebar() {
     unpinThread,
     reorderPinnedThread,
     deleteThread,
+    archiveThread,
   } = useThreadActions();
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
@@ -1934,6 +1935,39 @@ export default function Sidebar() {
   );
   const [settledShelfExpanded, setSettledShelfExpanded] = useState(true);
   const toggleSettledShelf = useCallback(() => setSettledShelfExpanded((value) => !value), []);
+  // Empties the whole shelf in one action. Archive, not delete: "clear" is
+  // about the sidebar, so every row stays recoverable from Settings → Archived.
+  const clearSettledThreads = useCallback(async () => {
+    const count = settledThreads.length;
+    if (count === 0) return;
+    const api = readLocalApi();
+    if (!api) return;
+    const confirmed = await settlePromise(() =>
+      api.dialogs.confirm(
+        [
+          `Clear ${count} settled thread${count === 1 ? "" : "s"} from the sidebar?`,
+          "They move to Archived and can be restored from Settings.",
+        ].join("\n"),
+      ),
+    );
+    if (confirmed._tag === "Failure" || !confirmed.value) return;
+    for (const thread of settledThreads) {
+      const result = await archiveThread(scopeThreadRef(thread.environmentId, thread.id));
+      if (result._tag === "Failure") {
+        if (!isAtomCommandInterrupted(result)) {
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Failed to clear settled threads",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        }
+        return;
+      }
+    }
+  }, [archiveThread, settledThreads]);
   const renderedSettledThreads = useMemo(() => {
     if (settledShelfExpanded) return visibleSettledThreads;
     if (routeThreadKey === null) return [];
@@ -3447,14 +3481,14 @@ export default function Sidebar() {
                       <li
                         key="settled-shelf-header"
                         data-thread-selection-safe
-                        className="list-none"
+                        className="mb-1 mt-3 flex list-none items-center gap-2 px-2.5"
                       >
                         <button
                           type="button"
                           onClick={toggleSettledShelf}
                           aria-expanded={settledShelfExpanded}
                           data-testid="sidebar-settled-shelf-toggle"
-                          className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
+                          className="flex flex-1 cursor-pointer items-center gap-2 text-left"
                         >
                           <span className="text-xs font-medium text-muted-foreground/50">
                             {settledShelfExpanded
@@ -3469,6 +3503,14 @@ export default function Sidebar() {
                               settledShelfExpanded && "rotate-180",
                             )}
                           />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={clearSettledThreads}
+                          data-testid="sidebar-settled-clear-all"
+                          className="shrink-0 cursor-pointer text-xs font-medium text-muted-foreground/50 transition-colors hover:text-sidebar-foreground"
+                        >
+                          Clear all
                         </button>
                       </li>,
                     );

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -11,3 +11,12 @@ other connected devices.
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.
+
+## Clearing settled threads
+
+Threads you have finished with collect in the **Settled** section at the bottom of the sidebar. On
+web and desktop, **Clear all** in that section's header empties it in one step, after asking you to
+confirm.
+
+Clearing archives those threads rather than deleting them. Their conversations are kept, and you can
+bring any of them back from **Settings → Archived**.


### PR DESCRIPTION
## Problem

The settled shelf in the sidebar only ever grows. Threads settle automatically, and the sole way to get one out of the list is archiving it individually from its row menu. After a busy week the shelf holds dozens of rows, and tidying up is one confirm-per-row at a time.

## Change

Adds a `Clear all` button to the settled shelf header, next to the collapse toggle.

- Confirms first, naming the count: *"Clear 12 settled threads from the sidebar?"*
- **Archives, does not delete.** "Clear" here is about the sidebar, so every thread stays recoverable from Settings → Archived.
- Reuses the existing `archiveThread` action from `useThreadActions`, and the same failure toast pattern as the other bulk sidebar actions.
- Header `<li>` now owns the flex layout so the toggle and the new button can sit side by side; the toggle's own classes moved up accordingly. No visual change to the header at rest.

Only file touched: `apps/web/src/components/Sidebar.tsx` (+44/-2).

## Testing

- `tsgo --noEmit` clean for the touched file.
- Manually exercised in a downstream build of this sidebar: confirm cancel is a no-op, confirm empties the shelf, and archived threads come back from Settings → Archived.

Happy to add a `Sidebar.logic` test or adjust the copy/placement if you'd rather it live in an overflow menu than as a bare header button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar-only UX using the existing archive path; no delete or new server APIs. Partial bulk archive on mid-loop failure is possible but matches other sequential bulk actions.
> 
> **Overview**
> The settled shelf header gets a **Clear all** button beside the expand/collapse control. Clicking it opens a confirm dialog with the thread count and a note that threads move to **Archived** in Settings.
> 
> On confirm, the handler loops `settledThreads` and calls existing `archiveThread` for each ref, stopping on the first failure with the same stacked error toast pattern used elsewhere in the sidebar. Cancel or an empty shelf is a no-op.
> 
> The settled header `<li>` is refactored to a horizontal flex row so the toggle and **Clear all** sit side by side (`data-testid="sidebar-settled-clear-all"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4479876fe39a746b8327fd958b4e5ed9f96afbb0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Clear all' button to the Settled shelf in the sidebar
> - Adds a `Clear all` button to the Settled shelf header that, after user confirmation, bulk-archives all currently settled threads.
> - Re-evaluates which threads are still settled at confirmation time, so only threads settled when the dialog is dismissed are archived.
> - Removes archived threads from the current selection and shows error toasts for navigation or mutation failures.
> - Documents the feature in [thread-sidebar.md](https://github.com/pingdotgg/t3code/pull/5689/files#diff-7bdc679f37b354bbc78160b5dc7435fb0d2d5a7d72c6a7015a8b682032a7150a), noting that archived threads can be restored from Settings → Archived.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e3e245.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->