### PR TITLE
feat(server): opt-in SuperCompress before coding-agent turns

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -43,6 +43,7 @@ import {
   resolveSourceControlWriterModelSelection,
   ServerSettingsService,
 } from "../../serverSettings.ts";
+import { compressTurnMessage } from "../../supercompress/compressTurnMessage.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
@@ -1161,9 +1162,52 @@ const make = Effect.gen(function* () {
         ),
       );
 
+    // Opt-in SuperCompress: shrink bulky pasted context before the provider
+    // turn. The thread message stays as the user wrote it; only the outbound
+    // provider payload is rewritten. Fail-open on any skip/error.
+    let outboundMessageText = message.text;
+    const serverSettings = yield* serverSettingsService.getSettings.pipe(
+      Effect.catchAll(() => Effect.succeed(null)),
+    );
+    const supercompress = serverSettings?.supercompress;
+    if (supercompress?.enabled && supercompress.apiKey.trim().length > 0) {
+      const codingAgent =
+        thread.session?.providerInstanceId ?? event.payload.modelSelection?.instanceId ?? "T3 Code";
+      const compressed = yield* Effect.tryPromise(() =>
+        compressTurnMessage({
+          text: message.text,
+          apiKey: supercompress.apiKey,
+          minChars: supercompress.minChars,
+          codingAgent: String(codingAgent),
+        }),
+      ).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            text: message.text,
+            compressed: false as const,
+            skipped: error instanceof Error ? error.message : "error",
+          }),
+        ),
+      );
+      if (compressed.compressed) {
+        outboundMessageText = compressed.text;
+        yield* Effect.logInfo("supercompress compressed outbound turn context", {
+          threadId: event.payload.threadId,
+          originalTokens: compressed.originalTokens,
+          compressedTokens: compressed.compressedTokens,
+          savingsPct: compressed.savingsPct,
+        });
+      } else if (compressed.skipped && compressed.skipped !== "no_context") {
+        yield* Effect.logDebug("supercompress skipped outbound turn context", {
+          threadId: event.payload.threadId,
+          reason: compressed.skipped,
+        });
+      }
+    }
+
     const sendTurnRequest = yield* buildSendTurnRequestForThread({
       threadId: event.payload.threadId,
-      messageText: message.text,
+      messageText: outboundMessageText,
       ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
       ...(event.payload.modelSelection !== undefined
         ? { modelSelection: event.payload.modelSelection }

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -49,6 +49,7 @@ import { fromJsonStringPretty, fromLenientJson } from "@t3tools/shared/schemaJso
 import {
   applyServerSettingsPatch,
   isModelSelectionProviderEnabled,
+  SUPERCOMPRESS_API_KEY_CONFIGURED_SENTINEL,
 } from "@t3tools/shared/serverSettings";
 import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 
@@ -109,7 +110,18 @@ export function redactServerSettingsForClient(settings: ServerSettings): ServerS
         : instance,
     ]),
   );
-  return { ...settings, providerInstances };
+  // Never ship the SuperCompress API key to browsers / remote clients.
+  // Clients treat a non-empty redacted sentinel as "key already configured"
+  // and only overwrite when the user pastes a new `sc_…` value.
+  const apiKey = settings.supercompress.apiKey.trim();
+  return {
+    ...settings,
+    providerInstances,
+    supercompress: {
+      ...settings.supercompress,
+      apiKey: apiKey.length > 0 ? SUPERCOMPRESS_API_KEY_CONFIGURED_SENTINEL : "",
+    },
+  };
 }
 
 export class ServerSettingsService extends Context.Service<

