### PR TITLE
fix(server): cap background-work deferral and report session-teardown losses

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1828,6 +1828,153 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("reports lost background agents when the stream ends cleanly", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "spawn agents",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-lost-a",
+        description: "Pass 5: fix-wave regression",
+        task_type: "local_agent",
+        tool_use_id: "toolu_lost_a",
+        uuid: "task-lost-a-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-lost-b",
+        description: "Pass 5: blind feature sweep",
+        task_type: "local_agent",
+        tool_use_id: "toolu_lost_b",
+        uuid: "task-lost-b-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+
+      // The claude child process exiting ends the SDK iterable cleanly.
+      // This is the incident shape: background agents still live, no error.
+      harness.query.finish();
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      runtimeEventsFiber.interruptUnsafe();
+
+      const runtimeError = runtimeEvents.find((event) => event.type === "runtime.error");
+      assert.equal(runtimeError?.type, "runtime.error");
+      if (runtimeError?.type === "runtime.error") {
+        assert.match(runtimeError.payload.message, /2 background agents were still running/);
+        assert.match(runtimeError.payload.message, /Pass 5: fix-wave regression/);
+        assert.match(runtimeError.payload.message, /Pass 5: blind feature sweep/);
+        assert.match(runtimeError.payload.message, /sending a new message resumes the session/i);
+      }
+
+      const stoppedTasks = runtimeEvents.filter(
+        (event) => event.type === "task.completed" && event.payload.status === "stopped",
+      );
+      assert.deepEqual(
+        stoppedTasks
+          .map((event) => (event.type === "task.completed" ? String(event.payload.taskId) : ""))
+          .sort(),
+        ["task-lost-a", "task-lost-b"],
+      );
+
+      assert.equal(
+        runtimeEvents.some((event) => event.type === "session.exited"),
+        true,
+      );
+      assert.equal(yield* adapter.hasSession(THREAD_ID), false);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("reports lost background agents when the stream fails", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "spawn agents",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-lost-on-failure",
+        description: "Pass 5: concurrency and consistency",
+        task_type: "local_agent",
+        tool_use_id: "toolu_lost_failure",
+        uuid: "task-lost-failure-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+
+      harness.query.fail(new Error("stream transport died"));
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      runtimeEventsFiber.interruptUnsafe();
+
+      // Trigger-agnostic: a failure exit with live tasks must be as loud as
+      // a clean one.
+      const lossReport = runtimeEvents.find(
+        (event) =>
+          event.type === "runtime.error" &&
+          /background agent was still running/.test(event.payload.message),
+      );
+      assert.equal(lossReport?.type, "runtime.error");
+      if (lossReport?.type === "runtime.error") {
+        assert.match(lossReport.payload.message, /Pass 5: concurrency and consistency/);
+      }
+
+      const stoppedTask = runtimeEvents.find(
+        (event) => event.type === "task.completed" && event.payload.status === "stopped",
+      );
+      assert.equal(stoppedTask?.type, "task.completed");
+      if (stoppedTask?.type === "task.completed") {
+        assert.equal(String(stoppedTask.payload.taskId), "task-lost-on-failure");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("keeps Claude stream failure events structural", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3567,6 +3567,34 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    // Background agents run inside the claude child process; the stream
+    // ending means that process is gone, and every still-tracked task with
+    // it. Report the loss before teardown — the previous behavior was a
+    // silent kill the user only discovered on their next message. The
+    // structured log captures the exit shape so the upstream trigger (what
+    // ends the stream minutes after a turn settles) stays measurable.
+    const lostTasks = Array.from(context.liveTaskIds, (taskId) => ({
+      taskId,
+      description: context.taskAgents.get(taskId)?.description,
+    }));
+    if (lostTasks.length > 0) {
+      yield* Effect.logWarning("claude.session.stream-ended-with-live-tasks", {
+        threadId: context.session.threadId,
+        exitKind: Exit.isFailure(exit) ? "failure" : "clean-end",
+        liveTaskCount: lostTasks.length,
+        taskDescriptions: lostTasks.map((task) => task.description ?? task.taskId),
+        sessionStartedAt: context.startedAt,
+        hadActiveTurn: context.turnState !== undefined,
+      });
+      const taskNames = lostTasks.map((task) => task.description ?? task.taskId).join(", ");
+      yield* emitRuntimeError(
+        context,
+        lostTasks.length === 1
+          ? `Claude runtime exited while a background agent was still running: ${taskNames}. The agent was stopped; sending a new message resumes the session.`
+          : `Claude runtime exited while ${lostTasks.length} background agents were still running: ${taskNames}. The agents were stopped; sending a new message resumes the session.`,
+      );
+    }
+
     if (Exit.isFailure(exit)) {
       if (isClaudeInterruptedCause(exit.cause)) {
         if (context.turnState) {
@@ -3620,6 +3648,39 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
     context.pendingApprovals.clear();
 
+    // Background agents live inside the claude child process, so no task
+    // survives its session. Emit the terminal event stopTask would have
+    // produced (see interruptTurn) so durable UI state settles at teardown
+    // instead of showing phantom running agents until the next resume.
+    const drainLiveTasks = Effect.gen(function* () {
+      for (const taskId of Array.from(context.liveTaskIds)) {
+        // A task_notification handler suspended mid-yield can resume between
+        // the snapshot above and this iteration and emit the task's real
+        // terminal event. `delete` returning false means exactly that — the
+        // task already settled, and emitting a second, contradictory
+        // `stopped` row here would overwrite its true final status.
+        if (!context.liveTaskIds.delete(taskId)) {
+          continue;
+        }
+        const taskStamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "task.completed",
+          eventId: taskStamp.eventId,
+          provider: PROVIDER,
+          createdAt: taskStamp.createdAt,
+          threadId: context.session.threadId,
+          ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+          payload: {
+            taskId: RuntimeTaskId.make(taskId),
+            status: "stopped",
+            ...taskLinkageFor(context.taskAgents, taskId),
+          },
+          providerRefs: nativeProviderRefs(context),
+        });
+      }
+    });
+    yield* drainLiveTasks;
+
     if (context.turnState) {
       yield* completeTurn(context, "interrupted", "Session stopped.");
     }
@@ -3631,6 +3692,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (streamFiber && streamFiber.pollUnsafe() === undefined) {
       yield* Fiber.interrupt(streamFiber);
     }
+
+    // A task_started handler suspended mid-yield on the stream fiber can
+    // resume between the first drain and the interrupt above, re-adding a
+    // task after it was drained. The fiber is dead now, so one more drain
+    // makes "zero live tasks after teardown" an invariant, not a race.
+    yield* drainLiveTasks;
 
     yield* Effect.try({
       try: () => context.query.close(),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -642,6 +642,411 @@ it.effect("ProviderServiceLive writes canonical events to the emitting thread se
   }).pipe(Effect.provide(NodeServices.layer)),
 );
 
+it.effect("marks the persisted binding stopped when session.exited flows through the pump", () =>
+  Effect.gen(function* () {
+    const codex = makeFakeCodexAdapter();
+    const registry = makeAdapterRegistryMock({
+      [ProviderDriverKind.make("codex")]: codex.adapter,
+    });
+    const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+      Layer.provide(SqlitePersistenceMemory),
+    );
+    const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+    const providerLayer = makeProviderServiceLive().pipe(
+      Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+      Layer.provide(directoryLayer),
+      Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(AnalyticsService.layerTest),
+      Layer.provide(
+        Layer.succeed(
+          ProviderEventLoggers.ProviderEventLoggers,
+          ProviderEventLoggers.NoOpProviderEventLoggers,
+        ),
+      ),
+    );
+
+    const threadId = asThreadId("thread-session-exit-binding");
+
+    // Single provide so every reference to the directory/repository layers
+    // resolves to the same in-memory database instance.
+    const testLayer = providerLayer.pipe(
+      Layer.provideMerge(directoryLayer),
+      Layer.provideMerge(runtimeRepositoryLayer),
+    );
+
+    // Adapter-internal exits (stream end, replace, adapter stopAll) never
+    // pass through ProviderService.stopSession; the pump must still leave
+    // the persisted binding stopped instead of a ghost `running` row.
+    yield* Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+      yield* ProviderService.ProviderService;
+      yield* directory.upsert({
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        threadId,
+        status: "running",
+      });
+      yield* advanceTestClock(10);
+      codex.emit({
+        eventId: asEventId("evt-session-exited-binding"),
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        type: "session.exited",
+        payload: {
+          reason: "Session stopped",
+          exitKind: "graceful",
+        },
+      });
+      yield* advanceTestClock(20);
+
+      // The pump processes the event on a forked fiber; poll briefly.
+      let runtime = yield* repository.getByThreadId({ threadId });
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (Option.isSome(runtime) && runtime.value.status === "stopped") {
+          break;
+        }
+        yield* Effect.yieldNow;
+        runtime = yield* repository.getByThreadId({ threadId });
+      }
+      assert.equal(Option.isSome(runtime), true);
+      if (Option.isSome(runtime)) {
+        assert.equal(runtime.value.status, "stopped");
+      }
+    }).pipe(Effect.provide(testLayer));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect(
+  "does not mark the binding stopped for a stale session.exited while a live session exists",
+  () =>
+    Effect.gen(function* () {
+      const codex = makeFakeCodexAdapter();
+      const registry = makeAdapterRegistryMock({
+        [ProviderDriverKind.make("codex")]: codex.adapter,
+      });
+      const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const providerLayer = makeProviderServiceLive().pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+        Layer.provide(directoryLayer),
+        Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(AnalyticsService.layerTest),
+        Layer.provide(
+          Layer.succeed(
+            ProviderEventLoggers.ProviderEventLoggers,
+            ProviderEventLoggers.NoOpProviderEventLoggers,
+          ),
+        ),
+      );
+
+      const threadId = asThreadId("thread-stale-exit-guard");
+
+      const testLayer = providerLayer.pipe(
+        Layer.provideMerge(directoryLayer),
+        Layer.provideMerge(runtimeRepositoryLayer),
+      );
+
+      // Replacement race: a new session is already live in the adapter when
+      // the torn-down session's exit event drains through the pump. The
+      // binding must stay running — marking it stopped would hide a live
+      // child process from the reaper and diagnosis tooling. The guard is
+      // identity-based (session createdAt newer than the exit event): a
+      // crash-exit for the CURRENT session — which some adapters emit
+      // without tearing down their session map — must still mark the
+      // binding stopped.
+      yield* Effect.gen(function* () {
+        const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+        const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+        yield* ProviderService.ProviderService;
+        yield* codex.adapter.startSession({
+          threadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          runtimeMode: "full-access",
+        });
+        yield* directory.upsert({
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          threadId,
+          status: "running",
+        });
+        yield* advanceTestClock(10);
+        // The fake adapter stamps sessions createdAt 2026-01-01T00:00:00Z;
+        // an exit event created BEFORE that models the replaced (old)
+        // session's teardown emission.
+        codex.emit({
+          eventId: asEventId("evt-stale-session-exited"),
+          provider: ProviderDriverKind.make("codex"),
+          threadId,
+          createdAt: "2025-12-31T23:59:00.000Z",
+          type: "session.exited",
+          payload: {
+            reason: "Session stopped",
+            exitKind: "graceful",
+          },
+        });
+        yield* advanceTestClock(20);
+        for (let attempt = 0; attempt < 50; attempt++) {
+          yield* Effect.yieldNow;
+        }
+
+        const runtime = yield* repository.getByThreadId({ threadId });
+        assert.equal(Option.isSome(runtime), true);
+        if (Option.isSome(runtime)) {
+          assert.equal(runtime.value.status, "running");
+        }
+      }).pipe(Effect.provide(testLayer));
+    }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect(
+  "does not mark the binding stopped when the exit comes from a different provider instance",
+  () =>
+    Effect.gen(function* () {
+      const codex = makeFakeCodexAdapter();
+      const registry = makeAdapterRegistryMock({
+        [ProviderDriverKind.make("codex")]: codex.adapter,
+      });
+      const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const providerLayer = makeProviderServiceLive().pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+        Layer.provide(directoryLayer),
+        Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(AnalyticsService.layerTest),
+        Layer.provide(
+          Layer.succeed(
+            ProviderEventLoggers.ProviderEventLoggers,
+            ProviderEventLoggers.NoOpProviderEventLoggers,
+          ),
+        ),
+      );
+
+      const threadId = asThreadId("thread-cross-instance-exit-guard");
+
+      const testLayer = providerLayer.pipe(
+        Layer.provideMerge(directoryLayer),
+        Layer.provideMerge(runtimeRepositoryLayer),
+      );
+
+      // Cross-instance replacement: the thread has moved to a session on a
+      // DIFFERENT provider instance, then the old instance's queued exit
+      // drains through the pump. The old adapter's listSessions cannot see
+      // the replacement, so only the instance-id comparison protects the
+      // fresh binding — it must stay running.
+      yield* Effect.gen(function* () {
+        const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+        const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+        yield* ProviderService.ProviderService;
+        yield* directory.upsert({
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex-replacement"),
+          threadId,
+          status: "running",
+        });
+        yield* advanceTestClock(10);
+        // No session exists in this adapter for the thread (the replacement
+        // lives elsewhere), and the exit event is stamped with this
+        // adapter's instance id ("codex") by the pump.
+        codex.emit({
+          eventId: asEventId("evt-cross-instance-session-exited"),
+          provider: ProviderDriverKind.make("codex"),
+          threadId,
+          createdAt: "2026-01-01T00:00:10.000Z",
+          type: "session.exited",
+          payload: {
+            reason: "Session stopped",
+            exitKind: "graceful",
+          },
+        });
+        yield* advanceTestClock(20);
+        for (let attempt = 0; attempt < 50; attempt++) {
+          yield* Effect.yieldNow;
+        }
+
+        const runtime = yield* repository.getByThreadId({ threadId });
+        assert.equal(Option.isSome(runtime), true);
+        if (Option.isSome(runtime)) {
+          assert.equal(runtime.value.status, "running");
+        }
+      }).pipe(Effect.provide(testLayer));
+    }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect(
+  "marks the binding stopped for a crash exit even when the adapter still reports the session",
+  () =>
+    Effect.gen(function* () {
+      const codex = makeFakeCodexAdapter();
+      const registry = makeAdapterRegistryMock({
+        [ProviderDriverKind.make("codex")]: codex.adapter,
+      });
+      const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const providerLayer = makeProviderServiceLive().pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+        Layer.provide(directoryLayer),
+        Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(AnalyticsService.layerTest),
+        Layer.provide(
+          Layer.succeed(
+            ProviderEventLoggers.ProviderEventLoggers,
+            ProviderEventLoggers.NoOpProviderEventLoggers,
+          ),
+        ),
+      );
+
+      const threadId = asThreadId("thread-crash-exit-binding");
+
+      const testLayer = providerLayer.pipe(
+        Layer.provideMerge(directoryLayer),
+        Layer.provideMerge(runtimeRepositoryLayer),
+      );
+
+      // Codex-style crash: the child process dies, the adapter emits
+      // session.exited but never removes its session map entry. The exit
+      // event is NEWER than the session, so the identity guard must not
+      // treat the dead session as a live replacement.
+      yield* Effect.gen(function* () {
+        const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+        const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+        yield* ProviderService.ProviderService;
+        yield* codex.adapter.startSession({
+          threadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          runtimeMode: "full-access",
+        });
+        yield* directory.upsert({
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          threadId,
+          status: "running",
+        });
+        yield* advanceTestClock(10);
+        codex.emit({
+          eventId: asEventId("evt-crash-session-exited"),
+          provider: ProviderDriverKind.make("codex"),
+          threadId,
+          createdAt: "2026-01-01T00:00:05.000Z",
+          type: "session.exited",
+          payload: {
+            reason: "codex app-server exited unexpectedly",
+            exitKind: "crash",
+          },
+        });
+        yield* advanceTestClock(20);
+
+        let runtime = yield* repository.getByThreadId({ threadId });
+        for (let attempt = 0; attempt < 100; attempt++) {
+          if (Option.isSome(runtime) && runtime.value.status === "stopped") {
+            break;
+          }
+          yield* Effect.yieldNow;
+          runtime = yield* repository.getByThreadId({ threadId });
+        }
+        assert.equal(Option.isSome(runtime), true);
+        if (Option.isSome(runtime)) {
+          assert.equal(runtime.value.status, "stopped");
+        }
+      }).pipe(Effect.provide(testLayer));
+    }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("refreshes the binding lastSeenAt when turn activity flows through the pump", () =>
+  Effect.gen(function* () {
+    const codex = makeFakeCodexAdapter();
+    const registry = makeAdapterRegistryMock({
+      [ProviderDriverKind.make("codex")]: codex.adapter,
+    });
+    const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+      Layer.provide(SqlitePersistenceMemory),
+    );
+    const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+    const providerLayer = makeProviderServiceLive().pipe(
+      Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+      Layer.provide(directoryLayer),
+      Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(AnalyticsService.layerTest),
+      Layer.provide(
+        Layer.succeed(
+          ProviderEventLoggers.ProviderEventLoggers,
+          ProviderEventLoggers.NoOpProviderEventLoggers,
+        ),
+      ),
+    );
+
+    const threadId = asThreadId("thread-turn-activity-touch");
+    const staleLastSeenAt = "2026-01-01T00:00:00.000Z";
+
+    const testLayer = providerLayer.pipe(
+      Layer.provideMerge(directoryLayer),
+      Layer.provideMerge(runtimeRepositoryLayer),
+    );
+
+    // Provider-initiated turns (background task notifications waking the
+    // agent) never route through sendTurn, so the pump must be the thing
+    // that keeps lastSeenAt honest — otherwise the reaper reads a thread
+    // doing autonomous work as idle since the user's last message.
+    yield* Effect.gen(function* () {
+      const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+      yield* ProviderService.ProviderService;
+      yield* repository.upsert({
+        threadId,
+        providerName: "codex",
+        providerInstanceId: codexInstanceId,
+        adapterKey: "codex",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: staleLastSeenAt,
+        resumeCursor: null,
+        runtimePayload: null,
+      });
+      yield* advanceTestClock(10);
+      codex.emit({
+        eventId: asEventId("evt-turn-activity-touch"),
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        type: "turn.completed",
+        payload: {
+          state: "completed",
+        },
+      });
+      yield* advanceTestClock(20);
+
+      let runtime = yield* repository.getByThreadId({ threadId });
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (Option.isSome(runtime) && runtime.value.lastSeenAt !== staleLastSeenAt) {
+          break;
+        }
+        yield* Effect.yieldNow;
+        runtime = yield* repository.getByThreadId({ threadId });
+      }
+      assert.equal(Option.isSome(runtime), true);
+      if (Option.isSome(runtime)) {
+        assert.notEqual(runtime.value.lastSeenAt, staleLastSeenAt);
+        // Turn activity must not change the binding status.
+        assert.equal(runtime.value.status, "running");
+      }
+    }).pipe(Effect.provide(testLayer));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
 it.effect("ProviderServiceLive keeps persisted resumable sessions on startup", () =>
   Effect.gen(function* () {
     const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-service-"));

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -25,6 +25,7 @@ import {
   type ProviderSession,
 } from "@t3tools/contracts";
 import { causeErrorTag } from "@t3tools/shared/observability";
+import * as Clock from "effect/Clock";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -281,10 +282,142 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       });
     });
 
+  // The event pump is the one funnel every adapter shares, so two binding
+  // invariants live here. Both are best-effort: a missing binding is a
+  // no-op and failures must never break event delivery.
+  //
+  // 1. `session.exited`: adapter-internal exits (stream end, session
+  //    replace, adapter stopAll) never pass through `stopSession`, which
+  //    left the persisted binding `running` — a ghost row the reaper keeps
+  //    sweeping and diagnosis tooling misreads. Guarded against stale
+  //    exits: if the adapter still holds a live session for the thread
+  //    (a replacement started before the old session's exit event drained),
+  //    the binding must stay `running`.
+  // 2. Turn and task lifecycle events: `lastSeenAt` previously moved only
+  //    on user-initiated `sendTurn`. Turns the provider starts on its own
+  //    (background task notifications waking the agent) and long-running
+  //    background tasks that heartbeat via `task.progress` never routed
+  //    through it, so a thread doing autonomous work read as idle from the
+  //    moment the user last typed — and got reaped mid-work. Touching the
+  //    binding on these events (throttled — task.progress ticks every few
+  //    seconds) makes the reaper's clock measure actual inactivity, and
+  //    turns the reaper's wedge cap into "no heartbeat at all for the cap
+  //    window", which is the definition of wedged.
+  const BINDING_TOUCH_THROTTLE_MS = 60_000;
+  const lastBindingTouchAtMs = new Map<string, number>();
+
+  const BINDING_TOUCH_EVENT_TYPES: ReadonlySet<ProviderRuntimeEvent["type"]> = new Set([
+    "turn.started",
+    "turn.completed",
+    "task.started",
+    "task.progress",
+    "task.updated",
+    "task.completed",
+  ]);
+
+  const syncBindingOnRuntimeEvent = (
+    adapter: ProviderAdapterShape<ProviderAdapterError>,
+    event: ProviderRuntimeEvent,
+  ): Effect.Effect<void> => {
+    const isSessionExit = event.type === "session.exited";
+    const isActivityTouch = BINDING_TOUCH_EVENT_TYPES.has(event.type);
+    if (!isSessionExit && !isActivityTouch) {
+      return Effect.void;
+    }
+    return Effect.gen(function* () {
+      const threadKey = String(event.threadId);
+      if (!isSessionExit) {
+        const nowMs = yield* Clock.currentTimeMillis;
+        const lastTouch = lastBindingTouchAtMs.get(threadKey);
+        if (lastTouch !== undefined && nowMs - lastTouch < BINDING_TOUCH_THROTTLE_MS) {
+          return;
+        }
+      } else {
+        lastBindingTouchAtMs.delete(threadKey);
+      }
+      const binding = Option.getOrUndefined(yield* directory.getBinding(event.threadId));
+      const providerInstanceId = binding?.providerInstanceId;
+      if (
+        binding === undefined ||
+        binding.status === "stopped" ||
+        providerInstanceId === undefined
+      ) {
+        return;
+      }
+      if (isSessionExit) {
+        // A session.exited that raced a replacement session must not stomp
+        // the fresh binding.
+        //
+        // Cross-instance replacement: the pump stamps every event with the
+        // instance that emitted it, so a binding owned by a DIFFERENT
+        // instance means the thread has already moved on — this exit belongs
+        // to a superseded session and the fresh binding must survive.
+        // (The emitting adapter's own listSessions cannot see a replacement
+        // living on another instance, so this check has to come first.)
+        if (
+          event.providerInstanceId !== undefined &&
+          event.providerInstanceId !== providerInstanceId
+        ) {
+          return;
+        }
+        // Same-instance replacement: thread-level `hasSession` is not enough
+        // here — a Codex child-process crash emits session.exited without
+        // tearing down the adapter's map entry, so the dead session itself
+        // still reports live. Skip only when the adapter holds a session
+        // created strictly after this exit event — that can only be a
+        // replacement. NaN-safe on purpose: an unparseable timestamp must
+        // not count as a replacement, or the ghost `running` row this sync
+        // exists to prevent comes back.
+        const activeSessions = yield* adapter.listSessions();
+        const current = activeSessions.find((session) => session.threadId === event.threadId);
+        if (current !== undefined) {
+          const currentCreatedAtMs = Date.parse(current.createdAt);
+          const exitCreatedAtMs = Date.parse(event.createdAt);
+          const replacementIsLive =
+            Number.isFinite(currentCreatedAtMs) &&
+            Number.isFinite(exitCreatedAtMs) &&
+            currentCreatedAtMs > exitCreatedAtMs;
+          if (replacementIsLive) {
+            return;
+          }
+        }
+      }
+      const lastRuntimeEventAt = yield* nowIso;
+      // On activity touches `status` is omitted so the directory preserves
+      // the existing value; the upsert itself refreshes `lastSeenAt`.
+      yield* directory.upsert({
+        threadId: event.threadId,
+        provider: binding.provider,
+        providerInstanceId,
+        ...(isSessionExit ? { status: "stopped" as const } : {}),
+        runtimePayload: {
+          ...(isSessionExit ? { activeTurnId: null } : {}),
+          lastRuntimeEvent: event.type,
+          lastRuntimeEventAt,
+        },
+      });
+      if (!isSessionExit) {
+        // Spend the throttle only after the touch actually landed — a missing
+        // binding or a failed upsert must not suppress the next 60s of
+        // touches for a refresh that never happened.
+        lastBindingTouchAtMs.set(threadKey, yield* Clock.currentTimeMillis);
+      }
+    }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("provider.session.binding-sync-failed", {
+          threadId: event.threadId,
+          eventType: event.type,
+          cause,
+        }),
+      ),
+    );
+  };
+
   const processRuntimeEvent = (
     source: {
       readonly instanceId: ProviderInstanceId;
       readonly provider: ProviderDriverKind;
+      readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
     },
     event: ProviderRuntimeEvent,
   ): Effect.Effect<void> =>
@@ -293,7 +426,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         increment(providerRuntimeEventsTotal, {
           provider: canonicalEvent.provider,
           eventType: canonicalEvent.type,
-        }).pipe(Effect.andThen(publishRuntimeEvent(canonicalEvent))),
+        }).pipe(
+          Effect.andThen(publishRuntimeEvent(canonicalEvent)),
+          Effect.andThen(syncBindingOnRuntimeEvent(source.adapter, canonicalEvent)),
+        ),
       ),
     );
 
@@ -336,6 +472,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
             {
               instanceId: id,
               provider: adapter.provider,
+              adapter,
             },
             event,
           ),

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -18,6 +18,8 @@ import * as Stream from "effect/Stream";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as ThreadBackgroundLiveness from "../../orchestration/ThreadBackgroundLiveness.ts";
+import { ThreadBackgroundLivenessService } from "../../orchestration/ThreadBackgroundLiveness.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
 import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntime.ts";
 import { ProviderValidationError } from "../Errors.ts";
@@ -150,6 +152,8 @@ describe("ProviderSessionReaper", () => {
     readonly stopSessionImplementation?: (input: {
       readonly threadId: ThreadId;
     }) => ReturnType<ProviderServiceShape["stopSession"]>;
+    readonly backgroundLiveness?: ThreadBackgroundLivenessService["Service"];
+    readonly backgroundWorkMaxIdleMs?: number;
   }) {
     const stoppedThreadIds = new Set<ThreadId>();
     const stopSession = vi.fn<ProviderServiceShape["stopSession"]>(
@@ -196,10 +200,18 @@ describe("ProviderSessionReaper", () => {
     const layer = makeProviderSessionReaperLive({
       inactivityThresholdMs: 1_000,
       sweepIntervalMs: 60_000,
+      ...(input.backgroundWorkMaxIdleMs !== undefined
+        ? { backgroundWorkMaxIdleMs: input.backgroundWorkMaxIdleMs }
+        : {}),
     }).pipe(
       Layer.provideMerge(providerSessionDirectoryLayer),
       Layer.provideMerge(runtimeRepositoryLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, providerService)),
+      Layer.provideMerge(
+        input.backgroundLiveness !== undefined
+          ? Layer.succeed(ThreadBackgroundLivenessService, input.backgroundLiveness)
+          : ThreadBackgroundLiveness.layer,
+      ),
       Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getCommandReadModel: () => Effect.die("unused"),
@@ -330,6 +342,10 @@ describe("ProviderSessionReaper", () => {
   it("skips stale sessions while background work is still live", async () => {
     const threadId = ThreadId.make("thread-reaper-background-work");
     const now = "2026-01-01T00:00:00.000Z";
+    // The sweep reads ThreadBackgroundLivenessService directly rather than
+    // the projected thread shell: the shell's backgroundLiveness is computed
+    // from the same service at snapshot-build time, so the direct read is
+    // the same signal without the snapshot staleness.
     const harness = await createHarness({
       readModel: makeReadModel([
         {
@@ -343,14 +359,23 @@ describe("ProviderSessionReaper", () => {
             lastError: null,
             updatedAt: now,
           },
-          backgroundLiveness: "working",
         },
       ]),
+      backgroundLiveness: {
+        recordTaskLiveness: () => {},
+        clearThreadLiveness: () => {},
+        getThreadBackgroundLiveness: () => "working",
+      },
     });
     const repository = await runtime!.runPromise(
       Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
     );
 
+    // Stale past the inactivity threshold but inside the wedge cap: live
+    // background work defers the reap. A session idle beyond the cap is
+    // reaped even with "live" work — that case is pinned by the wedge-cap
+    // test below.
+    const nowMs = await runtime!.runPromise(Clock.currentTimeMillis);
     await runtime!.runPromise(
       repository.upsert({
         threadId,
@@ -359,7 +384,7 @@ describe("ProviderSessionReaper", () => {
         adapterKey: "claudeAgent",
         runtimeMode: "full-access",
         status: "running",
-        lastSeenAt: "2026-04-14T00:00:00.000Z",
+        lastSeenAt: DateTime.formatIso(DateTime.makeUnsafe(nowMs - 10_000)),
         resumeCursor: {
           opaque: "resume-background-work",
         },
@@ -373,6 +398,116 @@ describe("ProviderSessionReaper", () => {
     expect(harness.stopSession).not.toHaveBeenCalled();
     const remaining = await runtime!.runPromise(repository.getByThreadId({ threadId }));
     expect(Option.isSome(remaining)).toBe(true);
+  });
+
+  it("skips idle sessions while background work is live", async () => {
+    const threadId = ThreadId.make("thread-reaper-background-work");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "claudeAgent",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+      backgroundLiveness: {
+        recordTaskLiveness: () => {},
+        clearThreadLiveness: () => {},
+        getThreadBackgroundLiveness: (id) => (id === threadId ? "working" : null),
+      },
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+
+    // Past the inactivity threshold (1s) but inside the default wedge cap.
+    const nowMs = await runtime!.runPromise(Clock.currentTimeMillis);
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: DateTime.formatIso(DateTime.makeUnsafe(nowMs - 10_000)),
+        resumeCursor: {
+          opaque: "resume-background-work",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
+    await runtime!.runPromise(drainFibers);
+
+    expect(harness.stopSession).not.toHaveBeenCalled();
+  });
+
+  it("reaps sessions with live background work once past the wedge cap", async () => {
+    const threadId = ThreadId.make("thread-reaper-wedged-background-work");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "claudeAgent",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+      backgroundLiveness: {
+        recordTaskLiveness: () => {},
+        clearThreadLiveness: () => {},
+        getThreadBackgroundLiveness: () => "working",
+      },
+      backgroundWorkMaxIdleMs: 5_000,
+    });
+    const repository = await runtime!.runPromise(
+      Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+    );
+
+    // Idle longer than the wedge cap: "live" background work that never
+    // reaches a terminal state must not pin the session forever.
+    const nowMs = await runtime!.runPromise(Clock.currentTimeMillis);
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        adapterKey: "claudeAgent",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: DateTime.formatIso(DateTime.makeUnsafe(nowMs - 60_000)),
+        resumeCursor: {
+          opaque: "resume-wedged-background-work",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await runtime!.runPromise(Scope.make("sequential"));
+    await runtime!.runPromise(reaper.start().pipe(Scope.provide(scope)));
+
+    await waitFor(() => harness.stopSession.mock.calls.length === 1);
+    expect(harness.stoppedThreadIds.has(threadId)).toBe(true);
   });
 
   it("does not reap sessions that are still within the inactivity threshold", async () => {

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -6,6 +6,7 @@ import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ThreadBackgroundLivenessService } from "../../orchestration/ThreadBackgroundLiveness.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import {
   ProviderSessionReaper,
@@ -16,10 +17,17 @@ import { ProviderService } from "../Services/ProviderService.ts";
 
 const DEFAULT_INACTIVITY_THRESHOLD_MS = 30 * 60 * 1000;
 const DEFAULT_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+// Live background work (subagent fleets, monitors) runs outside a turn, so
+// `activeTurnId` alone reads those sessions as idle. Defer reaping while the
+// liveness registry reports work — but only up to this cap: a task that has
+// been "live" this long without reaching a terminal state is wedged, and
+// holding its session (and child process) forever is worse than reaping it.
+const DEFAULT_BACKGROUND_WORK_MAX_IDLE_MS = 4 * 60 * 60 * 1000;
 
 export interface ProviderSessionReaperLiveOptions {
   readonly inactivityThresholdMs?: number;
   readonly sweepIntervalMs?: number;
+  readonly backgroundWorkMaxIdleMs?: number;
 }
 
 const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =>
@@ -27,12 +35,24 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
     const providerService = yield* ProviderService;
     const directory = yield* ProviderSessionDirectory;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+    const threadBackgroundLiveness = yield* ThreadBackgroundLivenessService;
 
     const inactivityThresholdMs = Math.max(
       1,
       options?.inactivityThresholdMs ?? DEFAULT_INACTIVITY_THRESHOLD_MS,
     );
     const sweepIntervalMs = Math.max(1, options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS);
+    // Floor STRICTLY above the inactivity threshold: the deferral branch only
+    // runs once idleDurationMs >= inactivityThresholdMs, so a cap equal to
+    // the threshold makes `idleDurationMs < backgroundWorkMaxIdleMs`
+    // unreachable and silently disables background-work deferral — the exact
+    // bug this reaper change exists to prevent. The floor is minimal (+1ms)
+    // on purpose: whether a sweep actually lands inside the deferral window
+    // is the caller's cadence choice, not something to silently rewrite.
+    const backgroundWorkMaxIdleMs = Math.max(
+      inactivityThresholdMs + 1,
+      options?.backgroundWorkMaxIdleMs ?? DEFAULT_BACKGROUND_WORK_MAX_IDLE_MS,
+    );
 
     const sweep = Effect.gen(function* () {
       const bindings = yield* directory.listBindings();
@@ -71,14 +91,19 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
           continue;
         }
 
-        // The turn can settle while background work runs on (subagent
-        // fleets, workflow runs, Monitor watch loops). Those live inside the
-        // provider process, so stopping the session would kill them silently,
-        // and nothing bumps lastSeenAt between turns.
-        if (thread?.backgroundLiveness != null) {
-          yield* Effect.logDebug("provider.session.reaper.skipped-background-work", {
+        // Background agents and monitors run on after the turn settles, with
+        // no activeTurnId and no lastSeenAt refresh. The liveness registry is
+        // the decaying signal for that work (entries clear on terminal task
+        // status, session exit, and server restart), so defer reaping while
+        // it reports work — up to the wedge cap. Info-level on purpose: rare
+        // and decision-bearing.
+        const backgroundLiveness = threadBackgroundLiveness.getThreadBackgroundLiveness(
+          binding.threadId,
+        );
+        if (backgroundLiveness !== null && idleDurationMs < backgroundWorkMaxIdleMs) {
+          yield* Effect.logInfo("provider.session.reaper.skipped-live-background-work", {
             threadId: binding.threadId,
-            backgroundLiveness: thread.backgroundLiveness,
+            backgroundLiveness,
             idleDurationMs,
           });
           continue;
@@ -138,6 +163,7 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
         yield* Effect.logInfo("provider.session.reaper.started", {
           inactivityThresholdMs,
           sweepIntervalMs,
+          backgroundWorkMaxIdleMs,
         });
       });
 

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -66,6 +66,33 @@ synchronization.
 3. [`CheckpointReactor`][checkpoint] captures workspace checkpoints on turn start and completion, and
    performs reverts.
 
+## Session teardown and background work
+
+Background tasks (subagent fleets, monitors, background shells) live inside the provider's child
+process, so no task survives its session. Three rules keep that honest:
+
+- **Teardown reports the loss.** When a Claude session tears down with tasks still tracked as live
+  (`liveTaskIds`), the adapter emits a terminal `task.completed(status: "stopped")` per task, and —
+  when the teardown was caused by the SDK stream ending rather than a user action — a
+  `runtime.error` naming the lost agents plus a structured `claude.session.stream-ended-with-live-tasks`
+  log capturing the exit shape. The session still tears down; resume happens through the normal
+  recovery path on the next message.
+- **The binding follows the session.** Every `session.exited` event that flows through
+  [`ProviderService`][service]'s event pump marks the persisted runtime binding `stopped`, so
+  adapter-internal exits (stream end, session replace, adapter stopAll) cannot leave ghost
+  `running` rows behind. A stale exit cannot stomp a replacement session's binding: the pump
+  skips the sync when the binding is owned by a different provider instance than the one that
+  emitted the exit, or when the emitting adapter holds a session created after the exit event.
+  The same pump touches the binding's `lastSeenAt` on turn lifecycle (`turn.started`,
+  `turn.completed`) and task lifecycle (`task.started`, `task.progress`, `task.updated`,
+  `task.completed`) events, throttled per thread: turns the provider starts on its own
+  (background task notifications waking the agent) never route through `sendTurn`, and without
+  the touch a thread doing autonomous work reads as idle from the user's last message.
+- **The reaper respects background work.** `ProviderSessionReaper` skips idle sessions while
+  `ThreadBackgroundLivenessService` reports live work for the thread, up to a wedge cap
+  (`backgroundWorkMaxIdleMs`, default 4h) after which a session is reaped anyway — a task that
+  never reaches a terminal state must not pin its child process forever.
+
 ### Buffered assistant delivery
 
 A thread in `buffered` assistant delivery mode accumulates assistant text instead of streaming each


### PR DESCRIPTION
## What Changed

Completes #5677. The background-liveness skip gets a wedge cap (`backgroundWorkMaxIdleMs`, default 4h) so a task that never reaches a terminal state cannot pin its session and child process forever. The binding's `lastSeenAt` now refreshes on provider-initiated turn/task lifecycle events, not just user `sendTurn`. `session.exited` flowing through the event pump marks the persisted binding `stopped` — guarded against stale exits from a replaced session, including replacements on a different provider instance. Claude session teardown drains still-live task ids with terminal `task.completed(stopped)` events, and a stream death with live tasks emits a `runtime.error` naming the lost agents plus a structured log.

## Why

#5677 correctly stopped the reaper from killing sessions with live background work, but the edges around it are still lossy or unbounded. The deferral is unconditional, so the failure mode just flips: a wedged task now pins its session forever instead of being killed too early. `lastSeenAt` still only moves on user-initiated turns, so a thread doing autonomous work reads as idle from the user's last keystroke — background liveness defers the reap, but the idle clock itself stays dishonest for anything else keyed to it. Adapter-internal exits (stream end, session replace, `stopAll`) never pass through `stopSession` and leave ghost `running` rows the sweep re-visits forever. And when teardown does kill live agents, the user finds out on their next message, potentially 40+ minutes later.

This was diagnosed from a production day with 13 session stops across three threads, each landing 30.1–39.7 minutes after the last user message while background agents were mid-work — one session was killed while running the test suite that verifies this fix. With the heartbeat in place, the wedge cap means "no heartbeat at all for the cap window", which is the definition of wedged.

The sweep reads `ThreadBackgroundLivenessService` directly rather than the projected shell — the shell's `backgroundLiveness` is computed from the same service at snapshot-build time, so it is the same signal minus the snapshot staleness. #5677's test is kept and adapted to the capped deferral: its months-stale scenario now correctly reaps, and that boundary is pinned by its own wedge-cap test. The stale-exit guard's cross-instance test fails without the guard (verified by reverting and re-running). `ProviderSessionReaper` + `ProviderService` + `ClaudeAdapter`: 110/110 on this base; `ProviderRuntimeIngestion`: 45/45; typecheck clean.

Bigger than the contributing guide prefers — it stays one PR because the four pieces enforce one invariant (background work is neither silently killed nor allowed to pin a session, and its loss is visible), and the heartbeat is what makes the cap meaningful. Happy to split it if you'd rather take it piecewise.

## Checklist

- [ ] This PR is small and focused (focused: one subsystem, one invariant — but not small, see note above)
- [x] I explained what changed and why
- [ ] ~~I included before/after screenshots for any UI changes~~ (no UI changes)
- [ ] ~~I included a video for animation/interaction changes~~ (n/a)

---
Change authored by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core provider session teardown, persisted binding sync, and reaper heuristics; mistakes could leave ghost running sessions or reap live autonomous work, though extensive guards and tests target the production failure modes.
> 
> **Overview**
> Tightens **background-work session lifecycle** so autonomous provider work is neither silently killed nor allowed to pin processes forever, and teardown losses are visible.
> 
> **Claude adapter:** On SDK stream exit (clean or failed) while `liveTaskIds` remain, the adapter now logs `claude.session.stream-ended-with-live-tasks`, emits a **`runtime.error`** naming the lost agents, and drains each live task with **`task.completed` (`stopped`)**, including a second drain after stream-fiber interrupt to close races with in-flight handlers.
> 
> **Provider event pump:** Adds **`syncBindingOnRuntimeEvent`** so **`session.exited`** marks the persisted binding **`stopped`** (clearing ghost `running` rows from adapter-internal exits), with guards for stale exits (newer replacement session on the same instance, or binding owned by a different provider instance). Turn/task lifecycle events **refresh `lastSeenAt`** (60s throttle) so provider-initiated work does not look idle since the user’s last `sendTurn`.
> 
> **Session reaper:** Defers reaping idle sessions while **`ThreadBackgroundLivenessService`** reports live work, but only up to **`backgroundWorkMaxIdleMs`** (default 4h, floored above the inactivity threshold); beyond that, wedged “live” work is reaped anyway. Sweep uses the liveness service directly instead of the projected shell.
> 
> Tests and **`docs/internals/providers.md`** document the three rules (teardown reports loss, binding follows session, reaper respects background work with a cap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aeeb1b52986c4aa5737bda0a2cb2b3d43c8bfd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap background-work deferral in session reaper and report live-task losses on session teardown
> - The Claude adapter's `handleStreamExit` now detects background tasks still tracked as live at stream termination, emits a `runtime.error` describing the loss, and emits `task.completed` (status `stopped`) for each live task. A structured warning is also logged.
> - The `ProviderSessionReaper` defers reaping idle sessions while background work is live, up to a configurable `backgroundWorkMaxIdleMs` cap (default 4h), after which the session is reaped regardless.
> - The `ProviderService` event pump now syncs persisted bindings: marks a binding `stopped` on `session.exited` (guarded against stale cross-instance or replaced-session exits), and refreshes `lastSeenAt` on turn/task lifecycle events with per-thread 60s throttling.
> - Tests and [providers.md](https://github.com/pingdotgg/t3code/pull/5711/files#diff-3d909027abc31a863f0c0e5ecef5aa50ac285620ad827db723eb0a4ac46d3f85) documentation are added for all three behaviors.
> - Behavioral Change: sessions with live background work that exceed the idle wedge cap are now reaped unconditionally, even if liveness still reports active.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5aeeb1b. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->