### PR TITLE
feat(swift-ios): default new tasks to recent project

### DIFF
--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -114,14 +114,14 @@ enum DailyUXCreationContext {
 
     static func recentProjects(in snapshot: FeatureSnapshot) -> [DailyUXRecentProject] {
         let groups = projectGroups(in: snapshot)
+        let availableProjectByID = projects(in: snapshot).reduce(
+            into: [String: FeatureProject]()
+        ) { $0[$1.id] = $1 }
         let groupByProjectID = groups.reduce(into: [String: DailyUXProjectGroup]()) {
             result, group in
             for projectID in group.memberProjectIDs {
                 result[projectID] = group
             }
-        }
-        let projectEnvironmentByID = snapshot.projects.reduce(into: [String: String]()) {
-            $0[$1.id] = $1.environmentID
         }
         var seenGroupIDs = Set<String>()
 
@@ -130,10 +130,7 @@ enum DailyUXCreationContext {
             .compactMap { thread in
                 guard let group = groupByProjectID[thread.projectID],
                       seenGroupIDs.insert(group.id).inserted,
-                      let project = group.preferredProject(
-                          environmentID: thread.environmentID
-                              ?? projectEnvironmentByID[thread.projectID]
-                      ) else {
+                      let project = availableProjectByID[thread.projectID] else {
                     return nil
                 }
                 return DailyUXRecentProject(group: group, project: project)
@@ -144,20 +141,14 @@ enum DailyUXCreationContext {
         in snapshot: FeatureSnapshot,
         requestedProjectID: String?
     ) -> FeatureProject? {
-        let groups = projectGroups(in: snapshot)
-
+        let availableProjects = projects(in: snapshot)
         if let requestedProjectID,
-           let requestedGroup = DailyUXProjectGrouping.group(
-               containing: requestedProjectID,
-               in: groups
-           ) {
-            let requestedEnvironmentID = snapshot.projects
-                .first(where: { $0.id == requestedProjectID })?
-                .environmentID
-            return requestedGroup.preferredProject(environmentID: requestedEnvironmentID)
+           let requestedProject = availableProjects.first(where: { $0.id == requestedProjectID }) {
+            return requestedProject
         }
 
-        return recentProjects(in: snapshot).first?.project ?? groups.first?.projects.first
+        return recentProjects(in: snapshot).first?.project
+            ?? projectGroups(in: snapshot).first?.projects.first
     }
 
     static func logicalProjectID(
@@ -184,6 +175,29 @@ enum DailyUXCreationContext {
         if lhsDate != rhsDate { return lhsDate > rhsDate }
         return lhs.id < rhs.id
     }
+
+    static func shouldAdoptAutomaticProject(
+        currentProjectID: String,
+        nextRecentProjectID: String?,
+        isAwaitingRecentActivity: Bool,
+        projectSelectionIsExplicit: Bool,
+        modelSelectionIsExplicit: Bool,
+        workspaceSelectionIsExplicit: Bool,
+        hasDraftContent: Bool,
+        draftRestoreIsComplete: Bool
+    ) -> Bool {
+        guard isAwaitingRecentActivity,
+              let nextRecentProjectID,
+              nextRecentProjectID != currentProjectID else {
+            return false
+        }
+        return !projectSelectionIsExplicit
+            && !modelSelectionIsExplicit
+            && !workspaceSelectionIsExplicit
+            && !hasDraftContent
+            && draftRestoreIsComplete
+    }
+
     static func providers(
         for project: FeatureProject?,
         in snapshot: FeatureSnapshot

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -129,8 +129,12 @@ enum DailyUXCreationContext {
             .sorted(by: recentUseOrder)
             .compactMap { thread in
                 guard let group = groupByProjectID[thread.projectID],
-                      seenGroupIDs.insert(group.id).inserted,
-                      let project = availableProjectByID[thread.projectID] else {
+                      let sourceProject = availableProjectByID[thread.projectID],
+                      let project = DailyUXProjectGrouping.physicalRepresentative(
+                          for: sourceProject,
+                          in: group
+                      ),
+                      seenGroupIDs.insert(group.id).inserted else {
                     return nil
                 }
                 return DailyUXRecentProject(group: group, project: project)
@@ -143,8 +147,16 @@ enum DailyUXCreationContext {
     ) -> FeatureProject? {
         let availableProjects = projects(in: snapshot)
         if let requestedProjectID,
-           let requestedProject = availableProjects.first(where: { $0.id == requestedProjectID }) {
-            return requestedProject
+           let requestedProject = availableProjects.first(where: { $0.id == requestedProjectID }),
+           let group = DailyUXProjectGrouping.group(
+               containing: requestedProjectID,
+               in: projectGroups(in: snapshot)
+           ),
+           let representative = DailyUXProjectGrouping.physicalRepresentative(
+               for: requestedProject,
+               in: group
+           ) {
+            return representative
         }
 
         return recentProjects(in: snapshot).first?.project
@@ -335,6 +347,17 @@ enum DailyUXProjectGrouping {
     ) -> FeatureProject? {
         groups.first { $0.id == groupID }?
             .preferredProject(environmentID: preferredEnvironmentID)
+    }
+
+    static func physicalRepresentative(
+        for project: FeatureProject,
+        in group: DailyUXProjectGroup
+    ) -> FeatureProject? {
+        let path = normalizedPath(project.path)
+        return group.projects.first {
+            $0.environmentID == project.environmentID
+                && normalizedPath($0.path) == path
+        }
     }
 
     private static func physicalKey(_ project: FeatureProject) -> String {

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -112,6 +112,54 @@ enum DailyUXCreationContext {
         )
     }
 
+    static func recentProjects(in snapshot: FeatureSnapshot) -> [DailyUXRecentProject] {
+        let groups = projectGroups(in: snapshot)
+        let groupByProjectID = groups.reduce(into: [String: DailyUXProjectGroup]()) {
+            result, group in
+            for projectID in group.memberProjectIDs {
+                result[projectID] = group
+            }
+        }
+        let projectEnvironmentByID = snapshot.projects.reduce(into: [String: String]()) {
+            $0[$1.id] = $1.environmentID
+        }
+        var seenGroupIDs = Set<String>()
+
+        return snapshot.threads
+            .sorted(by: recentUseOrder)
+            .compactMap { thread in
+                guard let group = groupByProjectID[thread.projectID],
+                      seenGroupIDs.insert(group.id).inserted,
+                      let project = group.preferredProject(
+                          environmentID: thread.environmentID
+                              ?? projectEnvironmentByID[thread.projectID]
+                      ) else {
+                    return nil
+                }
+                return DailyUXRecentProject(group: group, project: project)
+            }
+    }
+
+    static func initialProject(
+        in snapshot: FeatureSnapshot,
+        requestedProjectID: String?
+    ) -> FeatureProject? {
+        let groups = projectGroups(in: snapshot)
+
+        if let requestedProjectID,
+           let requestedGroup = DailyUXProjectGrouping.group(
+               containing: requestedProjectID,
+               in: groups
+           ) {
+            let requestedEnvironmentID = snapshot.projects
+                .first(where: { $0.id == requestedProjectID })?
+                .environmentID
+            return requestedGroup.preferredProject(environmentID: requestedEnvironmentID)
+        }
+
+        return recentProjects(in: snapshot).first?.project ?? groups.first?.projects.first
+    }
+
     static func logicalProjectID(
         for project: FeatureProject,
         in snapshot: FeatureSnapshot
@@ -130,6 +178,12 @@ enum DailyUXCreationContext {
             )
     }
 
+    private static func recentUseOrder(_ lhs: FeatureThread, _ rhs: FeatureThread) -> Bool {
+        let lhsDate = lhs.lastActivityAt ?? lhs.updatedAt
+        let rhsDate = rhs.lastActivityAt ?? rhs.updatedAt
+        if lhsDate != rhsDate { return lhsDate > rhsDate }
+        return lhs.id < rhs.id
+    }
     static func providers(
         for project: FeatureProject?,
         in snapshot: FeatureSnapshot
@@ -185,6 +239,11 @@ enum DailyUXCreationContext {
         return snapshot.preferencesByEnvironment?[environmentID]
             ?? FeatureEnvironmentPreferences()
     }
+}
+
+struct DailyUXRecentProject: Equatable {
+    let group: DailyUXProjectGroup
+    let project: FeatureProject
 }
 
 struct DailyUXProjectGroup: Identifiable, Equatable {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -11,6 +11,7 @@ public struct NewThreadView: View {
 
     @State private var projectID = ""
     @State private var projectSelectionIsExplicit = false
+    @State private var isAwaitingRecentProject = false
     @State private var prompt = ""
     @State private var selection: FeatureSelection?
     @State private var selectionIsExplicit = false
@@ -90,10 +91,14 @@ public struct NewThreadView: View {
         }
         .onAppear {
             if projectID.isEmpty {
+                let recentProject = DailyUXCreationContext.recentProjects(
+                    in: model.snapshot
+                ).first?.project
                 let initialID = DailyUXCreationContext.initialProject(
                     in: model.snapshot,
                     requestedProjectID: initialProjectID
                 )?.id ?? ""
+                isAwaitingRecentProject = initialProjectID == nil && recentProject == nil
                 selectInitialProject(initialID)
             }
         }
@@ -101,10 +106,14 @@ public struct NewThreadView: View {
         .onChange(of: creationProjectIDs) { _, ids in
             guard !ids.contains(projectID) else { return }
             if projectID.isEmpty {
+                let recentProject = DailyUXCreationContext.recentProjects(
+                    in: model.snapshot
+                ).first?.project
                 let initialID = DailyUXCreationContext.initialProject(
                     in: model.snapshot,
                     requestedProjectID: initialProjectID
                 )?.id ?? ""
+                isAwaitingRecentProject = initialProjectID == nil && recentProject == nil
                 selectInitialProject(initialID)
                 return
             }
@@ -567,6 +576,7 @@ public struct NewThreadView: View {
     private func selectProject(_ id: String) -> Bool {
         guard creationProjects.contains(where: { $0.id == id }) else { return false }
         projectSelectionIsExplicit = true
+        isAwaitingRecentProject = false
         guard id != projectID else { return true }
         persistCurrentDraftImmediately()
         projectID = id
@@ -599,17 +609,24 @@ public struct NewThreadView: View {
     }
 
     private func refreshAutomaticProjectIfNeeded() {
-        guard initialProjectID == nil,
-              !projectSelectionIsExplicit,
-              prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              attachments.isEmpty,
-              let nextProjectID = DailyUXCreationContext.initialProject(
-                  in: model.snapshot,
-                  requestedProjectID: nil
-              )?.id,
-              nextProjectID != projectID else {
+        let nextProjectID = DailyUXCreationContext.recentProjects(
+            in: model.snapshot
+        ).first?.project.id
+        guard DailyUXCreationContext.shouldAdoptAutomaticProject(
+            currentProjectID: projectID,
+            nextRecentProjectID: nextProjectID,
+            isAwaitingRecentActivity: isAwaitingRecentProject,
+            projectSelectionIsExplicit: projectSelectionIsExplicit,
+            modelSelectionIsExplicit: selectionIsExplicit,
+            workspaceSelectionIsExplicit: workspaceSelectionIsExplicit,
+            hasDraftContent: !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || !attachments.isEmpty,
+            draftRestoreIsComplete: restoredDraftProjectID == projectID
+        ) else {
             return
         }
+        isAwaitingRecentProject = false
+        guard let nextProjectID else { return }
         selectInitialProject(nextProjectID)
     }
 
@@ -771,6 +788,7 @@ public struct NewThreadView: View {
             scheduleDraftSave()
         }
         await loadBranches()
+        refreshAutomaticProjectIfNeeded()
     }
 
     private var currentDraftKey: String? {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -10,6 +10,7 @@ public struct NewThreadView: View {
     private let initialProjectID: String?
 
     @State private var projectID = ""
+    @State private var projectSelectionIsExplicit = false
     @State private var prompt = ""
     @State private var selection: FeatureSelection?
     @State private var selectionIsExplicit = false
@@ -116,6 +117,9 @@ public struct NewThreadView: View {
                 .preferredProject(environmentID: previousProject?.environmentID)
                 ?? creationProjectGroups.first?.projects.first
             selectInitialProject(replacement?.id ?? "")
+        }
+        .onChange(of: model.homePresentationRevision) { _, _ in
+            refreshAutomaticProjectIfNeeded()
         }
         .onChange(of: prompt) { scheduleDraftSave() }
         .onChange(of: selection) { scheduleDraftSave() }
@@ -561,8 +565,9 @@ public struct NewThreadView: View {
 
     @discardableResult
     private func selectProject(_ id: String) -> Bool {
-        guard id != projectID else { return true }
         guard creationProjects.contains(where: { $0.id == id }) else { return false }
+        projectSelectionIsExplicit = true
+        guard id != projectID else { return true }
         persistCurrentDraftImmediately()
         projectID = id
         prepareProjectIfNeeded(id)
@@ -576,6 +581,7 @@ public struct NewThreadView: View {
             preferredEnvironmentID: selectedProject?.environmentID,
             in: creationProjectGroups
         ) else { return false }
+        projectSelectionIsExplicit = true
         guard group.id != selectedProjectGroup?.id else { return true }
         return selectProject(target.id)
     }
@@ -590,6 +596,21 @@ public struct NewThreadView: View {
     private func selectInitialProject(_ id: String) {
         projectID = id
         prepareProjectIfNeeded(id)
+    }
+
+    private func refreshAutomaticProjectIfNeeded() {
+        guard initialProjectID == nil,
+              !projectSelectionIsExplicit,
+              prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              attachments.isEmpty,
+              let nextProjectID = DailyUXCreationContext.initialProject(
+                  in: model.snapshot,
+                  requestedProjectID: nil
+              )?.id,
+              nextProjectID != projectID else {
+            return
+        }
+        selectInitialProject(nextProjectID)
     }
 
     private func prepareProjectIfNeeded(_ id: String) {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -609,9 +609,16 @@ public struct NewThreadView: View {
     }
 
     private func refreshAutomaticProjectIfNeeded() {
+        guard isAwaitingRecentProject else { return }
         let nextProjectID = DailyUXCreationContext.recentProjects(
             in: model.snapshot
         ).first?.project.id
+        guard let nextProjectID else { return }
+        if nextProjectID == projectID {
+            isAwaitingRecentProject = false
+            return
+        }
+        let draftRestoreIsComplete = restoredDraftProjectID == projectID
         guard DailyUXCreationContext.shouldAdoptAutomaticProject(
             currentProjectID: projectID,
             nextRecentProjectID: nextProjectID,
@@ -621,12 +628,14 @@ public struct NewThreadView: View {
             workspaceSelectionIsExplicit: workspaceSelectionIsExplicit,
             hasDraftContent: !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 || !attachments.isEmpty,
-            draftRestoreIsComplete: restoredDraftProjectID == projectID
+            draftRestoreIsComplete: draftRestoreIsComplete
         ) else {
+            if draftRestoreIsComplete {
+                isAwaitingRecentProject = false
+            }
             return
         }
         isAwaitingRecentProject = false
-        guard let nextProjectID else { return }
         selectInitialProject(nextProjectID)
     }
 
@@ -787,8 +796,9 @@ public struct NewThreadView: View {
         if liveDraft != context.baseline {
             scheduleDraftSave()
         }
-        await loadBranches()
         refreshAutomaticProjectIfNeeded()
+        guard projectID == requestedProjectID else { return }
+        await loadBranches()
     }
 
     private var currentDraftKey: String? {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -89,22 +89,24 @@ public struct NewThreadView: View {
         }
         .onAppear {
             if projectID.isEmpty {
-                let initialProject = creationProjects.first { $0.id == initialProjectID }
-                let initialGroup = initialProject.flatMap {
-                    DailyUXProjectGrouping.group(
-                        containing: $0.id,
-                        in: creationProjectGroups
-                    )
-                }
-                let initialID = initialGroup?.preferredProject(
-                    environmentID: initialProject?.environmentID
-                )?.id ?? creationProjectGroups.first?.projects.first?.id ?? ""
+                let initialID = DailyUXCreationContext.initialProject(
+                    in: model.snapshot,
+                    requestedProjectID: initialProjectID
+                )?.id ?? ""
                 selectInitialProject(initialID)
             }
         }
         .onChange(of: projectID) { prepareProjectIfNeeded(projectID) }
         .onChange(of: creationProjectIDs) { _, ids in
             guard !ids.contains(projectID) else { return }
+            if projectID.isEmpty {
+                let initialID = DailyUXCreationContext.initialProject(
+                    in: model.snapshot,
+                    requestedProjectID: initialProjectID
+                )?.id ?? ""
+                selectInitialProject(initialID)
+                return
+            }
             persistCurrentDraftImmediately()
             let previousProject = model.snapshot.projects.first { $0.id == projectID }
             let previousGroupID = previousProject.map {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -564,7 +564,7 @@ public struct WorkspaceView: View {
     }
 
     private func openNewTaskOrProjectCreation() {
-        openNewTaskOrProjectCreation(initialProjectID: nil)
+        openNewTaskOrProjectCreation(initialProjectID: selectedProjectID)
     }
 
     private func openNewTaskOrProjectCreation(initialProjectID: String?) {

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -269,6 +269,42 @@ struct DailyUXNewTaskTests {
                 draftRestoreIsComplete: false
             )
         )
+        #expect(
+            !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: "recent",
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: true,
+                draftRestoreIsComplete: true
+            )
+        )
+        #expect(
+            !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: "fallback",
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: false,
+                draftRestoreIsComplete: true
+            )
+        )
+        #expect(
+            !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: nil,
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: false,
+                draftRestoreIsComplete: true
+            )
+        )
     }
 
     @Test
@@ -664,6 +700,21 @@ struct DailyUXNewTaskTests {
 
         #expect(group.projects.map(\.id) == ["remote", "current"])
         #expect(group.memberProjectIDs == ["stale", "current", "remote"])
+
+        let snapshot = rankedSnapshot(
+            projects: [stale, current, remote],
+            threads: [rankedThread("recent", projectID: stale.id, activity: 20)]
+        )
+        #expect(
+            DailyUXCreationContext.recentProjects(in: snapshot).first?.project.id
+                == current.id
+        )
+        #expect(
+            DailyUXCreationContext.initialProject(
+                in: snapshot,
+                requestedProjectID: stale.id
+            )?.id == current.id
+        )
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -6,6 +6,123 @@ import UIKit
 @Suite("Message-first task creation")
 struct DailyUXNewTaskTests {
     @Test
+    func recentProjectRankingDrivesTheDefaultAndKeepsUnusedProjectsOut() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let unused = rankedProject("unused", name: "Unused")
+        let value = rankedSnapshot(
+            projects: [unused, beta, alpha],
+            threads: [
+                rankedThread("older", projectID: alpha.id, activity: 10),
+                rankedThread("newer", projectID: beta.id, activity: 20),
+            ]
+        )
+
+        let ranking = DailyUXCreationContext.recentProjects(in: value)
+
+        #expect(ranking.map(\.project.id) == [beta.id, alpha.id])
+        #expect(
+            DailyUXCreationContext.initialProject(in: value, requestedProjectID: nil)?.id
+                == ranking.first?.project.id
+        )
+    }
+
+    @Test
+    func recentProjectRankingIsStableForTiesAndIgnoresMissingProjects() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let value = rankedSnapshot(
+            projects: [alpha, beta],
+            threads: [
+                rankedThread("z-thread", projectID: alpha.id, activity: 20),
+                rankedThread("missing", projectID: "missing", activity: 30),
+                rankedThread("a-thread", projectID: beta.id, activity: 20),
+            ]
+        )
+
+        #expect(
+            DailyUXCreationContext.recentProjects(in: value)
+                .map(\.project.id) == [beta.id, alpha.id]
+        )
+    }
+
+    @Test
+    func recentProjectRankingUsesActivityInsteadOfMetadataChanges() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let value = rankedSnapshot(
+            projects: [alpha, beta],
+            threads: [
+                rankedThread(
+                    "metadata-change",
+                    projectID: alpha.id,
+                    updatedAt: 100,
+                    lastActivityAt: 10
+                ),
+                rankedThread("actual-use", projectID: beta.id, activity: 20),
+            ]
+        )
+
+        #expect(
+            DailyUXCreationContext.recentProjects(in: value)
+                .map(\.project.id) == [beta.id, alpha.id]
+        )
+    }
+
+    @Test
+    func archivedAndSettledThreadsStillRepresentProjectUse() {
+        let archived = rankedProject("archived", name: "Archived")
+        let settled = rankedProject("settled", name: "Settled")
+        let value = rankedSnapshot(
+            projects: [archived, settled],
+            threads: [
+                rankedThread(
+                    "archived-thread",
+                    projectID: archived.id,
+                    activity: 30,
+                    isArchived: true
+                ),
+                rankedThread(
+                    "settled-thread",
+                    projectID: settled.id,
+                    activity: 20,
+                    isSettled: true
+                ),
+            ]
+        )
+
+        #expect(
+            DailyUXCreationContext.recentProjects(in: value)
+                .map(\.project.id) == [archived.id, settled.id]
+        )
+    }
+
+    @Test
+    func explicitProjectWinsAndNoActivityFallsBackAlphabetically() {
+        let zulu = rankedProject("zulu", name: "Zulu")
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let withActivity = rankedSnapshot(
+            projects: [zulu, alpha],
+            threads: [rankedThread("recent", projectID: zulu.id, activity: 20)]
+        )
+        let withoutActivity = rankedSnapshot(projects: [zulu, alpha], threads: [])
+
+        #expect(
+            DailyUXCreationContext.initialProject(
+                in: withActivity,
+                requestedProjectID: alpha.id
+            )?.id == alpha.id
+        )
+        #expect(DailyUXCreationContext.recentProjects(in: withoutActivity).isEmpty)
+        #expect(
+            DailyUXCreationContext.initialProject(
+                in: withoutActivity,
+                requestedProjectID: nil
+            )?.id == alpha.id
+        )
+    }
+
+    @Test
     func requestNormalizesLegacyModesAndKeepsImageBytes() {
         let image = FeatureDraftAttachment(
             data: Data([1, 2, 3]),
@@ -520,5 +637,37 @@ struct DailyUXNewTaskTests {
         #expect(max(prepared.size.width, prepared.size.height) <= 2_048)
         #expect(max(thumbnail.size.width, thumbnail.size.height) <= 160)
         #expect(attachment.mimeType == "image/jpeg")
+    }
+
+    private func rankedProject(_ id: String, name: String) -> FeatureProject {
+        FeatureProject(id: id, environmentID: "environment", name: name, path: "/\(id)")
+    }
+
+    private func rankedThread(
+        _ id: String,
+        projectID: String,
+        activity: TimeInterval? = nil,
+        updatedAt: TimeInterval? = nil,
+        lastActivityAt: TimeInterval? = nil,
+        isArchived: Bool = false,
+        isSettled: Bool = false
+    ) -> FeatureThread {
+        let updatedAt = updatedAt ?? activity ?? 0
+        return FeatureThread(
+            id: id,
+            projectID: projectID,
+            title: id,
+            updatedAt: Date(timeIntervalSince1970: updatedAt),
+            isArchived: isArchived,
+            isSettled: isSettled,
+            lastActivityAt: lastActivityAt.map(Date.init(timeIntervalSince1970:))
+        )
+    }
+
+    private func rankedSnapshot(
+        projects: [FeatureProject],
+        threads: [FeatureThread]
+    ) -> FeatureSnapshot {
+        FeatureSnapshot(projects: projects, threads: threads)
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -203,6 +203,75 @@ struct DailyUXNewTaskTests {
     }
 
     @Test
+    func recentProjectRankingKeepsTheExactWorktreeUsedByTheThread() {
+        let root = rankedProject(
+            "root",
+            name: "Project",
+            repositoryKey: "github.com/example/project"
+        )
+        let worktree = rankedProject(
+            "worktree",
+            name: "Project",
+            repositoryKey: "github.com/example/project"
+        )
+        let value = rankedSnapshot(
+            projects: [root, worktree],
+            threads: [rankedThread("recent", projectID: worktree.id, activity: 20)]
+        )
+
+        #expect(DailyUXCreationContext.recentProjects(in: value).first?.project.id == worktree.id)
+        #expect(
+            DailyUXCreationContext.initialProject(
+                in: value,
+                requestedProjectID: worktree.id
+            )?.id == worktree.id
+        )
+    }
+
+    @Test
+    func automaticProjectAdoptionWaitsForRestoreAndStopsAfterExplicitChoices() {
+        #expect(
+            DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: "recent",
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: false,
+                draftRestoreIsComplete: true
+            )
+        )
+
+        for explicitChoice in 0..<3 {
+            #expect(
+                !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                    currentProjectID: "fallback",
+                    nextRecentProjectID: "recent",
+                    isAwaitingRecentActivity: true,
+                    projectSelectionIsExplicit: explicitChoice == 0,
+                    modelSelectionIsExplicit: explicitChoice == 1,
+                    workspaceSelectionIsExplicit: explicitChoice == 2,
+                    hasDraftContent: false,
+                    draftRestoreIsComplete: true
+                )
+            )
+        }
+        #expect(
+            !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: "recent",
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: false,
+                draftRestoreIsComplete: false
+            )
+        )
+    }
+
+    @Test
     func requestNormalizesLegacyModesAndKeepsImageBytes() {
         let image = FeatureDraftAttachment(
             data: Data([1, 2, 3]),

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -123,6 +123,86 @@ struct DailyUXNewTaskTests {
     }
 
     @Test
+    func recentProjectRankingExcludesDisabledEnvironments() {
+        let enabled = rankedProject("enabled", name: "Enabled", environmentID: "enabled-env")
+        let disabled = rankedProject("disabled", name: "Disabled", environmentID: "disabled-env")
+        let value = rankedSnapshot(
+            environments: [
+                FeatureEnvironment(
+                    id: "enabled-env",
+                    name: "Enabled",
+                    endpoint: "http://enabled",
+                    isEnabled: true
+                ),
+                FeatureEnvironment(
+                    id: "disabled-env",
+                    name: "Disabled",
+                    endpoint: "http://disabled",
+                    isEnabled: false
+                ),
+            ],
+            projects: [enabled, disabled],
+            threads: [
+                rankedThread("enabled-thread", projectID: enabled.id, activity: 10),
+                rankedThread("disabled-thread", projectID: disabled.id, activity: 20),
+            ]
+        )
+
+        #expect(
+            DailyUXCreationContext.recentProjects(in: value).map(\.project.id) == [enabled.id]
+        )
+    }
+
+    @Test
+    func recentProjectRankingDeduplicatesARepositoryAcrossEnvironments() {
+        let local = rankedProject(
+            "local",
+            name: "Project",
+            environmentID: "local-env",
+            repositoryKey: "github.com/example/project"
+        )
+        let remote = rankedProject(
+            "remote",
+            name: "Project",
+            environmentID: "remote-env",
+            repositoryKey: "github.com/example/project"
+        )
+        let value = rankedSnapshot(
+            environments: [
+                FeatureEnvironment(
+                    id: "local-env",
+                    name: "Local",
+                    endpoint: "http://local"
+                ),
+                FeatureEnvironment(
+                    id: "remote-env",
+                    name: "Remote",
+                    endpoint: "http://remote"
+                ),
+            ],
+            projects: [local, remote],
+            threads: [
+                rankedThread(
+                    "local-thread",
+                    projectID: local.id,
+                    environmentID: "local-env",
+                    activity: 10
+                ),
+                rankedThread(
+                    "remote-thread",
+                    projectID: remote.id,
+                    environmentID: "remote-env",
+                    activity: 20
+                ),
+            ]
+        )
+
+        let ranking = DailyUXCreationContext.recentProjects(in: value)
+        #expect(ranking.count == 1)
+        #expect(ranking.first?.project.id == remote.id)
+    }
+
+    @Test
     func requestNormalizesLegacyModesAndKeepsImageBytes() {
         let image = FeatureDraftAttachment(
             data: Data([1, 2, 3]),
@@ -639,13 +719,27 @@ struct DailyUXNewTaskTests {
         #expect(attachment.mimeType == "image/jpeg")
     }
 
-    private func rankedProject(_ id: String, name: String) -> FeatureProject {
-        FeatureProject(id: id, environmentID: "environment", name: name, path: "/\(id)")
+    private func rankedProject(
+        _ id: String,
+        name: String,
+        environmentID: String = "environment",
+        repositoryKey: String? = nil
+    ) -> FeatureProject {
+        FeatureProject(
+            id: id,
+            environmentID: environmentID,
+            name: name,
+            path: "/\(id)",
+            repositoryIdentity: repositoryKey.map {
+                FeatureRepositoryIdentity(canonicalKey: $0)
+            }
+        )
     }
 
     private func rankedThread(
         _ id: String,
         projectID: String,
+        environmentID: String? = nil,
         activity: TimeInterval? = nil,
         updatedAt: TimeInterval? = nil,
         lastActivityAt: TimeInterval? = nil,
@@ -656,6 +750,7 @@ struct DailyUXNewTaskTests {
         return FeatureThread(
             id: id,
             projectID: projectID,
+            environmentID: environmentID,
             title: id,
             updatedAt: Date(timeIntervalSince1970: updatedAt),
             isArchived: isArchived,
@@ -665,9 +760,10 @@ struct DailyUXNewTaskTests {
     }
 
     private func rankedSnapshot(
+        environments: [FeatureEnvironment] = [],
         projects: [FeatureProject],
         threads: [FeatureThread]
     ) -> FeatureSnapshot {
-        FeatureSnapshot(projects: projects, threads: threads)
+        FeatureSnapshot(environments: environments, projects: projects, threads: threads)
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 


### PR DESCRIPTION
## What changed

Default the native SwiftUI New Task flow to the available project from the most recently active thread.

Selection order stays narrow:

1. A valid explicit project selection.
2. The project from the newest `lastActivityAt` thread, falling back to `updatedAt`.
3. The first alphabetically grouped available project.

Missing or unavailable projects are skipped; equal timestamps use thread ID as a stable tie-break.

This is SwiftUI-only under `apps/swift-ios`. It does not implement the React Native `apps/mobile` portion named in #5785, add a recents section, reorder project lists, or persist another preference.

Base: `pingdotgg/t3code:t3code/rebuild-mobile-app-swift` at `f98cab553546558e28d6e22f3dbe9807ecc3325f`.
Current head: `b6444b8ad3a2c9d1520c482c8b9171b970f57994`.

The current-head repair only updates native Swift Contract test fixtures from the legacy flat `providers` catalog to production's environment-scoped `providersByEnvironment`; product behavior is unchanged.

## Why

The previous alphabetical default could open a phone task in an unrelated project.

## UI evidence

Current head — New Task defaults to the retained Simulator's most recently used available project, Thread Menu Proof:

![PR #5802 current-head New Task default](https://github.com/saphid/t3code/releases/download/pr-evidence-20260809/pr5802-current-head-default-b6444b8.png)

[Playable current-head Simulator flow (MP4 wrapper)](https://alexs-macbook-pro-1.tail4e5636.ts.net:8767/pr5802-6131-exact-head-flow.html)

The child picker state remains isolated in #6131; this PR does not add the separate recents-section UI.

## Verification

- Current head `b6444b8`: `HomeThreadMetadataTests` + `DailyUXNewTaskTests` — 29 passed, 0 failed.
- Exact-current-head `apps/swift-ios/Scripts/ci-test.sh`: exit 0; 234 tests in 29 suites.
- Integrated iOS Simulator: exact-current-head app built and launched successfully; the New Task deep link selected Thread Menu Proof without another tap. Runtime accessibility also reported `Choose project | Thread Menu Proof`.
- Current-head image and video were visually inspected; durable assets return HTTP 200 with `image/png` / `video/mp4`.
- `git diff --check`: passed.
- Direct independent review: Claude Opus 5 high, exit 0; no actionable findings on the fixture-only repair or product selection behavior.
- Current-head GitHub `Contract fixtures and native tests`, `Test`, `Check`, mobile static analysis, and release smoke all passed. Macroscope correctness skipped the fixture-only refresh; approvability completed neutral because human review is required. A manual refresh request was denied for contributor permissions. The exact product head retains the later `t3-code` approval, and both superseded threads are resolved. The Vercel authorization failure is unrelated to this SwiftUI-only change.

## Checklist

- [x] Small and focused
- [x] Explained the SwiftUI-only scope
- [x] Current-head screenshot and playable video
- [x] Focused, full native, and integrated exact-head verification
- [x] Fresh independent cross-provider review
- [x] Current-head GitHub native/test jobs complete
- [ ] Maintainer scope alignment / human review

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default project selection for new tasks, which can send work to the wrong project if ranking or auto-adoption misfires. Explicit selection and draft safeguards reduce that risk.
> 
> **Overview**
> **Defaults New Task to the most recently used project** instead of the first alphabetical group.
> 
> Selection priority is now: explicit/requested project → project from newest thread activity (`lastActivityAt`, then `updatedAt`) → alphabetical fallback. Ranking deduplicates by project group, skips unavailable/disabled projects, and keeps the exact worktree that was used.
> 
> `NewThreadView` can later adopt a recent project once activity arrives, but only while awaiting recents and only if the user has not explicitly chosen project/model/workspace, has no draft content, and draft restore has finished. Opening New Task from the workspace also passes the currently selected project as the requested ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6444b8ad3a2c9d1520c482c8b9171b970f57994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default new task project selection to the most recently used project
> - When opening the new task sheet, the project now defaults to the currently selected project (if any), then the most recently used project by activity timestamp, then the first project alphabetically.
> - Adds `DailyUXCreationContext.recentProjects` to rank projects by last activity, deduplicated by logical group, and `initialProject` to resolve the correct physical worktree representative.
> - The new task screen can automatically switch from a fallback project to the first recent project once activity data arrives, but stops if the user makes an explicit selection or has draft content.
> - Behavioral Change: `WorkspaceView.openNewTaskOrProjectCreation` now passes the current `selectedProjectID` instead of `nil`, so the sheet no longer opens with an unset project when a project is already selected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6444b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Current head b6444b8 is locally and CI proven, approved, thread-clean, and mergeable. Macroscope approvability remains neutral pending human review; the unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
