### PR TITLE
fix(server): one greedy agent process no longer takes down the whole server

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -35,6 +35,18 @@ it("keeps systemd pinned to the stable launcher rather than a versioned server",
   expect(unit).not.toContain("versions/1.2.3");
 });
 
+it("survives the kernel OOM-killing a greedy agent child", () => {
+  const unit = BootService.renderBootServiceUnit({
+    nodePath: "/usr/bin/node",
+    launcherPath: "/home/theo/.t3/runtime/service-launcher.mjs",
+    baseDir: "/home/theo/.t3",
+    logPath: "/home/theo/.t3/userdata/logs/boot-service.log",
+    unitPath: "/home/theo/.config/systemd/user/t3code.service",
+  });
+
+  expect(unit).toContain("OOMPolicy=continue");
+});
+
 const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
   platform: NodeJS.Platform = "linux",
   usePinnedLauncher = false,

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -67,6 +67,11 @@ export function renderBootServiceUnit(plan: BootServicePlan): string {
     // Let the launcher mark an explicit stop before it signals the server.
     // systemd still SIGKILLs the whole cgroup if graceful shutdown times out.
     "KillMode=mixed",
+    // Agent tool calls run as children of the server, so they share this cgroup.
+    // With the systemd default of OOMPolicy=stop, the kernel killing one greedy
+    // child stops the whole unit: the server, every live agent, and the user's
+    // connection. Keep running and let Restart=always cover the main process.
+    "OOMPolicy=continue",
     "Restart=always",
     "RestartSec=5",
     `StandardOutput=append:${escapeSystemdSpecifiers(plan.logPath)}`,


### PR DESCRIPTION
## Problem

My connection kept dropping with `Relay environment endpoint is unavailable: endpoint_request_failed`, and it looked like a relay bug. It was not. The server was being killed and restarted underneath me.

An agent was running memory-hungry python scripts in a worktree. Three times in one hour they grew past 50 GB and the kernel OOM killer reaped them. That part is fine and working as intended.

The problem is what happened next. Agent tool calls run as children of the server, so they live in the same `t3code.service` cgroup. systemd defaults to `OOMPolicy=stop`, which means killing any one process in a unit stops the entire unit. So one bad python script took down the server, every live agent, and my ssh sessions:

```
t3code.service: The kernel OOM killer killed some processes in this unit.
t3code.service: Killing process 2065546 (claude) with signal SIGKILL.
t3code.service: Failed with result 'oom-kill'.
```

cloudflared survives those restarts, so the tunnel stays up and points at a dead origin. The relay's mint-credential request then gets:

```
Unable to reach the origin service ... dial tcp 127.0.0.1:3773: connect: connection refused
dest=.../api/t3-connect/mint-credential
```

which maps to `EnvironmentMintRequestFailed` and surfaces as the banner.

## Solution

Set `OOMPolicy=continue` on the generated unit. The kernel still reaps the greedy child, but the server keeps running and nobody gets disconnected. `Restart=always` still covers the case where the main process itself dies.

Existing installs heal themselves. `status.current` compares the installed unit against the rendered one, so the next update rewrites it.

## Verification

- `vp test run apps/server/src/cloud/bootService.test.ts` passes (7 tests).
- `systemd-analyze verify` accepts the rendered unit on systemd 259.
- Typecheck on `apps/server` is clean.

---

Written by Claude Opus 5 (1M context) in Claude Code, driven by Theo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-running service supervision behavior on Linux; misconfiguration could leave a degraded server running after OOM, though scope is limited to the generated unit and existing restart policy.
> 
> **Overview**
> **Prevents a single OOM-killed agent child from stopping the whole `t3code.service` unit.**
> 
> `renderBootServiceUnit` now emits **`OOMPolicy=continue`** in the generated systemd user unit. Agent tool processes share the server’s cgroup; with systemd’s default **`OOMPolicy=stop`**, the kernel reaping one memory-heavy child could tear down the server, other agents, and live sessions. The greedy process still dies; the main server keeps running, with **`Restart=always`** unchanged for when the main process itself exits.
> 
> A unit test asserts the rendered unit includes **`OOMPolicy=continue`**. Installs that compare the on-disk unit to the rendered template pick up the change on the next repair/update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf0584378c7e99c3d2b5b3e1faf3cc034ba44df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent OOM-killed agent child processes from stopping the server
> Adds `OOMPolicy=continue` to the systemd unit generated by `renderBootServiceUnit` in [bootService.ts](https://github.com/pingdotgg/t3code/pull/5788/files#diff-9ec1426b86c5c9f63a503a0c78a87a5165a6460ca539deb5c365bda9ff0576f0). This tells systemd to keep the parent service running when a child process is OOM-killed, rather than stopping the whole unit. A test is added to assert the directive is present in the generated unit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cf0584.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->