### PR TITLE
fix(web): point settings panels at a connected device

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -220,8 +220,8 @@ import { useEnvironmentQuery } from "../state/query";
 import {
   primaryServerAvailableEditorsAtom,
   primaryServerKeybindingsAtom,
-  primaryServerSettingsAtom,
   serverEnvironment,
+  settingsServerSettingsAtom,
 } from "../state/server";
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment, useEnvironmentThread } from "../state/threads";
@@ -1263,10 +1263,10 @@ function ChatViewContent(props: ChatViewProps) {
   }, [routeKind, routeThreadRef, routeThreadState]);
   const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
   const settings = useEnvironmentSettings(environmentId);
-  // New-thread defaults live in the primary environment's settings.json (the
-  // settings UI never writes to remote environments), so read them from the
-  // primary server rather than the thread's environment.
-  const primaryServerSettings = useAtomValue(primaryServerSettingsAtom);
+  // New-thread defaults live in the settings environment's settings.json —
+  // the one the settings UI writes to — so read them from there rather than
+  // from the thread's own environment.
+  const settingsServerSettings = useAtomValue(settingsServerSettingsAtom);
   const setStickyComposerModelSelection = useComposerDraftStore(
     (store) => store.setStickyModelSelection,
   );
@@ -4003,7 +4003,7 @@ function ChatViewContent(props: ChatViewProps) {
     ? (draftThread?.startFromOrigin ?? false)
     : canOverrideServerThreadEnvMode
       ? (pendingServerThreadStartFromOriginByThreadId[activeThread?.id ?? ""] ??
-        primaryServerSettings.newWorktreesStartFromOrigin)
+        settingsServerSettings.newWorktreesStartFromOrigin)
       : false;
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
@@ -5840,7 +5840,7 @@ function ChatViewContent(props: ChatViewProps) {
           envMode: mode,
           startFromOrigin: resolveNewDraftStartFromOrigin({
             envMode: mode,
-            newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+            newWorktreesStartFromOrigin: settingsServerSettings.newWorktreesStartFromOrigin,
           }),
           ...(mode === "worktree" && draftThread?.worktreePath ? { worktreePath: null } : {}),
         });