--- a/apps/server/src/supercompress/compressTurnMessage.test.ts
+++ b/apps/server/src/supercompress/compressTurnMessage.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  compressTurnMessage,
+  isSuperCompressApiKey,
+  splitAskAndContext,
+  SUPERCOMPRESS_API_URL,
+} from "./compressTurnMessage.ts";
+
+describe("isSuperCompressApiKey", () => {
+  it("accepts sc_ keys", () => {
+    expect(isSuperCompressApiKey("sc_live_abc")).toBe(true);
+  });
+
+  it("rejects placeholders and empty values", () => {
+    expect(isSuperCompressApiKey("")).toBe(false);
+    expect(isSuperCompressApiKey("${SUPERCOMPRESS_API_KEY}")).toBe(false);
+    expect(isSuperCompressApiKey("sk-openai")).toBe(false);
+  });
+});
+
+describe("splitAskAndContext", () => {
+  it("keeps short messages as ask-only", () => {
+    expect(splitAskAndContext("fix the flaky test", 800)).toEqual({
+      ask: "fix the flaky test",
+      context: "",
+    });
+  });
+
+  it("splits paragraph-separated pastes", () => {
+    const ask = "Summarize this dump and fix the bug.";
+    const context = `${"x".repeat(900)}\nmore context`;
+    const split = splitAskAndContext(`${ask}\n\n${context}`, 400);
+    expect(split.ask).toBe(ask);
+    expect(split.context).toBe(context);
+  });
+
+  it("uses a short head as ask for a single blob", () => {
+    const blob = `Please review:\n${"line\n".repeat(200)}`;
+    const split = splitAskAndContext(blob, 400);
+    expect(split.ask.length).toBeGreaterThan(0);
+    expect(split.context.length).toBeGreaterThan(split.ask.length);
+    expect(`${split.ask}${split.context === "" ? "" : `\n${split.context}`}`).toContain(
+      "Please review",
+    );
+  });
+});
+
+describe("compressTurnMessage", () => {
+  it("skips when no key is configured", async () => {
+    const result = await compressTurnMessage({
+      text: `ask\n\n${"context ".repeat(200)}`,
+      apiKey: "",
+      minChars: 100,
+    });
+    expect(result).toMatchObject({ compressed: false, skipped: "no_key" });
+  });
+
+  it("skips short ask-only messages", async () => {
+    const result = await compressTurnMessage({
+      text: "ship it",
+      apiKey: "sc_test",
+      minChars: 800,
+    });
+    expect(result).toMatchObject({ compressed: false, skipped: "no_context" });
+  });
+
+  it("compresses context and keeps the ask, fail-open on no savings", async () => {
+    const ask = "Find the race in this log.";
+    const context = "a".repeat(1200);
+    const fetchCalls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const result = await compressTurnMessage({
+      text: `${ask}\n\n${context}`,
+      apiKey: "sc_test_key",
+      minChars: 400,
+      codingAgent: "Codex",
+      fetchImpl: async (url, init) => {
+        fetchCalls.push({ url, init });
+        return Response.json({
+          compressed_text: "digest",
+          original_tokens: 300,
+          kept_tokens: 40,
+          tokens_saved_pct: 86.7,
+        });
+      },
+    });
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]?.url).toBe(SUPERCOMPRESS_API_URL);
+    expect(JSON.parse(String(fetchCalls[0]?.init?.body))).toMatchObject({
+      query: ask,
+      coding_agent: "Codex",
+      mode: "compiler",
+    });
+    expect(result.compressed).toBe(true);
+    expect(result.text.startsWith(ask)).toBe(true);
+    expect(result.text).toContain("digest");
+    expect(result.savingsPct).toBe(87);
+  });
+
+  it("returns the original text when the API fails", async () => {
+    const text = `ask\n\n${"b".repeat(1000)}`;
+    const result = await compressTurnMessage({
+      text,
+      apiKey: "sc_test",
+      minChars: 100,
+      fetchImpl: async () => new Response("nope", { status: 500 }),
+    });
+    expect(result).toEqual({ text, compressed: false, skipped: "http_500" });
+  });
+});

