### PR TITLE
fix(swift-ios): let the composer grow without a line cap

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -198,7 +198,7 @@ struct FeatureComposerView: View {
                 axis: .vertical
             )
                 .font(T3Typography.composer)
-                .lineLimit(1...7)
+                .modifier(FeatureComposerGrowingTextInput())
                 .focused(focused)
                 // Return is always editing input. Sending is deliberately button-only.
                 .submitLabel(.return)
@@ -445,6 +445,14 @@ struct FeatureComposerView: View {
                   canSend {
             onSend()
         }
+    }
+}
+
+struct FeatureComposerGrowingTextInput: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .lineLimit(1...)
+            .layoutPriority(1)
     }
 }
 

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -1,8 +1,46 @@
+import SwiftUI
 import Testing
+import UIKit
 @testable import T3Code
 
 @Suite("Composer power features")
 struct FeatureComposerPowerTests {
+    @MainActor
+    @Test
+    func composerTextInputGrowsBeyondThreeLinesWithoutANumericCap() {
+        let threeLineHeight = composerTextInputHeight(lineCount: 3)
+        let thirtyLineHeight = composerTextInputHeight(lineCount: 30)
+
+        #expect(thirtyLineHeight > threeLineHeight + 400)
+    }
+
+    @MainActor
+    @Test
+    func composerTextInputYieldsToTheAvailableViewportForVeryTallDrafts() {
+        let viewportHeight: CGFloat = 500
+
+        #expect(composerTextInputHeight(lineCount: 100, maximumHeight: viewportHeight) <= viewportHeight)
+    }
+
+    @MainActor
+    private func composerTextInputHeight(
+        lineCount: Int,
+        maximumHeight: CGFloat = .greatestFiniteMagnitude
+    ) -> CGFloat {
+        let text = Array(repeating: "A full visible prompt line", count: lineCount)
+            .joined(separator: "\n")
+        let controller = UIHostingController(
+            rootView: TextField("Ask anything…", text: .constant(text), axis: .vertical)
+                .font(T3Typography.composer)
+                .modifier(FeatureComposerGrowingTextInput())
+                .frame(width: 320)
+        )
+
+        return controller.sizeThatFits(
+            in: CGSize(width: 320, height: maximumHeight)
+        ).height
+    }
+
     @Test
     func detectsCommandsModelsSkillsAndPathsAtTheCursor() {
         #expect(


### PR DESCRIPTION
## What Changed

Allow the existing vertical SwiftUI composer `TextField` to use its ideal wrapped height without a numeric line cap.

The field still starts at one line. A small view modifier keeps the layout behavior explicit, and integration-style tests host the production composer input in a `UIHostingController`: a 30-line prompt is substantially taller than a 3-line prompt when space is available, while a 100-line prompt yields to a 500-point viewport and remains scrollable.

## Why

The composer had two independent constraints: its parent could compress it, and `.lineLimit(1...7)` forced it to stop growing after seven lines. The earlier PR version fixed only the parent compression, so longer prompts still stopped expanding. This revision removes that remaining cap.

## Scope

- `apps/swift-ios/Features/Chat/FeatureComposerView.swift`
- `apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift`
- no keyboard-clearance, protocol, signing, release, React Native, or bridge changes
- rebased on `t3code/rebuild-mobile-app-swift` at `497f54f3e67acf1d2562d22d60eddd70aefc9627`

## Verification

- Focused native suite: `FeatureComposerPowerTests` — 9 passed
- Required native CI: `apps/swift-ios/Scripts/ci-test.sh` — 220 tests in 27 suites passed
- Layout regression: production composer input, 3 lines versus 30 lines — passed; the long value exceeded the short value by more than 400 points
- Viewport regression: production composer input, 100 lines inside a 500-point proposal — passed; height stayed at or below the viewport
- Integrated simulator: New Thread accepted a 1,561-character draft, kept attachment/model/Send controls visible, and scrolled from the end back to the first line
- Personal approved-branch integration: corresponding UIKit adapter regression suite — 15 passed
- Independent Claude Opus 5 review was attempted, but the CLI exited 1 because the account had reached its weekly limit; no cross-provider review result is claimed

## UI Changes

The existing screenshots and interaction recording below demonstrate the compact and growing states. They were captured for the preceding revision, which grew through seven lines; the new 30-line production-view test is the proof that this revision no longer stops there.

### New thread — compact

![New thread composer at compact empty height](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/new-thread-compact.jpg)

### New thread — expanded

![New thread composer expanded with wrapped text](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/new-thread-seven-line-cap.jpg)

### Existing thread — compact

![Existing thread composer at compact empty height](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/existing-thread-compact.jpg)

### Existing thread — expanded

![Existing thread composer expanded for a long draft](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/existing-thread-expanded.jpg)

### Accessibility XXXL

![Existing thread composer at Accessibility XXXL](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/accessibility-xxxl-existing-thread.jpg)

### Interaction video — composer growth

![Animated preview of the SwiftUI composer growing with wrapped text](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/composer-growth.gif)

[Open the MP4](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/composer-growth.mp4)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the affected UI
- [x] I included a video for the interaction change

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI composer layout change with no auth, data, or API impact; regression risk is mainly chat input sizing on device.
> 
> **Overview**
> The chat composer **TextField** no longer stops growing after seven lines. Inline `.lineLimit(1...7)` is replaced by a **`FeatureComposerGrowingTextInput`** modifier that keeps a one-line minimum, uses an **unbounded** upper line limit (`.lineLimit(1...)`), and sets **`layoutPriority(1)`** so the field can take its ideal height instead of being compressed by siblings.
> 
> **`FeatureComposerPowerTests`** adds UIHostingController layout checks: a 30-line draft is much taller than a 3-line one when space allows, and a 100-line draft respects a bounded viewport height (scrollable behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b333c67a375643a4286ec3dbd1b06e8fa4844ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove 7-line cap on the iOS chat composer text input
> Replaces `.lineLimit(1...7)` on the composer `TextField` with a new `FeatureComposerGrowingTextInput` view modifier that applies `.lineLimit(1...)` (unbounded) and `.layoutPriority(1)`, allowing the input to grow with content up to the container's height. Two new tests in [FeatureComposerPowerTests.swift](https://github.com/pingdotgg/t3code/pull/5801/files#diff-350e83f86e57eb36ff75519830fab71b6851389935337c9b49655cbec9414328) verify that the input grows beyond three lines and respects the viewport height.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b333c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->