### PR TITLE
feat(server): vp run migrate-dev-db seeds worktree dev dbs with real data

### DIFF
--- a/apps/server/scripts/migrate-dev-db.test.ts
+++ b/apps/server/scripts/migrate-dev-db.test.ts
@@ -1,0 +1,148 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../src/persistence/Migrations.ts";
+import * as NodeSqliteClient from "../src/persistence/NodeSqliteClient.ts";
+import { runMigrateDevDb } from "./migrate-dev-db.ts";
+
+const withDatabase = <A, E>(
+  databasePath: string,
+  effect: Effect.Effect<A, E, SqlClient.SqlClient>,
+) => effect.pipe(Effect.provide(NodeSqliteClient.layer({ filename: databasePath })));
+
+/** A migrated source db with one thread per lifecycle state. Only
+ * `stopped-thread` qualifies for the clone. */
+const createFixtureSource = Effect.fn("createMigrateDevDbFixtureSource")(function* (
+  baseDir: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const stateDir = path.join(baseDir, "userdata");
+  const databasePath = path.join(stateDir, "state.sqlite");
+  yield* fs.makeDirectory(stateDir, { recursive: true });
+  yield* withDatabase(
+    databasePath,
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      // The real shared db carries this column from a branch build without a
+      // matching migration; reproduce that drift so the filter is exercised.
+      yield* sql`ALTER TABLE projection_threads ADD COLUMN monitor_json TEXT`;
+
+      yield* sql`INSERT INTO projection_projects
+        (project_id, title, workspace_root, scripts_json, created_at, updated_at, deleted_at)
+        VALUES
+        ('project-kept', 'Kept', '/tmp/kept', '[]', '2026-08-01', '2026-08-01', NULL),
+        ('project-deleted', 'Deleted', '/tmp/deleted', '[]', '2026-08-01', '2026-08-02', '2026-08-02')`;
+
+      const threads = [
+        ["stopped-thread", "project-kept", "stopped", null, null],
+        ["running-thread", "project-kept", "running", null, null],
+        ["settled-thread", "project-kept", "stopped", "2026-08-01", null],
+        ["monitored-thread", "project-kept", "stopped", null, '{"kind":"pr"}'],
+        ["deleted-project-thread", "project-deleted", "stopped", null, null],
+      ] as const;
+      for (const [threadId, projectId, status, settledAt, monitorJson] of threads) {
+        yield* sql`INSERT INTO projection_threads
+          (thread_id, project_id, title, created_at, updated_at, settled_at, monitor_json)
+          VALUES (${threadId}, ${projectId}, ${threadId}, '2026-08-01', '2026-08-01', ${settledAt}, ${monitorJson})`;
+        yield* sql`INSERT INTO projection_thread_sessions (thread_id, status, updated_at)
+          VALUES (${threadId}, ${status}, '2026-08-01')`;
+        yield* sql`INSERT INTO orchestration_events
+          (event_id, aggregate_kind, stream_id, stream_version, event_type, occurred_at, actor_kind, payload_json, metadata_json)
+          VALUES (${`event-${threadId}`}, 'thread', ${threadId}, 0, 'thread.created', '2026-08-01', 'user', '{}', '{}')`;
+      }
+      yield* sql`INSERT INTO auth_sessions (session_id, subject, scopes, method, issued_at, expires_at)
+        VALUES ('session-1', 'user', '[]', 'pairing', '2026-08-01', '2027-08-01')`;
+    }),
+  );
+  return databasePath;
+});
+
+it.layer(NodeServices.layer)("migrate-dev-db", (it) => {
+  it.effect("keeps only stopped threads from live projects and clears auth state", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const sourceDir = yield* fs.makeTempDirectoryScoped({ prefix: "migrate-dev-db-src-" });
+      const destDir = yield* fs.makeTempDirectoryScoped({ prefix: "migrate-dev-db-dest-" });
+      const source = yield* createFixtureSource(sourceDir);
+
+      const result = yield* runMigrateDevDb(
+        { baseDir: destDir, source, projects: 5, threadsPerProject: 10 },
+        { sharedHome: sourceDir },
+      );
+
+      assert.equal(result.databasePath, path.join(destDir, "userdata", "state.sqlite"));
+      const kept = yield* withDatabase(
+        result.databasePath,
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          const threads = yield* sql<{ thread_id: string }>`
+            SELECT thread_id FROM projection_threads ORDER BY thread_id`;
+          const events = yield* sql<{ stream_id: string }>`
+            SELECT stream_id FROM orchestration_events`;
+          const [auth] = yield* sql<{ count: number }>`
+            SELECT COUNT(*) AS count FROM auth_sessions`;
+          return { threads, events, authCount: auth?.count ?? 0 };
+        }),
+      );
+      assert.deepStrictEqual(
+        kept.threads.map((row) => row.thread_id),
+        ["stopped-thread"],
+      );
+      assert.deepStrictEqual(
+        kept.events.map((row) => row.stream_id),
+        ["stopped-thread"],
+      );
+      assert.equal(kept.authCount, 0);
+    }),
+  );
+
+  it.effect("fails loudly on a migration slot collision", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const sourceDir = yield* fs.makeTempDirectoryScoped({ prefix: "migrate-dev-db-slot-" });
+      const destDir = yield* fs.makeTempDirectoryScoped({ prefix: "migrate-dev-db-slot-dest-" });
+      const source = yield* createFixtureSource(sourceDir);
+      // Simulate another branch having claimed slot 1 first: the id is
+      // recorded, so this checkout's migration 1 silently never runs.
+      yield* withDatabase(
+        source,
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`UPDATE effect_sql_migrations
+            SET name = 'SomebodyElsesMigration' WHERE migration_id = 1`;
+        }),
+      );
+
+      const error = yield* runMigrateDevDb(
+        { baseDir: destDir, source, projects: 5, threadsPerProject: 10 },
+        { sharedHome: sourceDir },
+      ).pipe(Effect.flip);
+      assert.equal(error._tag, "MigrateDevDbSlotCollisionError");
+      if (error._tag === "MigrateDevDbSlotCollisionError") {
+        assert.equal(error.slot, 1);
+        assert.equal(error.appliedName, "SomebodyElsesMigration");
+      }
+    }),
+  );
+
+  it.effect("refuses to rebuild the shared home", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const sourceDir = yield* fs.makeTempDirectoryScoped({ prefix: "migrate-dev-db-shared-" });
+      const source = yield* createFixtureSource(sourceDir);
+
+      const error = yield* runMigrateDevDb(
+        { baseDir: sourceDir, source, projects: 5, threadsPerProject: 10 },
+        { sharedHome: sourceDir },
+      ).pipe(Effect.flip);
+      assert.equal(error._tag, "MigrateDevDbSharedHomeError");
+    }),
+  );
+});

