### PR TITLE
fix(server): raise Windows ACP/stdio provider probe timeouts

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -32,13 +32,13 @@ import {
   buildBooleanOptionDescriptor,
   buildSelectOptionDescriptor,
   buildServerProvider,
-  DEFAULT_TIMEOUT_MS,
   isCommandMissingCause,
   parseGenericCliVersion,
   providerModelsFromSettings,
   spawnAndCollect,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
+import { providerVersionProbeTimeoutMs } from "../providerProbeTimeouts.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
@@ -824,11 +824,12 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     });
   }
 
+  const versionTimeoutMs = yield* providerVersionProbeTimeoutMs;
   const versionProbe = yield* runClaudeCommand(
     claudeSettings,
     ["--version"],
     resolvedEnvironment,
-  ).pipe(Effect.timeoutOption(DEFAULT_TIMEOUT_MS), Effect.result);
+  ).pipe(Effect.timeoutOption(versionTimeoutMs), Effect.result);
 
   if (Result.isFailure(versionProbe)) {
     const error = versionProbe.failure;

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -32,6 +32,7 @@ import {
   buildServerProvider,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
+import { resolveProviderProbeCwd } from "../providerProbeTimeouts.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
@@ -545,7 +546,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     binaryPath: codexSettings.binaryPath,
     homePath: codexSettings.homePath,
     launchArgs: resolveCodexLaunchArgs(codexSettings.launchArgs, resolvedEnvironment),
-    cwd: process.cwd(),
+    cwd: resolveProviderProbeCwd(undefined, resolvedEnvironment),
     customModels: codexSettings.customModels,
     environment: resolvedEnvironment,
   }).pipe(

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -27,12 +27,8 @@ import { PREFERRED_DEFAULT_CODEX_MODELS, ServerSettingsError } from "@t3tools/co
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
-import {
-  AUTH_PROBE_TIMEOUT_MS,
-  buildServerProvider,
-  type ServerProviderDraft,
-} from "../providerSnapshot.ts";
-import { resolveProviderProbeCwd } from "../providerProbeTimeouts.ts";
+import { buildServerProvider, type ServerProviderDraft } from "../providerSnapshot.ts";
+import { providerAuthProbeTimeoutMs, resolveProviderProbeCwd } from "../providerProbeTimeouts.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
@@ -542,18 +538,16 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     });
   }
 
+  const authProbeTimeoutMs = yield* providerAuthProbeTimeoutMs;
+  const probeCwd = yield* resolveProviderProbeCwd(undefined, resolvedEnvironment);
   const probeResult = yield* probe({
     binaryPath: codexSettings.binaryPath,
     homePath: codexSettings.homePath,
     launchArgs: resolveCodexLaunchArgs(codexSettings.launchArgs, resolvedEnvironment),
-    cwd: resolveProviderProbeCwd(undefined, resolvedEnvironment),
+    cwd: probeCwd,
     customModels: codexSettings.customModels,
     environment: resolvedEnvironment,
-  }).pipe(
-    Effect.scoped,
-    Effect.timeoutOption(Duration.millis(AUTH_PROBE_TIMEOUT_MS)),
-    Effect.result,
-  );
+  }).pipe(Effect.scoped, Effect.timeoutOption(Duration.millis(authProbeTimeoutMs)), Effect.result);
 
   if (Result.isFailure(probeResult)) {
     const error = probeResult.failure;

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -11,6 +11,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 import type { CursorSettings } from "@t3tools/contracts";
 import { createModelCapabilities } from "@t3tools/shared/model";
 
+import { CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS } from "../providerProbeTimeouts.ts";
 import {
   buildCursorProviderSnapshot,
   buildCursorCapabilitiesFromConfigOptions,
@@ -333,11 +334,11 @@ describe("buildCursorProviderSnapshot", () => {
           status: "ready",
           auth: { status: "authenticated", type: "Team", label: "Cursor Team Subscription" },
         },
-        discoveryWarning: "Cursor ACP model discovery timed out after 15000ms.",
+        discoveryWarning: `Cursor ACP model discovery timed out after ${CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
       }),
     ).toMatchObject({
       status: "warning",
-      message: "Cursor ACP model discovery timed out after 15000ms.",
+      message: `Cursor ACP model discovery timed out after ${CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
       models: [],
     });
   });

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -11,7 +11,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 import type { CursorSettings } from "@t3tools/contracts";
 import { createModelCapabilities } from "@t3tools/shared/model";
 
-import { CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS } from "../providerProbeTimeouts.ts";
+import { cursorAcpModelDiscoveryTimeoutMsFor } from "../providerProbeTimeouts.ts";
 import {
   buildCursorProviderSnapshot,
   buildCursorCapabilitiesFromConfigOptions,
@@ -334,11 +334,11 @@ describe("buildCursorProviderSnapshot", () => {
           status: "ready",
           auth: { status: "authenticated", type: "Team", label: "Cursor Team Subscription" },
         },
-        discoveryWarning: `Cursor ACP model discovery timed out after ${CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+        discoveryWarning: `Cursor ACP model discovery timed out after ${cursorAcpModelDiscoveryTimeoutMsFor(process.platform === "win32")}ms.`,
       }),
     ).toMatchObject({
       status: "warning",
-      message: `Cursor ACP model discovery timed out after ${CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+      message: `Cursor ACP model discovery timed out after ${cursorAcpModelDiscoveryTimeoutMsFor(process.platform === "win32")}ms.`,
       models: [],
     });
   });

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -11,7 +11,6 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 import type { CursorSettings } from "@t3tools/contracts";
 import { createModelCapabilities } from "@t3tools/shared/model";
 
-import { cursorAcpModelDiscoveryTimeoutMsFor } from "../providerProbeTimeouts.ts";
 import {
   buildCursorProviderSnapshot,
   buildCursorCapabilitiesFromConfigOptions,
@@ -334,11 +333,12 @@ describe("buildCursorProviderSnapshot", () => {
           status: "ready",
           auth: { status: "authenticated", type: "Team", label: "Cursor Team Subscription" },
         },
-        discoveryWarning: `Cursor ACP model discovery timed out after ${cursorAcpModelDiscoveryTimeoutMsFor(process.platform === "win32")}ms.`,
+        // Fixed literal: buildCursorProviderSnapshot passes discoveryWarning through.
+        discoveryWarning: "Cursor ACP model discovery timed out after 20000ms.",
       }),
     ).toMatchObject({
       status: "warning",
-      message: `Cursor ACP model discovery timed out after ${cursorAcpModelDiscoveryTimeoutMsFor(process.platform === "win32")}ms.`,
+      message: "Cursor ACP model discovery timed out after 20000ms.",
       models: [],
     });
   });

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -20,6 +20,7 @@ import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
 import { HttpClient } from "effect/unstable/http";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
@@ -46,6 +47,11 @@ import {
 } from "../providerMaintenance.ts";
 import * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
 import { CursorListAvailableModelsResponse } from "../acp/CursorAcpExtension.ts";
