### PR TITLE
feat(web): show how many subagents are running at a glance

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5913,6 +5913,11 @@ function ChatViewContent(props: ChatViewProps) {
       rightPanelAvailable={activeProject !== null}
       rightPanelOpen={rightPanelOpen}
       rightPanelShortcutLabel={shortcutLabelForCommand(keybindings, "rightPanel.toggle")}
+      // Suppressed while the Agents surface is visible: the roster itself is
+      // on screen, so the toggle badge would be pointing at nothing.
+      liveAgentCount={
+        rightPanelOpen && activeRightPanelSurface?.kind === "agents" ? 0 : agentPanelModel.liveCount
+      }
       onToggleTerminal={toggleTerminalVisibility}
       onToggleRightPanel={toggleRightPanel}
     />
@@ -6419,6 +6424,7 @@ function ChatViewContent(props: ChatViewProps) {
           browserAvailable={isPreviewSupportedInRuntime()}
           diffAvailable={isServerThread && isGitRepo}
           filesAvailable={activeProject !== null}
+          liveAgentCount={agentPanelModel.liveCount}
         >
           {rightPanelContent}
         </RightPanelTabs>
@@ -6447,6 +6453,7 @@ function ChatViewContent(props: ChatViewProps) {
             browserAvailable={isPreviewSupportedInRuntime()}
             diffAvailable={isServerThread && isGitRepo}
             filesAvailable={activeProject !== null}
+            liveAgentCount={agentPanelModel.liveCount}
           >
             {rightPanelContent}
           </RightPanelTabs>

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -48,6 +48,8 @@ interface RightPanelTabsProps {
   browserAvailable: boolean;
   diffAvailable: boolean;
   filesAvailable: boolean;
+  /** Running + waiting subagents; badges the Agents card in the empty state. */
+  liveAgentCount: number;
   children: ReactNode;
 }
 
@@ -96,6 +98,7 @@ function RightPanelEmptyState(props: {
   browserAvailable: boolean;
   diffAvailable: boolean;
   filesAvailable: boolean;
+  liveAgentCount: number;
 }) {
   const actions = [
     {
@@ -105,6 +108,7 @@ function RightPanelEmptyState(props: {
       available: props.browserAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.browser,
       onClick: props.onAddBrowser,
+      badgeCount: 0,
     },
     {
       label: "Terminal",
@@ -113,6 +117,7 @@ function RightPanelEmptyState(props: {
       available: true,
       disabledReason: null,
       onClick: props.onAddTerminal,
+      badgeCount: 0,
     },
     {
       label: "Files",
@@ -121,6 +126,7 @@ function RightPanelEmptyState(props: {
       available: props.filesAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.files,
       onClick: props.onAddFiles,
+      badgeCount: 0,
     },
     {
       label: "Diff",
@@ -129,6 +135,7 @@ function RightPanelEmptyState(props: {
       available: props.diffAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.diff,
       onClick: props.onAddDiff,
+      badgeCount: 0,
     },
     {
       label: "Agents",
@@ -137,6 +144,7 @@ function RightPanelEmptyState(props: {
       available: true,
       disabledReason: null,
       onClick: props.onAddAgents,
+      badgeCount: props.liveAgentCount,
     },
   ] as const;
 
@@ -154,7 +162,17 @@ function RightPanelEmptyState(props: {
             const Icon = action.icon;
             const content = (
               <>
-                <Icon className="mb-3 size-5" />
+                <span className="relative mb-3 inline-flex">
+                  <Icon className="size-5" />
+                  {action.badgeCount > 0 ? (
+                    <span
+                      aria-hidden
+                      className="absolute -top-1.5 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-info px-1 text-[9px] font-semibold tabular-nums text-white"
+                    >
+                      {action.badgeCount}
+                    </span>
+                  ) : null}
+                </span>
                 <span className="text-sm font-medium">{action.label}</span>
                 <span className="mt-1 text-xs leading-relaxed text-muted-foreground">
                   {action.description}
@@ -498,6 +516,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
             browserAvailable={props.browserAvailable}
             diffAvailable={props.diffAvailable}
             filesAvailable={props.filesAvailable}
+            liveAgentCount={props.liveAgentCount}
           />
         ) : (
           props.children

--- a/apps/web/src/components/chat/PanelLayoutControls.tsx
+++ b/apps/web/src/components/chat/PanelLayoutControls.tsx
@@ -11,6 +11,8 @@ interface PanelLayoutControlsProps {
   rightPanelAvailable: boolean;
   rightPanelOpen: boolean;
   rightPanelShortcutLabel: string | null;
+  /** Running + waiting subagents in this thread; badges the right panel toggle. */
+  liveAgentCount: number;
   onToggleTerminal: () => void;
   onToggleRightPanel: () => void;
 }
@@ -22,6 +24,7 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
   rightPanelAvailable,
   rightPanelOpen,
   rightPanelShortcutLabel,
+  liveAgentCount,
   onToggleTerminal,
   onToggleRightPanel,
 }: PanelLayoutControlsProps) {
@@ -59,18 +62,34 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
               className="shrink-0 [-webkit-app-region:no-drag]"
               pressed={rightPanelOpen}
               onPressedChange={onToggleRightPanel}
-              aria-label="Toggle right panel"
+              aria-label={
+                liveAgentCount > 0
+                  ? `Toggle right panel, ${liveAgentCount} ${liveAgentCount === 1 ? "agent" : "agents"} working`
+                  : "Toggle right panel"
+              }
               variant="ghost"
               size="sm"
               disabled={!rightPanelAvailable}
             >
               <PanelRightIcon className="size-3.5" />
+              {liveAgentCount > 0 ? (
+                <span
+                  aria-hidden
+                  className="absolute -top-1 -right-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-info px-1 text-[9px] font-semibold tabular-nums text-white"
+                >
+                  {liveAgentCount}
+                </span>
+              ) : null}
             </Toggle>
           }
         />
         <TooltipPopup side="bottom">
           {rightPanelAvailable
-            ? `Toggle right panel${rightPanelShortcutLabel ? ` (${rightPanelShortcutLabel})` : ""}`
+            ? `Toggle right panel${rightPanelShortcutLabel ? ` (${rightPanelShortcutLabel})` : ""}${
+                liveAgentCount > 0
+                  ? ` · ${liveAgentCount} ${liveAgentCount === 1 ? "agent" : "agents"} working`
+                  : ""
+              }`
             : "Right panel is unavailable"}
         </TooltipPopup>
       </Tooltip>


### PR DESCRIPTION
A thread can have five subagents grinding away and nothing on screen says so once the spawn notices scroll up. You had to open the right panel manually to find out.

Now the right panel toggle wears a small count badge while subagents are running or waiting (same live count the Agents panel footer uses). The tooltip and aria-label say "N agents working". Details:

- The badge hides while the Agents surface is visible, since the roster itself is on screen.
- The Agents card in the panel's empty state carries the same badge, so after opening the panel you can see where the action is.
- Static badge, no animation.

<img width="2630" height="2180" alt="image" src="https://github.com/user-attachments/assets/7e3cb817-5bcc-45e6-a9b0-cf9d7d2c75f1" />


🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only badge and accessibility copy on existing panel controls; no backend or agent lifecycle changes.
> 
> **Overview**
> Surfaces **how many subagents are running or waiting** without opening the right panel, using the same `agentPanelModel.liveCount` as the Agents panel footer.
> 
> The **right panel toggle** in `PanelLayoutControls` gets a static count badge when `liveAgentCount > 0`, with tooltip and `aria-label` text like “N agents working”. In `ChatView`, that count is **forced to 0** while the right panel is open on the **Agents** surface so the badge does not duplicate the on-screen roster.
> 
> When the right panel has **no active surface**, the **Agents** card in `RightPanelEmptyState` shows the same badge so users can see activity after opening the panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6974ba250687bf18cd5d1f7386993f256018cdc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show live subagent count as a badge on the right panel toggle and Agents card
> - Adds a numeric badge to the right panel toggle in [`PanelLayoutControls`](https://github.com/pingdotgg/t3code/pull/5745/files#diff-4a8fd1569788ea7247bd600d44295eca372aea32c2d56bd144a3841b07dff51f) showing the number of running/waiting subagents; the badge is suppressed when the Agents panel is already open.
> - Updates [`RightPanelTabs`](https://github.com/pingdotgg/t3code/pull/5745/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91) to display the same count as a badge on the Agents card in the empty-state view.
> - Tooltip and `aria-label` on the toggle also include the live count with singular/plural handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6974ba2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->