### PR TITLE
fix(web): usage page loses the cost quality panel, gains a back button

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,5 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
-import { RefreshCwIcon } from "lucide-react";
+import { useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router";
+import { ArrowLeftIcon, RefreshCwIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { cn } from "../../lib/utils";
@@ -27,6 +28,9 @@ export function UsagePage() {
   const [windowDays, setWindowDays] = useState<number>(30);
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
   const [breakdown, setBreakdown] = useState<"model" | "day">("model");
+  const canGoBack = useCanGoBack();
+  const navigate = useNavigate();
+  const router = useRouter();
 
   // Recomputed only when the window length changes, so a re-render does not
   // shift the range and refetch every environment.
@@ -57,11 +61,27 @@ export function UsagePage() {
     <ScrollArea className="h-full">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-6">
         <header className="flex flex-wrap items-start justify-between gap-4">
-          <div className="flex flex-col gap-1">
-            <h1 className="text-2xl font-semibold text-foreground">Usage</h1>
-            <p className="text-sm text-muted-foreground">
-              {formatDayShort(window.sinceDay)} to {formatDayShort(window.untilDay)}
-            </p>
+          <div className="flex items-start gap-3">
+            <button
+              type="button"
+              aria-label="Back"
+              onClick={() => {
+                if (canGoBack) {
+                  router.history.back();
+                  return;
+                }
+                void navigate({ to: "/" });
+              }}
+              className="mt-1 cursor-pointer rounded-md border border-border p-2 text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeftIcon className="size-3.5" />
+            </button>
+            <div className="flex flex-col gap-1">
+              <h1 className="text-2xl font-semibold text-foreground">Usage</h1>
+              <p className="text-sm text-muted-foreground">
+                {formatDayShort(window.sinceDay)} to {formatDayShort(window.untilDay)}
+              </p>
+            </div>
           </div>
           <div className="flex items-center gap-2">
             <div className="flex overflow-hidden rounded-md border border-border">
@@ -222,140 +242,116 @@ export function UsagePage() {
               />
             </section>
 
-            <section className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,18rem)]">
-              <div className="flex flex-col gap-3">
-                <div className="flex items-center justify-between gap-3">
-                  <h2 className="text-sm font-medium text-foreground">Breakdown</h2>
-                  <div className="flex overflow-hidden rounded-md border border-border">
-                    {(["model", "day"] as const).map((option) => (
-                      <button
-                        key={option}
-                        type="button"
-                        onClick={() => setBreakdown(option)}
-                        className={cn(
-                          "cursor-pointer px-2.5 py-1 text-[10px] tracking-wide uppercase",
-                          option === breakdown
-                            ? "bg-muted text-foreground"
-                            : "text-muted-foreground hover:text-foreground",
-                        )}
-                      >
-                        {option}
-                      </button>
-                    ))}
-                  </div>
+            <section className="flex flex-col gap-3">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-sm font-medium text-foreground">Breakdown</h2>
+                <div className="flex overflow-hidden rounded-md border border-border">
+                  {(["model", "day"] as const).map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      onClick={() => setBreakdown(option)}
+                      className={cn(
+                        "cursor-pointer px-2.5 py-1 text-[10px] tracking-wide uppercase",
+                        option === breakdown
+                          ? "bg-muted text-foreground"
+                          : "text-muted-foreground hover:text-foreground",
+                      )}
+                    >
+                      {option}
+                    </button>
+                  ))}
                 </div>
-
-                {breakdown === "model" ? (
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-border text-left text-xs text-muted-foreground">
-                        <th className="py-2 font-normal">Model</th>
-                        <th className="py-2 text-right font-normal">Cost</th>
-                        <th className="py-2 text-right font-normal">Share</th>
-                        <th className="py-2 text-right font-normal">Tokens</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {merged.models.length === 0 ? (
-                        <tr>
-                          <td colSpan={4} className="py-6 text-center text-muted-foreground">
-                            No activity in this window.
-                          </td>
-                        </tr>
-                      ) : (
-                        merged.models.map((model) => (
-                          <tr
-                            key={`${model.provider}:${model.model}`}
-                            className="border-b border-border/50"
-                          >
-                            <td className="py-2 text-foreground">
-                              <span className="flex items-center gap-2">
-                                <ProviderMark provider={model.provider} className="size-3.5" />
-                                {model.model}
-                              </span>
-                            </td>
-                            <td className="py-2 text-right text-foreground tabular-nums">
-                              {formatUsd(model.costUsd)}
-                            </td>
-                            <td className="py-2 text-right text-muted-foreground tabular-nums">
-                              {formatPercent(model.costShare)}
-                            </td>
-                            <td className="py-2 text-right text-muted-foreground tabular-nums">
-                              {formatTokens(model.totalTokens)}
-                            </td>
-                          </tr>
-                        ))
-                      )}
-                    </tbody>
-                  </table>
-                ) : (
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-border text-left text-xs text-muted-foreground">
-                        <th className="py-2 font-normal">Day</th>
-                        {PROVIDER_ORDER.map((provider) => (
-                          <th key={provider} className="py-2 text-right font-normal">
-                            {PROVIDER_LABEL[provider]}
-                          </th>
-                        ))}
-                        <th className="py-2 text-right font-normal">Total</th>
-                        <th className="py-2 text-right font-normal">Tokens</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {recentDays.length === 0 ? (
-                        <tr>
-                          <td colSpan={5} className="py-6 text-center text-muted-foreground">
-                            No activity in this window.
-                          </td>
-                        </tr>
-                      ) : (
-                        recentDays.map((day) => (
-                          <tr key={day.day} className="border-b border-border/50">
-                            <td className="py-2 text-foreground">{formatDayShort(day.day)}</td>
-                            {PROVIDER_ORDER.map((provider) => (
-                              <td
-                                key={provider}
-                                className="py-2 text-right text-muted-foreground tabular-nums"
-                              >
-                                {formatUsd(day.byProvider.get(provider)?.costUsd ?? 0)}
-                              </td>
-                            ))}
-                            <td className="py-2 text-right text-foreground tabular-nums">
-                              {formatUsd(day.costUsd)}
-                            </td>
-                            <td className="py-2 text-right text-muted-foreground tabular-nums">
-                              {formatTokens(day.totalTokens)}
-                            </td>
-                          </tr>
-                        ))
-                      )}
-                    </tbody>
-                  </table>
-                )}
               </div>
 
-              <div className="flex flex-col gap-3">
-                <h2 className="text-sm font-medium text-foreground">Cost quality</h2>
-                <dl className="flex flex-col">
-                  <QualityRow
-                    label="Provider reported"
-                    value={formatPercent(merged.costQuality.providerReportedShare)}
-                  />
-                  <QualityRow
-                    label="Model priced"
-                    value={formatPercent(merged.costQuality.modelPricedShare)}
-                  />
-                  <QualityRow
-                    label="Unpriced"
-                    value={formatPercent(merged.costQuality.unpricedShare)}
-                  />
-                  <QualityRow
-                    label="Cache savings"
-                    value={formatUsd(merged.costQuality.cacheSavingsUsd)}
-                  />
-                </dl>
-              </div>
+              {breakdown === "model" ? (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                      <th className="py-2 font-normal">Model</th>
+                      <th className="py-2 text-right font-normal">Cost</th>
+                      <th className="py-2 text-right font-normal">Share</th>
+                      <th className="py-2 text-right font-normal">Tokens</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {merged.models.length === 0 ? (
+                      <tr>
+                        <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                          No activity in this window.
+                        </td>
+                      </tr>
+                    ) : (
+                      merged.models.map((model) => (
+                        <tr
+                          key={`${model.provider}:${model.model}`}
+                          className="border-b border-border/50"
+                        >
+                          <td className="py-2 text-foreground">
+                            <span className="flex items-center gap-2">
+                              <ProviderMark provider={model.provider} className="size-3.5" />
+                              {model.model}
+                            </span>
+                          </td>
+                          <td className="py-2 text-right text-foreground tabular-nums">
+                            {formatUsd(model.costUsd)}
+                          </td>
+                          <td className="py-2 text-right text-muted-foreground tabular-nums">
+                            {formatPercent(model.costShare)}
+                          </td>
+                          <td className="py-2 text-right text-muted-foreground tabular-nums">
+                            {formatTokens(model.totalTokens)}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                      <th className="py-2 font-normal">Day</th>
+                      {PROVIDER_ORDER.map((provider) => (
+                        <th key={provider} className="py-2 text-right font-normal">
+                          {PROVIDER_LABEL[provider]}
+                        </th>
+                      ))}
+                      <th className="py-2 text-right font-normal">Total</th>
+                      <th className="py-2 text-right font-normal">Tokens</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {recentDays.length === 0 ? (
+                      <tr>
+                        <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                          No activity in this window.
+                        </td>
+                      </tr>
+                    ) : (
+                      recentDays.map((day) => (
+                        <tr key={day.day} className="border-b border-border/50">
+                          <td className="py-2 text-foreground">{formatDayShort(day.day)}</td>
+                          {PROVIDER_ORDER.map((provider) => (
+                            <td
+                              key={provider}
+                              className="py-2 text-right text-muted-foreground tabular-nums"
+                            >
+                              {formatUsd(day.byProvider.get(provider)?.costUsd ?? 0)}
+                            </td>
+                          ))}
+                          <td className="py-2 text-right text-foreground tabular-nums">
+                            {formatUsd(day.costUsd)}
+                          </td>
+                          <td className="py-2 text-right text-muted-foreground tabular-nums">
+                            {formatTokens(day.totalTokens)}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              )}
             </section>
           </>
         )}
@@ -390,15 +386,6 @@ function Metric({
       <span className="text-xs text-muted-foreground">{label}</span>
       <span className="text-lg text-foreground tabular-nums">{value}</span>
       <span className="text-xs text-muted-foreground">{detail}</span>
-    </div>
-  );
-}
-
-function QualityRow({ label, value }: { readonly label: string; readonly value: string }) {
-  return (
-    <div className="flex items-center justify-between border-b border-border/50 py-2 text-sm">
-      <dt className="text-muted-foreground">{label}</dt>
-      <dd className="text-foreground tabular-nums">{value}</dd>
     </div>
   );
 }


### PR DESCRIPTION
The new usage page had a "Cost quality" side panel squeezing the breakdown table into a partial-width column. The panel was noise, so it is gone and the breakdown now takes the full width. The page also had no way to navigate back, so there is now a back button in the top left (history back, falls back to `/`).

Note: the "Cache savings" tile in the metrics strip still reads from the same cost-quality data. It is part of a different section and was kept.

---
Change made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and navigation changes on the usage page with no API or data pipeline impact.
> 
> **Overview**
> The **Usage** page header now includes a **Back** control that uses browser history when available, otherwise navigates to `/`.
> 
> The breakdown section is **full width** again: the right-hand **Cost quality** sidebar (provider reported / model priced / unpriced shares plus the `QualityRow` helper) is removed. The **Cache savings** metric in the top stats strip is unchanged and still surfaces cache savings from the same underlying data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4268ebbe040f344588b55e54df1741cc46452a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove cost quality sidebar and add back button to usage page
> - Removes the `QualityRow` component and the right-hand "Cost quality" sidebar from [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/5756/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead), replacing the two-column breakdown layout with a single-column flex layout.
> - Adds a back button to the page header using TanStack Router; it calls `router.history.back()` when history is available, otherwise navigates to `/`.
> - Behavioral Change: The cost quality breakdown rows are no longer visible on the usage page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4268ebb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->