--- a/apps/server/src/supercompress/compressTurnMessage.ts
+++ b/apps/server/src/supercompress/compressTurnMessage.ts
@@ -1,0 +1,183 @@
+// @effect-diagnostics globalFetch:off
+/**
+ * Pre-turn SuperCompress helper.
+ *
+ * Compresses bulky *context* in a user message before it is sent to a coding
+ * agent provider. The user ask / query is never compressed.
+ *
+ * Uses injectable `fetch` (not Effect HttpClient) so turn-start can fail-open
+ * through `Effect.tryPromise` without pulling HttpClient into the reactor.
+ */
+
+export const SUPERCOMPRESS_API_URL = "https://www.supercompress.dev/api/v1/compress";
+export const SUPERCOMPRESS_DEFAULT_TIMEOUT_MS = 14_000;
+
+export type CompressFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+export type CompressTurnMessageInput = {
+  readonly text: string;
+  readonly apiKey: string;
+  readonly minChars?: number | undefined;
+  readonly codingAgent?: string | undefined;
+  readonly fetchImpl?: CompressFetch | undefined;
+  readonly timeoutMs?: number | undefined;
+  readonly apiUrl?: string | undefined;
+};
+
+export type CompressTurnMessageResult = {
+  readonly text: string;
+  readonly compressed: boolean;
+  readonly skipped?: string | undefined;
+  readonly originalTokens?: number | undefined;
+  readonly compressedTokens?: number | undefined;
+  readonly savingsPct?: number | undefined;
+};
+
+export function isSuperCompressApiKey(value: string): boolean {
+  const key = value.trim();
+  return key.startsWith("sc_") && !key.includes("${");
+}
+
+/**
+ * Split a long user paste into ask (query) + context.
+ * Short messages → all ask, empty context (no compress).
+ * Long messages → first paragraph / ~400 chars as ask, rest as context.
+ */
+export function splitAskAndContext(
+  text: string,
+  minChars: number,
+): { readonly ask: string; readonly context: string } {
+  const raw = String(text ?? "");
+  if (raw.trim().length < minChars) {
+    return { ask: raw.trim(), context: "" };
+  }
+  const parts = raw.split(/\n\s*\n/);
+  if (parts.length >= 2 && parts[0]!.trim().length <= 500) {
+    return {
+      ask: parts[0]!.trim(),
+      context: parts.slice(1).join("\n\n").trim(),
+    };
+  }
+  const head = raw.slice(0, 400);
+  const nl = head.lastIndexOf("\n");
+  const cut = nl > 80 ? nl : 400;
+  return {
+    ask: raw.slice(0, cut).trim() || "Compress the following context for the coding task.",
+    context: raw.slice(cut).trim(),
+  };
+}
+
+function assembleCompressedMessage(ask: string, compressedContext: string): string {
+  const a = ask.trim();
+  const c = compressedContext.trim();
+  if (!c) return a;
+  if (!a) return c;
+  return `${a}\n\n${c}`;
+}
+
+/**
+ * Compress bulky context in a turn message. Fail-open: any skip/error returns
+ * the original text so the coding agent still runs.
+ */
+export async function compressTurnMessage(
+  input: CompressTurnMessageInput,
+): Promise<CompressTurnMessageResult> {
+  const original = String(input.text ?? "");
+  const apiKey = input.apiKey.trim();
+  const minChars = input.minChars ?? 800;
+
+  if (!isSuperCompressApiKey(apiKey)) {
+    return { text: original, compressed: false, skipped: "no_key" };
+  }
+
+  const { ask, context } = splitAskAndContext(original, minChars);
+  if (!context) {
+    return { text: original, compressed: false, skipped: "no_context" };
+  }
+  if (context.length < 40) {
+    return { text: original, compressed: false, skipped: "too_small" };
+  }
+
+  const fetchImpl: CompressFetch | undefined =
+    input.fetchImpl ??
+    (typeof globalThis.fetch === "function"
+      ? (url, init) => globalThis.fetch(url, init)
+      : undefined);
+  if (!fetchImpl) {
+    return { text: original, compressed: false, skipped: "no_fetch" };
+  }
+
+  const clipped = context.length > 160_000 ? context.slice(0, 160_000) : context;
+  const timeoutMs = input.timeoutMs ?? SUPERCOMPRESS_DEFAULT_TIMEOUT_MS;
+  const signal =
+    typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
+      ? AbortSignal.timeout(timeoutMs)
+      : undefined;
+
+  try {
+    const response = await fetchImpl(input.apiUrl ?? SUPERCOMPRESS_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": apiKey,
+      },
+      body: JSON.stringify({
+        context: clipped,
+        query: ask || "Compress this context for the coding task.",
+        mode: "compiler",
+        coding_agent: input.codingAgent || "T3 Code",
+      }),
+      ...(signal ? { signal } : {}),
+    });
+
+    if (!response.ok) {
+      return { text: original, compressed: false, skipped: `http_${response.status}` };
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+    const compressedContext =
+      (typeof body.compressed_text === "string" && body.compressed_text) ||
+      (typeof body.compressed_context === "string" && body.compressed_context) ||
+      (typeof body.compressed === "string" && body.compressed) ||
+      clipped;
+
+    if (typeof compressedContext !== "string" || compressedContext.trim().length === 0) {
+      return { text: original, compressed: false, skipped: "empty_result" };
+    }
+
+    // Never expand the payload.
+    if (compressedContext.length >= clipped.length) {
+      return { text: original, compressed: false, skipped: "no_savings" };
+    }
+
+    const inTok =
+      typeof body.original_tokens === "number"
+        ? body.original_tokens
+        : Math.round(clipped.length / 4);
+    const outTok =
+      typeof body.kept_tokens === "number"
+        ? body.kept_tokens
+        : typeof body.compressed_tokens === "number"
+          ? body.compressed_tokens
+          : Math.round(compressedContext.length / 4);
+    const savingsPct =
+      typeof body.tokens_saved_pct === "number"
+        ? Math.round(body.tokens_saved_pct)
+        : typeof body.kv_savings_pct === "number"
+          ? Math.round(body.kv_savings_pct)
+          : inTok > 0
+            ? Math.round(((inTok - outTok) / inTok) * 100)
+            : 0;
+
+    return {
+      text: assembleCompressedMessage(ask, compressedContext),
+      compressed: true,
+      originalTokens: inTok,
+      compressedTokens: outTok,
+      savingsPct,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "error";
+    return { text: original, compressed: false, skipped: message };
+  }
+}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -116,6 +116,7 @@ import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../
 import { Switch } from "../ui/switch";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { SuperCompressSettingsSection } from "./SuperCompressSettings";
 import { ThemeLibrary } from "./ThemeSettings";
 import {
   backgroundActivityOverrideSettings,
@@ -2206,6 +2207,8 @@ export function GeneralSettingsPanel() {
           }
         />
       </SettingsSection>
+
+      <SuperCompressSettingsSection />
 
       <SettingsSection title="About">
         {isElectron || HOSTED_APP_CHANNEL ? (

--- a/apps/web/src/components/settings/SuperCompressSettings.tsx
+++ b/apps/web/src/components/settings/SuperCompressSettings.tsx
@@ -1,0 +1,160 @@
+import { useMemo, useState } from "react";
+import {
+  DEFAULT_SUPERCOMPRESS_MIN_CHARS,
+  DEFAULT_UNIFIED_SETTINGS,
+  MAX_SUPERCOMPRESS_MIN_CHARS,
+  MIN_SUPERCOMPRESS_MIN_CHARS,
+} from "@t3tools/contracts/settings";
+import { SUPERCOMPRESS_API_KEY_CONFIGURED_SENTINEL } from "@t3tools/shared/serverSettings";
+import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { Button } from "../ui/button";
+import { DraftInput } from "../ui/draft-input";
+import { Input } from "../ui/input";
+import { Switch } from "../ui/switch";
+import { SettingResetButton, SettingsRow, SettingsSection } from "./settingsLayout";
+import { searchableSetting } from "./settingsSearch";
+
+const CONFIGURED_SENTINEL = SUPERCOMPRESS_API_KEY_CONFIGURED_SENTINEL;
+
+function looksLikeSuperCompressKey(value: string): boolean {
+  const key = value.trim();
+  return key.startsWith("sc_") && key !== CONFIGURED_SENTINEL && !key.includes("${");
+}
+
+export function SuperCompressSettingsSection() {
+  const settings = usePrimarySettings();
+  const updateSettings = useUpdatePrimarySettings();
+  const configured = settings.supercompress.apiKey === CONFIGURED_SENTINEL;
+  const [draftKey, setDraftKey] = useState("");
+
+  const status = useMemo(() => {
+    if (!settings.supercompress.enabled) return "Off";
+    if (configured || looksLikeSuperCompressKey(settings.supercompress.apiKey)) {
+      return "Connected";
+    }
+    return "Needs API key";
+  }, [configured, settings.supercompress.apiKey, settings.supercompress.enabled]);
+
+  const canReset =
+    settings.supercompress.enabled !== DEFAULT_UNIFIED_SETTINGS.supercompress.enabled ||
+    settings.supercompress.minChars !== DEFAULT_UNIFIED_SETTINGS.supercompress.minChars ||
+    settings.supercompress.apiKey.length > 0;
+
+  return (
+    <SettingsSection title="SuperCompress">
+      <SettingsRow
+        {...searchableSetting("supercompress")}
+        description="Compress bulky pasted context before each coding-agent turn. Your ask stays as you wrote it. Fail-open if SuperCompress is unavailable."
+        resetAction={
+          canReset ? (
+            <SettingResetButton
+              label="SuperCompress"
+              onClick={() => {
+                setDraftKey("");
+                updateSettings({
+                  supercompress: {
+                    enabled: false,
+                    apiKey: "",
+                    minChars: DEFAULT_SUPERCOMPRESS_MIN_CHARS,
+                  },
+                });
+              }}
+            />
+          ) : null
+        }
+        control={
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">{status}</span>
+            <Switch
+              checked={settings.supercompress.enabled}
+              onCheckedChange={(checked) =>
+                updateSettings({ supercompress: { enabled: Boolean(checked) } })
+              }
+              aria-label="Compress bulky context before agent turns"
+            />
+          </div>
+        }
+      />
+
+      {settings.supercompress.enabled ? (
+        <>
+          <SettingsRow
+            title="API key"
+            description={
+              <>
+                Paste an <code className="text-xs">sc_…</code> key from{" "}
+                <a
+                  className="underline underline-offset-2 hover:text-foreground"
+                  href="https://www.supercompress.dev/dashboard"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  supercompress.dev/dashboard
+                </a>
+                . Stored with this environment’s server settings.
+              </>
+            }
+            control={
+              <div className="flex w-full max-w-sm flex-col gap-2 sm:items-end">
+                <DraftInput
+                  type="password"
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="w-full"
+                  placeholder={configured ? "Key saved — paste to replace" : "sc_…"}
+                  value={draftKey}
+                  onCommit={(next) => {
+                    const trimmed = next.trim();
+                    setDraftKey(trimmed);
+                    if (!looksLikeSuperCompressKey(trimmed)) return;
+                    updateSettings({ supercompress: { apiKey: trimmed } });
+                    setDraftKey("");
+                  }}
+                  aria-label="SuperCompress API key"
+                />
+                {configured ? (
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="outline"
+                    onClick={() => {
+                      setDraftKey("");
+                      updateSettings({ supercompress: { apiKey: "" } });
+                    }}
+                  >
+                    Clear key
+                  </Button>
+                ) : null}
+              </div>
+            }
+          />
+
+          <SettingsRow
+            title="Minimum message size"
+            description="Messages shorter than this stay uncompressed. Raise it if short prompts should skip SuperCompress."
+            control={
+              <Input
+                type="number"
+                inputMode="numeric"
+                className="w-28 bg-background"
+                min={MIN_SUPERCOMPRESS_MIN_CHARS}
+                max={MAX_SUPERCOMPRESS_MIN_CHARS}
+                value={settings.supercompress.minChars}
+                onChange={(event) => {
+                  const next = Number(event.target.value);
+                  if (!Number.isFinite(next)) return;
+                  const clamped = Math.min(
+                    MAX_SUPERCOMPRESS_MIN_CHARS,
+                    Math.max(MIN_SUPERCOMPRESS_MIN_CHARS, Math.round(next)),
+                  );
+                  updateSettings({ supercompress: { minChars: clamped } });
+                }}
+                aria-label="SuperCompress minimum message size in characters"
+              />
+            }
+          />
+        </>
+      ) : null}
+    </SettingsSection>
+  );
+}

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -175,6 +175,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/keybindings",
   },
   {
+    id: "supercompress",
+    title: "SuperCompress",
+    to: "/settings/general",
+  },
+  {
     id: "providers",
     title: "Providers",
     to: "/settings/providers",

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 - [Source control integrations](./user/source-control.md)
 - [Background service (Linux)](./user/background-service.md)
 - Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md)
+- [SuperCompress](./user/supercompress.md)
 
 Mobile app: [apps/mobile/README.md](../apps/mobile/README.md)
 

--- a/docs/user/supercompress.md
+++ b/docs/user/supercompress.md
@@ -1,0 +1,38 @@
+# SuperCompress
+
+Use SuperCompress when long pastes and tool dumps are burning tokens on every coding-agent turn.
+
+T3 Code can compress bulky _context_ before the request reaches Codex, Claude, Cursor, Grok, or OpenCode. Your ask stays as you wrote it.
+
+## Connect SuperCompress
+
+1. Create an API key at [supercompress.dev/dashboard](https://www.supercompress.dev/dashboard).
+2. In T3 Code, open **Settings → General → SuperCompress**.
+3. Turn **Compress bulky context before agent turns** on.
+4. Paste your `sc_…` API key.
+5. Leave the minimum size at `800` characters unless you know you want shorter pastes compressed too.
+
+The key is stored with your environment’s server settings (same class of secret as other provider credentials on that machine).
+
+## What gets compressed
+
+On each turn start, T3 Code:
+
+1. Splits your message into a short **ask** and the remaining **context**
+2. Sends only the context to SuperCompress
+3. Rebuilds the provider prompt as `ask + compressed context`
+4. Leaves the message shown in the thread unchanged
+
+Short messages are left alone. If SuperCompress is unreachable or returns no savings, T3 Code sends the original text (fail-open).
+
+## When to use it
+
+- Pasting long logs, traces, or file dumps into a turn
+- Forwarding large agent transcripts as context
+- Keeping provider context windows colder without rewriting your ask
+
+SuperCompress does not replace provider-native context compaction. It runs earlier, on the text you are about to send.
+
+## Turn it off
+
+Toggle the setting off, or clear the API key. Existing thread history is unchanged.

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -297,3 +297,34 @@ describe("ServerSettingsPatch string normalization", () => {
     expect(encoded.providers?.codex?.launchArgs).toBe("--strict-config");
   });
 });
+
+describe("ServerSettings SuperCompress", () => {
+  it("defaults to disabled with an 800-character threshold", () => {
+    const settings = decodeServerSettings({});
+    expect(settings.supercompress).toEqual({
+      enabled: false,
+      apiKey: "",
+      minChars: 800,
+    });
+  });
+
+  it("accepts an opt-in connection patch", () => {
+    const patch = decodeServerSettingsPatch({
+      supercompress: {
+        enabled: true,
+        apiKey: "sc_live_test",
+        minChars: 1200,
+      },
+    });
+    expect(patch.supercompress).toEqual({
+      enabled: true,
+      apiKey: "sc_live_test",
+      minChars: 1200,
+    });
+  });
+
+  it("rejects an out-of-range minimum size", () => {
+    expect(() => decodeServerSettings({ supercompress: { minChars: 50 } })).toThrow();
+    expect(() => decodeServerSettingsPatch({ supercompress: { minChars: 50_000 } })).toThrow();
+  });
+});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -475,6 +475,31 @@ export const ObservabilitySettings = Schema.Struct({
 });
 export type ObservabilitySettings = typeof ObservabilitySettings.Type;
 
+/**
+ * Opt-in SuperCompress connection. When enabled with an API key, T3 compresses
+ * bulky pasted context on each coding-agent turn *before* the provider request
+ * leaves the server. The user ask stays uncompressed.
+ */
+export const MIN_SUPERCOMPRESS_MIN_CHARS = 200;
+export const MAX_SUPERCOMPRESS_MIN_CHARS = 20_000;
+export const DEFAULT_SUPERCOMPRESS_MIN_CHARS = 800;
+export const SuperCompressMinChars = Schema.Int.check(
+  Schema.isBetween({
+    minimum: MIN_SUPERCOMPRESS_MIN_CHARS,
+    maximum: MAX_SUPERCOMPRESS_MIN_CHARS,
+  }),
+);
+export type SuperCompressMinChars = typeof SuperCompressMinChars.Type;
+
+export const SuperCompressSettings = Schema.Struct({
+  enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  apiKey: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  minChars: SuperCompressMinChars.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SUPERCOMPRESS_MIN_CHARS)),
+  ),
+});
+export type SuperCompressSettings = typeof SuperCompressSettings.Type;
+
 export const SourceControlWritingStyleMode = Schema.Literals([
   "repo_conventions",
   "conventional_commits",
@@ -609,6 +634,7 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed({})),
   ),
   observability: ObservabilitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  supercompress: SuperCompressSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
 });
 export type ServerSettings = typeof ServerSettings.Type;
 
