### PR TITLE
chore: vouch gfsaaser24

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -15,6 +15,7 @@ github:chrisdeeming
 github:chuks-qua
 github:cursoragent
 github:gbarros-dev
+github:gfsaaser24
 github:github-actions[bot]
 github:hwanseoc
 github:jamesx0416


### PR DESCRIPTION
PR #5710 was merged after review, but `gfsaaser24` is not in the trusted contributor list. Add the account so future PRs use the vouched workflow.

Validation:
- `vp check`
- `vp run typecheck`
- `git diff --check`

Made by GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line trust-list update with no application or security logic changes.
> 
> **Overview**
> Adds **`github:gfsaaser24`** to `.github/VOUCHED.td` in alphabetical order so the vouch workflow treats that account as a trusted external contributor (e.g. `vouch:trusted` labeling) after their reviewed PR landed without being on the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c353e16f9f0f628fc093068c557ff9839eb117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Vouch GitHub user `gfsaaser24` in VOUCHED list
> Adds `github:gfsaaser24` to [VOUCHED.td](https://github.com/pingdotgg/t3code/pull/5761/files#diff-98d74b85391a94d09bfa48e57f8d6c673093c12dde140f21c9e7d01153e9cab0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4c353e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->