### PR TITLE
fix(web): sidebar rows show the branch again, not a truncated plan step

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1168,18 +1168,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               ) : null}
             </div>
             <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-secondary-label text-xs">
-              {/* While working, the current plan step outranks the branch:
-                  it's the one line that says what the thread is doing. */}
-              {status === "working" && thread.planProgress ? (
-                <span className="min-w-0 flex-1 truncate whitespace-nowrap">
-                  {thread.planProgress.step}
-                  {/* Completed count, matching the transcript chip's n/m. */}
-                  <span className="text-icon-muted tabular-nums">
-                    {" "}
-                    {thread.planProgress.completedSteps}/{thread.planProgress.totalSteps}
-                  </span>
-                </span>
-              ) : thread.branch ? (
+              {/* Always the branch. The plan step used to take this slot while
+                  working, but it truncated to a half-sentence and dropped the
+                  branch, so the row lost its most stable identifier. */}
+              {thread.branch ? (
                 <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
               ) : (
                 <span className="flex-1" />


### PR DESCRIPTION
Some sidebar rows stopped showing the branch name and showed a random-looking sentence fragment instead. Gross.

That text was the agent's current plan step. #5558 gave it the branch's slot on any working row, and #5672 made that sidebar the default, so it showed up everywhere at once. Two problems with it:

- The step text almost always overflowed and truncated to a half-sentence.
- The `n/m` progress counter sat inside the same truncating span, so it got cut off too.

The row gave up its most stable identifier and got nothing readable back. Now the subtitle is always the branch.

`thread.planProgress` is still on the wire and the chat view still derives its own step label from activities, so the in-chat working row is unchanged. The sidebar was the only reader of the server field, so `getThreadPlanProgress` is now dead weight in the projection snapshot query. Left it alone here since removing it touches the contract.

---
Made with Claude Opus 5 (1M context) on Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional UI change in the sidebar with no auth, data, or API contract changes in this diff.
> 
> **Overview**
> **Sidebar card rows** no longer swap the subtitle for the agent’s current plan step while a thread is **Working**. That slot always shows **`thread.branch`** again (or stays empty when there is no branch).
> 
> Previously, working rows prioritized `thread.planProgress` (step text plus `completedSteps/totalSteps`), which often truncated mid-sentence and hid the branch—the row’s most stable identifier. In-chat working UI still derives its step label from activities; only the sidebar read of server `planProgress` is removed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a05804be1d730a3270e05f036f40015d3f33fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar thread rows to show branch instead of truncated plan step
> In [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/5776/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), the secondary metadata line in `SidebarThreadRow` previously swapped to showing the current plan step and completed/total counters while a thread was in `working` status. It now unconditionally shows `thread.branch` when available, removing the plan progress display entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57a0580.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->