+import {
+  CURSOR_ABOUT_TIMEOUT_MS,
+  CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
+  resolveProviderProbeCwd,
+} from "../providerProbeTimeouts.ts";
 
 const decodeCursorListAvailableModelsResponse = Schema.decodeUnknownEffect(
   CursorListAvailableModelsResponse,
@@ -59,7 +65,6 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
 
-const CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 const CURSOR_PARAMETERIZED_MODEL_PICKER_MIN_VERSION_DATE = 2026_04_08;
 const CURSOR_CLI_INSTALLATION_DOCS_URL = "https://cursor.com/docs/cli/installation";
 const CURSOR_ACP_MODEL_DISCOVERY_FAILED_MESSAGE = [
@@ -406,6 +411,7 @@ const makeCursorAcpProbeRuntime = (
 ) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const probeCwd = resolveProviderProbeCwd(undefined, environment);
     const acpContext = yield* Layer.build(
       AcpSessionRuntime.layer({
         spawn: {
@@ -414,10 +420,10 @@ const makeCursorAcpProbeRuntime = (
             ...(cursorSettings.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
             "acp",
           ],
-          cwd: process.cwd(),
+          cwd: probeCwd,
           ...(environment ? { env: environment } : {}),
         },
-        cwd: process.cwd(),
+        cwd: probeCwd,
         clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
         authMethodId: "cursor_login",
         clientCapabilities: CURSOR_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
@@ -576,9 +582,6 @@ export function getCursorFallbackModels(
 ): ReadonlyArray<ServerProviderModel> {
   return providerModelsFromSettings([], cursorSettings.customModels, EMPTY_CAPABILITIES);
 }
-
-/** Timeout for `agent about` — it's slower than a simple `--version` probe. */
-const ABOUT_TIMEOUT_MS = 8_000;
 
 /** Strip ANSI escape sequences so we can parse plain key-value lines. */
 function stripAnsi(text: string): string {
@@ -948,17 +951,21 @@ const runCursorCommand = (
 ) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const probeCwd = resolveProviderProbeCwd(undefined, environment);
     const spawnCommand = yield* resolveSpawnCommand(
       cursorSettings.binaryPath,
       args,
       environment ? { env: environment } : {},
     );
     const command = ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+      cwd: probeCwd,
       ...(environment ? { env: environment } : { extendEnv: true }),
       shell: spawnCommand.shell,
     });
 
     const child = yield* spawner.spawn(command);
+    // Non-interactive probes (about/status) hang on Windows if stdin stays open.
+    yield* Stream.run(Stream.empty, child.stdin).pipe(Effect.ignore);
     const [stdout, stderr, exitCode] = yield* Effect.all(
       [
         collectStreamAsString(child.stdout),
@@ -1013,7 +1020,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
 
   // Single `agent about` probe: returns version + auth status in one call.
   const aboutProbe = yield* runCursorAboutCommand(cursorSettings, environment).pipe(
-    Effect.timeoutOption(ABOUT_TIMEOUT_MS),
+    Effect.timeoutOption(CURSOR_ABOUT_TIMEOUT_MS),
     Effect.result,
   );
 

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -48,8 +48,8 @@ import {
 import * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
 import { CursorListAvailableModelsResponse } from "../acp/CursorAcpExtension.ts";
 import {
-  CURSOR_ABOUT_TIMEOUT_MS,
-  CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
+  cursorAboutTimeoutMs,
+  cursorAcpModelDiscoveryTimeoutMs,
   resolveProviderProbeCwd,
 } from "../providerProbeTimeouts.ts";
 
@@ -411,7 +411,7 @@ const makeCursorAcpProbeRuntime = (
 ) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const probeCwd = resolveProviderProbeCwd(undefined, environment);
+    const probeCwd = yield* resolveProviderProbeCwd(undefined, environment);
     const acpContext = yield* Layer.build(
       AcpSessionRuntime.layer({
         spawn: {
@@ -951,7 +951,7 @@ const runCursorCommand = (
 ) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const probeCwd = resolveProviderProbeCwd(undefined, environment);
+    const probeCwd = yield* resolveProviderProbeCwd(undefined, environment);
     const spawnCommand = yield* resolveSpawnCommand(
       cursorSettings.binaryPath,
       args,
@@ -1019,8 +1019,9 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
   }
 
   // Single `agent about` probe: returns version + auth status in one call.
+  const aboutTimeoutMs = yield* cursorAboutTimeoutMs;
   const aboutProbe = yield* runCursorAboutCommand(cursorSettings, environment).pipe(
-    Effect.timeoutOption(CURSOR_ABOUT_TIMEOUT_MS),
+    Effect.timeoutOption(aboutTimeoutMs),
     Effect.result,
   );
 
@@ -1090,9 +1091,10 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
   let discoveredModels = Option.none<ReadonlyArray<ServerProviderModel>>();
   let discoveryWarning: string | undefined;
   if (parsed.auth.status !== "unauthenticated") {
+    const acpDiscoveryTimeoutMs = yield* cursorAcpModelDiscoveryTimeoutMs;
     const discoveryExit = yield* Effect.exit(
       discoverCursorModelsViaAcp(cursorSettings, environment).pipe(
-        Effect.timeoutOption(CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
+        Effect.timeoutOption(acpDiscoveryTimeoutMs),
       ),
     );
     if (Exit.isFailure(discoveryExit)) {
@@ -1101,7 +1103,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       });
       discoveryWarning = CURSOR_ACP_MODEL_DISCOVERY_FAILED_MESSAGE;
     } else if (Option.isNone(discoveryExit.value)) {
-      discoveryWarning = `Cursor ACP model discovery timed out after ${CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`;
+      discoveryWarning = `Cursor ACP model discovery timed out after ${acpDiscoveryTimeoutMs}ms.`;
     } else if (discoveryExit.value.value.length === 0) {
       discoveryWarning = "Cursor ACP model discovery returned no built-in models.";
     } else {

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -31,8 +31,8 @@ import {
 } from "../providerMaintenance.ts";
 import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
 import {
-  GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
-  PROVIDER_VERSION_PROBE_TIMEOUT_MS,
+  grokAcpModelDiscoveryTimeoutMs,
+  providerVersionProbeTimeoutMs,
   resolveProviderProbeCwd,
 } from "../providerProbeTimeouts.ts";
 
@@ -45,8 +45,6 @@ const GROK_PRESENTATION = {
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
-
-const VERSION_PROBE_TIMEOUT_MS = PROVIDER_VERSION_PROBE_TIMEOUT_MS;
 
 const GROK_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   {
@@ -133,7 +131,7 @@ const discoverGrokModelsViaAcp = (
 ) =>
   Effect.gen(function* () {
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const probeCwd = resolveProviderProbeCwd(undefined, environment);
+    const probeCwd = yield* resolveProviderProbeCwd(undefined, environment);
     const acp = yield* makeGrokAcpRuntime({
       grokSettings,
       environment,
@@ -151,7 +149,7 @@ const runGrokVersionCommand = (
 ) =>
   Effect.gen(function* () {
     const command = grokSettings.binaryPath || "grok";
-    const probeCwd = resolveProviderProbeCwd(undefined, environment);
+    const probeCwd = yield* resolveProviderProbeCwd(undefined, environment);
     const spawnCommand = yield* resolveSpawnCommand(command, ["--version"], {
       env: environment,
     });
@@ -192,8 +190,9 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
+  const versionTimeoutMs = yield* providerVersionProbeTimeoutMs;
   const versionResult = yield* runGrokVersionCommand(grokSettings, environment).pipe(
-    Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
+    Effect.timeoutOption(versionTimeoutMs),
     Effect.result,
   );
 
@@ -258,8 +257,9 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
+  const acpDiscoveryTimeoutMs = yield* grokAcpModelDiscoveryTimeoutMs;
   const discoveryExit = yield* discoverGrokModelsViaAcp(grokSettings, environment).pipe(
-    Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
+    Effect.timeoutOption(acpDiscoveryTimeoutMs),
     Effect.exit,
   );
   if (Exit.isFailure(discoveryExit)) {
@@ -282,7 +282,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
   }
   if (Option.isNone(discoveryExit.value)) {
     yield* Effect.logWarning(
-      `Grok ACP model discovery timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+      `Grok ACP model discovery timed out after ${acpDiscoveryTimeoutMs}ms.`,
     );
     return buildServerProvider({
       presentation: GROK_PRESENTATION,
@@ -294,7 +294,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
         version,
         status: "error",
         auth: { status: "unknown" },
-        message: `Grok CLI is installed but ACP startup timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+        message: `Grok CLI is installed but ACP startup timed out after ${acpDiscoveryTimeoutMs}ms.`,
       },
     });
   }

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -30,6 +30,11 @@ import {
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
 import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
+import {
+  GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
+  PROVIDER_VERSION_PROBE_TIMEOUT_MS,
+  resolveProviderProbeCwd,
+} from "../providerProbeTimeouts.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -41,8 +46,7 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
 
-const VERSION_PROBE_TIMEOUT_MS = 4_000;
-const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+const VERSION_PROBE_TIMEOUT_MS = PROVIDER_VERSION_PROBE_TIMEOUT_MS;
 
 const GROK_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   {
@@ -129,11 +133,12 @@ const discoverGrokModelsViaAcp = (
 ) =>
   Effect.gen(function* () {
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const probeCwd = resolveProviderProbeCwd(undefined, environment);
     const acp = yield* makeGrokAcpRuntime({
       grokSettings,
       environment,
       childProcessSpawner,
-      cwd: process.cwd(),
+      cwd: probeCwd,
       clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
     });
     const started = yield* acp.start();
@@ -146,12 +151,14 @@ const runGrokVersionCommand = (
 ) =>
   Effect.gen(function* () {
     const command = grokSettings.binaryPath || "grok";
+    const probeCwd = resolveProviderProbeCwd(undefined, environment);
     const spawnCommand = yield* resolveSpawnCommand(command, ["--version"], {
       env: environment,
     });
     return yield* spawnAndCollect(
       command,
       ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        cwd: probeCwd,
         env: environment,
         shell: spawnCommand.shell,
       }),

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -512,7 +512,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           );
 
           yield* Effect.yieldNow;
-          // AUTH_PROBE_TIMEOUT_MS is platform-aware (15s non-Windows, 45s Windows).
+          // providerAuthProbeTimeoutMs is platform-aware (15s non-Windows, 45s Windows).
           // Advance past either bound so the timeout fires in CI on all platforms.
           yield* TestClock.adjust("46 seconds");
           yield* Effect.yieldNow;

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -512,7 +512,9 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           );
 
           yield* Effect.yieldNow;
-          yield* TestClock.adjust("11 seconds");
+          // AUTH_PROBE_TIMEOUT_MS is platform-aware (15s non-Windows, 45s Windows).
+          // Advance past either bound so the timeout fires in CI on all platforms.
+          yield* TestClock.adjust("46 seconds");
           yield* Effect.yieldNow;
 
           const status = yield* Fiber.join(statusFiber);

--- a/apps/server/src/provider/providerProbeTimeouts.test.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it } from "@effect/vitest";
 import * as NodeFs from "node:fs";
 import * as NodeOs from "node:os";
 import * as NodePath from "node:path";
@@ -31,16 +31,18 @@ describe("providerProbeTimeouts", () => {
     expect(providerVersionProbeTimeoutMsFor(false)).toBe(4_000);
   });
 
-  it("Effect timeout values follow HostProcessPlatform", async () => {
-    const winAbout = await Effect.runPromise(
-      cursorAboutTimeoutMs.pipe(Effect.provideService(HostProcessPlatform, "win32")),
-    );
-    const linuxAuth = await Effect.runPromise(
-      providerAuthProbeTimeoutMs.pipe(Effect.provideService(HostProcessPlatform, "linux")),
-    );
-    expect(winAbout).toBe(45_000);
-    expect(linuxAuth).toBe(15_000);
-  });
+  it.effect("Effect timeout values follow HostProcessPlatform", () =>
+    Effect.gen(function* () {
+      const winAbout = yield* cursorAboutTimeoutMs.pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+      );
+      const linuxAuth = yield* providerAuthProbeTimeoutMs.pipe(
+        Effect.provideService(HostProcessPlatform, "linux"),
+      );
+      expect(winAbout).toBe(45_000);
+      expect(linuxAuth).toBe(15_000);
+    }),
+  );
 
   it("resolveProviderProbeCwdSync prefers explicit cwd when it is usable", () => {
     const preferred = NodeOs.tmpdir();
@@ -65,21 +67,23 @@ describe("providerProbeTimeouts", () => {
     expect(isUsableProbeDirectory(missing)).toBe(false);
   });
 
-  it("resolveProviderProbeCwd Effect form matches sync", async () => {
-    const preferred = NodeOs.tmpdir();
-    const viaEffect = await Effect.runPromise(resolveProviderProbeCwd(preferred, {}));
-    expect(viaEffect).toBe(resolveProviderProbeCwdSync(preferred, {}));
-    expect(NodeFs.statSync(viaEffect).isDirectory()).toBe(true);
-  });
+  it.effect("resolveProviderProbeCwd Effect form matches sync", () =>
+    Effect.gen(function* () {
+      const preferred = NodeOs.tmpdir();
+      const viaEffect = yield* resolveProviderProbeCwd(preferred, {});
+      expect(viaEffect).toBe(resolveProviderProbeCwdSync(preferred, {}));
+      expect(NodeFs.statSync(viaEffect).isDirectory()).toBe(true);
+    }),
+  );
 
-  it("resolveProviderProbeCwd uses HostProcessWorkingDirectory as a candidate", async () => {
-    const preferredMissing = NodePath.join(NodeOs.tmpdir(), `t3-missing-wd-${Date.now()}`);
-    const overrideCwd = NodeOs.tmpdir();
-    const viaEffect = await Effect.runPromise(
-      resolveProviderProbeCwd(preferredMissing, {}).pipe(
+  it.effect("resolveProviderProbeCwd uses HostProcessWorkingDirectory as a candidate", () =>
+    Effect.gen(function* () {
+      const preferredMissing = NodePath.join(NodeOs.tmpdir(), `t3-missing-wd-${Date.now()}`);
+      const overrideCwd = NodeOs.tmpdir();
+      const viaEffect = yield* resolveProviderProbeCwd(preferredMissing, {}).pipe(
         Effect.provideService(HostProcessWorkingDirectory, overrideCwd),
-      ),
-    );
-    expect(viaEffect).toBe(overrideCwd);
-  });
+      );
+      expect(viaEffect).toBe(overrideCwd);
+    }),
+  );
 });

--- a/apps/server/src/provider/providerProbeTimeouts.test.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.test.ts
@@ -3,7 +3,7 @@ import * as NodeFs from "node:fs";
 import * as NodeOs from "node:os";
 import * as NodePath from "node:path";
 import * as Effect from "effect/Effect";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { HostProcessPlatform, HostProcessWorkingDirectory } from "@t3tools/shared/hostProcess";
 
 import {
   cursorAboutTimeoutMs,
@@ -70,5 +70,16 @@ describe("providerProbeTimeouts", () => {
     const viaEffect = await Effect.runPromise(resolveProviderProbeCwd(preferred, {}));
     expect(viaEffect).toBe(resolveProviderProbeCwdSync(preferred, {}));
     expect(NodeFs.statSync(viaEffect).isDirectory()).toBe(true);
+  });
+
+  it("resolveProviderProbeCwd uses HostProcessWorkingDirectory as a candidate", async () => {
+    const preferredMissing = NodePath.join(NodeOs.tmpdir(), `t3-missing-wd-${Date.now()}`);
+    const overrideCwd = NodeOs.tmpdir();
+    const viaEffect = await Effect.runPromise(
+      resolveProviderProbeCwd(preferredMissing, {}).pipe(
+        Effect.provideService(HostProcessWorkingDirectory, overrideCwd),
+      ),
+    );
+    expect(viaEffect).toBe(overrideCwd);
   });
 });

--- a/apps/server/src/provider/providerProbeTimeouts.test.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import {
+  CURSOR_ABOUT_TIMEOUT_MS,
+  CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
+  GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
+  PROVIDER_AUTH_PROBE_TIMEOUT_MS,
+  PROVIDER_VERSION_PROBE_TIMEOUT_MS,
+  resolveProviderProbeCwd,
+} from "./providerProbeTimeouts.ts";
+
+describe("providerProbeTimeouts", () => {
+  it("uses higher probe timeouts on Windows", () => {
+    if (process.platform === "win32") {
+      expect(CURSOR_ABOUT_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+      expect(CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+      expect(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+      expect(PROVIDER_AUTH_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+      expect(PROVIDER_VERSION_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
+    } else {
+      expect(CURSOR_ABOUT_TIMEOUT_MS).toBeGreaterThanOrEqual(15_000);
+      expect(PROVIDER_AUTH_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
+    }
+  });
+
+  it("resolveProviderProbeCwd prefers explicit cwd when it exists", () => {
+    const preferred = NodeOs.tmpdir();
+    expect(resolveProviderProbeCwd(preferred)).toBe(preferred);
+  });
+
+  it("resolveProviderProbeCwd ignores non-directories and falls back", () => {
+    const missing = NodePath.join(NodeOs.tmpdir(), `t3-missing-cwd-${Date.now()}`);
+    const resolved = resolveProviderProbeCwd(missing, {
+      T3_PROVIDER_CWD: NodeOs.tmpdir(),
+    });
+    expect(resolved).toBe(NodeOs.tmpdir());
+  });
+});

--- a/apps/server/src/provider/providerProbeTimeouts.test.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.test.ts
@@ -2,45 +2,73 @@ import { describe, expect, it } from "vite-plus/test";
 import * as NodeFs from "node:fs";
 import * as NodeOs from "node:os";
 import * as NodePath from "node:path";
+import * as Effect from "effect/Effect";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import {
-  CURSOR_ABOUT_TIMEOUT_MS,
-  CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
-  GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
-  PROVIDER_AUTH_PROBE_TIMEOUT_MS,
-  PROVIDER_VERSION_PROBE_TIMEOUT_MS,
+  cursorAboutTimeoutMs,
+  cursorAboutTimeoutMsFor,
+  cursorAcpModelDiscoveryTimeoutMsFor,
+  grokAcpModelDiscoveryTimeoutMsFor,
+  isUsableProbeDirectory,
+  providerAuthProbeTimeoutMs,
+  providerAuthProbeTimeoutMsFor,
+  providerVersionProbeTimeoutMsFor,
   resolveProviderProbeCwd,
+  resolveProviderProbeCwdSync,
 } from "./providerProbeTimeouts.ts";
 
 describe("providerProbeTimeouts", () => {
-  it("uses higher probe timeouts on Windows", () => {
-    if (process.platform === "win32") {
-      expect(CURSOR_ABOUT_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
-      expect(CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
-      expect(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
-      expect(PROVIDER_AUTH_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
-      expect(PROVIDER_VERSION_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
-    } else {
-      expect(CURSOR_ABOUT_TIMEOUT_MS).toBeGreaterThanOrEqual(15_000);
-      expect(PROVIDER_AUTH_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
-    }
+  it("uses higher probe timeouts on Windows via pure helpers", () => {
+    expect(cursorAboutTimeoutMsFor(true)).toBe(45_000);
+    expect(cursorAcpModelDiscoveryTimeoutMsFor(true)).toBe(45_000);
+    expect(grokAcpModelDiscoveryTimeoutMsFor(true)).toBe(45_000);
+    expect(providerAuthProbeTimeoutMsFor(true)).toBe(45_000);
+    expect(providerVersionProbeTimeoutMsFor(true)).toBe(15_000);
+
+    expect(cursorAboutTimeoutMsFor(false)).toBe(20_000);
+    expect(providerAuthProbeTimeoutMsFor(false)).toBe(15_000);
+    expect(providerVersionProbeTimeoutMsFor(false)).toBe(4_000);
   });
 
-  it("resolveProviderProbeCwd prefers explicit cwd when it exists", () => {
+  it("Effect timeout values follow HostProcessPlatform", async () => {
+    const winAbout = await Effect.runPromise(
+      cursorAboutTimeoutMs.pipe(Effect.provideService(HostProcessPlatform, "win32")),
+    );
+    const linuxAuth = await Effect.runPromise(
+      providerAuthProbeTimeoutMs.pipe(Effect.provideService(HostProcessPlatform, "linux")),
+    );
+    expect(winAbout).toBe(45_000);
+    expect(linuxAuth).toBe(15_000);
+  });
+
+  it("resolveProviderProbeCwdSync prefers explicit cwd when it is usable", () => {
     const preferred = NodeOs.tmpdir();
-    expect(resolveProviderProbeCwd(preferred)).toBe(preferred);
+    expect(resolveProviderProbeCwdSync(preferred)).toBe(preferred);
   });
 
-  it("resolveProviderProbeCwd ignores non-directories and falls back", () => {
+  it("resolveProviderProbeCwdSync ignores non-directories and falls back", () => {
     const missing = NodePath.join(NodeOs.tmpdir(), `t3-missing-cwd-${Date.now()}`);
-    const resolved = resolveProviderProbeCwd(missing, {
+    const resolved = resolveProviderProbeCwdSync(missing, {
       T3_PROVIDER_CWD: NodeOs.tmpdir(),
     });
     expect(resolved).toBe(NodeOs.tmpdir());
   });
 
-  it("resolveProviderProbeCwd always returns an existing directory", () => {
-    const resolved = resolveProviderProbeCwd(null, {});
-    expect(NodeFs.statSync(resolved).isDirectory()).toBe(true);
+  it("resolveProviderProbeCwdSync always returns an existing usable directory", () => {
+    const resolved = resolveProviderProbeCwdSync(null, {});
+    expect(isUsableProbeDirectory(resolved)).toBe(true);
+  });
+
+  it("isUsableProbeDirectory rejects missing paths", () => {
+    const missing = NodePath.join(NodeOs.tmpdir(), `t3-no-such-dir-${Date.now()}`);
+    expect(isUsableProbeDirectory(missing)).toBe(false);
+  });
+
+  it("resolveProviderProbeCwd Effect form matches sync", async () => {
+    const preferred = NodeOs.tmpdir();
+    const viaEffect = await Effect.runPromise(resolveProviderProbeCwd(preferred, {}));
+    expect(viaEffect).toBe(resolveProviderProbeCwdSync(preferred, {}));
+    expect(NodeFs.statSync(viaEffect).isDirectory()).toBe(true);
   });
 });

--- a/apps/server/src/provider/providerProbeTimeouts.test.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import * as NodeFs from "node:fs";
 import * as NodeOs from "node:os";
 import * as NodePath from "node:path";
 
@@ -36,5 +37,10 @@ describe("providerProbeTimeouts", () => {
       T3_PROVIDER_CWD: NodeOs.tmpdir(),
     });
     expect(resolved).toBe(NodeOs.tmpdir());
+  });
+
+  it("resolveProviderProbeCwd always returns an existing directory", () => {
+    const resolved = resolveProviderProbeCwd(null, {});
+    expect(NodeFs.statSync(resolved).isDirectory()).toBe(true);
   });
 });

--- a/apps/server/src/provider/providerProbeTimeouts.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.ts
@@ -1,7 +1,11 @@
 import * as NodeFs from "node:fs";
 import * as NodeOs from "node:os";
 import * as Effect from "effect/Effect";
-import { HostProcessEnvironment, isHostWindows } from "@t3tools/shared/hostProcess";
+import {
+  HostProcessEnvironment,
+  HostProcessWorkingDirectory,
+  isHostWindows,
+} from "@t3tools/shared/hostProcess";
 
 /**
  * Provider status probes spawn local CLIs over stdio/ACP.
@@ -83,34 +87,27 @@ export function isUsableProbeDirectory(path: string): boolean {
   }
 }
 
-function safeProcessCwd(): string | undefined {
-  try {
-    const cwd = process.cwd();
-    return cwd.trim().length > 0 ? cwd : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * Resolve a usable working directory for provider status probes.
  *
  * Electron/desktop backends can end up with a non-directory or inaccessible
- * `process.cwd()` (empty welcome state). Spawning with an invalid cwd on
+ * working directory (empty welcome state). Spawning with an invalid cwd on
  * Windows can hang or fail instead of failing cleanly.
  *
  * Pure (sync) form — prefer {@link resolveProviderProbeCwd} Effect for new call sites
- * that already run inside Effect.gen.
+ * that already run inside Effect.gen. Pass `workingDirectory` from
+ * `HostProcessWorkingDirectory` when available; do not read `process.cwd()` here.
  */
 export function resolveProviderProbeCwdSync(
   preferred?: string | null,
   environment: NodeJS.ProcessEnv = process.env,
+  workingDirectory?: string | null,
 ): string {
   const candidates: Array<string | undefined> = [
     preferred?.trim() || undefined,
     environment.T3_PROVIDER_CWD?.trim() || undefined,
     environment.T3CODE_PROVIDER_CWD?.trim() || undefined,
-    safeProcessCwd(),
+    workingDirectory?.trim() || undefined,
     environment.USERPROFILE?.trim() || undefined,
     environment.HOME?.trim() || undefined,
     NodeOs.homedir(),
@@ -128,13 +125,17 @@ export function resolveProviderProbeCwdSync(
 }
 
 /**
- * Effect form: reads optional env overrides from `HostProcessEnvironment` when
- * `environment` is not passed explicitly.
+ * Effect form: env from `HostProcessEnvironment` (unless overridden) and
+ * working directory from `HostProcessWorkingDirectory`.
  */
 export const resolveProviderProbeCwd = Effect.fn("resolveProviderProbeCwd")(function* (
   preferred?: string | null,
   environment?: NodeJS.ProcessEnv,
 ) {
   const env = environment ?? (yield* HostProcessEnvironment);
-  return resolveProviderProbeCwdSync(preferred, env);
+  const workingDirectory = yield* HostProcessWorkingDirectory.pipe(
+    Effect.map((cwd) => (cwd.trim().length > 0 ? cwd : undefined)),
+    Effect.catch(() => Effect.succeed(undefined as string | undefined)),
+  );
+  return resolveProviderProbeCwdSync(preferred, env, workingDirectory);
 });

--- a/apps/server/src/provider/providerProbeTimeouts.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.ts
@@ -1,5 +1,7 @@
 import * as NodeFs from "node:fs";
 import * as NodeOs from "node:os";
+import * as Effect from "effect/Effect";
+import { HostProcessEnvironment, isHostWindows } from "@t3tools/shared/hostProcess";
 
 /**
  * Provider status probes spawn local CLIs over stdio/ACP.
@@ -11,35 +13,96 @@ import * as NodeOs from "node:os";
  *
  * Timeouts below are deliberately higher on win32 so healthy installs are not
  * reported as "Unavailable" during normal machine load.
+ *
+ * Prefer the Effect forms at probe sites (`yield* providerAuthProbeTimeoutMs`) so
+ * platform comes from `HostProcessPlatform` and tests can override it.
  */
-const isWindows = process.platform === "win32";
+
+/** Pure helpers for message construction and unit tests. */
+export function providerVersionProbeTimeoutMsFor(isWindows: boolean): number {
+  return isWindows ? 15_000 : 4_000;
+}
+
+export function providerAuthProbeTimeoutMsFor(isWindows: boolean): number {
+  return isWindows ? 45_000 : 15_000;
+}
+
+export function cursorAboutTimeoutMsFor(isWindows: boolean): number {
+  return isWindows ? 45_000 : 20_000;
+}
+
+export function cursorAcpModelDiscoveryTimeoutMsFor(isWindows: boolean): number {
+  return isWindows ? 45_000 : 20_000;
+}
+
+export function grokAcpModelDiscoveryTimeoutMsFor(isWindows: boolean): number {
+  return isWindows ? 45_000 : 20_000;
+}
 
 /** Quick `--version` style probes. */
-export const PROVIDER_VERSION_PROBE_TIMEOUT_MS = isWindows ? 15_000 : 4_000;
+export const providerVersionProbeTimeoutMs = Effect.map(
+  isHostWindows,
+  providerVersionProbeTimeoutMsFor,
+);
 
 /**
  * Codex app-server account/model probe.
- * Shared with {@link AUTH_PROBE_TIMEOUT_MS} in providerSnapshot for import stability.
  */
-export const PROVIDER_AUTH_PROBE_TIMEOUT_MS = isWindows ? 45_000 : 15_000;
+export const providerAuthProbeTimeoutMs = Effect.map(isHostWindows, providerAuthProbeTimeoutMsFor);
 
 /** Cursor `agent about` (version + auth). Measured ~8–12s cold on Windows. */
-export const CURSOR_ABOUT_TIMEOUT_MS = isWindows ? 45_000 : 20_000;
+export const cursorAboutTimeoutMs = Effect.map(isHostWindows, cursorAboutTimeoutMsFor);
 
 /** Cursor ACP model discovery after about succeeds. */
-export const CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS = isWindows ? 45_000 : 20_000;
+export const cursorAcpModelDiscoveryTimeoutMs = Effect.map(
+  isHostWindows,
+  cursorAcpModelDiscoveryTimeoutMsFor,
+);
 
 /** Grok `agent stdio` ACP initialize for model discovery. */
-export const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = isWindows ? 45_000 : 20_000;
+export const grokAcpModelDiscoveryTimeoutMs = Effect.map(
+  isHostWindows,
+  grokAcpModelDiscoveryTimeoutMsFor,
+);
+
+/**
+ * True when `path` is a directory the process can read (and therefore use as cwd).
+ * `stat` alone is not enough: ACL-denied dirs still look like directories.
+ */
+export function isUsableProbeDirectory(path: string): boolean {
+  try {
+    if (!NodeFs.statSync(path).isDirectory()) {
+      return false;
+    }
+    NodeFs.accessSync(path, NodeFs.constants.R_OK);
+    // Confirm we can actually enter/list — closer to spawn-with-cwd success.
+    NodeFs.readdirSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function safeProcessCwd(): string | undefined {
+  try {
+    const cwd = process.cwd();
+    return cwd.trim().length > 0 ? cwd : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Resolve a usable working directory for provider status probes.
  *
  * Electron/desktop backends can end up with a non-directory or inaccessible
  * `process.cwd()` (empty welcome state). Spawning with an invalid cwd on
- * Windows can hang instead of failing cleanly.
+ * Windows can hang or fail instead of failing cleanly.
+ *
+ * Pure (sync) form — prefer {@link resolveProviderProbeCwd} Effect for new call sites
+ * that already run inside Effect.gen.
  */
-export function resolveProviderProbeCwd(
+export function resolveProviderProbeCwdSync(
   preferred?: string | null,
   environment: NodeJS.ProcessEnv = process.env,
 ): string {
@@ -55,26 +118,23 @@ export function resolveProviderProbeCwd(
 
   for (const candidate of candidates) {
     if (!candidate) continue;
-    try {
-      if (NodeFs.statSync(candidate).isDirectory()) {
-        return candidate;
-      }
-    } catch {
-      // try next
+    if (isUsableProbeDirectory(candidate)) {
+      return candidate;
     }
   }
 
   // Last resort: absolute directory independent of process.cwd().
-  // NodePath.resolve(".") calls process.cwd() and throws ENOENT when cwd is gone —
-  // the exact failure mode this helper is meant to survive.
   return NodeOs.tmpdir();
 }
 
-function safeProcessCwd(): string | undefined {
-  try {
-    const cwd = process.cwd();
-    return cwd.trim().length > 0 ? cwd : undefined;
-  } catch {
-    return undefined;
-  }
-}
+/**
+ * Effect form: reads optional env overrides from `HostProcessEnvironment` when
+ * `environment` is not passed explicitly.
+ */
+export const resolveProviderProbeCwd = Effect.fn("resolveProviderProbeCwd")(function* (
+  preferred?: string | null,
+  environment?: NodeJS.ProcessEnv,
+) {
+  const env = environment ?? (yield* HostProcessEnvironment);
+  return resolveProviderProbeCwdSync(preferred, env);
+});

--- a/apps/server/src/provider/providerProbeTimeouts.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.ts
@@ -1,0 +1,79 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+/**
+ * Provider status probes spawn local CLIs over stdio/ACP.
+ *
+ * On Windows, cold starts are substantially slower:
+ * - Cursor `agent about` commonly takes 7–12s (PowerShell + Node bootstrap)
+ * - Parallel Codex/Grok ACP handshakes compete for CPU/disk during desktop startup
+ * - Leaving stdin open can keep non-interactive probes waiting until timeout
+ *
+ * Timeouts below are deliberately higher on win32 so healthy installs are not
+ * reported as "Unavailable" during normal machine load.
+ */
+const isWindows = process.platform === "win32";
+
+/** Quick `--version` style probes. */
+export const PROVIDER_VERSION_PROBE_TIMEOUT_MS = isWindows ? 15_000 : 4_000;
+
+/**
+ * Codex app-server account/model probe.
+ * Shared with {@link AUTH_PROBE_TIMEOUT_MS} in providerSnapshot for import stability.
+ */
+export const PROVIDER_AUTH_PROBE_TIMEOUT_MS = isWindows ? 45_000 : 15_000;
+
+/** Cursor `agent about` (version + auth). Measured ~8–12s cold on Windows. */
+export const CURSOR_ABOUT_TIMEOUT_MS = isWindows ? 45_000 : 20_000;
+
+/** Cursor ACP model discovery after about succeeds. */
+export const CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS = isWindows ? 45_000 : 20_000;
+
+/** Grok `agent stdio` ACP initialize for model discovery. */
+export const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = isWindows ? 45_000 : 20_000;
+
+/**
+ * Resolve a usable working directory for provider status probes.
+ *
+ * Electron/desktop backends can end up with a non-directory or inaccessible
+ * `process.cwd()` (empty welcome state). Spawning with an invalid cwd on
+ * Windows can hang instead of failing cleanly.
+ */
+export function resolveProviderProbeCwd(
+  preferred?: string | null,
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const candidates: Array<string | undefined> = [
+    preferred?.trim() || undefined,
+    environment.T3_PROVIDER_CWD?.trim() || undefined,
+    environment.T3CODE_PROVIDER_CWD?.trim() || undefined,
+    safeProcessCwd(),
+    environment.USERPROFILE?.trim() || undefined,
+    environment.HOME?.trim() || undefined,
+    NodeOs.homedir(),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      if (NodeFs.statSync(candidate).isDirectory()) {
+        return candidate;
+      }
+    } catch {
+      // try next
+    }
+  }
+
+  // Last resort: always a real directory on Node.
+  return NodePath.resolve(".");
+}
+
+function safeProcessCwd(): string | undefined {
+  try {
+    const cwd = process.cwd();
+    return cwd.trim().length > 0 ? cwd : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/server/src/provider/providerProbeTimeouts.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.ts
@@ -1,6 +1,7 @@
 import * as NodeFs from "node:fs";
 import * as NodeOs from "node:os";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import {
   HostProcessEnvironment,
   HostProcessWorkingDirectory,
@@ -133,9 +134,14 @@ export const resolveProviderProbeCwd = Effect.fn("resolveProviderProbeCwd")(func
   environment?: NodeJS.ProcessEnv,
 ) {
   const env = environment ?? (yield* HostProcessEnvironment);
-  const workingDirectory = yield* HostProcessWorkingDirectory.pipe(
-    Effect.map((cwd) => (cwd.trim().length > 0 ? cwd : undefined)),
-    Effect.catch(() => Effect.succeed(undefined as string | undefined)),
+  // HostProcessWorkingDirectory is typed as infallible, but its defaultValue
+  // calls process.cwd() which can throw a defect when cwd is gone. Use Exit so
+  // defects fall through to home/tmpdir instead of failing the probe.
+  const workingDirectoryExit = yield* Effect.exit(
+    Effect.map(HostProcessWorkingDirectory, (cwd) => (cwd.trim().length > 0 ? cwd : undefined)),
   );
+  const workingDirectory = Exit.isSuccess(workingDirectoryExit)
+    ? workingDirectoryExit.value
+    : undefined;
   return resolveProviderProbeCwdSync(preferred, env, workingDirectory);
 });

--- a/apps/server/src/provider/providerProbeTimeouts.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.ts
@@ -1,7 +1,6 @@
 import * as NodeFs from "node:fs";
 import * as NodeOs from "node:os";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
 import {
   HostProcessEnvironment,
   HostProcessWorkingDirectory,

--- a/apps/server/src/provider/providerProbeTimeouts.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.ts
@@ -1,6 +1,5 @@
 import * as NodeFs from "node:fs";
 import * as NodeOs from "node:os";
-import * as NodePath from "node:path";
 
 /**
  * Provider status probes spawn local CLIs over stdio/ACP.
@@ -65,8 +64,10 @@ export function resolveProviderProbeCwd(
     }
   }
 
-  // Last resort: always a real directory on Node.
-  return NodePath.resolve(".");
+  // Last resort: absolute directory independent of process.cwd().
+  // NodePath.resolve(".") calls process.cwd() and throws ENOENT when cwd is gone —
+  // the exact failure mode this helper is meant to survive.
+  return NodeOs.tmpdir();
 }
 
 function safeProcessCwd(): string | undefined {

--- a/apps/server/src/provider/providerProbeTimeouts.ts
+++ b/apps/server/src/provider/providerProbeTimeouts.ts
@@ -134,13 +134,10 @@ export const resolveProviderProbeCwd = Effect.fn("resolveProviderProbeCwd")(func
 ) {
   const env = environment ?? (yield* HostProcessEnvironment);
   // HostProcessWorkingDirectory is typed as infallible, but its defaultValue
-  // calls process.cwd() which can throw a defect when cwd is gone. Use Exit so
-  // defects fall through to home/tmpdir instead of failing the probe.
-  const workingDirectoryExit = yield* Effect.exit(
-    Effect.map(HostProcessWorkingDirectory, (cwd) => (cwd.trim().length > 0 ? cwd : undefined)),
-  );
-  const workingDirectory = Exit.isSuccess(workingDirectoryExit)
-    ? workingDirectoryExit.value
-    : undefined;
+  // calls process.cwd() which can throw a defect when cwd is gone. Catch only
+  // defects (not fiber interrupts) so cancelled probes still stop promptly.
+  const workingDirectory = yield* Effect.map(HostProcessWorkingDirectory, (cwd) =>
+    cwd.trim().length > 0 ? cwd : undefined,
+  ).pipe(Effect.catchDefect(() => Effect.succeed(undefined as string | undefined)));
   return resolveProviderProbeCwdSync(preferred, env, workingDirectory);
 });

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -18,16 +18,6 @@ import { isWindowsCommandNotFound } from "../processRunner.ts";
 import { createProviderVersionAdvisory } from "./providerMaintenance.ts";
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
 
-import {
-  PROVIDER_AUTH_PROBE_TIMEOUT_MS,
-  PROVIDER_VERSION_PROBE_TIMEOUT_MS,
-} from "./providerProbeTimeouts.ts";
-
-/** @deprecated Prefer PROVIDER_VERSION_PROBE_TIMEOUT_MS for new code. */
-export const DEFAULT_TIMEOUT_MS = PROVIDER_VERSION_PROBE_TIMEOUT_MS;
-// Auth status checks involve disk/network lookups and can be slow on first run (especially Windows)
-export const AUTH_PROBE_TIMEOUT_MS = PROVIDER_AUTH_PROBE_TIMEOUT_MS;
-
 export interface CommandResult {
   readonly stdout: string;
   readonly stderr: string;

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -18,9 +18,15 @@ import { isWindowsCommandNotFound } from "../processRunner.ts";
 import { createProviderVersionAdvisory } from "./providerMaintenance.ts";
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
 
-export const DEFAULT_TIMEOUT_MS = 4_000;
+import {
+  PROVIDER_AUTH_PROBE_TIMEOUT_MS,
+  PROVIDER_VERSION_PROBE_TIMEOUT_MS,
+} from "./providerProbeTimeouts.ts";
+
+/** @deprecated Prefer PROVIDER_VERSION_PROBE_TIMEOUT_MS for new code. */
+export const DEFAULT_TIMEOUT_MS = PROVIDER_VERSION_PROBE_TIMEOUT_MS;
 // Auth status checks involve disk/network lookups and can be slow on first run (especially Windows)
-export const AUTH_PROBE_TIMEOUT_MS = 10_000;
+export const AUTH_PROBE_TIMEOUT_MS = PROVIDER_AUTH_PROBE_TIMEOUT_MS;
 
 export interface CommandResult {
   readonly stdout: string;
@@ -76,6 +82,9 @@ export const spawnAndCollect = (binaryPath: string, command: ChildProcess.Comman
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const child = yield* spawner.spawn(command);
+    // Close stdin immediately. Non-interactive probes (`agent about`, `grok --version`,
+    // etc.) can hang on Windows if stdin stays open waiting for EOF.
+    yield* Stream.run(Stream.empty, child.stdin).pipe(Effect.ignore);
     const [stdout, stderr, exitCode] = yield* Effect.all(
       [
         collectStreamAsString(child.stdout),

--- a/docs/windows-provider-timeouts.md
+++ b/docs/windows-provider-timeouts.md
@@ -18,13 +18,13 @@ Root causes observed on Windows:
 
 ## Changes
 
-| Area                       | Change                                                |
-| -------------------------- | ----------------------------------------------------- |
-| `providerProbeTimeouts.ts` | Platform-aware timeouts + `resolveProviderProbeCwd()` |
-| `providerSnapshot.ts`      | Longer auth probe timeout; close stdin after spawn    |
-| `CursorProvider.ts`        | Longer about/ACP timeouts; safe cwd; close stdin      |
-| `GrokProvider.ts`          | Longer ACP timeout; safe cwd                          |
-| `CodexProvider.ts`         | Safe cwd for app-server probe                         |
+| Area                       | Change                                                        |
+| -------------------------- | ------------------------------------------------------------- |
+| `providerProbeTimeouts.ts` | Timeouts via `HostProcessPlatform`; accessible cwd resolution |
+| `providerSnapshot.ts`      | Close stdin after spawn for CLI health probes                 |
+| `CursorProvider.ts`        | Longer about/ACP timeouts; safe cwd; close stdin              |
+| `GrokProvider.ts`          | Longer ACP/version timeouts; safe cwd                         |
+| `CodexProvider.ts`         | Longer auth probe timeout; safe cwd                           |
 
 ### Timeouts (Windows / non-Windows)
 

--- a/docs/windows-provider-timeouts.md
+++ b/docs/windows-provider-timeouts.md
@@ -18,23 +18,23 @@ Root causes observed on Windows:
 
 ## Changes
 
-| Area | Change |
-|------|--------|
+| Area                       | Change                                                |
+| -------------------------- | ----------------------------------------------------- |
 | `providerProbeTimeouts.ts` | Platform-aware timeouts + `resolveProviderProbeCwd()` |
-| `providerSnapshot.ts` | Longer auth probe timeout; close stdin after spawn |
-| `CursorProvider.ts` | Longer about/ACP timeouts; safe cwd; close stdin |
-| `GrokProvider.ts` | Longer ACP timeout; safe cwd |
-| `CodexProvider.ts` | Safe cwd for app-server probe |
+| `providerSnapshot.ts`      | Longer auth probe timeout; close stdin after spawn    |
+| `CursorProvider.ts`        | Longer about/ACP timeouts; safe cwd; close stdin      |
+| `GrokProvider.ts`          | Longer ACP timeout; safe cwd                          |
+| `CodexProvider.ts`         | Safe cwd for app-server probe                         |
 
 ### Timeouts (Windows / non-Windows)
 
-| Probe | Windows | Other |
-|-------|---------|-------|
-| Version (`--version`) | 15s | 4s |
-| Codex app-server auth | 45s | 15s |
-| Cursor `agent about` | 45s | 20s |
-| Cursor ACP discovery | 45s | 20s |
-| Grok ACP discovery | 45s | 20s |
+| Probe                 | Windows | Other |
+| --------------------- | ------- | ----- |
+| Version (`--version`) | 15s     | 4s    |
+| Codex app-server auth | 45s     | 15s   |
+| Cursor `agent about`  | 45s     | 20s   |
+| Cursor ACP discovery  | 45s     | 20s   |
+| Grok ACP discovery    | 45s     | 20s   |
 
 Env override for probe cwd (optional):
 
@@ -43,12 +43,13 @@ Env override for probe cwd (optional):
 
 ## How to verify
 
+From the repository root:
+
 ```bash
-cd Documents/t3-code-fork/t3code
 pnpm install
-pnpm --filter @t3tools/server test -- src/provider/providerProbeTimeouts.test.ts
-pnpm --filter @t3tools/server test -- src/provider/Layers/CursorProvider.test.ts
-pnpm --filter @t3tools/server test -- src/provider/Layers/ProviderRegistry.test.ts
+pnpm --filter t3 test -- src/provider/providerProbeTimeouts.test.ts
+pnpm --filter t3 test -- src/provider/Layers/CursorProvider.test.ts
+pnpm --filter t3 test -- src/provider/Layers/ProviderRegistry.test.ts
 ```
 
-Then run the desktop app from this fork and open a real project folder before checking Providers.
+Then run the desktop app and open a real project folder before checking Providers.

--- a/docs/windows-provider-timeouts.md
+++ b/docs/windows-provider-timeouts.md
@@ -1,0 +1,54 @@
+# Windows provider status probe timeouts
+
+## Problem
+
+On Windows, T3 Code provider health checks for **Codex**, **Cursor**, and **Grok** often reported:
+
+- `Timed out while checking Codex app-server provider status.`
+- `Cursor Agent CLI is installed but timed out while running \`agent about\`.`
+- `Grok CLI is installed but ACP startup timed out after 15000ms.`
+
+Claude and OpenCode continued to work because they do not rely on the same ACP/stdio cold-start path.
+
+Root causes observed on Windows:
+
+1. **Too-short timeouts** — e.g. Cursor `agent about` was capped at **8s** while cold starts commonly take **7–12s**.
+2. **Invalid / unstable `process.cwd()`** for desktop probes when no project folder is open.
+3. **Open stdin** on non-interactive probes — some CLIs wait for EOF and never exit until the probe times out.
+
+## Changes
+
+| Area | Change |
+|------|--------|
+| `providerProbeTimeouts.ts` | Platform-aware timeouts + `resolveProviderProbeCwd()` |
+| `providerSnapshot.ts` | Longer auth probe timeout; close stdin after spawn |
+| `CursorProvider.ts` | Longer about/ACP timeouts; safe cwd; close stdin |
+| `GrokProvider.ts` | Longer ACP timeout; safe cwd |
+| `CodexProvider.ts` | Safe cwd for app-server probe |
+
+### Timeouts (Windows / non-Windows)
+
+| Probe | Windows | Other |
+|-------|---------|-------|
+| Version (`--version`) | 15s | 4s |
+| Codex app-server auth | 45s | 15s |
+| Cursor `agent about` | 45s | 20s |
+| Cursor ACP discovery | 45s | 20s |
+| Grok ACP discovery | 45s | 20s |
+
+Env override for probe cwd (optional):
+
+- `T3_PROVIDER_CWD`
+- `T3CODE_PROVIDER_CWD`
+
+## How to verify
+
+```bash
+cd Documents/t3-code-fork/t3code
+pnpm install
+pnpm --filter @t3tools/server test -- src/provider/providerProbeTimeouts.test.ts
+pnpm --filter @t3tools/server test -- src/provider/Layers/CursorProvider.test.ts
+pnpm --filter @t3tools/server test -- src/provider/Layers/ProviderRegistry.test.ts
+```
+
+Then run the desktop app from this fork and open a real project folder before checking Providers.


### PR DESCRIPTION
## Summary

On Windows, Codex / Cursor / Grok provider status checks were often marked **Unavailable** because cold CLI starts exceeded the old 8–15s budgets, probes used `process.cwd()` even when invalid, and non-interactive probes left stdin open (which can hang until timeout).

Claude and OpenCode were less affected because they do not use the same ACP/stdio cold-start path.

## Changes

- Add platform-aware `providerProbeTimeouts` helpers (Windows vs other)
- Close stdin after spawn for CLI health probes
- Use `resolveProviderProbeCwd` for Codex / Cursor / Grok status probes
- Docs: `docs/windows-provider-timeouts.md`

### Timeouts (Windows / non-Windows)

| Probe | Windows | Other |
|-------|---------|-------|
| Version (`--version`) | 15s | 4s |
| Codex app-server auth | 45s | 15s |
| Cursor `agent about` | 45s | 20s |
| Cursor ACP discovery | 45s | 20s |
| Grok ACP discovery | 45s | 20s |

Optional probe cwd overrides: `T3_PROVIDER_CWD` / `T3CODE_PROVIDER_CWD`.

## Test plan

- [x] `providerProbeTimeouts` unit tests pass
- [ ] On Windows with Codex / Cursor / Grok installed: providers show Available after open folder
- [ ] Non-Windows timeouts unchanged for fast paths
- [ ] No regression for Claude / OpenCode provider status

## Notes

Observed Cursor cold `agent about` times of ~7–12s on Windows, which already exceeded the previous 8s budget.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider health-check timing and spawn behavior for multiple CLIs; non-Windows timeouts also increased slightly (e.g. Cursor about 8s→20s), which can delay “unavailable” reporting but should reduce false negatives on Windows.
> 
> **Overview**
> Fixes **Codex**, **Cursor**, and **Grok** often showing **Unavailable** on Windows when cold CLI/ACP probes exceeded short budgets, used a bad working directory, or hung with stdin left open.
> 
> Introduces **`providerProbeTimeouts`** with **platform-aware** limits via `HostProcessPlatform` (e.g. Codex auth **45s / 15s**, Cursor `agent about` and ACP discovery **45s / 20s**, version probes **15s / 4s**). Claude and other providers wire version checks through the same helpers instead of scattered constants in `providerSnapshot`.
> 
> **`resolveProviderProbeCwd`** picks a validated directory (env overrides `T3_PROVIDER_CWD` / `T3CODE_PROVIDER_CWD`, host working directory, home, tmp) for Codex/Cursor/Grok spawns instead of **`process.cwd()`**.
> 
> **Closes stdin** immediately after spawn in shared **`spawnAndCollect`** and Cursor **`runCursorCommand`** so non-interactive probes do not wait for EOF. Tests and **`docs/windows-provider-timeouts.md`** document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 162cbd738b0ab4c811f303659a9ec0fa0276ccff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise provider probe timeouts on Windows and fix stdin hangs in CLI probes
> - Introduces platform-aware timeout helpers in [`providerProbeTimeouts.ts`](https://github.com/pingdotgg/t3code/pull/5794/files#diff-d53679e4717b473fc00f883a17cf678cd8926ce5f6a9639bdc25a319fc9f7e5d) that return longer durations on Windows (e.g. 45s vs 15s) for version, auth, Cursor, and Grok probes.
> - Replaces all hardcoded `DEFAULT_TIMEOUT_MS` / `AUTH_PROBE_TIMEOUT_MS` constants with these dynamic values across `ClaudeProvider`, `CodexProvider`, `CursorProvider`, and `GrokProvider`.
> - Fixes hangs on Windows by closing stdin after spawning child processes in `spawnAndCollect` and `runCursorCommand`.
> - Adds `resolveProviderProbeCwd` to select a usable working directory instead of `process.cwd()`, which can be inaccessible in some Windows environments.
> - Behavioral Change: probe timeouts are now significantly longer on Windows; test virtual-time advances were updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 162cbd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->