@@ -5852,7 +5852,7 @@ function ChatViewContent(props: ChatViewProps) {
       composerDraftTarget,
       draftThread?.worktreePath,
       isLocalDraftThread,
-      primaryServerSettings.newWorktreesStartFromOrigin,
+      settingsServerSettings.newWorktreesStartFromOrigin,
       setPendingServerThreadEnvMode,
       scheduleComposerFocus,
       setDraftThreadContext,

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -40,7 +40,7 @@ import { isElectron } from "../../env";
 import {
   useClientSettings,
   useUpdateClientSettings,
-  usePrimarySettings,
+  useGlobalSettings,
 } from "../../hooks/useSettings";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { useT3ProjectFileState } from "../../hooks/useT3ProjectFileScripts";
@@ -68,7 +68,7 @@ import {
 import { useEnvironments, usePrimaryEnvironmentId } from "../../state/environments";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { projectEnvironment } from "../../state/projects";
-import { primaryServerProvidersAtom, serverEnvironment } from "../../state/server";
+import { settingsServerProvidersAtom, serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { TraitsPicker } from "../chat/TraitsPicker";
@@ -303,10 +303,10 @@ export function ProjectSettingsPanel({ projectKey }: { projectKey: string }) {
 
 function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
   const navigate = useNavigate();
-  const settings = usePrimarySettings();
+  const settings = useGlobalSettings();
   const updateClientSettings = useUpdateClientSettings();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const serverProviders = useAtomValue(settingsServerProvidersAtom);
   const threads = useThreadShells();
   const updateProject = useAtomCommand(projectEnvironment.update, { reportFailure: false });
   const deleteProject = useAtomCommand(projectEnvironment.delete, { reportFailure: false });

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1600,8 +1600,8 @@ const LEGACY_FEATURE_TARGET_IDS: ReadonlySet<string> = new Set([
  * jump to one of the rows unfolds the section.
  */
 function LegacyFeaturesSection() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   const [open, setOpen] = useState(false);
   const searchTargetId = useSettingsSearchTargetId();
   // Unfold once per search jump; tracking the handled id lets the user fold

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -62,7 +62,7 @@ import {
   useTheme,
 } from "../../hooks/useTheme";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useGlobalSettings, useUpdateGlobalSettings } from "../../hooks/useSettings";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -76,7 +76,7 @@ import {
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
 import { isMacPlatform } from "../../lib/utils";
-import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
+import { primaryServerObservabilityAtom, settingsServerProvidersAtom } from "../../state/server";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel } from "../../timestampFormat";
@@ -459,8 +459,8 @@ export function useSettingsRestore(onRestored?: () => void) {
     clearThemeHalves,
     themeHalves,
   } = useTheme();
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
 
   const isTextGenerationModelDirty = !Equal.equals(
     settings.textGenerationModelSelection ?? null,
@@ -679,8 +679,8 @@ function BackgroundActivityAdvancedDialog({
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
 }) {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
   const activeProfile = resolvedBackgroundActivity.profile;
   const automaticGitFetchIntervalSeconds = durationToSeconds(
@@ -951,8 +951,8 @@ export function AppearanceSettingsPanel() {
   } = useTheme();
   const customThemes = useCustomThemes();
   const [isImportThemeOpen, setIsImportThemeOpen] = useState(false);
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   const environmentStageLabel = useEnvironmentStageLabel();
   const showEnvironmentIdentification =
     resolveEnvironmentIdentificationPillLabel(environmentStageLabel) !== null;
@@ -1077,7 +1077,7 @@ export function AppearanceSettingsPanel() {
 }
 
 function useFontDefaultFamilies() {
-  const settings = usePrimarySettings();
+  const settings = useGlobalSettings();
   // An unset preference shows the font it resolves to on this machine; the
   // default stacks are the platform's own faces, so the name is probed, not
   // hardcoded.
@@ -1097,8 +1097,8 @@ function useFontDefaultFamilies() {
 }
 
 function InterfaceFontRow({ preview }: { preview?: ReactNode }) {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   const defaults = useFontDefaultFamilies();
   return (
     <FontFamilySettingsRow
@@ -1120,8 +1120,8 @@ function InterfaceFontRow({ preview }: { preview?: ReactNode }) {
 }
 
 function PromptFontRow() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   const defaults = useFontDefaultFamilies();
   return (
     <FontFamilySettingsRow
@@ -1151,8 +1151,8 @@ function CodeFontRow({
   description?: string;
   preview?: ReactNode;
 }) {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   const defaults = useFontDefaultFamilies();
   return (
     <FontFamilySettingsRow
@@ -1176,8 +1176,8 @@ function CodeFontRow({
 }
 
 function TerminalFontRow() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   const defaults = useFontDefaultFamilies();
   return (
     <FontFamilySettingsRow
@@ -1209,8 +1209,8 @@ function TerminalFontRow() {
 }
 
 function FontSmoothingRow() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   if (!isMacPlatform(navigator.platform)) return null;
   return (
     <SettingsRow
@@ -1238,8 +1238,8 @@ function FontSmoothingRow() {
 }
 
 function WordWrapRow() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   return (
     <SettingsRow
       {...searchableSetting("word-wrap")}
@@ -1281,7 +1281,7 @@ function FontSettingsGroup() {
  * under each row show every surface the choice reaches.
  */
 function SimpleFontRows() {
-  const settings = usePrimarySettings();
+  const settings = useGlobalSettings();
   return (
     <>
       <InterfaceFontRow preview={<PromptFontPreview />} />
@@ -1691,14 +1691,14 @@ function LegacyFeaturesSection() {
 }
 
 export function GeneralSettingsPanel() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   const [backgroundActivityDialogOpen, setBackgroundActivityDialogOpen] = useState(false);
   const lastEnabledProjectGroupingMode = useRef<SidebarProjectGroupingMode>(
     readLastEnabledProjectGroupingMode(),
   );
   const observability = useAtomValue(primaryServerObservabilityAtom);
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const serverProviders = useAtomValue(settingsServerProvidersAtom);
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
     otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -19,8 +19,8 @@ import {
 
 import { useGlobalSettings, useUpdateGlobalSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
-import { usePrimaryEnvironment } from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
+import { useSettingsEnvironmentId } from "../../state/settingsEnvironment";
 import { sourceControlEnvironment } from "../../state/sourceControl";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -508,7 +508,10 @@ function EmptySourceControlDiscovery({
 }
 
 export function SourceControlSettingsPanel() {
-  const environmentId = usePrimaryEnvironment()?.environmentId ?? null;
+  // The same environment the writing settings below read and write, so the
+  // discovery scan and the writer controls agree about which device they
+  // describe — and so both still mount on a session with no primary device.
+  const environmentId = useSettingsEnvironmentId();
   const discovery = useEnvironmentQuery(
     environmentId === null
       ? null

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -17,7 +17,7 @@ import {
   resolveServerBackgroundActivitySettings,
 } from "@t3tools/shared/backgroundActivitySettings";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useGlobalSettings, useUpdateGlobalSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { usePrimaryEnvironment } from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
@@ -347,8 +347,8 @@ function DiscoveryItemRow({
 }
 
 function GitFetchIntervalSettings() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
   const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
   const automaticGitFetchIntervalSeconds = durationToSeconds(
     resolvedBackgroundActivity.automaticGitFetchInterval,

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import { createModelSelection } from "@t3tools/shared/model";
 import { resolveSourceControlWriterModelSelection } from "@t3tools/shared/serverSettings";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useGlobalSettings, useUpdateGlobalSettings } from "../../hooks/useSettings";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -15,7 +15,7 @@ import {
   getCustomModelOptionsByInstance,
   resolveAppModelSelectionState,
 } from "../../modelSelection";
-import { primaryServerProvidersAtom } from "../../state/server";
+import { settingsServerProvidersAtom } from "../../state/server";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
@@ -41,9 +41,9 @@ const MODE_OPTIONS: Record<SourceControlWritingStyleMode, { label: string; descr
   };
 
 export function SourceControlWritingSettingsSection() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const settings = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings();
+  const serverProviders = useAtomValue(settingsServerProvidersAtom);
   const customInstructionsRef = useRef<HTMLTextAreaElement>(null);
   const style = settings.sourceControlWritingStyle;
   const defaults = DEFAULT_UNIFIED_SETTINGS.sourceControlWritingStyle;

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -25,7 +25,7 @@ import { resolveDefaultThreadEnvMode } from "@t3tools/shared/threadEnvMode";
 import { readThreadShell, useProjects, useThread } from "../state/entities";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
 import { readT3ProjectFileDefaultThreadEnvMode } from "../lib/t3ProjectFileDefaults";
-import { primaryServerSettingsAtom } from "../state/server";
+import { settingsServerSettingsAtom } from "../state/server";
 import { resolveThreadRouteTarget } from "../threadRoutes";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { useClientSettings } from "./useSettings";
@@ -52,11 +52,13 @@ function pickExplicitWorkspaceOptions(options: NewThreadWorkspaceOptions | undef
 export function useNewThreadHandler() {
   const projects = useProjects();
   // New-thread defaults are a user preference, and the settings UI only ever
-  // edits the primary environment's settings.json. Reading the target
+  // edits the settings environment's settings.json. Reading the target
   // environment's own settings here would silently reset remote projects to
   // the decoded defaults ("local" mode, current branch), since nothing can
-  // set those values on a remote server.
-  const primaryServerSettings = useAtomValue(primaryServerSettingsAtom);
+  // set those values on a remote server. This must stay the same environment
+  // the settings panels write to, or the General controls would save and
+  // re-display values that new threads never pick up.
+  const settingsServerSettings = useAtomValue(settingsServerSettingsAtom);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const router = useRouter();
   const getCurrentRouteTarget = useCallback(() => {
@@ -140,7 +142,7 @@ export function useNewThreadHandler() {
                 project.workspaceRoot,
               )
             : null,
-          globalDefault: primaryServerSettings.defaultThreadEnvMode,
+          globalDefault: settingsServerSettings.defaultThreadEnvMode,
         });
       };
       const logicalProjectKey = project
@@ -229,7 +231,7 @@ export function useNewThreadHandler() {
               envMode: defaultEnvMode,
               startFromOrigin: resolveNewDraftStartFromOrigin({
                 envMode: defaultEnvMode,
-                newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+                newWorktreesStartFromOrigin: settingsServerSettings.newWorktreesStartFromOrigin,
               }),
             };
           }
@@ -359,7 +361,7 @@ export function useNewThreadHandler() {
             options?.startFromOrigin ??
             resolveNewDraftStartFromOrigin({
               envMode: initialEnvMode,
-              newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+              newWorktreesStartFromOrigin: settingsServerSettings.newWorktreesStartFromOrigin,
             }),
           runtimeMode: carryRuntimeMode ?? DEFAULT_RUNTIME_MODE,
           ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
@@ -381,7 +383,7 @@ export function useNewThreadHandler() {
         });
       })();
     },
-    [getCurrentRouteTarget, primaryServerSettings, projectGroupingSettings, projects, router],
+    [getCurrentRouteTarget, settingsServerSettings, projectGroupingSettings, projects, router],
   );
 }
 

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -5,9 +5,10 @@
  * `settings.json` on the server, fetched via `server.getConfig`) and
  * client-only settings (persisted in localStorage).
  *
- * Live server settings always require an environment id. Primary-environment
+ * Live server settings always require an environment id. Environment-scoped
  * access is intentionally named as such so environment-sensitive consumers
- * cannot silently read the wrong server's settings.
+ * cannot silently read the wrong server's settings; the global settings UI
+ * uses the `useGlobalSettings` pair, which resolves its own target.
  */
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { useAtomValue } from "@effect/atom-react";
@@ -33,8 +34,8 @@ import {
   subscribeToThemePreview,
 } from "~/themePalette";
 import * as Struct from "effect/Struct";
-import { primaryServerSettingsAtom, serverEnvironment } from "~/state/server";
-import { usePrimaryEnvironment } from "~/state/environments";
+import { settingsServerSettingsAtom, serverEnvironment } from "~/state/server";
+import { useSettingsEnvironmentId } from "~/state/settingsEnvironment";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { useTheme } from "./useTheme";
 
@@ -287,11 +288,11 @@ export function useEnvironmentSettings<T = UnifiedSettings>(
   return useMergedSettings(serverSettings ?? DEFAULT_SERVER_SETTINGS, selector);
 }
 
-/** Primary-only settings access for the settings UI and other explicitly global surfaces. */
-export function usePrimarySettings<T = UnifiedSettings>(
+/** Settings access for the settings UI and other explicitly global surfaces. */
+export function useGlobalSettings<T = UnifiedSettings>(
   selector?: (settings: UnifiedSettings) => T,
 ): T {
-  return useMergedSettings(useAtomValue(primaryServerSettingsAtom), selector);
+  return useMergedSettings(useAtomValue(settingsServerSettingsAtom), selector);
 }
 
 /**
@@ -334,8 +335,8 @@ export function useUpdateEnvironmentSettings(environmentId: EnvironmentId) {
   return useUpdateSettingsTarget(environmentId);
 }
 
-export function useUpdatePrimarySettings() {
-  return useUpdateSettingsTarget(usePrimaryEnvironment()?.environmentId ?? null);
+export function useUpdateGlobalSettings() {
+  return useUpdateSettingsTarget(useSettingsEnvironmentId());
 }
 
 export function useUpdateClientSettings() {

--- a/apps/web/src/state/server.ts
+++ b/apps/web/src/state/server.ts
@@ -17,6 +17,7 @@ import { environmentCatalog } from "../connection/catalog";
 import { connectionAtomRuntime } from "../connection/runtime";
 import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
 import { environmentSession } from "./session";
+import { settingsEnvironmentIdAtom } from "./settingsEnvironment";
 
 export const serverEnvironment = createServerEnvironmentAtoms(connectionAtomRuntime, {
   initialConfigValueAtom: environmentSession.initialConfigValueAtom,
@@ -79,6 +80,24 @@ export const primaryServerProvidersAtom = Atom.make(
   (get): ReadonlyArray<ServerProvider> =>
     get(primaryServerConfigAtom)?.providers ?? EMPTY_SERVER_PROVIDERS,
 ).pipe(Atom.withLabel("web-primary-server-providers"));
+
+/**
+ * Server config for the environment the global settings UI edits. Distinct
+ * from `primaryServerConfigAtom`: it resolves to a connected device even when
+ * the session has no primary one. See `settingsEnvironmentIdAtom`.
+ */
+export const settingsServerConfigAtom = Atom.make((get): ServerConfig | null =>
+  get(serverEnvironment.configValueAtom(get(settingsEnvironmentIdAtom))),
+).pipe(Atom.withLabel("web-settings-server-config"));
+
+export const settingsServerSettingsAtom = Atom.make(
+  (get): ServerSettings => get(settingsServerConfigAtom)?.settings ?? DEFAULT_SERVER_SETTINGS,
+).pipe(Atom.withLabel("web-settings-server-settings"));
+
+export const settingsServerProvidersAtom = Atom.make(
+  (get): ReadonlyArray<ServerProvider> =>
+    get(settingsServerConfigAtom)?.providers ?? EMPTY_SERVER_PROVIDERS,
+).pipe(Atom.withLabel("web-settings-server-providers"));
 
 export const primaryServerKeybindingsAtom = Atom.make(
   (get): ServerConfig["keybindings"] =>

--- a/apps/web/src/state/settingsEnvironment.test.ts
+++ b/apps/web/src/state/settingsEnvironment.test.ts
@@ -1,7 +1,10 @@
 import { EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveSettingsEnvironmentId } from "./settingsEnvironment";
+import {
+  filterConnectedCatalogEnvironmentIds,
+  resolveSettingsEnvironmentId,
+} from "./settingsEnvironment";
 
 const primary = EnvironmentId.make("primary");
 const relayA = EnvironmentId.make("relay-a");
@@ -20,5 +23,24 @@ describe("resolveSettingsEnvironmentId", () => {
 
   it("returns null before the catalog hydrates", () => {
     expect(resolveSettingsEnvironmentId(null, [])).toBeNull();
+  });
+});
+
+describe("filterConnectedCatalogEnvironmentIds", () => {
+  it("keeps catalog order while dropping offline devices", () => {
+    const connected = new Set([relayB]);
+    expect(
+      filterConnectedCatalogEnvironmentIds([relayA, relayB], (id) => connected.has(id)),
+    ).toEqual([relayB]);
+  });
+
+  it("lets the fallback skip a stale offline head entry", () => {
+    const connected = new Set([relayB]);
+    expect(
+      resolveSettingsEnvironmentId(
+        null,
+        filterConnectedCatalogEnvironmentIds([relayA, relayB], (id) => connected.has(id)),
+      ),
+    ).toBe(relayB);
   });
 });

--- a/apps/web/src/state/settingsEnvironment.test.ts
+++ b/apps/web/src/state/settingsEnvironment.test.ts
@@ -1,0 +1,24 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveSettingsEnvironmentId } from "./settingsEnvironment";
+
+const primary = EnvironmentId.make("primary");
+const relayA = EnvironmentId.make("relay-a");
+const relayB = EnvironmentId.make("relay-b");
+
+describe("resolveSettingsEnvironmentId", () => {
+  it("prefers the primary environment when the session has one", () => {
+    expect(resolveSettingsEnvironmentId(primary, [relayA, primary])).toBe(primary);
+  });
+
+  it("falls back to a connected device when no primary connection exists", () => {
+    // The hosted app has no PrimaryConnectionTarget; without this fallback the
+    // settings panels read schema defaults and drop every write.
+    expect(resolveSettingsEnvironmentId(null, [relayA, relayB])).toBe(relayA);
+  });
+
+  it("returns null before the catalog hydrates", () => {
+    expect(resolveSettingsEnvironmentId(null, [])).toBeNull();
+  });
+});

--- a/apps/web/src/state/settingsEnvironment.ts
+++ b/apps/web/src/state/settingsEnvironment.ts
@@ -1,0 +1,51 @@
+/**
+ * Environment targeted by the global settings UI.
+ *
+ * @module state/settingsEnvironment
+ */
+import { useAtomValue } from "@effect/atom-react";
+import type { EnvironmentId } from "@t3tools/contracts";
+import { Atom } from "effect/unstable/reactivity";
+
+import { environmentCatalog } from "../connection/catalog";
+import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
+
+/**
+ * Environment whose server settings the global settings panels read and write.
+ *
+ * Prefers the primary device, but falls back to the first catalog entry when
+ * no `PrimaryConnectionTarget` exists. The hosted app is exactly that case —
+ * every device is paired remotely — and a primary-only lookup degrades badly
+ * there: server-backed rows render against schema defaults, provider-driven
+ * controls like the text generation model picker have no instances to offer
+ * ("No models found"), and every write is dropped on the floor because
+ * `useUpdateSettingsTarget` no-ops on a null environment id.
+ *
+ * Only the zero-primary case changes; a session with a primary device still
+ * resolves to it. When several remote devices are connected this picks one
+ * arbitrarily, matching how `resolveSelectedProviderEnvironmentId` seeds the
+ * Providers panel's device selector.
+ */
+export function resolveSettingsEnvironmentId(
+  primaryEnvironmentId: EnvironmentId | null,
+  catalogEnvironmentIds: Iterable<EnvironmentId>,
+): EnvironmentId | null {
+  if (primaryEnvironmentId !== null) {
+    return primaryEnvironmentId;
+  }
+  for (const environmentId of catalogEnvironmentIds) {
+    return environmentId;
+  }
+  return null;
+}
+
+export const settingsEnvironmentIdAtom = Atom.make((get): EnvironmentId | null =>
+  resolveSettingsEnvironmentId(
+    get(primaryEnvironmentIdAtom),
+    get(environmentCatalog.catalogValueAtom).entries.keys(),
+  ),
+).pipe(Atom.withLabel("web-settings-environment-id"));
+
+export function useSettingsEnvironmentId(): EnvironmentId | null {
+  return useAtomValue(settingsEnvironmentIdAtom);
+}

--- a/apps/web/src/state/settingsEnvironment.ts
+++ b/apps/web/src/state/settingsEnvironment.ts
@@ -4,8 +4,10 @@
  * @module state/settingsEnvironment
  */
 import { useAtomValue } from "@effect/atom-react";
+import { AVAILABLE_CONNECTION_STATE } from "@t3tools/client-runtime/connection";
 import type { EnvironmentId } from "@t3tools/contracts";
-import { Atom } from "effect/unstable/reactivity";
+import * as Option from "effect/Option";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import { environmentCatalog } from "../connection/catalog";
 import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
@@ -13,18 +15,20 @@ import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
 /**
  * Environment whose server settings the global settings panels read and write.
  *
- * Prefers the primary device, but falls back to the first catalog entry when
- * no `PrimaryConnectionTarget` exists. The hosted app is exactly that case —
- * every device is paired remotely — and a primary-only lookup degrades badly
- * there: server-backed rows render against schema defaults, provider-driven
- * controls like the text generation model picker have no instances to offer
- * ("No models found"), and every write is dropped on the floor because
- * `useUpdateSettingsTarget` no-ops on a null environment id.
+ * Prefers the primary device, but falls back to the first *connected* catalog
+ * entry when no `PrimaryConnectionTarget` exists. The hosted app is exactly
+ * that case — every device is paired remotely — and a primary-only lookup
+ * degrades badly there: server-backed rows render against schema defaults,
+ * provider-driven controls like the text generation model picker have no
+ * instances to offer ("No models found"), and every write is dropped on the
+ * floor because `useUpdateSettingsTarget` no-ops on a null environment id.
  *
  * Only the zero-primary case changes; a session with a primary device still
- * resolves to it. When several remote devices are connected this picks one
- * arbitrarily, matching how `resolveSelectedProviderEnvironmentId` seeds the
- * Providers panel's device selector.
+ * resolves to it. Offline catalog entries are skipped so a stale persisted
+ * device ahead of a live one cannot steal the fallback. When several remote
+ * devices are connected this picks one arbitrarily, matching how
+ * `resolveSelectedProviderEnvironmentId` seeds the Providers panel's device
+ * selector.
  */
 export function resolveSettingsEnvironmentId(
   primaryEnvironmentId: EnvironmentId | null,
@@ -39,12 +43,33 @@ export function resolveSettingsEnvironmentId(
   return null;
 }
 
-export const settingsEnvironmentIdAtom = Atom.make((get): EnvironmentId | null =>
-  resolveSettingsEnvironmentId(
+/** Keep catalog order; drop environments the connection supervisor has not connected. */
+export function filterConnectedCatalogEnvironmentIds(
+  catalogEnvironmentIds: Iterable<EnvironmentId>,
+  isConnected: (environmentId: EnvironmentId) => boolean,
+): EnvironmentId[] {
+  const connectedEnvironmentIds: EnvironmentId[] = [];
+  for (const environmentId of catalogEnvironmentIds) {
+    if (isConnected(environmentId)) {
+      connectedEnvironmentIds.push(environmentId);
+    }
+  }
+  return connectedEnvironmentIds;
+}
+
+export const settingsEnvironmentIdAtom = Atom.make((get): EnvironmentId | null => {
+  const catalog = get(environmentCatalog.catalogValueAtom);
+  return resolveSettingsEnvironmentId(
     get(primaryEnvironmentIdAtom),
-    get(environmentCatalog.catalogValueAtom).entries.keys(),
-  ),
-).pipe(Atom.withLabel("web-settings-environment-id"));
+    filterConnectedCatalogEnvironmentIds(catalog.entries.keys(), (environmentId) => {
+      const connection = Option.getOrElse(
+        AsyncResult.value(get(environmentCatalog.stateAtom(environmentId))),
+        () => AVAILABLE_CONNECTION_STATE,
+      );
+      return connection.phase === "connected";
+    }),
+  );
+}).pipe(Atom.withLabel("web-settings-environment-id"));
 
 export function useSettingsEnvironmentId(): EnvironmentId | null {
   return useAtomValue(settingsEnvironmentIdAtom);


### PR DESCRIPTION
## What Changed

The settings panels resolve their server-settings target to the primary device when there is one, and to the first connected device otherwise.

- New `apps/web/src/state/settingsEnvironment.ts` — `resolveSettingsEnvironmentId` (pure, unit tested) plus the atom and hook wrapping it.
- New `settingsServerConfigAtom` / `settingsServerSettingsAtom` / `settingsServerProvidersAtom` in `state/server.ts`, scoped to that environment.
- `usePrimarySettings` / `useUpdatePrimarySettings` → `useGlobalSettings` / `useUpdateGlobalSettings`, reading and writing that environment. Renamed rather than silently re-pointed, because the module header documents the primary-only scoping as deliberate and that is no longer what the hooks do.
- The three settings components consuming them updated accordingly.

Unchanged: the primary-scoped atoms behind the primary-device update notification, sidebar and command palette, and the diagnostics panel, whose RPCs target the primary environment. A session that has a primary device resolves to it exactly as before.

## Why

The settings panels read and write server settings through the primary environment, which only resolves via a `PrimaryConnectionTarget` (`state/primaryEnvironment.ts:7`). The hosted app never has one — every device is paired remotely — so the panels degraded silently there, in three compounding ways:

1. `primaryServerProvidersAtom` returned `EMPTY_SERVER_PROVIDERS`, so `deriveProviderInstanceEntries` produced nothing and the model picker rendered "No models found". The **Text generation model** and **Source control writer model** pickers were therefore unusable, and the model backing thread titles, commit messages, change request content and branch names could not be changed at all.
2. `useUpdatePrimarySettings` resolved to a null environment id, and `useUpdateSettingsTarget` no-ops on null (`hooks/useSettings.ts:326`), so every write from these panels was dropped without an error.
3. Reads fell back to `DEFAULT_SERVER_SETTINGS`, presenting the schema default (`instanceId: "codex"` / `gpt-5.6-luna`, `packages/contracts/src/settings.ts:566`) as if it were the user's configuration.

The user-visible symptom is that generated commit messages, change request titles and bodies, branch names and thread titles are all produced by the hardcoded default model with no way to change it, on a device where that provider may not even be the one in use.

## UI Changes

No layout or styling changes. The behavioural difference is that the **Text generation model** and **Source control writer model** pickers populate instead of showing an empty "No models found" popup, and edits in these panels now persist. Reproducing the before state requires a hosted session with no primary device.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which server's `settings.json` the global UI edits when there is no primary (e.g. hosted); multi-remote-device fallback is arbitrary but matches existing provider-panel behavior. Primary-device sessions are unchanged.
> 
> **Overview**
> **Fixes hosted and no-primary sessions** where settings panels showed schema defaults, model pickers were empty, and writes were silently dropped because everything keyed off the primary server only.
> 
> Introduces **`settingsEnvironmentIdAtom`** (primary when present, otherwise first **connected** catalog device, skipping offline entries) plus **`settingsServerSettingsAtom`** / **`settingsServerProvidersAtom`** scoped to that environment. **`usePrimarySettings`** / **`useUpdatePrimarySettings`** are renamed to **`useGlobalSettings`** / **`useUpdateGlobalSettings`** and wired through all settings panels, **`ChatView`**, and **`useNewThreadHandler`** so displayed values, persistence, and new-thread defaults (`defaultThreadEnvMode`, `newWorktreesStartFromOrigin`) match the same environment the settings UI writes. **Source control** discovery uses **`useSettingsEnvironmentId`** for the same reason.
> 
> Sessions **with** a primary device behave as before; primary-only atoms for diagnostics and similar surfaces are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e304faf106004a31b161be98e5c256bc14e8aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Point settings panels at a connected device when no primary device is present
> - Introduces `settingsEnvironmentIdAtom` in [settingsEnvironment.ts](https://github.com/pingdotgg/t3code/pull/5692/files#diff-15f04af63706deecc94c31d97135a16af62552e88abba8e6365efed170b1643c) to select a settings target: the primary environment if available, otherwise the first connected catalog environment.
> - Adds `settingsServerConfigAtom`, `settingsServerSettingsAtom`, and `settingsServerProvidersAtom` in [server.ts](https://github.com/pingdotgg/t3code/pull/5692/files#diff-6cfcbd44b429d0d6698431ae078b2de64766ef68788e6c13c69b20020bc9723e) to expose config, settings, and providers for the chosen environment.
> - Replaces `usePrimarySettings`/`useUpdatePrimarySettings` with `useGlobalSettings`/`useUpdateGlobalSettings` across all settings panels (appearance, general, source control, fonts, legacy features) so reads and writes target the settings environment.
> - New thread creation and `ChatView` draft-thread defaults (env mode, start-from-origin) now also read from the settings environment.
> - Behavioral Change: settings panels now mount and operate against the first connected device when no primary device is available; previously they would not function in that state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24e304f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->