### PR TITLE
fix(server): recover empty collaboration-wait loops

### DIFF
--- a/apps/server/src/cloud/selfUpdate.test.ts
+++ b/apps/server/src/cloud/selfUpdate.test.ts
@@ -11,13 +11,14 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 import * as ServerConfig from "../config.ts";
 import * as ProcessRunner from "../processRunner.ts";
 import * as ServiceLauncherClient from "./serviceLauncherClient.ts";
+import { EMPTY_COLLAB_WAIT_RECOVERY_PROTOCOL } from "./servicePreflight.ts";
 import { SERVICE_LAUNCHER_PROTOCOL } from "./serviceProtocol.ts";
 import * as ServerSelfUpdate from "./selfUpdate.ts";
 
 interface HarnessOptions {
   readonly mode?: "web" | "desktop";
   readonly managed?: boolean;
-  readonly preflight?: "ready" | "blocked";
+  readonly preflight?: "ready" | "blocked" | "unsafe-collab-wait";
   readonly requestUpdate?: ServiceLauncherClient.ServiceLauncherClient["Service"]["requestUpdate"];
 }
 
@@ -48,14 +49,18 @@ const makeHarness = Effect.fn("test.make_self_update_harness")(function* (
           };
         }
         order.push("preflight");
+        const readyResult = {
+          status: "ready",
+          version: "1.1.0",
+          launcherProtocol: SERVICE_LAUNCHER_PROTOCOL,
+          ...(options.preflight === "unsafe-collab-wait"
+            ? {}
+            : { emptyCollabWaitRecoveryProtocol: EMPTY_COLLAB_WAIT_RECOVERY_PROTOCOL }),
+        };
         const result =
           options.preflight === "blocked"
             ? { status: "blocked", version: "1.1.0", reason: "local update required" }
-            : {
-                status: "ready",
-                version: "1.1.0",
-                launcherProtocol: SERVICE_LAUNCHER_PROTOCOL,
-              };
+            : readyResult;
         return {
           // @effect-diagnostics-next-line preferSchemaOverJson:off - fake child-process stdout.
           stdout: JSON.stringify(result),
@@ -126,6 +131,15 @@ it.layer(NodeServices.layer)("server self update", (it) => {
     }),
   );
 