--- a/apps/server/scripts/migrate-dev-db.test.ts
+++ b/apps/server/scripts/migrate-dev-db.test.ts
@@ -151,9 +151,8 @@ it.layer(NodeServices.layer)("migrate-dev-db", (it) => {
         { baseDir: destDir, source, projects: 5, threadsPerProject: 10 },
         { sharedHome: sourceDir },
       ).pipe(Effect.flip);
-      assert.equal(error._tag, "MigrateDevDbDestinationBusyError");
-      if (error._tag === "MigrateDevDbDestinationBusyError") {
-        assert.equal(error.reason, "server-running");
+      assert.equal(error._tag, "MigrateDevDbServerRunningError");
+      if (error._tag === "MigrateDevDbServerRunningError") {
         assert.equal(error.pid, process.pid);
       }
     }),

--- a/apps/server/scripts/migrate-dev-db.test.ts
+++ b/apps/server/scripts/migrate-dev-db.test.ts
@@ -132,6 +132,27 @@ it.layer(NodeServices.layer)("migrate-dev-db", (it) => {
     }),
   );
 
+  it.effect("refuses a source that resolves to a destination path", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const sharedDir = yield* fs.makeTempDirectoryScoped({ prefix: "migrate-dev-db-overlap-" });
+      const destDir = yield* fs.makeTempDirectoryScoped({ prefix: "migrate-dev-db-overlap-dest-" });
+      // A leftover snapshot from a prior failed run, passed as --source: it
+      // must not be deleted before it is read.
+      const leftoverSnapshot = path.join(destDir, "userdata", "state.sqlite.migrate-dev-db-tmp");
+      yield* fs.makeDirectory(path.dirname(leftoverSnapshot), { recursive: true });
+      yield* fs.writeFileString(leftoverSnapshot, "not a real db");
+
+      const error = yield* runMigrateDevDb(
+        { baseDir: destDir, source: leftoverSnapshot, projects: 5, threadsPerProject: 10 },
+        { sharedHome: sharedDir },
+      ).pipe(Effect.flip);
+      assert.equal(error._tag, "MigrateDevDbSourceIsDestinationError");
+      assert.equal(yield* fs.exists(leftoverSnapshot), true);
+    }),
+  );
+
   it.effect("refuses to rebuild the shared home", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/scripts/migrate-dev-db.test.ts
+++ b/apps/server/scripts/migrate-dev-db.test.ts
@@ -132,6 +132,33 @@ it.layer(NodeServices.layer)("migrate-dev-db", (it) => {
     }),
   );
 
+  it.effect("refuses while a dev server holds the destination", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const sourceDir = yield* fs.makeTempDirectoryScoped({ prefix: "migrate-dev-db-busy-" });
+      const destDir = yield* fs.makeTempDirectoryScoped({ prefix: "migrate-dev-db-busy-dest-" });
+      const source = yield* createFixtureSource(sourceDir);
+      // This test process stands in for a live dev server.
+      const stateDir = path.join(destDir, "userdata");
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(
+        path.join(stateDir, "server-runtime.json"),
+        `{"version":1,"pid":${process.pid}}`,
+      );
+
+      const error = yield* runMigrateDevDb(
+        { baseDir: destDir, source, projects: 5, threadsPerProject: 10 },
+        { sharedHome: sourceDir },
+      ).pipe(Effect.flip);
+      assert.equal(error._tag, "MigrateDevDbDestinationBusyError");
+      if (error._tag === "MigrateDevDbDestinationBusyError") {
+        assert.equal(error.reason, "server-running");
+        assert.equal(error.pid, process.pid);
+      }
+    }),
+  );
+
   it.effect("refuses a source that resolves to a destination path", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/scripts/migrate-dev-db.ts
+++ b/apps/server/scripts/migrate-dev-db.ts
@@ -81,19 +81,27 @@ export class MigrateDevDbSourceIsDestinationError extends Schema.TaggedErrorClas
   }
 }
 
