### PR TITLE
fix(ssh): preserve external runtime ownership

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -104,7 +104,7 @@ import * as ResourceTelemetry from "./resourceTelemetry/ResourceTelemetry.ts";
 import * as UsageService from "./usage/UsageService.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
 import {
-  clearPersistedServerRuntimeState,
+  clearPersistedServerRuntimeStateIfOwned,
   makePersistedServerRuntimeState,
   persistServerRuntimeState,
 } from "./serverRuntimeState.ts";
@@ -496,13 +496,19 @@ export const makeServerLayer = Layer.unwrap(
               Effect.logWarning("Failed to persist server runtime state", { cause }),
             ),
           );
+          return state;
         }),
-        () =>
-          clearPersistedServerRuntimeState(config.serverRuntimeStatePath).pipe(
-            Effect.catchCause((cause) =>
-              Effect.logWarning("Failed to clear server runtime state", { cause }),
-            ),
-          ),
+        (state) =>
+          state === undefined
+            ? Effect.void
+            : clearPersistedServerRuntimeStateIfOwned({
+                path: config.serverRuntimeStatePath,
+                state,
+              }).pipe(
+                Effect.catchCause((cause) =>
+                  Effect.logWarning("Failed to clear server runtime state", { cause }),
+                ),
+              ),
       ),
     );
     const tailscaleServeLayer = config.tailscaleServeEnabled

