### PR TITLE
feat(server): steer Codex mid-turn instead of starting a phantom turn

### DIFF
--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -609,6 +609,7 @@ function workEntryIcon(entry: DerivedWorkLogEntry): ThreadFeedActivity["icon"] {
     return "message";
   }
   if (entry.activityKind === "runtime.warning") return "warning";
+  if (entry.activityKind === "provider.turn.steer.rejected") return "warning";
   if (entry.requestKind === "command") return "command";
   if (entry.requestKind === "file-read") return "eye";
   if (entry.requestKind === "file-change") return "edit";

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2382,6 +2382,164 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  effectIt.effect("keeps the session healthy when the provider refuses to steer a turn", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const now = "2026-01-01T00:00:00.000Z";
+
+      // A turn is running: this is the state a mid-turn send arrives in.
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-steering"),
+        threadId: ThreadId.make("thread-1"),
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-running"),
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      });
+
+      // A turn that cannot absorb the message — a `/review`, or one whose
+      // settings the send asks to change. The provider declined; nothing is
+      // broken.
+      harness.sendTurn.mockImplementationOnce(
+        () =>
+          Effect.fail(
+            new ProviderAdapterRequestError({
+              provider: "codex",
+              method: "turn/steer",
+              detail: "Codex is running a review turn, which does not accept new messages.",
+            }),
+          ) as unknown as ReturnType<typeof harness.sendTurn>,
+      );
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-steer-refused"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-steer-refused"),
+          role: "user",
+          text: "one more thing",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      });
+
+      yield* Effect.promise(() =>
+        waitFor(async () => {
+          const readModel = await harness.readModel();
+          const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+          return (
+            thread?.activities.some(
+              (activity) => activity.kind === "provider.turn.steer.rejected",
+            ) ?? false
+          );
+        }),
+      );
+
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(
+        thread?.activities.find((activity) => activity.kind === "provider.turn.steer.rejected"),
+      ).toMatchObject({
+        tone: "info",
+        summary: "Message not sent",
+        payload: { detail: expect.stringContaining("does not accept new messages") },
+      });
+      // Reporting it as a turn-start failure would mark the session errored
+      // and null out its active turn, making the turn the provider is still
+      // working on vanish from the UI.
+      expect(
+        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed"),
+      ).toBe(false);
+      expect(thread?.session?.status).not.toBe("error");
+      expect(thread?.session?.lastError ?? null).toBe(null);
+    }),
+  );
+
+  effectIt.effect("reports uncertain delivery when steer succeeds for an unexpected turn", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const now = "2026-01-01T00:00:00.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-steer-uncertain"),
+        threadId: ThreadId.make("thread-1"),
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-running"),
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      });
+
+      const uncertainError = Object.assign(
+        new ProviderAdapterRequestError({
+          provider: "codex",
+          method: "turn/steer",
+          detail: "Codex steered turn turn-other instead of the expected active turn turn-running.",
+        }),
+        { reason: "turn-id-mismatch", delivery: "uncertain" as const },
+      );
+      harness.sendTurn.mockImplementationOnce(
+        () => Effect.fail(uncertainError) as unknown as ReturnType<typeof harness.sendTurn>,
+      );
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-steer-uncertain"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-steer-uncertain"),
+          role: "user",
+          text: "one more thing",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      });
+
+      yield* Effect.promise(() =>
+        waitFor(async () => {
+          const readModel = await harness.readModel();
+          const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+          return (
+            thread?.activities.some(
+              (activity) => activity.kind === "provider.turn.steer.rejected",
+            ) ?? false
+          );
+        }),
+      );
+
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(
+        thread?.activities.find((activity) => activity.kind === "provider.turn.steer.rejected"),
+      ).toMatchObject({
+        tone: "info",
+        summary: "Delivery uncertain",
+        payload: { detail: expect.stringContaining("unexpected active turn") },
+      });
+      expect(thread?.session?.status).not.toBe("error");
+    }),
+  );
+
   it("rejects cross-driver provider changes after the existing thread session has stopped", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -4,6 +4,7 @@ import {
   EventId,
   type ModelSelection,
   type OrchestrationEvent,
+  type OrchestrationThreadActivityTone,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -342,6 +343,7 @@ const make = Effect.gen(function* () {
     readonly threadId: ThreadId;
     readonly kind:
       | "provider.turn.start.failed"
+      | "provider.turn.steer.rejected"
       | "provider.turn.interrupt.failed"
       | "provider.approval.respond.failed"
       | "provider.user-input.respond.failed"
@@ -351,6 +353,8 @@ const make = Effect.gen(function* () {
     readonly turnId: TurnId | null;
     readonly createdAt: string;
     readonly requestId?: string;
+    /** Defaults to "error"; declined-but-healthy outcomes pass "info". */
+    readonly tone?: OrchestrationThreadActivityTone;
   }) =>
     Effect.all({
       commandId: serverCommandId("provider-failure-activity"),
@@ -363,7 +367,7 @@ const make = Effect.gen(function* () {
           threadId: input.threadId,
           activity: {
             id: eventId,
-            tone: "error",
+            tone: input.tone ?? "error",
             kind: input.kind,
             summary: input.summary,
             payload: {
@@ -387,6 +391,23 @@ const make = Effect.gen(function* () {
       return providerError.detail;
     }
     return Cause.pretty(cause);
+  };
+
+  /**
+   * A refused `turn/steer` is not a broken session. The provider declined to
+   * fold this message into the turn that is still running — most often
+   * because that turn is a `/review` or `/compact`, which the protocol
+   * documents as never accepting same-turn steering. Treating it like a
+   * turn-start failure would mark the session errored and null out
+   * `activeTurnId`, making the running turn vanish from the UI while it is
+   * still working.
+   */
+  const readSteerRejection = (cause: Cause.Cause<unknown>) => {
+    const failReason = cause.reasons.find(Cause.isFailReason);
+    return isProviderAdapterRequestError(failReason?.error) &&
+      failReason.error.method === "turn/steer"
+      ? failReason.error
+      : undefined;
   };
 
   const setThreadSession = (input: {
@@ -1130,6 +1151,25 @@ const make = Effect.gen(function* () {
         return Effect.void;
       }
       const detail = formatFailureDetail(cause);
+      // The provider declined to fold this message into the turn it is still
+      // running. Nothing was sent and nothing is broken: leave the session
+      // and its active turn alone, and tell the user their message did not
+      // go out so they can send it again once the turn finishes.
+      const steerRejection = readSteerRejection(cause);
+      if (steerRejection) {
+        const deliveryUncertain = steerRejection.delivery === "uncertain";
+        return appendProviderFailureActivity({
+          threadId: event.payload.threadId,
+          kind: "provider.turn.steer.rejected",
+          tone: "info",
+          summary: deliveryUncertain ? "Delivery uncertain" : "Message not sent",
+          detail: deliveryUncertain
+            ? `${detail} The message may have been delivered to an unexpected active turn; do not resend it automatically.`
+            : detail,
+          turnId: null,
+          createdAt: event.payload.createdAt,
+        }).pipe(Effect.asVoid);
+      }
       return setThreadSessionErrorOnTurnStartFailure({
         threadId: event.payload.threadId,
         detail,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2703,7 +2703,7 @@ describe("ProviderRuntimeIngestion", () => {
       harness.readModel,
       (entry) =>
         entry.session?.status === "error" &&
-        entry.session?.activeTurnId === "turn-3" &&
+        entry.session?.activeTurnId === null &&
         entry.session?.lastError === "runtime exploded",
     );
     expect(thread.session?.status).toBe("error");
@@ -3553,7 +3553,7 @@ describe("ProviderRuntimeIngestion", () => {
       harness.readModel,
       (entry) =>
         entry.session?.status === "error" &&
-        entry.session?.activeTurnId === "turn-after-failure" &&
+        entry.session?.activeTurnId === null &&
         entry.session?.lastError === "runtime still processed",
     );
     expect(thread.session?.status).toBe("error");

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1882,7 +1882,7 @@ const make = Effect.gen(function* () {
                 ? { providerInstanceId: event.providerInstanceId }
                 : {}),
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
-              activeTurnId: eventTurnId ?? null,
+              activeTurnId: null,
               lastError: runtimeErrorMessage,
               updatedAt: now,
             },

--- a/apps/server/src/provider/Errors.ts
+++ b/apps/server/src/provider/Errors.ts
@@ -2,6 +2,9 @@ import * as Schema from "effect/Schema";
 
 import type { CheckpointServiceError } from "../checkpointing/Errors.ts";
 
+export const ProviderRequestDelivery = Schema.Literals(["not-delivered", "uncertain"]);
+export type ProviderRequestDelivery = typeof ProviderRequestDelivery.Type;
+
 /**
  * ProviderAdapterValidationError - Invalid adapter API input.
  */
@@ -60,6 +63,8 @@ export class ProviderAdapterRequestError extends Schema.TaggedErrorClass<Provide
     provider: Schema.String,
     method: Schema.String,
     detail: Schema.String,
+    reason: Schema.optionalKey(Schema.String),
+    delivery: Schema.optionalKey(ProviderRequestDelivery),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -13,7 +13,6 @@ import {
   type ProviderApprovalDecision,
   type ProviderEvent,
   type ProviderSession,
-  type ProviderTurnStartResult,
   type ProviderUserInputAnswers,
   ThreadId,
   TurnId,
@@ -36,17 +35,21 @@ import * as CodexErrors from "effect-codex-app-server/errors";
 
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
-import { ProviderAdapterValidationError } from "../Errors.ts";
+import { ProviderAdapterRequestError, ProviderAdapterValidationError } from "../Errors.ts";
 import type { CodexAdapterShape } from "../Services/CodexAdapter.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import {
+  CodexSessionRuntimeTurnSteerRejectedError,
+  type CodexSendTurnResult,
   type CodexSessionRuntimeOptions,
+  type CodexSessionRuntimeError,
   type CodexSessionRuntimeSendTurnInput,
   type CodexSessionRuntimeShape,
   type CodexThreadSnapshot,
 } from "./CodexSessionRuntime.ts";
 import { makeCodexAdapter } from "./CodexAdapter.ts";
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
+const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 
 // Test-local service tag so the rest of the file can keep using `yield* CodexAdapter`.
 class CodexAdapter extends Context.Service<CodexAdapter, CodexAdapterShape>()(
@@ -76,10 +79,11 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
   );
 
   public readonly sendTurnImpl = vi.fn(
-    (_input: CodexSessionRuntimeSendTurnInput): Promise<ProviderTurnStartResult> =>
+    (_input: CodexSessionRuntimeSendTurnInput): Promise<CodexSendTurnResult> =>
       Promise.resolve({
         threadId: this.options.threadId,
         turnId: asTurnId("turn-1"),
+        steered: false,
       }),
   );
 
@@ -127,7 +131,9 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
 
   getSession = Effect.promise(() => this.startImpl());
 
-  sendTurn(input: CodexSessionRuntimeSendTurnInput) {
+  sendTurn(
+    input: CodexSessionRuntimeSendTurnInput,
+  ): Effect.Effect<CodexSendTurnResult, CodexSessionRuntimeError> {
     return Effect.promise(() => this.sendTurnImpl(input));
   }
 
@@ -357,6 +363,39 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
         effort: "high",
         serviceTier: "priority",
       });
+    }),
+  );
+
+  it.effect("preserves steer rejection reason and delivery certainty", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("sess-steer-mismatch");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const runtime = sessionRuntimeFactory.lastRuntime;
+      NodeAssert.ok(runtime);
+      vi.spyOn(runtime, "sendTurn").mockReturnValue(
+        Effect.fail(
+          new CodexSessionRuntimeTurnSteerRejectedError({
+            threadId,
+            expectedTurnId: "turn-expected",
+            steeredTurnId: "turn-other",
+            reason: "turn-id-mismatch",
+          }),
+        ),
+      );
+
+      const result = yield* adapter
+        .sendTurn({ threadId, input: "hello", attachments: [] })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.ok(isProviderAdapterRequestError(result.failure));
+      NodeAssert.equal(result.failure.reason, "turn-id-mismatch");
+      NodeAssert.equal(result.failure.delivery, "uncertain");
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -57,6 +57,7 @@ import { ServerConfig } from "../../config.ts";
 import {
   CodexResumeCursorSchema,
   CodexSessionRuntimeThreadIdMissingError,
+  CodexSessionRuntimeTurnSteerRejectedError,
   makeCodexSessionRuntime,
   type CodexSessionRuntimeError,
   type CodexSessionRuntimeOptions,
@@ -68,6 +69,9 @@ const isCodexAppServerProcessExitedError = Schema.is(CodexErrors.CodexAppServerP
 const isCodexAppServerTransportError = Schema.is(CodexErrors.CodexAppServerTransportError);
 const isCodexSessionRuntimeThreadIdMissingError = Schema.is(
   CodexSessionRuntimeThreadIdMissingError,
+);
+const isCodexSessionRuntimeTurnSteerRejectedError = Schema.is(
+  CodexSessionRuntimeTurnSteerRejectedError,
 );
 const isCodexResumeCursorSchema = Schema.is(CodexResumeCursorSchema);
 
@@ -112,6 +116,19 @@ function mapCodexRuntimeError(
     return new ProviderAdapterSessionNotFoundError({
       provider: PROVIDER,
       threadId,
+      cause: error,
+    });
+  }
+
+  // A refused steer is not a failed turn start: reporting it under the method
+  // that was actually attempted keeps the surfaced detail honest.
+  if (isCodexSessionRuntimeTurnSteerRejectedError(error)) {
+    return new ProviderAdapterRequestError({
+      provider: PROVIDER,
+      method: "turn/steer",
+      detail: error.message,
+      reason: error.reason,
+      delivery: error.reason === "turn-id-mismatch" ? "uncertain" : "not-delivered",
       cause: error,
     });
   }

--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -73,6 +73,39 @@ function buildScript() {
 const scriptPath = NodePath.join(import.meta.dirname, "../testFixtures/.collab-script.json");
 const peerPath = NodePath.join(import.meta.dirname, "../testFixtures/codexCollabMockPeer.sh");
 
+/** Append-only sidecars the mock peer writes so tests can assert what the
+ * runtime actually put on the wire. */
+const SIDECARS = ["starts", "steers", "interrupts"] as const;
+
+function readSidecar(path: string): ReadonlyArray<unknown> {
+  if (!NodeFS.existsSync(path)) {
+    return [];
+  }
+  const raw = NodeFS.readFileSync(path, "utf8").trim();
+  return raw.length === 0 ? [] : raw.split("\n").map((line) => JSON.parse(line) as unknown);
+}
+
+/** Writes the script, clears stale sidecars, and registers cleanup. */
+const useScript = Effect.fnUntraced(function* (script: unknown) {
+  // @effect-diagnostics-next-line preferSchemaOverJson:off
+  NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+  const paths = Object.fromEntries(
+    SIDECARS.map((name) => [name, `${scriptPath}.${name}`]),
+  ) as Record<(typeof SIDECARS)[number], string>;
+  for (const path of Object.values(paths)) {
+    NodeFS.rmSync(path, { force: true });
+  }
+  yield* Effect.addFinalizer(() =>
+    Effect.sync(() => {
+      NodeFS.rmSync(scriptPath, { force: true });
+      for (const path of Object.values(paths)) {
+        NodeFS.rmSync(path, { force: true });
+      }
+    }),
+  );
+  return paths;
+});
+
 describe("CodexSessionRuntime collab integration", () => {
   it.effect("replays the captured fan-out into synthetic agent events without child leaks", () =>
     Effect.gen(function* () {
@@ -246,26 +279,30 @@ describe("CodexSessionRuntime collab integration", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
-  it.live("Stop targets the active turn when Codex has accepted a queued follow-up", () =>
+  it.live("folds a mid-turn send into the running turn and keeps Stop pointed at it", () =>
     Effect.gen(function* () {
       const activeTurnId = "019fe3e8-f908-7f31-8d51-283f4a47897a";
-      const queuedTurnId = "019fe3eb-8faf-7de3-a85b-ac64c7f9c8c3";
       const script = {
         rootThreadId: ROOT,
         holdTurnOpen: true,
-        onlyFirstTurnStarts: true,
-        turnIds: [activeTurnId, queuedTurnId],
+        // A single scripted turn id: a second turn/start would answer with the
+        // fixture's own id, so the assertions below catch a regression to
+        // queueing a follow-up turn.
+        turnIds: [activeTurnId],
         expectedActiveTurnId: activeTurnId,
         notifications: [],
       };
       // @effect-diagnostics-next-line preferSchemaOverJson:off
       NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
       const interruptsPath = `${scriptPath}.interrupts`;
+      const steersPath = `${scriptPath}.steers`;
       NodeFS.rmSync(interruptsPath, { force: true });
+      NodeFS.rmSync(steersPath, { force: true });
       yield* Effect.addFinalizer(() =>
         Effect.sync(() => {
           NodeFS.rmSync(scriptPath, { force: true });
           NodeFS.rmSync(interruptsPath, { force: true });
+          NodeFS.rmSync(steersPath, { force: true });
         }),
       );
 
@@ -278,9 +315,25 @@ describe("CodexSessionRuntime collab integration", () => {
       });
 
       yield* runtime.start();
-      yield* runtime.sendTurn({ input: "keep working" });
-      yield* runtime.sendTurn({ input: "queued follow-up" });
+      const started = yield* runtime.sendTurn({ input: "keep working" });
+      const steered = yield* runtime.sendTurn({ input: "follow-up while running" });
       yield* runtime.interruptTurn();
+
+      assert.equal(started.turnId, activeTurnId);
+      // The follow-up steers the turn that is already running rather than
+      // queueing a second one, so it reports the same turn id back.
+      assert.equal(steered.turnId, activeTurnId);
+      const steers = NodeFS.readFileSync(steersPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as unknown);
+      assert.deepEqual(steers, [
+        {
+          threadId: ROOT,
+          expectedTurnId: activeTurnId,
+          input: [{ type: "text", text: "follow-up while running" }],
+        },
+      ]);
 
       const interrupts = NodeFS.readFileSync(interruptsPath, "utf8")
         .trim()
@@ -290,6 +343,312 @@ describe("CodexSessionRuntime collab integration", () => {
         threadId: ROOT,
         turnId: activeTurnId,
       });
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("rejects a message typed after Stop until terminal lifecycle arrives", () =>
+    Effect.gen(function* () {
+      const activeTurnId = "019fe3e8-f908-7f31-8d51-283f4a47897a";
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        turnIds: [activeTurnId],
+        expectedActiveTurnId: activeTurnId,
+        notifications: [],
+      };
+      const paths = yield* useScript(script);
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-codex-stop-then-type"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "keep working" });
+      yield* runtime.interruptTurn();
+      const afterStop = yield* runtime
+        .sendTurn({ input: "actually, do this instead" })
+        .pipe(Effect.flip);
+
+      assert.equal(afterStop._tag, "CodexSessionRuntimeTurnSteerRejectedError");
+      if (afterStop._tag !== "CodexSessionRuntimeTurnSteerRejectedError") {
+        return;
+      }
+      assert.equal(afterStop.reason, "turn-interrupting");
+      assert.equal(afterStop.retryable, true);
+      assert.deepEqual(readSidecar(paths.steers), []);
+      assert.deepEqual(
+        readSidecar(paths.starts).map((entry) => (entry as { input?: unknown }).input),
+        [[{ type: "text", text: "keep working" }]],
+      );
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("rolls back interrupting when the parent interrupt RPC fails", () =>
+    Effect.gen(function* () {
+      const activeTurnId = "019fe3e8-f908-7f31-8d51-283f4a47897a";
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        turnIds: [activeTurnId],
+        failInterruptFor: ROOT,
+        notifications: [],
+      };
+      const paths = yield* useScript(script);
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-codex-interrupt-rollback"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "keep working" });
+      yield* runtime.interruptTurn().pipe(Effect.flip);
+      const afterFailure = yield* runtime.sendTurn({ input: "still add this" });
+
+      assert.equal(afterFailure.steered, true);
+      assert.equal(afterFailure.turnId, activeTurnId);
+      assert.deepEqual(
+        readSidecar(paths.starts).map((entry) => (entry as { turnId?: string }).turnId),
+        [activeTurnId],
+      );
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("does not start a phantom turn when a no-active refusal outruns lifecycle", () =>
+    Effect.gen(function* () {
+      const activeTurnId = "019fe3e8-f908-7f31-8d51-283f4a47897a";
+      const nextTurnId = "019fe3eb-8faf-7de3-a85b-ac64c7f9c8c3";
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        turnIds: [activeTurnId, nextTurnId],
+        notifications: [],
+        // The turn ended just before the steer landed. Quoted verbatim from
+        // a captured transcript (codex-cli 0.147.0): a bare `-32600` with no
+        // `data` and no structured error info to key on.
+        steerRejection: {
+          code: -32600,
+          message: "no active turn to steer",
+        },
+      };
+      const paths = yield* useScript(script);
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-codex-steer-race"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "keep working" });
+      const raced = yield* runtime.sendTurn({ input: "one more thing" }).pipe(Effect.flip);
+
+      assert.equal(raced._tag, "CodexSessionRuntimeTurnSteerRejectedError");
+      assert.equal(readSidecar(paths.steers).length, 1);
+      assert.deepEqual(
+        readSidecar(paths.starts).map((entry) => (entry as { input?: unknown }).input),
+        [[{ type: "text", text: "keep working" }]],
+      );
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("serializes concurrent sends so an end-of-turn race starts exactly one fallback", () =>
+    Effect.gen(function* () {
+      const activeTurnId = "019fe3e8-f908-7f31-8d51-283f4a47897a";
+      const fallbackTurnId = "019fe3eb-8faf-7de3-a85b-ac64c7f9c8c3";
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        turnIds: [activeTurnId, fallbackTurnId],
+        endTurnBeforeFirstSteer: true,
+        deferStaleSteerResponses: true,
+        notifications: [],
+      };
+      const paths = yield* useScript(script);
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-codex-concurrent-steer-race"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "keep working" });
+      const results = yield* Effect.all(
+        [
+          runtime.sendTurn({ input: "first follow-up" }),
+          runtime.sendTurn({ input: "second follow-up" }),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      assert.deepEqual(
+        readSidecar(paths.starts).map((entry) => (entry as { turnId?: string }).turnId),
+        [activeTurnId, fallbackTurnId],
+      );
+      assert.equal(
+        results.filter((result) => result.steered === false).length,
+        1,
+        "only one concurrent send may own the stale-steer fallback",
+      );
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("reconciles rather than starting when a steer reports another active turn", () =>
+    Effect.gen(function* () {
+      const responseTurnId = "019fe4ff-f18b-76f2-b132-c93f3a6c5bfb";
+      const notifiedTurnId = "019fe4ff-f223-7401-8ef3-930a168477a8";
+      const nextTurnId = "019fe3eb-8faf-7de3-a85b-ac64c7f9c8c3";
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        turnIds: [responseTurnId, nextTurnId],
+        turnStartedBeforeResponse: true,
+        startedTurnIdOverride: notifiedTurnId,
+        notifications: [],
+        // Captured `/review` behaviour: the notification publishes one id
+        // while the server accepts only the response id. This refusal proves
+        // the found id is still active, so the runtime must reconcile it and
+        // must not fall back to a mid-turn turn/start. Verbatim from
+        // review-steer.attempt-2.jsonl.
+        steerRejection: {
+          code: -32600,
+          message: `expected active turn id \`${notifiedTurnId}\` but found \`${responseTurnId}\``,
+        },
+      };
+      const paths = yield* useScript(script);
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-codex-review-split"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "keep working" });
+      const rejected = yield* runtime.sendTurn({ input: "and also this" }).pipe(Effect.flip);
+
+      assert.equal(rejected._tag, "CodexSessionRuntimeTurnSteerRejectedError");
+      assert.equal(readSidecar(paths.steers).length, 1);
+      assert.deepEqual(
+        readSidecar(paths.starts).map((entry) => (entry as { input?: unknown }).input),
+        [[{ type: "text", text: "keep working" }]],
+      );
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("tracks the start response's turn id when turn/started names another", () =>
+    Effect.gen(function* () {
+      const responseTurnId = "019fe3e8-f908-7f31-8d51-283f4a47897a";
+      const notifiedTurnId = "019fe3eb-8faf-7de3-a85b-ac64c7f9c8c3";
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        turnIds: [responseTurnId],
+        // `turn/started` wins the race and publishes a different id. A
+        // captured `/review` shows exactly this split, with the server
+        // accepting only the id it returned in the response.
+        turnStartedBeforeResponse: true,
+        startedTurnIdOverride: notifiedTurnId,
+        expectedActiveTurnId: responseTurnId,
+        notifications: [],
+      };
+      const paths = yield* useScript(script);
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-codex-started-race"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+
+      yield* runtime.start();
+      const started = yield* runtime.sendTurn({ input: "keep working" });
+      const steered = yield* runtime.sendTurn({ input: "and also this" });
+      yield* runtime.interruptTurn();
+
+      assert.equal(started.turnId, responseTurnId);
+      // Both the follow-up steer and Stop address the id the server accepts.
+      assert.equal(steered.steered, true);
+      assert.deepEqual(
+        readSidecar(paths.steers).map(
+          (entry) => (entry as { expectedTurnId?: string }).expectedTurnId,
+        ),
+        [responseTurnId],
+      );
+      assert.deepEqual(readSidecar(paths.interrupts).at(-1), {
+        threadId: ROOT,
+        turnId: responseTurnId,
+      });
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("projects one authoritative lifecycle when turn/started names a split review id", () =>
+    Effect.gen(function* () {
+      const responseTurnId = "019fe4ff-f18b-76f2-b132-c93f3a6c5bfb";
+      const notifiedTurnId = "019fe4ff-f223-7401-8ef3-930a168477a8";
+      const script = {
+        rootThreadId: ROOT,
+        turnIds: [responseTurnId],
+        turnStartedBeforeResponse: true,
+        startedTurnIdOverride: notifiedTurnId,
+        notifications: [],
+      };
+      yield* useScript(script);
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-codex-review-projection"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const eventsFiber = yield* runtime.events.pipe(
+        Stream.takeUntil((event) => event.method === "turn/completed"),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "review this" });
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      const started = events.find((event) => event.method === "turn/started");
+      const completed = events.find((event) => event.method === "turn/completed");
+
+      assert.equal(started?.turnId, responseTurnId);
+      assert.equal(
+        (started?.payload as { turn?: { id?: string } } | undefined)?.turn?.id,
+        responseTurnId,
+      );
+      assert.equal(completed?.turnId, responseTurnId);
 
       yield* runtime.close;
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -2,11 +2,19 @@ import * as NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import { describe } from "vite-plus/test";
-import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
+import {
+  DEFAULT_MODEL,
+  ProviderDriverKind,
+  ThreadId,
+  TurnId,
+  type ProviderSession,
+} from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
+import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
 import {
   buildCodexDeveloperInstructions,
@@ -16,11 +24,19 @@ import {
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
+  buildTurnSteerParams,
+  type CodexActiveTurnState,
+  CodexSessionRuntimeTurnSteerRejectedError,
+  type CodexSessionRuntimeSendTurnInput,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
   openCodexThread,
+  sendCodexTurn,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+const isCodexSessionRuntimeTurnSteerRejectedError = Schema.is(
+  CodexSessionRuntimeTurnSteerRejectedError,
+);
 
 describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   it("retains identifier purpose and the random source failure", () => {
@@ -466,6 +482,699 @@ describe("openCodexThread", () => {
 
       NodeAssert.ok(isCodexAppServerRequestError(error));
       NodeAssert.equal(error.errorMessage, "timed out waiting for server");
+    }),
+  );
+});
+
+describe("buildTurnSteerParams", () => {
+  it.effect("carries the required active turn id and the message only", () =>
+    Effect.gen(function* () {
+      const params = yield* buildTurnSteerParams({
+        threadId: "provider-thread-1",
+        expectedTurnId: TurnId.make("turn-active"),
+        prompt: "Also update the changelog",
+        attachments: [
+          {
+            type: "image",
+            url: "data:image/png;base64,abc",
+          },
+        ],
+      });
+
+      NodeAssert.deepStrictEqual(params, {
+        threadId: "provider-thread-1",
+        expectedTurnId: "turn-active",
+        input: [
+          {
+            type: "text",
+            text: "Also update the changelog",
+          },
+          {
+            type: "image",
+            url: "data:image/png;base64,abc",
+          },
+        ],
+      });
+    }),
+  );
+});
+const PROVIDER_THREAD_ID = "provider-thread-1";
+const ACTIVE_TURN_ID = TurnId.make("turn-active");
+
+function makeCodexSession(overrides: Partial<ProviderSession>): ProviderSession {
+  return {
+    provider: ProviderDriverKind.make("codex"),
+    status: "ready",
+    runtimeMode: "full-access",
+    cwd: "/tmp/project",
+    model: "gpt-5.3-codex",
+    threadId: ThreadId.make("thread-1"),
+    resumeCursor: { threadId: PROVIDER_THREAD_ID },
+    createdAt: "2026-04-18T00:00:00.000Z",
+    updatedAt: "2026-04-18T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeActiveTurn(overrides: Partial<CodexActiveTurnState> = {}): CodexActiveTurnState {
+  return {
+    turnId: ACTIVE_TURN_ID,
+    model: "gpt-5.3-codex",
+    effort: undefined,
+    serviceTier: undefined,
+    interactionMode: undefined,
+    interrupting: false,
+    ...overrides,
+  };
+}
+
+/** Session + turn record for a thread that is genuinely mid-turn. */
+const runningSession = Effect.all({
+  sessionRef: Ref.make(makeCodexSession({ status: "running", activeTurnId: ACTIVE_TURN_ID })),
+  activeTurnRef: Ref.make<CodexActiveTurnState | undefined>(makeActiveTurn()),
+});
+
+const idleSession = Effect.all({
+  sessionRef: Ref.make(makeCodexSession({ status: "ready" })),
+  activeTurnRef: Ref.make<CodexActiveTurnState | undefined>(undefined),
+});
+
+interface RecordedTurnCall {
+  readonly method: string;
+  readonly payload: unknown;
+}
+
+function makeTurnClient(input: {
+  readonly calls: Array<RecordedTurnCall>;
+  readonly startedTurnId?: string;
+  readonly steer?: (
+    payload: EffectCodexSchema.V2TurnSteerParams,
+  ) => Effect.Effect<EffectCodexSchema.V2TurnSteerResponse, CodexErrors.CodexAppServerError>;
+  readonly onTurnStart?: () => Effect.Effect<void>;
+}) {
+  return {
+    raw: {
+      request: (method: string, payload?: unknown) => {
+        input.calls.push({ method, payload });
+        return (input.onTurnStart ? input.onTurnStart() : Effect.void).pipe(
+          Effect.as({
+            turn: {
+              id: input.startedTurnId ?? "turn-started",
+              items: [],
+              status: "inProgress",
+            },
+          } as unknown),
+        ) as Effect.Effect<unknown, CodexErrors.CodexAppServerError>;
+      },
+    },
+    request: (_method: "turn/steer", payload: EffectCodexSchema.V2TurnSteerParams) => {
+      input.calls.push({ method: "turn/steer", payload });
+      return input.steer
+        ? input.steer(payload)
+        : Effect.succeed({ turnId: payload.expectedTurnId });
+    },
+  };
+}
+
+const failSteer = (error: CodexErrors.CodexAppServerRequestError) => () => Effect.fail(error);
+
+const sendTurnInput = { input: "Also update the changelog" } as const;
+
+const send = (input: {
+  readonly calls: Array<RecordedTurnCall>;
+  readonly sessionRef: Ref.Ref<ProviderSession>;
+  readonly activeTurnRef: Ref.Ref<CodexActiveTurnState | undefined>;
+  readonly turn?: CodexSessionRuntimeSendTurnInput;
+  readonly startedTurnId?: string;
+  readonly steer?: (
+    payload: EffectCodexSchema.V2TurnSteerParams,
+  ) => Effect.Effect<EffectCodexSchema.V2TurnSteerResponse, CodexErrors.CodexAppServerError>;
+  readonly onTurnStart?: () => Effect.Effect<void>;
+}) =>
+  sendCodexTurn({
+    client: makeTurnClient({
+      calls: input.calls,
+      ...(input.startedTurnId ? { startedTurnId: input.startedTurnId } : {}),
+      ...(input.steer ? { steer: input.steer } : {}),
+      ...(input.onTurnStart ? { onTurnStart: input.onTurnStart } : {}),
+    }),
+    sessionRef: input.sessionRef,
+    activeTurnRef: input.activeTurnRef,
+    threadId: ThreadId.make("thread-1"),
+    runtimeMode: "full-access",
+    turn: input.turn ?? sendTurnInput,
+  });
+
+describe("sendCodexTurn", () => {
+  it.effect("steers the running turn instead of starting a second one", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+      const sessionBefore = yield* Ref.get(sessionRef);
+
+      const result = yield* send({ calls, sessionRef, activeTurnRef });
+
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer"],
+      );
+      NodeAssert.deepStrictEqual(calls[0]?.payload, {
+        threadId: PROVIDER_THREAD_ID,
+        expectedTurnId: "turn-active",
+        input: [
+          {
+            type: "text",
+            text: "Also update the changelog",
+          },
+        ],
+      });
+      NodeAssert.equal(result.turnId, "turn-active");
+      NodeAssert.equal(result.steered, true);
+      NodeAssert.deepStrictEqual(yield* Ref.get(sessionRef), sessionBefore);
+    }),
+  );
+
+  it.effect("reports the running turn so nothing downstream projects a new turn", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+
+      const result = yield* send({ calls, sessionRef, activeTurnRef });
+
+      // A new turn is only ever projected from a `turn/started` notification,
+      // which the app-server does not send for a steer. Returning the running
+      // turn's id keeps the caller's active-turn record pointed at the turn
+      // that `turn/interrupt` accepts.
+      NodeAssert.deepStrictEqual(result, {
+        threadId: "thread-1",
+        turnId: "turn-active",
+        resumeCursor: { threadId: PROVIDER_THREAD_ID },
+        steered: true,
+      });
+    }),
+  );
+
+  it.effect("starts a turn when the session is idle", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* idleSession;
+
+      const result = yield* send({ calls, sessionRef, activeTurnRef });
+
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/start"],
+      );
+      NodeAssert.equal(result.turnId, "turn-started");
+      NodeAssert.equal(result.steered, false);
+      const session = yield* Ref.get(sessionRef);
+      NodeAssert.equal(session.status, "running");
+      NodeAssert.equal(session.activeTurnId, "turn-started");
+      // The turn's settings become the baseline a later mid-turn send is
+      // checked against.
+      NodeAssert.deepStrictEqual(yield* Ref.get(activeTurnRef), {
+        turnId: "turn-started",
+        model: "gpt-5.3-codex",
+        effort: undefined,
+        serviceTier: undefined,
+        interactionMode: undefined,
+        interrupting: false,
+      });
+    }),
+  );
+
+  it.effect("prefers the start response's turn id over a racing turn/started", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* idleSession;
+
+      // `turn/started` wins the race against the turn/start response and
+      // publishes a different id. Captured against codex-cli 0.147.0, the
+      // server validates `expectedTurnId` and `turn/interrupt` against the
+      // id it returned in the response, so that one has to win.
+      const result = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        startedTurnId: "turn-from-response",
+        onTurnStart: () =>
+          Ref.update(sessionRef, (session) => ({
+            ...session,
+            status: "running" as const,
+            activeTurnId: TurnId.make("turn-from-notification"),
+          })),
+      });
+
+      NodeAssert.equal(result.turnId, "turn-from-response");
+      NodeAssert.equal((yield* Ref.get(sessionRef)).activeTurnId, "turn-from-response");
+      NodeAssert.equal((yield* Ref.get(activeTurnRef))?.turnId, "turn-from-response");
+    }),
+  );
+
+  it.effect("rejects retryably instead of starting while Stop awaits terminal lifecycle", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const sessionRef = yield* Ref.make(
+        makeCodexSession({ status: "running", activeTurnId: ACTIVE_TURN_ID }),
+      );
+      const activeTurnRef = yield* Ref.make<CodexActiveTurnState | undefined>(
+        makeActiveTurn({ interrupting: true }),
+      );
+
+      const error = yield* send({ calls, sessionRef, activeTurnRef }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.reason, "turn-interrupting");
+      NodeAssert.equal(error.retryable, true);
+      NodeAssert.deepStrictEqual(calls, []);
+    }),
+  );
+
+  it.effect("does not start a phantom turn when the running turn's settings are unknown", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const sessionRef = yield* Ref.make(
+        makeCodexSession({ status: "running", activeTurnId: ACTIVE_TURN_ID }),
+      );
+      const activeTurnRef = yield* Ref.make<CodexActiveTurnState | undefined>(undefined);
+
+      const error = yield* send({ calls, sessionRef, activeTurnRef }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.reason, "rejected");
+      NodeAssert.match(error.message, /metadata is unavailable/);
+      NodeAssert.deepStrictEqual(calls, []);
+    }),
+  );
+
+  for (const change of [
+    { label: "model", turn: { ...sendTurnInput, model: "gpt-5.4" }, setting: "the model" },
+    {
+      label: "reasoning effort",
+      turn: { ...sendTurnInput, effort: "high" },
+      setting: "reasoning effort",
+    },
+    {
+      label: "interaction mode",
+      turn: { ...sendTurnInput, interactionMode: "plan" },
+      setting: "the interaction mode",
+    },
+    {
+      label: "service tier",
+      turn: { ...sendTurnInput, serviceTier: "priority" },
+      setting: "the service tier",
+    },
+  ] as const) {
+    it.effect(`refuses to silently drop a ${change.label} switch mid-turn`, () =>
+      Effect.gen(function* () {
+        const calls: Array<RecordedTurnCall> = [];
+        const { sessionRef, activeTurnRef } = yield* runningSession;
+        const sessionBefore = yield* Ref.get(sessionRef);
+
+        const error = yield* send({
+          calls,
+          sessionRef,
+          activeTurnRef,
+          turn: change.turn as CodexSessionRuntimeSendTurnInput,
+        }).pipe(Effect.flip);
+
+        NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+        NodeAssert.equal(error.reason, "turn-settings-changed");
+        NodeAssert.equal(error.changedSetting, change.setting);
+        NodeAssert.equal(error.retryable, false);
+        // Refused before any RPC: the message is not sent anywhere.
+        NodeAssert.deepStrictEqual(calls, []);
+        NodeAssert.deepStrictEqual(yield* Ref.get(sessionRef), sessionBefore);
+      }),
+    );
+  }
+
+  it.effect("steers when the send repeats the settings the turn already runs with", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const sessionRef = yield* Ref.make(
+        makeCodexSession({ status: "running", activeTurnId: ACTIVE_TURN_ID }),
+      );
+      const activeTurnRef = yield* Ref.make<CodexActiveTurnState | undefined>(
+        makeActiveTurn({ effort: "high", interactionMode: "default" }),
+      );
+
+      const result = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        turn: {
+          ...sendTurnInput,
+          model: "gpt-5.3-codex",
+          effort: "high",
+          interactionMode: "default",
+        },
+      });
+
+      NodeAssert.equal(result.steered, true);
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer"],
+      );
+    }),
+  );
+
+  it.effect("records the effective default effort used by interaction mode", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* idleSession;
+
+      yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        turn: { ...sendTurnInput, interactionMode: "default" },
+      });
+      const repeated = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        turn: { ...sendTurnInput, effort: "medium", interactionMode: "default" },
+      });
+
+      NodeAssert.equal(repeated.steered, true);
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/start", "turn/steer"],
+      );
+      NodeAssert.equal((yield* Ref.get(activeTurnRef))?.effort, "medium");
+    }),
+  );
+
+  it.effect("re-issues after a no-active refusal only when the runtime has become idle", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+
+      const result = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        steer: () =>
+          Ref.update(sessionRef, (session) => ({
+            ...session,
+            status: "ready" as const,
+            activeTurnId: undefined,
+          })).pipe(
+            Effect.andThen(Ref.set(activeTurnRef, undefined)),
+            Effect.andThen(
+              Effect.fail(
+                new CodexErrors.CodexAppServerRequestError({
+                  code: -32600,
+                  errorMessage: "no active turn to steer",
+                }),
+              ),
+            ),
+          ),
+      });
+
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer", "turn/start"],
+      );
+      NodeAssert.equal(result.turnId, "turn-started");
+      NodeAssert.equal(result.steered, false);
+    }),
+  );
+
+  it.effect("does not start after a no-active refusal while the runtime still sees a turn", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+
+      const error = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        steer: failSteer(
+          new CodexErrors.CodexAppServerRequestError({
+            code: -32600,
+            errorMessage: "no active turn to steer",
+          }),
+        ),
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.retryable, false);
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer"],
+      );
+    }),
+  );
+
+  it.effect("reconciles a found active turn without starting a phantom turn", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+      const foundTurnId = "019fe4fe-eaeb-7a02-b448-18071e35f6f9";
+
+      const error = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        steer: failSteer(
+          new CodexErrors.CodexAppServerRequestError({
+            code: -32600,
+            errorMessage: `expected active turn id \`${ACTIVE_TURN_ID}\` but found \`${foundTurnId}\``,
+          }),
+        ),
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.retryable, false);
+      NodeAssert.equal((yield* Ref.get(sessionRef)).activeTurnId, foundTurnId);
+      NodeAssert.equal((yield* Ref.get(activeTurnRef))?.turnId, foundTurnId);
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer"],
+      );
+    }),
+  );
+
+  it.effect("keeps a refusal terminal when the session still sees the turn running", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+      const sessionBefore = yield* Ref.get(sessionRef);
+
+      // Neither captured precondition message: re-issuing could double post.
+      const error = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        steer: failSteer(
+          new CodexErrors.CodexAppServerRequestError({
+            code: -32600,
+            errorMessage: "steering is disabled",
+          }),
+        ),
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.reason, "rejected");
+      NodeAssert.equal(error.retryable, false);
+      NodeAssert.equal(error.detail, "steering is disabled");
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer"],
+      );
+      NodeAssert.deepStrictEqual(yield* Ref.get(sessionRef), sessionBefore);
+    }),
+  );
+
+  it.effect("keeps a precondition-shaped message terminal under another code", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+
+      const error = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        steer: failSteer(
+          new CodexErrors.CodexAppServerRequestError({
+            code: -32603,
+            errorMessage: "no active turn to steer",
+          }),
+        ),
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.reason, "rejected");
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer"],
+      );
+    }),
+  );
+
+  it.effect("classifies the schema-declared activeTurnNotSteerable refusal", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+      const sessionBefore = yield* Ref.get(sessionRef);
+
+      // Schema-declared, wire-unproven: no capture of this refusal exists.
+      const error = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        steer: failSteer(
+          new CodexErrors.CodexAppServerRequestError({
+            code: -32600,
+            errorMessage: "active turn cannot be steered",
+            data: { codexErrorInfo: { activeTurnNotSteerable: { turnKind: "review" } } },
+          }),
+        ),
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.reason, "active-turn-not-steerable");
+      NodeAssert.equal(error.turnKind, "review");
+      NodeAssert.equal(error.retryable, false);
+      NodeAssert.match(error.message, /running a review turn/);
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer"],
+      );
+      NodeAssert.deepStrictEqual(yield* Ref.get(sessionRef), sessionBefore);
+    }),
+  );
+
+  it.effect("never re-issues an activeTurnNotSteerable refusal worded like a stale one", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+
+      // The variant wins over the message prefix: a `/review` turn is still
+      // running, so re-issuing would post into it.
+      const error = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        steer: failSteer(
+          new CodexErrors.CodexAppServerRequestError({
+            code: -32600,
+            errorMessage: "no active turn to steer",
+            data: { codexErrorInfo: { activeTurnNotSteerable: { turnKind: "compact" } } },
+          }),
+        ),
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.reason, "active-turn-not-steerable");
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer"],
+      );
+    }),
+  );
+
+  it.effect("never renders a placeholder turn kind the app-server did not name", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+
+      const error = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        steer: failSteer(
+          new CodexErrors.CodexAppServerRequestError({
+            code: -32600,
+            errorMessage: "active turn cannot be steered",
+            data: { codexErrorInfo: { activeTurnNotSteerable: {} } },
+          }),
+        ),
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.reason, "active-turn-not-steerable");
+      NodeAssert.equal(error.turnKind, undefined);
+      NodeAssert.doesNotMatch(error.message, /unknown/);
+    }),
+  );
+
+  it.effect("rejects when the app-server steers a turn we did not ask for", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+      const sessionBefore = yield* Ref.get(sessionRef);
+
+      const error = yield* send({
+        calls,
+        sessionRef,
+        activeTurnRef,
+        steer: () => Effect.succeed({ turnId: "turn-other" }),
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeTurnSteerRejectedError(error));
+      NodeAssert.equal(error.reason, "turn-id-mismatch");
+      NodeAssert.equal(error.steeredTurnId, "turn-other");
+      // The message may have landed on that turn, so it is never re-issued.
+      NodeAssert.equal(error.retryable, false);
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer"],
+      );
+      NodeAssert.deepStrictEqual(yield* Ref.get(sessionRef), sessionBefore);
+    }),
+  );
+
+  it.effect("keeps a failed fallback typed as the turn-start failure it is", () =>
+    Effect.gen(function* () {
+      const calls: Array<RecordedTurnCall> = [];
+      const { sessionRef, activeTurnRef } = yield* runningSession;
+
+      const error = yield* sendCodexTurn({
+        client: {
+          raw: {
+            request: (method: string, payload?: unknown) => {
+              calls.push({ method, payload });
+              return Effect.fail(
+                new CodexErrors.CodexAppServerProcessExitedError({ code: 1 }),
+              ) as Effect.Effect<unknown, CodexErrors.CodexAppServerError>;
+            },
+          },
+          request: (_method: "turn/steer", payload: EffectCodexSchema.V2TurnSteerParams) => {
+            calls.push({ method: "turn/steer", payload });
+            return Ref.update(sessionRef, (session) => ({
+              ...session,
+              status: "ready" as const,
+              activeTurnId: undefined,
+            })).pipe(
+              Effect.andThen(Ref.set(activeTurnRef, undefined)),
+              Effect.andThen(
+                Effect.fail(
+                  new CodexErrors.CodexAppServerRequestError({
+                    code: -32600,
+                    errorMessage: "no active turn to steer",
+                  }),
+                ),
+              ),
+            );
+          },
+        },
+        sessionRef,
+        activeTurnRef,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        turn: sendTurnInput,
+      }).pipe(Effect.flip);
+
+      // Disguising this as a steer rejection would cost the adapter its
+      // session-closed classification.
+      NodeAssert.equal(error._tag, "CodexAppServerProcessExitedError");
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["turn/steer", "turn/start"],
+      );
     }),
   );
 });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -28,6 +28,7 @@ import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as CodexClient from "effect-codex-app-server/client";
