### PR TITLE
fix(web): usage window controls no longer overlap native titlebar buttons

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -2,8 +2,10 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 import { RefreshCwIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import { isElectron } from "../../env";
 import { cn } from "../../lib/utils";
 import { useUsage } from "../../state/usage";
+import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import {
   enumerateDays,
   formatCount,
@@ -53,128 +55,209 @@ export function UsagePage() {
   const observedInput = merged.uncachedInputTokens + merged.cachedInputTokens;
   const cachedShare = observedInput === 0 ? 0 : merged.cachedInputTokens / observedInput;
 
+  const windowControls = (
+    <div className="flex items-center gap-2">
+      <div className="flex overflow-hidden rounded-md border border-border">
+        {WINDOW_OPTIONS.map((option) => (
+          <button
+            key={option.days}
+            type="button"
+            onClick={() => setWindowDays(option.days)}
+            className={cn(
+              "px-3 py-1.5 text-xs",
+              option.days === windowDays
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={refresh}
+        aria-label="Refresh usage"
+        className="rounded-md border border-border p-2 text-muted-foreground hover:text-foreground"
+      >
+        <RefreshCwIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+
   return (
-    <ScrollArea className="h-full">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-6">
-        <header className="flex flex-wrap items-start justify-between gap-4">
-          <div className="flex flex-col gap-1">
-            <h1 className="text-2xl font-semibold text-foreground">Usage</h1>
-            <p className="text-sm text-muted-foreground">
-              {formatDayShort(window.sinceDay)} to {formatDayShort(window.untilDay)}
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="flex overflow-hidden rounded-md border border-border">
-              {WINDOW_OPTIONS.map((option) => (
-                <button
-                  key={option.days}
-                  type="button"
-                  onClick={() => setWindowDays(option.days)}
-                  className={cn(
-                    "px-3 py-1.5 text-xs",
-                    option.days === windowDays
-                      ? "bg-muted text-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {option.label}
-                </button>
-              ))}
-            </div>
-            <button
-              type="button"
-              onClick={refresh}
-              aria-label="Refresh usage"
-              className="rounded-md border border-border p-2 text-muted-foreground hover:text-foreground"
-            >
-              <RefreshCwIcon className="size-3.5" />
-            </button>
-          </div>
+    <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+      {isElectron ? (
+        <div
+          className={cn(
+            "drag-region flex h-[52px] shrink-0 items-center px-5 transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]",
+            COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
+          )}
+        >
+          <span className="text-xs font-medium tracking-wide text-muted-foreground/70">Usage</span>
+          <div className="ms-auto flex items-center gap-2">{windowControls}</div>
+        </div>
+      ) : (
+        <header
+          className={cn(
+            "workspace-topbar px-3 transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none sm:px-5",
+            COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
+          )}
+        >
+          <span className="text-sm font-medium text-foreground">Usage</span>
+          <div className="ms-auto flex items-center gap-2">{windowControls}</div>
         </header>
+      )}
 
-        <UsageCoverageNotice
-          environments={environments}
-          duplicateSources={merged.duplicateSources}
-          staleEnvironments={merged.staleEnvironments}
-          isPartial={isPartial}
-        />
-
-        {isPending ? (
-          <p className="py-16 text-center text-sm text-muted-foreground">
-            Scanning provider transcripts…
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-6">
+          <p className="text-sm text-muted-foreground">
+            {formatDayShort(window.sinceDay)} to {formatDayShort(window.untilDay)}
           </p>
-        ) : (
-          <>
-            {/* Cost first: the financial answer, then the provider split. */}
-            <section className="grid gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)]">
-              {/* The summary follows the chart toggle, so the headline and the
+
+          <UsageCoverageNotice
+            environments={environments}
+            duplicateSources={merged.duplicateSources}
+            staleEnvironments={merged.staleEnvironments}
+            isPartial={isPartial}
+          />
+
+          {isPending ? (
+            <p className="py-16 text-center text-sm text-muted-foreground">
+              Scanning provider transcripts…
+            </p>
+          ) : (
+            <>
+              {/* Cost first: the financial answer, then the provider split. */}
+              <section className="grid gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)]">
+                {/* The summary follows the chart toggle, so the headline and the
                   series are always reading the same units. */}
-              <div className="flex flex-col gap-5">
-                <div className="flex flex-col gap-1">
-                  <span className="text-xs tracking-wide text-muted-foreground uppercase">
-                    {metric === "cost" ? "Raw token cost" : "Processed tokens"}
-                  </span>
-                  <span className="text-4xl font-semibold text-foreground tabular-nums">
-                    {metric === "cost"
-                      ? `${formatUsd(merged.costUsd)}*`
-                      : formatTokens(merged.totalTokens)}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {metric === "cost"
-                      ? "* if billed at full API rate"
-                      : `Input, cache reads and output across ${formatCount(merged.sessions)} sessions.`}
-                  </span>
+                <div className="flex flex-col gap-5">
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs tracking-wide text-muted-foreground uppercase">
+                      {metric === "cost" ? "Raw token cost" : "Processed tokens"}
+                    </span>
+                    <span className="text-4xl font-semibold text-foreground tabular-nums">
+                      {metric === "cost"
+                        ? `${formatUsd(merged.costUsd)}*`
+                        : formatTokens(merged.totalTokens)}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {metric === "cost"
+                        ? "* if billed at full API rate"
+                        : `Input, cache reads and output across ${formatCount(merged.sessions)} sessions.`}
+                    </span>
+                  </div>
+
+                  {orderedProviders.map((provider) => {
+                    const share = metric === "cost" ? provider.costShare : provider.tokenShare;
+                    return (
+                      <div key={provider.provider} className="flex flex-col gap-1.5">
+                        <div className="flex items-baseline justify-between">
+                          <span className="flex items-center gap-2 text-sm text-foreground">
+                            <ProviderMark provider={provider.provider} className="size-4" />
+                            {PROVIDER_LABEL[provider.provider]}
+                          </span>
+                          <span className="text-sm text-foreground tabular-nums">
+                            {metric === "cost"
+                              ? formatUsd(provider.costUsd)
+                              : formatTokens(provider.totalTokens)}
+                          </span>
+                        </div>
+                        <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+                          <div
+                            className="h-full"
+                            style={{
+                              width: `${(share * 100).toFixed(1)}%`,
+                              backgroundColor: PROVIDER_COLOR[provider.provider],
+                            }}
+                          />
+                        </div>
+                        <span className="text-xs text-muted-foreground">
+                          {metric === "cost"
+                            ? `${formatPercent(share)} of cost · ${formatTokens(provider.totalTokens)} tokens`
+                            : `${formatPercent(share)} of tokens · ${formatUsd(provider.costUsd)}`}
+                        </span>
+                      </div>
+                    );
+                  })}
                 </div>
 
-                {orderedProviders.map((provider) => {
-                  const share = metric === "cost" ? provider.costShare : provider.tokenShare;
-                  return (
-                    <div key={provider.provider} className="flex flex-col gap-1.5">
-                      <div className="flex items-baseline justify-between">
-                        <span className="flex items-center gap-2 text-sm text-foreground">
-                          <ProviderMark provider={provider.provider} className="size-4" />
-                          {PROVIDER_LABEL[provider.provider]}
-                        </span>
-                        <span className="text-sm text-foreground tabular-nums">
-                          {metric === "cost"
-                            ? formatUsd(provider.costUsd)
-                            : formatTokens(provider.totalTokens)}
-                        </span>
+                <div className="flex flex-col gap-3">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <h2 className="text-sm font-medium text-foreground">
+                      Daily {metric === "tokens" ? "processed tokens" : "cost"}
+                    </h2>
+                    <div className="flex items-center gap-4">
+                      <div className="flex overflow-hidden rounded-md border border-border">
+                        {(["cost", "tokens"] as const).map((option) => (
+                          <button
+                            key={option}
+                            type="button"
+                            onClick={() => setMetric(option)}
+                            className={cn(
+                              "px-2.5 py-1 text-[10px] tracking-wide uppercase",
+                              option === metric
+                                ? "bg-muted text-foreground"
+                                : "text-muted-foreground hover:text-foreground",
+                            )}
+                          >
+                            {option}
+                          </button>
+                        ))}
                       </div>
-                      <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
-                        <div
-                          className="h-full"
-                          style={{
-                            width: `${(share * 100).toFixed(1)}%`,
-                            backgroundColor: PROVIDER_COLOR[provider.provider],
-                          }}
-                        />
-                      </div>
-                      <span className="text-xs text-muted-foreground">
-                        {metric === "cost"
-                          ? `${formatPercent(share)} of cost · ${formatTokens(provider.totalTokens)} tokens`
-                          : `${formatPercent(share)} of tokens · ${formatUsd(provider.costUsd)}`}
-                      </span>
+                      <UsageChartLegend />
                     </div>
-                  );
-                })}
-              </div>
+                  </div>
+                  <UsageProviderChart days={days} daily={merged.daily} metric={metric} />
+                </div>
+              </section>
 
-              <div className="flex flex-col gap-3">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <h2 className="text-sm font-medium text-foreground">
-                    Daily {metric === "tokens" ? "processed tokens" : "cost"}
-                  </h2>
-                  <div className="flex items-center gap-4">
+              <section className="grid grid-cols-2 gap-px border-y border-border bg-border md:grid-cols-5">
+                <Metric
+                  label="Processed tokens"
+                  value={formatTokens(merged.totalTokens)}
+                  detail={`${formatTokens(dailyAverage)} per active day`}
+                />
+                <Metric
+                  label="Cached input"
+                  value={formatTokens(merged.cachedInputTokens)}
+                  detail={`${formatPercent(cachedShare)} of observed input`}
+                />
+                <Metric
+                  label="Uncached input"
+                  value={formatTokens(merged.uncachedInputTokens)}
+                  detail={`${formatTokens(merged.cacheCreationTokens)} cache writes`}
+                />
+                <Metric
+                  label="Output"
+                  value={formatTokens(merged.outputTokens)}
+                  detail={`includes ${formatTokens(merged.reasoningTokens)} reasoning`}
+                />
+                <Metric
+                  label="Cache savings"
+                  value={formatUsd(merged.costQuality.cacheSavingsUsd)}
+                  detail={
+                    merged.costUsd > 0
+                      ? `${(merged.costQuality.cacheSavingsUsd / merged.costUsd).toFixed(1)}x the raw token cost`
+                      : "vs full input rates"
+                  }
+                />
+              </section>
+
+              <section className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,18rem)]">
+                <div className="flex flex-col gap-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <h2 className="text-sm font-medium text-foreground">Breakdown</h2>
                     <div className="flex overflow-hidden rounded-md border border-border">
-                      {(["cost", "tokens"] as const).map((option) => (
+                      {(["model", "day"] as const).map((option) => (
                         <button
                           key={option}
                           type="button"
-                          onClick={() => setMetric(option)}
+                          onClick={() => setBreakdown(option)}
                           className={cn(
                             "px-2.5 py-1 text-[10px] tracking-wide uppercase",
-                            option === metric
+                            option === breakdown
                               ? "bg-muted text-foreground"
                               : "text-muted-foreground hover:text-foreground",
                           )}
@@ -183,184 +266,125 @@ export function UsagePage() {
                         </button>
                       ))}
                     </div>
-                    <UsageChartLegend />
                   </div>
-                </div>
-                <UsageProviderChart days={days} daily={merged.daily} metric={metric} />
-              </div>
-            </section>
 
-            <section className="grid grid-cols-2 gap-px border-y border-border bg-border md:grid-cols-5">
-              <Metric
-                label="Processed tokens"
-                value={formatTokens(merged.totalTokens)}
-                detail={`${formatTokens(dailyAverage)} per active day`}
-              />
-              <Metric
-                label="Cached input"
-                value={formatTokens(merged.cachedInputTokens)}
-                detail={`${formatPercent(cachedShare)} of observed input`}
-              />
-              <Metric
-                label="Uncached input"
-                value={formatTokens(merged.uncachedInputTokens)}
-                detail={`${formatTokens(merged.cacheCreationTokens)} cache writes`}
-              />
-              <Metric
-                label="Output"
-                value={formatTokens(merged.outputTokens)}
-                detail={`includes ${formatTokens(merged.reasoningTokens)} reasoning`}
-              />
-              <Metric
-                label="Cache savings"
-                value={formatUsd(merged.costQuality.cacheSavingsUsd)}
-                detail={
-                  merged.costUsd > 0
-                    ? `${(merged.costQuality.cacheSavingsUsd / merged.costUsd).toFixed(1)}x the raw token cost`
-                    : "vs full input rates"
-                }
-              />
-            </section>
-
-            <section className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,18rem)]">
-              <div className="flex flex-col gap-3">
-                <div className="flex items-center justify-between gap-3">
-                  <h2 className="text-sm font-medium text-foreground">Breakdown</h2>
-                  <div className="flex overflow-hidden rounded-md border border-border">
-                    {(["model", "day"] as const).map((option) => (
-                      <button
-                        key={option}
-                        type="button"
-                        onClick={() => setBreakdown(option)}
-                        className={cn(
-                          "px-2.5 py-1 text-[10px] tracking-wide uppercase",
-                          option === breakdown
-                            ? "bg-muted text-foreground"
-                            : "text-muted-foreground hover:text-foreground",
-                        )}
-                      >
-                        {option}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {breakdown === "model" ? (
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-border text-left text-xs text-muted-foreground">
-                        <th className="py-2 font-normal">Model</th>
-                        <th className="py-2 text-right font-normal">Cost</th>
-                        <th className="py-2 text-right font-normal">Share</th>
-                        <th className="py-2 text-right font-normal">Tokens</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {merged.models.length === 0 ? (
-                        <tr>
-                          <td colSpan={4} className="py-6 text-center text-muted-foreground">
-                            No activity in this window.
-                          </td>
+                  {breakdown === "model" ? (
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                          <th className="py-2 font-normal">Model</th>
+                          <th className="py-2 text-right font-normal">Cost</th>
+                          <th className="py-2 text-right font-normal">Share</th>
+                          <th className="py-2 text-right font-normal">Tokens</th>
                         </tr>
-                      ) : (
-                        merged.models.map((model) => (
-                          <tr
-                            key={`${model.provider}:${model.model}`}
-                            className="border-b border-border/50"
-                          >
-                            <td className="py-2 text-foreground">
-                              <span className="flex items-center gap-2">
-                                <ProviderMark provider={model.provider} className="size-3.5" />
-                                {model.model}
-                              </span>
-                            </td>
-                            <td className="py-2 text-right text-foreground tabular-nums">
-                              {formatUsd(model.costUsd)}
-                            </td>
-                            <td className="py-2 text-right text-muted-foreground tabular-nums">
-                              {formatPercent(model.costShare)}
-                            </td>
-                            <td className="py-2 text-right text-muted-foreground tabular-nums">
-                              {formatTokens(model.totalTokens)}
+                      </thead>
+                      <tbody>
+                        {merged.models.length === 0 ? (
+                          <tr>
+                            <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                              No activity in this window.
                             </td>
                           </tr>
-                        ))
-                      )}
-                    </tbody>
-                  </table>
-                ) : (
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-border text-left text-xs text-muted-foreground">
-                        <th className="py-2 font-normal">Day</th>
-                        {PROVIDER_ORDER.map((provider) => (
-                          <th key={provider} className="py-2 text-right font-normal">
-                            {PROVIDER_LABEL[provider]}
-                          </th>
-                        ))}
-                        <th className="py-2 text-right font-normal">Total</th>
-                        <th className="py-2 text-right font-normal">Tokens</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {recentDays.length === 0 ? (
-                        <tr>
-                          <td colSpan={5} className="py-6 text-center text-muted-foreground">
-                            No activity in this window.
-                          </td>
-                        </tr>
-                      ) : (
-                        recentDays.map((day) => (
-                          <tr key={day.day} className="border-b border-border/50">
-                            <td className="py-2 text-foreground">{formatDayShort(day.day)}</td>
-                            {PROVIDER_ORDER.map((provider) => (
-                              <td
-                                key={provider}
-                                className="py-2 text-right text-muted-foreground tabular-nums"
-                              >
-                                {formatUsd(day.byProvider.get(provider)?.costUsd ?? 0)}
+                        ) : (
+                          merged.models.map((model) => (
+                            <tr
+                              key={`${model.provider}:${model.model}`}
+                              className="border-b border-border/50"
+                            >
+                              <td className="py-2 text-foreground">
+                                <span className="flex items-center gap-2">
+                                  <ProviderMark provider={model.provider} className="size-3.5" />
+                                  {model.model}
+                                </span>
                               </td>
-                            ))}
-                            <td className="py-2 text-right text-foreground tabular-nums">
-                              {formatUsd(day.costUsd)}
-                            </td>
-                            <td className="py-2 text-right text-muted-foreground tabular-nums">
-                              {formatTokens(day.totalTokens)}
+                              <td className="py-2 text-right text-foreground tabular-nums">
+                                {formatUsd(model.costUsd)}
+                              </td>
+                              <td className="py-2 text-right text-muted-foreground tabular-nums">
+                                {formatPercent(model.costShare)}
+                              </td>
+                              <td className="py-2 text-right text-muted-foreground tabular-nums">
+                                {formatTokens(model.totalTokens)}
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  ) : (
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                          <th className="py-2 font-normal">Day</th>
+                          {PROVIDER_ORDER.map((provider) => (
+                            <th key={provider} className="py-2 text-right font-normal">
+                              {PROVIDER_LABEL[provider]}
+                            </th>
+                          ))}
+                          <th className="py-2 text-right font-normal">Total</th>
+                          <th className="py-2 text-right font-normal">Tokens</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {recentDays.length === 0 ? (
+                          <tr>
+                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                              No activity in this window.
                             </td>
                           </tr>
-                        ))
-                      )}
-                    </tbody>
-                  </table>
-                )}
-              </div>
+                        ) : (
+                          recentDays.map((day) => (
+                            <tr key={day.day} className="border-b border-border/50">
+                              <td className="py-2 text-foreground">{formatDayShort(day.day)}</td>
+                              {PROVIDER_ORDER.map((provider) => (
+                                <td
+                                  key={provider}
+                                  className="py-2 text-right text-muted-foreground tabular-nums"
+                                >
+                                  {formatUsd(day.byProvider.get(provider)?.costUsd ?? 0)}
+                                </td>
+                              ))}
+                              <td className="py-2 text-right text-foreground tabular-nums">
+                                {formatUsd(day.costUsd)}
+                              </td>
+                              <td className="py-2 text-right text-muted-foreground tabular-nums">
+                                {formatTokens(day.totalTokens)}
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
 
-              <div className="flex flex-col gap-3">
-                <h2 className="text-sm font-medium text-foreground">Cost quality</h2>
-                <dl className="flex flex-col">
-                  <QualityRow
-                    label="Provider reported"
-                    value={formatPercent(merged.costQuality.providerReportedShare)}
-                  />
-                  <QualityRow
-                    label="Model priced"
-                    value={formatPercent(merged.costQuality.modelPricedShare)}
-                  />
-                  <QualityRow
-                    label="Unpriced"
-                    value={formatPercent(merged.costQuality.unpricedShare)}
-                  />
-                  <QualityRow
-                    label="Cache savings"
-                    value={formatUsd(merged.costQuality.cacheSavingsUsd)}
-                  />
-                </dl>
-              </div>
-            </section>
-          </>
-        )}
-      </div>
-    </ScrollArea>
+                <div className="flex flex-col gap-3">
+                  <h2 className="text-sm font-medium text-foreground">Cost quality</h2>
+                  <dl className="flex flex-col">
+                    <QualityRow
+                      label="Provider reported"
+                      value={formatPercent(merged.costQuality.providerReportedShare)}
+                    />
+                    <QualityRow
+                      label="Model priced"
+                      value={formatPercent(merged.costQuality.modelPricedShare)}
+                    />
+                    <QualityRow
+                      label="Unpriced"
+                      value={formatPercent(merged.costQuality.unpricedShare)}
+                    />
+                    <QualityRow
+                      label="Cache savings"
+                      value={formatUsd(merged.costQuality.cacheSavingsUsd)}
+                    />
+                  </dl>
+                </div>
+              </section>
+            </>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
   );
 }
 


### PR DESCRIPTION
On Windows, the native minimize/close buttons overlay the top-right corner of the Usage page, colliding with the 7/30/90-day window selector and the refresh button.

Moved the header into the app's standard `workspace-topbar` layout, the same pattern Settings and the chat view use. On desktop it is now a drag region with height matching `env(titlebar-area-height)` and right padding that reserves the window-controls overlay width, so the window selector and refresh button sit clear of the native buttons. The web topbar keeps the same padding as the rest of the app.

Verified on Windows in the Electron app: the window selector and refresh button no longer overlap minimize/close. Before/after screenshots to be attached.

Before:
<img width="1590" height="117" alt="Screenshot 2026-08-09 031721" src="https://github.com/user-attachments/assets/be9b8151-7a5a-4764-b354-bf0b13c7dcc0" />

After:
<img width="1055" height="117" alt="Screenshot 2026-08-09 031733" src="https://github.com/user-attachments/assets/67680576-c286-4384-8ec2-ab1736b69690" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only changes to Usage page chrome; no usage data or API behavior changes.
> 
> **Overview**
> **Fixes Usage page controls overlapping Windows minimize/close** by giving the page a fixed top bar (like Chat and Settings) instead of putting window controls inside the scrollable header.
> 
> The **7/30/90-day selector and refresh** are extracted into shared `windowControls` and pinned in a **workspace top bar**: on **Electron**, a drag region with `wco` right padding so controls sit left of native titlebar buttons; on **web**, `workspace-topbar` with `COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS`. Scrollable metrics/charts live in a **`flex-1` `ScrollArea`** below; the date range moves into that body as muted text (the large in-page “Usage” title is removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a38a035aee0f9722bec6eb54cebb48b82f953dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix usage page window controls overlapping native titlebar buttons in Electron
> Reworks the layout of [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/5730/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) to prevent the window range and refresh controls from overlapping native Electron titlebar buttons. In Electron, a compact top bar renders with `COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS` and a small 'Usage' label; on web, a `workspace-topbar` header uses the same inset class. The date range display moves from the header into the main content area, and the main content is wrapped in a `ScrollArea` that fills remaining space.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a38a03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->