### PR TITLE
fix(desktop): keep Clerk redirects on app root

### DIFF
--- a/apps/web/src/components/clerk/authRedirect.test.ts
+++ b/apps/web/src/components/clerk/authRedirect.test.ts
@@ -8,11 +8,17 @@ describe("resolveClerkSignInProps", () => {
     expect(resolveClerkSignInProps(href, false)).toEqual({ forceRedirectUrl: href });
   });
 
-  it("omits the redirect override on packaged desktop", () => {
-    expect(resolveClerkSignInProps("t3code://app/#/settings/general", true)).toEqual({});
+  it("returns packaged desktop auth flows to the renderer root", () => {
+    expect(resolveClerkSignInProps("t3code://app/#/settings/archived", true)).toEqual({
+      forceRedirectUrl: "t3code://app/",
+      signUpForceRedirectUrl: "t3code://app/",
+    });
   });
 
-  it("omits the redirect override on development desktop", () => {
-    expect(resolveClerkSignInProps("t3code-dev://app/#/settings/general", true)).toEqual({});
+  it("returns development desktop auth flows to the renderer root", () => {
+    expect(resolveClerkSignInProps("t3code-dev://app/#/settings/general", true)).toEqual({
+      forceRedirectUrl: "t3code-dev://app/",
+      signUpForceRedirectUrl: "t3code-dev://app/",
+    });
   });
 });

--- a/apps/web/src/components/clerk/authRedirect.ts
+++ b/apps/web/src/components/clerk/authRedirect.ts
@@ -1,12 +1,15 @@
 export interface ClerkSignInProps {
   forceRedirectUrl?: string;
+  signUpForceRedirectUrl?: string;
 }
 
 // Clerk's native-app allowlist only authorizes the bare renderer root
-// (t3code://app/), which @clerk/electron's OAuth transport already supplies,
-// so any page-derived redirect override gets the whole sign-in request
-// rejected. On Electron, omit the override and let Clerk use its defaults.
+// (t3code://app/). Keep both modal completion paths on that root; otherwise
+// Clerk derives a virtual sign-up URL from the current hash route and rejects it.
+// @clerk/electron supplies the same root separately for the OAuth callback.
 export function resolveClerkSignInProps(href: string, isElectron: boolean): ClerkSignInProps {
-  if (isElectron) return {};
-  return { forceRedirectUrl: href };
+  if (!isElectron) return { forceRedirectUrl: href };
+
+  const rendererRoot = new URL("/", href).toString();
+  return { forceRedirectUrl: rendererRoot, signUpForceRedirectUrl: rendererRoot };
 }


### PR DESCRIPTION
## Problem

Desktop sign-up can still send Clerk a virtual modal URL such as `t3code://app/CLERK-ROUTER/VIRTUAL/sign-up#/settings/archived`. The Electron instance only authorizes the renderer root, so Clerk rejects the request. Omitting `forceRedirectUrl` as in #4809 leaves the sign-up completion URL to Clerk's modal default and does not cover this path.

## Fix

Force both sign-in and sign-up modal completion URLs to the renderer root derived from the current Electron URL. Hosted web continues returning to the full current browser URL, and `@clerk/electron` continues supplying the renderer root separately for the OAuth callback.

Fixes #5315

## Validation

- `vp test run src/components/clerk/authRedirect.test.ts --project unit` — 3 tests passed
- Targeted `vp fmt --check` passed
- Targeted `vp lint` passed
- `vp run --filter @t3tools/web typecheck` passed
- `git diff --check` passed

## UI changes

None. This changes the native authentication redirect policy rather than rendered UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication redirect URLs on desktop; scope is small and covered by unit tests, but wrong URLs could break sign-in/sign-up completion.
> 
> **Overview**
> **Desktop Clerk modals** now pin both sign-in and sign-up completion to the **renderer root** (`t3code://app/` or `t3code-dev://app/`) instead of omitting redirect props. That replaces the prior Electron behavior of returning `{}`, which let Clerk build virtual sign-up URLs from the current hash route and get rejected by the native allowlist.
> 
> `resolveClerkSignInProps` gains `signUpForceRedirectUrl` on the returned props; hosted web still uses `forceRedirectUrl: href` only. OAuth callback handling via `@clerk/electron` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26eb5e87a2b3af4b56c0c67b0a5abd650d417ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Clerk redirect URLs in Electron to point to renderer root
> In Electron contexts, `resolveClerkSignInProps` previously returned no redirect overrides, which caused Clerk sign-in/sign-up flows to redirect to URLs outside the renderer. It now computes the renderer root via `new URL('/', href).toString()` and returns both `forceRedirectUrl` and `signUpForceRedirectUrl` set to that root. Non-Electron behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26eb5e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->