@@ -83,6 +84,7 @@ const CodexTurnStartParamsWithCollaborationMode = EffectCodexSchema.V2TurnStartP
 const decodeCodexTurnStartParamsWithCollaborationMode = Schema.decodeUnknownEffect(
   CodexTurnStartParamsWithCollaborationMode,
 );
+const decodeCodexTurnSteerParams = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnSteerParams);
 
 export type CodexTurnStartParamsWithCollaborationMode =
   typeof CodexTurnStartParamsWithCollaborationMode.Type;
@@ -135,7 +137,7 @@ export interface CodexSessionRuntimeShape {
   readonly getSession: Effect.Effect<ProviderSession>;
   readonly sendTurn: (
     input: CodexSessionRuntimeSendTurnInput,
-  ) => Effect.Effect<ProviderTurnStartResult, CodexSessionRuntimeError>;
+  ) => Effect.Effect<CodexSendTurnResult, CodexSessionRuntimeError>;
   readonly interruptTurn: (turnId?: TurnId) => Effect.Effect<void, CodexSessionRuntimeError>;
   readonly readThread: Effect.Effect<CodexThreadSnapshot, CodexSessionRuntimeError>;
   readonly rollbackThread: (
@@ -158,7 +160,8 @@ export type CodexSessionRuntimeError =
   | CodexSessionRuntimePendingApprovalNotFoundError
   | CodexSessionRuntimePendingUserInputNotFoundError
   | CodexSessionRuntimeInvalidUserInputAnswersError
-  | CodexSessionRuntimeThreadIdMissingError;
+  | CodexSessionRuntimeThreadIdMissingError
+  | CodexSessionRuntimeTurnSteerRejectedError;
 
 export class CodexSessionRuntimePendingApprovalNotFoundError extends Schema.TaggedErrorClass<CodexSessionRuntimePendingApprovalNotFoundError>()(
   "CodexSessionRuntimePendingApprovalNotFoundError",
@@ -201,6 +204,97 @@ export class CodexSessionRuntimeThreadIdMissingError extends Schema.TaggedErrorC
 ) {
   override get message(): string {
     return `Codex session is missing a provider thread id for ${this.threadId}`;
+  }
+}
+
+/**
+ * The one rejection the runtime may recover from on its own: the steer lost
+ * a race with the end of the turn it named, so nothing was delivered and the
+ * message can be re-issued as a fresh `turn/start`. Kept as its own literal
+ * union so retryability is a type-level property rather than a convention —
+ * {@link isRetryableCodexTurnSteerRejection} is the only place that decides.
+ */
+export const CodexTurnSteerRetryableReason = Schema.Literals([
+  "stale-expected-turn-id",
+  "turn-interrupting",
+]);
+export type CodexTurnSteerRetryableReason = typeof CodexTurnSteerRetryableReason.Type;
+
+export const CodexTurnSteerTerminalReason = Schema.Literals([
+  // Documented protocol outcome, not a fault: the running turn is a
+  // `/review` or manual `/compact`, which never accepts same-turn steering.
+  "active-turn-not-steerable",
+  // The send asks for a model/effort/service tier/interaction mode the
+  // running turn cannot adopt — steering would silently drop the switch.
+  "turn-settings-changed",
+  // The app-server answered with some other turn: the message may have
+  // landed, so re-issuing it risks a double post.
+  "turn-id-mismatch",
+  // Refused while the runtime still sees the turn running: unclassified, and
+  // re-issuing could double post.
+  "rejected",
+]);
+export type CodexTurnSteerTerminalReason = typeof CodexTurnSteerTerminalReason.Type;
+
+export const CodexTurnSteerRejectionReason = Schema.Union([
+  CodexTurnSteerRetryableReason,
+  CodexTurnSteerTerminalReason,
+]);
+export type CodexTurnSteerRejectionReason = typeof CodexTurnSteerRejectionReason.Type;
+
+const isCodexTurnSteerRetryableReason = Schema.is(CodexTurnSteerRetryableReason);
+
+export function isRetryableCodexTurnSteerRejection(
+  reason: CodexTurnSteerRejectionReason,
+): reason is CodexTurnSteerRetryableReason {
+  return isCodexTurnSteerRetryableReason(reason);
+}
+
+export class CodexSessionRuntimeTurnSteerRejectedError extends Schema.TaggedErrorClass<CodexSessionRuntimeTurnSteerRejectedError>()(
+  "CodexSessionRuntimeTurnSteerRejectedError",
+  {
+    threadId: Schema.String,
+    expectedTurnId: Schema.String,
+    reason: CodexTurnSteerRejectionReason,
+    turnKind: Schema.optionalKey(Schema.String),
+    changedSetting: Schema.optionalKey(Schema.String),
+    steeredTurnId: Schema.optionalKey(Schema.String),
+    detail: Schema.optionalKey(Schema.String),
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {
+  /**
+   * A rejected steer never delivers the message, and it never means the
+   * session is broken — the running turn keeps going. Callers use this to
+   * keep the send out of the session-error path.
+   */
+  get retryable(): boolean {
+    return isRetryableCodexTurnSteerRejection(this.reason);
+  }
+
+  override get message(): string {
+    switch (this.reason) {
+      case "active-turn-not-steerable":
+        // `turnKind` is only rendered when the app-server actually named one;
+        // a placeholder would read as a real turn kind to the user.
+        return this.turnKind
+          ? `Codex is running a ${this.turnKind} turn, which does not accept new messages until it finishes.`
+          : "Codex is running a turn that does not accept new messages until it finishes.";
+      case "turn-settings-changed":
+        return `Codex cannot change ${this.changedSetting ?? "turn settings"} while a turn is running; send this message after the current turn finishes.`;
+      case "turn-id-mismatch":
+        return `Codex steered turn ${this.steeredTurnId ?? "an unnamed turn"} instead of the expected active turn ${this.expectedTurnId}.`;
+      case "stale-expected-turn-id":
+        return `Codex turn ${this.expectedTurnId} ended before the message reached it${
+          this.detail ? `: ${this.detail}` : "."
+        }`;
+      case "turn-interrupting":
+        return `Codex turn ${this.expectedTurnId} is stopping; the message was not sent.`;
+      default:
+        return `Codex rejected steering turn ${this.expectedTurnId}${
+          this.detail ? `: ${this.detail}` : "."
+        }`;
+    }
   }
 }
 
@@ -408,6 +502,51 @@ export function buildTurnStartParams(input: {
         "decode-request-payload",
         cause,
         { method: "turn/start" },
+      ),
+    ),
+  );
+}
+
+/**
+ * Steering carries the message and nothing else: the wire contract has no
+ * model, effort, sandbox or collaboration fields because the turn that is
+ * already running keeps the settings it started with. `expectedTurnId` is a
+ * precondition — the app-server fails the request when it is not the turn
+ * currently active on the thread.
+ */
+export function buildTurnSteerParams(input: {
+  readonly threadId: string;
+  readonly expectedTurnId: TurnId;
+  readonly prompt?: string;
+  readonly attachments?: ReadonlyArray<{
+    readonly type: "image";
+    readonly url: string;
+  }>;
+}): Effect.Effect<
+  EffectCodexSchema.V2TurnSteerParams,
+  CodexErrors.CodexAppServerProtocolParseError
+> {
+  const turnInput: Array<EffectCodexSchema.V2TurnSteerParams__UserInput> = [];
+  if (input.prompt) {
+    turnInput.push({
+      type: "text",
+      text: input.prompt,
+    });
+  }
+  for (const attachment of input.attachments ?? []) {
+    turnInput.push(attachment);
+  }
+
+  return decodeCodexTurnSteerParams({
+    threadId: input.threadId,
+    expectedTurnId: input.expectedTurnId,
+    input: turnInput,
+  }).pipe(
+    Effect.mapError((cause) =>
+      CodexErrors.CodexAppServerProtocolParseError.fromSchemaError(
+        "decode-request-payload",
+        cause,
+        { method: "turn/steer" },
       ),
     ),
   );
@@ -838,6 +977,423 @@ function parseThreadSnapshot(
   };
 }
 
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * JSON-RPC code every steer rejection captured against codex-cli 0.147.0
+ * carries. Anything else is not a steer precondition failure.
+ */
+const CODEX_STEER_REJECTION_CODE = -32600;
+
+/**
+ * Matching on message text is unavoidable here: captured codex-cli 0.147.0
+ * responses carry no structured error data. Keep the two observed refusals
+ * distinct. "No active" permits a fresh start only after the serialized
+ * runtime view is also idle; "found B" proves B is running and must never
+ * directly fall back to turn/start.
+ */
+function isNoActiveTurnRejection(cause: CodexErrors.CodexAppServerRequestError): boolean {
+  return (
+    cause.code === CODEX_STEER_REJECTION_CODE &&
+    cause.errorMessage.trim().toLowerCase().startsWith("no active turn to steer")
+  );
+}
+
+function readFoundActiveTurnId(cause: CodexErrors.CodexAppServerRequestError): TurnId | undefined {
+  if (cause.code !== CODEX_STEER_REJECTION_CODE) {
+    return undefined;
+  }
+  const match = /^expected active turn id `[^`]+` but found `([^`]+)`/i.exec(
+    cause.errorMessage.trim(),
+  );
+  return match?.[1] ? TurnId.make(match[1]) : undefined;
+}
+
+/**
+ * Reads the `activeTurnNotSteerable` codex error info the generated schema
+ * declares as a `CodexErrorInfo` variant.
+ *
+ * Schema-declared, wire-unproven: no capture of this refusal exists. Every
+ * steer rejection captured against codex-cli 0.147.0 is a bare
+ * `{code: -32600, message}` with no `data`, and the `/review` refusal that
+ * would carry the variant was never reproduced. This reads the one position
+ * the schema implies (`data.codexErrorInfo`) purely so the day it appears is
+ * a better message rather than a surprise.
+ *
+ * A miss can only make a rejection *more* conservative: unmatched refusals
+ * stay terminal and are never re-issued. `turnKind` stays absent unless the
+ * payload names one — the user-facing message must not invent a turn kind.
+ */
+function readActiveTurnNotSteerable(
+  data: unknown,
+): { readonly turnKind: string | undefined } | undefined {
+  const variant = readRecord(readRecord(readRecord(data)?.codexErrorInfo)?.activeTurnNotSteerable);
+  return variant
+    ? { turnKind: typeof variant.turnKind === "string" ? variant.turnKind : undefined }
+    : undefined;
+}
+
+interface CodexTurnSubmitClient {
+  readonly raw: {
+    readonly request: (
+      method: string,
+      payload?: unknown,
+    ) => Effect.Effect<unknown, CodexErrors.CodexAppServerError>;
+  };
+  readonly request: (
+    method: "turn/steer",
+    payload: CodexRpc.ClientRequestParamsByMethod["turn/steer"],
+  ) => Effect.Effect<
+    CodexRpc.ClientRequestResponsesByMethod["turn/steer"],
+    CodexErrors.CodexAppServerError
+  >;
+}
+
+/**
+ * Settings the running turn was started with. Steering carries none of them
+ * (the wire contract has no such fields), so a send that asks to change one
+ * has to be refused rather than folded in — otherwise the UI shows a switch
+ * the model never received.
+ *
+ * `interrupting` flips the moment `turn/interrupt` is issued: a message typed
+ * right after Stop must not be folded into the turn being aborted.
+ */
+export interface CodexActiveTurnState {
+  readonly turnId: TurnId;
+  readonly model: string | undefined;
+  readonly effort: EffectCodexSchema.V2TurnStartParams__ReasoningEffort | undefined;
+  readonly serviceTier: CodexServiceTier | undefined;
+  readonly interactionMode: ProviderInteractionMode | undefined;
+  readonly interrupting: boolean;
+}
+
+export interface CodexSendTurnResult extends ProviderTurnStartResult {
+  /** True when the message folded into an already-running turn. */
+  readonly steered: boolean;
+}
+
+/**
+ * Names the first setting the send asks to change, or undefined when it asks
+ * for nothing the running turn cannot already provide. An omitted field is
+ * "no preference", not "reset to default", so it never counts as a change.
+ */
+function readTurnSettingsChange(
+  active: CodexActiveTurnState,
+  turn: CodexSessionRuntimeSendTurnInput,
+): string | undefined {
+  const requestedModel = normalizeCodexModelSlug(turn.model);
+  if (requestedModel !== undefined && requestedModel !== active.model) {
+    return "the model";
+  }
+  if (turn.effort !== undefined && turn.effort !== active.effort) {
+    return "reasoning effort";
+  }
+  if (turn.serviceTier !== undefined && turn.serviceTier !== active.serviceTier) {
+    return "the service tier";
+  }
+  if (turn.interactionMode !== undefined && turn.interactionMode !== active.interactionMode) {
+    return "the interaction mode";
+  }
+  return undefined;
+}
+
+/**
+ * Submits one user message to a Codex thread.
+ *
+ * Idle session → `turn/start`, which opens a new provider turn exactly as
+ * before.
+ *
+ * Mid-turn → `turn/steer`, which folds the message into the turn that is
+ * already running. Codex answers a steer with the id of that same turn and
+ * emits no `turn/started` notification, so nothing downstream projects a new
+ * turn and the runtime's active-turn bookkeeping is left untouched: the
+ * caller gets the running turn's id back and the message lands in that
+ * turn's stream.
+ *
+ * Issuing `turn/start` mid-turn instead — what this runtime used to do — is
+ * worse than it looks. Captured against codex-cli 0.147.0, the response
+ * hands back a *different* turn id that never starts: no `turn/started`, no
+ * items and no `turn/completed` ever carry it, while the message itself
+ * folds into the turn already running. The runtime then reported that
+ * phantom id as the turn's id, so callers persisted it as the active turn
+ * and `turn/interrupt` was refused ("expected active turn id … but found
+ * …"). Steering returns the id the server actually accepts.
+ *
+ * Only an idle session takes the `turn/start` path. A turn already being
+ * interrupted rejects the send retryably until its terminal lifecycle
+ * arrives, while a known active turn whose start-time settings are missing
+ * rejects rather than risking a mid-turn phantom `turn/start` response.
+ *
+ * Rejections split by whether the message can still be delivered:
+ *
+ * - The steer lost a race with the end of its turn — the app-server refuses a
+ *   stale `expectedTurnId`, and the runtime's own view has since gone idle.
+ *   Nothing was delivered (the precondition failed), so the message is
+ *   re-issued as a `turn/start` exactly once. This is the ordinary
+ *   end-of-turn race, not a fault.
+ * - `activeTurnNotSteerable` (`/review`, manual `/compact`) is a documented
+ *   protocol outcome and is never re-issued: the running turn keeps going and
+ *   the caller is told the message was not sent.
+ * - A refusal reporting "found B" is terminal and reconciles B as active;
+ *   its failed precondition proves this message was not delivered. A
+ *   successful response naming a different turn is also terminal, but its
+ *   delivery is uncertain, so re-issuing it risks a double post.
+ *
+ * No rejection is ever a session-level failure — see
+ * `CodexSessionRuntimeTurnSteerRejectedError`.
+ */
+export const sendCodexTurn = (input: {
+  readonly client: CodexTurnSubmitClient;
+  readonly sessionRef: Ref.Ref<ProviderSession>;
+  readonly activeTurnRef: Ref.Ref<CodexActiveTurnState | undefined>;
+  readonly pendingTurnStartIdRef?: Ref.Ref<Deferred.Deferred<TurnId | undefined> | undefined>;
+  readonly threadId: ThreadId;
+  readonly runtimeMode: RuntimeMode;
+  readonly turn: CodexSessionRuntimeSendTurnInput;
+}): Effect.Effect<CodexSendTurnResult, CodexSessionRuntimeError> =>
+  Effect.gen(function* () {
+    const session = yield* Ref.get(input.sessionRef);
+    const providerThreadId = currentProviderThreadId(session);
+    if (!providerThreadId) {
+      return yield* new CodexSessionRuntimeThreadIdMissingError({
+        threadId: input.threadId,
+      });
+    }
+
+    const startTurn = Effect.gen(function* () {
+      const pendingTurnStartId = input.pendingTurnStartIdRef
+        ? yield* Deferred.make<TurnId | undefined>()
+        : undefined;
+      if (pendingTurnStartId && input.pendingTurnStartIdRef) {
+        yield* Ref.set(input.pendingTurnStartIdRef, pendingTurnStartId);
+      }
+
+      return yield* Effect.gen(function* () {
+        // Read the model fresh: on the end-of-turn retry path the session has
+        // moved on since the snapshot above.
+        const current = yield* Ref.get(input.sessionRef);
+        const requestedModel = normalizeCodexModelSlug(input.turn.model ?? current.model);
+        const effectiveSettings = {
+          model:
+            requestedModel ??
+            (input.turn.interactionMode !== undefined ? DEFAULT_MODEL : undefined),
+          effort:
+            input.turn.effort ?? (input.turn.interactionMode !== undefined ? "medium" : undefined),
+          serviceTier: input.turn.serviceTier,
+          interactionMode: input.turn.interactionMode,
+        } as const;
+        const startParams = yield* buildTurnStartParams({
+          threadId: providerThreadId,
+          runtimeMode: input.runtimeMode,
+          ...(input.turn.input ? { prompt: input.turn.input } : {}),
+          ...(input.turn.attachments ? { attachments: input.turn.attachments } : {}),
+          ...(effectiveSettings.model ? { model: effectiveSettings.model } : {}),
+          ...(effectiveSettings.serviceTier ? { serviceTier: effectiveSettings.serviceTier } : {}),
+          ...(effectiveSettings.effort ? { effort: effectiveSettings.effort } : {}),
+          ...(effectiveSettings.interactionMode
+            ? { interactionMode: effectiveSettings.interactionMode }
+            : {}),
+        });
+        const rawResponse = yield* input.client.raw.request("turn/start", startParams);
+        const response = yield* decodeV2TurnStartResponse(rawResponse).pipe(
+          Effect.mapError((error) =>
+            CodexErrors.CodexAppServerProtocolParseError.fromSchemaError(
+              "decode-response-payload",
+              error,
+              { method: "turn/start" },
+            ),
+          ),
+        );
+        const startedTurnId = TurnId.make(response.turn.id);
+        // The response id is what the server validates `expectedTurnId` and
+        // `turn/interrupt` against, so it wins over any id a `turn/started`
+        // notification published — including when that notification arrived
+        // first. The two agree for ordinary turns; a captured `/review` shows
+        // them diverging, with the server naming the response id as active.
+        yield* updateSession(input.sessionRef, {
+          status: "running",
+          activeTurnId: startedTurnId,
+          ...(effectiveSettings.model ? { model: effectiveSettings.model } : {}),
+        });
+        yield* Ref.set(input.activeTurnRef, {
+          turnId: startedTurnId,
+          ...effectiveSettings,
+          interrupting: false,
+        });
+        if (pendingTurnStartId) {
+          yield* Deferred.succeed(pendingTurnStartId, startedTurnId);
+        }
+        return startedTurnId;
+      }).pipe(
+        Effect.ensuring(
+          pendingTurnStartId && input.pendingTurnStartIdRef
+            ? Deferred.succeed(pendingTurnStartId, undefined).pipe(
+                Effect.andThen(Ref.set(input.pendingTurnStartIdRef, undefined)),
+              )
+            : Effect.void,
+        ),
+      );
+    });
+
+    const finish = (turnId: TurnId, steered: boolean) =>
+      Effect.gen(function* () {
+        const resumedProviderThreadId = currentProviderThreadId(yield* Ref.get(input.sessionRef));
+        return {
+          threadId: input.threadId,
+          turnId,
+          ...(resumedProviderThreadId
+            ? { resumeCursor: { threadId: resumedProviderThreadId } }
+            : {}),
+          steered,
+        } satisfies CodexSendTurnResult;
+      });
+
+    const activeTurnId = session.activeTurnId;
+    const activeTurn = yield* Ref.get(input.activeTurnRef);
+    if (activeTurnId === undefined) {
+      return yield* finish(yield* startTurn, false);
+    }
+    if (activeTurn === undefined || activeTurn.turnId !== activeTurnId) {
+      return yield* new CodexSessionRuntimeTurnSteerRejectedError({
+        threadId: input.threadId,
+        expectedTurnId: activeTurnId,
+        reason: "rejected",
+        detail: "active turn metadata is unavailable; message was not sent",
+      });
+    }
+    if (activeTurn.interrupting) {
+      return yield* new CodexSessionRuntimeTurnSteerRejectedError({
+        threadId: input.threadId,
+        expectedTurnId: activeTurnId,
+        reason: "turn-interrupting",
+      });
+    }
+
+    const changedSetting = readTurnSettingsChange(activeTurn, input.turn);
+    if (changedSetting) {
+      return yield* new CodexSessionRuntimeTurnSteerRejectedError({
+        threadId: input.threadId,
+        expectedTurnId: activeTurnId,
+        reason: "turn-settings-changed",
+        changedSetting,
+      });
+    }
+
+    // `expectedTurnId` must be the id the SERVER considers active, which is
+    // the one it returned from `turn/start` — not necessarily the one a
+    // `turn/started` notification published. A captured `/review` shows the
+    // two diverging, with the server accepting only the response id. The
+    // runtime tracks the response id for exactly this reason (see the start
+    // path). If the server still reports a different active id, reconcile it
+    // below and leave this message terminally undelivered.
+    const steerParams = yield* buildTurnSteerParams({
+      threadId: providerThreadId,
+      expectedTurnId: activeTurnId,
+      ...(input.turn.input ? { prompt: input.turn.input } : {}),
+      ...(input.turn.attachments ? { attachments: input.turn.attachments } : {}),
+    });
+    const steered = yield* input.client.request("turn/steer", steerParams).pipe(
+      Effect.map((response) => ({ ok: true as const, turnId: TurnId.make(response.turnId) })),
+      Effect.catchTag("CodexAppServerRequestError", (cause) =>
+        Effect.succeed({ ok: false as const, cause }),
+      ),
+    );
+
+    if (steered.ok) {
+      if (steered.turnId !== activeTurnId) {
+        return yield* new CodexSessionRuntimeTurnSteerRejectedError({
+          threadId: input.threadId,
+          expectedTurnId: activeTurnId,
+          reason: "turn-id-mismatch",
+          steeredTurnId: steered.turnId,
+        });
+      }
+      // Deliberately no session update: the steered message belongs to a turn
+      // that is already tracked, and its settings are unchanged by
+      // construction (see the refusal above).
+      return yield* finish(activeTurnId, true);
+    }
+
+    // Classify from the response itself. The `activeTurnNotSteerable`
+    // variant is checked first so the schema-declared refusal, if it ever
+    // arrives, cannot be mistaken for a stale precondition and re-issued.
+    const notSteerable = readActiveTurnNotSteerable(steered.cause.data);
+    if (notSteerable) {
+      return yield* new CodexSessionRuntimeTurnSteerRejectedError({
+        threadId: input.threadId,
+        expectedTurnId: activeTurnId,
+        reason: "active-turn-not-steerable",
+        ...(notSteerable.turnKind ? { turnKind: notSteerable.turnKind } : {}),
+        detail: steered.cause.message,
+        cause: steered.cause,
+      });
+    }
+
+    const foundActiveTurnId = readFoundActiveTurnId(steered.cause);
+    if (foundActiveTurnId !== undefined) {
+      yield* updateSession(input.sessionRef, {
+        status: "running",
+        activeTurnId: foundActiveTurnId,
+      });
+      yield* Ref.set(input.activeTurnRef, {
+        ...activeTurn,
+        turnId: foundActiveTurnId,
+      });
+      return yield* new CodexSessionRuntimeTurnSteerRejectedError({
+        threadId: input.threadId,
+        expectedTurnId: activeTurnId,
+        reason: "rejected",
+        steeredTurnId: foundActiveTurnId,
+        detail: `${steered.cause.message}; active turn reconciled, message was not sent`,
+        cause: steered.cause,
+      });
+    }
+
+    if (!isNoActiveTurnRejection(steered.cause)) {
+      return yield* new CodexSessionRuntimeTurnSteerRejectedError({
+        threadId: input.threadId,
+        expectedTurnId: activeTurnId,
+        reason: "rejected",
+        detail: steered.cause.message,
+        cause: steered.cause,
+      });
+    }
+
+    const latestSession = yield* Ref.get(input.sessionRef);
+    const latestActiveTurn = yield* Ref.get(input.activeTurnRef);
+    if (latestSession.activeTurnId !== undefined || latestActiveTurn !== undefined) {
+      return yield* new CodexSessionRuntimeTurnSteerRejectedError({
+        threadId: input.threadId,
+        expectedTurnId: activeTurnId,
+        reason: "rejected",
+        detail: `${steered.cause.message}; runtime still reports an active turn, message was not sent`,
+        cause: steered.cause,
+      });
+    }
+
+    const rejection = new CodexSessionRuntimeTurnSteerRejectedError({
+      threadId: input.threadId,
+      expectedTurnId: activeTurnId,
+      reason: "stale-expected-turn-id",
+      detail: steered.cause.message,
+      cause: steered.cause,
+    });
+
+    // The serialized runtime view independently confirms the refused turn is
+    // gone. Re-issue exactly once as a fresh turn. A failure here keeps its
+    // turn-start error type rather than being disguised as a steer rejection.
+    yield* Effect.logDebug("codex refused a stale steer precondition; re-issuing as turn/start", {
+      threadId: input.threadId,
+      expectedTurnId: activeTurnId,
+      cause: rejection.detail,
+    });
+    return yield* finish(yield* startTurn, false);
+  });
+
 export const makeCodexSessionRuntime = (
   options: CodexSessionRuntimeOptions,
 ): Effect.Effect<
@@ -857,6 +1413,19 @@ export const makeCodexSessionRuntime = (
     const collabChildAgentsRef = yield* Ref.make(new Map<string, CollabChildAgentState>());
     /** Child provider-thread id → its currently running provider turn id. */
     const collabChildLiveTurnsRef = yield* Ref.make(new Map<string, string>());
+    /**
+     * Settings of the turn currently running, plus whether it is being
+     * interrupted. Steering carries neither, so both have to be remembered
+     * here to decide whether a mid-turn send can fold in.
+     */
+    const activeTurnRef = yield* Ref.make<CodexActiveTurnState | undefined>(undefined);
+    const pendingTurnStartIdRef = yield* Ref.make<
+      Deferred.Deferred<TurnId | undefined> | undefined
+    >(undefined);
+    // One runtime owns one provider thread. Serialize the complete
+    // decision/RPC/fallback span so concurrent sends always re-read the state
+    // produced by the preceding send before choosing steer versus start.
+    const turnSubmissionSemaphore = yield* Semaphore.make(1);
     const closedRef = yield* Ref.make(false);
 
     // `~` is not shell-expanded when env vars are set via
@@ -1249,7 +1818,7 @@ export const makeCodexSessionRuntime = (
 
     const handleRawNotification = (notification: CodexServerNotification) =>
       Effect.gen(function* () {
-        const payload = notification.params;
+        let payload: unknown = notification.params;
         const route = readRouteFields(notification);
         const collabReceiverTurns = yield* Ref.get(collabReceiverTurnsRef);
         const childParentTurnId = (() => {
@@ -1352,6 +1921,23 @@ export const makeCodexSessionRuntime = (
           }
         }
 
+        if (notification.method === "turn/started") {
+          const pendingTurnStartId = yield* Ref.get(pendingTurnStartIdRef);
+          const authoritativeTurnId = pendingTurnStartId
+            ? yield* Deferred.await(pendingTurnStartId)
+            : (yield* Ref.get(sessionRef)).activeTurnId;
+          if (authoritativeTurnId) {
+            turnId = authoritativeTurnId;
+            payload = {
+              ...notification.params,
+              turn: {
+                ...notification.params.turn,
+                id: authoritativeTurnId,
+              },
+            };
+          }
+        }
+
         yield* Ref.set(collabReceiverTurnsRef, collabReceiverTurns);
         yield* emitEvent({
           kind: "notification",
@@ -1389,10 +1975,15 @@ export const makeCodexSessionRuntime = (
           if (providerThreadId && payload.threadId !== providerThreadId) {
             return Effect.void;
           }
-          return updateSession(sessionRef, {
+          return updateSession(sessionRef, (session) => ({
             status: "running",
-            activeTurnId: TurnId.make(payload.turn.id),
-          });
+            // Only fills a gap — it never renames a turn the runtime already
+            // tracks. A captured `/review` publishes a different id here than
+            // the one the server accepts for steer and interrupt, so letting
+            // this overwrite the start response's id would point both at an
+            // id the server rejects.
+            activeTurnId: session.activeTurnId ?? TurnId.make(payload.turn.id),
+          }));
         }),
       ),
     );
@@ -1411,26 +2002,43 @@ export const makeCodexSessionRuntime = (
             status: payload.turn.status === "failed" ? "error" : "ready",
             activeTurnId: undefined,
             ...(lastError ? { lastError } : {}),
-          });
+          }).pipe(Effect.andThen(Ref.set(activeTurnRef, undefined)));
         }),
       ),
     );
 
     yield* client.handleServerNotification("error", (payload) =>
-      currentSessionProviderThreadId.pipe(
-        Effect.flatMap((providerThreadId) => {
-          const payloadThreadId = payload.threadId;
-          if (providerThreadId && payloadThreadId && payloadThreadId !== providerThreadId) {
-            return Effect.void;
-          }
-          const errorMessage = payload.error.message;
-          const willRetry = payload.willRetry;
-          return updateSession(sessionRef, {
-            status: willRetry ? "running" : "error",
+      Effect.gen(function* () {
+        const session = yield* Ref.get(sessionRef);
+        const providerThreadId = currentProviderThreadId(session);
+        const payloadThreadId = payload.threadId;
+        if (providerThreadId && payloadThreadId && payloadThreadId !== providerThreadId) {
+          return;
+        }
+        const errorMessage = payload.error.message;
+        // The protocol makes `turnId` required. An error about some other
+        // turn must not rewrite this session's status, and — the bug this
+        // scoping fixes — a terminal error must not leave `activeTurnId`
+        // pointing at a turn that is already dead, which is what made a
+        // later send try to steer a turn that no longer existed.
+        if (session.activeTurnId === undefined || payload.turnId !== session.activeTurnId) {
+          return yield* errorMessage
+            ? updateSession(sessionRef, { lastError: errorMessage })
+            : Effect.void;
+        }
+        if (payload.willRetry) {
+          return yield* updateSession(sessionRef, {
+            status: "running",
             ...(errorMessage ? { lastError: errorMessage } : {}),
           });
-        }),
-      ),
+        }
+        yield* updateSession(sessionRef, {
+          status: "error",
+          activeTurnId: undefined,
+          ...(errorMessage ? { lastError: errorMessage } : {}),
+        });
+        yield* Ref.set(activeTurnRef, undefined);
+      }),
     );
 
     yield* client.handleServerRequest("item/commandExecution/requestApproval", (payload) =>
@@ -1666,6 +2274,7 @@ export const makeCodexSessionRuntime = (
               status: nextStatus,
               activeTurnId: undefined,
             }).pipe(
+              Effect.andThen(Ref.set(activeTurnRef, undefined)),
               Effect.andThen(
                 emitSessionEvent(
                   "session/exited",
@@ -1733,6 +2342,7 @@ export const makeCodexSessionRuntime = (
         status: "closed",
         activeTurnId: undefined,
       });
+      yield* Ref.set(activeTurnRef, undefined);
       yield* emitSessionEvent("session/closed", "Session stopped").pipe(
         Effect.catch((cause) =>
           Effect.logError("Failed to emit Codex session closed event.", { cause }),
@@ -1747,62 +2357,47 @@ export const makeCodexSessionRuntime = (
       start,
       getSession: Ref.get(sessionRef),
       sendTurn: (input) =>
-        Effect.gen(function* () {
-          const providerThreadId = yield* readProviderThreadId;
-          if (hasConfiguredMcpServer(options.appServerArgs)) {
-            yield* client.request("config/mcpServer/reload", undefined).pipe(
-              Effect.catch((cause) =>
-                Effect.logWarning("Failed to refresh Codex MCP tool catalog before turn.", {
-                  cause,
-                }),
-              ),
-            );
-          }
-          const normalizedModel = normalizeCodexModelSlug(
-            input.model ?? (yield* Ref.get(sessionRef)).model,
-          );
-          const params = yield* buildTurnStartParams({
-            threadId: providerThreadId,
-            runtimeMode: options.runtimeMode,
-            ...(input.input ? { prompt: input.input } : {}),
-            ...(input.attachments ? { attachments: input.attachments } : {}),
-            ...(normalizedModel ? { model: normalizedModel } : {}),
-            ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
-            ...(input.effort ? { effort: input.effort } : {}),
-            ...(input.interactionMode ? { interactionMode: input.interactionMode } : {}),
-          });
-          const rawResponse = yield* client.raw.request("turn/start", params);
-          const response = yield* decodeV2TurnStartResponse(rawResponse).pipe(
-            Effect.mapError((error) =>
-              CodexErrors.CodexAppServerProtocolParseError.fromSchemaError(
-                "decode-response-payload",
-                error,
-                { method: "turn/start" },
-              ),
-            ),
-          );
-          const turnId = TurnId.make(response.turn.id);
-          yield* updateSession(sessionRef, (session) => ({
-            status: "running",
-            // Codex accepts follow-ups while the current turn is still
-            // running. The response contains the queued turn id, but
-            // turn/interrupt only accepts the id that is active now.
-            activeTurnId: session.activeTurnId ?? turnId,
-            ...(normalizedModel ? { model: normalizedModel } : {}),
-          }));
-          const resumedProviderThreadId = currentProviderThreadId(yield* Ref.get(sessionRef));
-          return {
-            threadId: options.threadId,
-            turnId,
-            ...(resumedProviderThreadId
-              ? { resumeCursor: { threadId: resumedProviderThreadId } }
-              : {}),
-          } satisfies ProviderTurnStartResult;
-        }),
+        turnSubmissionSemaphore.withPermit(
+          Effect.gen(function* () {
+            // Fail before touching the MCP catalog when the session has no
+            // provider thread yet.
+            yield* readProviderThreadId;
+            if (hasConfiguredMcpServer(options.appServerArgs)) {
+              yield* client.request("config/mcpServer/reload", undefined).pipe(
+                Effect.catch((cause) =>
+                  Effect.logWarning("Failed to refresh Codex MCP tool catalog before turn.", {
+                    cause,
+                  }),
+                ),
+              );
+            }
+            return yield* sendCodexTurn({
+              client,
+              sessionRef,
+              activeTurnRef,
+              pendingTurnStartIdRef,
+              threadId: options.threadId,
+              runtimeMode: options.runtimeMode,
+              turn: input,
+            });
+          }),
+        ),
       interruptTurn: (turnId) =>
         Effect.gen(function* () {
           const providerThreadId = yield* readProviderThreadId;
           const session = yield* Ref.get(sessionRef);
+          const effectiveTurnId = turnId ?? session.activeTurnId;
+          if (!effectiveTurnId) {
+            return;
+          }
+          const previousActiveTurn = yield* Ref.get(activeTurnRef);
+          // Stop makes the turn unsteerable from this instant, before any RPC
+          // goes out: a message typed right after Stop belongs to the next
+          // turn, not the one being aborted (it would otherwise be folded
+          // into a turn that is about to stop reading).
+          yield* Ref.update(activeTurnRef, (current) =>
+            current?.turnId === effectiveTurnId ? { ...current, interrupting: true } : current,
+          );
           // Stop-everything: children are full threads with their own turns;
           // interrupting only the parent leaves the fleet running. Interrupt
           // each live child turn first, best-effort per child, BOUNDED: the
@@ -1823,14 +2418,22 @@ export const makeCodexSessionRuntime = (
                 .pipe(Effect.timeoutOption("3 seconds"), Effect.ignore),
             { concurrency: 8, discard: true },
           ).pipe(Effect.timeoutOption("10 seconds"), Effect.ignore);
-          const effectiveTurnId = turnId ?? session.activeTurnId;
-          if (!effectiveTurnId) {
-            return;
-          }
-          yield* client.request("turn/interrupt", {
-            threadId: providerThreadId,
-            turnId: effectiveTurnId,
-          });
+          yield* client
+            .request("turn/interrupt", {
+              threadId: providerThreadId,
+              turnId: effectiveTurnId,
+            })
+            .pipe(
+              Effect.onExit((exit) =>
+                Exit.isSuccess(exit)
+                  ? Effect.void
+                  : Ref.update(activeTurnRef, (current) =>
+                      current?.turnId === effectiveTurnId && current.interrupting
+                        ? previousActiveTurn
+                        : current,
+                    ),
+              ),
+            );
         }),
       readThread: Effect.gen(function* () {
         const providerThreadId = yield* readProviderThreadId;
@@ -1851,6 +2454,7 @@ export const makeCodexSessionRuntime = (
             status: "ready",
             activeTurnId: undefined,
           });
+          yield* Ref.set(activeTurnRef, undefined);
           return parseThreadSnapshot(response);
         }),
       respondToRequest: (requestId, decision) =>

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1110,6 +1110,55 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect("does not persist a model selection a steered turn never applied", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      const threadId = asThreadId("thread-steer-model-selection");
+      const runningModel = createModelSelection(codexInstanceId, "gpt-5.3-codex");
+
+      yield* provider.startSession(threadId, {
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        threadId,
+        cwd: "/tmp/project-steer-model-selection",
+        modelSelection: runningModel,
+        runtimeMode: "full-access",
+      });
+      yield* provider.sendTurn({
+        threadId,
+        input: "start working",
+        attachments: [],
+        modelSelection: runningModel,
+      });
+
+      // The adapter folded this one into the turn already running: its model
+      // selection never reached the model.
+      routing.codex.sendTurn.mockImplementationOnce((input: ProviderSendTurnInput) =>
+        Effect.succeed({
+          threadId: input.threadId,
+          turnId: asTurnId("turn-running"),
+          steered: true,
+        }),
+      );
+      yield* provider.sendTurn({
+        threadId,
+        input: "one more thing",
+        attachments: [],
+        modelSelection: createModelSelection(codexInstanceId, "gpt-5.4"),
+      });
+
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const runtimePayload = binding?.runtimePayload as
+        | { readonly modelSelection?: { readonly model?: string }; readonly activeTurnId?: string }
+        | undefined;
+      // Persisting it would make the UI claim a switch that never happened
+      // after a reconnect.
+      assert.equal(runtimePayload?.modelSelection?.model, "gpt-5.3-codex");
+      assert.equal(runtimePayload?.activeTurnId, "turn-running");
+    }),
+  );
+
   it.effect("dies when an active session conflicts with its persisted binding", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService.ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -740,7 +740,13 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         status: "running",
         ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
         runtimePayload: {
-          ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
+          // A steered message folds into a turn that is already running, so
+          // its model selection never reached the model. Persisting it would
+          // make the directory — and the UI after a reconnect — report a
+          // switch that did not happen.
+          ...(input.modelSelection !== undefined && turn.steered !== true
+            ? { modelSelection: input.modelSelection }
+            : {}),
           activeTurnId: turn.turnId,
           lastRuntimeEvent: "provider.sendTurn",
           lastRuntimeEventAt: yield* nowIso,

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -42,6 +42,17 @@ export interface ProviderThreadSnapshot {
   readonly turns: ReadonlyArray<ProviderThreadTurnSnapshot>;
 }
 
+/**
+ * Server-internal widening of the wire contract: adapters that fold a
+ * mid-turn message into the running turn report it here, so callers can tell
+ * "a new turn started" from "an existing turn absorbed this message" without
+ * inferring it from turn ids. Absent means a new turn, which is what every
+ * adapter that cannot steer reports.
+ */
+export interface ProviderAdapterTurnStartResult extends ProviderTurnStartResult {
+  readonly steered?: boolean;
+}
+
 export interface ProviderAdapterShape<TError> {
   /**
    * Provider kind implemented by this adapter.
@@ -61,7 +72,7 @@ export interface ProviderAdapterShape<TError> {
    */
   readonly sendTurn: (
     input: ProviderSendTurnInput,
-  ) => Effect.Effect<ProviderTurnStartResult, TError>;
+  ) => Effect.Effect<ProviderAdapterTurnStartResult, TError>;
 
   /**
    * Interrupt an active turn.

--- a/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
+++ b/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
@@ -16,7 +16,16 @@ const fixture = JSON.parse(
 const script = JSON.parse(NodeFS.readFileSync(process.env.T3_CODEX_COLLAB_SCRIPT, "utf8"));
 
 const write = (message) => process.stdout.write(`${JSON.stringify(message)}\n`);
+const appendSidecar = (suffix, entry) =>
+  NodeFS.appendFileSync(
+    `${process.env.T3_CODEX_COLLAB_SCRIPT}.${suffix}`,
+    `${JSON.stringify(entry)}\n`,
+  );
 let turnStartCount = 0;
+/** Turn id the thread is currently running, mirroring the app-server's own
+ * precondition state: `turn/steer` is only accepted against this id. */
+let activeTurnId;
+let steerCount = 0;
 
 const rl = NodeReadline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {
@@ -49,19 +58,58 @@ rl.on("line", (line) => {
       ? { ...fixture.responses.turnStart.turn, id: turnId }
       : fixture.responses.turnStart.turn;
     turnStartCount += 1;
-    write({ id, result: { ...fixture.responses.turnStart, turn } });
+    appendSidecar("starts", { turnId: turn.id, input: message.params?.input });
     const rootThreadId = script.rootThreadId;
-    if (script.onlyFirstTurnStarts !== true || turnStartCount === 1) {
+    // `turn/started` normally follows the response, but the notification can
+    // win the race on a real app-server. `turnStartedBeforeResponse` replays
+    // that ordering, and `startedTurnIdOverride` lets it name a different id
+    // than the response so the runtime's preference between the two is
+    // actually observable.
+    const startedTurn = script.startedTurnIdOverride
+      ? { ...turn, id: script.startedTurnIdOverride }
+      : turn;
+    if (activeTurnId !== undefined) {
+      // Captured codex-cli 0.147.0 behavior: mid-turn `turn/start` returns a
+      // different phantom id but folds the user message into the active turn.
+      // It does not start a second lifecycle and must not replace the active
+      // id the peer validates for steer/interrupt.
+      write({ id, result: { ...fixture.responses.turnStart, turn } });
+      const foldedItem = {
+        id: `mid-turn-start-item-${turnStartCount}`,
+        type: "userMessage",
+        text: message.params?.input?.find((entry) => entry.type === "text")?.text ?? "",
+      };
+      for (const itemMethod of ["item/started", "item/completed"]) {
+        write({
+          jsonrpc: "2.0",
+          method: itemMethod,
+          params: { threadId: script.rootThreadId, turnId: activeTurnId, item: foldedItem },
+        });
+      }
+      return;
+    }
+    // The server validates steer/interrupt against the id it RETURNS, even
+    // when the notification publishes another one (captured `/review`
+    // behaviour), so the response id is the authoritative active turn here.
+    activeTurnId = turn.id;
+    const writeTurnStarted = () =>
       write({
         jsonrpc: "2.0",
         method: "turn/started",
-        params: { threadId: rootThreadId, turn },
+        params: { threadId: rootThreadId, turn: startedTurn },
       });
+    if (script.turnStartedBeforeResponse === true) {
+      writeTurnStarted();
+      write({ id, result: { ...fixture.responses.turnStart, turn } });
+    } else {
+      write({ id, result: { ...fixture.responses.turnStart, turn } });
+      writeTurnStarted();
     }
     for (const notification of script.notifications) {
       write({ jsonrpc: "2.0", method: notification.method, params: notification.params });
     }
     if (script.holdTurnOpen !== true) {
+      activeTurnId = undefined;
       write({
         jsonrpc: "2.0",
         method: "turn/completed",
@@ -69,6 +117,86 @@ rl.on("line", (line) => {
           threadId: rootThreadId,
           turn: { ...turn, status: "completed" },
         },
+      });
+    }
+    return;
+  }
+  if (method === "turn/steer") {
+    // Record the steer (append-only sidecar the test reads) so mid-turn send
+    // coverage can assert the message folded into the running turn.
+    steerCount += 1;
+    appendSidecar("steers", {
+      threadId: message.params?.threadId,
+      expectedTurnId: message.params?.expectedTurnId,
+      input: message.params?.input,
+    });
+    if (script.endTurnBeforeFirstSteer === true && steerCount === 1) {
+      const endedTurnId = activeTurnId;
+      activeTurnId = undefined;
+      write({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          threadId: script.rootThreadId,
+          turn: { ...fixture.responses.turnStart.turn, id: endedTurnId, status: "completed" },
+        },
+      });
+    }
+    if (script.deferStaleSteerResponses === true && activeTurnId === undefined) {
+      setImmediate(() => {
+        write({ id, error: { code: -32600, message: "no active turn to steer" } });
+      });
+      return;
+    }
+    // `steerRejectAfter` lets a script serve N steers then refuse.
+    const rejectNow =
+      script.steerRejection &&
+      (script.steerRejectAfter === undefined || steerCount > script.steerRejectAfter);
+    if (rejectNow) {
+      write({ id, error: script.steerRejection });
+      return;
+    }
+    // expectedTurnId is a precondition on the real app-server. Both refusals
+    // are quoted from captured transcripts (codex-cli 0.147.0): bare
+    // `{code: -32600, message}`, with no `data` and no structured error info.
+    if (activeTurnId === undefined) {
+      write({ id, error: { code: -32600, message: "no active turn to steer" } });
+      return;
+    }
+    if (message.params?.expectedTurnId !== activeTurnId) {
+      write({
+        id,
+        error: {
+          code: -32600,
+          message: `expected active turn id \`${message.params?.expectedTurnId}\` but found \`${activeTurnId}\``,
+        },
+      });
+      return;
+    }
+    // Captured shape (codex-cli 0.147.0): the steered message joins the
+    // running turn as a `userMessage` item with both `item/started` and
+    // `item/completed` carrying the ORIGINAL turn id, and the response
+    // echoes that same id. The turn keeps running and completes once.
+    const steerItem = {
+      id: `steer-item-${steerCount}`,
+      type: "userMessage",
+      text: message.params?.input?.find((entry) => entry.type === "text")?.text ?? "",
+    };
+    for (const itemMethod of ["item/started", "item/completed"]) {
+      write({
+        jsonrpc: "2.0",
+        method: itemMethod,
+        params: { threadId: script.rootThreadId, turnId: activeTurnId, item: steerItem },
+      });
+    }
+    write({ id, result: { turnId: activeTurnId } });
+    if (script.completeTurnAfterSteer === true) {
+      const steeredTurn = { ...fixture.responses.turnStart.turn, id: activeTurnId };
+      activeTurnId = undefined;
+      write({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: { threadId: script.rootThreadId, turn: { ...steeredTurn, status: "completed" } },
       });
     }
     return;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2232,7 +2232,12 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const [expanded, setExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
-  const entryIconName = showWarningIndicator ? "x" : workEntryIconName(workEntry);
+  const showRejectedIndicator = workEntry.sourceActivityKind === "provider.turn.steer.rejected";
+  const entryIconName = showWarningIndicator
+    ? "x"
+    : showRejectedIndicator
+      ? "circle-alert"
+      : workEntryIconName(workEntry);
   const heading = toolWorkEntryHeading(workEntry);
   const rawPreview = workEntryPreview(workEntry, workspaceRoot);
   const preview =
@@ -2252,17 +2257,21 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
     "flex size-5 shrink-0 items-center justify-center",
     showWarningIndicator
       ? "text-destructive"
-      : showDestructiveRowStyle
-        ? "text-destructive"
-        : workEntry.tone === "tool" || showFailedIndicator
-          ? "text-icon-muted"
-          : iconConfig.className,
+      : showRejectedIndicator
+        ? "text-warning"
+        : showDestructiveRowStyle
+          ? "text-destructive"
+          : workEntry.tone === "tool" || showFailedIndicator
+            ? "text-icon-muted"
+            : iconConfig.className,
   );
   const headingClass = showWarningIndicator
     ? "font-medium text-warning"
-    : showDestructiveRowStyle
-      ? "font-medium text-destructive"
-      : "font-medium text-foreground";
+    : showRejectedIndicator
+      ? "font-medium text-warning"
+      : showDestructiveRowStyle
+        ? "font-medium text-destructive"
+        : "font-medium text-foreground";
   const turnSettled = !activity.activeTurnInProgress;
   const showNeutralIndicator = !turnSettled && workEntryIndicatesToolNeutralStatus(workEntry);
   const showSuccessIndicator =


### PR DESCRIPTION
## Problem

`CodexSessionRuntime` issues `turn/start` unconditionally, even while a turn is running. Live-wire forensics against `codex app-server` 0.147.0 (byte-level stdio transcripts, summarized below) show what actually happens on a mid-turn `turn/start`: the response returns a **phantom turn id** — it never starts, gets no `turn/started`, no items, no `turn/completed` — while the message silently folds into the running turn. The runtime then adopts that phantom id into its bookkeeping, so subsequent `turn/interrupt` (and any turn-targeted operation) aims at a turn the server does not recognize. The protocol's native `turn/steer` (with `expectedTurnId` precondition) exists precisely for this and was unwired.

## Change

- Mid-turn sends now issue `turn/steer` with the active turn id; idle sends are byte-for-byte unchanged `turn/start`.
- A successful steer returns the running turn's id, emits no new-turn projection, and matches the wire behavior (steered user message arrives as `item/started`/`item/completed` on the active turn).
- Rejections are classified from the captured wire shapes (bare `-32600`, no `error.data`): stale-turn rejections re-check the runtime's own state under a per-session semaphore and fall back to `turn/start` exactly once only when the session is genuinely idle; "expected id A but found B" adopts B (the server just told us it is running) and reports a clean non-delivery; unknown rejections fail closed. `activeTurnNotSteerable` (schema-declared, not yet wire-captured) surfaces as a non-fatal notice — the session no longer flips to an error state while a healthy `/review` turn keeps running.
- Send decision/RPC/state-update are serialized per session, closing a double-fallback race that could re-introduce phantom ids under concurrent sends.
- Turn-id bookkeeping now prefers the `turn/start`/`review/start` **response** id; the `turn/started` notification only fills an empty slot, and conflicting notification ids are canonicalized before emission. Forensics captured `/review` emitting **different** ids in the response vs the notification, with the server validating steers against the response id — previously this poisoned interrupt targeting and could leave the projected session "Working" forever.
- `interruptTurn` marks the session as not-steerable (rolled back if the interrupt fails), so stop-then-type queues instead of steering into an aborting turn; terminal `error(willRetry:false)` clears `activeTurnId` scoped by the notification's `turnId`, and `runtime.error` ingestion no longer resurrects the cleared id.
- Mid-turn model/effort/interaction-mode changes are rejected cleanly (`turn-settings-changed`) instead of silently dropped while the UI claims they applied; `turn-id-mismatch` after a successful steer RPC is surfaced as **delivery uncertain** (the message may have landed) rather than a definite "not sent" that invites a duplicate.
- Steer-rejection notices render as a warning glyph (web + mobile) instead of a success checkmark.

## Evidence

- Forensic transcripts (mid-turn `turn/start` ×2, successful steer, stale-id rejection ×2, `/review` id-split ×2) captured from real `codex app-server` 0.147.0 via raw stdio; happy to attach the JSONL + report if useful.
- Two independent adversarial review rounds (14 findings adopted overall); every Major carries a red-green test.
- `vitest` provider + orchestration suites: 782 passed / 6 skipped. Lint and format clean; `tsgo --noEmit` matches the pre-change baseline exactly.

## Known limitations

- `activeTurnNotSteerable`'s wire payload was not captured (review turns split ids before a steer could land); the schema-declared probe is kept but commented as wire-unverified, and unknown rejections fail closed.
- Ordering between a successful `turn/interrupt` response and the terminal turn lifecycle is not wire-verified; the code conservatively waits for terminal lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to Codex turn lifecycle, concurrent send ordering, and orchestration error handling; mistakes could drop messages, double-post, or leave sessions stuck with wrong active turn ids.
> 
> **Overview**
> **Codex mid-turn messaging** now folds follow-ups into the running turn via `turn/steer` instead of issuing another `turn/start` (which could return phantom turn ids and break interrupt/steer targeting). Idle sends still use `turn/start`; results include `steered: boolean`, and steered sends no longer persist model-selection changes that never reached the model.
> 
> **`sendCodexTurn`** serializes concurrent sends, tracks active-turn settings, prefers the `turn/start` response id over racing `turn/started` notifications, and classifies steer failures (review/compact, settings changes, interrupt-in-progress, stale-turn retry to one `turn/start`, turn-id mismatch with uncertain delivery). **`ProviderCommandReactor`** maps `turn/steer` failures to **`provider.turn.steer.rejected`** info activities instead of session errors. **Runtime error ingestion** clears `activeTurnId` on terminal errors. **Web/mobile** show steer rejections with warning styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0080c707daffba779912f640e99440ef5628cc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Steer Codex mid-turn instead of starting a phantom turn when a message arrives during an active turn
> - `sendCodexTurn` in [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/5795/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) now detects an active turn and issues a `turn/steer` RPC instead of a `turn/start`, returning `steered: true` to callers.
> - Steer rejections are classified as retryable or terminal and surfaced as `CodexSessionRuntimeTurnSteerRejectedError` without marking the session as errored or clearing the active turn.
> - The mock peer in [codexCollabMockPeer.mjs](https://github.com/pingdotgg/t3code/pull/5795/files#diff-52a6fb55324add786e7ae3a566aa7174f1e469420c7f47b50de5260f74addbd6) now implements the `turn/steer` RPC and writes sidecar files for test assertions.
> - `ProviderCommandReactor` treats `turn/steer` rejections as non-fatal, recording a `provider.turn.steer.rejected` info activity instead of a session error.
> - UI surfaces the new activity kind with a warning icon and style in both the web timeline and mobile thread feed.
> - Behavioral Change: concurrent `sendTurn` calls are now serialized via a semaphore; `turn/started` notifications no longer overwrite the authoritative turn id established by the start response; `activeTurnId` is cleared on terminal errors and turn completion rather than retained.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0080c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->