+export class MigrateDevDbServerRunningError extends Schema.TaggedErrorClass<MigrateDevDbServerRunningError>()(
+  "MigrateDevDbServerRunningError",
+  {
+    databasePath: Schema.String,
+    pid: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Dev database at '${this.databasePath}' is open by a running server (pid ${this.pid} per server-runtime.json). Stop that server first; if that pid is not actually a T3 server (stale descriptor, reused pid), delete the server-runtime.json next to the database and retry.`;
+  }
+}
+
 export class MigrateDevDbDestinationBusyError extends Schema.TaggedErrorClass<MigrateDevDbDestinationBusyError>()(
   "MigrateDevDbDestinationBusyError",
   {
     databasePath: Schema.String,
-    reason: Schema.Literals(["server-running", "write-locked", "wal-held"]),
-    pid: Schema.optional(Schema.Number),
+    reason: Schema.Literals(["write-locked", "wal-held"]),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    if (this.reason === "server-running") {
-      return `Dev database at '${this.databasePath}' is open by a running server (pid ${this.pid ?? "unknown"} per server-runtime.json). Stop that server first; if that pid is not actually a T3 server (stale descriptor, reused pid), delete the server-runtime.json next to the database and retry.`;
-    }
     const detail =
       this.reason === "write-locked"
         ? "the database is write-locked"
@@ -191,9 +199,8 @@ const ensureNotInUse = Effect.fn("ensureDevDbNotInUse")(function* (databasePath:
     Effect.option,
   );
   if (Option.isSome(runtimeState) && isProcessAlive(runtimeState.value.pid)) {
-    return yield* new MigrateDevDbDestinationBusyError({
+    return yield* new MigrateDevDbServerRunningError({
       databasePath,
-      reason: "server-running",
       pid: runtimeState.value.pid,
     });
   }
@@ -346,6 +353,11 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
   input: RunMigrateDevDbInput,
   options: RunMigrateDevDbOptions = {},
 ) {
+  // SQLite treats a negative LIMIT as "no limit", which would clone
+  // everything. The CLI flags validate this too; this covers direct callers.
+  if (input.projects < 1 || input.threadsPerProject < 0) {
+    return yield* Effect.die("projects must be >= 1 and threadsPerProject >= 0");
+  }
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
 

--- a/apps/server/scripts/migrate-dev-db.ts
+++ b/apps/server/scripts/migrate-dev-db.ts
@@ -91,12 +91,13 @@ export class MigrateDevDbDestinationBusyError extends Schema.TaggedErrorClass<Mi
   },
 ) {
   override get message(): string {
+    if (this.reason === "server-running") {
+      return `Dev database at '${this.databasePath}' is open by a running server (pid ${this.pid ?? "unknown"} per server-runtime.json). Stop that server first; if that pid is not actually a T3 server (stale descriptor, reused pid), delete the server-runtime.json next to the database and retry.`;
+    }
     const detail =
-      this.reason === "server-running"
-        ? `a running server has it open (pid ${this.pid ?? "unknown"} per server-runtime.json)`
-        : this.reason === "write-locked"
-          ? "the database is write-locked"
-          : "another connection is holding its WAL";
+      this.reason === "write-locked"
+        ? "the database is write-locked"
+        : "another connection is holding its WAL";
     return `Dev database at '${this.databasePath}' looks in use (${detail}). Stop the dev server first; if none is running, delete the -wal/-shm files next to it.`;
   }
 }

--- a/apps/server/scripts/migrate-dev-db.ts
+++ b/apps/server/scripts/migrate-dev-db.ts
@@ -85,11 +85,16 @@ export class MigrateDevDbDestinationBusyError extends Schema.TaggedErrorClass<Mi
   "MigrateDevDbDestinationBusyError",
   {
     databasePath: Schema.String,
-    reason: Schema.String,
+    reason: Schema.Literals(["write-locked", "wal-held"]),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return `Dev database at '${this.databasePath}' looks in use (${this.reason}). Stop the dev server first; if none is running, delete the -wal/-shm files next to it.`;
+    const detail =
+      this.reason === "write-locked"
+        ? "the database is write-locked"
+        : "another connection is holding its WAL";
+    return `Dev database at '${this.databasePath}' looks in use (${detail}). Stop the dev server first; if none is running, delete the -wal/-shm files next to it.`;
   }
 }
 
@@ -168,17 +173,18 @@ const ensureNotInUse = Effect.fn("ensureDevDbNotInUse")(function* (databasePath:
   }).pipe(
     Effect.provide(NodeSqliteClient.layer({ filename: databasePath })),
     Effect.mapError(
-      () =>
+      (cause) =>
         new MigrateDevDbDestinationBusyError({
           databasePath,
-          reason: "the database is write-locked",
+          reason: "write-locked",
+          cause,
         }),
     ),
   );
   if (checkpoint[0] !== undefined && Number(checkpoint[0].busy) !== 0) {
     return yield* new MigrateDevDbDestinationBusyError({
       databasePath,
-      reason: "another connection is holding its WAL",
+      reason: "wal-held",
     });
   }
 });
@@ -408,11 +414,10 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
 
   yield* verifyMigrationSlots().pipe(
     Effect.provide(NodeSqliteClient.layer({ filename: databasePath })),
-    Effect.mapError((cause) =>
-      cause._tag === "MigrateDevDbSlotCollisionError"
-        ? cause
-        : new MigrateDevDbPhaseError({ phase: "verify", databasePath, cause }),
-    ),
+    Effect.catchTags({
+      SqlError: (cause) =>
+        Effect.fail(new MigrateDevDbPhaseError({ phase: "verify", databasePath, cause })),
+    }),
   );
 
   const size = (yield* fs.stat(databasePath)).size;

--- a/apps/server/scripts/migrate-dev-db.ts
+++ b/apps/server/scripts/migrate-dev-db.ts
@@ -1,0 +1,457 @@
+#!/usr/bin/env node
+
+/**
+ * Rebuild an isolated dev database from a pruned snapshot of the real
+ * ~/.t3 database, then run this checkout's migrations against it.
+ *
+ * `vp run migrate-dev-db` from a worktree:
+ *   1. Nukes `<worktree>/.t3/userdata/state.sqlite`.
+ *   2. Snapshots the real db (read-only VACUUM INTO) and prunes it to the
+ *      most recently updated projects and, per project, the most recent
+ *      threads that have fully stopped. Working, settled, and monitored
+ *      threads are skipped so the dev server never adopts live work.
+ *      Auth sessions, pairing links, command receipts, and provider
+ *      runtime rows are dropped — pair a fresh browser against dev.
+ *   3. Runs migrations on the result. Because the clone carries the real
+ *      `effect_sql_migrations` table, this proves a new migration applies
+ *      on top of the real applied set, and the slot check below catches
+ *      the silent failure where two branches claim the same
+ *      `Migrations/NNN_` id (the second one's CREATE TABLE is skipped).
+ *
+ * The event log (`orchestration_events`) is pruned per stream while
+ * `sqlite_sequence` and `projection_state` carry over untouched, so new
+ * events keep appending after the old high-water mark and projection
+ * cursors never rewind.
+ */
+
+// @effect-diagnostics nodeBuiltinImport:off - node:os resolves the shared T3 home guard.
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as NodeOS from "node:os";
+import { resolveWorktreeT3Home } from "@t3tools/shared/devHome";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { Command, Flag } from "effect/unstable/cli";
+
+import { migrationManifest, runMigrations } from "../src/persistence/Migrations.ts";
+import * as NodeSqliteClient from "../src/persistence/NodeSqliteClient.ts";
+
+export class MigrateDevDbNotInWorktreeError extends Schema.TaggedErrorClass<MigrateDevDbNotInWorktreeError>()(
+  "MigrateDevDbNotInWorktreeError",
+  {},
+) {
+  override get message(): string {
+    return "Not inside a linked git worktree. Pass --base-dir to target an isolated .t3 directory.";
+  }
+}
+
+export class MigrateDevDbSharedHomeError extends Schema.TaggedErrorClass<MigrateDevDbSharedHomeError>()(
+  "MigrateDevDbSharedHomeError",
+  {},
+) {
+  override get message(): string {
+    return "Refusing to rebuild the shared ~/.t3 database. Use an isolated --base-dir.";
+  }
+}
+
+export class MigrateDevDbSourceMissingError extends Schema.TaggedErrorClass<MigrateDevDbSourceMissingError>()(
+  "MigrateDevDbSourceMissingError",
+  {
+    sourcePath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Source database does not exist at '${this.sourcePath}'.`;
+  }
+}
+
+export class MigrateDevDbDestinationBusyError extends Schema.TaggedErrorClass<MigrateDevDbDestinationBusyError>()(
+  "MigrateDevDbDestinationBusyError",
+  {
+    databasePath: Schema.String,
+    reason: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Dev database at '${this.databasePath}' looks in use (${this.reason}). Stop the dev server first; if none is running, delete the -wal/-shm files next to it.`;
+  }
+}
+
+/**
+ * Two branches claimed the same Migrations/NNN_ slot: the id was already
+ * recorded under a different name, so this checkout's migration was
+ * silently skipped and its schema changes never applied.
+ */
+export class MigrateDevDbSlotCollisionError extends Schema.TaggedErrorClass<MigrateDevDbSlotCollisionError>()(
+  "MigrateDevDbSlotCollisionError",
+  {
+    slot: Schema.Number,
+    codeName: Schema.String,
+    appliedName: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Migration slot collision at ${this.slot}: this checkout registers '${this.codeName}' but the database already applied '${this.appliedName}' in that slot. Renumber the new migration to a free slot.`;
+  }
+}
+
+export class MigrateDevDbPhaseError extends Schema.TaggedErrorClass<MigrateDevDbPhaseError>()(
+  "MigrateDevDbPhaseError",
+  {
+    phase: Schema.Literals(["snapshot", "prune", "compact", "migrate", "verify"]),
+    databasePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `migrate-dev-db failed during ${this.phase} on '${this.databasePath}'.`;
+  }
+}
+
+export interface RunMigrateDevDbInput {
+  /** Isolated .t3 directory. Defaults to `<worktree>/.t3` of the cwd. */
+  readonly baseDir?: string | undefined;
+  /** Source database. Defaults to `~/.t3/userdata/state.sqlite`. */
+  readonly source?: string | undefined;
+  readonly projects: number;
+  readonly threadsPerProject: number;
+}
+
+export interface RunMigrateDevDbOptions {
+  /** Overridable for tests; the directory writes must never target. */
+  readonly sharedHome?: string | undefined;
+}
+
+interface KeptProject {
+  readonly title: string;
+  readonly threads: number;
+}
+
+const removeDatabaseFiles = Effect.fn("removeDatabaseFiles")(function* (databasePath: string) {
+  const fs = yield* FileSystem.FileSystem;
+  for (const suffix of ["", "-wal", "-shm"]) {
+    yield* fs.remove(`${databasePath}${suffix}`).pipe(Effect.orElseSucceed(() => undefined));
+  }
+});
+
+/** Best-effort liveness probe for a running dev server: BEGIN IMMEDIATE
+ * fails while a writer is active, and wal_checkpoint(TRUNCATE) reports busy
+ * while another connection holds the WAL. A leftover -shm alone is not a
+ * signal — read-only connections cannot clean it up on close. */
+const ensureNotInUse = Effect.fn("ensureDevDbNotInUse")(function* (databasePath: string) {
+  const fs = yield* FileSystem.FileSystem;
+  if (!(yield* fs.exists(databasePath))) {
+    return;
+  }
+  const checkpoint = yield* Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* sql.unsafe("PRAGMA busy_timeout = 0").unprepared;
+    yield* sql.unsafe("BEGIN IMMEDIATE").unprepared;
+    yield* sql.unsafe("ROLLBACK").unprepared;
+    return yield* sql.unsafe<{ busy: number }>("PRAGMA wal_checkpoint(TRUNCATE)").unprepared;
+  }).pipe(
+    Effect.provide(NodeSqliteClient.layer({ filename: databasePath })),
+    Effect.mapError(
+      () =>
+        new MigrateDevDbDestinationBusyError({
+          databasePath,
+          reason: "the database is write-locked",
+        }),
+    ),
+  );
+  if (checkpoint[0] !== undefined && Number(checkpoint[0].busy) !== 0) {
+    return yield* new MigrateDevDbDestinationBusyError({
+      databasePath,
+      reason: "another connection is holding its WAL",
+    });
+  }
+});
+
+const pruneSnapshot = Effect.fn("pruneDevDbSnapshot")(function* (input: RunMigrateDevDbInput) {
+  const sql = yield* SqlClient.SqlClient;
+
+  // The shared db can carry monitor_json from a branch build even though no
+  // migration in this checkout creates it, so filter it only when present.
+  const threadColumns = yield* sql<{ name: string }>`
+    SELECT name FROM pragma_table_info('projection_threads')`;
+  const monitorFilter = threadColumns.some((column) => column.name === "monitor_json")
+    ? "AND t.monitor_json IS NULL"
+    : "";
+
+  // "Stopped" is the persisted subset of the UI's thread status: the session
+  // reached status 'stopped' and nothing marks the thread settled or
+  // monitored. The in-memory working/monitoring liveness never persists, so
+  // filtering the session status is sufficient.
+  yield* sql.unsafe(`CREATE TEMP TABLE stopped_threads AS
+    SELECT t.thread_id, t.project_id, t.updated_at
+    FROM projection_threads t
+    JOIN projection_thread_sessions s ON s.thread_id = t.thread_id
+    WHERE t.deleted_at IS NULL
+      AND t.archived_at IS NULL
+      AND t.settled_at IS NULL
+      AND (t.settled_override IS NULL OR t.settled_override <> 'settled')
+      ${monitorFilter}
+      AND s.status = 'stopped'`).unprepared;
+
+  // Projects with clonable threads outrank empty-but-recent ones: the point
+  // of the exercise is thread data, not the project list.
+  yield* sql`CREATE TEMP TABLE kept_projects AS
+    SELECT p.project_id
+    FROM projection_projects p
+    LEFT JOIN (
+      SELECT project_id, MAX(updated_at) AS last_stopped_at
+      FROM stopped_threads
+      GROUP BY project_id
+    ) q ON q.project_id = p.project_id
+    WHERE p.deleted_at IS NULL
+    ORDER BY (q.last_stopped_at IS NULL) ASC,
+      COALESCE(q.last_stopped_at, p.updated_at) DESC
+    LIMIT ${input.projects}`;
+
+  yield* sql`CREATE TEMP TABLE kept_threads AS
+    SELECT thread_id FROM (
+      SELECT
+        st.thread_id,
+        ROW_NUMBER() OVER (
+          PARTITION BY st.project_id
+          ORDER BY st.updated_at DESC
+        ) AS recency_rank
+      FROM stopped_threads st
+      JOIN kept_projects kp ON kp.project_id = st.project_id
+    )
+    WHERE recency_rank <= ${input.threadsPerProject}`;
+
+  yield* sql.withTransaction(
+    Effect.gen(function* () {
+      yield* sql`DELETE FROM projection_projects
+        WHERE project_id NOT IN (SELECT project_id FROM kept_projects)`;
+      yield* sql`DELETE FROM projection_threads
+        WHERE thread_id NOT IN (SELECT thread_id FROM kept_threads)`;
+      for (const table of [
+        "projection_thread_messages",
+        "projection_thread_activities",
+        "projection_thread_sessions",
+        "projection_turns",
+        "projection_pending_approvals",
+        "projection_thread_proposed_plans",
+        "checkpoint_diff_blobs",
+      ]) {
+        yield* sql.unsafe(
+          `DELETE FROM ${table} WHERE thread_id NOT IN (SELECT thread_id FROM kept_threads)`,
+        ).unprepared;
+      }
+      yield* sql`DELETE FROM orchestration_events
+        WHERE (aggregate_kind = 'thread'
+            AND stream_id NOT IN (SELECT thread_id FROM kept_threads))
+           OR (aggregate_kind = 'project'
+            AND stream_id NOT IN (SELECT project_id FROM kept_projects))`;
+      yield* sql`DELETE FROM orchestration_command_receipts`;
+      yield* sql`DELETE FROM provider_session_runtime`;
+      yield* sql`DELETE FROM auth_sessions`;
+      yield* sql`DELETE FROM auth_pairing_links`;
+    }),
+  );
+
+  const keptProjects = yield* sql<{ title: string; threads: number }>`
+    SELECT
+      p.title,
+      (SELECT COUNT(*) FROM projection_threads t WHERE t.project_id = p.project_id) AS threads
+    FROM projection_projects p
+    ORDER BY p.updated_at DESC`;
+  const [events] = yield* sql<{ count: number }>`
+    SELECT COUNT(*) AS count FROM orchestration_events`;
+
+  return {
+    projects: keptProjects as ReadonlyArray<KeptProject>,
+    eventCount: events?.count ?? 0,
+  };
+});
+
+/** Compare this checkout's migration registry against what the cloned
+ * database recorded: same slot under a different name means the migration
+ * was skipped, not applied. */
+const verifyMigrationSlots = Effect.fn("verifyMigrationSlots")(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const applied = yield* sql<{ migration_id: number; name: string }>`
+    SELECT migration_id, name FROM effect_sql_migrations`;
+  const appliedById = new Map(applied.map((row) => [Number(row.migration_id), row.name]));
+  for (const [slot, codeName] of migrationManifest) {
+    const appliedName = appliedById.get(slot);
+    if (appliedName !== undefined && appliedName !== codeName) {
+      return yield* new MigrateDevDbSlotCollisionError({ slot, codeName, appliedName });
+    }
+  }
+});
+
+export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
+  input: RunMigrateDevDbInput,
+  options: RunMigrateDevDbOptions = {},
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const sharedHome = path.resolve(options.sharedHome ?? path.join(NodeOS.homedir(), ".t3"));
+  const sourcePath = path.resolve(
+    input.source ?? path.join(sharedHome, "userdata", "state.sqlite"),
+  );
+
+  const baseDir =
+    input.baseDir !== undefined
+      ? path.resolve(input.baseDir)
+      : yield* resolveWorktreeT3Home(process.cwd());
+  if (baseDir === undefined) {
+    return yield* new MigrateDevDbNotInWorktreeError();
+  }
+  const stateDir = path.join(baseDir, "userdata");
+  const databasePath = path.join(stateDir, "state.sqlite");
+  const snapshotPath = `${databasePath}.migrate-dev-db-tmp`;
+
+  if (!(yield* fs.exists(sourcePath))) {
+    return yield* new MigrateDevDbSourceMissingError({ sourcePath });
+  }
+  const [canonicalBaseDir, canonicalSharedHome] = yield* Effect.all([
+    fs.realPath(baseDir).pipe(Effect.orElseSucceed(() => baseDir)),
+    fs.realPath(sharedHome).pipe(Effect.orElseSucceed(() => sharedHome)),
+  ]);
+  if (canonicalBaseDir === canonicalSharedHome) {
+    return yield* new MigrateDevDbSharedHomeError();
+  }
+
+  yield* fs.makeDirectory(stateDir, { recursive: true });
+  yield* ensureNotInUse(databasePath);
+
+  const wrapPhase =
+    (phase: MigrateDevDbPhaseError["phase"], phaseDatabasePath: string) =>
+    <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.mapError(
+          (cause) => new MigrateDevDbPhaseError({ phase, databasePath: phaseDatabasePath, cause }),
+        ),
+      );
+
+  yield* Console.log(`Snapshotting ${sourcePath} (read-only)...`);
+  yield* removeDatabaseFiles(snapshotPath);
+  yield* Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* sql`VACUUM INTO ${snapshotPath}`;
+  }).pipe(
+    Effect.provide(NodeSqliteClient.layer({ filename: sourcePath, readonly: true })),
+    wrapPhase("snapshot", sourcePath),
+  );
+
+  yield* Console.log(
+    `Pruning to ${input.projects} projects, ${input.threadsPerProject} stopped threads each...`,
+  );
+  const pruned = yield* pruneSnapshot(input).pipe(
+    Effect.provide(NodeSqliteClient.layer({ filename: snapshotPath })),
+    wrapPhase("prune", snapshotPath),
+  );
+
+  yield* Console.log(`Compacting into ${databasePath}...`);
+  yield* removeDatabaseFiles(databasePath);
+  yield* Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* sql`VACUUM INTO ${databasePath}`;
+  }).pipe(
+    Effect.provide(NodeSqliteClient.layer({ filename: snapshotPath })),
+    wrapPhase("compact", databasePath),
+  );
+  yield* removeDatabaseFiles(snapshotPath);
+  yield* fs.chmod(databasePath, 0o600);
+
+  yield* Console.log("Running migrations...");
+  const executedMigrations = yield* Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    // Mirror server boot (persistence/Layers/Sqlite.ts) so first `vp run dev`
+    // finds the database exactly as it would have left it.
+    yield* sql.unsafe("PRAGMA foreign_keys = ON").unprepared;
+    yield* sql.unsafe("PRAGMA journal_mode = WAL").unprepared;
+    return yield* runMigrations();
+  }).pipe(
+    Effect.provide(NodeSqliteClient.layer({ filename: databasePath })),
+    wrapPhase("migrate", databasePath),
+  );
+
+  yield* verifyMigrationSlots().pipe(
+    Effect.provide(NodeSqliteClient.layer({ filename: databasePath })),
+    Effect.mapError((cause) =>
+      cause._tag === "MigrateDevDbSlotCollisionError"
+        ? cause
+        : new MigrateDevDbPhaseError({ phase: "verify", databasePath, cause }),
+    ),
+  );
+
+  const size = (yield* fs.stat(databasePath)).size;
+  return {
+    databasePath,
+    sizeBytes: Number(size),
+    projects: pruned.projects,
+    eventCount: pruned.eventCount,
+    executedMigrations: executedMigrations.map(([id, name]) => `${id}_${name}`),
+  };
+});
+
+const formatSize = (bytes: number): string =>
+  bytes >= 1024 * 1024
+    ? `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+    : `${(bytes / 1024).toFixed(0)} KB`;
+
+export const migrateDevDbCommand = Command.make(
+  "migrate-dev-db",
+  {
+    projects: Flag.integer("projects").pipe(
+      Flag.withDefault(5),
+      Flag.withDescription("How many recently updated projects to keep."),
+    ),
+    threadsPerProject: Flag.integer("threads-per-project").pipe(
+      Flag.withDefault(10),
+      Flag.withDescription("How many recent stopped threads to keep per project."),
+    ),
+    baseDir: Flag.string("base-dir").pipe(
+      Flag.optional,
+      Flag.withDescription("Isolated .t3 directory. Defaults to the current worktree's .t3."),
+    ),
+    source: Flag.string("source").pipe(
+      Flag.optional,
+      Flag.withDescription("Source database. Defaults to ~/.t3/userdata/state.sqlite."),
+    ),
+  },
+  ({ projects, threadsPerProject, baseDir, source }) =>
+    Effect.gen(function* () {
+      const result = yield* runMigrateDevDb({
+        projects,
+        threadsPerProject,
+        baseDir: Option.getOrUndefined(baseDir),
+        source: Option.getOrUndefined(source),
+      });
+      yield* Console.log("");
+      yield* Console.log(
+        `Dev database ready: ${result.databasePath} (${formatSize(result.sizeBytes)})`,
+      );
+      for (const project of result.projects) {
+        yield* Console.log(`  ${project.title}: ${project.threads} threads`);
+      }
+      yield* Console.log(`  ${result.eventCount} orchestration events kept`);
+      yield* Console.log(
+        result.executedMigrations.length === 0
+          ? "  Migrations: already current (no new migrations in this checkout)"
+          : `  Migrations applied: ${result.executedMigrations.join(", ")}`,
+      );
+    }),
+).pipe(
+  Command.withDescription(
+    "Rebuild the worktree dev database from a pruned snapshot of the real ~/.t3 data, then run migrations.",
+  ),
+);
+
+if (import.meta.main) {
+  Command.run(migrateDevDbCommand, { version: "0.0.0" }).pipe(
+    Effect.provide(NodeServices.layer),
+    NodeRuntime.runMain,
+  );
+}

--- a/apps/server/scripts/migrate-dev-db.ts
+++ b/apps/server/scripts/migrate-dev-db.ts
@@ -464,6 +464,9 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
     );
 
     yield* Console.log(`Compacting into ${databasePath}...`);
+    // Re-check right before the swap: a dev server started while the
+    // snapshot was migrating and pruning must not lose its database.
+    yield* ensureNotInUse(databasePath);
     yield* removeDatabaseFiles(databasePath);
     yield* Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;

--- a/apps/server/scripts/migrate-dev-db.ts
+++ b/apps/server/scripts/migrate-dev-db.ts
@@ -85,15 +85,18 @@ export class MigrateDevDbDestinationBusyError extends Schema.TaggedErrorClass<Mi
   "MigrateDevDbDestinationBusyError",
   {
     databasePath: Schema.String,
-    reason: Schema.Literals(["write-locked", "wal-held"]),
+    reason: Schema.Literals(["server-running", "write-locked", "wal-held"]),
+    pid: Schema.optional(Schema.Number),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
     const detail =
-      this.reason === "write-locked"
-        ? "the database is write-locked"
-        : "another connection is holding its WAL";
+      this.reason === "server-running"
+        ? `a running server has it open (pid ${this.pid ?? "unknown"} per server-runtime.json)`
+        : this.reason === "write-locked"
+          ? "the database is write-locked"
+          : "another connection is holding its WAL";
     return `Dev database at '${this.databasePath}' looks in use (${detail}). Stop the dev server first; if none is running, delete the -wal/-shm files next to it.`;
   }
 }
@@ -155,12 +158,45 @@ const removeDatabaseFiles = Effect.fn("removeDatabaseFiles")(function* (database
   }
 });
 
-/** Best-effort liveness probe for a running dev server: BEGIN IMMEDIATE
- * fails while a writer is active, and wal_checkpoint(TRUNCATE) reports busy
- * while another connection holds the WAL. A leftover -shm alone is not a
- * signal — read-only connections cannot clean it up on close. */
+/** The slice of server-runtime.json this script cares about. */
+const ServerRuntimeState = Schema.fromJsonString(Schema.Struct({ pid: Schema.Number }));
+const decodeServerRuntimeState = Schema.decodeEffect(ServerRuntimeState);
+
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but belongs to someone else.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+};
+
+/** Liveness probe for a running dev server. The server writes its pid to
+ * server-runtime.json next to the database, which also catches an idle
+ * server holding an open-but-inactive connection. The SQL probes below back
+ * that up: BEGIN IMMEDIATE fails while a writer is active, and
+ * wal_checkpoint(TRUNCATE) reports busy while another connection holds the
+ * WAL. A leftover -shm alone is not a signal — read-only connections cannot
+ * clean it up on close. */
 const ensureNotInUse = Effect.fn("ensureDevDbNotInUse")(function* (databasePath: string) {
   const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const runtimeStatePath = path.join(path.dirname(databasePath), "server-runtime.json");
+  const runtimeState = yield* fs.readFileString(runtimeStatePath).pipe(
+    Effect.flatMap(decodeServerRuntimeState),
+    // A missing or malformed descriptor is not a liveness signal.
+    Effect.option,
+  );
+  if (Option.isSome(runtimeState) && isProcessAlive(runtimeState.value.pid)) {
+    return yield* new MigrateDevDbDestinationBusyError({
+      databasePath,
+      reason: "server-running",
+      pid: runtimeState.value.pid,
+    });
+  }
+
   if (!(yield* fs.exists(databasePath))) {
     return;
   }
@@ -368,7 +404,7 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
   yield* removeDatabaseFiles(snapshotPath);
   // The snapshot is a full-size copy of the source; make sure it is removed
   // even when a phase fails partway through.
-  const pruned = yield* Effect.gen(function* () {
+  const { executedMigrations, pruned } = yield* Effect.gen(function* () {
     yield* Console.log(`Snapshotting ${sourcePath} (read-only)...`);
     yield* Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
@@ -376,6 +412,21 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
     }).pipe(
       Effect.provide(NodeSqliteClient.layer({ filename: sourcePath, readonly: true })),
       wrapPhase("snapshot", sourcePath),
+    );
+
+    // Migrate before pruning: a source older than this checkout would
+    // otherwise crash the prune queries on columns that don't exist yet.
+    // Running against the full snapshot also exercises new migrations on the
+    // same data volume the real database would face.
+    yield* Console.log("Running migrations on the snapshot...");
+    const executed = yield* Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      // Mirror server boot (persistence/Layers/Sqlite.ts).
+      yield* sql.unsafe("PRAGMA foreign_keys = ON").unprepared;
+      return yield* runMigrations();
+    }).pipe(
+      Effect.provide(NodeSqliteClient.layer({ filename: snapshotPath })),
+      wrapPhase("migrate", snapshotPath),
     );
 
     yield* Console.log(
@@ -395,24 +446,17 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
       Effect.provide(NodeSqliteClient.layer({ filename: snapshotPath })),
       wrapPhase("compact", databasePath),
     );
-    return result;
+    return { executedMigrations: executed, pruned: result };
   }).pipe(Effect.ensuring(removeDatabaseFiles(snapshotPath)));
   yield* fs.chmod(databasePath, 0o600);
 
-  yield* Console.log("Running migrations...");
-  const executedMigrations = yield* Effect.gen(function* () {
+  yield* Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
-    // Mirror server boot (persistence/Layers/Sqlite.ts) so first `vp run dev`
-    // finds the database exactly as it would have left it.
-    yield* sql.unsafe("PRAGMA foreign_keys = ON").unprepared;
+    // WAL does not survive VACUUM INTO; set it so first `vp run dev` finds
+    // the database exactly as server boot would have left it.
     yield* sql.unsafe("PRAGMA journal_mode = WAL").unprepared;
-    return yield* runMigrations();
+    yield* verifyMigrationSlots();
   }).pipe(
-    Effect.provide(NodeSqliteClient.layer({ filename: databasePath })),
-    wrapPhase("migrate", databasePath),
-  );
-
-  yield* verifyMigrationSlots().pipe(
     Effect.provide(NodeSqliteClient.layer({ filename: databasePath })),
     Effect.catchTags({
       SqlError: (cause) =>

--- a/apps/server/scripts/migrate-dev-db.ts
+++ b/apps/server/scripts/migrate-dev-db.ts
@@ -430,6 +430,19 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
       wrapPhase("migrate", snapshotPath),
     );
 
+    // Verify while the snapshot is still the only thing touched: a slot
+    // collision must abort before the old worktree db gets replaced with a
+    // schema whose colliding migration was silently skipped.
+    yield* verifyMigrationSlots().pipe(
+      Effect.provide(NodeSqliteClient.layer({ filename: snapshotPath })),
+      Effect.catchTags({
+        SqlError: (cause) =>
+          Effect.fail(
+            new MigrateDevDbPhaseError({ phase: "verify", databasePath: snapshotPath, cause }),
+          ),
+      }),
+    );
+
     yield* Console.log(
       `Pruning to ${input.projects} projects, ${input.threadsPerProject} stopped threads each...`,
     );
@@ -456,13 +469,9 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
     // WAL does not survive VACUUM INTO; set it so first `vp run dev` finds
     // the database exactly as server boot would have left it.
     yield* sql.unsafe("PRAGMA journal_mode = WAL").unprepared;
-    yield* verifyMigrationSlots();
   }).pipe(
     Effect.provide(NodeSqliteClient.layer({ filename: databasePath })),
-    Effect.catchTags({
-      SqlError: (cause) =>
-        Effect.fail(new MigrateDevDbPhaseError({ phase: "verify", databasePath, cause })),
-    }),
+    wrapPhase("compact", databasePath),
   );
 
   const size = (yield* fs.stat(databasePath)).size;

--- a/apps/server/scripts/migrate-dev-db.ts
+++ b/apps/server/scripts/migrate-dev-db.ts
@@ -70,6 +70,17 @@ export class MigrateDevDbSourceMissingError extends Schema.TaggedErrorClass<Migr
   }
 }
 
+export class MigrateDevDbSourceIsDestinationError extends Schema.TaggedErrorClass<MigrateDevDbSourceIsDestinationError>()(
+  "MigrateDevDbSourceIsDestinationError",
+  {
+    sourcePath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Source database '${this.sourcePath}' resolves to a path this command rewrites. Pick a different --source or --base-dir.`;
+  }
+}
+
 export class MigrateDevDbDestinationBusyError extends Schema.TaggedErrorClass<MigrateDevDbDestinationBusyError>()(
   "MigrateDevDbDestinationBusyError",
   {
@@ -321,6 +332,20 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
   if (canonicalBaseDir === canonicalSharedHome) {
     return yield* new MigrateDevDbSharedHomeError();
   }
+  // The destination db and snapshot both get deleted below; a --source that
+  // resolves to either (e.g. a leftover snapshot file) would be destroyed
+  // before it is ever read.
+  const canonicalSourcePath = yield* fs
+    .realPath(sourcePath)
+    .pipe(Effect.orElseSucceed(() => sourcePath));
+  for (const destination of [databasePath, snapshotPath]) {
+    const canonicalDestination = yield* fs
+      .realPath(destination)
+      .pipe(Effect.orElseSucceed(() => destination));
+    if (canonicalSourcePath === canonicalDestination) {
+      return yield* new MigrateDevDbSourceIsDestinationError({ sourcePath });
+    }
+  }
 
   yield* fs.makeDirectory(stateDir, { recursive: true });
   yield* ensureNotInUse(databasePath);
@@ -334,34 +359,38 @@ export const runMigrateDevDb = Effect.fn("runMigrateDevDb")(function* (
         ),
       );
 
-  yield* Console.log(`Snapshotting ${sourcePath} (read-only)...`);
   yield* removeDatabaseFiles(snapshotPath);
-  yield* Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-    yield* sql`VACUUM INTO ${snapshotPath}`;
-  }).pipe(
-    Effect.provide(NodeSqliteClient.layer({ filename: sourcePath, readonly: true })),
-    wrapPhase("snapshot", sourcePath),
-  );
+  // The snapshot is a full-size copy of the source; make sure it is removed
+  // even when a phase fails partway through.
+  const pruned = yield* Effect.gen(function* () {
+    yield* Console.log(`Snapshotting ${sourcePath} (read-only)...`);
+    yield* Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`VACUUM INTO ${snapshotPath}`;
+    }).pipe(
+      Effect.provide(NodeSqliteClient.layer({ filename: sourcePath, readonly: true })),
+      wrapPhase("snapshot", sourcePath),
+    );
 
