### PR TITLE
fix(web): keep the composer glass aligned with the context strip at any interface font size

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -458,27 +458,31 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   .chat-composer-glass-shell-with-context::before {
     border-radius: 0;
     /*
-     * One continuous glass layer: a 22px composer joined to a 16px strip,
-     * whose visible sides align with the composer's bottom tangents.
+     * One continuous glass layer: a 22px composer joined to a 16px strip. The
+     * strip is inset 1.375rem per side, so the step-in positions and their
+     * curve controls stay in rem to keep tracking it at non-default interface
+     * font sizes; the composer's 22px top radius and the strip's 16px bottom
+     * radius are px by design.
      */
     clip-path: shape(
       from 0 22px,
       curve to 22px 0 with 0 9.85px / 9.85px 0,
       line to calc(100% - 22px) 0,
       curve to 100% 22px with calc(100% - 9.85px) 0 / 100% 9.85px,
-      line to 100% calc(100% - var(--chat-composer-context-extension) - 22px),
-      curve to calc(100% - 22px) calc(100% - var(--chat-composer-context-extension)) with 100%
-        calc(100% - var(--chat-composer-context-extension) - 9.85px) / calc(100% - 9.85px)
+      line to 100% calc(100% - var(--chat-composer-context-extension) - 1.375rem),
+      curve to calc(100% - 1.375rem) calc(100% - var(--chat-composer-context-extension)) with 100%
+        calc(100% - var(--chat-composer-context-extension) - 0.6156rem) / calc(100% - 0.6156rem)
         calc(100% - var(--chat-composer-context-extension)),
-      line to calc(100% - 22px) calc(100% - 16px),
-      curve to calc(100% - 38px) 100% with calc(100% - 22px) calc(100% - 7.16px) /
-        calc(100% - 29.16px) 100%,
-      line to 38px 100%,
-      curve to 22px calc(100% - 16px) with 29.16px 100% / 22px calc(100% - 7.16px),
-      line to 22px calc(100% - var(--chat-composer-context-extension)),
-      curve to 0 calc(100% - var(--chat-composer-context-extension) - 22px) with 9.85px
+      line to calc(100% - 1.375rem) calc(100% - 16px),
+      curve to calc(100% - 1.375rem - 16px) 100% with calc(100% - 1.375rem) calc(100% - 7.16px) /
+        calc(100% - 1.375rem - 7.16px) 100%,
+      line to calc(1.375rem + 16px) 100%,
+      curve to 1.375rem calc(100% - 16px) with calc(1.375rem + 7.16px) 100% / 1.375rem
+        calc(100% - 7.16px),
+      line to 1.375rem calc(100% - var(--chat-composer-context-extension)),
+      curve to 0 calc(100% - var(--chat-composer-context-extension) - 1.375rem) with 0.6156rem
         calc(100% - var(--chat-composer-context-extension)) / 0
-        calc(100% - var(--chat-composer-context-extension) - 9.85px),
+        calc(100% - var(--chat-composer-context-extension) - 0.6156rem),
       line to 0 22px,
       close
     );


### PR DESCRIPTION
Fixes #5662.

The "Current checkout" strip is laid out in rem (`w-[calc(100%-2.75rem)]` in `BranchToolbar.tsx`), but the glass slab that traces it is clipped by a `shape()` whose step-in constants were hardcoded px. `22px == 1.375rem` only at the default interface font size, so at any other Typography setting the slab overhangs the strip's hairline by a few px per side (~5.5px at size 20).

This converts only the step-in values to rem so the silhouette tracks the strip:

- `22px` → `1.375rem` (step-in/side positions only)
- `9.85px` → `0.6156rem` (the step-transition curve controls)
- `38px` → `calc(1.375rem + 16px)`
- `29.16px` → `calc(1.375rem + 7.16px)`

Deliberately unchanged: the composer's 22px top corner radius and the strip's `16px`/`7.16px` bottom corner values, which match the strip's px-literal `border-radius: 0 0 16px 16px`. At the default font size the computed path is identical to before.

I've been running exactly this substitution as a local override and it is pixel-correct at interface sizes 16 and 20 (verified with devtools screenshots against a textured background — repro details in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only visual fix to a single clip-path; no logic, auth, or data changes; default font size preserves the prior shape.
> 
> **Overview**
> Fixes misalignment between the chat composer **glass** `clip-path` and the **“Current checkout”** context strip when Typography interface font size is not the default.
> 
> The strip in `BranchToolbar` is inset with **rem** (`2.75rem` total width), but the continuous glass `shape()` used **px** for the side step-in (`22px`, `38px`, etc.). Those only match `1.375rem` at default root font size, so the glass could overhang the strip hairline at larger sizes.
> 
> This PR converts **only** the step-in geometry in `.chat-composer-glass-shell-with-context::before` to **rem** (e.g. `1.375rem`, `0.6156rem`, and `calc(1.375rem + 16px)` for bottom corners), while leaving the composer top **22px** radius and strip **16px** bottom radius in px to match the strip’s px `border-radius`. At default font size the path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a69de9fe16251fd1357a3a99798507d47a4cef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer glass clip-path to scale with interface font size
> Converts hard-coded `px` values in the `clip-path` of [`.chat-composer-glass-with-context::before`](https://github.com/pingdotgg/t3code/pull/5703/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to `rem` equivalents so the shape scales correctly at non-default root font sizes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a69de9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->