### PR TITLE
fix(shared): bound the file-link label so bracket runs stop rescanning

### DIFF
--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -129,4 +129,25 @@ describe("collectComposerInlineTokens", () => {
       },
     ]);
   });
+
+  it("still collects a file link whose label is at the length cap", () => {
+    const label = `${"a".repeat(508)}.tsx`;
+    const tokens = collectComposerInlineTokens(`see [${label}](src/${label}) ok`);
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.value).toBe(`src/${label}`);
+  });
+
+  it("leaves a file link past the label cap as plain text", () => {
+    const label = `${"a".repeat(509)}.tsx`;
+    expect(collectComposerInlineTokens(`see [${label}](src/${label}) ok`)).toEqual([]);
+  });
+
+  it("stays fast on unterminated bracket runs", () => {
+    // Unbounded, the label body rescanned the rest of the text from every
+    // whitespace: this input took seconds.
+    const started = performance.now();
+    expect(collectComposerInlineTokens(" [[".repeat(40_000))).toEqual([]);
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
 });

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -20,7 +20,21 @@ export interface CollectComposerInlineTokensOptions {
 
 const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s)/g;
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
-const FILE_LINK_TOKEN_REGEX = /(^|\s)\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)(?=\s)/g;
+/**
+ * The label body is bounded rather than `*`. Unbounded, every whitespace in
+ * the composer is a candidate start: the engine scans the rest of the text for
+ * a closing `]`, fails, and rescans from the next whitespace — quadratic on
+ * input like " [[[[[…". A cap makes each attempt constant-bounded.
+ *
+ * Only a basename ever survives the `label !== basename` check below, so this
+ * cannot reject a link a user could meaningfully write; the longest filename
+ * any common filesystem allows is 255.
+ */
+const MAX_FILE_LINK_LABEL_LENGTH = 512;
+const FILE_LINK_TOKEN_REGEX = new RegExp(
+  `(^|\\s)\\[((?:\\\\.|[^\\]\\\\]){0,${MAX_FILE_LINK_LABEL_LENGTH}})\\]\\(([^)\\s]+)\\)(?=\\s)`,
+  "g",
+);
 const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
 // Autocomplete emits canonical file links, so ambiguous bare @scope/package text stays a package.


### PR DESCRIPTION
# fix(shared): bound the file-link label so bracket runs stop rescanning

## What changed

`FILE_LINK_TOKEN_REGEX` in `packages/shared/src/composerInlineTokens.ts` let the
label body repeat without a bound:

```js
/(^|\s)\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)(?=\s)/g
```

This caps it at 512 characters. Two files, +36/-1.

## Why it should exist

With an unbounded body, every whitespace in the composer is a candidate start:
the engine scans the rest of the text for a closing `]`, fails, then rescans
from the next whitespace. On a run of unterminated brackets that is quadratic,
and `collectComposerInlineTokens` runs on raw composer text — so pasting one
freezes the tab.

Measured on `" [["` repeated, before → after:

| input | before | after |
|---|---|---|
| 30k chars | 167ms | 8ms |
| 60k chars | 676ms | 17ms |
| 120k chars | 2838ms | 33ms |

Doubling the input quadruples the old time, which is the quadratic signature.

Scope, stated honestly: ordinary pastes are unaffected, because a `]` anywhere
ahead bounds each attempt. A 104k-char markdown table of `[a] [b] [c]` cells and
a 172k-char code paste full of `arr[i][j][k]` both measure 0ms before and after.
The trigger is a long run of `[` with no closing bracket following. So this is a
self-inflicted UI freeze on degenerate or hostile paste content, not a server-side
availability issue — worth fixing, not worth alarm.

## Why the cap is safe

The cap cannot reject a link anyone could meaningfully write. Only a basename
survives the `label !== basename` check immediately below the match, and the
longest filename any common filesystem allows is 255.

## How it was verified

Behavioural equivalence against the old pattern over **156,504 generated
inputs** — exhaustive triples over an alphabet of `[ ] ( ) \ @ "`, tab, newline,
space and path-ish fragments; structured `[label](path)` shapes across prefix and
suffix contexts; and 150,000 randomized fuzz strings. Compared match count, match
offsets, and every capture group.

**Zero differences.**

The single intended difference is at the cap itself: a 512-character label still
matches, 513 no longer does. The two new boundary tests pin exactly that, and a
third asserts the bracket-run case completes in under a second.

No UI change, so no screenshots — this is pure tokenizer logic behind the
composer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized tokenizer regex change with extensive equivalence testing; only rejects implausibly long link labels and improves client-side paste performance.
> 
> **Overview**
> **Fixes composer freezes** when pasted text has long runs of unclosed `[` brackets by capping how much of a `[label](path)` label the file-link regex will scan.
> 
> `FILE_LINK_TOKEN_REGEX` in `composerInlineTokens.ts` no longer uses an unbounded label repeat; it limits the label body to **512 characters** via `MAX_FILE_LINK_LABEL_LENGTH`, so each match attempt is constant-bounded instead of rescanning the rest of the string from every whitespace (quadratic on inputs like repeated `" [["`).
> 
> Normal file links are unchanged in practice because only basenames pass validation and real filenames are far below the cap. Links with labels at 512 chars still tokenize; longer labels are left as plain text.
> 
> Tests add cap boundary cases and a performance guard on a 40k-char unterminated bracket run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b71e345a1d9934dab7d523e19f550d25dd613a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound file-link label length to 512 chars to prevent catastrophic bracket rescanning
> - Introduces `MAX_FILE_LINK_LABEL_LENGTH = 512` in [composerInlineTokens.ts](https://github.com/pingdotgg/t3code/pull/5782/files#diff-5cffe3270b732b403f881278a2c54291483129bca7ee5cdb8c14f1cc6aac666c) and rebuilds `FILE_LINK_TOKEN_REGEX` with a bounded quantifier to cap label body length.
> - Prevents catastrophic backtracking when the tokenizer encounters long runs of unterminated brackets.
> - Behavioral Change: file link tokens with labels exceeding 512 characters are no longer recognized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b71e34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->