@@ -733,6 +759,13 @@ export const ServerSettingsPatch = Schema.Struct({
     Schema.Struct({
       otlpTracesUrl: Schema.optionalKey(TrimmedString),
       otlpMetricsUrl: Schema.optionalKey(TrimmedString),
+    }),
+  ),
+  supercompress: Schema.optionalKey(
+    Schema.Struct({
+      enabled: Schema.optionalKey(Schema.Boolean),
+      apiKey: Schema.optionalKey(TrimmedString),
+      minChars: Schema.optionalKey(SuperCompressMinChars),
     }),
   ),
   providers: Schema.optionalKey(

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -512,4 +512,45 @@ describe("serverSettings helpers", () => {
 
     expect(resolved.pauseWhenOnBattery).toBe(false);
   });
+
+  it("does not persist the redacted SuperCompress API key sentinel", () => {
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      supercompress: {
+        enabled: true,
+        apiKey: "sc_live_real",
+        minChars: 800,
+      },
+    };
+    const next = applyServerSettingsPatch(current, {
+      supercompress: {
+        enabled: true,
+        apiKey: "sc_configured",
+        minChars: 1000,
+      },
+    });
+    expect(next.supercompress.apiKey).toBe("sc_live_real");
+    expect(next.supercompress.minChars).toBe(1000);
+  });
+
+  it("allows replacing or clearing a SuperCompress API key", () => {
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      supercompress: {
+        enabled: true,
+        apiKey: "sc_live_old",
+        minChars: 800,
+      },
+    };
+    expect(
+      applyServerSettingsPatch(current, {
+        supercompress: { apiKey: "sc_live_new" },
+      }).supercompress.apiKey,
+    ).toBe("sc_live_new");
+    expect(
+      applyServerSettingsPatch(current, {
+        supercompress: { apiKey: "" },
+      }).supercompress.apiKey,
+    ).toBe("");
+  });
 });

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -121,18 +121,36 @@ function mergeModelSelectionOptionsById(input: {
   return [...merged.entries()].map(([id, value]) => ({ id, value }));
 }
 
+/** Redacted placeholder returned to clients when a SuperCompress key is stored. */
+export const SUPERCOMPRESS_API_KEY_CONFIGURED_SENTINEL = "sc_configured";
+
 export function applyServerSettingsPatch(
   current: ServerSettings,
   patch: ServerSettingsPatch,
 ): ServerSettings {
   const selectionPatch = patch.textGenerationModelSelection;
+  // Clients round-trip a redacted sentinel for configured keys. Never persist it.
+  const supercompressPatch =
+    patch.supercompress === undefined
+      ? undefined
+      : patch.supercompress.apiKey === SUPERCOMPRESS_API_KEY_CONFIGURED_SENTINEL
+        ? (() => {
+            const { apiKey: _omit, ...rest } = patch.supercompress;
+            return Object.keys(rest).length > 0 ? rest : undefined;
+          })()
+        : patch.supercompress;
   const {
     automaticGitFetchInterval,
     providerHealthRefreshInterval,
     backgroundActivityProfile,
     backgroundActivity,
-    ...patchForMerge
+    supercompress: _ignoredSupercompress,
+    ...restPatch
   } = patch;
+  const patchForMerge = {
+    ...restPatch,
+    ...(supercompressPatch !== undefined ? { supercompress: supercompressPatch } : {}),
+  };
   const currentBackgroundActivity = normalizeServerBackgroundActivitySettings(current);
   const backgroundActivityPatch =
     backgroundActivityProfile !== undefined


### PR DESCRIPTION
## Summary

- Adds an opt-in **Settings → General → SuperCompress** connection (API key + enable + min size)
- On turn start, compresses bulky pasted **context** before the provider request; the user ask is never compressed
- Thread UI keeps the original message; outbound provider payload is rewritten; failures fail open
- API key is redacted for clients (`sc_configured` sentinel) and never persisted from that sentinel

Related: https://github.com/pingdotgg/t3code/issues/5707

## Why this exists

T3 Code already ships multi-provider coding agents. Large pastes still leave the environment as full context on every turn. SuperCompress is a small, opt-in pre-turn step that matches how people already use it with Cursor/Claude hooks: compress context, keep the ask.

This is deliberately not a new provider, not MCP sprawl across adapters, and not on by default.

## Behavior

1. Connect at Settings → General → SuperCompress with an `sc_…` key from [supercompress.dev/dashboard](https://www.supercompress.dev/dashboard)
2. When enabled, `ProviderCommandReactor` calls SuperCompress only if the message clears `minChars` (default 800)
3. Ask/context split keeps the short ask; only context is sent to `POST /api/v1/compress`
4. If SuperCompress is offline / returns no savings / key missing → original text is sent

## Test plan

- [x] `vp test run` on `compressTurnMessage`, contracts settings, shared serverSettings (68 tests)
- [ ] Settings → General → SuperCompress: enable, paste `sc_` key, status shows Connected
- [ ] Short message (< minChars): unchanged outbound turn
- [ ] Long paste (`ask\n\n` + dump): outbound prompt is ask + compressed digest; thread still shows original
- [ ] Clear key / disable: turns skip SuperCompress
- [ ] Remote/web client: settings payload does not include the raw API key

## Docs

User guide: `docs/user/supercompress.md`

## UI note

New settings section under General. I can add before/after screenshots on request once a maintainer confirms the approach is welcome (per CONTRIBUTING, drive-by features may be declined).

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in SuperCompress integration to reduce context size before coding-agent turns
> - Adds a `supercompress` section to server settings with `enabled`, `apiKey`, and `minChars` fields, validated and defaulted via the contracts layer.
> - Implements `compressTurnMessage` in [compressTurnMessage.ts](https://github.com/pingdotgg/t3code/pull/5708/files#diff-592427a9b35522b80262ea446a2e83914ab5ae7b27627c3dbc6bfcf7d862e277) to split message text into ask and context, POST the context to the SuperCompress API, and return a compressed result or skip with a reason on failure.
> - Integrates compression into [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/5708/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d): when enabled with a valid API key, outbound turn messages are compressed before the provider request is built; on skip or error, the original text is sent unchanged.
> - Adds a SuperCompress settings UI in [SuperCompressSettings.tsx](https://github.com/pingdotgg/t3code/pull/5708/files#diff-29b0eaa6ddf3d96d8cd1e76f734349631b10102c712125db779102d1ca351b5e) for toggling, key management, and `minChars` configuration, and adds the section to the General settings page.
> - The stored API key is redacted to the sentinel `sc_configured` in client-visible settings; `applyServerSettingsPatch` ignores the sentinel to avoid overwriting the real key.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 782d518. 10 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->