+  it.effect("refuses an update that would remove empty collaboration-wait recovery", () =>
+    Effect.gen(function* () {
+      const { selfUpdate, order } = yield* makeHarness({ preflight: "unsafe-collab-wait" });
+      expect((yield* selfUpdate.update({ targetVersion: "1.1.0" }).pipe(Effect.flip)).reason).toBe(
+        "This T3 Code release does not include the required empty collaboration-wait recovery. The current server was kept running.",
+      );
+      expect(order).toEqual(["install", "preflight"]);
+    }),
+  );
   it.effect("allows only one update at a time", () =>
     Effect.gen(function* () {
       const requested = yield* Deferred.make<void>();

--- a/apps/server/src/cloud/servicePreflight.test.ts
+++ b/apps/server/src/cloud/servicePreflight.test.ts
@@ -1,6 +1,11 @@
 import { expect, it } from "@effect/vitest";
 
-import { runServicePreflight } from "./servicePreflight.ts";
+import {
+  decodeServicePreflightResult,
+  EMPTY_COLLAB_WAIT_RECOVERY_PROTOCOL,
+  EMPTY_COLLAB_WAIT_RECOVERY_REQUIRED_REASON,
+  runServicePreflight,
+} from "./servicePreflight.ts";
 import { SERVICE_LAUNCHER_PROTOCOL } from "./serviceProtocol.ts";
 
 it("requires the database-snapshot launcher protocol", () => {
@@ -22,5 +27,20 @@ it("requires the database-snapshot launcher protocol", () => {
     status: "ready",
     version: "1.2.3",
     launcherProtocol: SERVICE_LAUNCHER_PROTOCOL,
+    emptyCollabWaitRecoveryProtocol: EMPTY_COLLAB_WAIT_RECOVERY_PROTOCOL,
+  });
+});
+
+it("blocks a candidate that would remove empty collaboration-wait recovery", () => {
+  expect(
+    decodeServicePreflightResult({
+      status: "ready",
+      version: "1.2.4",
+      launcherProtocol: SERVICE_LAUNCHER_PROTOCOL,
+    }),
+  ).toEqual({
+    status: "blocked",
+    version: "1.2.4",
+    reason: EMPTY_COLLAB_WAIT_RECOVERY_REQUIRED_REASON,
   });
 });

--- a/apps/server/src/cloud/servicePreflight.ts
+++ b/apps/server/src/cloud/servicePreflight.ts
@@ -1,11 +1,15 @@
 import packageJson from "../../package.json" with { type: "json" };
 import { SERVICE_LAUNCHER_PROTOCOL } from "./serviceProtocol.ts";
 
+export const EMPTY_COLLAB_WAIT_RECOVERY_PROTOCOL = 1 as const;
+export const EMPTY_COLLAB_WAIT_RECOVERY_REQUIRED_REASON =
+  "This T3 Code release does not include the required empty collaboration-wait recovery. The current server was kept running.";
 export type ServicePreflightResult =
   | {
       readonly status: "ready";
       readonly version: string;
       readonly launcherProtocol: typeof SERVICE_LAUNCHER_PROTOCOL;
+      readonly emptyCollabWaitRecoveryProtocol: typeof EMPTY_COLLAB_WAIT_RECOVERY_PROTOCOL;
     }
   | {
       readonly status: "blocked";
@@ -29,7 +33,12 @@ export function runServicePreflight(input: {
     };
   }
 
-  return { status: "ready", version, launcherProtocol: SERVICE_LAUNCHER_PROTOCOL };
+  return {
+    status: "ready",
+    version,
+    launcherProtocol: SERVICE_LAUNCHER_PROTOCOL,
+    emptyCollabWaitRecoveryProtocol: EMPTY_COLLAB_WAIT_RECOVERY_PROTOCOL,
+  };
 }
 
 export function decodeServicePreflightResult(value: unknown): ServicePreflightResult | undefined {
@@ -42,10 +51,18 @@ export function decodeServicePreflightResult(value: unknown): ServicePreflightRe
     record.launcherProtocol === SERVICE_LAUNCHER_PROTOCOL &&
     typeof record.version === "string"
   ) {
+    if (record.emptyCollabWaitRecoveryProtocol !== EMPTY_COLLAB_WAIT_RECOVERY_PROTOCOL) {
+      return {
+        status: "blocked",
+        version: record.version,
+        reason: EMPTY_COLLAB_WAIT_RECOVERY_REQUIRED_REASON,
+      };
+    }
     return {
       status: "ready",
       version: record.version,
       launcherProtocol: SERVICE_LAUNCHER_PROTOCOL,
+      emptyCollabWaitRecoveryProtocol: EMPTY_COLLAB_WAIT_RECOVERY_PROTOCOL,
     };
   }
   if (

--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -25,6 +25,32 @@ import { makeCodexSessionRuntime } from "./CodexSessionRuntime.ts";
 const ROOT = wireFixture.rootThreadId;
 const [CHILD_A, CHILD_B] = wireFixture.childThreadIds as [string, string];
 
+function collabWaitCompletion(input: {
+  readonly id: string;
+  readonly receiverThreadIds?: ReadonlyArray<string>;
+}) {
+  return {
+    method: "item/completed",
+    params: {
+      item: {
+        type: "collabAgentToolCall",
+        id: input.id,
+        tool: "wait",
+        status: "completed",
+        senderThreadId: ROOT,
+        receiverThreadIds: input.receiverThreadIds ?? [],
+        prompt: null,
+        model: null,
+        reasoningEffort: null,
+        agentsStates: {},
+      },
+      threadId: ROOT,
+      turnId: wireFixture.responses.turnStart.turn.id,
+      completedAtMs: 1_785_898_349_931,
+    },
+  } as const;
+}
+
 /**
  * The captured sequence, extended with the shapes the live capture didn't
  * include: a collabAgentToolCall with receiverThreadIds (feeds the legacy
@@ -290,6 +316,111 @@ describe("CodexSessionRuntime collab integration", () => {
         threadId: ROOT,
         turnId: activeTurnId,
       });
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("interrupts a turn after three empty collaboration waits", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        notifications: [
+          collabWaitCompletion({ id: "empty-wait-1" }),
+          collabWaitCompletion({ id: "empty-wait-2" }),
+          collabWaitCompletion({ id: "empty-wait-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-collab-wait"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const guardEventFiber = yield* runtime.events.pipe(
+        Stream.filter(
+          (event) =>
+            event.method === "process/stderr" &&
+            event.message?.includes("three completed collaboration waits") === true,
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait without workers" });
+      const guardEvents = yield* Fiber.join(guardEventFiber).pipe(Effect.timeout("2 seconds"));
+      assert.lengthOf(Array.from(guardEvents), 1);
+
+      const interrupted = NodeFS.readFileSync(interruptsPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as { threadId?: string });
+      assert.deepEqual(
+        interrupted.map((entry) => entry.threadId),
+        [ROOT],
+      );
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("resets empty collaboration waits when a receiver appears", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        notifications: [
+          collabWaitCompletion({ id: "empty-wait-1" }),
+          collabWaitCompletion({ id: "empty-wait-2" }),
+          collabWaitCompletion({ id: "receiver-wait", receiverThreadIds: [CHILD_A] }),
+          collabWaitCompletion({ id: "empty-wait-3" }),
+          collabWaitCompletion({ id: "empty-wait-4" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-collab-wait-reset"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const completedFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "turn/completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait for a real receiver" });
+      yield* Fiber.join(completedFiber).pipe(Effect.timeout("2 seconds"));
+      assert.isFalse(NodeFS.existsSync(interruptsPath));
 
       yield* runtime.close;
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),

--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -380,6 +380,109 @@ describe("CodexSessionRuntime collab integration", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
+  it.live("recovers when conservative Stop bookkeeping contains stale child turns", () =>
+    Effect.gen(function* () {
+      const captured = wireFixture.notifications;
+      const isTurnStarted = (entry: (typeof captured)[number], child: string) =>
+        entry.method === "turn/started" &&
+        (entry.params as { threadId?: string }).threadId === child;
+      const isRegistration = (entry: (typeof captured)[number], child: string) => {
+        const item = (entry.params as { item?: { type?: string; agentThreadId?: string } }).item;
+        return item?.type === "subAgentActivity" && item.agentThreadId === child;
+      };
+      const unregisteredChildTurn = captured.find((entry) => isTurnStarted(entry, CHILD_A));
+      const registeredChildTurn = captured.find((entry) => isTurnStarted(entry, CHILD_B));
+      const registeredChildActivity = captured.find((entry) => isRegistration(entry, CHILD_B));
+      assert.isDefined(unregisteredChildTurn);
+      assert.isDefined(registeredChildTurn);
+      assert.isDefined(registeredChildActivity);
+      if (
+        unregisteredChildTurn === undefined ||
+        registeredChildTurn === undefined ||
+        registeredChildActivity === undefined
+      ) {
+        return yield* Effect.die(
+          new Error("captured collaboration lifecycle fixture is incomplete"),
+        );
+      }
+      const registeredChildTurnId = (
+        registeredChildTurn.params as { readonly turn: { readonly id: string } }
+      ).turn.id;
+
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        notifications: [
+          // An unregistered foreign turn is remembered so Stop can still
+          // reach it if registration arrives late. Its missing terminal row
+          // must not disable empty-wait recovery forever.
+          unregisteredChildTurn,
+          // A registered child remains a Stop target across retryable errors.
+          // That conservative entry is equally unsuitable as a liveness gate.
+          registeredChildActivity,
+          registeredChildTurn,
+          {
+            method: "error",
+            params: {
+              threadId: CHILD_B,
+              turnId: registeredChildTurnId,
+              error: { message: "Reconnecting... 2/5" },
+              willRetry: true,
+            },
+          },
+          collabWaitCompletion({ id: "empty-wait-after-stale-child-1" }),
+          collabWaitCompletion({ id: "empty-wait-after-stale-child-2" }),
+          collabWaitCompletion({ id: "empty-wait-after-stale-child-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-wait-with-stale-children"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const guardEventFiber = yield* runtime.events.pipe(
+        Stream.filter(
+          (event) =>
+            event.method === "process/stderr" &&
+            event.message?.includes("three completed collaboration waits") === true,
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait after stale child lifecycle" });
+      const guardEvents = yield* Fiber.join(guardEventFiber).pipe(Effect.timeout("2 seconds"));
+      assert.lengthOf(Array.from(guardEvents), 1);
+
+      const interrupted = NodeFS.readFileSync(interruptsPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as { threadId?: string });
+      assert.deepEqual(
+        interrupted.map((entry) => entry.threadId),
+        [ROOT],
+      );
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   it.live("resets empty collaboration waits when a receiver appears", () =>
     Effect.gen(function* () {
       const script = {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -52,8 +52,10 @@ const BENIGN_ERROR_LOG_SNIPPETS = [
   "state db record_discrepancy: find_thread_path_by_id_str_in_subdir, falling_back",
 ];
 const CODEX_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
-// A child can settle while a wait request is in flight. Two empty completions
-// absorb that race; a third with no live child is a provider liveness failure.
+// A child can settle while a wait request is in flight. Two consecutive empty
+// completions absorb that race; a third provider-confirmed empty result is a
+// liveness failure. Do not gate this on collabChildLiveTurnsRef: that map is a
+// deliberately conservative Stop target cache and can contain stale entries.
 const EMPTY_COLLAB_WAIT_INTERRUPT_THRESHOLD = 3;
 const EMPTY_COLLAB_WAIT_INTERRUPT_TIMEOUT = "5 seconds" as const;
 const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
@@ -1370,15 +1372,7 @@ export const makeCodexSessionRuntime = (
         const activeTurnId = childParentTurnId ?? route.turnId ?? session.activeTurnId ?? null;
         const providerThreadId = currentProviderThreadId(session);
         const completedEmptyCollabWait = isCompletedEmptyCollabWait(notification);
-        const hasLiveCollabChildren = completedEmptyCollabWait
-          ? (yield* Ref.get(collabChildLiveTurnsRef)).size > 0
-          : false;
-        if (
-          completedEmptyCollabWait &&
-          activeTurnId !== null &&
-          providerThreadId !== undefined &&
-          !hasLiveCollabChildren
-        ) {
+        if (completedEmptyCollabWait && activeTurnId !== null && providerThreadId !== undefined) {
           const shouldInterrupt = yield* Ref.modify(emptyCollabWaitGuardRef, (current) => {
             if (current.turnId === activeTurnId && current.interruptRequested) {
               return [false, current] as const;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -52,6 +52,10 @@ const BENIGN_ERROR_LOG_SNIPPETS = [
   "state db record_discrepancy: find_thread_path_by_id_str_in_subdir, falling_back",
 ];
 const CODEX_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
+// A child can settle while a wait request is in flight. Two empty completions
+// absorb that race; a third with no live child is a provider liveness failure.
+const EMPTY_COLLAB_WAIT_INTERRUPT_THRESHOLD = 3;
+const EMPTY_COLLAB_WAIT_INTERRUPT_TIMEOUT = "5 seconds" as const;
 const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "not found",
   "missing thread",
@@ -239,6 +243,37 @@ function makeCodexServerNotification<M extends CodexRpc.ServerNotificationMethod
   params: CodexRpc.ServerNotificationParamsByMethod[M],
 ): CodexServerNotification {
   return { method, params } as CodexServerNotification;
+}
+
+interface EmptyCollabWaitGuardState {
+  readonly turnId: TurnId | null;
+  readonly completedWaits: number;
+  readonly interruptRequested: boolean;
+}
+
+function isCompletedEmptyCollabWait(notification: CodexServerNotification): boolean {
+  if (notification.method !== "item/completed") {
+    return false;
+  }
+  const item = notification.params.item;
+  return (
+    item.type === "collabAgentToolCall" &&
+    item.tool === "wait" &&
+    item.status === "completed" &&
+    item.receiverThreadIds.length === 0 &&
+    Object.keys(item.agentsStates).length === 0
+  );
+}
+
+function isMeaningfulItemCompletion(notification: CodexServerNotification): boolean {
+  if (notification.method !== "item/completed") {
+    return false;
+  }
+  const item = notification.params.item;
+  if (item.type === "reasoning" || item.type === "agentMessage") {
+    return false;
+  }
+  return !isCompletedEmptyCollabWait(notification);
 }
 
 function normalizeCodexModelSlug(
@@ -928,6 +963,11 @@ export const makeCodexSessionRuntime = (
       updatedAt: sessionCreatedAt,
     } satisfies ProviderSession;
     const sessionRef = yield* Ref.make<ProviderSession>(initialSession);
+    const emptyCollabWaitGuardRef = yield* Ref.make<EmptyCollabWaitGuardState>({
+      turnId: null,
+      completedWaits: 0,
+      interruptRequested: false,
+    });
     const offerEvent = (event: ProviderEvent) => Queue.offer(events, event).pipe(Effect.asVoid);
 
     const emitEvent = (event: Omit<ProviderEvent, "id" | "provider" | "createdAt">) =>
@@ -1324,6 +1364,76 @@ export const makeCodexSessionRuntime = (
           }
           yield* Ref.set(collabReceiverTurnsRef, collabReceiverTurns);
           return;
+        }
+
+        const session = yield* Ref.get(sessionRef);
+        const activeTurnId = childParentTurnId ?? route.turnId ?? session.activeTurnId ?? null;
+        const providerThreadId = currentProviderThreadId(session);
+        const completedEmptyCollabWait = isCompletedEmptyCollabWait(notification);
+        const hasLiveCollabChildren = completedEmptyCollabWait
+          ? (yield* Ref.get(collabChildLiveTurnsRef)).size > 0
+          : false;
+        if (
+          completedEmptyCollabWait &&
+          activeTurnId !== null &&
+          providerThreadId !== undefined &&
+          !hasLiveCollabChildren
+        ) {
+          const shouldInterrupt = yield* Ref.modify(emptyCollabWaitGuardRef, (current) => {
+            if (current.turnId === activeTurnId && current.interruptRequested) {
+              return [false, current] as const;
+            }
+            const completedWaits = current.turnId === activeTurnId ? current.completedWaits + 1 : 1;
+            const interruptRequested = completedWaits >= EMPTY_COLLAB_WAIT_INTERRUPT_THRESHOLD;
+            return [
+              interruptRequested,
+              {
+                turnId: activeTurnId,
+                completedWaits,
+                interruptRequested,
+              },
+            ] as const;
+          });
+          if (shouldInterrupt) {
+            const interruptExit = yield* client
+              .request("turn/interrupt", {
+                threadId: providerThreadId,
+                turnId: activeTurnId,
+              })
+              .pipe(Effect.timeout(EMPTY_COLLAB_WAIT_INTERRUPT_TIMEOUT), Effect.exit);
+            if (Exit.isFailure(interruptExit)) {
+              yield* Ref.set(emptyCollabWaitGuardRef, {
+                turnId: activeTurnId,
+                completedWaits: 0,
+                interruptRequested: false,
+              });
+              yield* Effect.logWarning("Failed to interrupt an empty collaboration-wait loop.", {
+                threadId: options.threadId,
+                turnId: activeTurnId,
+                cause: interruptExit.cause,
+              });
+            } else {
+              yield* emitEvent({
+                kind: "notification",
+                threadId: options.threadId,
+                turnId: activeTurnId,
+                method: "process/stderr",
+                message:
+                  "Interrupted a stalled Codex turn after three completed collaboration waits reported no active agents.",
+              });
+            }
+          }
+        } else if (
+          completedEmptyCollabWait ||
+          notification.method === "turn/started" ||
+          notification.method === "turn/completed" ||
+          isMeaningfulItemCompletion(notification)
+        ) {
+          yield* Ref.set(emptyCollabWaitGuardRef, {
+            turnId: activeTurnId,
+            completedWaits: 0,
+            interruptRequested: false,
+          });
         }
 
         let requestId: ApprovalRequestId | undefined;


### PR DESCRIPTION
## Summary

- interrupt a provider turn after three completed collaboration waits report no active receivers or agents
- reset the guard when a receiver or meaningful completion appears
- expose and require `emptyCollabWaitRecoveryProtocol: 1` in the service preflight and self-update checks

Fixes https://github.com/pingdotgg/t3code/issues/5754

## Validation

- `corepack pnpm --filter t3 exec vp test run src/cloud/servicePreflight.test.ts src/cloud/selfUpdate.test.ts src/provider/Layers/CodexCollabRuntime.integration.test.ts` (11 passed)
- `corepack pnpm --filter t3 typecheck` (passed; existing suggestions only)
- `corepack pnpm exec vp fmt --check` on the five changed files (passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live Codex turn interruption and self-update gating; behavior is covered by preflight, self-update, and integration tests but affects provider liveness and upgrade safety.
> 
> **Overview**
> Adds **empty collaboration-wait recovery** in the Codex session runtime so turns that repeatedly complete `collabAgentToolCall` **wait** with no receivers or agent state do not spin forever. After **three** such completions on the same turn, the runtime issues **`turn/interrupt`**, surfaces a **`process/stderr`** notice, and deliberately **does not** use conservative child live-turn bookkeeping as a gate (stale Stop-cache entries must not block recovery).
> 
> The guard **resets** on turn boundaries and on progress signals (non-empty waits, meaningful item completions). Integration tests cover the interrupt path, reset when a receiver appears, and recovery with stale child lifecycle rows.
> 
> **Service preflight and self-update** now advertise and require **`emptyCollabWaitRecoveryProtocol: 1`**. Staged builds that report `ready` without that field are decoded as **blocked**, so self-update refuses releases that would drop this recovery behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 908774e8f6be75c9eba24ff9e98060b54cc826a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Interrupt Codex turns after three consecutive empty collaboration waits
> - Adds `emptyCollabWaitGuardRef` to `CodexSessionRuntime` in [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/5759/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) to track empty collab-wait completions per turn; after three consecutive waits with no active agents, a `turn/interrupt` request is issued and a `process/stderr` notification is emitted.
> - The counter resets on turn start/completion, meaningful item completions, or a successful interrupt; on interrupt failure the guard resets and logs a warning.
> - Introduces `emptyCollabWaitRecoveryProtocol` in [servicePreflight.ts](https://github.com/pingdotgg/t3code/pull/5759/files#diff-013be68670e08585324834df0d29c959c3374cdefb2f20b005277d51add4febe) as a required field on ready preflight results; candidates missing it are blocked with `EMPTY_COLLAB_WAIT_RECOVERY_REQUIRED_REASON`.
> - Behavioral Change: server releases that lack `emptyCollabWaitRecoveryProtocol=1` in their preflight result will now be refused during self-update decode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 908774e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->