### PR TITLE
fix(swift-ios): open workspace file links

### DIFF
--- a/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
@@ -81,8 +81,14 @@ struct MarkdownMessageView: View {
             UIPasteboard.general.string = source
         }
         .environment(\.openURL, OpenURLAction { url in
-            if onOpenURL?(url) == true { return .handled }
-            return .systemAction
+            switch MarkdownOpenURLDisposition.resolve(url: url, onOpenURL: onOpenURL) {
+            case .handled:
+                return .handled
+            case .discarded:
+                return .discarded
+            case .systemAction:
+                return .systemAction
+            }
         })
         .task(id: RenderRequest(revision: revision, isStreaming: isStreaming)) {
             if !isStreaming {

--- a/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
@@ -1,6 +1,17 @@
 import SwiftUI
 import UIKit
 
+private struct MarkdownTextSelectionEnabledKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+private extension EnvironmentValues {
+    var markdownTextSelectionEnabled: Bool {
+        get { self[MarkdownTextSelectionEnabledKey.self] }
+        set { self[MarkdownTextSelectionEnabledKey.self] = newValue }
+    }
+}
+
 /// Native chat Markdown with block-aware layout and Foundation inline parsing.
 struct MarkdownMessageView: View {
     private struct RenderRequest: Hashable {
@@ -11,13 +22,19 @@ struct MarkdownMessageView: View {
     private let source: String
     private let revision: MarkdownContentRevision
     private let isStreaming: Bool
+    private let onOpenURL: ((URL) -> Bool)?
     @State private var renderedDocument: MarkdownRenderedDocument?
     @State private var streamingRenderer = StreamingMarkdownRenderer()
     @State private var isSelectingText = false
 
-    init(_ source: String, isStreaming: Bool = false) {
+    init(
+        _ source: String,
+        isStreaming: Bool = false,
+        onOpenURL: ((URL) -> Bool)? = nil
+    ) {
         self.source = source
         self.isStreaming = isStreaming
+        self.onOpenURL = onOpenURL
         let revision = MarkdownContentRevision(source)
         self.revision = revision
         let initialDocument = if isStreaming {
@@ -44,6 +61,7 @@ struct MarkdownMessageView: View {
             }
         }
         .modifier(MarkdownTextSelectionModifier(isEnabled: isSelectingText))
+        .environment(\.markdownTextSelectionEnabled, isSelectingText)
         .contextMenu {
             Button {
                 isSelectingText.toggle()
@@ -62,6 +80,10 @@ struct MarkdownMessageView: View {
         .accessibilityAction(named: "Copy message") {
             UIPasteboard.general.string = source
         }
+        .environment(\.openURL, OpenURLAction { url in
+            if onOpenURL?(url) == true { return .handled }
+            return .systemAction
+        })
         .task(id: RenderRequest(revision: revision, isStreaming: isStreaming)) {
             if !isStreaming {
                 streamingRenderer.cancel()
@@ -216,7 +238,6 @@ private struct MarkdownBlockView: View, Equatable {
         switch block {
         case let .paragraph(inline):
             MarkdownInlineText(inline)
-                .lineSpacing(4)
 
         case let .heading(level, inline):
             MarkdownInlineText(inline)
@@ -290,7 +311,6 @@ private struct MarkdownTableView: View {
         GridRow(alignment: .top) {
             ForEach(cells.indices, id: \.self) { columnIndex in
                 MarkdownInlineText(cells[columnIndex])
-                    .lineSpacing(3)
                     .frame(
                         width: columnWidths[columnIndex],
                         alignment: alignment(for: columnIndex)
@@ -470,18 +490,199 @@ enum MarkdownCodeBlockWrapping {
 }
 
 private struct MarkdownInlineText: View {
+    @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @SwiftUI.Environment(\.legibilityWeight) private var legibilityWeight
+    @SwiftUI.Environment(\.markdownTextSelectionEnabled) private var isTextSelectionEnabled
+
     private let attributedText: AttributedString
     private let font: Font
+    private let style: MarkdownInlineStyle
+    private let hasLinks: Bool
 
     init(_ rendered: MarkdownRenderedInline) {
         attributedText = rendered.attributedText
         font = rendered.style.font
+        style = rendered.style
+        hasLinks = rendered.attributedText.runs.contains { $0.link != nil }
     }
 
     var body: some View {
         Text(attributedText)
             .font(font)
+            .lineSpacing(style.lineSpacing)
             .fixedSize(horizontal: false, vertical: true)
+            .overlay {
+                if hasLinks {
+                    MarkdownLinkInteractionOverlay(
+                        attributedText: attributedText,
+                        baseFont: style.uiFont(
+                            dynamicTypeSize: dynamicTypeSize,
+                            legibilityWeight: legibilityWeight
+                        ),
+                        lineSpacing: style.lineSpacing
+                    )
+                    .allowsHitTesting(!isTextSelectionEnabled)
+                }
+            }
+    }
+}
+
+@MainActor
+final class MarkdownLinkActionRelay {
+    var handler: (URL) -> Void = { _ in }
+
+    func open(_ url: URL) {
+        handler(url)
+    }
+}
+
+private struct MarkdownLinkInteractionOverlay: UIViewRepresentable {
+    @SwiftUI.Environment(\.openURL) private var openURL
+
+    let attributedText: AttributedString
+    let baseFont: UIFont
+    let lineSpacing: CGFloat
+
+    func makeCoordinator() -> MarkdownLinkActionRelay {
+        MarkdownLinkActionRelay()
+    }
+
+    func makeUIView(context: Context) -> MarkdownLinkInteractionView {
+        let relay = context.coordinator
+        let view = MarkdownLinkInteractionView()
+        view.onOpenURL = { relay.open($0) }
+        return view
+    }
+
+    func updateUIView(_ view: MarkdownLinkInteractionView, context: Context) {
+        // UIHostingConfiguration recycles transcript cells. Updating this relay
+        // keeps a reused link wired to the current SwiftUI environment.
+        context.coordinator.handler = { url in openURL(url) }
+        view.render(attributedText, baseFont: baseFont, lineSpacing: lineSpacing)
+    }
+}
+
+private final class MarkdownLinkInteractionView: UIView {
+    var onOpenURL: ((URL) -> Void)?
+
+    private let textStorage = NSTextStorage()
+    private let layoutManager = NSLayoutManager()
+    private let textContainer = NSTextContainer(size: .zero)
+    private var initialTouch: (point: CGPoint, url: URL, timestamp: TimeInterval)?
+    private var renderedText: AttributedString?
+    private var renderedFont: UIFont?
+    private var renderedLineSpacing: CGFloat?
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        isOpaque = false
+        isUserInteractionEnabled = true
+        isAccessibilityElement = false
+        accessibilityElementsHidden = true
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func render(_ text: AttributedString, baseFont: UIFont, lineSpacing: CGFloat) {
+        guard renderedText != text
+                || renderedFont?.isEqual(baseFont) != true
+                || renderedLineSpacing != lineSpacing else { return }
+        renderedText = text
+        renderedFont = baseFont
+        renderedLineSpacing = lineSpacing
+
+        let rendered = NSMutableAttributedString()
+        for run in text.runs {
+            let string = String(text[run.range].characters)
+            var attributes: [NSAttributedString.Key: Any] = [
+                .font: font(for: run.inlinePresentationIntent, baseFont: baseFont),
+                .foregroundColor: UIColor.clear,
+            ]
+            if let link = run.link { attributes[.link] = link }
+            rendered.append(NSAttributedString(string: string, attributes: attributes))
+        }
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = lineSpacing
+        rendered.addAttribute(
+            .paragraphStyle,
+            value: paragraph,
+            range: NSRange(location: 0, length: rendered.length)
+        )
+        textStorage.setAttributedString(rendered)
+        setNeedsLayout()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        textContainer.size = bounds.size
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        link(at: point) != nil
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first,
+              let url = link(at: touch.location(in: self)) else {
+            initialTouch = nil
+            super.touchesBegan(touches, with: event)
+            return
+        }
+        initialTouch = (touch.location(in: self), url, touch.timestamp)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first, let initialTouch,
+              initialTouch.url == link(at: touch.location(in: self)),
+              hypot(
+                  touch.location(in: self).x - initialTouch.point.x,
+                  touch.location(in: self).y - initialTouch.point.y
+              ) <= 10,
+              touch.timestamp - initialTouch.timestamp <= 0.5 else {
+            self.initialTouch = nil
+            super.touchesEnded(touches, with: event)
+            return
+        }
+        self.initialTouch = nil
+        onOpenURL?(initialTouch.url)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        initialTouch = nil
+        super.touchesCancelled(touches, with: event)
+    }
+
+    private func link(at point: CGPoint) -> URL? {
+        guard textStorage.length > 0, bounds.contains(point) else { return nil }
+        let glyph = layoutManager.glyphIndex(for: point, in: textContainer)
+        guard glyph < layoutManager.numberOfGlyphs else { return nil }
+        let glyphRect = layoutManager.boundingRect(
+            forGlyphRange: NSRange(location: glyph, length: 1),
+            in: textContainer
+        )
+        guard glyphRect.insetBy(dx: -6, dy: -4).contains(point) else { return nil }
+        let character = layoutManager.characterIndexForGlyph(at: glyph)
+        guard character < textStorage.length else { return nil }
+        return textStorage.attribute(.link, at: character, effectiveRange: nil) as? URL
+    }
+
+    private func font(for intent: InlinePresentationIntent?, baseFont: UIFont) -> UIFont {
+        var descriptor = baseFont.fontDescriptor
+        if intent?.contains(.code) == true {
+            descriptor = descriptor.withDesign(.monospaced) ?? descriptor
+        }
+        var traits = descriptor.symbolicTraits
+        if intent?.contains(.stronglyEmphasized) == true { traits.insert(.traitBold) }
+        if intent?.contains(.emphasized) == true { traits.insert(.traitItalic) }
+        guard let descriptor = descriptor.withSymbolicTraits(traits) else { return baseFont }
+        return UIFont(descriptor: descriptor, size: baseFont.pointSize)
     }
 }
 

--- a/apps/swift-ios/Features/Chat/MarkdownOpenURLDisposition.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownOpenURLDisposition.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum MarkdownOpenURLDisposition: Equatable {
+    case handled
+    case discarded
+    case systemAction
+
+    static func resolve(
+        url: URL,
+        onOpenURL: ((URL) -> Bool)?
+    ) -> Self {
+        if onOpenURL?(url) == true {
+            return .handled
+        }
+        if url.scheme?.caseInsensitiveCompare("file") == .orderedSame {
+            return .discarded
+        }
+        return .systemAction
+    }
+}

--- a/apps/swift-ios/Features/Chat/MarkdownRenderCache.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownRenderCache.swift
@@ -54,6 +54,52 @@ enum MarkdownInlineStyle: String, Hashable, Sendable {
         }
     }
 
+    func uiFont(
+        dynamicTypeSize: DynamicTypeSize,
+        legibilityWeight: LegibilityWeight?
+    ) -> UIFont {
+        let textStyle: UIFont.TextStyle
+        let weight: UIFont.Weight
+        switch self {
+        case .body, .tableCell:
+            textStyle = .body
+            weight = .regular
+        case .heading1:
+            textStyle = .title2
+            weight = .bold
+        case .heading2:
+            textStyle = .title3
+            weight = .bold
+        case .heading3:
+            textStyle = .headline
+            weight = .bold
+        case .heading4, .tableHeader:
+            textStyle = .body
+            weight = .semibold
+        }
+        let traits = UITraitCollection(traitsFrom: [
+            UITraitCollection(
+                preferredContentSizeCategory: UIContentSizeCategory(dynamicTypeSize)
+            ),
+            UITraitCollection(
+                legibilityWeight: legibilityWeight == .bold ? .bold : .unspecified
+            ),
+        ])
+        let preferred = UIFont.preferredFont(forTextStyle: textStyle, compatibleWith: traits)
+        let effectiveWeight: UIFont.Weight = legibilityWeight == .bold
+            ? max(weight, .semibold)
+            : weight
+        return UIFont.systemFont(ofSize: preferred.pointSize, weight: effectiveWeight)
+    }
+
+    var lineSpacing: CGFloat {
+        switch self {
+        case .body: 4
+        case .tableHeader, .tableCell: 3
+        case .heading1, .heading2, .heading3, .heading4: 0
+        }
+    }
+
     static func heading(level: Int) -> Self {
         switch level {
         case 1: .heading1

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -21,6 +21,8 @@ public struct ThreadDetailView: View {
     @State private var didRestoreDraft = false
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var toolSurface: FeatureThreadToolSurface?
+    @State private var linkedFile: FeatureWorkspaceFileLink?
+    @State private var fileLinkFailureMessage: String?
     @FocusState private var composerFocused: Bool
 
     public init(
@@ -101,10 +103,37 @@ public struct ThreadDetailView: View {
             .presentationDetents([.large])
             .presentationDragIndicator(.visible)
         }
+        .sheet(item: $linkedFile) { link in
+            NavigationStack {
+                FeatureFilePreviewView(
+                    client: model.client,
+                    threadID: thread.id,
+                    entry: link.entry
+                )
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { linkedFile = nil }
+                    }
+                }
+            }
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+        }
         .alert("Message not sent", isPresented: $sendFailed) {
             Button("OK") {}
         } message: {
             Text("Your draft is still here. Check your connection and try again.")
+        }
+        .alert(
+            "File link unavailable",
+            isPresented: Binding(
+                get: { fileLinkFailureMessage != nil },
+                set: { if !$0 { fileLinkFailureMessage = nil } }
+            )
+        ) {
+            Button("OK") { fileLinkFailureMessage = nil }
+        } message: {
+            Text(fileLinkFailureMessage ?? "This file is not inside the active workspace.")
         }
         .simultaneousGesture(edgeBackGesture)
     }
@@ -128,6 +157,11 @@ public struct ThreadDetailView: View {
 
     private var currentThread: FeatureThread {
         detail?.thread ?? thread
+    }
+
+    private var workspaceRoot: String? {
+        currentThread.worktreePath
+            ?? model.snapshot.projects.first { $0.id == currentThread.projectID }?.path
     }
 
     private var currentSelection: FeatureSelection? {
@@ -334,6 +368,7 @@ public struct ThreadDetailView: View {
                     onLoadEarlier: {
                         Task { await model.loadEarlierTurns(for: thread.id) }
                     },
+                    onOpenURL: openURL,
                     onDismissKeyboard: dismissKeyboard
                 )
             }
@@ -366,6 +401,18 @@ public struct ThreadDetailView: View {
             )
             .simultaneousGesture(composerKeyboardDismissGesture)
         }
+    }
+
+    private func openURL(_ url: URL) -> Bool {
+        guard let link = FeatureWorkspaceFileLink(url: url, workspaceRoot: workspaceRoot) else {
+            guard FeatureWorkspaceFileLink.isWorkspaceDestination(url) else { return false }
+            fileLinkFailureMessage = workspaceRoot == nil
+                ? "The active workspace is not available for this thread."
+                : "This file is not inside the active workspace."
+            return true
+        }
+        linkedFile = link
+        return true
     }
 
     private var composerKeyboardDismissGesture: some Gesture {
@@ -644,6 +691,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
     let canLoadEarlier: Bool
     let isLoadingEarlier: Bool
     let onLoadEarlier: () -> Void
+    let onOpenURL: (URL) -> Bool
     let onDismissKeyboard: () -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -679,6 +727,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             canLoadEarlier: canLoadEarlier,
             isLoadingEarlier: isLoadingEarlier,
             onLoadEarlier: onLoadEarlier,
+            onOpenURL: onOpenURL,
             onDismissKeyboard: onDismissKeyboard,
             in: collectionView
         )
@@ -730,6 +779,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         private var currentIsLoadingEarlier = false
         private var markdownPrefetches: [String: MarkdownPrefetch] = [:]
         private var onLoadEarlier: (() -> Void)?
+        private var onOpenURL: ((URL) -> Bool)?
         private var onDismissKeyboard: (() -> Void)?
 
         deinit {
@@ -770,7 +820,10 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 }
 
                 cell.contentConfiguration = UIHostingConfiguration {
-                    FeatureMessageView(message: message)
+                    FeatureMessageView(
+                        message: message,
+                        onOpenURL: { [weak self] url in self?.onOpenURL?(url) == true }
+                    )
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .margins(.all, 0)
@@ -803,11 +856,13 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             canLoadEarlier: Bool,
             isLoadingEarlier: Bool,
             onLoadEarlier: @escaping () -> Void,
+            onOpenURL: @escaping (URL) -> Bool,
             onDismissKeyboard: @escaping () -> Void,
             in collectionView: UICollectionView
         ) {
             guard let dataSource else { return }
             self.onLoadEarlier = onLoadEarlier
+            self.onOpenURL = onOpenURL
             self.onDismissKeyboard = onDismissKeyboard
 
             let threadChanged = currentThreadID != threadID
@@ -1501,6 +1556,7 @@ private enum FeatureAttachmentThumbnailError: Error {
 
 struct FeatureMessageView: View {
     let message: FeatureMessage
+    let onOpenURL: (URL) -> Bool
 
     var body: some View {
         switch message.role {
@@ -1512,7 +1568,8 @@ struct FeatureMessageView: View {
                     if !message.text.isEmpty {
                         MarkdownMessageView(
                             message.text,
-                            isStreaming: message.state == .streaming
+                            isStreaming: message.state == .streaming,
+                            onOpenURL: onOpenURL
                         )
                     }
                 }
@@ -1546,7 +1603,8 @@ struct FeatureMessageView: View {
                 if !message.text.isEmpty {
                     MarkdownMessageView(
                         message.text,
-                        isStreaming: message.state == .streaming
+                        isStreaming: message.state == .streaming,
+                        onOpenURL: onOpenURL
                     )
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -105,11 +105,7 @@ public struct ThreadDetailView: View {
         }
         .sheet(item: $linkedFile) { link in
             NavigationStack {
-                FeatureFilePreviewView(
-                    client: model.client,
-                    threadID: thread.id,
-                    entry: link.entry
-                )
+                linkedFileDestination(link)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Done") { linkedFile = nil }
@@ -136,6 +132,24 @@ public struct ThreadDetailView: View {
             Text(fileLinkFailureMessage ?? "This file is not inside the active workspace.")
         }
         .simultaneousGesture(edgeBackGesture)
+    }
+
+    @ViewBuilder
+    private func linkedFileDestination(_ link: FeatureWorkspaceFileLink) -> some View {
+        if link.kind == .directory {
+            FeatureFileDirectoryView(
+                client: model.client,
+                threadID: thread.id,
+                path: link.path,
+                title: link.entry.name
+            )
+        } else {
+            FeatureFilePreviewView(
+                client: model.client,
+                threadID: thread.id,
+                entry: link.entry
+            )
+        }
     }
 
     private var edgeBackGesture: some Gesture {

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -160,8 +160,12 @@ public struct ThreadDetailView: View {
     }
 
     private var workspaceRoot: String? {
-        currentThread.worktreePath
-            ?? model.snapshot.projects.first { $0.id == currentThread.projectID }?.path
+        FeatureWorkspaceFileLink.resolvedWorkspaceRoot(
+            worktreePath: currentThread.worktreePath,
+            projectPath: model.snapshot.projects.first {
+                $0.id == currentThread.projectID
+            }?.path
+        )
     }
 
     private var currentSelection: FeatureSelection? {

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -408,15 +408,18 @@ public struct ThreadDetailView: View {
     }
 
     private func openURL(_ url: URL) -> Bool {
-        guard let link = FeatureWorkspaceFileLink(url: url, workspaceRoot: workspaceRoot) else {
-            guard FeatureWorkspaceFileLink.isWorkspaceDestination(url) else { return false }
+        switch FeatureWorkspaceFileLinkRoute.resolve(url: url, workspaceRoot: workspaceRoot) {
+        case let .open(link):
+            linkedFile = link
+            return true
+        case .rejectedWorkspaceDestination:
             fileLinkFailureMessage = workspaceRoot == nil
                 ? "The active workspace is not available for this thread."
                 : "This file is not inside the active workspace."
             return true
+        case .external:
+            return false
         }
-        linkedFile = link
-        return true
     }
 
     private var composerKeyboardDismissGesture: some Gesture {

--- a/apps/swift-ios/Features/Files/FeatureFilesView.swift
+++ b/apps/swift-ios/Features/Files/FeatureFilesView.swift
@@ -17,7 +17,7 @@ public struct FeatureFilesView: View {
     }
 }
 
-private struct FeatureFileDirectoryView: View {
+struct FeatureFileDirectoryView: View {
     let client: any FeatureClient
     let threadID: String
     let path: String?

--- a/apps/swift-ios/Features/Files/FeatureFilesView.swift
+++ b/apps/swift-ios/Features/Files/FeatureFilesView.swift
@@ -149,7 +149,7 @@ private struct FeatureFileRow: View {
     }
 }
 
-private struct FeatureFilePreviewView: View {
+struct FeatureFilePreviewView: View {
     let client: any FeatureClient
     let threadID: String
     let entry: FeatureFileEntry
@@ -211,6 +211,7 @@ private struct FeatureFilePreviewView: View {
         .background(T3Colors.background)
         .navigationTitle(entry.name)
         .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("workspace-file-preview")
         .toolbar {
             if let assetURL {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
+++ b/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
@@ -21,13 +21,14 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
     ]
 
     public let path: String
+    public let kind: FeatureFileKind
     public var id: String { path }
 
     public var entry: FeatureFileEntry {
         FeatureFileEntry(
             path: path,
             name: URL(fileURLWithPath: path).lastPathComponent,
-            kind: .file
+            kind: kind
         )
     }
 
@@ -65,6 +66,9 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         if usesWindowsPaths {
             destination.path = destination.path.replacingOccurrences(of: "\\", with: "/")
         }
+        let kind: FeatureFileKind = url.hasDirectoryPath || destination.path.hasSuffix("/")
+            ? .directory
+            : .file
 
         guard !destination.path.isEmpty,
               !Self.containsDisallowedColon(destination.path, usesWindowsPaths: usesWindowsPaths),
@@ -85,6 +89,7 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
                 return nil
             }
             path = relative
+            self.kind = kind
             return
         }
 
@@ -99,6 +104,7 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
 
         guard let relative = Self.relativePath(for: absolute, in: root) else { return nil }
         path = relative
+        self.kind = kind
     }
 
     public static func isWorkspaceDestination(_ url: URL) -> Bool {

--- a/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
+++ b/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
@@ -102,10 +102,10 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
     }
 
     public static func isWorkspaceDestination(_ url: URL) -> Bool {
+        if url.scheme?.lowercased() == "file" { return true }
         guard url.host == nil, url.user == nil, url.password == nil, url.port == nil else {
             return false
         }
-        if url.scheme?.lowercased() == "file" { return true }
         if positionedWindowsAbsoluteDestination(from: url) != nil { return true }
         if url.scheme == nil {
             return url.path.hasPrefix("/")
@@ -311,5 +311,20 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         let relative = String(absolutePath.dropFirst(prefix.count))
         guard !relative.isEmpty, relative != ".", !relative.hasPrefix("../") else { return nil }
         return relative
+    }
+}
+
+enum FeatureWorkspaceFileLinkRoute: Equatable {
+    case open(FeatureWorkspaceFileLink)
+    case rejectedWorkspaceDestination
+    case external
+
+    static func resolve(url: URL, workspaceRoot: String?) -> Self {
+        if let link = FeatureWorkspaceFileLink(url: url, workspaceRoot: workspaceRoot) {
+            return .open(link)
+        }
+        return FeatureWorkspaceFileLink.isWorkspaceDestination(url)
+            ? .rejectedWorkspaceDestination
+            : .external
     }
 }

--- a/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
+++ b/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Resolves transcript destinations to paths accepted by the workspace file APIs.
+/// The server expects workspace-relative paths, so absolute destinations must remain
+/// inside the active workspace and relative destinations must not escape it.
+public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hashable {
+    private static let conventionalFileNames: Set<String> = [
+        "AUTHORS", "Brewfile", "BUILD", "Caddyfile", "CHANGELOG", "CODEOWNERS",
+        "Containerfile", "CONTRIBUTORS", "COPYING", "Dockerfile", "Fastfile",
+        "Gemfile", "GNUmakefile", "Jenkinsfile", "Justfile", "LICENSE", "LICENCE",
+        "Makefile", "NOTICE", "Podfile", "Procfile", "README", "Rakefile",
+        "Vagrantfile", "WORKSPACE", "justfile", "makefile",
+    ]
+
+    private static let positionedPathExtensions: Set<String> = [
+        "c", "cc", "conf", "cpp", "cs", "css", "csv", "env", "go", "h", "hpp",
+        "html", "ini", "java", "js", "json", "jsx", "kt", "kts", "m", "md",
+        "mdx", "mm", "php", "plist", "py", "rb", "rs", "scss", "sh", "sql",
+        "swift", "text", "toml", "ts", "tsx", "txt", "vue", "xml", "yaml",
+        "yml", "zsh",
+    ]
+
+    public let path: String
+    public var id: String { path }
+
+    public var entry: FeatureFileEntry {
+        FeatureFileEntry(
+            path: path,
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            kind: .file
+        )
+    }
+
+    public init?(url: URL, workspaceRoot: String?) {
+        guard let workspaceRoot, !workspaceRoot.isEmpty,
+              url.host == nil, url.user == nil, url.password == nil, url.port == nil else {
+            return nil
+        }
+
+        let destination: ParsedDestination
+        switch url.scheme?.lowercased() {
+        case nil:
+            destination = Self.parsePosition(from: url.path)
+        case "file":
+            destination = Self.parsePosition(from: url.path)
+        default:
+            guard let positioned = Self.positionedRelativeDestination(from: url) else {
+                return nil
+            }
+            destination = positioned
+        }
+
+        guard !destination.path.isEmpty,
+              !destination.path.contains(":"),
+              !destination.path.unicodeScalars.contains(where: { $0.value == 0 }) else {
+            return nil
+        }
+
+        if !destination.path.hasPrefix("/"), !destination.path.contains("/"),
+           !Self.isRecognizableFilePath(destination.path) {
+            return nil
+        }
+
+        let root = (workspaceRoot as NSString).standardizingPath
+        let absolute: String
+        if destination.path.hasPrefix("/") {
+            absolute = (destination.path as NSString).standardizingPath
+        } else {
+            absolute = ((root as NSString).appendingPathComponent(destination.path) as NSString)
+                .standardizingPath
+        }
+
+        guard let relative = Self.relativePath(for: absolute, in: root) else { return nil }
+        path = relative
+    }
+
+    public static func isWorkspaceDestination(_ url: URL) -> Bool {
+        guard url.host == nil, url.user == nil, url.password == nil, url.port == nil else {
+            return false
+        }
+        if url.scheme?.lowercased() == "file" { return true }
+        if url.scheme == nil {
+            return url.path.hasPrefix("/")
+                || url.path.contains("/")
+                || isRecognizableFilePath(parsePosition(from: url.path).path)
+        }
+        return positionedRelativeDestination(from: url) != nil
+    }
+
+    private struct ParsedDestination {
+        var path: String
+        var line: Int?
+        var column: Int?
+    }
+
+    private static func positionedRelativeDestination(from url: URL) -> ParsedDestination? {
+        let raw = url.absoluteString
+            .split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+            .split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)[0]
+        let decoded = String(raw).removingPercentEncoding ?? String(raw)
+        let destination = parsePosition(from: decoded)
+        guard destination.line != nil, isRecognizableFilePath(destination.path) else { return nil }
+        return destination
+    }
+
+    private static func parsePosition(from rawPath: String) -> ParsedDestination {
+        var path = rawPath
+        var trailingNumbers: [Int] = []
+        while trailingNumbers.count < 2, let separator = path.lastIndex(of: ":") {
+            let suffix = path[path.index(after: separator)...]
+            guard !suffix.isEmpty, suffix.allSatisfy(\.isNumber), let value = Int(suffix) else {
+                break
+            }
+            trailingNumbers.append(value)
+            path.removeSubrange(separator...)
+        }
+        return ParsedDestination(
+            path: path,
+            line: trailingNumbers.last,
+            column: trailingNumbers.count == 2 ? trailingNumbers.first : nil
+        )
+    }
+
+    private static func isRecognizableFilePath(_ path: String) -> Bool {
+        let name = (path as NSString).lastPathComponent
+        if conventionalFileNames.contains(name) { return true }
+        let fileExtension = (name as NSString).pathExtension.lowercased()
+        return positionedPathExtensions.contains(fileExtension)
+    }
+
+    private static func relativePath(for absolutePath: String, in root: String) -> String? {
+        guard absolutePath != root else { return nil }
+        let prefix = root == "/" ? root : root + "/"
+        guard absolutePath.hasPrefix(prefix) else { return nil }
+        let relative = String(absolutePath.dropFirst(prefix.count))
+        guard !relative.isEmpty, relative != ".", !relative.hasPrefix("../") else { return nil }
+        return relative
+    }
+}

--- a/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
+++ b/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
@@ -106,6 +106,7 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
             return false
         }
         if url.scheme?.lowercased() == "file" { return true }
+        if positionedWindowsAbsoluteDestination(from: url) != nil { return true }
         if url.scheme == nil {
             return url.path.hasPrefix("/")
                 || url.path.contains("/")
@@ -120,17 +121,23 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         var column: Int?
     }
 
+    private enum WindowsRoot {
+        case drive(String)
+        case unc(server: String, share: String)
+    }
+
     private struct WindowsAbsolutePath {
-        var drive: String
+        var root: WindowsRoot
         var components: [String]
     }
 
     private static func nonBlank(_ value: String?) -> String? {
-        guard let value,
-              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
             return nil
         }
-        return value
+        return trimmed
     }
 
     private static func positionedWindowsAbsoluteDestination(from url: URL) -> ParsedDestination? {
@@ -205,13 +212,17 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
             absolute = normalizedDestination
         } else {
             guard !destination.hasPrefix("/") else { return nil }
-            let rootText = "\(normalizedRoot.drive):/\(normalizedRoot.components.joined(separator: "/"))"
+            let rootPrefix = switch normalizedRoot.root {
+            case let .drive(drive): "\(drive):/"
+            case let .unc(server, share): "//\(server)/\(share)/"
+            }
+            let rootText = rootPrefix + normalizedRoot.components.joined(separator: "/")
             guard let normalizedDestination = windowsAbsolutePath(rootText + "/" + destination) else {
                 return nil
             }
             absolute = normalizedDestination
         }
-        guard absolute.drive.caseInsensitiveCompare(normalizedRoot.drive) == .orderedSame,
+        guard windowsRootsMatch(absolute.root, normalizedRoot.root),
               absolute.components.count > normalizedRoot.components.count else {
             return nil
         }
@@ -228,8 +239,20 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         var path = rawPath
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: "\\", with: "/")
-        if path.hasPrefix("/"), path.dropFirst().dropFirst(1).first == ":" {
+        if path.hasPrefix("/"), !path.hasPrefix("//"), path.dropFirst().dropFirst(1).first == ":" {
             path.removeFirst()
+        }
+        if path.hasPrefix("//") {
+            let parts = path.dropFirst(2).split(separator: "/", omittingEmptySubsequences: true)
+            guard parts.count >= 2 else { return nil }
+            let server = String(parts[0])
+            let share = String(parts[1])
+            guard isValidWindowsComponent(server), isValidWindowsComponent(share) else { return nil }
+            guard let components = normalizedWindowsComponents(parts.dropFirst(2)) else { return nil }
+            return WindowsAbsolutePath(
+                root: .unc(server: server, share: share),
+                components: components
+            )
         }
         let scalars = Array(path.unicodeScalars.prefix(3))
         guard scalars.count == 3,
@@ -239,8 +262,16 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
             return nil
         }
 
+        guard let components = normalizedWindowsComponents(
+            path.dropFirst(3).split(separator: "/", omittingEmptySubsequences: true)
+        ) else { return nil }
+        return WindowsAbsolutePath(root: .drive(String(scalars[0])), components: components)
+    }
+
+    private static func normalizedWindowsComponents<S: Sequence>(_ raw: S) -> [String]?
+    where S.Element: StringProtocol {
         var components: [String] = []
-        for component in path.dropFirst(3).split(separator: "/", omittingEmptySubsequences: true) {
+        for component in raw {
             switch component {
             case ".":
                 continue
@@ -248,14 +279,29 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
                 guard !components.isEmpty else { return nil }
                 components.removeLast()
             default:
-                guard !component.contains(":"),
-                      !component.unicodeScalars.contains(where: { $0.value == 0 }) else {
-                    return nil
-                }
+                guard isValidWindowsComponent(component) else { return nil }
                 components.append(String(component))
             }
         }
-        return WindowsAbsolutePath(drive: String(scalars[0]), components: components)
+        return components
+    }
+
+    private static func isValidWindowsComponent(_ component: some StringProtocol) -> Bool {
+        !component.isEmpty
+            && !component.contains(":")
+            && !component.unicodeScalars.contains(where: { $0.value == 0 })
+    }
+
+    private static func windowsRootsMatch(_ lhs: WindowsRoot, _ rhs: WindowsRoot) -> Bool {
+        switch (lhs, rhs) {
+        case let (.drive(left), .drive(right)):
+            left.caseInsensitiveCompare(right) == .orderedSame
+        case let (.unc(leftServer, leftShare), .unc(rightServer, rightShare)):
+            leftServer.caseInsensitiveCompare(rightServer) == .orderedSame
+                && leftShare.caseInsensitiveCompare(rightShare) == .orderedSame
+        default:
+            false
+        }
     }
 
     private static func relativePath(for absolutePath: String, in root: String) -> String? {

--- a/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
+++ b/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
@@ -31,27 +31,43 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         )
     }
 
+    static func resolvedWorkspaceRoot(worktreePath: String?, projectPath: String?) -> String? {
+        if let worktreePath = Self.nonBlank(worktreePath) {
+            return worktreePath
+        }
+        return Self.nonBlank(projectPath)
+    }
+
     public init?(url: URL, workspaceRoot: String?) {
-        guard let workspaceRoot, !workspaceRoot.isEmpty,
+        guard let workspaceRoot = Self.nonBlank(workspaceRoot),
               url.host == nil, url.user == nil, url.password == nil, url.port == nil else {
             return nil
         }
 
-        let destination: ParsedDestination
-        switch url.scheme?.lowercased() {
-        case nil:
-            destination = Self.parsePosition(from: url.path)
-        case "file":
-            destination = Self.parsePosition(from: url.path)
-        default:
-            guard let positioned = Self.positionedRelativeDestination(from: url) else {
-                return nil
-            }
+        let usesWindowsPaths = Self.windowsAbsolutePath(workspaceRoot) != nil
+        var destination: ParsedDestination
+        if usesWindowsPaths,
+           let positioned = Self.positionedWindowsAbsoluteDestination(from: url) {
             destination = positioned
+        } else {
+            switch url.scheme?.lowercased() {
+            case nil:
+                destination = Self.parsePosition(from: url.path)
+            case "file":
+                destination = Self.parsePosition(from: url.path)
+            default:
+                guard let positioned = Self.positionedRelativeDestination(from: url) else {
+                    return nil
+                }
+                destination = positioned
+            }
+        }
+        if usesWindowsPaths {
+            destination.path = destination.path.replacingOccurrences(of: "\\", with: "/")
         }
 
         guard !destination.path.isEmpty,
-              !destination.path.contains(":"),
+              !Self.containsDisallowedColon(destination.path, usesWindowsPaths: usesWindowsPaths),
               !destination.path.unicodeScalars.contains(where: { $0.value == 0 }) else {
             return nil
         }
@@ -59,6 +75,17 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         if !destination.path.hasPrefix("/"), !destination.path.contains("/"),
            !Self.isRecognizableFilePath(destination.path) {
             return nil
+        }
+
+        if usesWindowsPaths {
+            guard let relative = Self.windowsRelativePath(
+                for: destination.path,
+                in: workspaceRoot
+            ) else {
+                return nil
+            }
+            path = relative
+            return
         }
 
         let root = (workspaceRoot as NSString).standardizingPath
@@ -91,6 +118,39 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         var path: String
         var line: Int?
         var column: Int?
+    }
+
+    private struct WindowsAbsolutePath {
+        var drive: String
+        var components: [String]
+    }
+
+    private static func nonBlank(_ value: String?) -> String? {
+        guard let value,
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func positionedWindowsAbsoluteDestination(from url: URL) -> ParsedDestination? {
+        let raw: String
+        if url.scheme?.lowercased() == "file" {
+            raw = url.path
+        } else {
+            raw = url.absoluteString
+                .split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+                .split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)[0]
+                .description
+        }
+        let decoded = raw.removingPercentEncoding ?? raw
+        var destination = parsePosition(from: decoded)
+        if destination.path.hasPrefix("/"),
+           windowsAbsolutePath(String(destination.path.dropFirst())) != nil {
+            destination.path.removeFirst()
+        }
+        guard windowsAbsolutePath(destination.path) != nil else { return nil }
+        return destination
     }
 
     private static func positionedRelativeDestination(from url: URL) -> ParsedDestination? {
@@ -126,6 +186,76 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         if conventionalFileNames.contains(name) { return true }
         let fileExtension = (name as NSString).pathExtension.lowercased()
         return positionedPathExtensions.contains(fileExtension)
+    }
+
+    private static func containsDisallowedColon(
+        _ path: String,
+        usesWindowsPaths: Bool
+    ) -> Bool {
+        guard usesWindowsPaths, windowsAbsolutePath(path) != nil else {
+            return path.contains(":")
+        }
+        return path.dropFirst(2).contains(":")
+    }
+
+    private static func windowsRelativePath(for destination: String, in root: String) -> String? {
+        guard let normalizedRoot = windowsAbsolutePath(root) else { return nil }
+        let absolute: WindowsAbsolutePath
+        if let normalizedDestination = windowsAbsolutePath(destination) {
+            absolute = normalizedDestination
+        } else {
+            guard !destination.hasPrefix("/") else { return nil }
+            let rootText = "\(normalizedRoot.drive):/\(normalizedRoot.components.joined(separator: "/"))"
+            guard let normalizedDestination = windowsAbsolutePath(rootText + "/" + destination) else {
+                return nil
+            }
+            absolute = normalizedDestination
+        }
+        guard absolute.drive.caseInsensitiveCompare(normalizedRoot.drive) == .orderedSame,
+              absolute.components.count > normalizedRoot.components.count else {
+            return nil
+        }
+        for (rootComponent, destinationComponent) in zip(
+            normalizedRoot.components,
+            absolute.components
+        ) where rootComponent.caseInsensitiveCompare(destinationComponent) != .orderedSame {
+            return nil
+        }
+        return absolute.components.dropFirst(normalizedRoot.components.count).joined(separator: "/")
+    }
+
+    private static func windowsAbsolutePath(_ rawPath: String) -> WindowsAbsolutePath? {
+        var path = rawPath
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\\", with: "/")
+        if path.hasPrefix("/"), path.dropFirst().dropFirst(1).first == ":" {
+            path.removeFirst()
+        }
+        let scalars = Array(path.unicodeScalars.prefix(3))
+        guard scalars.count == 3,
+              CharacterSet.letters.contains(scalars[0]),
+              scalars[1] == ":",
+              scalars[2] == "/" else {
+            return nil
+        }
+
+        var components: [String] = []
+        for component in path.dropFirst(3).split(separator: "/", omittingEmptySubsequences: true) {
+            switch component {
+            case ".":
+                continue
+            case "..":
+                guard !components.isEmpty else { return nil }
+                components.removeLast()
+            default:
+                guard !component.contains(":"),
+                      !component.unicodeScalars.contains(where: { $0.value == 0 }) else {
+                    return nil
+                }
+                components.append(String(component))
+            }
+        }
+        return WindowsAbsolutePath(drive: String(scalars[0]), components: components)
     }
 
     private static func relativePath(for absolutePath: String, in root: String) -> String? {

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -635,9 +635,12 @@ extension FeatureThread {
             .first(where: { $0.id == projectID })?
             .environmentID
         let resolvedEnvironmentID = environmentID ?? projectEnvironmentID
-        let providers = resolvedEnvironmentID.flatMap {
-            snapshot.providersByEnvironment?[$0]
-        } ?? snapshot.providers
+        let providers: [FeatureProvider]
+        if let providersByEnvironment = snapshot.providersByEnvironment {
+            providers = resolvedEnvironmentID.flatMap { providersByEnvironment[$0] } ?? []
+        } else {
+            providers = snapshot.providers
+        }
         return providers.first(where: { $0.id == providerID })?.name ?? providerID
     }
 

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -637,7 +637,7 @@ extension FeatureThread {
         let resolvedEnvironmentID = environmentID ?? projectEnvironmentID
         let providers = resolvedEnvironmentID.flatMap {
             snapshot.providersByEnvironment?[$0]
-        } ?? []
+        } ?? snapshot.providers
         return providers.first(where: { $0.id == providerID })?.name ?? providerID
     }
 

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -780,9 +780,12 @@ struct HomeThreadRowContext: Equatable {
             let explicitProvider = thread.providerName?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let configuredProvider = thread.providerID.flatMap { providerID in
-                environmentID.flatMap {
-                    snapshot.providersByEnvironment?[$0]?.first(where: { $0.id == providerID })
-                } ?? snapshot.providers.first(where: { $0.id == providerID })
+                if let providersByEnvironment = snapshot.providersByEnvironment {
+                    return environmentID.flatMap {
+                        providersByEnvironment[$0]?.first(where: { $0.id == providerID })
+                    }
+                }
+                return snapshot.providers.first(where: { $0.id == providerID })
             }
             let providerName = (explicitProvider?.isEmpty == false ? explicitProvider : nil)
                 ?? configuredProvider?.name

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -782,7 +782,7 @@ struct HomeThreadRowContext: Equatable {
             let configuredProvider = thread.providerID.flatMap { providerID in
                 environmentID.flatMap {
                     snapshot.providersByEnvironment?[$0]?.first(where: { $0.id == providerID })
-                }
+                } ?? snapshot.providers.first(where: { $0.id == providerID })
             }
             let providerName = (explicitProvider?.isEmpty == false ? explicitProvider : nil)
                 ?? configuredProvider?.name

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -53,6 +53,18 @@ struct FeatureToolStateTests {
         )
         #expect(
             FeatureWorkspaceFileLink.resolvedWorkspaceRoot(
+                worktreePath: "  /repo/worktree \n",
+                projectPath: "/repo"
+            ) == "/repo/worktree"
+        )
+        #expect(
+            FeatureWorkspaceFileLink.resolvedWorkspaceRoot(
+                worktreePath: "  C:\\repo\\worktree \n",
+                projectPath: "C:\\repo"
+            ) == "C:\\repo\\worktree"
+        )
+        #expect(
+            FeatureWorkspaceFileLink.resolvedWorkspaceRoot(
                 worktreePath: "C:\\repo\\worktree",
                 projectPath: "C:\\repo"
             ) == "C:\\repo\\worktree"
@@ -97,6 +109,34 @@ struct FeatureToolStateTests {
         #expect(FeatureWorkspaceFileLink(url: otherDrive, workspaceRoot: "C:\\repo") == nil)
         #expect(FeatureWorkspaceFileLink(url: traversal, workspaceRoot: "C:\\repo") == nil)
         #expect(FeatureWorkspaceFileLink(url: driveRootRelative, workspaceRoot: "C:\\repo") == nil)
+
+        let containedWithoutPosition = try #require(URL(string: "C:/repo/App.swift"))
+        let outsideWithoutPosition = try #require(URL(string: "C:/other/App.swift"))
+        #expect(
+            FeatureWorkspaceFileLink(url: containedWithoutPosition, workspaceRoot: "C:\\repo")?.path
+                == "App.swift"
+        )
+        #expect(FeatureWorkspaceFileLink(url: outsideWithoutPosition, workspaceRoot: "C:\\repo") == nil)
+        #expect(FeatureWorkspaceFileLink.isWorkspaceDestination(outsideWithoutPosition))
+    }
+
+    @Test
+    func workspaceFileLinksResolveContainedUNCPathsAndRejectUNCLeaks() throws {
+        let contained = try #require(URL(string: "%5C%5Cserver%5Cshare%5Crepo%5CSources%5CApp.swift"))
+        let outside = try #require(URL(string: "%5C%5Cserver%5Cshare%5Cother%5CApp.swift"))
+        let otherShare = try #require(URL(string: "%5C%5Cserver%5Cother%5Crepo%5CApp.swift"))
+        let otherServer = try #require(URL(string: "%5C%5Cother%5Cshare%5Crepo%5CApp.swift"))
+        let traversal = try #require(URL(string: "..%5C..%5Csecret.txt"))
+        let authority = try #require(URL(string: "file://server/share/repo/App.swift"))
+        let root = "\\\\server\\share\\repo"
+
+        #expect(FeatureWorkspaceFileLink(url: contained, workspaceRoot: root)?.path == "Sources/App.swift")
+        #expect(FeatureWorkspaceFileLink(url: outside, workspaceRoot: root) == nil)
+        #expect(FeatureWorkspaceFileLink(url: otherShare, workspaceRoot: root) == nil)
+        #expect(FeatureWorkspaceFileLink(url: otherServer, workspaceRoot: root) == nil)
+        #expect(FeatureWorkspaceFileLink(url: traversal, workspaceRoot: root) == nil)
+        // UNC links are accepted in serialized path form; file URL authorities remain external.
+        #expect(FeatureWorkspaceFileLink(url: authority, workspaceRoot: root) == nil)
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -44,6 +44,62 @@ struct FeatureToolStateTests {
     }
 
     @Test
+    func workspaceFileLinksUseProjectPathWhenWorktreePathIsBlank() {
+        #expect(
+            FeatureWorkspaceFileLink.resolvedWorkspaceRoot(
+                worktreePath: "  \n",
+                projectPath: "/repo"
+            ) == "/repo"
+        )
+        #expect(
+            FeatureWorkspaceFileLink.resolvedWorkspaceRoot(
+                worktreePath: "C:\\repo\\worktree",
+                projectPath: "C:\\repo"
+            ) == "C:\\repo\\worktree"
+        )
+    }
+
+    @Test
+    func workspaceFileLinksResolveContainedWindowsPaths() throws {
+        let forwardSlash = try #require(URL(string: "C:/repo/Sources/App.swift:42"))
+        #expect(
+            FeatureWorkspaceFileLink(
+                url: forwardSlash,
+                workspaceRoot: "c:\\Repo"
+            )?.path == "Sources/App.swift"
+        )
+
+        let backslash = try #require(URL(string: "C:%5CRepo%5CSources%5CApp.swift:42:7"))
+        #expect(
+            FeatureWorkspaceFileLink(
+                url: backslash,
+                workspaceRoot: "C:/repo/"
+            )?.path == "Sources/App.swift"
+        )
+
+        let fileURL = try #require(URL(string: "file:///C:/repo/Sources/App.swift:42"))
+        #expect(
+            FeatureWorkspaceFileLink(
+                url: fileURL,
+                workspaceRoot: "C:/repo"
+            )?.path == "Sources/App.swift"
+        )
+    }
+
+    @Test
+    func workspaceFileLinksRejectWindowsEscapesAndOtherDrives() throws {
+        let outside = try #require(URL(string: "C:/other/App.swift:42"))
+        let otherDrive = try #require(URL(string: "D:/repo/App.swift:42"))
+        let traversal = try #require(URL(string: "../secret.txt"))
+        let driveRootRelative = try #require(URL(string: "file:///Windows/System32/config.txt"))
+
+        #expect(FeatureWorkspaceFileLink(url: outside, workspaceRoot: "C:\\repo") == nil)
+        #expect(FeatureWorkspaceFileLink(url: otherDrive, workspaceRoot: "C:\\repo") == nil)
+        #expect(FeatureWorkspaceFileLink(url: traversal, workspaceRoot: "C:\\repo") == nil)
+        #expect(FeatureWorkspaceFileLink(url: driveRootRelative, workspaceRoot: "C:\\repo") == nil)
+    }
+
+    @Test
     func workspaceFileLinksStripLineAndColumnPositions() throws {
         let relative = try #require(URL(string: "Sources/App.swift:42:7"))
         let link = try #require(FeatureWorkspaceFileLink(url: relative, workspaceRoot: "/repo"))

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import T3Code
 
@@ -25,6 +26,64 @@ struct FeatureToolStateTests {
         #expect(FeatureFilePreviewKind.infer(path: "Package.swift") == .source)
         #expect(FeatureFilePreviewKind.infer(path: "LICENSE") == .plainText)
         #expect(FeatureFilePreviewKind.infer(path: "template", language: "html") == .source)
+    }
+
+    @Test
+    func workspaceFileLinksResolveRelativeAndContainedAbsolutePaths() throws {
+        let relative = try #require(URL(string: "docs/My%20Notes.txt#L12"))
+        #expect(
+            FeatureWorkspaceFileLink(url: relative, workspaceRoot: "/repo")?.path
+                == "docs/My Notes.txt"
+        )
+
+        let absolute = URL(fileURLWithPath: "/repo/Sources/App.swift")
+        #expect(
+            FeatureWorkspaceFileLink(url: absolute, workspaceRoot: "/repo")?.path
+                == "Sources/App.swift"
+        )
+    }
+
+    @Test
+    func workspaceFileLinksStripLineAndColumnPositions() throws {
+        let relative = try #require(URL(string: "Sources/App.swift:42:7"))
+        let link = try #require(FeatureWorkspaceFileLink(url: relative, workspaceRoot: "/repo"))
+        #expect(link.path == "Sources/App.swift")
+
+        let readme = try #require(URL(string: "README.md:12"))
+        #expect(FeatureWorkspaceFileLink(url: readme, workspaceRoot: "/repo")?.path == "README.md")
+    }
+
+    @Test
+    func workspaceFileLinksRejectEscapesAuthoritiesSchemesAndOutsidePaths() throws {
+        let rejected = [
+            try #require(URL(string: "../../secret.txt")),
+            try #require(URL(string: "sub/../../secret.txt")),
+            try #require(URL(string: "%2E%2E/secret.txt")),
+            try #require(URL(string: "//example.com/repo/README.md")),
+            try #require(URL(string: "tel:123")),
+            try #require(URL(string: "org.example:123")),
+            URL(fileURLWithPath: "/other/secret.txt"),
+        ]
+        for url in rejected {
+            #expect(FeatureWorkspaceFileLink(url: url, workspaceRoot: "/repo") == nil)
+        }
+
+        let trailingRoot = URL(fileURLWithPath: "/repo/Sources/App.swift")
+        #expect(
+            FeatureWorkspaceFileLink(url: trailingRoot, workspaceRoot: "/repo/")?.path
+                == "Sources/App.swift"
+        )
+
+        let rootFile = URL(fileURLWithPath: "/README.md")
+        #expect(FeatureWorkspaceFileLink(url: rootFile, workspaceRoot: "/")?.path == "README.md")
+    }
+
+    @Test
+    func remoteLinksRemainOutsideWorkspaceRouting() throws {
+        let remote = try #require(URL(string: "https://example.com/readme.txt"))
+        #expect(FeatureWorkspaceFileLink(url: remote, workspaceRoot: "/repo") == nil)
+        let bareDomain = try #require(URL(string: "www.example.com"))
+        #expect(FeatureWorkspaceFileLink(url: bareDomain, workspaceRoot: "/repo") == nil)
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -135,8 +135,15 @@ struct FeatureToolStateTests {
         #expect(FeatureWorkspaceFileLink(url: otherShare, workspaceRoot: root) == nil)
         #expect(FeatureWorkspaceFileLink(url: otherServer, workspaceRoot: root) == nil)
         #expect(FeatureWorkspaceFileLink(url: traversal, workspaceRoot: root) == nil)
-        // UNC links are accepted in serialized path form; file URL authorities remain external.
+        // UNC links are accepted in serialized path form; file URL authorities fail closed.
         #expect(FeatureWorkspaceFileLink(url: authority, workspaceRoot: root) == nil)
+        #expect(FeatureWorkspaceFileLink.isWorkspaceDestination(authority))
+        #expect(
+            FeatureWorkspaceFileLinkRoute.resolve(url: authority, workspaceRoot: root)
+                == .rejectedWorkspaceDestination
+        )
+        let web = try #require(URL(string: "https://example.com/App.swift"))
+        #expect(FeatureWorkspaceFileLinkRoute.resolve(url: web, workspaceRoot: root) == .external)
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -157,6 +157,18 @@ struct FeatureToolStateTests {
     }
 
     @Test
+    func workspaceDirectoryLinksPreserveDirectoryKind() throws {
+        let directory = URL(fileURLWithPath: "/repo/Sources", isDirectory: true)
+        let link = try #require(
+            FeatureWorkspaceFileLink(url: directory, workspaceRoot: "/repo")
+        )
+
+        #expect(link.path == "Sources")
+        #expect(link.kind == .directory)
+        #expect(link.entry.kind == .directory)
+    }
+
+    @Test
     func workspaceFileLinksRejectEscapesAuthoritiesSchemesAndOutsidePaths() throws {
         let rejected = [
             try #require(URL(string: "../../secret.txt")),

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -195,4 +195,36 @@ struct HomeThreadMetadataTests {
             ) == nil
         )
     }
+
+    @Test
+    func environmentCatalogMissDoesNotUseLegacyProviders() throws {
+        let thread = FeatureThread(
+            id: "thread",
+            projectID: "project",
+            title: "Use provider",
+            providerID: "shared-id"
+        )
+        let snapshot = FeatureSnapshot(
+            projects: [
+                FeatureProject(
+                    id: "project",
+                    environmentID: "remote",
+                    name: "Remote",
+                    path: "/remote"
+                ),
+            ],
+            threads: [thread],
+            providers: [
+                FeatureProvider(id: "shared-id", name: "Wrong environment", driver: "codex"),
+            ],
+            providersByEnvironment: ["local": [
+                FeatureProvider(id: "shared-id", name: "Local only", driver: "codex"),
+            ]]
+        )
+
+        #expect(thread.homeProviderLabel(in: snapshot) == "shared-id")
+        let context = try #require(HomeThreadRowContext.index(snapshot: snapshot)[thread.id])
+        #expect(context.providerName == "shared-id")
+        #expect(context.providerDriver == "shared-id")
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
@@ -263,4 +263,19 @@ struct MarkdownDocumentTests {
         #expect(runs.contains { $0.inlinePresentationIntent?.contains(.code) == true })
         #expect(runs.contains { $0.link == URL(string: "https://example.com") })
     }
+
+    @Test @MainActor
+    func recycledMarkdownLinkRelayUsesItsLatestHandler() throws {
+        let relay = MarkdownLinkActionRelay()
+        let url = try #require(URL(string: "Sources/App.swift"))
+        var firstHandlerCount = 0
+        var currentHandlerCount = 0
+
+        relay.handler = { _ in firstHandlerCount += 1 }
+        relay.handler = { _ in currentHandlerCount += 1 }
+        relay.open(url)
+
+        #expect(firstHandlerCount == 0)
+        #expect(currentHandlerCount == 1)
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/MarkdownOpenURLDispositionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/MarkdownOpenURLDispositionTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+struct MarkdownOpenURLDispositionTests {
+    @Test(arguments: [
+        "file:///private/other/App.swift",
+        "file://server/share/repo/App.swift",
+        "FiLe:///private/other/App.swift",
+    ])
+    func unhandledFileURLIsDiscarded(_ rawURL: String) throws {
+        let url = try #require(URL(string: rawURL))
+
+        #expect(MarkdownOpenURLDisposition.resolve(url: url, onOpenURL: nil) == .discarded)
+    }
+
+    @Test
+    func unhandledWebURLUsesSystemAction() throws {
+        let url = try #require(URL(string: "https://example.com/docs"))
+
+        #expect(MarkdownOpenURLDisposition.resolve(url: url, onOpenURL: nil) == .systemAction)
+    }
+
+    @Test
+    func explicitlyHandledURLIsHandled() throws {
+        let url = try #require(URL(string: "file:///repo/App.swift"))
+
+        #expect(
+            MarkdownOpenURLDisposition.resolve(url: url, onOpenURL: { _ in true }) == .handled
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- Makes workspace-file links in native SwiftUI transcripts tappable inside recycled `UICollectionView` cells while preserving text selection across linked text.
- Resolves repository-relative and contained absolute paths, strips `:line[:column]`, and opens the existing Files preview.
- Keeps ordinary web URLs on the system path and rejects authorities, traversal, and paths outside the workspace.

This is deliberately limited to transcript → existing Files preview. It does not add recursive navigation between Markdown file previews or change server, wire, web, React Native, signing, or release behavior.

Base: `pingdotgg/t3code:t3code/rebuild-mobile-app-swift` at `e55c7ffd1` (owner PR #5178).  
Reviewed head: `2ce29335a0a9e8a820a5c0d89da4434a8d0e9242` (tree-identical metadata refresh after an unrelated WebKit simulator flake).

## Why

SwiftUI `Text(AttributedString)` links hosted through `UIHostingConfiguration` were rendered as links but did not reliably receive taps. The overlay is limited to linked glyphs and disables its own hit testing while text-selection mode is active, so transcript scrolling and selection remain unchanged.

Ambiguous dotted bare destinations such as `README.md:42` can also be custom URL schemes, so they remain on the system path; use the explicit relative form `./README.md:42`. Slash-containing relative paths and conventional extensionless names such as `Makefile:12` remain supported.

## UI evidence

Before:

![Workspace link before tap](https://raw.githubusercontent.com/saphid/t3code/agent/pr-media-swiftui-file-links/pr-media/5803/before.jpg)

After — exact rebased head opening the existing workspace preview:

![Workspace file preview](https://github.com/saphid/t3code/releases/download/pr-evidence-20260809/pr5803-rebased-workspace-preview.jpg)

![Tap workspace link and open Files preview](https://raw.githubusercontent.com/saphid/t3code/agent/pr-media-swiftui-file-links/pr-media/5803/interaction.gif)

[Full-resolution MP4](https://github.com/saphid/t3code/raw/refs/heads/agent/pr-media-swiftui-file-links/pr-media/5803/interaction.mp4)

## Verification

- `T3CodeTests/FeatureToolStateTests`: passed again on the final reviewed head (21 test cases, 0 failed).
- Full native gate: 223 tests in 27 suites passed on the exact rebased head.
- Exact-head integrated iOS run: a seeded `CONTRIBUTING.md:1` transcript link was exposed as a semantic link target and opened `workspace-file-preview` with the expected file.
- `git diff --check`: passed; rebase preserved the feature patch exactly.
- GPT-5.6 Sol high reviewed the frozen head, the MacroScope follow-up fix, and the text-selection hit-testing fix: no actionable findings; judged minimally scoped for the bug.
- Direct Claude Opus 5 high review attempt: Claude Code 2.1.224, exit 1, HTTP 429 weekly-limit response before review; no Claude findings are claimed.
- MacroScope's custom-scheme finding is fixed and covered by `org.example:123`, ambiguous bare-file, explicit-relative-file, and conventional extensionless-file cases. Cursor's text-selection finding is fixed by disabling only the invisible link overlay's hit testing while selection mode is active. MacroScope correctness passed on the identical reviewed tree, Cursor passed on the final metadata-only head, and MacroScope approvability defers this user-facing change to human review.
- The first final-head native CI attempt hit the repository's existing `ProjectFaviconStoreTests.svgFaviconsAreRasterizedBeforeCaching()` iOS 27 WebKit GPU-process timeout. The commit metadata was refreshed to rerun CI; tree SHA `69cd4cae8fe3e8606ea34f00cd3efd65548271e8` and stable patch ID `dcaf0513e45ce447433da2c650bc93c573d788e8` are unchanged.

## Checklist

- [x] Small, focused bug fix
- [x] Explained what changed and why
- [x] Before/after UI evidence and interaction video
- [x] Focused tests, full native gate, and exact-head simulator proof
- [x] Independent Sol-high minimum-change review
- [x] Current fixed-head CI/MacroScope complete

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New path parsing and workspace boundary checks must reject traversal and out-of-root paths; link overlay touch handling interacts with text selection in recycled cells, though both areas have broad tests.
> 
> **Overview**
> Makes **workspace file links** in native chat markdown tappable and routes them into the existing **Files** preview sheet, while **https** links still use the system browser.
> 
> **Markdown** gains an optional `onOpenURL` callback, a `MarkdownOpenURLDisposition` helper (unhandled `file:` URLs are **discarded** instead of opening externally), and a **UIKit link hit-test overlay** on linked text so taps work inside recycled transcript cells; the overlay turns off during **Select text** mode.
> 
> **Thread detail** resolves taps via new `FeatureWorkspaceFileLink` / `FeatureWorkspaceFileLinkRoute` logic (POSIX, Windows, UNC, relative paths, `:line[:column]`, workspace containment) and shows an alert when a link looks like a workspace path but is rejected.
> 
> A small **provider label** fix stops using global `snapshot.providers` when `providersByEnvironment` exists but has no entry for the thread’s environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b377392739d629c1f857de320634eb32f1b4fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open workspace file links from markdown messages in the iOS chat transcript
> - Tapping a file or directory link in a chat message opens a preview sheet scoped to the active workspace; unsupported workspace destinations show an alert and external links fall back to system handling.
> - Adds `MarkdownLinkInteractionView` (UIKit) with precise glyph-level hit-testing for inline links, bridged into SwiftUI via `MarkdownLinkInteractionOverlay`; link taps are disabled while text selection is active.
> - Adds `FeatureWorkspaceFileLink` to validate and normalize POSIX, Windows drive, and UNC paths, preventing workspace escapes and stripping line/column positions.
> - Fixes provider label resolution in `FeatureThread.homeProviderLabel` and `HomeThreadRowContext` to fall back to the global providers list when the environment-scoped catalog is missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b37739.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable with runnable checks green; requested review changes remain. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
