### PR TITLE
fix(server): advertise 256-color TERM on Windows terminals

### DIFF
--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -33,6 +33,7 @@ const testLayer = NodePtyAdapter.layer.pipe(
 
 it.effect("spawns through the public adapter with the provided host references", () =>
   Effect.gen(function* () {
+    spawn.mockClear();
     const adapter = yield* PtyAdapter.PtyAdapter;
     const process = yield* adapter.spawn({
       shell: "powershell.exe",
@@ -52,8 +53,35 @@ it.effect("spawns through the public adapter with the provided host references",
         cwd: "C:\\workspace",
         cols: 120,
         rows: 40,
-        env: {},
-        name: "xterm-color",
+        env: { TERM: "xterm-256color" },
+        name: "xterm-256color",
+      },
+    ]);
+  }).pipe(Effect.provide(testLayer)),
+);
+
+it.effect("preserves a caller-provided TERM in the spawn env on win32", () =>
+  Effect.gen(function* () {
+    spawn.mockClear();
+    const adapter = yield* PtyAdapter.PtyAdapter;
+    yield* adapter.spawn({
+      shell: "powershell.exe",
+      cwd: "C:\\workspace",
+      cols: 80,
+      rows: 24,
+      env: { TERM: "xterm-direct" },
+    });
+
+    assert.equal(spawn.mock.calls.length, 1);
+    assert.deepEqual(spawn.mock.calls[0], [
+      "powershell.exe",
+      [],
+      {
+        cwd: "C:\\workspace",
+        cols: 80,
+        rows: 24,
+        env: { TERM: "xterm-direct" },
+        name: "xterm-256color",
       },
     ]);
   }).pipe(Effect.provide(testLayer)),

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -141,13 +141,20 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
   return PtyAdapter.PtyAdapter.of({
     spawn: Effect.fn("NodePtyAdapter.spawn")(function* (input) {
       yield* ensureNodePtySpawnHelperExecutableCached;
+      // node-pty only writes `name` into the child's TERM on the Unix path;
+      // the ConPTY path leaves the environment untouched, so Windows children
+      // inherit a missing or 16-color TERM unless it is set here.
+      const env =
+        platform === "win32" && input.env["TERM"] === undefined
+          ? { ...input.env, TERM: "xterm-256color" }
+          : input.env;
       const ptyProcess = yield* Effect.try({
         try: () =>
           nodePty.spawn(input.shell, input.args ?? [], {
             cwd: input.cwd,
             cols: input.cols,
             rows: input.rows,
-            env: input.env,
+            env,
             name: "xterm-256color",
           }),
         catch: (cause) =>

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -148,7 +148,7 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
             cols: input.cols,
             rows: input.rows,
             env: input.env,
-            name: platform === "win32" ? "xterm-color" : "xterm-256color",
+            name: "xterm-256color",
           }),
         catch: (cause) =>
           new PtyAdapter.PtySpawnError({


### PR DESCRIPTION
## Problem

Windows PTY sessions spawn with `name: xterm-color`, which advertises a 16-color terminal type. Every other platform gets `xterm-256color`. TUIs and agent CLIs that key off `TERM` render a degraded palette on Windows only. Likely cause of #3491 (terminal colors are faint in Windows).

## Fix

Two parts in `apps/server/src/terminal/NodePtyAdapter.ts`:

1. Use `xterm-256color` as the pty `name` unconditionally.
2. Default `TERM=xterm-256color` in the spawn env on win32. node-pty only writes `name` into the child TERM on the Unix path; the ConPTY path never touches the environment, so the `name` change alone does nothing on Windows (caught by Bugbot in review). A caller-provided TERM still wins.

---
Model: Claude Fable 5 · Harness: Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, platform-scoped spawn env default for Windows terminals with no auth or data-path changes; caller `TERM` is preserved when set.
> 
> **Overview**
> Fixes degraded terminal colors on Windows by aligning PTY capability with Unix: **`NodePtyAdapter`** always passes **`name: xterm-256color`** to node-pty (replacing win32-only **`xterm-color`**) and, on **win32 only**, sets **`TERM=xterm-256color`** in the spawn environment when the caller did not supply **`TERM`**—because ConPTY does not apply **`name`** to the child env the way the Unix path does.
> 
> Tests on the win32 layer now expect the injected env and **`xterm-256color`** name, plus a case that a caller-provided **`TERM`** (e.g. **`xterm-direct`**) is left unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c86c88d4ee0b1ba6ebd9ec3e68f2ca04d70dfeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `NodePtyAdapter` to advertise `xterm-256color` on Windows terminals
> - On Windows, spawned processes now receive `TERM=xterm-256color` by default; a caller-provided `TERM` value is preserved as-is.
> - The `name` option passed to node-pty is now `xterm-256color` on all platforms, replacing the previous `xterm-color` on Windows.
> - Behavioral Change: Windows terminal sessions will advertise 256-color support where they previously advertised only 8-color (`xterm-color`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c86c88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->