### PR TITLE
feat(ios): show app and environment versions

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -2584,6 +2584,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                         ]
                         let config = ServerConfigSnapshot(
                             providers: providers,
+                            environment: previous?.environment,
                             settings: previous?.settings,
                             threadSnapshotPagination: previous?.threadSnapshotPagination
                         )
@@ -2595,6 +2596,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                         ]?.providers ?? self.latestServerConfig?.providers ?? []
                         let config = ServerConfigSnapshot(
                             providers: providers,
+                            environment: self.serverConfigsByEnvironmentID[
+                                activeClient.environment.id
+                            ]?.environment,
                             settings: settings,
                             threadSnapshotPagination: self.serverConfigsByEnvironmentID[
                                 activeClient.environment.id
@@ -3821,10 +3825,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     private func mapEnvironment(_ environment: Environment, activeID: String?) -> FeatureEnvironment {
-        FeatureEnvironment(
+        let pairedVersion = environment.descriptor?.serverVersion
+        let serverVersion = serverConfigsByEnvironmentID[environment.id]
+            .map { $0.serverVersion(fallingBackTo: pairedVersion) }
+            ?? pairedVersion
+        return FeatureEnvironment(
             id: environment.id,
             name: environment.label,
             endpoint: environment.httpBaseURL.absoluteString,
+            serverVersion: serverVersion,
             isActive: environment.id == activeID,
             isEnabled: environment.isEnabled,
             source: environment.kind == .managedDPoP ? .t3Connect : .direct,

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -3826,7 +3826,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func mapEnvironment(_ environment: Environment, activeID: String?) -> FeatureEnvironment {
         let serverVersion = serverConfigsByEnvironmentID[environment.id]?
-            .environment?.serverVersion
+            .serverVersion(fallingBackTo: environment.descriptor?.serverVersion)
         return FeatureEnvironment(
             id: environment.id,
             name: environment.label,

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -3825,8 +3825,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     private func mapEnvironment(_ environment: Environment, activeID: String?) -> FeatureEnvironment {
+        let pairedServerVersion = environment.descriptor?.serverVersion
         let serverVersion = serverConfigsByEnvironmentID[environment.id]?
-            .serverVersion(fallingBackTo: environment.descriptor?.serverVersion)
+            .serverVersion(fallingBackTo: pairedServerVersion)
+            ?? pairedServerVersion
         return FeatureEnvironment(
             id: environment.id,
             name: environment.label,

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -3825,10 +3825,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     private func mapEnvironment(_ environment: Environment, activeID: String?) -> FeatureEnvironment {
-        let pairedVersion = environment.descriptor?.serverVersion
-        let serverVersion = serverConfigsByEnvironmentID[environment.id]
-            .map { $0.serverVersion(fallingBackTo: pairedVersion) }
-            ?? pairedVersion
+        let serverVersion = serverConfigsByEnvironmentID[environment.id]?
+            .environment?.serverVersion
         return FeatureEnvironment(
             id: environment.id,
             name: environment.label,

--- a/apps/swift-ios/Core/ServerConfigModels.swift
+++ b/apps/swift-ios/Core/ServerConfigModels.swift
@@ -161,26 +161,37 @@ public struct ServerSettingsSnapshot: Codable, Equatable, Sendable {
 
 /// Narrow decode view of the much larger `ServerConfig` RPC result.
 public struct ServerConfigSnapshot: Codable, Equatable, Sendable {
+    public let environment: EnvironmentDescriptor?
     public let providers: [ServerProviderSnapshot]
     public let settings: ServerSettingsSnapshot?
     public let threadSnapshotPagination: Bool?
 
     public init(
         providers: [ServerProviderSnapshot],
+        environment: EnvironmentDescriptor? = nil,
         settings: ServerSettingsSnapshot? = nil,
         threadSnapshotPagination: Bool? = nil
     ) {
+        self.environment = environment
         self.providers = providers
         self.settings = settings
         self.threadSnapshotPagination = threadSnapshotPagination
     }
 
+    public func serverVersion(fallingBackTo pairedVersion: String?) -> String? {
+        environment?.serverVersion ?? pairedVersion
+    }
+
     private enum CodingKeys: String, CodingKey {
-        case providers, settings, threadSnapshotPagination
+        case environment, providers, settings, threadSnapshotPagination
     }
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        environment = try container.decodeIfPresent(
+            EnvironmentDescriptor.self,
+            forKey: .environment
+        )
         providers = try container.decode(
             [LossyDecodableElement<ServerProviderSnapshot>].self,
             forKey: .providers
@@ -194,6 +205,7 @@ public struct ServerConfigSnapshot: Codable, Equatable, Sendable {
 
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(environment, forKey: .environment)
         try container.encode(providers, forKey: .providers)
         try container.encodeIfPresent(settings, forKey: .settings)
         try container.encodeIfPresent(

--- a/apps/swift-ios/Core/ServerConfigModels.swift
+++ b/apps/swift-ios/Core/ServerConfigModels.swift
@@ -188,7 +188,7 @@ public struct ServerConfigSnapshot: Codable, Equatable, Sendable {
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        environment = try container.decodeIfPresent(
+        environment = try? container.decodeIfPresent(
             EnvironmentDescriptor.self,
             forKey: .environment
         )

--- a/apps/swift-ios/Features/Settings/ConnectionsView.swift
+++ b/apps/swift-ios/Features/Settings/ConnectionsView.swift
@@ -202,6 +202,17 @@ struct ConnectionsView: View {
                         }
                         .font(T3Typography.supporting)
                         .foregroundStyle(T3Colors.textSecondary)
+
+                        if let version = SettingsAboutMetadata.connectedEnvironmentVersion(
+                            connectionState: environment.connectionState,
+                            serverVersion: environment.serverVersion
+                        ) {
+                            Text("Server \(version)")
+                                .font(T3Typography.supporting)
+                                .foregroundStyle(T3Colors.textTertiary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
                     }
 
                     Spacer(minLength: 8)

--- a/apps/swift-ios/Features/Settings/SettingsAboutMetadata.swift
+++ b/apps/swift-ios/Features/Settings/SettingsAboutMetadata.swift
@@ -7,12 +7,12 @@ enum SettingsAboutMetadata {
         return "\(version) (\(build))"
     }
 
-    static func environmentVersionLabel(
-        connectionState: FeatureConnection.State,
+    static func connectedEnvironmentVersion(
+        connectionState: FeatureConnection.State?,
         serverVersion: String?
-    ) -> String {
-        guard connectionState == .connected else { return "Not connected" }
-        return normalized(serverVersion) ?? "Unknown"
+    ) -> String? {
+        guard connectionState == .connected else { return nil }
+        return normalized(serverVersion)
     }
 
     private static func resolvedValue(_ key: String, info: [String: Any]?) -> String? {

--- a/apps/swift-ios/Features/Settings/SettingsAboutMetadata.swift
+++ b/apps/swift-ios/Features/Settings/SettingsAboutMetadata.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum SettingsAboutMetadata {
+    static func appVersionLabel(info: [String: Any]?) -> String {
+        let version = resolvedValue("CFBundleShortVersionString", info: info) ?? "?"
+        let build = resolvedValue("CFBundleVersion", info: info) ?? "?"
+        return "\(version) (\(build))"
+    }
+
+    static func environmentVersionLabel(
+        connectionState: FeatureConnection.State,
+        serverVersion: String?
+    ) -> String {
+        guard connectionState == .connected else { return "Not connected" }
+        return normalized(serverVersion) ?? "Unknown"
+    }
+
+    private static func resolvedValue(_ key: String, info: [String: Any]?) -> String? {
+        normalized(info?[key] as? String)
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("$(") else { return nil }
+        return trimmed
+    }
+}

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -6,10 +6,12 @@ public struct SettingsView: View {
     @State private var settings: FeatureSettings
     @State private var isSaving = false
     @State private var saveErrorMessage: String?
+    private let appVersionLabel: String
 
     public init(model: FeatureRootModel) {
         self.model = model
         _settings = State(initialValue: model.snapshot.settings)
+        appVersionLabel = SettingsAboutMetadata.appVersionLabel(info: Bundle.main.infoDictionary)
     }
 
     public var body: some View {
@@ -168,6 +170,10 @@ public struct SettingsView: View {
             VStack(spacing: 0) {
                 SettingsValueRow(title: "App", value: appDisplayName)
                 settingsDivider
+                SettingsValueRow(title: "App version", value: appVersionLabel)
+                settingsDivider
+                SettingsValueRow(title: "Environment version", value: environmentVersionLabel)
+                settingsDivider
                 SettingsValueRow(title: "Platform", value: "Native SwiftUI")
                 settingsDivider
                 Link(destination: URL(string: "https://github.com/pingdotgg/t3code")!) {
@@ -192,6 +198,14 @@ public struct SettingsView: View {
     private var appDisplayName: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             ?? "T3 Code SwiftUI"
+    }
+
+    private var environmentVersionLabel: String {
+        let activeEnvironment = model.snapshot.environments.first(where: \.isActive)
+        return SettingsAboutMetadata.environmentVersionLabel(
+            connectionState: model.snapshot.connection.state,
+            serverVersion: activeEnvironment?.serverVersion
+        )
     }
 
     private var canSave: Bool {

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -172,8 +172,6 @@ public struct SettingsView: View {
                 settingsDivider
                 SettingsValueRow(title: "App version", value: appVersionLabel)
                 settingsDivider
-                SettingsValueRow(title: "Environment version", value: environmentVersionLabel)
-                settingsDivider
                 SettingsValueRow(title: "Platform", value: "Native SwiftUI")
                 settingsDivider
                 Link(destination: URL(string: "https://github.com/pingdotgg/t3code")!) {
@@ -198,14 +196,6 @@ public struct SettingsView: View {
     private var appDisplayName: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             ?? "T3 Code SwiftUI"
-    }
-
-    private var environmentVersionLabel: String {
-        let activeEnvironment = model.snapshot.environments.first(where: \.isActive)
-        return SettingsAboutMetadata.environmentVersionLabel(
-            connectionState: model.snapshot.connection.state,
-            serverVersion: activeEnvironment?.serverVersion
-        )
     }
 
     private var canSave: Bool {

--- a/apps/swift-ios/Features/Shared/FeatureModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureModels.swift
@@ -35,6 +35,7 @@ public struct FeatureEnvironment: Identifiable, Sendable, Equatable, Hashable, C
     public let id: String
     public var name: String
     public var endpoint: String
+    public var serverVersion: String?
     /// Internal stream-leader compatibility. Product routing must use the
     /// project or thread environment instead.
     public var isActive: Bool
@@ -49,6 +50,7 @@ public struct FeatureEnvironment: Identifiable, Sendable, Equatable, Hashable, C
         id: String,
         name: String,
         endpoint: String,
+        serverVersion: String? = nil,
         isActive: Bool = false,
         isEnabled: Bool = true,
         source: Source = .direct,
@@ -58,6 +60,7 @@ public struct FeatureEnvironment: Identifiable, Sendable, Equatable, Hashable, C
         self.id = id
         self.name = name
         self.endpoint = endpoint
+        self.serverVersion = serverVersion
         self.isActive = isActive
         self.isEnabled = isEnabled
         self.source = source
@@ -69,6 +72,7 @@ public struct FeatureEnvironment: Identifiable, Sendable, Equatable, Hashable, C
         case id
         case name
         case endpoint
+        case serverVersion
         case isActive
         case isEnabled
         case source
@@ -81,6 +85,7 @@ public struct FeatureEnvironment: Identifiable, Sendable, Equatable, Hashable, C
         id = try container.decode(String.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         endpoint = try container.decode(String.self, forKey: .endpoint)
+        serverVersion = try container.decodeIfPresent(String.self, forKey: .serverVersion)
         isActive = try container.decodeIfPresent(Bool.self, forKey: .isActive) ?? false
         isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
         source = try container.decodeIfPresent(Source.self, forKey: .source) ?? .direct

--- a/apps/swift-ios/README.md
+++ b/apps/swift-ios/README.md
@@ -51,8 +51,9 @@ the active selection are stored separately in Application Support.
 - Workspace files and previews, working-tree review, Git status and common actions,
   plus Ghostty-rendered terminal sessions with VT/ANSI output, scrollback, hardware
   and software keyboard controls, and per-thread session switching.
-- Native settings with persisted appearance and behavior preferences, platform
-  deep links, shortcuts, background refresh, and notification routing.
+- Native settings with app and connected-environment version details, persisted
+  appearance and behavior preferences, platform deep links, shortcuts,
+  background refresh, and notification routing.
 - A Share extension that imports text, URLs, and images into persistent project
   drafts, plus Home Screen widgets and aggregate Live Activities for active work.
 - DPoP-bound T3 Connect sessions with account-scoped relay credentials, APNs

--- a/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
@@ -75,10 +75,20 @@ final class CoreContractTests: XCTestCase {
     func testServerConfigAdvertisesThreadSnapshotPagination() throws {
         let config = try JSONDecoder.t3.decode(
             ServerConfigSnapshot.self,
-            from: Data(#"{"providers":[],"threadSnapshotPagination":true}"#.utf8)
+            from: Data(
+                #"{"environment":{"environmentId":"server-1","label":"Studio","platform":{"os":"darwin","arch":"arm64"},"serverVersion":"0.2.0","capabilities":{"repositoryIdentity":true}},"providers":[],"threadSnapshotPagination":true}"#.utf8
+            )
         )
 
         XCTAssertEqual(config.threadSnapshotPagination, true)
+        XCTAssertEqual(config.environment?.serverVersion, "0.2.0")
+        XCTAssertEqual(config.serverVersion(fallingBackTo: "0.1.0"), "0.2.0")
+
+        let legacyConfig = try JSONDecoder.t3.decode(
+            ServerConfigSnapshot.self,
+            from: Data(#"{"providers":[]}"#.utf8)
+        )
+        XCTAssertEqual(legacyConfig.serverVersion(fallingBackTo: "0.1.0"), "0.1.0")
     }
 
     func testCommandBuildersMatchOrchestrationContract() throws {

--- a/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
@@ -91,6 +91,19 @@ final class CoreContractTests: XCTestCase {
         XCTAssertEqual(legacyConfig.serverVersion(fallingBackTo: "0.1.0"), "0.1.0")
     }
 
+    func testServerConfigDropsMalformedEnvironmentWithoutLosingProviders() throws {
+        let config = try JSONDecoder.t3.decode(
+            ServerConfigSnapshot.self,
+            from: Data(
+                #"{"environment":{"serverVersion":"0.2.0"},"providers":[],"threadSnapshotPagination":true}"#.utf8
+            )
+        )
+
+        XCTAssertNil(config.environment)
+        XCTAssertEqual(config.providers, [])
+        XCTAssertEqual(config.threadSnapshotPagination, true)
+    }
+
     func testCommandBuildersMatchOrchestrationContract() throws {
         let model = ModelSelection(instanceId: "codex", model: "gpt-5.6-sol")
         let command = try OrchestrationCommands.createThread(

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -97,7 +97,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "codex-work", name: "Config name")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "codex-work", name: "Config name")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "leftbook")

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -95,6 +95,10 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             snapshot.environments.first(where: { $0.id == "two" })?.connectionState,
             .connected
         )
+        XCTAssertEqual(
+            snapshot.environments.first(where: { $0.id == "two" })?.serverVersion,
+            "0.0.2"
+        )
 
         let detail = try await fixture.client.loadThread(id: remoteThread.id)
         XCTAssertEqual(detail.thread.environmentID, "two")
@@ -439,13 +443,23 @@ final class NativeMultiEnvironmentTests: XCTestCase {
                 id: "one",
                 label: "Left Book",
                 httpBaseURL: URL(string: "https://one.example")!,
-                webSocketBaseURL: URL(string: "wss://one.example")!
+                webSocketBaseURL: URL(string: "wss://one.example")!,
+                descriptor: multiEnvironmentDescriptor(
+                    environmentID: "one",
+                    label: "Left Book",
+                    serverVersion: "0.0.1"
+                )
             ),
             Environment(
                 id: "two",
                 label: "Steam Box",
                 httpBaseURL: URL(string: "https://two.example")!,
-                webSocketBaseURL: URL(string: "wss://two.example")!
+                webSocketBaseURL: URL(string: "wss://two.example")!,
+                descriptor: multiEnvironmentDescriptor(
+                    environmentID: "two",
+                    label: "Steam Box",
+                    serverVersion: "0.0.2"
+                )
             ),
         ]
         let store = EnvironmentStore(
@@ -499,6 +513,27 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             )
         )
     }
+}
+
+private func multiEnvironmentDescriptor(
+    environmentID: String,
+    label: String,
+    serverVersion: String
+) -> EnvironmentDescriptor {
+    try! JSONDecoder.t3.decode(
+        EnvironmentDescriptor.self,
+        from: Data(
+            """
+            {
+              "environmentId": "\(environmentID)",
+              "label": "\(label)",
+              "platform": {"os": "darwin", "arch": "arm64"},
+              "serverVersion": "\(serverVersion)",
+              "capabilities": {"repositoryIdentity": true}
+            }
+            """.utf8
+        )
+    )
 }
 
 private actor FailOnceAggregateEnvironmentLoader {

--- a/apps/swift-ios/Tests/FeatureTests/SettingsAboutMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/SettingsAboutMetadataTests.swift
@@ -20,7 +20,7 @@ struct SettingsAboutMetadataTests {
 
     @Test
     func formatsConnectedEnvironmentVersion() {
-        #expect(SettingsAboutMetadata.environmentVersionLabel(
+        #expect(SettingsAboutMetadata.connectedEnvironmentVersion(
             connectionState: .connected,
             serverVersion: "2.3.4"
         ) == "2.3.4")
@@ -28,29 +28,29 @@ struct SettingsAboutMetadataTests {
 
     @Test
     func formatsUnknownConnectedEnvironmentVersion() {
-        #expect(SettingsAboutMetadata.environmentVersionLabel(
+        #expect(SettingsAboutMetadata.connectedEnvironmentVersion(
             connectionState: .connected,
             serverVersion: nil
-        ) == "Unknown")
-        #expect(SettingsAboutMetadata.environmentVersionLabel(
+        ) == nil)
+        #expect(SettingsAboutMetadata.connectedEnvironmentVersion(
             connectionState: .connected,
             serverVersion: "  "
-        ) == "Unknown")
+        ) == nil)
     }
 
     @Test
     func hidesStaleEnvironmentVersionWhileDisconnected() {
-        #expect(SettingsAboutMetadata.environmentVersionLabel(
+        #expect(SettingsAboutMetadata.connectedEnvironmentVersion(
             connectionState: .disconnected,
             serverVersion: "2.3.4"
-        ) == "Not connected")
-        #expect(SettingsAboutMetadata.environmentVersionLabel(
+        ) == nil)
+        #expect(SettingsAboutMetadata.connectedEnvironmentVersion(
             connectionState: .reconnecting,
             serverVersion: "2.3.4"
-        ) == "Not connected")
-        #expect(SettingsAboutMetadata.environmentVersionLabel(
+        ) == nil)
+        #expect(SettingsAboutMetadata.connectedEnvironmentVersion(
             connectionState: .connecting,
             serverVersion: "2.3.4"
-        ) == "Not connected")
+        ) == nil)
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/SettingsAboutMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/SettingsAboutMetadataTests.swift
@@ -1,0 +1,56 @@
+import Testing
+@testable import T3Code
+
+@Suite("Settings about metadata")
+struct SettingsAboutMetadataTests {
+    @Test
+    func formatsAppVersionAndBuild() {
+        let info: [String: Any] = [
+            "CFBundleShortVersionString": "1.2.3",
+            "CFBundleVersion": "456",
+        ]
+
+        #expect(SettingsAboutMetadata.appVersionLabel(info: info) == "1.2.3 (456)")
+        #expect(SettingsAboutMetadata.appVersionLabel(info: nil) == "? (?)")
+        #expect(SettingsAboutMetadata.appVersionLabel(info: [
+            "CFBundleShortVersionString": "$(MARKETING_VERSION)",
+            "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
+        ]) == "? (?)")
+    }
+
+    @Test
+    func formatsConnectedEnvironmentVersion() {
+        #expect(SettingsAboutMetadata.environmentVersionLabel(
+            connectionState: .connected,
+            serverVersion: "2.3.4"
+        ) == "2.3.4")
+    }
+
+    @Test
+    func formatsUnknownConnectedEnvironmentVersion() {
+        #expect(SettingsAboutMetadata.environmentVersionLabel(
+            connectionState: .connected,
+            serverVersion: nil
+        ) == "Unknown")
+        #expect(SettingsAboutMetadata.environmentVersionLabel(
+            connectionState: .connected,
+            serverVersion: "  "
+        ) == "Unknown")
+    }
+
+    @Test
+    func hidesStaleEnvironmentVersionWhileDisconnected() {
+        #expect(SettingsAboutMetadata.environmentVersionLabel(
+            connectionState: .disconnected,
+            serverVersion: "2.3.4"
+        ) == "Not connected")
+        #expect(SettingsAboutMetadata.environmentVersionLabel(
+            connectionState: .reconnecting,
+            serverVersion: "2.3.4"
+        ) == "Not connected")
+        #expect(SettingsAboutMetadata.environmentVersionLabel(
+            connectionState: .connecting,
+            serverVersion: "2.3.4"
+        ) == "Not connected")
+    }
+}