-  yield* Console.log(
-    `Pruning to ${input.projects} projects, ${input.threadsPerProject} stopped threads each...`,
-  );
-  const pruned = yield* pruneSnapshot(input).pipe(
-    Effect.provide(NodeSqliteClient.layer({ filename: snapshotPath })),
-    wrapPhase("prune", snapshotPath),
-  );
+    yield* Console.log(
+      `Pruning to ${input.projects} projects, ${input.threadsPerProject} stopped threads each...`,
+    );
+    const result = yield* pruneSnapshot(input).pipe(
+      Effect.provide(NodeSqliteClient.layer({ filename: snapshotPath })),
+      wrapPhase("prune", snapshotPath),
+    );
 
-  yield* Console.log(`Compacting into ${databasePath}...`);
-  yield* removeDatabaseFiles(databasePath);
-  yield* Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-    yield* sql`VACUUM INTO ${databasePath}`;
-  }).pipe(
-    Effect.provide(NodeSqliteClient.layer({ filename: snapshotPath })),
-    wrapPhase("compact", databasePath),
-  );
-  yield* removeDatabaseFiles(snapshotPath);
+    yield* Console.log(`Compacting into ${databasePath}...`);
+    yield* removeDatabaseFiles(databasePath);
+    yield* Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`VACUUM INTO ${databasePath}`;
+    }).pipe(
+      Effect.provide(NodeSqliteClient.layer({ filename: snapshotPath })),
+      wrapPhase("compact", databasePath),
+    );
+    return result;
+  }).pipe(Effect.ensuring(removeDatabaseFiles(snapshotPath)));
   yield* fs.chmod(databasePath, 0o600);
 
   yield* Console.log("Running migrations...");

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:web": "node scripts/dev-runner.ts dev:web",
     "dev:marketing": "vp run --filter @t3tools/marketing dev",
     "dev:desktop": "node scripts/dev-runner.ts dev:desktop",
