### PR TITLE
feat(desktop): add privacy-safe Discord Rich Presence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@
 # secrets. Remove or comment them out to build with cloud features disabled.
 # Do not add server-side secrets to this file.
 
+# Optional: Discord Rich Presence. This application ID is public; create an
+# application in the Discord Developer Portal and use its Application ID here.
+# T3CODE_DISCORD_APPLICATION_ID=123456789012345678
+
 # Production Clerk instance. To use your own, get these from the Clerk Dashboard
 # under API keys, JWT templates, and OAuth applications.
 T3CODE_CLERK_PUBLISHABLE_KEY=pk_live_Y2xlcmsudDMuY29kZXMk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,6 +330,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     env:
+      T3CODE_DISCORD_APPLICATION_ID: ${{ vars.T3CODE_DISCORD_APPLICATION_ID }}
       T3CODE_CLERK_PUBLISHABLE_KEY: ${{ needs.relay_public_config.outputs.clerk_publishable_key }}
       T3CODE_CLERK_JWT_TEMPLATE: ${{ needs.relay_public_config.outputs.clerk_jwt_template }}
       T3CODE_CLERK_CLI_OAUTH_CLIENT_ID: ${{ needs.relay_public_config.outputs.clerk_cli_oauth_client_id }}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Full docs live in [docs/](./docs). There's no docs site yet.
 - [Install and first run](./docs/user/install.md)
 - [Permission modes](./docs/user/permission-modes.md)
 - [Keyboard shortcuts](./docs/user/keybindings.md)
+- [Discord Rich Presence](./docs/user/discord-rich-presence.md)
 - [Remote access from a phone or another machine](./docs/user/remote-access.md)
 - [Keeping app and server in sync](./docs/user/updating.md)
 - [Source control integrations](./docs/user/source-control.md)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
     "@t3tools/shared": "workspace:*",
     "@t3tools/ssh": "workspace:*",
     "@t3tools/tailscale": "workspace:*",
+    "@xhayper/discord-rpc": "^1.3.4",
     "effect": "catalog:",
     "electron": "41.5.0",
     "electron-store": "^8.2.0",

