### PR TITLE
fix(usage): stop counting replayed codex rollout heads

### DIFF
--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -51,7 +51,7 @@ import {
   pruneScanCache,
   type ScanCache,
 } from "./usageScanCache.ts";
-import type { UsageRecord } from "./usageTranscripts.ts";
+import { dropReplayedRolloutHead, type UsageRecord } from "./usageTranscripts.ts";
 
 const LITELLM_RATES_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
@@ -354,7 +354,10 @@ export const make = Effect.gen(function* () {
 
       for (const file of files) {
         livePaths.add(file.path);
-        const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
+        const parsed = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
+        // Applied after the cache on purpose: cached entries keep the raw
+        // records, so the replay heuristic can evolve without a version bump.
+        const records = provider === "codex" ? dropReplayedRolloutHead(parsed) : parsed;
         if (records.length === 0) {
           skippedFiles += 1;
           continue;

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "@effect/vitest";
 
+import type { UsageRecord } from "./usageTranscripts.ts";
 import {
+  dropReplayedRolloutHead,
   initialCodexScanState,
   parseClaudeLine,
   parseCodexLine,
@@ -133,6 +135,59 @@ describe("parseCodexLine", () => {
     expect(parseCodexLine(tokenCount(100, 0, 10, 0), state)).toBeNull();
     parseCodexLine(turnContext, state);
     expect(parseCodexLine(tokenCount(100, 0, 10, 0), state)).not.toBeNull();
+  });
+});
+
+describe("dropReplayedRolloutHead", () => {
+  const base = Date.parse("2026-08-05T09:00:00.000Z");
+
+  const eventAt = (offsetMs: number, outputTokens: number): UsageRecord => ({
+    provider: "codex",
+    timestampMs: base + offsetMs,
+    model: "gpt-5.6-sol",
+    sessionId: "session-a",
+    totals: {
+      uncachedInputTokens: 100,
+      cachedInputTokens: 0,
+      cacheCreationTokens: 0,
+      outputTokens,
+      reasoningTokens: 0,
+    },
+    reportedCostUsd: null,
+    dedupeKey: null,
+  });
+
+  it("drops a sub-second head burst and keeps the work after the pause", () => {
+    // A resumed session replays its history in one burst, then the user's own
+    // turns follow at human pace.
+    const kept = dropReplayedRolloutHead([
+      eventAt(0, 10),
+      eventAt(200, 20),
+      eventAt(400, 30),
+      eventAt(30_000, 40),
+      eventAt(95_000, 50),
+    ]);
+
+    expect(kept.map((record) => record.totals.outputTokens)).toEqual([40, 50]);
+  });
+
+  it("keeps a file whose head opens at working pace", () => {
+    const records = [eventAt(0, 10), eventAt(20_000, 20), eventAt(65_000, 30)];
+
+    expect(dropReplayedRolloutHead(records)).toEqual(records);
+  });
+
+  it("never drops a lone leading event", () => {
+    const records = [eventAt(0, 10)];
+
+    expect(dropReplayedRolloutHead(records)).toEqual(records);
+  });
+
+  it("drops everything when the whole file is a replay", () => {
+    // A fork that has done no work of its own yet is nothing but the copy.
+    const kept = dropReplayedRolloutHead([eventAt(0, 10), eventAt(150, 20), eventAt(300, 30)]);
+
+    expect(kept).toHaveLength(0);
   });
 });
 

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -177,6 +177,12 @@ describe("dropReplayedRolloutHead", () => {
     expect(dropReplayedRolloutHead(records)).toEqual(records);
   });
 
+  it("treats a gap of exactly one second as a pause, not part of the burst", () => {
+    const records = [eventAt(0, 10), eventAt(1_000, 20), eventAt(2_000, 30)];
+
+    expect(dropReplayedRolloutHead(records)).toEqual(records);
+  });
+
   it("never drops a lone leading event", () => {
     const records = [eventAt(0, 10)];
 

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -269,14 +269,16 @@ export function dropReplayedRolloutHead(records: readonly UsageRecord[]): readon
   const first = records[0];
   const second = records[1];
   if (first === undefined || second === undefined) return records;
-  if (second.timestampMs - first.timestampMs > REPLAYED_HEAD_GAP_MS) return records;
+  // Inclusive boundary: a gap of a full second is a pause, not part of the
+  // burst — matching the "under a second apart" the constant documents.
+  if (second.timestampMs - first.timestampMs >= REPLAYED_HEAD_GAP_MS) return records;
 
   let index = 1;
   while (index < records.length) {
     const previous = records[index - 1];
     const current = records[index];
     if (previous === undefined || current === undefined) break;
-    if (current.timestampMs - previous.timestampMs > REPLAYED_HEAD_GAP_MS) break;
+    if (current.timestampMs - previous.timestampMs >= REPLAYED_HEAD_GAP_MS) break;
     index += 1;
   }
 

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -238,9 +238,49 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     totals,
     // Codex does not report cost in the rollout.
     reportedCostUsd: null,
-    // Rollout files are unique per session, so events need no global dedup.
+    // Codex events carry no stable id to key on; the cross-file duplicates —
+    // replayed rollout heads — are handled by `dropReplayedRolloutHead`.
     dedupeKey: null,
   };
+}
+
+/**
+ * Two usage events written less than a second apart did not happen a second
+ * apart: that is a history being rewritten into a new file, not work being
+ * done.
+ */
+const REPLAYED_HEAD_GAP_MS = 1_000;
+
+/**
+ * Drops the replayed head of a Codex rollout's records.
+ *
+ * Rollout files are not unique per session. Resuming a session, forking it,
+ * and every subagent it spawns replay the conversation so far into a fresh
+ * rollout — `token_count` events included — with fresh timestamps, so neither
+ * a dedupe key nor the clock can identify the copies. What does identify them
+ * is the write pattern: the copied history lands in one sub-second burst at
+ * the head of the file, while real work has pauses between turns.
+ *
+ * A lone leading event is never dropped, and a head that opens with a real
+ * pause is left alone — a genuine first turn does not emit two `token_count`s
+ * within a second of each other.
+ */
+export function dropReplayedRolloutHead(records: readonly UsageRecord[]): readonly UsageRecord[] {
+  const first = records[0];
+  const second = records[1];
+  if (first === undefined || second === undefined) return records;
+  if (second.timestampMs - first.timestampMs > REPLAYED_HEAD_GAP_MS) return records;
+
+  let index = 1;
+  while (index < records.length) {
+    const previous = records[index - 1];
+    const current = records[index];
+    if (previous === undefined || current === undefined) break;
+    if (current.timestampMs - previous.timestampMs > REPLAYED_HEAD_GAP_MS) break;
+    index += 1;
+  }
+
+  return records.slice(index);
 }
 
 export { EMPTY_TOTALS };


### PR DESCRIPTION
## What changed

Codex usage scanning now drops the **replayed head** of a rollout file before aggregation.

- `usageTranscripts.ts` — new pure `dropReplayedRolloutHead`: a file whose records open with `token_count` events spaced under a second apart replayed a history it did not spend; the burst is dropped up to the first real pause. A lone leading event, or a head that opens at working pace, is left alone.
- `UsageService.ts` — applies it to Codex files, after the scan cache on purpose (cached entries keep the raw records, so the heuristic can evolve without a cache version bump).

## Why it should exist

`parseCodexLine` currently returns `dedupeKey: null` with the comment "rollout files are unique per session, so events need no global dedup" — and that assumption doesn't hold. Resuming a session, forking it, and every subagent it spawns replay the entire conversation so far into a *fresh* rollout file, `token_count` events included, **with fresh timestamps**. So there is no key and no clock to dedupe on, and the existing consecutive-duplicate filter (single-slot, per file) cannot see copies that live in another file. Every replayed event is counted again, and lands on the day the resume happened.

The write pattern is what identifies a copy: replayed history is flushed in one sub-second burst at the head of the file, while real work has pauses between turns — a genuine first turn never emits two `token_count`s within a second of each other. On our logs the double counting is far from cosmetic: days with heavy resume/subagent use read ~1.5× their true Codex volume, and a 90-day window read roughly a third high.

## Notes

- A fully-replayed file (a fork that has done nothing of its own yet) drops to zero records and counts as a skipped file.
- A follow-up could anchor the head against the parent rollout via `session_meta`'s `forked_from_id` / `parent_thread_id` for exact prefix matching; the burst rule alone already removes the bulk of the double counting with far less machinery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reported Codex token/session totals (often downward) via a timing heuristic; wrong classification could under- or over-count, but scope is limited to usage aggregation and is covered by unit tests.
> 
> **Overview**
> Codex usage scanning now strips **replayed rollout heads** before aggregation so resume/fork/subagent copies of prior `token_count` events are not counted again.
> 
> Adds **`dropReplayedRolloutHead`** in `usageTranscripts.ts`: if a file’s records start with consecutive events less than **1 second** apart, that prefix is treated as copied history and dropped up to the first real pause; a single leading event or a head that already opens at working pace is unchanged. Comments on Codex **`dedupeKey`** now point at this path instead of assuming one rollout per session.
> 
> **`UsageService`** runs the filter only for Codex, **after** the per-file scan cache returns parsed records, so cached payloads stay raw and the heuristic can change without a cache version bump. Files that become empty after filtering count as skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b034bcd99b8f37be1780b07b3689fbedcad15f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix usage counting by filtering replayed rollout heads from Codex transcripts
> - Introduces `dropReplayedRolloutHead` in [usageTranscripts.ts](https://github.com/pingdotgg/t3code/pull/5701/files#diff-639e969b22f50fb1c28800a8caacb40faa709fb5b829f6c1e0a06a1be5fd5871), which removes the leading burst of events where consecutive gaps are under 1,000 ms — the signature of a replayed rollout head.
> - [UsageService](https://github.com/pingdotgg/t3code/pull/5701/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70) now applies this filter for `provider === "codex"` before counting records toward usage, sessions, and costs.
> - Behavioral Change: Codex usage counts will decrease for any session that previously included replayed rollout head events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b034bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->