### PR TITLE
fix(server): stop reaping sessions with live background work

### DIFF
--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -56,6 +56,13 @@ const drainFibers = Effect.forEach(Array.from({ length: 10 }), () => Effect.yiel
 
 const unsupported = () => Effect.die(new Error("Unsupported provider call in test")) as never;
 
+/**
+ * Idle for longer than the harness's 1s inactivity threshold but well inside
+ * the background-work extension ceiling.
+ */
+const recentlyIdleLastSeenAt = (nowMs: number): string =>
+  DateTime.formatIso(DateTime.makeUnsafe(nowMs - 3_000));
+
 function makeReadModel(
   threads: ReadonlyArray<{
     readonly id: ThreadId;
@@ -68,6 +75,7 @@ function makeReadModel(
       readonly lastError: string | null;
       readonly updatedAt: string;
     } | null;
+    readonly backgroundLiveness?: "working" | "monitoring" | null;
   }>,
 ) {
   const now = "2026-01-01T00:00:00.000Z";
@@ -106,6 +114,7 @@ function makeReadModel(
       hasPendingApprovals: false,
       hasPendingUserInput: false,
       hasActionableProposedPlan: false,
+      backgroundLiveness: thread.backgroundLiveness ?? null,
       latestTurn: null,
       messages: [],
       session: thread.session,
@@ -140,6 +149,7 @@ describe("ProviderSessionReaper", () => {
     readonly stopSessionImplementation?: (input: {
       readonly threadId: ThreadId;
     }) => ReturnType<ProviderServiceShape["stopSession"]>;
+    readonly backgroundExtensionLimitMultiplier?: number;
   }) {
     const stoppedThreadIds = new Set<ThreadId>();
     const stopSession = vi.fn<ProviderServiceShape["stopSession"]>(
@@ -186,6 +196,9 @@ describe("ProviderSessionReaper", () => {
     const layer = makeProviderSessionReaperLive({
       inactivityThresholdMs: 1_000,
       sweepIntervalMs: 60_000,
+      ...(input.backgroundExtensionLimitMultiplier !== undefined
+        ? { backgroundExtensionLimitMultiplier: input.backgroundExtensionLimitMultiplier }
+        : {}),
     }).pipe(
       Layer.provideMerge(providerSessionDirectoryLayer),
       Layer.provideMerge(runtimeRepositoryLayer),
@@ -417,6 +430,214 @@ describe("ProviderSessionReaper", () => {
     expect(harness.stopSession).not.toHaveBeenCalled();
     const remaining = await runtime!.runPromise(repository.getByThreadId({ threadId }));
     expect(Option.isSome(remaining)).toBe(true);
+  });
+
+  it("skips idle sessions whose native background work is still running", async () => {
+    const threadId = ThreadId.make("thread-reaper-background-working");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          // The turn that spawned the fleet already settled; the subagents
+          // outlived it.
+          backgroundLiveness: "working",
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "claudeAgent",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+    const nowMs = await runtime!.runPromise(Clock.currentTimeMillis);
+
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: recentlyIdleLastSeenAt(nowMs),
+        resumeCursor: {
+          opaque: "resume-background-working",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
+    await runtime!.runPromise(drainFibers);
+
+    expect(harness.stopSession).not.toHaveBeenCalled();
+    const remaining = await runtime!.runPromise(repository.getByThreadId({ threadId }));
+    expect(Option.isSome(remaining)).toBe(true);
+  });
+
+  it("reaps idle sessions whose only background work is a monitoring loop", async () => {
+    const threadId = ThreadId.make("thread-reaper-background-monitoring");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          // Watch loops tick forever by design: honouring them would make the
+          // session immortal.
+          backgroundLiveness: "monitoring",
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "claudeAgent",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+    const nowMs = await runtime!.runPromise(Clock.currentTimeMillis);
+
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: recentlyIdleLastSeenAt(nowMs),
+        resumeCursor: {
+          opaque: "resume-background-monitoring",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
+
+    await waitFor(() => harness.stopSession.mock.calls.length === 1);
+
+    expect(harness.stopSession.mock.calls[0]?.[0]).toEqual({ threadId });
+  });
+
+  it("reaps idle sessions that report no background work", async () => {
+    const threadId = ThreadId.make("thread-reaper-background-none");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          backgroundLiveness: null,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "claudeAgent",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+    const nowMs = await runtime!.runPromise(Clock.currentTimeMillis);
+
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: recentlyIdleLastSeenAt(nowMs),
+        resumeCursor: {
+          opaque: "resume-background-none",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
+
+    await waitFor(() => harness.stopSession.mock.calls.length === 1);
+
+    expect(harness.stopSession.mock.calls[0]?.[0]).toEqual({ threadId });
+  });
+
+  it("reaps sessions whose background work outlives the extension ceiling", async () => {
+    const threadId = ThreadId.make("thread-reaper-background-wedged");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      // 1s threshold x 2 = a 2s ceiling on the reprieve.
+      backgroundExtensionLimitMultiplier: 2,
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          // Still claiming to work — but wedged, and past the ceiling.
+          backgroundLiveness: "working",
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "claudeAgent",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+    const nowMs = await runtime!.runPromise(Clock.currentTimeMillis);
+
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: recentlyIdleLastSeenAt(nowMs),
+        resumeCursor: {
+          opaque: "resume-background-wedged",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
+
+    await waitFor(() => harness.stopSession.mock.calls.length === 1);
+
+    expect(harness.stopSession.mock.calls[0]?.[0]).toEqual({ threadId });
   });
 
   it("continues reaping other sessions when one stop attempt fails", async () => {

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -16,10 +16,19 @@ import { ProviderService } from "../Services/ProviderService.ts";
 
 const DEFAULT_INACTIVITY_THRESHOLD_MS = 30 * 60 * 1000;
 const DEFAULT_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+/**
+ * Ceiling on the reprieve live background work can buy, as a multiple of the
+ * inactivity threshold: 48 x 30min = 24h by default. A wedged-but-chatty agent
+ * (one still emitting task_progress while making no progress) would otherwise
+ * pin its session open forever, which is exactly the leak this reaper exists
+ * to prevent.
+ */
+const DEFAULT_BACKGROUND_EXTENSION_LIMIT_MULTIPLIER = 48;
 
 export interface ProviderSessionReaperLiveOptions {
   readonly inactivityThresholdMs?: number;
   readonly sweepIntervalMs?: number;
+  readonly backgroundExtensionLimitMultiplier?: number;
 }
 
 const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =>
@@ -33,6 +42,11 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
       options?.inactivityThresholdMs ?? DEFAULT_INACTIVITY_THRESHOLD_MS,
     );
     const sweepIntervalMs = Math.max(1, options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS);
+    const backgroundExtensionLimitMultiplier = Math.max(
+      1,
+      options?.backgroundExtensionLimitMultiplier ?? DEFAULT_BACKGROUND_EXTENSION_LIMIT_MULTIPLIER,
+    );
+    const backgroundExtensionLimitMs = inactivityThresholdMs * backgroundExtensionLimitMultiplier;
 
     const sweep = Effect.gen(function* () {
       const bindings = yield* directory.listBindings();
@@ -67,6 +81,36 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
             threadId: binding.threadId,
             activeTurnId: thread.session.activeTurnId,
             idleDurationMs,
+          });
+          continue;
+        }
+
+        // `lastSeenAt` only advances on turns (ProviderService.sendTurn), but a
+        // session keeps working between turns: subagent fleets and workflow
+        // runs outlive the turn that spawned them. Reaping one of those killed
+        // 30+ minutes of in-flight work. `backgroundLiveness` is the projection's
+        // existing answer to "is native background work still alive", fed by the
+        // same task lifecycle stream for every provider and cleared on
+        // session.exited.
+        //
+        // Only "working" earns a reprieve. "monitoring" is watch loops (monitor
+        // tasks, background shells) that tick forever by design — honouring it
+        // would make those sessions immortal, and the sweep would stop being a
+        // leak backstop. Losing a watch loop to the reaper is recoverable;
+        // losing a running agent is not.
+        //
+        // The reprieve is bounded: past `backgroundExtensionLimitMs` the session
+        // is reaped anyway, so an agent that is wedged yet still emitting
+        // progress cannot pin its session open indefinitely.
+        if (
+          thread?.backgroundLiveness === "working" &&
+          idleDurationMs < backgroundExtensionLimitMs
+        ) {
+          yield* Effect.logDebug("provider.session.reaper.skipped-background-work", {
+            threadId: binding.threadId,
+            provider: binding.provider,
+            idleDurationMs,
+            backgroundExtensionLimitMs,
           });
           continue;
         }


### PR DESCRIPTION
## Problem

`ProviderSessionReaper` measures idleness from `ProviderSessionDirectory.lastSeenAt`, which only advances on turns (`ProviderService.sendTurn`). But a Claude session keeps working *between* turns — subagent fleets, workflow runs, background shells all outlive the turn that spawned them. A session with no user turn for 30 minutes gets `stopSession`'d while its agents are still running, silently killing the in-flight work.

Hit this in production use tonight: a 30+ minute background implementation agent was killed mid-run twice; the only surviving evidence was the worktree state.

## Fix

The projection already answers "is native background work still alive": `ThreadBackgroundLiveness` is fed by the canonical task lifecycle stream for every provider, drops terminal/idle/inert tasks, and is cleared on `session.exited`. Its `backgroundLiveness` verdict already rides on the `OrchestrationThreadShell` the reaper fetches for its existing `activeTurnId` check — so this is a read of an existing field, not new plumbing. Two files touched.

- Idle-by-`lastSeenAt` sessions are spared while `backgroundLiveness === "working"`.
- `"monitoring"` deliberately does **not** earn a reprieve: watch loops tick forever by design and would make sessions immortal, turning the sweep into a no-op as a leak backstop. Losing a watch loop is recoverable; losing a running agent is not.
- The reprieve is bounded by `backgroundExtensionLimitMultiplier` (48× threshold = 24 h by default, configurable like the other two options), so a wedged-but-chatty agent cannot pin its session open forever.
- The `activeTurnId` skip is unchanged.

## Tests

Four new cases in `ProviderSessionReaper.test.ts` (idle+working → spared; monitoring → reaped; null → reaped; working past ceiling → reaped). Red-green verified against two deliberately unpatched variants — each new guard is independently load-bearing. Full `src/provider` suite: 490 passed, 6 skipped. Lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when long-idle provider sessions are stopped, which can affect in-flight subagents vs. session leaks; behavior is bounded by a configurable ceiling and covered by new tests.
> 
> **Overview**
> **Provider session reaper** no longer stops sessions that are idle on `lastSeenAt` but still have real background agent work, using the thread shell’s existing `backgroundLiveness` field.
> 
> After the usual inactivity and `activeTurnId` checks, the sweep **skips** `stopSession` when `backgroundLiveness === "working"` and idle time is below a new cap (`inactivityThresholdMs × backgroundExtensionLimitMultiplier`, default **48× → 24h**). **`"monitoring"`** does not get that reprieve (watch loops would otherwise keep sessions open indefinitely). **`null`** or idle past the cap is still reaped, including wedged agents that keep reporting `"working"`.
> 
> Tests cover working (spared), monitoring/null (reaped), and working past a lowered multiplier ceiling (reaped); the harness can pass `backgroundExtensionLimitMultiplier`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23f9b8ba0886bf13475e7834057580531d918c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop reaping provider sessions with live background work
> - The session reaper now skips stopping sessions when `backgroundLiveness` is `'working'` and the idle duration is below a configurable ceiling (`inactivityThresholdMs × backgroundExtensionLimitMultiplier`, defaulting to 48×).
> - Sessions with `backgroundLiveness` of `'monitoring'` or `null` continue to be reaped at the normal inactivity threshold.
> - Sessions where background work outlives the ceiling are reaped regardless.
> - A new debug log `provider.session.reaper.skipped-background-work` is emitted when a session is deferred.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23f9b8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->