### PR TITLE
fix(desktop): skip the PowerShell profile probe when node is already resolvable

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -10,6 +10,8 @@ import * as Stream from "effect/Stream";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
+import { CommandAvailability } from "@t3tools/shared/shell";
+
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopShellEnvironment from "./DesktopShellEnvironment.ts";
 
@@ -69,7 +71,11 @@ function runShellEnvironment(input: {
   readonly platform: NodeJS.Platform;
   readonly handler: (command: ChildProcess.Command) => string;
   readonly failure?: PlatformError.PlatformError;
+  readonly nodeAvailable?: boolean;
 }) {
+  const commandAvailabilityLayer = Layer.succeed(CommandAvailability, () =>
+    Effect.succeed(input.nodeAvailable ?? false),
+  );
   const environmentLayer = Layer.succeed(
     DesktopEnvironment.DesktopEnvironment,
     DesktopEnvironment.DesktopEnvironment.of({
@@ -91,7 +97,14 @@ function runShellEnvironment(input: {
   }).pipe(
     Effect.provide(
       DesktopShellEnvironment.layer.pipe(
-        Layer.provide(Layer.mergeAll(environmentLayer, NodeServices.layer, spawnerLayer)),
+        Layer.provide(
+          Layer.mergeAll(
+            environmentLayer,
+            NodeServices.layer,
+            spawnerLayer,
+            commandAvailabilityLayer,
+          ),
+        ),
       ),
     ),
   );
@@ -197,7 +210,7 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
-  it.effect("loads PowerShell profile environment on Windows", () =>
+  it.effect("loads PowerShell profile environment on Windows when node is missing", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {
         PATH: "C:\\Windows\\System32",
@@ -209,6 +222,7 @@ describe("DesktopShellEnvironment", () => {
       yield* runShellEnvironment({
         env,
         platform: "win32",
+        nodeAvailable: false,
         handler: (command) => {
           if (command._tag !== "StandardCommand") return "";
           const loadProfile = !command.args.includes("-NoProfile");
@@ -241,6 +255,50 @@ describe("DesktopShellEnvironment", () => {
         env.FNM_MULTISHELL_PATH,
         "C:\\Users\\testuser\\AppData\\Local\\fnm_multishells\\123",
       );
+    }),
+  );
+
+  it.effect("skips the PowerShell profile probe on Windows when node is already resolvable", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        PATH: "C:\\Windows\\System32",
+        APPDATA: "C:\\Users\\testuser\\AppData\\Roaming",
+        LOCALAPPDATA: "C:\\Users\\testuser\\AppData\\Local",
+        USERPROFILE: "C:\\Users\\testuser",
+      };
+      const commands: ChildProcess.Command[] = [];
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        nodeAvailable: true,
+        handler: (command) => {
+          commands.push(command);
+          if (command._tag !== "StandardCommand") return "";
+          return command.args.includes("-NoProfile")
+            ? envOutput({ PATH: "C:\\Custom\\Bin;C:\\Windows\\System32" })
+            : envOutput({ PATH: "C:\\Profile\\Node;C:\\Windows\\System32" });
+        },
+      });
+
+      assert.equal(commands.length, 1);
+      assert.isTrue(
+        commands[0]?._tag === "StandardCommand" && commands[0].args.includes("-NoProfile"),
+      );
+      assert.equal(
+        env.PATH,
+        [
+          "C:\\Users\\testuser\\AppData\\Roaming\\npm",
+          "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
+          "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
+          "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+          "C:\\Users\\testuser\\.bun\\bin",
+          "C:\\Users\\testuser\\scoop\\shims",
+          "C:\\Custom\\Bin",
+          "C:\\Windows\\System32",
+        ].join(";"),
+      );
+      assert.isUndefined(env.FNM_DIR);
     }),
   );
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -4,9 +4,11 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import { CommandAvailability } from "@t3tools/shared/shell";
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 
@@ -378,17 +380,33 @@ const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEn
 const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWindowsEnvironment")(
   function* (
     config: ShellEnvironmentConfig,
-  ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner> {
+  ): Effect.fn.Return<
+    void,
+    never,
+    ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+  > {
     const noProfile = yield* readWindowsEnvironment(["PATH"], { loadProfile: false });
-    const profile = yield* readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, {
-      loadProfile: true,
-    });
-    const mergedPath = mergePaths("win32", [
-      trimNonEmpty(profile.PATH),
+    const baselinePath = mergePaths("win32", [
       trimNonEmpty(knownWindowsCliDirs(config.env).join(";")),
       trimNonEmpty(noProfile.PATH),
       readEnvPath(config.env),
     ]);
+
+    if (Option.isSome(baselinePath)) {
+      config.env.PATH = baselinePath.value;
+    }
+
+    // Each profile probe spends a fresh timeout on every candidate shell, so only
+    // pay for it when the baseline environment cannot already resolve node.
+    const commandAvailable = yield* CommandAvailability;
+    if (yield* commandAvailable("node", { env: config.env })) {
+      return;
+    }
+
+    const profile = yield* readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, {
+      loadProfile: true,
+    });
+    const mergedPath = mergePaths("win32", [trimNonEmpty(profile.PATH), baselinePath]);
 
     if (Option.isSome(mergedPath)) {
       config.env.PATH = mergedPath.value;
@@ -484,7 +502,11 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
 
 const installShellEnvironment = (
   config: ShellEnvironmentConfig,
-): Effect.Effect<void, never, ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem> => {
+): Effect.Effect<
+  void,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> => {
   if (config.platform === "win32") {
     return installWindowsEnvironment(config);
   }
@@ -497,7 +519,9 @@ const installShellEnvironment = (
 export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const commandAvailable = yield* CommandAvailability;
   const installIntoProcess: DesktopShellEnvironment["Service"]["installIntoProcess"] =
     installShellEnvironment({
       env: process.env,
@@ -505,7 +529,9 @@ export const make = Effect.gen(function* () {
       userShell: Option.none(),
     }).pipe(
       Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(Path.Path, path),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Effect.provideService(CommandAvailability, commandAvailable),
       Effect.withSpan("desktop.shellEnvironment.installIntoProcess"),
     );
 


### PR DESCRIPTION
## Problem

On Windows, `installWindowsEnvironment` runs two PowerShell probes on every desktop start: one with `-NoProfile`, then one that loads the user profile. Each probe walks `pwsh.exe` and then `powershell.exe`, and every candidate gets its own 5 second timeout, so a slow or failing profile can burn up to four timeout budgets before the window appears.

The profile probe was never meant to be unconditional. #1729 added it as a fallback for when node is missing, and `resolveWindowsEnvironment` in `packages/shared/src/shell.ts` still works that way:

```ts
if (yield* commandAvailable("node", { env: baselineEnv })) {
  return baselinePatch
}
```

The desktop copy lost that gate in #2546 when the app was ported to Effect, so both probes now run every time.

## Fix

- build the baseline PATH from the no-profile probe, the known CLI directories, and the inherited environment
- return early when node already resolves from that baseline
- fall through to the profile probe only when it does not, so fnm users still get `FNM_DIR` and `FNM_MULTISHELL_PATH`
- resolve `CommandAvailability` in `make` alongside the other services, so the check is injectable in tests

PATH precedence is unchanged: profile, then known CLI directories, then the no-profile probe, then the inherited environment.

## Validation

- `vp test run src/shell/DesktopShellEnvironment.test.ts` in `apps/desktop` (10 passed)
- `vp run --filter @t3tools/desktop typecheck`
- `vp lint --report-unused-disable-directives` (clean; the one warning it reports is pre-existing in `apps/web`)

The new test fails with `expected 2 to equal 1` when the gate is removed, so it covers the regression rather than just the current behavior.

I did not measure packaged-app startup traces, so the probe count is covered by the test rather than by a trace comparison.

Closes #4403

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Windows shell hydration logic with shared parity to `resolveWindowsEnvironment`; profile fallback remains when node is missing.
> 
> **Overview**
> **Windows desktop startup** no longer always runs the slow PowerShell **profile** probe. After the existing **no-profile** PATH probe, known CLI directories, and inherited `PATH` are merged into a baseline, the app uses shared **`CommandAvailability`** to check whether `node` resolves; if it does, it **returns early** and skips the profile probe (and fnm env vars unless needed).
> 
> When `node` is still missing, behavior matches before: profile probe runs to pick up profile `PATH`, `FNM_DIR`, and `FNM_MULTISHELL_PATH`, with the same PATH merge order (profile ahead of baseline). **`CommandAvailability`** is resolved in `make` and injected into `installIntoProcess` so tests can stub it.
> 
> Tests gain a **`nodeAvailable`** hook and a case that asserts only one PowerShell invocation (`-NoProfile`) when node is already available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb618c6e66e3130d69e91bb1671f69f7f8fc5aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip PowerShell profile probe on Windows when `node` is already resolvable
> - On Windows, a baseline PATH is now computed by merging known CLI directories, a `-NoProfile` PATH probe, and the existing process PATH before any profile probing occurs.
> - If `node` is resolvable in the baseline environment, the full PowerShell profile probe is skipped entirely, avoiding slow or side-effectful profile execution.
> - When `node` is not resolvable, the existing profile-loading behavior is preserved and FNM-related variables (`FNM_DIR`, `FNM_MULTISHELL_PATH`) are still populated.
> - `DesktopShellEnvironment.make` now explicitly depends on `Path.Path` and `CommandAvailability` services to support the new resolution check.
> - Behavioral Change: baseline PATH is always set before profile probing, which changes the PATH order on Windows even when the probe runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccb618c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->