### PR TITLE
fix(mobile): detect PowerShell cmdlet errors in work log rows

### DIFF
--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -554,6 +554,8 @@ function toolDetailTextLooksLikeFailure(text: string): boolean {
     normalized.includes("command not found") ||
     (normalized.includes("cannot find path") && normalized.includes("because it does not exist")) ||
     (normalized.includes("is not recognized") && normalized.includes("the term '")) ||
+    normalized.includes("is not recognized as the name of a cmdlet") ||
+    normalized.includes("a parameter cannot be found that matches parameter name") ||
     /<exited with exit code\s+[1-9]\d*\s*>/i.test(text) ||
     /exit(?:ed)? with exit code\s+[1-9]\d*/i.test(text) ||
     /exit code\s*[:\s]\s*[1-9]\d*\b/i.test(text)


### PR DESCRIPTION
## What Changed

Adds two PowerShell failure patterns to the mobile tool-failure heuristic `toolDetailTextLooksLikeFailure` in `apps/mobile/src/lib/threadActivity.ts`:

- `is not recognized as the name of a cmdlet`
- `a parameter cannot be found that matches parameter name`

Same substring matches web already makes in `apps/web/src/session-logic.ts` (#3022).

## Why

The web heuristic gained these two patterns in #3022; the mobile copy at `apps/mobile/src/lib/threadActivity.ts` never received them. Identical failing PowerShell output therefore renders as a failure row on web but as neutral on mobile. This restores cross-surface parity (web/mobile should classify the same tool output identically).

Fixes https://github.com/pingdotgg/t3code/issues/5724

## UI Changes

N/A — classification-only fix. Affected rows already render the failure affordance on web; this only makes mobile agree. No layout, motion, or visual differences.

## Checklist

- [x] This PR is small and focused (2-line diff)
- [x] I explained what changed and why
- [x] N/A — no UI screenshots needed (classification fix only)
- [x] N/A — no animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two heuristic substring checks in mobile-only classification logic; no auth, data, or API changes.
> 
> **Overview**
> Aligns mobile work-log **tool failure** detection with web by extending `toolDetailTextLooksLikeFailure` in `threadActivity.ts` with two PowerShell error substrings: `is not recognized as the name of a cmdlet` and `a parameter cannot be found that matches parameter name`.
> 
> Tool rows whose detail/command text matches these patterns are classified as **failure** instead of neutral, so the same failing PowerShell output shows the failure affordance on mobile as it already does on web (#3022).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80e92caf78d0d6b6b76bedbe0dfabfc74236faf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect PowerShell cmdlet errors as failures in work log rows
> Extends `toolDetailTextLooksLikeFailure` in [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/5726/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5) to recognize two additional PowerShell error phrases: "is not recognized as the name of a cmdlet" and "a parameter cannot be found that matches parameter name". These strings are now treated as failure indicators alongside existing checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e80e92c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->