--- a/apps/desktop/src/discord/DesktopDiscordPresence.test.ts
+++ b/apps/desktop/src/discord/DesktopDiscordPresence.test.ts
@@ -2,20 +2,14 @@ import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import {
-  DesktopDiscordPresence,
-  DiscordPresenceSessionError,
-  formatDiscordPresence,
-  make,
-  type DiscordRpcClient,
-} from "./DesktopDiscordPresence.ts";
+import * as DesktopDiscordPresence from "./DesktopDiscordPresence.ts";
 
 function makeFakeClient() {
   const activities: string[] = [];
   let clearCount = 0;
   let destroyCount = 0;
   let connected = false;
-  const client: DiscordRpcClient = {
+  const client: DesktopDiscordPresence.DiscordRpcClient = {
     get isConnected() {
       return connected;
     },
@@ -54,7 +48,9 @@ function makeFakeClient() {
 
 describe("DesktopDiscordPresence", () => {
   it("models a missing Discord user session as structured context", () => {
-    const error = new DiscordPresenceSessionError({ operation: "setActivity" });
+    const error = new DesktopDiscordPresence.DiscordPresenceSessionError({
+      operation: "setActivity",
+    });
     expect(error._tag).toBe("DiscordPresenceSessionError");
     expect(error.operation).toBe("setActivity");
     expect(error.message).toBe(
@@ -63,19 +59,24 @@ describe("DesktopDiscordPresence", () => {
   });
 
   it("formats singular and plural presence without project details", () => {
-    expect(formatDiscordPresence(1)).toBe("Working in T3 Code on 1 project");
-    expect(formatDiscordPresence(3)).toBe("Working in T3 Code on 3 projects");
+    expect(DesktopDiscordPresence.formatDiscordPresence(1)).toBe("Working in T3 Code on 1 project");
+    expect(DesktopDiscordPresence.formatDiscordPresence(3)).toBe(
+      "Working in T3 Code on 3 projects",
+    );
   });
 
   it.effect("connects lazily, updates the count, and clears at zero", () => {
     const fake = makeFakeClient();
     const layer = Layer.effect(
-      DesktopDiscordPresence,
-      make({ applicationId: "public-app-id", createClient: () => fake.client }),
+      DesktopDiscordPresence.DesktopDiscordPresence,
+      DesktopDiscordPresence.make({
+        applicationId: "public-app-id",
+        createClient: () => fake.client,
+      }),
     );
 
     return Effect.gen(function* () {
-      const presence = yield* DesktopDiscordPresence;
+      const presence = yield* DesktopDiscordPresence.DesktopDiscordPresence;
       expect(presence.available).toBe(true);
       expect(fake.activities).toEqual([]);
 
@@ -95,8 +96,8 @@ describe("DesktopDiscordPresence", () => {
   it.effect("stays unavailable and does not connect without an application ID", () => {
     let createCount = 0;
     const layer = Layer.effect(
-      DesktopDiscordPresence,
-      make({
+      DesktopDiscordPresence.DesktopDiscordPresence,
+      DesktopDiscordPresence.make({
         applicationId: "",
         createClient: () => {
           createCount += 1;
@@ -106,7 +107,7 @@ describe("DesktopDiscordPresence", () => {
     );
 
     return Effect.gen(function* () {
-      const presence = yield* DesktopDiscordPresence;
+      const presence = yield* DesktopDiscordPresence.DesktopDiscordPresence;
       expect(presence.available).toBe(false);
       yield* presence.setActiveProjectCount(1);
       expect(createCount).toBe(0);

--- a/apps/desktop/src/discord/DesktopDiscordPresence.test.ts
+++ b/apps/desktop/src/discord/DesktopDiscordPresence.test.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 
 import {
   DesktopDiscordPresence,
+  DiscordPresenceSessionError,
   formatDiscordPresence,
   make,
   type DiscordRpcClient,
@@ -52,6 +53,15 @@ function makeFakeClient() {
 }
 
 describe("DesktopDiscordPresence", () => {
+  it("models a missing Discord user session as structured context", () => {
+    const error = new DiscordPresenceSessionError({ operation: "setActivity" });
+    expect(error._tag).toBe("DiscordPresenceSessionError");
+    expect(error.operation).toBe("setActivity");
+    expect(error.message).toBe(
+      "Discord RPC connected without a user session while attempting to set activity.",
+    );
+  });
+
   it("formats singular and plural presence without project details", () => {
     expect(formatDiscordPresence(1)).toBe("Working in T3 Code on 1 project");
     expect(formatDiscordPresence(3)).toBe("Working in T3 Code on 3 projects");

--- a/apps/desktop/src/discord/DesktopDiscordPresence.test.ts
+++ b/apps/desktop/src/discord/DesktopDiscordPresence.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import {
+  DesktopDiscordPresence,
+  formatDiscordPresence,
+  make,
+  type DiscordRpcClient,
+} from "./DesktopDiscordPresence.ts";
+
+function makeFakeClient() {
+  const activities: string[] = [];
+  let clearCount = 0;
+  let destroyCount = 0;
+  let connected = false;
+  const client: DiscordRpcClient = {
+    get isConnected() {
+      return connected;
+    },
+    user: {
+      setActivity: ({ details }) => {
+        activities.push(details);
+        return Promise.resolve();
+      },
+      clearActivity: () => {
+        clearCount += 1;
+        return Promise.resolve();
+      },
+    },
+    login: () => {
+      connected = true;
+      return Promise.resolve();
+    },
+    destroy: () => {
+      connected = false;
+      destroyCount += 1;
+      return Promise.resolve();
+    },
+    on: () => client,
+  };
+  return {
+    client,
+    activities,
+    get clearCount() {
+      return clearCount;
+    },
+    get destroyCount() {
+      return destroyCount;
+    },
+  };
+}
+
+describe("DesktopDiscordPresence", () => {
+  it("formats singular and plural presence without project details", () => {
+    expect(formatDiscordPresence(1)).toBe("Working in T3 Code on 1 project");
+    expect(formatDiscordPresence(3)).toBe("Working in T3 Code on 3 projects");
+  });
+
+  it.effect("connects lazily, updates the count, and clears at zero", () => {
+    const fake = makeFakeClient();
+    const layer = Layer.effect(
+      DesktopDiscordPresence,
+      make({ applicationId: "public-app-id", createClient: () => fake.client }),
+    );
+
+    return Effect.gen(function* () {
+      const presence = yield* DesktopDiscordPresence;
+      expect(presence.available).toBe(true);
+      expect(fake.activities).toEqual([]);
+
+      yield* presence.setActiveProjectCount(2);
+      yield* presence.setActiveProjectCount(4);
+      expect(fake.activities).toEqual([
+        "Working in T3 Code on 2 projects",
+        "Working in T3 Code on 4 projects",
+      ]);
+
+      yield* presence.setActiveProjectCount(0);
+      expect(fake.clearCount).toBe(1);
+      expect(fake.destroyCount).toBe(1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.effect("stays unavailable and does not connect without an application ID", () => {
+    let createCount = 0;
+    const layer = Layer.effect(
+      DesktopDiscordPresence,
+      make({
+        applicationId: "",
+        createClient: () => {
+          createCount += 1;
+          return makeFakeClient().client;
+        },
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const presence = yield* DesktopDiscordPresence;
+      expect(presence.available).toBe(false);
+      yield* presence.setActiveProjectCount(1);
+      expect(createCount).toBe(0);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+});

--- a/apps/desktop/src/discord/DesktopDiscordPresence.ts
+++ b/apps/desktop/src/discord/DesktopDiscordPresence.ts
@@ -1,0 +1,173 @@
+// @effect-diagnostics globalTimers:off - Discord RPC reconnects from an imperative SDK callback.
+import { Client } from "@xhayper/discord-rpc";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+declare const __T3CODE_BUILD_DISCORD_APPLICATION_ID__: string | undefined;
+
+const RETRY_DELAY_MS = 15_000;
+
+interface DiscordRpcUser {
+  readonly setActivity: (activity: { readonly details: string }) => Promise<unknown>;
+  readonly clearActivity: () => Promise<unknown>;
+}
+
+export interface DiscordRpcClient {
+  readonly isConnected: boolean;
+  readonly user: DiscordRpcUser | undefined;
+  readonly login: () => Promise<unknown>;
+  readonly destroy: () => Promise<unknown>;
+  readonly on: (event: "disconnected", listener: () => void) => unknown;
+}
+
+export type DiscordRpcClientFactory = (applicationId: string) => DiscordRpcClient;
+
+export function formatDiscordPresence(activeProjectCount: number): string {
+  return `Working in T3 Code on ${activeProjectCount} ${activeProjectCount === 1 ? "project" : "projects"}`;
+}
+
+class DiscordPresenceController {
+  private desiredCount = 0;
+  private appliedCount: number | null = null;
+  private client: DiscordRpcClient | null = null;
+  private operation = Promise.resolve();
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+  readonly applicationId: string;
+  private readonly createClient: DiscordRpcClientFactory;
+  private readonly retryDelayMs: number;
+
+  constructor(
+    applicationId: string,
+    createClient: DiscordRpcClientFactory,
+    retryDelayMs = RETRY_DELAY_MS,
+  ) {
+    this.applicationId = applicationId;
+    this.createClient = createClient;
+    this.retryDelayMs = retryDelayMs;
+  }
+
+  setActiveProjectCount(count: number): Promise<void> {
+    if (this.disposed || count === this.desiredCount) return this.operation;
+    this.desiredCount = count;
+    this.clearRetry();
+    return this.enqueue();
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    this.desiredCount = 0;
+    this.clearRetry();
+    await this.operation.catch(() => undefined);
+    await this.disconnect(true);
+  }
+
+  private enqueue(): Promise<void> {
+    this.operation = this.operation
+      .then(() => this.reconcile())
+      .catch(() => {
+        this.scheduleRetry();
+      });
+    return this.operation;
+  }
+
+  private async reconcile(): Promise<void> {
+    if (this.disposed) return;
+    if (this.desiredCount === 0) {
+      await this.disconnect(true);
+      return;
+    }
+    if (!this.applicationId) return;
+
+    if (!this.client?.isConnected) {
+      await this.disconnect(false);
+      const client = this.createClient(this.applicationId);
+      this.client = client;
+      client.on("disconnected", () => {
+        if (this.client !== client || this.disposed) return;
+        this.appliedCount = null;
+        this.scheduleRetry();
+      });
+      await client.login();
+    }
+
+    if (this.disposed || this.desiredCount === 0) {
+      await this.disconnect(true);
+      return;
+    }
+    if (this.desiredCount === this.appliedCount) return;
+
+    const user = this.client?.user;
+    if (!user) throw new Error("Discord RPC connected without a user session");
+    const count = this.desiredCount;
+    await user.setActivity({ details: formatDiscordPresence(count) });
+    this.appliedCount = count;
+  }
+
+  private async disconnect(clearActivity: boolean): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    this.appliedCount = null;
+    if (!client) return;
+
+    if (clearActivity && client.isConnected && client.user) {
+      await client.user.clearActivity().catch(() => undefined);
+    }
+    await client.destroy().catch(() => undefined);
+  }
+
+  private scheduleRetry(): void {
+    if (this.disposed || this.desiredCount === 0 || this.retryTimer !== null) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      this.enqueue();
+    }, this.retryDelayMs);
+  }
+
+  private clearRetry(): void {
+    if (this.retryTimer === null) return;
+    clearTimeout(this.retryTimer);
+    this.retryTimer = null;
+  }
+}
+
+export class DesktopDiscordPresence extends Context.Service<
+  DesktopDiscordPresence,
+  {
+    readonly available: boolean;
+    readonly setActiveProjectCount: (count: number) => Effect.Effect<void>;
+  }
+>()("@t3tools/desktop/discord/DesktopDiscordPresence") {}
+
+export function make({
+  applicationId,
+  createClient = (clientId) => new Client({ clientId }),
+  retryDelayMs,
+}: {
+  readonly applicationId: string;
+  readonly createClient?: DiscordRpcClientFactory;
+  readonly retryDelayMs?: number;
+}) {
+  return Effect.acquireRelease(
+    Effect.sync(
+      () => new DiscordPresenceController(applicationId.trim(), createClient, retryDelayMs),
+    ),
+    (controller) => Effect.promise(() => controller.dispose()),
+  ).pipe(
+    Effect.map((controller) =>
+      DesktopDiscordPresence.of({
+        available: controller.applicationId.length > 0,
+        setActiveProjectCount: (count) =>
+          Effect.promise(() => controller.setActiveProjectCount(count)),
+      }),
+    ),
+  );
+}
+
+const applicationId =
+  typeof __T3CODE_BUILD_DISCORD_APPLICATION_ID__ === "undefined"
+    ? ""
+    : __T3CODE_BUILD_DISCORD_APPLICATION_ID__;
+
+export const layer = Layer.effect(DesktopDiscordPresence, make({ applicationId }));

--- a/apps/desktop/src/discord/DesktopDiscordPresence.ts
+++ b/apps/desktop/src/discord/DesktopDiscordPresence.ts
@@ -3,6 +3,7 @@ import { Client } from "@xhayper/discord-rpc";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 
 declare const __T3CODE_BUILD_DISCORD_APPLICATION_ID__: string | undefined;
 
@@ -22,6 +23,25 @@ export interface DiscordRpcClient {
 }
 
 export type DiscordRpcClientFactory = (applicationId: string) => DiscordRpcClient;
+
+export class DiscordPresenceSessionError extends Schema.TaggedErrorClass<DiscordPresenceSessionError>()(
+  "DiscordPresenceSessionError",
+  {
+    operation: Schema.Literals(["setActivity"]),
+  },
+) {
+  override get message(): string {
+    return "Discord RPC connected without a user session while attempting to set activity.";
+  }
+}
+
+export class DesktopDiscordPresence extends Context.Service<
+  DesktopDiscordPresence,
+  {
+    readonly available: boolean;
+    readonly setActiveProjectCount: (count: number) => Effect.Effect<void>;
+  }
+>()("@t3tools/desktop/discord/DesktopDiscordPresence") {}
 
 export function formatDiscordPresence(activeProjectCount: number): string {
   return `Working in T3 Code on ${activeProjectCount} ${activeProjectCount === 1 ? "project" : "projects"}`;
@@ -99,7 +119,9 @@ class DiscordPresenceController {
     if (this.desiredCount === this.appliedCount) return;
 
     const user = this.client?.user;
-    if (!user) throw new Error("Discord RPC connected without a user session");
+    if (!user) {
+      throw new DiscordPresenceSessionError({ operation: "setActivity" });
+    }
     const count = this.desiredCount;
     await user.setActivity({ details: formatDiscordPresence(count) });
     this.appliedCount = count;
@@ -131,14 +153,6 @@ class DiscordPresenceController {
     this.retryTimer = null;
   }
 }
-
-export class DesktopDiscordPresence extends Context.Service<
-  DesktopDiscordPresence,
-  {
-    readonly available: boolean;
-    readonly setActiveProjectCount: (count: number) => Effect.Effect<void>;
-  }
->()("@t3tools/desktop/discord/DesktopDiscordPresence") {}
 
 export function make({
   applicationId,

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -3,6 +3,10 @@ import * as Effect from "effect/Effect";
 import * as DesktopIpc from "./DesktopIpc.ts";
 import { getClientSettings, setClientSettings } from "./methods/clientSettings.ts";
 import {
+  getDiscordRichPresenceAvailable,
+  setDiscordRichPresence,
+} from "./methods/discordPresence.ts";
+import {
   clearConnectionCatalog,
   getConnectionCatalog,
   setConnectionCatalog,
@@ -56,6 +60,8 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
 
   yield* ipc.handle(getClientSettings);
   yield* ipc.handle(setClientSettings);
+  yield* ipc.handleSync(getDiscordRichPresenceAvailable);
+  yield* ipc.handle(setDiscordRichPresence);
   yield* ipc.handle(getConnectionCatalog);
   yield* ipc.handle(setConnectionCatalog);
   yield* ipc.handle(clearConnectionCatalog);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -19,6 +19,9 @@ export const GET_LOCAL_ENVIRONMENT_BEARER_TOKEN_CHANNEL =
   "desktop:get-local-environment-bearer-token";
 export const GET_CLIENT_SETTINGS_CHANNEL = "desktop:get-client-settings";
 export const SET_CLIENT_SETTINGS_CHANNEL = "desktop:set-client-settings";
+export const GET_DISCORD_RICH_PRESENCE_AVAILABLE_CHANNEL =
+  "desktop:get-discord-rich-presence-available";
+export const SET_DISCORD_RICH_PRESENCE_CHANNEL = "desktop:set-discord-rich-presence";
 export const GET_CONNECTION_CATALOG_CHANNEL = "desktop:get-connection-catalog";
 export const SET_CONNECTION_CATALOG_CHANNEL = "desktop:set-connection-catalog";
 export const CLEAR_CONNECTION_CATALOG_CHANNEL = "desktop:clear-connection-catalog";

--- a/apps/desktop/src/ipc/methods/discordPresence.ts
+++ b/apps/desktop/src/ipc/methods/discordPresence.ts
@@ -1,0 +1,26 @@
+import { DesktopDiscordPresenceInputSchema } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import * as DesktopDiscordPresence from "../../discord/DesktopDiscordPresence.ts";
+import * as IpcChannels from "../channels.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
+
+export const getDiscordRichPresenceAvailable = DesktopIpc.makeSyncIpcMethod({
+  channel: IpcChannels.GET_DISCORD_RICH_PRESENCE_AVAILABLE_CHANNEL,
+  result: Schema.Boolean,
+  handler: Effect.fn("desktop.ipc.discordPresence.available")(function* () {
+    const presence = yield* DesktopDiscordPresence.DesktopDiscordPresence;
+    return presence.available;
+  }),
+});
+
+export const setDiscordRichPresence = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.SET_DISCORD_RICH_PRESENCE_CHANNEL,
+  payload: DesktopDiscordPresenceInputSchema,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.discordPresence.set")(function* ({ activeProjectCount }) {
+    const presence = yield* DesktopDiscordPresence.DesktopDiscordPresence;
+    yield* presence.setActiveProjectCount(activeProjectCount);
+  }),
+});

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -42,6 +42,7 @@ import * as DesktopBackendPool from "./backend/DesktopBackendPool.ts";
 import * as DesktopLocalEnvironmentAuth from "./backend/DesktopLocalEnvironmentAuth.ts";
 import * as DesktopNetworkInterfaces from "./backend/DesktopNetworkInterfaces.ts";
 import * as DesktopEnvironment from "./app/DesktopEnvironment.ts";
+import * as DesktopDiscordPresence from "./discord/DesktopDiscordPresence.ts";
 import * as DesktopLifecycle from "./app/DesktopLifecycle.ts";
 import * as DesktopLinuxUrlHandler from "./app/DesktopLinuxUrlHandler.ts";
 import * as DesktopShutdown from "./app/DesktopShutdown.ts";
@@ -135,6 +136,7 @@ const desktopFoundationLayer = Layer.mergeAll(
   DesktopConnectionCatalogStore.layer.pipe(Layer.provideMerge(DesktopSavedEnvironments.layer)),
   DesktopAssets.layer,
   DesktopObservability.layer,
+  DesktopDiscordPresence.layer,
 ).pipe(Layer.provideMerge(desktopEnvironmentLayer));
 
 const desktopSshLayer = desktopSshEnvironmentLayer.pipe(

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -47,6 +47,10 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   getClientSettings: () => ipcRenderer.invoke(IpcChannels.GET_CLIENT_SETTINGS_CHANNEL),
   setClientSettings: (settings) =>
     ipcRenderer.invoke(IpcChannels.SET_CLIENT_SETTINGS_CHANNEL, settings),
+  getDiscordRichPresenceAvailable: () =>
+    ipcRenderer.sendSync(IpcChannels.GET_DISCORD_RICH_PRESENCE_AVAILABLE_CHANNEL) === true,
+  setDiscordRichPresence: (input) =>
+    ipcRenderer.invoke(IpcChannels.SET_DISCORD_RICH_PRESENCE_CHANNEL, input),
   getConnectionCatalog: () => ipcRenderer.invoke(IpcChannels.GET_CONNECTION_CATALOG_CHANNEL),
   setConnectionCatalog: (catalog) =>
     ipcRenderer.invoke(IpcChannels.SET_CONNECTION_CATALOG_CHANNEL, catalog),

--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -17,6 +17,7 @@ const clientSettings: ClientSettings = {
   confirmThreadDelete: false,
   dismissedProviderUpdateNotificationKeys: [],
   diffIgnoreWhitespace: true,
+  discordRichPresenceEnabled: false,
   environmentIdentificationMode: "artwork",
   favorites: [],
   fontFamilyCode: "",

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -5,6 +5,9 @@ import { loadRepoEnv } from "../../scripts/lib/public-config.ts";
 const repoEnv = loadRepoEnv();
 const shouldLaunchElectronAfterPack = process.env.T3CODE_DESKTOP_DEV === "1";
 const publicConfigDefine = {
+  __T3CODE_BUILD_DISCORD_APPLICATION_ID__: JSON.stringify(
+    repoEnv.T3CODE_DISCORD_APPLICATION_ID?.trim() ?? "",
+  ),
   __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__: JSON.stringify(
     repoEnv.T3CODE_CLERK_PUBLISHABLE_KEY?.trim() ?? "",
   ),

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -456,6 +456,10 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode
         ? ["Environment identification"]
         : []),
+      ...(settings.discordRichPresenceEnabled !==
+      DEFAULT_UNIFIED_SETTINGS.discordRichPresenceEnabled
+        ? ["Discord Rich Presence"]
+        : []),
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
@@ -520,6 +524,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
+      settings.discordRichPresenceEnabled,
       settings.environmentIdentificationMode,
       settings.fontFamilyCode,
       settings.fontFamilyComposer,
@@ -607,6 +612,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+      discordRichPresenceEnabled: DEFAULT_UNIFIED_SETTINGS.discordRichPresenceEnabled,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
@@ -932,6 +938,9 @@ export function AppearanceSettingsPanel() {
   const environmentStageLabel = useEnvironmentStageLabel();
   const showEnvironmentIdentification =
     resolveEnvironmentIdentificationPillLabel(environmentStageLabel) !== null;
+  const showDiscordRichPresence = window.desktopBridge?.setDiscordRichPresence !== undefined;
+  const discordRichPresenceAvailable =
+    window.desktopBridge?.getDiscordRichPresenceAvailable?.() ?? false;
   const glassOpacityRatio =
     (settings.glassOpacity - MIN_GLASS_OPACITY) / (MAX_GLASS_OPACITY - MIN_GLASS_OPACITY);
   const glassOpacitySliderStyle = {
@@ -1042,6 +1051,41 @@ export function AppearanceSettingsPanel() {
                   ))}
                 </SelectPopup>
               </Select>
+            }
+          />
+        ) : null}
+
+        {showDiscordRichPresence ? (
+          <SettingsRow
+            {...searchableSetting("discord-rich-presence")}
+            description={
+              discordRichPresenceAvailable
+                ? "Shows “Working in T3 Code on X projects” in Discord while agents are active. Only the count is shared; project and thread names stay private."
+                : "Unavailable in this build because no Discord application ID was configured."
+            }
+            resetAction={
+              settings.discordRichPresenceEnabled !==
+              DEFAULT_UNIFIED_SETTINGS.discordRichPresenceEnabled ? (
+                <SettingResetButton
+                  label="Discord Rich Presence"
+                  onClick={() =>
+                    updateSettings({
+                      discordRichPresenceEnabled:
+                        DEFAULT_UNIFIED_SETTINGS.discordRichPresenceEnabled,
+                    })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <Switch
+                checked={settings.discordRichPresenceEnabled && discordRichPresenceAvailable}
+                disabled={!discordRichPresenceAvailable}
+                onCheckedChange={(checked) =>
+                  updateSettings({ discordRichPresenceEnabled: Boolean(checked) })
+                }
+                aria-label="Discord Rich Presence"
+              />
             }
           />
         ) : null}

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -83,5 +83,9 @@ describe("searchSettings", () => {
       to: "/settings/appearance",
       targetId: "appearance",
     });
+    expect(searchSettings("discord rich presence")[0]).toMatchObject({
+      id: "discord-rich-presence",
+      to: "/settings/appearance",
+    });
   });
 });

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -64,6 +64,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     targetId: "appearance",
   },
   {
+    id: "discord-rich-presence",
+    title: "Discord Rich Presence",
+    to: "/settings/appearance",
+  },
+  {
     id: "interface-font",
     title: "Interface font",
     to: "/settings/appearance",

--- a/apps/web/src/discordPresence.test.ts
+++ b/apps/web/src/discordPresence.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { countActiveDiscordPresenceProjects } from "./discordPresence";
+
+const thread = (
+  environmentId: string,
+  projectId: string,
+  options: {
+    readonly status?: string;
+    readonly backgroundLiveness?: "working" | "monitoring";
+  } = {},
+) => ({
+  environmentId,
+  projectId,
+  session: options.status ? { status: options.status } : null,
+  backgroundLiveness: options.backgroundLiveness ?? null,
+});
+
+describe("countActiveDiscordPresenceProjects", () => {
+  it("deduplicates running threads in the same project", () => {
+    expect(
+      countActiveDiscordPresenceProjects([
+        thread("local", "project-a", { status: "running" }),
+        thread("local", "project-a", { status: "starting" }),
+      ]),
+    ).toBe(1);
+  });
+
+  it("keeps projects from different environments distinct", () => {
+    expect(
+      countActiveDiscordPresenceProjects([
+        thread("local", "project-a", { status: "running" }),
+        thread("remote", "project-a", { status: "running" }),
+      ]),
+    ).toBe(2);
+  });
+
+  it("counts background work but excludes monitoring and inactive threads", () => {
+    expect(
+      countActiveDiscordPresenceProjects([
+        thread("local", "background", { backgroundLiveness: "working" }),
+        thread("local", "monitoring", { backgroundLiveness: "monitoring" }),
+        thread("local", "waiting"),
+        thread("local", "failed", { status: "error" }),
+      ]),
+    ).toBe(1);
+  });
+});

--- a/apps/web/src/discordPresence.ts
+++ b/apps/web/src/discordPresence.ts
@@ -1,0 +1,22 @@
+interface DiscordPresenceThread {
+  readonly environmentId: string;
+  readonly projectId: string;
+  readonly session: { readonly status: string } | null;
+  readonly backgroundLiveness?: "working" | "monitoring" | null | undefined;
+}
+
+export function countActiveDiscordPresenceProjects(
+  threads: ReadonlyArray<DiscordPresenceThread>,
+): number {
+  const activeProjects = new Set<string>();
+  for (const thread of threads) {
+    const isWorking =
+      thread.session?.status === "starting" ||
+      thread.session?.status === "running" ||
+      thread.backgroundLiveness === "working";
+    if (isWorking) {
+      activeProjects.add(`${thread.environmentId}\0${thread.projectId}`);
+    }
+  }
+  return activeProjects.size;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -8,7 +8,7 @@ import {
   useLocation,
   useNavigate,
 } from "@tanstack/react-router";
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 
 import { APP_BASE_NAME, APP_DISPLAY_NAME, APP_STAGE_LABEL } from "../branding";
 import { resolveServerBackedAppDisplayName } from "../branding.logic";
@@ -29,7 +29,8 @@ import {
 } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { applyAppearanceFontVariables } from "~/appearanceFonts";
-import { useClientSettings } from "../hooks/useSettings";
+import { useClientSettings, useClientSettingsHydrated } from "../hooks/useSettings";
+import { countActiveDiscordPresenceProjects } from "../discordPresence";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKeyFromPath,
@@ -49,7 +50,12 @@ import {
   primaryServerConfigEventAtom,
   primaryServerWelcomeAtom,
 } from "../state/server";
-import { readProject, setActiveEnvironmentId, useActiveEnvironmentId } from "../state/entities";
+import {
+  readProject,
+  setActiveEnvironmentId,
+  useActiveEnvironmentId,
+  useThreadShells,
+} from "../state/entities";
 import {
   createKeybindingsUpdateToastController,
   type KeybindingsUpdateToastController,
@@ -131,6 +137,7 @@ function RootRouteView() {
         <DocumentTitleSync />
         <GlassAppearanceSync />
         <FontAppearanceSync />
+        <DiscordPresenceSync />
         {primaryEnvironmentAuthenticated ? <AuthenticatedTracingBootstrap /> : null}
         <RelayClientInstallDialog />
         <ConnectOnboardingDialog />
@@ -146,6 +153,21 @@ function RootRouteView() {
       </AnchoredToastProvider>
     </ToastProvider>
   );
+}
+
+function DiscordPresenceSync() {
+  const enabled = useClientSettings((settings) => settings.discordRichPresenceEnabled);
+  const settingsHydrated = useClientSettingsHydrated();
+  const threads = useThreadShells();
+  const activeProjectCount = useMemo(() => countActiveDiscordPresenceProjects(threads), [threads]);
+
+  useEffect(() => {
+    const setPresence = window.desktopBridge?.setDiscordRichPresence;
+    if (!settingsHydrated || !setPresence) return;
+    void setPresence({ activeProjectCount: enabled ? activeProjectCount : 0 }).catch(() => {});
+  }, [activeProjectCount, enabled, settingsHydrated]);
+
+  return null;
 }
 
 function GlassAppearanceSync() {

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Install and first run](./user/install.md)
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
+- [Discord Rich Presence](./user/discord-rich-presence.md)
 - [Organizing threads](./user/thread-sidebar.md)
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)

--- a/docs/user/discord-rich-presence.md
+++ b/docs/user/discord-rich-presence.md
@@ -1,0 +1,13 @@
+# Discord Rich Presence
+
+The desktop app can show a private-by-default activity summary in Discord.
+
+Open **Settings → Appearance** and turn on **Discord Rich Presence**. While agents are actively
+working, Discord shows **Working in T3 Code on X projects**. Multiple active threads in the same
+project count once, and the activity disappears when no projects have active work.
+
+Only the number of active projects is shared. T3 Code never includes project or thread names,
+prompts, providers, branches, approval requests, or waiting status in the Discord activity.
+
+Discord must be running on the same computer as the T3 Code desktop app. This setting does not
+appear in the web or mobile apps.

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -1,7 +1,18 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { DesktopEnvironmentBootstrapSchema } from "./ipc.ts";
+import { DesktopDiscordPresenceInputSchema, DesktopEnvironmentBootstrapSchema } from "./ipc.ts";
+
+describe("DesktopDiscordPresenceInputSchema", () => {
+  const decode = Schema.decodeUnknownSync(DesktopDiscordPresenceInputSchema);
+
+  it("accepts only non-negative integer project counts", () => {
+    expect(decode({ activeProjectCount: 0 })).toEqual({ activeProjectCount: 0 });
+    expect(decode({ activeProjectCount: 3 })).toEqual({ activeProjectCount: 3 });
+    expect(() => decode({ activeProjectCount: -1 })).toThrow();
+    expect(() => decode({ activeProjectCount: 1.5 })).toThrow();
+  });
+});
 
 describe("DesktopEnvironmentBootstrapSchema", () => {
   const decode = Schema.decodeUnknownSync(DesktopEnvironmentBootstrapSchema);

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -994,6 +994,11 @@ export const DesktopPreviewAutomationWaitForInputSchema = Schema.Struct({
   input: PreviewAutomationWaitForInput,
 });
 
+export const DesktopDiscordPresenceInputSchema = Schema.Struct({
+  activeProjectCount: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+});
+export type DesktopDiscordPresenceInput = typeof DesktopDiscordPresenceInputSchema.Type;
+
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
   // One bootstrap per pool instance currently registered with bootstrap
@@ -1003,6 +1008,8 @@ export interface DesktopBridge {
   getLocalEnvironmentBearerToken: () => Promise<string>;
   getClientSettings: () => Promise<ClientSettings | null>;
   setClientSettings: (settings: ClientSettings) => Promise<void>;
+  getDiscordRichPresenceAvailable?: () => boolean;
+  setDiscordRichPresence?: (input: DesktopDiscordPresenceInput) => Promise<void>;
   getConnectionCatalog?: () => Promise<string | null>;
   setConnectionCatalog?: (catalog: string) => Promise<boolean>;
   clearConnectionCatalog?: () => Promise<void>;

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -33,6 +33,15 @@ describe("ClientSettings word wrap", () => {
   });
 });
 
+describe("ClientSettings Discord Rich Presence", () => {
+  it("is private by default and accepts an explicit opt-in", () => {
+    expect(decodeClientSettings({}).discordRichPresenceEnabled).toBe(false);
+    expect(
+      decodeClientSettingsPatch({ discordRichPresenceEnabled: true }).discordRichPresenceEnabled,
+    ).toBe(true);
+  });
+});
+
 describe("ClientSettings glass opacity", () => {
   it("defaults to a readable translucent surface", () => {
     expect(decodeClientSettings({}).glassOpacity).toBe(80);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -117,6 +117,9 @@ export const ClientSettingsSchema = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed([])),
   ),
   diffIgnoreWhitespace: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  discordRichPresenceEnabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
+  ),
   environmentIdentificationMode: EnvironmentIdentificationMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE)),
   ),
@@ -756,6 +759,7 @@ export const ClientSettingsPatch = Schema.Struct({
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
+  discordRichPresenceEnabled: Schema.optionalKey(Schema.Boolean),
   environmentIdentificationMode: Schema.optionalKey(EnvironmentIdentificationMode),
   glassOpacity: Schema.optionalKey(GlassOpacity),
   fontSizeInterface: Schema.optionalKey(InterfaceFontSize),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       '@t3tools/tailscale':
         specifier: workspace:*
         version: link:../../packages/tailscale
+      '@xhayper/discord-rpc':
+        specifier: ^1.3.4
+        version: 1.3.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       effect:
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6)
@@ -1839,6 +1842,18 @@ packages:
 
   '@cloudflare/workers-types@5.20260726.1':
     resolution: {integrity: sha512-fKgRSm3sDmOdak1LGWehS4vSPSj7/zeu0NfmE62VPjBMqWgODcOGljYvq6A75sL+7YfY3iGFGb0jVEDYq+hlmw==}
+
+  '@discordjs/collection@2.1.1':
+    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/rest@2.6.3':
+    resolution: {integrity: sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/util@1.2.0':
+    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
+    engines: {node: '>=18'}
 
   '@distilled.cloud/aws@0.30.2':
     resolution: {integrity: sha512-Uw2yZf7PJ2ienrKG49HN1ajnke65mTtHBUrSb/3ykeZ/8cLaSgwVhPscHxSzGByY0TEtYcYKNNmfUVISgGQl9g==}
@@ -4328,6 +4343,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/snowflake@3.5.5':
+    resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@shikijs/core@4.2.0':
     resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
     engines: {node: '>=20'}
@@ -5018,6 +5041,10 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
+  '@vladfrangu/async_event_emitter@2.4.7':
+    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@voidzero-dev/vite-plus-core@0.2.2':
     resolution: {integrity: sha512-yAbKexF3npOGjg1N5EtXxun+7vdM/0x6QE5jucO/dv0LFhCAIzSN3UvLVCeamJt/Bz3jt7DLqQHEgXXrjy8drA==}
     engines: {node: ^20.19.0 || ^22.18.0 || >=24.11.0}
@@ -5152,6 +5179,10 @@ packages:
 
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
+  '@xhayper/discord-rpc@1.3.4':
+    resolution: {integrity: sha512-ff0uEXuibh9wi+l4vOj7xInLUjtlTaQBje/SCyQkeXZ0j2V0y+Zge5PQIQFRHH9TjjGaYJkTofEcQhncM2q7/w==}
+    engines: {node: '>=20'}
 
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
@@ -6122,6 +6153,9 @@ packages:
 
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
+
+  discord-api-types@0.38.53:
+    resolution: {integrity: sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A==}
 
   dmg-builder@26.15.6:
     resolution: {integrity: sha512-nr5vQxEhM0REomp1qiHbc6V99yrfBZy+wUU56VXADfSOlLj8PdLqsHiRe7b+FbqKesiyv4ax+k1GVwGonYKuCg==}
@@ -7861,6 +7895,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-bytes.js@1.13.1:
+    resolution: {integrity: sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -9861,8 +9898,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
   undici@7.27.1:
@@ -11665,6 +11702,24 @@ snapshots:
   '@cloudflare/workers-types@4.20260604.1': {}
 
   '@cloudflare/workers-types@5.20260726.1': {}
+
+  '@discordjs/collection@2.1.1': {}
+
+  '@discordjs/rest@2.6.3':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@sapphire/snowflake': 3.5.5
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.53
+      magic-bytes.js: 1.13.1
+      tslib: 2.8.1
+      undici: 6.28.0
+
+  '@discordjs/util@1.2.0':
+    dependencies:
+      discord-api-types: 0.38.53
 
   '@distilled.cloud/aws@0.30.2(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))':
     dependencies:
@@ -14494,6 +14549,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.61.0':
     optional: true
 
+  '@sapphire/async-queue@1.5.5': {}
+
+  '@sapphire/snowflake@3.5.5': {}
+
   '@shikijs/core@4.2.0':
     dependencies:
       '@shikijs/primitive': 4.2.0
@@ -15224,6 +15283,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@vladfrangu/async_event_emitter@2.4.7': {}
+
   '@voidzero-dev/vite-plus-core@0.2.2(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.138.0
@@ -15313,6 +15374,16 @@ snapshots:
       vscode-uri: 3.1.0
 
   '@vscode/l10n@0.0.18': {}
+
+  '@xhayper/discord-rpc@1.3.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@discordjs/rest': 2.6.3
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.53
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@xmldom/xmldom@0.8.13': {}
 
@@ -16432,6 +16503,8 @@ snapshots:
     dependencies:
       minimatch: 3.1.5
       p-limit: 3.1.0
+
+  discord-api-types@0.38.53: {}
 
   dmg-builder@26.15.6(electron-builder-squirrel-windows@26.15.6):
     dependencies:
@@ -18449,6 +18522,8 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  magic-bytes.js@1.13.1: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -19228,7 +19303,7 @@ snapshots:
       semver: 7.8.5
       tar: 7.5.16
       tinyglobby: 0.2.17
-      undici: 6.26.0
+      undici: 6.28.0
       which: 6.0.1
 
   node-int64@0.4.0: {}
@@ -21126,7 +21201,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.26.0: {}
+  undici@6.28.0: {}
 
   undici@7.27.1: {}
 

--- a/scripts/lib/public-config.test.ts
+++ b/scripts/lib/public-config.test.ts
@@ -19,6 +19,7 @@ describe("loadRepoEnv", () => {
     const env = loadRepoEnv({ baseEnv: {}, repoRoot: makeTemporaryDirectory() });
 
     expect(env.T3CODE_CLERK_PUBLISHABLE_KEY).toBeUndefined();
+    expect(env.T3CODE_DISCORD_APPLICATION_ID).toBeUndefined();
     expect(env.T3CODE_CLERK_CLI_OAUTH_CLIENT_ID).toBeUndefined();
     expect(env.VITE_CLERK_PUBLISHABLE_KEY).toBeUndefined();
     expect(env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY).toBeUndefined();
@@ -90,6 +91,7 @@ describe("loadRepoEnv", () => {
         EXPO_PUBLIC_OTLP_TRACES_TOKEN: "mobile-token",
       }),
     ).toEqual({
+      discordApplicationId: undefined,
       clerkPublishableKey: "pk_legacy",
       clerkJwtTemplate: "template_legacy",
       clerkCliOAuthClientId: "oauth_canonical",
@@ -101,6 +103,15 @@ describe("loadRepoEnv", () => {
       relayClientOtlpTracesDataset: undefined,
       relayClientOtlpTracesToken: undefined,
     });
+  });
+
+  it("projects the public Discord application ID", () => {
+    expect(
+      loadRepoEnv({
+        baseEnv: { T3CODE_DISCORD_APPLICATION_ID: " 123456789012345678 " },
+        repoRoot: makeTemporaryDirectory(),
+      }),
+    ).toEqual({ T3CODE_DISCORD_APPLICATION_ID: "123456789012345678" });
   });
 
   it("projects canonical relay client tracing values to web build aliases", () => {

--- a/scripts/lib/public-config.ts
+++ b/scripts/lib/public-config.ts
@@ -5,6 +5,7 @@ import * as NodeURL from "node:url";
 import * as NodeUtil from "node:util";
 
 export interface T3CodePublicConfig {
+  readonly discordApplicationId: string | undefined;
   readonly clerkPublishableKey: string | undefined;
   readonly clerkJwtTemplate: string | undefined;
   readonly clerkCliOAuthClientId: string | undefined;
@@ -38,6 +39,9 @@ export function loadRepoEnv({
     ...rootEnv,
     ...localEnv,
     ...baseEnv,
+    ...(config.discordApplicationId
+      ? { T3CODE_DISCORD_APPLICATION_ID: config.discordApplicationId }
+      : {}),
     ...(config.clerkPublishableKey
       ? {
           T3CODE_CLERK_PUBLISHABLE_KEY: config.clerkPublishableKey,
@@ -105,6 +109,7 @@ export function loadRepoEnv({
 
 export function resolvePublicConfig(...sources: readonly Environment[]): T3CodePublicConfig {
   return {
+    discordApplicationId: firstNonEmpty(sources, "T3CODE_DISCORD_APPLICATION_ID"),
     clerkPublishableKey: firstNonEmpty(
       sources,
       "T3CODE_CLERK_PUBLISHABLE_KEY",


### PR DESCRIPTION
## Problem

T3 Code has no Discord Rich Presence integration, so users cannot optionally show that they are actively working in the app. A naive implementation could also leak sensitive context such as project names, prompts, providers, branches, approval requests, or waiting states.

## What this changes

- Adds an opt-in **Discord Rich Presence** switch under **Settings → Appearance** in the desktop app. It defaults off and is absent from web and mobile.
- Publishes only `Working in T3 Code on X projects` while agents are actively working.
- Counts distinct projects rather than threads, so concurrent threads in one project count once. Projects in different environments remain distinct.
- Treats starting/running sessions and active background work as working. Monitoring, inactive, failed, waiting, and approval labels are never published.
- Clears presence when the setting is disabled, no projects are active, or the desktop app shuts down.
- Uses `@xhayper/discord-rpc` behind a T3-owned scoped desktop service, with lazy connection, update deduplication, disconnect cleanup, and retry behavior when Discord is unavailable.
- Adds a typed, count-only IPC boundary so names and other thread metadata never enter the desktop presence service.
- Documents the behavior and privacy boundary.

## Decisions and rationale

### Privacy-first payload

The renderer derives a single non-negative project count. The desktop process never receives project names, thread names, prompts, providers, branches, approval state, or waiting state. Keeping the IPC contract count-only makes accidental metadata exposure harder in future changes.

### Distinct active projects

The count reflects work breadth without producing noisy changes when multiple threads run in one project. Environment ID is included only in the local deduplication key so identically keyed projects on separate local/SSH/remote environments remain distinct; that key is never sent to Discord.

### Desktop-owned RPC

Discord Rich Presence communicates with the Discord desktop client over platform-specific local IPC. Keeping the integration in Electron main avoids browser capability differences and lets one scoped service own connection, retry, and shutdown cleanup across macOS, Windows, and Linux.

### Library choice

`@xhayper/discord-rpc` is a maintained, pure-JavaScript RPC client with current Node support and cross-platform Discord IPC discovery. Wrapping it keeps the dependency at the adapter boundary and leaves the renderer library-agnostic.

### Appearance placement

The setting currently lives under Appearance because it controls how the user's T3 Code activity is presented externally. It uses the existing settings row and switch patterns rather than introducing a new settings surface for one experimental option.

## Discord Application ID not included

This commit intentionally does **not** provide a real Discord key/Application ID. Discord calls this value an **Application ID**; it is a public identifier rather than a secret, but it must belong to a T3 Code application registered in the Discord Developer Portal.

Official builds must configure the repository Actions variable `T3CODE_DISCORD_APPLICATION_ID`. Source builds can set the same public value in their build environment. Without it, the Appearance row reports that Rich Presence is unavailable and the desktop service does not attempt to connect.

No bot token, OAuth secret, Discord login, or user credential is required.

## Verification

- Focused typechecks passed for contracts, web, desktop, and scripts.
- Targeted lint and formatting checks passed for the changed code.
- Direct schema/aggregation smoke check passed, including same-project deduplication and cross-environment counting.
- Direct desktop RPC lifecycle smoke check passed for lazy connect, activity update, clearing at zero, and scoped cleanup.
- The production web build completed successfully.
- Focused unit tests were added for settings defaults, IPC validation, project aggregation/privacy, search placement, and desktop RPC lifecycle.

Local Vitest execution is currently blocked before test discovery by the checkout's Vite+ runner (`vite-plus/test` cannot find the active suite), including untouched existing suites. The local desktop packaging command also reaches the desktop pack step but is blocked by the globally installed Vite+ package being unable to resolve `typescript`. CI and native macOS/Windows artifact testing are therefore still expected before this leaves draft.

Integrated UI/browser verification and screenshots have not been run yet.

Implemented with GPT-5.6 Sol through the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add privacy-safe Discord Rich Presence to the desktop app
> - Adds a `DiscordPresenceController` in the desktop main process that connects to Discord RPC, updates activity with the current active project count, and auto-reconnects on disconnection.
> - Adds a `DiscordPresenceSync` React component in the renderer that computes active project count from thread state via `countActiveDiscordPresenceProjects` and pushes updates to the main process over IPC.
> - Exposes `getDiscordRichPresenceAvailable` and `setDiscordRichPresence` IPC methods and preload bridge methods so the renderer can query availability and set the count.
> - Adds a `discordRichPresenceEnabled` setting (default `false`) and a toggle in Settings → Appearance, visible only in desktop builds and disabled when no Discord application ID is configured at build time.
> - The Discord application ID is injected at build time via `T3CODE_DISCORD_APPLICATION_ID` and exposed as `__T3CODE_BUILD_DISCORD_APPLICATION_ID__`; without it, the feature reports as unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2361932. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->