+    "migrate-dev-db": "node apps/server/scripts/migrate-dev-db.ts",
     "start": "vp run --filter t3 start",
     "start:desktop": "vp run --filter @t3tools/desktop start",
     "start:marketing": "vp run --filter @t3tools/marketing preview",


### PR DESCRIPTION
Worktree dev servers start with an empty database, so testing anything real means clicking around to fabricate projects and threads. And nothing checks that a new migration applies cleanly on top of the real database's applied-migration state — fresh CI databases always pass.

`vp run migrate-dev-db` fixes both. It snapshots the real `~/.t3` database read-only (`VACUUM INTO`), prunes it to a handful of recent projects and their fully-stopped threads, and drops it into the worktree's isolated `.t3`. Then it runs this checkout's migrations against the result, which is real applied state, and fails loudly if a migration slot id was already taken under a different name (the silent-skip collision that has bitten parallel PRs before).

Details:
- Keeps threads only when their session is `stopped` and they are not settled, monitored, archived, or deleted. Working/monitoring liveness is in-memory only, so the persisted filter is exact.
- Event-sourcing stays consistent: kept threads keep their full `orchestration_events` streams, and `sqlite_sequence` plus `projection_state` cursors carry over, so nothing rewinds.
- Auth sessions, pairing links, command receipts, and provider runtime rows are dropped. Pair a fresh browser.
- Refuses to touch the shared `~/.t3` and refuses while a dev server holds the destination db.
- Flags: `--projects` (5), `--threads-per-project` (10), `--base-dir`, `--source`.
- Tolerates the `monitor_json` column that exists in the live db without a matching migration.

