### PR TITLE
fix(web): pinned reorder no longer reshuffles while writes land

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2269,22 +2269,28 @@ export default function Sidebar() {
   );
   // Drag-to-reorder for the pinned block. A drop computes ONE fractional key
   // for the moved thread and sends it to that thread's own server (see
-  // planPinnedReorder for the keyless-neighbor materialization case). The
-  // optimistic order keeps the card where it was dropped until the
-  // confirming event round-trips; canonical order matching it releases the
-  // override, and a failed write clears it (the card snaps back) with a toast.
-  // ANY membership change (new pin, unpin, snooze/wake) also releases it:
-  // the override can't say where members it never saw belong, and holding it
-  // would misplace them and launder the stale order into later drags.
+  // planPinnedReorder for the keyless-neighbor materialization case, which
+  // instead rewrites every key in the section). The optimistic order keeps
+  // the card where it was dropped until EVERY key the drop wrote is
+  // reflected in canonical state — a section rewrite is several sequential
+  // writes, and releasing on the first landed key would expose the
+  // half-written canonical order, reshuffling the block once per write.
+  // A failed write clears the override (the card snaps back) with a toast.
+  // A key we did NOT write landing (a concurrent client's reorder that must
+  // win) and ANY membership change (new pin, unpin, snooze/wake) also
+  // release it: the override can't say where members it never saw belong,
+  // and holding it would launder a stale order into later drags.
   const pinnedDndSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   );
   const [optimisticPinnedOrder, setOptimisticPinnedOrder] = useState<{
     readonly order: readonly string[];
-    /** pinOrderKey per thread as of the drop, so ANY landed write (ours
-        confirming, or a concurrent one from another client) releases the
-        override rather than fighting canonical state. */
+    /** pinOrderKey per thread as of the drop — the baseline that tells a
+        concurrent client's write apart from one of our own landing. */
     readonly keysAtDrop: ReadonlyMap<string, string | null>;
+    /** The keys this drop writes (one per planned assignment). The
+        override holds until all of them appear in canonical state. */
+    readonly assignedKeys: ReadonlyMap<string, string>;
   } | null>(null);
   const orderedPinnedThreads = useMemo(() => {
     if (optimisticPinnedOrder === null) return pinnedThreads;
@@ -2303,24 +2309,32 @@ export default function Sidebar() {
       scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
     );
     // The override represents one drop against one snapshot of the world.
-    // Release it as soon as the world moves on in any way: membership
-    // changed (pin/unpin/snooze/wake — the override can't say where members
-    // it never saw belong), a key changed (our write confirming, or a
-    // concurrent client's reorder that must win), or canonical already
-    // matches. Holding it longer would misplace newcomers and launder the
-    // stale order into later drags.
+    // Release it when the world moves on: membership changed (pin/unpin/
+    // snooze/wake — the override can't say where members it never saw
+    // belong), a key changed to something we did NOT write (a concurrent
+    // client's reorder that must win), every key we wrote has landed, or
+    // canonical already matches. Releasing on the FIRST landed key instead
+    // of the last exposes the half-written order mid-materialization and
+    // the block visibly reshuffles once per write.
     const membershipChanged =
       canonicalKeys.length !== optimisticPinnedOrder.order.length ||
       canonicalKeys.some((key) => !optimisticPinnedOrder.order.includes(key));
-    const anyKeyLanded = canonical.some(
-      (thread, index) =>
-        optimisticPinnedOrder.keysAtDrop.get(canonicalKeys[index]!) !==
-        (thread.pinOrderKey ?? null),
+    const foreignKeyLanded = canonical.some((thread, index) => {
+      const threadKey = canonicalKeys[index]!;
+      const currentKey = thread.pinOrderKey ?? null;
+      if (currentKey === optimisticPinnedOrder.keysAtDrop.get(threadKey)) return false;
+      return currentKey !== optimisticPinnedOrder.assignedKeys.get(threadKey);
+    });
+    const currentKeyByThreadKey = new Map(
+      canonical.map((thread, index) => [canonicalKeys[index]!, thread.pinOrderKey ?? null]),
+    );
+    const allAssignmentsLanded = [...optimisticPinnedOrder.assignedKeys].every(
+      ([threadKey, orderKey]) => currentKeyByThreadKey.get(threadKey) === orderKey,
     );
     const orderConfirmed =
       !membershipChanged &&
       canonicalKeys.every((key, index) => key === optimisticPinnedOrder.order[index]);
-    if (membershipChanged || anyKeyLanded || orderConfirmed) {
+    if (membershipChanged || foreignKeyLanded || allAssignmentsLanded || orderConfirmed) {
       setOptimisticPinnedOrder(null);
     }
   }, [optimisticPinnedOrder, pinnedThreads, reorderablePinnedKeys]);
@@ -2390,7 +2404,13 @@ export default function Sidebar() {
         movedId: activeKey,
       });
       if (assignments.length === 0) return;
-      setOptimisticPinnedOrder({ order: newOrder, keysAtDrop });
+      setOptimisticPinnedOrder({
+        order: newOrder,
+        keysAtDrop,
+        assignedKeys: new Map(
+          assignments.map((assignment) => [assignment.id, assignment.orderKey]),
+        ),
+      });
       void (async () => {
         // Sequential, stop on first failure. There is deliberately no
         // rollback: every key write is a complete, valid placement on its
@@ -2404,8 +2424,12 @@ export default function Sidebar() {
             scopeThreadRef(thread.environmentId, thread.id),
             assignment.orderKey,
           );
-          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+          if (result._tag === "Failure") {
+            // Any failure — interrupted included — releases the override:
+            // a key that never lands would otherwise hold it until some
+            // unrelated world change came along.
             setOptimisticPinnedOrder(null);
+            if (isAtomCommandInterrupted(result)) return;
             const error = squashAtomCommandFailure(result);
             toastManager.add(
               stackedThreadToast({


### PR DESCRIPTION
Dragging a card in the pinned section landed in the right place eventually, but the block visibly shuffled around for a moment after the drop.

The sidebar already holds an optimistic order after a drop, but it released that override as soon as *any* `pinOrderKey` changed in canonical state. That is fine for the common single-key drop. When a neighbor has no key yet (threads pinned before reordering shipped), the drop rewrites every key in the section as several sequential writes — and the override released after the first one landed, exposing the half-written canonical order. The block then reshuffled once per remaining write.

The fix: the drop now remembers which keys it planned to write, and the override holds until all of them show up in canonical state. A key we did not write landing (a concurrent client reordering) still releases immediately so their write wins, and the existing membership-change and failure releases are unchanged. One small hardening: an interrupted write now also clears the override, since a key that never lands could otherwise hold it indefinitely.

No new state machinery — one extra field on the existing optimistic state and a tighter release condition.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sidebar DnD optimistic-state logic with no auth or data-model changes; behavior is easier to reason about and reduces visible UI flicker.
> 
> **Overview**
> Fixes **post-drop shuffling** in the pinned sidebar block when a drag triggers **full-section key materialization** (neighbors without `pinOrderKey`).
> 
> The optimistic order override now stores **`assignedKeys`** from `planPinnedReorder` and stays active until **every** planned `pinOrderKey` appears in canonical state—not on the first key change. **Foreign** key updates (another client’s reorder) still drop the override immediately; membership changes and order confirmation behave as before.
> 
> Reorder failures (including **interrupted** commands) now **always** clear the override so a key that never lands cannot pin stale order indefinitely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8700385292b24a6fee30a53b0d8849909aaa5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pinned sidebar reorder to persist optimistic order until all writes land
> - The optimistic pinned order in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/5767/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) previously released too early during multi-key materialization, causing the list to reshuffle while writes were still in flight.
> - Adds an `assignedKeys` map to `optimisticPinnedOrder` tracking the exact order keys this client planned to write.
> - The release effect now waits until all assigned keys appear in canonical state (`allAssignmentsLanded`), and also releases early if a foreign (non-assigned) key lands or membership changes.
> - Interrupted write failures now clear the optimistic override silently; only non-interrupted failures show an error toast.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6e87003. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->