--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -214,6 +214,44 @@ describe("serverRuntimeState", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
+  it.effect("restores replacement state when the filesystem rejects hard links", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-link-fallback-test-",
+      });
+      const statePath = path.join(root, "server.json");
+      const replacementState: ServerRuntimeState.PersistedServerRuntimeState = {
+        version: 1,
+        pid: 456,
+        port: 3_773,
+        origin: "http://127.0.0.1:3773",
+        startedAt: "2026-08-09T05:10:06.000Z",
+      };
+
+      yield* ServerRuntimeState.persistServerRuntimeState({
+        path: statePath,
+        state: replacementState,
+      });
+      const noHardLinksFileSystem = {
+        ...fileSystem,
+        link: (from: string, to: string) =>
+          from.includes(".clearing-")
+            ? fileSystem.link(path.join(root, "missing-link-source"), to)
+            : fileSystem.link(from, to),
+      } satisfies FileSystem.FileSystem;
+
+      yield* ServerRuntimeState.clearPersistedServerRuntimeStateIfOwned({
+        path: statePath,
+        state: { pid: 123, startedAt: "2026-08-09T05:09:57.000Z" },
+      }).pipe(Effect.provideService(FileSystem.FileSystem, noHardLinksFileSystem));
+
+      const preserved = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+      assert.deepEqual(Option.getOrThrow(preserved), replacementState);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("preserves malformed state decode failures", () => {
     const logs: CapturedLog[] = [];
     const logger = Logger.make(({ fiber, message }) => {

--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -78,6 +78,44 @@ describe("serverRuntimeState", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
+  it.effect("only clears runtime state owned by the stopping server", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-test-",
+      });
+      const statePath = path.join(root, "server.json");
+      const liveState: ServerRuntimeState.PersistedServerRuntimeState = {
+        version: 1,
+        pid: 456,
+        port: 3_774,
+        origin: "http://127.0.0.1:3774",
+        startedAt: "2026-08-08T18:42:31.153Z",
+      };
+
+      yield* ServerRuntimeState.persistServerRuntimeState({ path: statePath, state: liveState });
+      yield* ServerRuntimeState.clearPersistedServerRuntimeStateIfOwned({
+        path: statePath,
+        state: { pid: 123, startedAt: "2026-08-08T18:42:26.000Z" },
+      });
+      yield* ServerRuntimeState.clearPersistedServerRuntimeStateIfOwned({
+        path: statePath,
+        state: { pid: liveState.pid, startedAt: "2026-08-08T18:42:26.000Z" },
+      });
+
+      const preserved = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+      assert.deepEqual(Option.getOrThrow(preserved), liveState);
+
+      yield* ServerRuntimeState.clearPersistedServerRuntimeStateIfOwned({
+        path: statePath,
+        state: liveState,
+      });
+      const cleared = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+      assert.isTrue(Option.isNone(cleared));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("preserves malformed state decode failures", () => {
     const logs: CapturedLog[] = [];
     const logger = Logger.make(({ fiber, message }) => {

--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -116,6 +116,104 @@ describe("serverRuntimeState", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
+  it.effect("preserves replacement state written before ownership capture", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-race-test-",
+      });
+      const statePath = path.join(root, "server.json");
+      const stoppingState: ServerRuntimeState.PersistedServerRuntimeState = {
+        version: 1,
+        pid: 123,
+        port: 3_773,
+        origin: "http://127.0.0.1:3773",
+        startedAt: "2026-08-09T05:09:57.000Z",
+      };
+      const replacementState: ServerRuntimeState.PersistedServerRuntimeState = {
+        version: 1,
+        pid: 456,
+        port: 3_773,
+        origin: "http://127.0.0.1:3773",
+        startedAt: "2026-08-09T05:10:06.000Z",
+      };
+
+      yield* ServerRuntimeState.persistServerRuntimeState({
+        path: statePath,
+        state: stoppingState,
+      });
+      const racingFileSystem = {
+        ...fileSystem,
+        rename: (from: string, to: string) =>
+          from === statePath
+            ? fileSystem
+                .writeFileString(statePath, `${JSON.stringify(replacementState)}\n`)
+                .pipe(Effect.andThen(fileSystem.rename(from, to)))
+            : fileSystem.rename(from, to),
+      } satisfies FileSystem.FileSystem;
+
+      yield* ServerRuntimeState.clearPersistedServerRuntimeStateIfOwned({
+        path: statePath,
+        state: stoppingState,
+      }).pipe(Effect.provideService(FileSystem.FileSystem, racingFileSystem));
+
+      const preserved = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+      assert.deepEqual(Option.getOrThrow(preserved), replacementState);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("preserves replacement state written after ownership capture", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-race-test-",
+      });
+      const statePath = path.join(root, "server.json");
+      const stoppingState: ServerRuntimeState.PersistedServerRuntimeState = {
+        version: 1,
+        pid: 123,
+        port: 3_773,
+        origin: "http://127.0.0.1:3773",
+        startedAt: "2026-08-09T05:09:57.000Z",
+      };
+      const replacementState: ServerRuntimeState.PersistedServerRuntimeState = {
+        version: 1,
+        pid: 456,
+        port: 3_773,
+        origin: "http://127.0.0.1:3773",
+        startedAt: "2026-08-09T05:10:06.000Z",
+      };
+
+      yield* ServerRuntimeState.persistServerRuntimeState({
+        path: statePath,
+        state: stoppingState,
+      });
+      const racingFileSystem = {
+        ...fileSystem,
+        rename: (from: string, to: string) =>
+          from === statePath
+            ? fileSystem
+                .rename(from, to)
+                .pipe(
+                  Effect.andThen(
+                    fileSystem.writeFileString(statePath, `${JSON.stringify(replacementState)}\n`),
+                  ),
+                )
+            : fileSystem.rename(from, to),
+      } satisfies FileSystem.FileSystem;
+
+      yield* ServerRuntimeState.clearPersistedServerRuntimeStateIfOwned({
+        path: statePath,
+        state: stoppingState,
+      }).pipe(Effect.provideService(FileSystem.FileSystem, racingFileSystem));
+
+      const preserved = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+      assert.deepEqual(Option.getOrThrow(preserved), replacementState);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("preserves malformed state decode failures", () => {
     const logs: CapturedLog[] = [];
     const logger = Logger.make(({ fiber, message }) => {

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -155,3 +155,20 @@ export const readPersistedServerRuntimeState = (path: string) =>
         ),
     }),
   );
+
+export const clearPersistedServerRuntimeStateIfOwned = (input: {
+  readonly path: string;
+  readonly state: Pick<PersistedServerRuntimeState, "pid" | "startedAt">;
+}) =>
+  Effect.gen(function* () {
+    const current = yield* readPersistedServerRuntimeState(input.path);
+    if (
+      Option.isNone(current) ||
+      current.value.pid !== input.state.pid ||
+      current.value.startedAt !== input.state.startedAt
+    ) {
+      return;
+    }
+
+    yield* clearPersistedServerRuntimeState(input.path);
+  });

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -2,6 +2,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as PlatformError from "effect/PlatformError";
 import * as Random from "effect/Random";
 import * as Schema from "effect/Schema";
 
@@ -160,24 +161,25 @@ export const readPersistedServerRuntimeState = (path: string) =>
 export const clearPersistedServerRuntimeStateIfOwned = (input: {
   readonly path: string;
   readonly state: Pick<PersistedServerRuntimeState, "pid" | "startedAt">;
-}) =>
+}): Effect.Effect<void, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const nonce = yield* Random.nextInt;
     const capturedPath = `${input.path}.clearing-${process.pid}-${nonce.toString(36)}`;
     const captured = yield* fs.rename(input.path, capturedPath).pipe(
       Effect.as(true),
-      Effect.catchTag("PlatformError", (cause) =>
-        cause.reason._tag === "NotFound"
-          ? Effect.succeed(false)
-          : Effect.fail(
-              new ServerRuntimeStateError({
-                operation: "clear",
-                statePath: input.path,
-                cause,
-              }),
-            ),
-      ),
+      Effect.catchTags({
+        PlatformError: (cause) =>
+          cause.reason._tag === "NotFound"
+            ? Effect.succeed(false)
+            : Effect.fail(
+                new ServerRuntimeStateError({
+                  operation: "clear",
+                  statePath: input.path,
+                  cause,
+                }),
+              ),
+      }),
     );
     if (!captured) {
       return;
@@ -190,18 +192,54 @@ export const clearPersistedServerRuntimeStateIfOwned = (input: {
       current.value.startedAt === input.state.startedAt;
 
     if (!ownsCapturedState) {
-      yield* fs.link(capturedPath, input.path).pipe(
-        Effect.catchTag("PlatformError", (cause) =>
-          cause.reason._tag === "AlreadyExists"
-            ? Effect.void
-            : Effect.fail(
-                new ServerRuntimeStateError({
-                  operation: "clear",
-                  statePath: input.path,
-                  cause,
+      const restoreCapturedState = (
+        linkCause: PlatformError.PlatformError,
+      ): Effect.Effect<void, ServerRuntimeStateError> =>
+        fs.readFileString(capturedPath).pipe(
+          Effect.mapError(
+            (restoreCause) =>
+              new ServerRuntimeStateError({
+                operation: "clear",
+                statePath: input.path,
+                cause: { linkCause, restoreCause },
+              }),
+          ),
+          Effect.flatMap((contents) =>
+            fs
+              .writeFileString(input.path, contents, {
+                flag: "wx",
+                mode: 0o600,
+              })
+              .pipe(
+                Effect.catchTags({
+                  PlatformError: (restoreCause) =>
+                    restoreCause.reason._tag === "AlreadyExists"
+                      ? Effect.void
+                      : Effect.fail(
+                          new ServerRuntimeStateError({
+                            operation: "clear",
+                            statePath: input.path,
+                            cause: { linkCause, restoreCause },
+                          }),
+                        ),
                 }),
               ),
-        ),
+          ),
+        );
+
+      yield* fs.link(capturedPath, input.path).pipe(
+        Effect.catchTags({
+          PlatformError: (linkCause) => {
+            if (linkCause.reason._tag === "AlreadyExists") {
+              return Effect.void;
+            }
+            // Some filesystems do not support hard links. Preserve the same
+            // no-clobber contract with an exclusive create so a concurrent
+            // replacement writer always wins. The captured file stays in
+            // place unless this durable fallback completes.
+            return restoreCapturedState(linkCause);
+          },
+        }),
       );
     }
 
@@ -216,13 +254,14 @@ export const clearPersistedServerRuntimeStateIfOwned = (input: {
       ),
     );
   }).pipe(
-    Effect.catchTag("ServerRuntimeStateError", (error) =>
-      Effect.logWarning(error.message).pipe(
-        Effect.annotateLogs({
-          operation: error.operation,
-          statePath: error.statePath,
-          cause: error,
-        }),
-      ),
-    ),
+    Effect.catchTags({
+      ServerRuntimeStateError: (error) =>
+        Effect.logWarning(error.message).pipe(
+          Effect.annotateLogs({
+            operation: error.operation,
+            statePath: error.statePath,
+            cause: error,
+          }),
+        ),
+    }),
   );

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -2,6 +2,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Random from "effect/Random";
 import * as Schema from "effect/Schema";
 
 import { writeFileStringAtomically } from "./atomicWrite.ts";
@@ -161,14 +162,67 @@ export const clearPersistedServerRuntimeStateIfOwned = (input: {
   readonly state: Pick<PersistedServerRuntimeState, "pid" | "startedAt">;
 }) =>
   Effect.gen(function* () {
-    const current = yield* readPersistedServerRuntimeState(input.path);
-    if (
-      Option.isNone(current) ||
-      current.value.pid !== input.state.pid ||
-      current.value.startedAt !== input.state.startedAt
-    ) {
+    const fs = yield* FileSystem.FileSystem;
+    const nonce = yield* Random.nextInt;
+    const capturedPath = `${input.path}.clearing-${process.pid}-${nonce.toString(36)}`;
+    const captured = yield* fs.rename(input.path, capturedPath).pipe(
+      Effect.as(true),
+      Effect.catchTag("PlatformError", (cause) =>
+        cause.reason._tag === "NotFound"
+          ? Effect.succeed(false)
+          : Effect.fail(
+              new ServerRuntimeStateError({
+                operation: "clear",
+                statePath: input.path,
+                cause,
+              }),
+            ),
+      ),
+    );
+    if (!captured) {
       return;
     }
 
-    yield* clearPersistedServerRuntimeState(input.path);
-  });
+    const current = yield* readPersistedServerRuntimeState(capturedPath);
+    const ownsCapturedState =
+      Option.isSome(current) &&
+      current.value.pid === input.state.pid &&
+      current.value.startedAt === input.state.startedAt;
+
+    if (!ownsCapturedState) {
+      yield* fs.link(capturedPath, input.path).pipe(
+        Effect.catchTag("PlatformError", (cause) =>
+          cause.reason._tag === "AlreadyExists"
+            ? Effect.void
+            : Effect.fail(
+                new ServerRuntimeStateError({
+                  operation: "clear",
+                  statePath: input.path,
+                  cause,
+                }),
+              ),
+        ),
+      );
+    }
+
+    yield* fs.remove(capturedPath, { force: true }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ServerRuntimeStateError({
+            operation: "clear",
+            statePath: input.path,
+            cause,
+          }),
+      ),
+    );
+  }).pipe(
+    Effect.catchTag("ServerRuntimeStateError", (error) =>
+      Effect.logWarning(error.message).pipe(
+        Effect.annotateLogs({
+          operation: error.operation,
+          statePath: error.statePath,
+          cause: error,
+        }),
+      ),
+    ),
+  );

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -140,6 +140,8 @@ SSH launch is a desktop feature because it needs local process and SSH access. O
 
 The desktop SSH launcher connects with a non-interactive `sh` session, writes a small launcher script under `~/.t3/ssh-launch/<host-key>/`, starts or reuses a remote T3 server, and forwards the remote loopback port back to your desktop.
 
+When the launcher discovers a server that is already managed by the remote host, it records that server as externally owned and only reconnects to it. A brief service restart can make an SSH connection attempt fail, but the launcher will not start a competing server. Disconnect the SSH environment before reconnecting if you intentionally want the desktop app to take ownership instead.
+
 The remote host must have a compatible Node.js runtime. T3 Code uses the server package's `engines.node` requirement:
 
 ```text

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -1,10 +1,14 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import { HostProcessExecutablePath, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as NetService from "@t3tools/shared/Net";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Result from "effect/Result";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
@@ -202,9 +206,12 @@ describe("ssh tunnel scripts", () => {
     );
     assert.include(buildRemoteLaunchScript(), 'PID_TO_STOP="${REMOTE_PID:-$DEFAULT_RUNTIME_PID}"');
     assert.include(buildRemoteLaunchScript(), 'REMOTE_PORT="$DEFAULT_REMOTE_PORT"');
+    assert.include(buildRemoteLaunchScript(), "DEFAULT_RUNTIME_IS_MANAGED=1");
+    assert.include(buildRemoteLaunchScript(), '[ "$DEFAULT_RUNTIME_IS_MANAGED" -eq 0 ]');
     assert.include(buildRemoteLaunchScript(), 'rm -f "$PID_FILE"');
     assert.include(buildRemoteLaunchScript(), "printf 'external\\n' >\"$MANAGED_FILE\"");
     assert.include(buildRemoteLaunchScript(), 'if [ -z "$REMOTE_PORT" ]; then');
+    assert.include(buildRemoteLaunchScript(), "refusing to replace it with a managed SSH server");
     assert.isBelow(
       buildRemoteLaunchScript().indexOf('if [ "$REMOTE_MANAGED" = "managed" ]'),
       buildRemoteLaunchScript().indexOf("printf 'external\\n' >\"$MANAGED_FILE\""),
@@ -214,6 +221,85 @@ describe("ssh tunnel scripts", () => {
       buildRemoteLaunchScript().indexOf('elif [ -n "$REMOTE_PID" ]'),
     );
   });
+
+  it.effect("reuses its own managed runtime without replacing it", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        if ((yield* HostProcessPlatform) === "win32") return;
+
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const executablePath = yield* HostProcessExecutablePath;
+        const home = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-ssh-launch-test-",
+        });
+        const stateKey = "managed-runtime";
+        const stateDir = path.join(home, ".t3", "ssh-launch", stateKey);
+        const runtimeDir = path.join(home, ".t3", "userdata");
+        const server = yield* spawner.spawn(
+          ChildProcess.make(
+            executablePath,
+            [
+              "-e",
+              `const http = require("node:http");
+const server = http.createServer((_request, response) => {
+  response.writeHead(200);
+  response.end("ok");
+});
+server.listen(0, "127.0.0.1", () => process.stdout.write(String(server.address().port) + "\\n"));`,
+            ],
+            { detached: false },
+          ),
+        );
+        yield* Effect.addFinalizer(() => server.kill().pipe(Effect.catchCause(() => Effect.void)));
+
+        const portLine = yield* server.stdout.pipe(
+          Stream.decodeText(),
+          Stream.splitLines,
+          Stream.runHead,
+        );
+        const port = Number.parseInt(Option.getOrThrow(portLine), 10);
+        assert.isTrue(Number.isInteger(port));
+
+        yield* fileSystem.makeDirectory(stateDir, { recursive: true });
+        yield* fileSystem.makeDirectory(runtimeDir, { recursive: true });
+        yield* fileSystem.writeFileString(path.join(stateDir, "managed"), "managed\n");
+        yield* fileSystem.writeFileString(path.join(stateDir, "pid"), `${server.pid}\n`);
+        yield* fileSystem.writeFileString(path.join(stateDir, "port"), `${port}\n`);
+        yield* fileSystem.writeFileString(
+          path.join(stateDir, "run-t3.sh"),
+          `${buildRemoteT3RunnerScript()}\n`,
+        );
+        yield* fileSystem.writeFileString(
+          path.join(runtimeDir, "server-runtime.json"),
+          `{"version":1,"pid":${server.pid},"port":${port},"origin":"http://127.0.0.1:${port}","startedAt":"2026-08-08T18:42:26.000Z"}\n`,
+        );
+
+        const shell = yield* spawner.spawn(
+          ChildProcess.make("sh", ["-s", "--", stateKey], {
+            detached: false,
+            env: { HOME: home },
+            extendEnv: true,
+            stdin: Stream.make(new TextEncoder().encode(buildRemoteLaunchScript())),
+          }),
+        );
+        const [stdout, stderr, exitCode] = yield* Effect.all(
+          [
+            Stream.mkString(Stream.decodeText(shell.stdout)),
+            Stream.mkString(Stream.decodeText(shell.stderr)),
+            shell.exitCode,
+          ],
+          { concurrency: "unbounded" },
+        );
+
+        assert.equal(exitCode, 0, stderr);
+        assert.include(stdout, `{"remotePort":${port},"serverKind":"managed"}`);
+        assert.isTrue(yield* server.isRunning);
+        assert.equal(yield* fileSystem.readFileString(path.join(stateDir, "managed")), "managed\n");
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
 
   it.effect("accepts launch JSON after remote shell startup noise", () => {
     const target = {

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -301,6 +301,194 @@ server.listen(0, "127.0.0.1", () => process.stdout.write(String(server.address()
     ),
   );
 
+  it.effect("reuses an externally owned runtime even when the SSH runner changed", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        if ((yield* HostProcessPlatform) === "win32") return;
+
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const executablePath = yield* HostProcessExecutablePath;
+        const home = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-ssh-external-runtime-test-",
+        });
+        const stateKey = "external-runtime";
+        const stateDir = path.join(home, ".t3", "ssh-launch", stateKey);
+        const runtimeDir = path.join(home, ".t3", "userdata");
+        const externalServer = yield* spawner.spawn(
+          ChildProcess.make(
+            executablePath,
+            [
+              "-e",
+              `const http = require("node:http");
+const server = http.createServer((_request, response) => {
+  response.writeHead(200);
+  response.end("ok");
+});
+server.listen(0, "127.0.0.1", () => process.stdout.write(String(server.address().port) + "\\n"));`,
+            ],
+            { detached: false },
+          ),
+        );
+        yield* Effect.addFinalizer(() =>
+          externalServer.kill().pipe(Effect.catchCause(() => Effect.void)),
+        );
+
+        const portLine = yield* externalServer.stdout.pipe(
+          Stream.decodeText(),
+          Stream.splitLines,
+          Stream.runHead,
+        );
+        const port = Number.parseInt(Option.getOrThrow(portLine), 10);
+        assert.isTrue(Number.isInteger(port));
+
+        yield* fileSystem.makeDirectory(stateDir, { recursive: true });
+        yield* fileSystem.makeDirectory(runtimeDir, { recursive: true });
+        yield* fileSystem.writeFileString(
+          path.join(stateDir, "run-t3.sh"),
+          "#!/bin/sh\n# deliberately stale runner\n",
+        );
+        yield* fileSystem.writeFileString(
+          path.join(runtimeDir, "server-runtime.json"),
+          `{"version":1,"pid":${externalServer.pid},"port":${port},"origin":"http://127.0.0.1:${port}","startedAt":"2026-08-09T05:10:06.000Z"}\n`,
+        );
+
+        const shell = yield* spawner.spawn(
+          ChildProcess.make("sh", ["-s", "--", stateKey], {
+            detached: false,
+            env: { HOME: home },
+            extendEnv: true,
+            stdin: Stream.make(new TextEncoder().encode(buildRemoteLaunchScript())),
+          }),
+        );
+        const [stdout, stderr, exitCode] = yield* Effect.all(
+          [
+            Stream.mkString(Stream.decodeText(shell.stdout)),
+            Stream.mkString(Stream.decodeText(shell.stderr)),
+            shell.exitCode,
+          ],
+          { concurrency: "unbounded" },
+        );
+
+        assert.equal(exitCode, 0, stderr);
+        assert.include(stdout, `{"remotePort":${port},"serverKind":"external"}`);
+        assert.isTrue(yield* externalServer.isRunning);
+        assert.equal(
+          yield* fileSystem.readFileString(path.join(stateDir, "managed")),
+          "external\n",
+        );
+        assert.equal(yield* fileSystem.readFileString(path.join(stateDir, "port")), `${port}\n`);
+        assert.isFalse(yield* fileSystem.exists(path.join(stateDir, "pid")));
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+
+  it.effect("converges a competing managed runtime onto the external owner", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        if ((yield* HostProcessPlatform) === "win32") return;
+
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const executablePath = yield* HostProcessExecutablePath;
+        const home = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-ssh-owner-convergence-test-",
+        });
+        const stateKey = "owner-convergence";
+        const stateDir = path.join(home, ".t3", "ssh-launch", stateKey);
+        const runtimeDir = path.join(home, ".t3", "userdata");
+
+        const startServer = () =>
+          spawner.spawn(
+            ChildProcess.make(
+              executablePath,
+              [
+                "-e",
+                `const http = require("node:http");
+const server = http.createServer((_request, response) => {
+  response.writeHead(200);
+  response.end("ok");
+});
+server.listen(0, "127.0.0.1", () => process.stdout.write(String(server.address().port) + "\\n"));`,
+              ],
+              { detached: false },
+            ),
+          );
+        const managedServer = yield* startServer();
+        const externalServer = yield* startServer();
+        yield* Effect.addFinalizer(() =>
+          managedServer.kill().pipe(Effect.catchCause(() => Effect.void)),
+        );
+        yield* Effect.addFinalizer(() =>
+          externalServer.kill().pipe(Effect.catchCause(() => Effect.void)),
+        );
+
+        const managedPortLine = yield* managedServer.stdout.pipe(
+          Stream.decodeText(),
+          Stream.splitLines,
+          Stream.runHead,
+        );
+        const externalPortLine = yield* externalServer.stdout.pipe(
+          Stream.decodeText(),
+          Stream.splitLines,
+          Stream.runHead,
+        );
+        const managedPort = Number.parseInt(Option.getOrThrow(managedPortLine), 10);
+        const externalPort = Number.parseInt(Option.getOrThrow(externalPortLine), 10);
+        assert.isTrue(Number.isInteger(managedPort));
+        assert.isTrue(Number.isInteger(externalPort));
+        assert.notEqual(managedPort, externalPort);
+
+        yield* fileSystem.makeDirectory(stateDir, { recursive: true });
+        yield* fileSystem.makeDirectory(runtimeDir, { recursive: true });
+        yield* fileSystem.writeFileString(path.join(stateDir, "managed"), "managed\n");
+        yield* fileSystem.writeFileString(path.join(stateDir, "pid"), `${managedServer.pid}\n`);
+        yield* fileSystem.writeFileString(path.join(stateDir, "port"), `${managedPort}\n`);
+        yield* fileSystem.writeFileString(
+          path.join(stateDir, "run-t3.sh"),
+          `${buildRemoteT3RunnerScript()}\n`,
+        );
+        yield* fileSystem.writeFileString(
+          path.join(runtimeDir, "server-runtime.json"),
+          `{"version":1,"pid":${externalServer.pid},"port":${externalPort},"origin":"http://127.0.0.1:${externalPort}","startedAt":"2026-08-09T05:10:06.000Z"}\n`,
+        );
+
+        const shell = yield* spawner.spawn(
+          ChildProcess.make("sh", ["-s", "--", stateKey], {
+            detached: false,
+            env: { HOME: home },
+            extendEnv: true,
+            stdin: Stream.make(new TextEncoder().encode(buildRemoteLaunchScript())),
+          }),
+        );
+        const [stdout, stderr, exitCode] = yield* Effect.all(
+          [
+            Stream.mkString(Stream.decodeText(shell.stdout)),
+            Stream.mkString(Stream.decodeText(shell.stderr)),
+            shell.exitCode,
+          ],
+          { concurrency: "unbounded" },
+        );
+
+        assert.equal(exitCode, 0, stderr);
+        assert.include(stdout, `{"remotePort":${externalPort},"serverKind":"external"}`);
+        assert.isFalse(yield* managedServer.isRunning);
+        assert.isTrue(yield* externalServer.isRunning);
+        assert.equal(
+          yield* fileSystem.readFileString(path.join(stateDir, "managed")),
+          "external\n",
+        );
+        assert.equal(
+          yield* fileSystem.readFileString(path.join(stateDir, "port")),
+          `${externalPort}\n`,
+        );
+        assert.isFalse(yield* fileSystem.exists(path.join(stateDir, "pid")));
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+
   it.effect("accepts launch JSON after remote shell startup noise", () => {
     const target = {
       alias: "devbox",

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -204,7 +204,12 @@ describe("ssh tunnel scripts", () => {
       buildRemoteLaunchScript(),
       "if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(port))",
     );
-    assert.include(buildRemoteLaunchScript(), 'PID_TO_STOP="${REMOTE_PID:-$DEFAULT_RUNTIME_PID}"');
+    assert.include(buildRemoteLaunchScript(), '[ "$DEFAULT_RUNTIME_PID" = "$REMOTE_PID" ]');
+    assert.include(
+      buildRemoteLaunchScript(),
+      '[ "$PREVIOUS_REMOTE_PORT" != "$DEFAULT_REMOTE_PORT" ]',
+    );
+    assert.notInclude(buildRemoteLaunchScript(), "PID_TO_STOP");
     assert.include(buildRemoteLaunchScript(), 'REMOTE_PORT="$DEFAULT_REMOTE_PORT"');
     assert.include(buildRemoteLaunchScript(), "DEFAULT_RUNTIME_IS_MANAGED=1");
     assert.include(buildRemoteLaunchScript(), '[ "$DEFAULT_RUNTIME_IS_MANAGED" -eq 0 ]');
@@ -483,6 +488,101 @@ server.listen(0, "127.0.0.1", () => process.stdout.write(String(server.address()
         assert.equal(
           yield* fileSystem.readFileString(path.join(stateDir, "port")),
           `${externalPort}\n`,
+        );
+        assert.isFalse(yield* fileSystem.exists(path.join(stateDir, "pid")));
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+
+  it.effect("does not adopt or signal a reused managed PID on the external runtime port", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        if ((yield* HostProcessPlatform) === "win32") return;
+
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const executablePath = yield* HostProcessExecutablePath;
+        const home = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-ssh-pid-reuse-test-",
+        });
+        const stateKey = "pid-reuse";
+        const stateDir = path.join(home, ".t3", "ssh-launch", stateKey);
+        const runtimeDir = path.join(home, ".t3", "userdata");
+
+        const externalServer = yield* spawner.spawn(
+          ChildProcess.make(
+            executablePath,
+            [
+              "-e",
+              `const http = require("node:http");
+const server = http.createServer((_request, response) => {
+  response.writeHead(200);
+  response.end("ok");
+});
+server.listen(0, "127.0.0.1", () => process.stdout.write(String(server.address().port) + "\\n"));`,
+            ],
+            { detached: false },
+          ),
+        );
+        const unrelatedProcess = yield* spawner.spawn(
+          ChildProcess.make(executablePath, ["-e", "setInterval(() => {}, 1_000)"], {
+            detached: false,
+          }),
+        );
+        yield* Effect.addFinalizer(() =>
+          externalServer.kill().pipe(Effect.catchCause(() => Effect.void)),
+        );
+        yield* Effect.addFinalizer(() =>
+          unrelatedProcess.kill().pipe(Effect.catchCause(() => Effect.void)),
+        );
+
+        const portLine = yield* externalServer.stdout.pipe(
+          Stream.decodeText(),
+          Stream.splitLines,
+          Stream.runHead,
+        );
+        const port = Number.parseInt(Option.getOrThrow(portLine), 10);
+        assert.isTrue(Number.isInteger(port));
+
+        yield* fileSystem.makeDirectory(stateDir, { recursive: true });
+        yield* fileSystem.makeDirectory(runtimeDir, { recursive: true });
+        yield* fileSystem.writeFileString(path.join(stateDir, "managed"), "managed\n");
+        yield* fileSystem.writeFileString(path.join(stateDir, "pid"), `${unrelatedProcess.pid}\n`);
+        yield* fileSystem.writeFileString(path.join(stateDir, "port"), `${port}\n`);
+        yield* fileSystem.writeFileString(
+          path.join(stateDir, "run-t3.sh"),
+          `${buildRemoteT3RunnerScript()}\n`,
+        );
+        yield* fileSystem.writeFileString(
+          path.join(runtimeDir, "server-runtime.json"),
+          `{"version":1,"pid":${externalServer.pid},"port":${port},"origin":"http://127.0.0.1:${port}","startedAt":"2026-08-09T05:10:06.000Z"}\n`,
+        );
+
+        const shell = yield* spawner.spawn(
+          ChildProcess.make("sh", ["-s", "--", stateKey], {
+            detached: false,
+            env: { HOME: home },
+            extendEnv: true,
+            stdin: Stream.make(new TextEncoder().encode(buildRemoteLaunchScript())),
+          }),
+        );
+        const [stdout, stderr, exitCode] = yield* Effect.all(
+          [
+            Stream.mkString(Stream.decodeText(shell.stdout)),
+            Stream.mkString(Stream.decodeText(shell.stderr)),
+            shell.exitCode,
+          ],
+          { concurrency: "unbounded" },
+        );
+
+        assert.equal(exitCode, 0, stderr);
+        assert.include(stdout, `{"remotePort":${port},"serverKind":"external"}`);
+        assert.isTrue(yield* externalServer.isRunning);
+        assert.isTrue(yield* unrelatedProcess.isRunning);
+        assert.equal(
+          yield* fileSystem.readFileString(path.join(stateDir, "managed")),
+          "external\n",
         );
         assert.isFalse(yield* fileSystem.exists(path.join(stateDir, "pid")));
       }).pipe(Effect.provide(NodeServices.layer)),

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -516,17 +516,17 @@ if [ -n "$DEFAULT_RUNTIME_INFO" ]; then
   DEFAULT_RUNTIME_PID="\${DEFAULT_RUNTIME_INFO%% *}"
   DEFAULT_REMOTE_PORT="\${DEFAULT_RUNTIME_INFO#* }"
 fi
-if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$REMOTE_PID" ] && [ -n "$REMOTE_PORT" ] && [ "$DEFAULT_REMOTE_PORT" = "$REMOTE_PORT" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
+if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$REMOTE_PID" ] && [ -n "$REMOTE_PORT" ] && [ -n "$DEFAULT_RUNTIME_PID" ] && [ "$DEFAULT_RUNTIME_PID" = "$REMOTE_PID" ] && [ "$DEFAULT_REMOTE_PORT" = "$REMOTE_PORT" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
   DEFAULT_RUNTIME_IS_MANAGED=1
 fi
 if [ -n "$DEFAULT_REMOTE_PORT" ] && [ "$DEFAULT_RUNTIME_IS_MANAGED" -eq 0 ]; then
+  PREVIOUS_REMOTE_PORT="$REMOTE_PORT"
   REMOTE_PORT="$DEFAULT_REMOTE_PORT"
   if wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
     if [ "$REMOTE_MANAGED" = "managed" ]; then
-      PID_TO_STOP="\${REMOTE_PID:-$DEFAULT_RUNTIME_PID}"
-      if [ -n "$PID_TO_STOP" ] && kill -0 "$PID_TO_STOP" 2>/dev/null; then
-        kill "$PID_TO_STOP" 2>/dev/null || true
-        wait_for_pid_exit "$PID_TO_STOP"
+      if [ -n "$REMOTE_PID" ] && [ -n "$PREVIOUS_REMOTE_PORT" ] && [ "$PREVIOUS_REMOTE_PORT" != "$DEFAULT_REMOTE_PORT" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
+        kill "$REMOTE_PID" 2>/dev/null || true
+        wait_for_pid_exit "$REMOTE_PID"
       fi
       REMOTE_PID=""
       REMOTE_PORT="$DEFAULT_REMOTE_PORT"

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -511,11 +511,15 @@ REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
 DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port 2>/dev/null || true)"
 DEFAULT_RUNTIME_PID=""
 DEFAULT_REMOTE_PORT=""
+DEFAULT_RUNTIME_IS_MANAGED=0
 if [ -n "$DEFAULT_RUNTIME_INFO" ]; then
   DEFAULT_RUNTIME_PID="\${DEFAULT_RUNTIME_INFO%% *}"
   DEFAULT_REMOTE_PORT="\${DEFAULT_RUNTIME_INFO#* }"
 fi
-if [ -n "$DEFAULT_REMOTE_PORT" ]; then
+if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$REMOTE_PID" ] && [ -n "$REMOTE_PORT" ] && [ "$DEFAULT_REMOTE_PORT" = "$REMOTE_PORT" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
+  DEFAULT_RUNTIME_IS_MANAGED=1
+fi
+if [ -n "$DEFAULT_REMOTE_PORT" ] && [ "$DEFAULT_RUNTIME_IS_MANAGED" -eq 0 ]; then
   REMOTE_PORT="$DEFAULT_REMOTE_PORT"
   if wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
     if [ "$REMOTE_MANAGED" = "managed" ]; then
@@ -543,10 +547,13 @@ if [ -n "$DEFAULT_REMOTE_PORT" ]; then
   fi
 fi
 if [ "$REMOTE_MANAGED" = "external" ]; then
-  if [ -z "$REMOTE_PORT" ] || ! wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
+  if [ -z "$REMOTE_PORT" ]; then
     REMOTE_PID=""
     REMOTE_PORT=""
     REMOTE_MANAGED=""
+  elif ! wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
+    printf 'External T3 server did not become ready on 127.0.0.1:%s; refusing to replace it with a managed SSH server. Disconnect the SSH environment to clear external ownership.\\n' "$REMOTE_PORT" >&2
+    exit 1
   fi
 elif [ -n "$REMOTE_PID" ] && [ -n "$REMOTE_PORT" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
   if [ "$RUNNER_CHANGED" -eq 1 ]; then


### PR DESCRIPTION
Closes #5749.

## What changed

- Distinguish the SSH launcher's own managed runtime record from an externally owned T3 service.
- Adopt a healthy external service without first stopping it.
- Keep external ownership during a transient service restart instead of launching a competing server.
- Clear `server-runtime.json` only when the shutting-down process still owns that exact PID/start-time record.
- Document the persistent-host ownership contract.

## Why

Two T3 servers and two relay tunnels sharing one base directory make reconnect behavior nondeterministic: HTTP requests and WebSockets can reach different processes. This keeps the supported persistent service as the single owner.

## Verification

- `packages/ssh/src/tunnel.test.ts`
- `apps/server/src/serverRuntimeState.test.ts`
- Focused combined reliability suite: 82/82 passing
- Server typecheck passing
- Production server bundle build passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SSH launch and persisted runtime discovery on shutdown, including atomic rename/restore races; wrong behavior could leave no server or duplicate servers on one data dir.
> 
> **Overview**
> Keeps a single T3 server owner when SSH reconnects to a host that already runs a persistent service, and stops shutdown from wiping a replacement process’s `server-runtime.json`.
> 
> **SSH remote launch** now treats `server-runtime.json` as the source of truth for an **externally owned** runtime: it reconnects without stopping that process, marks SSH state as `external`, and only tears down a prior **managed** SSH-launched PID when the default runtime port changed. If external ownership is recorded but the server is not ready, launch **fails** instead of starting a competing managed server. Competing managed state converges onto the external owner (including PID-reuse edge cases).
> 
> **Server shutdown** persists runtime state on startup and, on release, calls **`clearPersistedServerRuntimeStateIfOwned`** with that snapshot so only the matching `pid` + `startedAt` record is removed; mismatches are restored via rename/link (with a no-hard-link fallback). Docs note that SSH will not take ownership while an external service is active.
> 
> Tests cover ownership clearing, rename races, link fallback, and end-to-end SSH launch script behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b6923bf00fdc07d92175a7f16b2ea6ca3e6449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve external SSH runtime ownership on server shutdown and reconnect
> - Replaces the unconditional `clearPersistedServerRuntimeState` call with `clearPersistedServerRuntimeStateIfOwned`, which atomically renames the state file and only deletes it if the current process's `pid` and `startedAt` match the captured file.
> - If the state is owned by another process, the original file is restored via hard link or exclusive-write fallback to avoid clobbering a replacement written during a race.
> - The SSH launch script in [`tunnel.ts`](https://github.com/pingdotgg/t3code/pull/5751/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072) now detects externally owned runtimes, reuses them without replacement, avoids killing unrelated processes on port switch, and exits fast with an explanatory message if the external server is not ready.
> - Behavioral Change: servers that did not previously own their runtime state will no longer clear it on shutdown; the SSH launcher will refuse to start a competing server when an external owner is detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19b6923.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->