Tested end to end on the real database (2.5 GB in, ~145 MB out, 17 threads across 5 projects) plus three colocated tests covering the lifecycle filter, slot-collision detection, and the shared-home guard.

Built by Claude Fable 5 running in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real user database copies and rewrites worktree dev SQLite, but refuses the shared home and active servers; main risk is mistaken --base-dir/--source paths or incomplete prune semantics for edge thread states.
> 
> **Overview**
> Adds **`migrate-dev-db`** (`pnpm migrate-dev-db` / `vp run migrate-dev-db`) so a git worktree can get a **pruned copy of the real `~/.t3` SQLite state** instead of an empty dev database.
> 
> The command **read-only snapshots** the source (`VACUUM INTO`), **runs this checkout’s migrations** on that clone (so new migrations are exercised against real `effect_sql_migrations` history), **verifies migration slot names** and fails with `MigrateDevDbSlotCollisionError` when a slot was applied under a different name, then **prunes** to recent live projects and **fully stopped** threads (skips running, settled, monitored, deleted/archived), **drops auth/pairing/command receipts/provider runtime**, trims `orchestration_events` per kept stream while leaving projection cursors/sequences intact, and **compacts** into the worktree’s isolated `.t3/userdata/state.sqlite` with `0600` and WAL.
> 
> **Guards** block rebuilding shared `~/.t3`, using a source that resolves to the destination or temp snapshot path, and overwriting the DB while `server-runtime.json` indicates a live server or SQLite reports write/WAL contention.
> 
> Vitest coverage exercises the prune filter, slot collision, server-running refusal, source/destination overlap, and shared-home refusal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 451a1adfddae36d7ab52b3e3db1396443160639a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `migrate-dev-db` script to seed worktree dev databases with real data
> - Adds [migrate-dev-db.ts](https://github.com/pingdotgg/t3code/pull/5773/files#diff-7a61f20d86e31fd0943f3507d20d0428a6c28b5a65f5defbe50fef9a385b24dc) — a new CLI script and programmatic API (`runMigrateDevDb`) that snapshots a source SQLite database, runs pending migrations, prunes it to recent stopped threads and their projects, strips auth/runtime state, and compacts the result into a destination dev database.
> - Pruning keeps the N most recently updated projects (default 5) and, per project, the M most recent stopped threads (default 10), dropping all auth sessions, pairing links, and provider runtime state.
> - Adds multiple guard checks before touching the destination: detects a live dev server via `server-runtime.json`, checks for write-locks and WAL holds on the destination file, refuses to target the shared `~/.t3` home, and rejects a source path that resolves to the destination.
> - Introduces typed errors (`MigrateDevDbSlotCollisionError`, `MigrateDevDbServerRunningError`, etc.) and phase-wrapped errors for snapshot, prune, compact, migrate, and verify stages.
> - Adds `npm run migrate-dev-db` in [package.json](https://github.com/pingdotgg/t3code/pull/5773/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) as the CLI entrypoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 451a1ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->