### PR TITLE
fix(web): usage totals no longer jump while devices report in

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,10 +1,10 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 import { useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router";
-import { ArrowLeftIcon, RefreshCwIcon } from "lucide-react";
+import { ArrowLeftIcon, CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { cn } from "../../lib/utils";
-import { useUsage } from "../../state/usage";
+import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
 import {
   enumerateDays,
   formatCount,
@@ -36,6 +36,11 @@ export function UsagePage() {
   // shift the range and refetch every environment.
   const window = useMemo(() => makeWindow(windowDays), [windowDays]);
   const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
+
+  // Hold the content until every environment is terminal. Rendering merged
+  // totals while devices are still answering makes every number on the page
+  // jump as each one lands.
+  const settling = isPending || isPartial;
 
   const days = useMemo(
     () => enumerateDays(window.sinceDay, window.untilDay),
@@ -112,19 +117,19 @@ export function UsagePage() {
           </div>
         </header>
 
-        <UsageCoverageNotice
-          environments={environments}
-          duplicateSources={merged.duplicateSources}
-          staleEnvironments={merged.staleEnvironments}
-          isPartial={isPartial}
-        />
-
-        {isPending ? (
-          <p className="py-16 text-center text-sm text-muted-foreground">
-            Scanning provider transcripts…
-          </p>
+        {settling ? (
+          <>
+            {environments.length > 1 ? <UsageDeviceStrip environments={environments} /> : null}
+            <UsageSkeleton />
+          </>
         ) : (
           <>
+            <UsageCoverageNotice
+              environments={environments}
+              duplicateSources={merged.duplicateSources}
+              staleEnvironments={merged.staleEnvironments}
+            />
+
             {/* Cost first: the financial answer, then the provider split. */}
             <section className="grid gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)]">
               {/* The summary follows the chart toggle, so the headline and the
@@ -391,37 +396,30 @@ function Metric({
 }
 
 /**
- * Says plainly when the totals are incomplete: an environment still answering,
- * one that failed, or one whose transcripts another environment already
- * reported.
+ * Says plainly when the totals are incomplete: an environment that failed, or
+ * one whose transcripts another environment already reported. Environments
+ * that are still answering never reach this notice; the page shows the
+ * loading skeleton until every one is terminal.
  */
 function UsageCoverageNotice({
   environments,
   duplicateSources,
   staleEnvironments,
-  isPartial,
 }: {
-  readonly environments: readonly {
-    environmentId: string;
-    label: string;
-    error: string | null;
-    isPending: boolean;
-  }[];
+  readonly environments: readonly EnvironmentUsageStatus[];
   readonly duplicateSources: readonly string[];
   readonly staleEnvironments: readonly string[];
-  readonly isPartial: boolean;
 }) {
   const failed = environments.filter((environment) => environment.error !== null);
   const stale = environments.filter((environment) =>
     staleEnvironments.includes(environment.environmentId),
   );
-  if (failed.length === 0 && stale.length === 0 && duplicateSources.length === 0 && !isPartial) {
+  if (failed.length === 0 && stale.length === 0 && duplicateSources.length === 0) {
     return null;
   }
 
   return (
     <div className="flex flex-col gap-1 border border-border px-3 py-2 text-xs text-muted-foreground">
-      {isPartial ? <span>Some environments are still reporting. Totals are partial.</span> : null}
       {failed.map((environment) => (
         <span key={environment.label}>{environment.label} could not report usage.</span>
       ))}
@@ -437,5 +435,128 @@ function UsageCoverageNotice({
         </span>
       ) : null}
     </div>
+  );
+}
+
+/**
+ * Per-device progress while the page waits for every environment to answer.
+ * Only rendered with two or more devices; a lone device has nothing to
+ * enumerate.
+ */
+function UsageDeviceStrip({
+  environments,
+}: {
+  readonly environments: readonly EnvironmentUsageStatus[];
+}) {
+  const scanning = environments.filter(
+    (environment) => environment.summary === null && environment.error === null,
+  );
+  return (
+    <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 border border-border px-3 py-2 text-xs">
+      {environments.map((environment) => {
+        if (environment.summary !== null) {
+          return (
+            <span
+              key={environment.environmentId}
+              className="flex items-center gap-1 text-foreground"
+            >
+              <CheckIcon className="size-3 text-emerald-600 dark:text-emerald-300/90" aria-hidden />
+              {environment.label}
+            </span>
+          );
+        }
+        if (environment.error !== null) {
+          return (
+            <span
+              key={environment.environmentId}
+              className="flex items-center gap-1 text-destructive"
+            >
+              <XIcon className="size-3" aria-hidden />
+              {environment.label}
+            </span>
+          );
+        }
+        return (
+          <span
+            key={environment.environmentId}
+            className="animate-status-pulse text-muted-foreground"
+          >
+            {environment.label}…
+          </span>
+        );
+      })}
+      <span className="ms-auto text-muted-foreground">
+        {scanning.length === 1
+          ? "1 device still scanning"
+          : `${scanning.length} devices still scanning`}
+      </span>
+    </div>
+  );
+}
+
+/** Deterministic bar heights (each unique: they double as keys). */
+const SKELETON_BAR_HEIGHTS = [34, 58, 41, 72, 22, 12, 49, 63, 80, 38, 55, 26, 44, 67];
+
+/**
+ * Static stand-in with the loaded page's shape: headline, provider split,
+ * chart and metrics strip. No shimmer; blocks fill in exactly once when the
+ * last device answers.
+ */
+function UsageSkeleton() {
+  return (
+    <>
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)]">
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-1">
+            <span className="text-xs tracking-wide text-muted-foreground uppercase">
+              Raw token cost
+            </span>
+            <div className="my-1.5 h-8 w-36 rounded-sm bg-muted" />
+            <div className="h-3 w-28 rounded-sm bg-muted" />
+          </div>
+
+          {PROVIDER_ORDER.map((provider) => (
+            <div key={provider} className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between">
+                <span className="flex items-center gap-2 text-sm text-foreground">
+                  <ProviderMark provider={provider} className="size-4" />
+                  {PROVIDER_LABEL[provider]}
+                </span>
+                <div className="h-3.5 w-14 rounded-sm bg-muted" />
+              </div>
+              <div className="h-1 w-full rounded-full bg-muted" />
+              <div className="h-3 w-36 rounded-sm bg-muted" />
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <h2 className="py-1 text-sm font-medium text-foreground">Daily cost</h2>
+          {/* Mirrors the chart's h-56 body and w-14 axis gutter to avoid a
+              relayout when the real chart swaps in. */}
+          <div className="flex h-56 items-end gap-1 pl-16">
+            {SKELETON_BAR_HEIGHTS.map((height) => (
+              <div
+                key={height}
+                className="flex-1 rounded-sm bg-muted"
+                style={{ height: `${height}%` }}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-2 gap-px border-y border-border bg-border md:grid-cols-5">
+        {["Processed tokens", "Cached input", "Uncached input", "Output", "Cache savings"].map(
+          (label) => (
+            <div key={label} className="flex flex-col gap-0.5 bg-background px-4 py-3">
+              <span className="text-xs text-muted-foreground">{label}</span>
+              <div className="my-1 h-5 w-16 rounded-sm bg-muted" />
+              <div className="h-3 w-24 rounded-sm bg-muted" />
+            </div>
+          ),
+        )}
+      </section>
+    </>
   );
 }


### PR DESCRIPTION
Opening the usage page with several connected devices was gross: totals rendered as soon as the first device answered, then every number on the page revised itself as each remaining device landed.

The page now holds its content until every device is terminal (reported, failed, or stale). While waiting it keeps the header toggles live and shows a static skeleton in the page's final shape, topped with a per-device strip: reported devices get a check, failed ones an x, and still-scanning ones a duty-cycled pulse. The strip only appears with two or more devices; a single-device user just sees the skeleton. Failed and stale devices never block the gate, and changing the window or hitting refresh restarts it.

No shimmer or continuous animation; the skeleton is static and the scanning pulse reuses the existing duty-cycled `status-pulse` keyframes.

Built by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading and presentation changes on the usage page; no changes to how usage is fetched or merged.
> 
> **Overview**
> **Fixes jumping usage numbers** when several connected environments report at different times. The page no longer renders merged totals while any device is still scanning; it waits until every environment is terminal (success, error, or excluded as stale).
> 
> While loading, the header stays interactive and the body shows a **static skeleton** shaped like the final layout (no shimmer). With **two or more devices**, a **per-device strip** shows checkmarks for finished devices, an X for failures, and a pulsed label for devices still scanning, plus a count of devices left.
> 
> **Coverage messaging** moves behind the gate: the “partial totals” line is removed because in-progress devices never show real numbers anymore. Failed, stale, and duplicate-transcript warnings still appear once the page settles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7aa04dfec2777307073e56821a0046cb5dafb1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix usage totals jumping on the Usage page while devices report in
> - Replaces the previous partial-totals display with a static skeleton layout while usage data is still collecting from environments, preventing layout shifts as devices report in.
> - Adds a `UsageDeviceStrip` component (shown when multiple environments are present) that displays per-device status (completed, failed, or scanning) and a count of devices still scanning.
> - `UsageCoverageNotice` no longer shows a 'totals are partial' message; it only renders after all environments reach a terminal state, covering failures, stale environments, and duplicate sources.
> - The `UsageSkeleton` uses fixed bar heights (`SKELETON_BAR_HEIGHTS`) to avoid layout shifts and is replaced atomically when data is ready.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e7aa04d. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->