### PR TITLE
fix(server): stop Codex threads with queued follow-ups

### DIFF
--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -245,4 +245,53 @@ describe("CodexSessionRuntime collab integration", () => {
       yield* runtime.close;
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
+
+  it.live("Stop targets the active turn when Codex has accepted a queued follow-up", () =>
+    Effect.gen(function* () {
+      const activeTurnId = "019fe3e8-f908-7f31-8d51-283f4a47897a";
+      const queuedTurnId = "019fe3eb-8faf-7de3-a85b-ac64c7f9c8c3";
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        onlyFirstTurnStarts: true,
+        turnIds: [activeTurnId, queuedTurnId],
+        expectedActiveTurnId: activeTurnId,
+        notifications: [],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-codex-queued-stop"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "keep working" });
+      yield* runtime.sendTurn({ input: "queued follow-up" });
+      yield* runtime.interruptTurn();
+
+      const interrupts = NodeFS.readFileSync(interruptsPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { threadId?: string; turnId?: string });
+      assert.deepEqual(interrupts.at(-1), {
+        threadId: ROOT,
+        turnId: activeTurnId,
+      });
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
 });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -814,13 +814,13 @@ function currentProviderThreadId(session: ProviderSession): string | undefined {
 
 function updateSession(
   sessionRef: Ref.Ref<ProviderSession>,
-  updates: Partial<ProviderSession>,
+  updates: Partial<ProviderSession> | ((session: ProviderSession) => Partial<ProviderSession>),
 ): Effect.Effect<void> {
   return Effect.gen(function* () {
     const updatedAt = DateTime.formatIso(yield* DateTime.now);
     yield* Ref.update(sessionRef, (session) => ({
       ...session,
-      ...updates,
+      ...(typeof updates === "function" ? updates(session) : updates),
       updatedAt,
     }));
   });
@@ -1782,11 +1782,14 @@ export const makeCodexSessionRuntime = (
             ),
           );
           const turnId = TurnId.make(response.turn.id);
-          yield* updateSession(sessionRef, {
+          yield* updateSession(sessionRef, (session) => ({
             status: "running",
-            activeTurnId: turnId,
+            // Codex accepts follow-ups while the current turn is still
+            // running. The response contains the queued turn id, but
+            // turn/interrupt only accepts the id that is active now.
+            activeTurnId: session.activeTurnId ?? turnId,
             ...(normalizedModel ? { model: normalizedModel } : {}),
-          });
+          }));
           const resumedProviderThreadId = currentProviderThreadId(yield* Ref.get(sessionRef));
           return {
             threadId: options.threadId,

--- a/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
+++ b/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
@@ -16,6 +16,7 @@ const fixture = JSON.parse(
 const script = JSON.parse(NodeFS.readFileSync(process.env.T3_CODEX_COLLAB_SCRIPT, "utf8"));
 
 const write = (message) => process.stdout.write(`${JSON.stringify(message)}\n`);
+let turnStartCount = 0;
 
 const rl = NodeReadline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {
@@ -43,14 +44,20 @@ rl.on("line", (line) => {
     return;
   }
   if (method === "turn/start") {
-    write({ id, result: fixture.responses.turnStart });
+    const turnId = script.turnIds?.[turnStartCount];
+    const turn = turnId
+      ? { ...fixture.responses.turnStart.turn, id: turnId }
+      : fixture.responses.turnStart.turn;
+    turnStartCount += 1;
+    write({ id, result: { ...fixture.responses.turnStart, turn } });
     const rootThreadId = script.rootThreadId;
-    const turn = fixture.responses.turnStart.turn;
-    write({
-      jsonrpc: "2.0",
-      method: "turn/started",
-      params: { threadId: rootThreadId, turn },
-    });
+    if (script.onlyFirstTurnStarts !== true || turnStartCount === 1) {
+      write({
+        jsonrpc: "2.0",
+        method: "turn/started",
+        params: { threadId: rootThreadId, turn },
+      });
+    }
     for (const notification of script.notifications) {
       write({ jsonrpc: "2.0", method: notification.method, params: notification.params });
     }
@@ -75,6 +82,20 @@ rl.on("line", (line) => {
       `${process.env.T3_CODEX_COLLAB_SCRIPT}.interrupts`,
       `${JSON.stringify({ threadId: target, turnId: message.params?.turnId })}\n`,
     );
+    if (
+      script.expectedActiveTurnId &&
+      message.params?.threadId === script.rootThreadId &&
+      message.params?.turnId !== script.expectedActiveTurnId
+    ) {
+      write({
+        id,
+        error: {
+          code: -32000,
+          message: `expected active turn id ${message.params?.turnId} but found ${script.expectedActiveTurnId}`,
+        },
+      });
+      return;
+    }
     if (script.failInterruptFor && script.failInterruptFor === target) {
       write({ id, error: { code: -32000, message: "thread already closed" } });
       return;


### PR DESCRIPTION
Codex stop requests failed when a thread had a queued follow-up. T3 replaced the active provider turn ID with the queued turn ID, so Codex rejected the interrupt.

Keep the existing active turn ID until Codex sends turn lifecycle notifications that advance it. The integration test reproduces the observed active and queued turn ordering.

Test: `vp test run apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts`

Created by GPT-5.6 in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn-tracking used by Stop/interrupt on the Codex provider path; scope is narrow and covered by a new integration test, but incorrect active-turn bookkeeping could still break interrupt behavior.
> 
> **Overview**
> **Stop** on Codex threads failed when a follow-up was queued while the current turn was still running: each `turn/start` response overwrote `activeTurnId` with the **queued** turn id, but Codex `turn/interrupt` only accepts the **currently active** turn.
> 
> `sendTurn` now keeps the existing `activeTurnId` when Codex returns a queued follow-up (`session.activeTurnId ?? turnId`); lifecycle handlers (`turn/started` / `turn/completed`) still advance or clear it. `updateSession` accepts an updater function so that logic can read the prior session state.
> 
> Adds an integration test (two `sendTurn` calls, then `interruptTurn`) and extends the collab mock peer with per-call turn ids, optional suppression of a second `turn/started`, and interrupt validation when the wrong turn id is sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f5321eee812e3e7c369ad8ffbe9fd9e2c81883. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `interruptTurn` to target the active turn when Codex has a queued follow-up
> - When Codex accepts a queued follow-up via `turn/start`, `session.activeTurnId` was being overwritten with the new (queued) turn id, causing subsequent interrupts to target the wrong turn.
> - Fixes this by switching `updateSession` calls in the `turn/start` flow to a functional form that preserves the existing `activeTurnId` if one is already set.
> - Extends [`codexCollabMockPeer.mjs`](https://github.com/pingdotgg/t3code/pull/5762/files#diff-52a6fb55324add786e7ae3a566aa7174f1e469420c7f47b50de5260f74addbd6) to support deterministic turn ids, suppressing `turn/started` for queued turns, and validating interrupt targets.
> - Adds an integration test in [`CodexCollabRuntime.integration.test.ts`](https://github.com/pingdotgg/t3code/pull/5762/files#diff-74a2db2843e796753b7d03057676efea76b0abcccece800a4db4336224872182) that reproduces the bug and asserts the interrupt targets the first (active) turn id.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 84f5321. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->