### PR TITLE
chore: vouch saphid

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -27,6 +27,7 @@ github:Noojuno
 github:notkainoa
 github:PatrickBauer
 github:realAhmedRoach
+github:saphid
 github:shiroyasha9
 github:StiensWout
 github:Yash-Singh1


### PR DESCRIPTION
PRs from `saphid` are blocked by the unvouched contributor gate.

Add the account to the trusted contributor list so its PRs receive the correct vouch label and can run CI without maintainer approval.

Validation: `git diff --check origin/main...HEAD`

Made by GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line trust-list update with no application, auth, or data-handling changes.
> 
> **Overview**
> Adds **`github:saphid`** to `.github/VOUCHED.td` in alphabetical order so the vouch workflow treats that account as trusted.
> 
> Their pull requests should get the **`vouch:trusted`** label instead of being blocked by the unvouched contributor gate, so CI can run without extra maintainer approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c69224e3a15e863b2056ce5a335977798f27564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add saphid to VOUCHED list
> Adds `github:saphid` to [VOUCHED.td](https://github.com/pingdotgg/t3code/pull/5763/files#diff-98d74b85391a94d09bfa48e57f8d6c673093c12dde140f21c9e7d01153e9cab0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c69224.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->