### PR TITLE
fix(codex): interactions no longer revive idle sub-agents

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1150,6 +1150,68 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
       });
     }),
   );
+
+  it.effect("keeps interacted sub-agent activity liveness-neutral after completion", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 3)).pipe(
+        Effect.forkChild,
+      );
+      const child = "child-thread-fixture-1";
+      const linkage = {
+        agentThreadId: child,
+        agentPath: "/root/mock_worker",
+        nickname: "mock_worker",
+        role: "worker",
+      };
+
+      yield* runtime.emit({
+        id: asEventId("evt-collab-turn-started"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "collabAgent/turnStarted",
+        payload: linkage,
+      } satisfies ProviderEvent);
+      yield* runtime.emit({
+        id: asEventId("evt-collab-turn-completed"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:01.000Z",
+        method: "collabAgent/turnCompleted",
+        payload: {
+          ...linkage,
+          turn: { id: "child-turn-fixture-1", status: "completed", items: [] },
+        },
+      } satisfies ProviderEvent);
+      yield* runtime.emit({
+        id: asEventId("evt-collab-interacted"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:02.000Z",
+        method: "collabAgent/activity",
+        payload: { ...linkage, activityKind: "interacted" },
+      } satisfies ProviderEvent);
+      yield* runtime.emit({
+        id: asEventId("evt-collab-closed"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:03.000Z",
+        method: "collabAgent/closed",
+        payload: linkage,
+      } satisfies ProviderEvent);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      NodeAssert.deepStrictEqual(
+        events.map((event) => (event.type === "task.updated" ? event.payload.status : event.type)),
+        ["running", "idle", "interrupted"],
+      );
+    }),
+  );
 });
 
 const scopedLifecycleRuntimeFactory = makeScopedRuntimeFactory();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -588,14 +588,9 @@ function mapCollabAgentEvent(
           },
         ];
       }
-      // interacted → the child is (again) actively driven.
-      return [
-        {
-          ...base,
-          type: "task.updated",
-          payload: { taskId, status: "running", ...statusLinkage },
-        },
-      ];
+      // `interacted` records communication with the child, not execution.
+      // A resumed child emits collabAgent/turnStarted when it is running.
+      return [];
     }
     case "collabAgent/turnStarted":
       return [


### PR DESCRIPTION
## Problem

Codex emits `interacted` activity when the parent communicates with a child agent. T3 treated every interaction as proof that the child was running, so a message arriving after turn completion could revive an idle task row and leave the UI showing stale work.

## Fix

- Keep `interacted` activity liveness-neutral at the Codex adapter boundary.
- Continue using `collabAgent/turnStarted` as the signal that a child resumed execution.
- Cover the running-to-idle sequence with a focused adapter-stream regression using synthetic identifiers.

## Validation

- `vp test run apps/server/src/provider/Layers/CodexAdapter.test.ts` — 26 passed
- Targeted lint for both changed files
- Targeted formatting check for both changed files
- `vp run --filter t3 typecheck`

Model: GPT-5.6 Sol; harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `collabAgent/activity` interactions to no longer revive idle sub-agents
> In `mapCollabAgentEvent`, `collabAgent/activity` events with `activityKind: 'interacted'` previously emitted a `task.updated` event with status `running`, which caused idle sub-agents to appear active again. These events now return an empty array since `interacted` signals communication, not execution — only `collabAgent/turnStarted` triggers the running state. A test is added to assert the correct `running → idle → interrupted` sequence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ce04fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow event-mapping fix in the Codex adapter with a focused regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes sub-agent task rows flipping back to **running** when Codex sends `collabAgent/activity` with `activityKind: 'interacted'` after a child turn has already completed.
> 
> In `mapCollabAgentEvent`, **`interacted`** no longer emits a `task.updated` with status `running`; it returns no events because it signals parent–child communication, not execution. **`collabAgent/turnStarted`** remains the signal that a child resumed work.
> 
> A lifecycle regression test asserts the adapter stream stays **`running → idle → interrupted`** when `interacted` arrives between turn completion and agent close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce04fee45994da06d6633931feaf221698d4138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task status reporting for collaborative agent activity.
  - Interactive activity no longer incorrectly changes a task to “Running.”
  - Tasks now remain “Running” only when a turn begins, transition to “Idle” after completion, and become “Interrupted” when activity is interrupted or closed.

- **Tests**
  - Added coverage validating the full task-status lifecycle and event sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->