### PR DESCRIPTION
## What changed

- Shows the SwiftUI app marketing version and build number in Settings → About.
- Shows the active environment's already-advertised server version, with `Not connected` and `Unknown` fallbacks.
- Carries one already-persisted descriptor field into the existing `FeatureEnvironment` snapshot.
- Adds focused formatting/state coverage.

This is the narrow display-only version of the idea. It does not implement source comparison or changelog links, refresh descriptors, add network or persistence lifecycles, change Info.plist, or modify install scripts. It should not be treated as closing a broader source-comparison proposal without maintainer agreement.

Base: `pingdotgg/t3code:t3code/rebuild-mobile-app-swift` at `e55c7ffd1`.  
Reviewed head: `106e970770f2c875c32ddc02d148f37ae984591d`.

## Why

The two versions make client/server mismatch reports diagnosable from one screen using data the app already has.

## UI evidence

Exact rebased head, paired to a disposable loopback environment:

![Settings app and environment versions](https://github.com/saphid/t3code/releases/download/pr-evidence-20260809/pr5790-rebased-settings-versions.jpg)

The screen shows app version `0.1.0 (19)` and the active environment descriptor version.

## Verification

- `T3CodeTests/SettingsVersionMetadataTests`: 2 focused tests passed.
- Full native gate: 220 tests in 28 suites passed.
- Exact-head integrated signed Debug build/install: Settings displayed `0.1.0 (19)` and the paired environment version.
- `git diff --check`: passed; rebase preserved the feature patch exactly.
- GPT-5.6 Sol high: no actionable findings; judged minimally scoped for the stated display goal.
- Direct Claude Opus 5 high attempt exited 1 with HTTP 429 before review; no Claude findings are claimed.
- Both historical MacroScope threads apply to removed descriptor-refresh code and are resolved. Current-head Check, Test, SwiftUI native, mobile static-analysis, release-smoke, MacroScope correctness/approvability, CodeRabbit, and Cursor checks pass.

## Checklist

- [x] Small and focused
- [x] Explained the deliberately narrow scope
- [x] Exact-head UI screenshot attached
- [x] Focused, full native, and integrated simulator verification
- [x] Current rebased-head CI/MacroScope complete
- [ ] Maintainer scope alignment / human review

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only Settings/Connections UI plus optional model fields; no auth, networking, or persistence lifecycle changes.
> 
> **Overview**
> Surfaces **app and connected-server versions** in Settings so client/server mismatches are diagnosable from one screen.
> 
> Adds an **App version** row in About (marketing version + build from the bundle). Connected environment rows in Connections now show `Server {version}` when a valid version is available.
> 
> Propagates already-advertised server version into `FeatureEnvironment` via `ServerConfigSnapshot.environment`, preferring live config and falling back to the paired descriptor. Malformed environment payloads are dropped without losing providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405c4c2ba46e2e4756c66fe2c269b95bd46fe3c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show app and server version in iOS Settings
> - Adds an 'App version' row to the Settings About section using a new `SettingsAboutMetadata.appVersionLabel` helper that reads `CFBundleShortVersionString` and `CFBundleVersion` from the main bundle.
> - Displays a 'Server <version>' label in the Connections list for connected environments via `SettingsAboutMetadata.connectedEnvironmentVersion`.
> - Threads `serverVersion` through `FeatureEnvironment` and `ServerConfigSnapshot`, resolving it from the environment descriptor or falling back to the latest stored config snapshot.
> - Adds `ServerConfigSnapshot.serverVersion(fallingBackTo:)` and an optional `environment: EnvironmentDescriptor?` property to support version resolution at the model layer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 405c4c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Owner readiness revalidation (2026-08-12)

- Current head: `405c4c2ba`; direct merge-base: Theo `f98cab553`.
- Repaired environment-scoped provider fixtures and preserved the persisted descriptor version when live config is absent; approved version-display behavior is unchanged.
- Every actionable version-fallback review thread has an explicit current-head response and is resolved; no review threads remain open.
- Focused 35-test native set passed; `apps/swift-ios/Scripts/ci-test.sh` passed 229 tests in 30 suites.
- Exact-head Simulator evidence shows app `0.1.0 (26)` and an online direct environment at Server `0.0.32`.
- Direct Claude Opus 5 high reviewed the prior frozen head and identified the nil-config fallback/test gap fixed in `405c4c2ba`; the final-head retry exited 1 with HTTP 429. Current-head Cursor and both Macroscope gates pass.

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none (land after #5789; no code dependency)
Merge order: after #5789; refresh after #5789 lands
Validation status: Current-head Check, Test, Contract fixtures/native tests, Mobile Native Static Analysis, Release Smoke, Cursor, and both Macroscope checks pass. All actionable review threads are resolved; Vercel authorization is unrelated.
<!-- swiftui-delivery:end -->