### PR TITLE
feat(swift-ios): link thread rows to pull requests

### DIFF
--- a/apps/swift-ios/Features/Shared/FeatureToolModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureToolModels.swift
@@ -825,6 +825,19 @@ public struct FeaturePullRequest: Sendable, Equatable, Hashable, Codable {
         self.state = state
         self.url = url
     }
+
+    /// Only hand credential-free web destinations to the system browser.
+    public var safeExternalURL: URL? {
+        guard let url,
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host?.isEmpty == false,
+              url.user == nil,
+              url.password == nil else {
+            return nil
+        }
+        return url
+    }
 }
 
 public enum FeatureSourceControlAction: String, CaseIterable, Sendable, Codable {

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -635,9 +635,12 @@ extension FeatureThread {
             .first(where: { $0.id == projectID })?
             .environmentID
         let resolvedEnvironmentID = environmentID ?? projectEnvironmentID
-        let providers = resolvedEnvironmentID.flatMap {
-            snapshot.providersByEnvironment?[$0]
-        } ?? snapshot.providers
+        let providers: [FeatureProvider]
+        if let providersByEnvironment = snapshot.providersByEnvironment {
+            providers = resolvedEnvironmentID.flatMap { providersByEnvironment[$0] } ?? []
+        } else {
+            providers = snapshot.providers
+        }
         return providers.first(where: { $0.id == providerID })?.name ?? providerID
     }
 

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -637,7 +637,7 @@ extension FeatureThread {
         let resolvedEnvironmentID = environmentID ?? projectEnvironmentID
         let providers = resolvedEnvironmentID.flatMap {
             snapshot.providersByEnvironment?[$0]
-        } ?? []
+        } ?? snapshot.providers
         return providers.first(where: { $0.id == providerID })?.name ?? providerID
     }
 

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -362,7 +362,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
         private func loadPullRequestIfNeeded(for thread: FeatureThread) {
             guard let key = HomeThreadPullRequestLookupKey(thread: thread),
-                  pullRequestResolutions[key] == nil,
+                  pullRequestResolutions[key]?.needsLoad(at: .now) ?? true,
                   pullRequestTasks[key] == nil else { return }
             let token = UUID()
             let client = parent.projectFaviconClient
@@ -374,12 +374,14 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 } catch {
                     guard let self, pullRequestTasks[key]?.token == token else { return }
                     pullRequestTasks[key] = nil
+                    pullRequestResolutions[key] = .failed(at: .now)
+                    reconfigureThreadRows(matching: key)
                     return
                 }
                 guard !Task.isCancelled, let self,
                       pullRequestTasks[key]?.token == token else { return }
                 pullRequestTasks[key] = nil
-                pullRequestResolutions[key] = .resolved(presentation)
+                pullRequestResolutions[key] = .cached(presentation, at: .now)
                 reconfigureThreadRows(matching: key)
             }
             pullRequestTasks[key] = (token, task)
@@ -796,12 +798,30 @@ struct HomeThreadPullRequestLookupKey: Hashable {
     }
 }
 
-private enum HomeThreadPullRequestResolution {
-    case resolved(HomeThreadPullRequestPresentation?)
+enum HomeThreadPullRequestResolution {
+    private static let cacheLifetime: TimeInterval = 5 * 60
+    private static let failureRetryDelay: TimeInterval = 10
+
+    private case resolved(HomeThreadPullRequestPresentation?, expiresAt: Date)
+    private case retryAfter(Date)
+
+    static func cached(_ presentation: HomeThreadPullRequestPresentation?, at date: Date) -> Self {
+        .resolved(presentation, expiresAt: date.addingTimeInterval(cacheLifetime))
+    }
+
+    static func failed(at date: Date) -> Self {
+        .retryAfter(date.addingTimeInterval(failureRetryDelay))
+    }
 
     var presentation: HomeThreadPullRequestPresentation? {
+        guard case let .resolved(presentation, _) = self else { return nil }
+        return presentation
+    }
+
+    func needsLoad(at date: Date) -> Bool {
         switch self {
-        case let .resolved(presentation): presentation
+        case let .resolved(_, expiresAt): expiresAt <= date
+        case let .retryAfter(retryAfter): retryAfter <= date
         }
     }
 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -802,8 +802,8 @@ enum HomeThreadPullRequestResolution {
     private static let cacheLifetime: TimeInterval = 5 * 60
     private static let failureRetryDelay: TimeInterval = 10
 
-    private case resolved(HomeThreadPullRequestPresentation?, expiresAt: Date)
-    private case retryAfter(Date)
+    case resolved(HomeThreadPullRequestPresentation?, expiresAt: Date)
+    case retryAfter(Date)
 
     static func cached(_ presentation: HomeThreadPullRequestPresentation?, at date: Date) -> Self {
         .resolved(presentation, expiresAt: date.addingTimeInterval(cacheLifetime))

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -59,6 +59,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
     static func dismantleUIView(_ collectionView: UICollectionView, coordinator: Coordinator) {
         coordinator.invalidateTimer()
+        coordinator.invalidatePullRequestLookups()
         collectionView.delegate = nil
     }
 
@@ -77,6 +78,12 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         private var timer: Timer?
         private var timerTick = 0
         private var timerInterval: TimeInterval = 0
+        private var pullRequestResolutions: [
+            HomeThreadPullRequestLookupKey: HomeThreadPullRequestResolution
+        ] = [:]
+        private var pullRequestTasks: [
+            HomeThreadPullRequestLookupKey: (token: UUID, task: Task<Void, Never>)
+        ] = [:]
 
         init(parent: HomeThreadCollectionView) {
             self.parent = parent
@@ -117,6 +124,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 seenIdentifiers.insert(item.id).inserted
             }
             itemsByID = Dictionary(uniqueKeysWithValues: items.map { ($0.id, $0) })
+            prunePullRequestLookups(to: Set(items.compactMap(\.pullRequestLookupKey)))
             // After items land: picks 1 Hz when a working thread is present,
             // 60s otherwise, and is a no-op when the interval is unchanged.
             startTimer()
@@ -149,6 +157,12 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         func invalidateTimer() {
             timer?.invalidate()
             timer = nil
+        }
+
+        func invalidatePullRequestLookups() {
+            pullRequestTasks.values.forEach { $0.task.cancel() }
+            pullRequestTasks.removeAll()
+            pullRequestResolutions.removeAll()
         }
 
         func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -250,12 +264,21 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             now: Date
         ) {
             guard let item = itemsByID[identifier] else { return }
+            let pullRequest: HomeThreadPullRequestPresentation?
+            if case let .thread(thread, _, _, _, _) = item {
+                loadPullRequestIfNeeded(for: thread)
+                pullRequest = HomeThreadPullRequestLookupKey(thread: thread)
+                    .flatMap { pullRequestResolutions[$0]?.presentation }
+            } else {
+                pullRequest = nil
+            }
             cell.contentConfiguration = UIHostingConfiguration {
                 HomeCollectionCellContent(
                     item: item,
                     projectFaviconClient: parent.projectFaviconClient,
                     isSelected: identifier.threadID == selectedThreadID,
-                    now: now
+                    now: now,
+                    pullRequest: pullRequest
                 )
             }
             .margins(.all, 0)
@@ -268,6 +291,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         }
 
         private func configureAccessibility(_ cell: HomeCollectionCell, item: HomeCollectionItem) {
+            cell.accessibilityCustomActions = nil
             switch item {
             case let .thread(thread, context, _, _, _):
                 cell.isAccessibilityElement = true
@@ -275,8 +299,19 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     ? [.button, .selected]
                     : .button
                 cell.accessibilityLabel = thread.title
-                cell.accessibilityValue = threadAccessibilityValue(thread, context: context)
+                let baseValue = threadAccessibilityValue(thread, context: context)
+                cell.accessibilityValue = baseValue
                 cell.accessibilityHint = "Opens task"
+                if let key = HomeThreadPullRequestLookupKey(thread: thread),
+                   let pullRequest = pullRequestResolutions[key]?.presentation {
+                    cell.accessibilityValue = pullRequest.accessibilityValue(appending: baseValue)
+                    cell.accessibilityCustomActions = [
+                        UIAccessibilityCustomAction(name: pullRequest.accessibilityActionName) { _ in
+                            UIApplication.shared.open(pullRequest.destination)
+                            return true
+                        },
+                    ]
+                }
                 cell.onAccessibilityActivate = { [weak self] in
                     guard let self else { return }
                     let previousSelection = self.selectedThreadID
@@ -323,6 +358,51 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 cell.isAccessibilityElement = false
                 cell.onAccessibilityActivate = nil
             }
+        }
+
+        private func loadPullRequestIfNeeded(for thread: FeatureThread) {
+            guard let key = HomeThreadPullRequestLookupKey(thread: thread),
+                  pullRequestResolutions[key] == nil,
+                  pullRequestTasks[key] == nil else { return }
+            let token = UUID()
+            let client = parent.projectFaviconClient
+            let task = Task { [weak self] in
+                let presentation: HomeThreadPullRequestPresentation?
+                do {
+                    let status = try await client.sourceControlStatus(threadID: thread.id)
+                    presentation = HomeThreadPullRequestPresentation(thread: thread, status: status)
+                } catch {
+                    guard let self, pullRequestTasks[key]?.token == token else { return }
+                    pullRequestTasks[key] = nil
+                    return
+                }
+                guard !Task.isCancelled, let self,
+                      pullRequestTasks[key]?.token == token else { return }
+                pullRequestTasks[key] = nil
+                pullRequestResolutions[key] = .resolved(presentation)
+                reconfigureThreadRows(matching: key)
+            }
+            pullRequestTasks[key] = (token, task)
+        }
+
+        private func prunePullRequestLookups(to activeKeys: Set<HomeThreadPullRequestLookupKey>) {
+            pullRequestResolutions = pullRequestResolutions.filter { activeKeys.contains($0.key) }
+            let inactiveTasks = pullRequestTasks.filter { !activeKeys.contains($0.key) }
+            for (key, lookup) in inactiveTasks {
+                lookup.task.cancel()
+                pullRequestTasks[key] = nil
+            }
+        }
+
+        private func reconfigureThreadRows(matching key: HomeThreadPullRequestLookupKey) {
+            guard let dataSource else { return }
+            let identifiers = itemsByID.compactMap { identifier, item in
+                item.pullRequestLookupKey == key ? identifier : nil
+            }
+            guard !identifiers.isEmpty else { return }
+            var snapshot = dataSource.snapshot()
+            snapshot.reconfigureItems(identifiers)
+            dataSource.apply(snapshot, animatingDifferences: false)
         }
 
         private func threadAccessibilityValue(
@@ -645,6 +725,7 @@ private struct HomeCollectionCellContent: View {
     let projectFaviconClient: any FeatureClient
     let isSelected: Bool
     let now: Date
+    let pullRequest: HomeThreadPullRequestPresentation?
 
     @ViewBuilder
     var body: some View {
@@ -657,7 +738,8 @@ private struct HomeCollectionCellContent: View {
                 isSelected: isSelected,
                 style: style,
                 now: now,
-                allowsMultilineTitle: allowsMultilineTitle
+                allowsMultilineTitle: allowsMultilineTitle,
+                pullRequest: pullRequest
             )
         case let .shelfHeader(shelf, count, isExpanded):
             HomeShelfHeader(
@@ -694,6 +776,40 @@ private struct HomeCollectionCellContent: View {
                 .padding(.horizontal, 18)
                 .padding(.vertical, 3)
         }
+    }
+}
+
+struct HomeThreadPullRequestLookupKey: Hashable {
+    let environmentID: String?
+    let projectID: String
+    let branch: String
+    let worktreePath: String?
+
+    init?(thread: FeatureThread) {
+        guard let branch = thread.branch?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !branch.isEmpty else { return nil }
+        environmentID = thread.environmentID
+        projectID = thread.projectID
+        self.branch = branch
+        let path = thread.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines)
+        worktreePath = path?.isEmpty == false ? path : nil
+    }
+}
+
+private enum HomeThreadPullRequestResolution {
+    case resolved(HomeThreadPullRequestPresentation?)
+
+    var presentation: HomeThreadPullRequestPresentation? {
+        switch self {
+        case let .resolved(presentation): presentation
+        }
+    }
+}
+
+private extension HomeCollectionItem {
+    var pullRequestLookupKey: HomeThreadPullRequestLookupKey? {
+        guard case let .thread(thread, _, _, _, _) = self else { return nil }
+        return HomeThreadPullRequestLookupKey(thread: thread)
     }
 }
 

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -374,7 +374,10 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 } catch {
                     guard let self, pullRequestTasks[key]?.token == token else { return }
                     pullRequestTasks[key] = nil
-                    pullRequestResolutions[key] = .failed(at: .now)
+                    pullRequestResolutions[key] = .failed(
+                        at: .now,
+                        preserving: pullRequestResolutions[key]?.presentation
+                    )
                     reconfigureThreadRows(matching: key)
                     return
                 }
@@ -803,25 +806,33 @@ enum HomeThreadPullRequestResolution {
     private static let failureRetryDelay: TimeInterval = 10
 
     case resolved(HomeThreadPullRequestPresentation?, expiresAt: Date)
-    case retryAfter(Date)
+    case retryAfter(Date, previous: HomeThreadPullRequestPresentation?)
 
     static func cached(_ presentation: HomeThreadPullRequestPresentation?, at date: Date) -> Self {
         .resolved(presentation, expiresAt: date.addingTimeInterval(cacheLifetime))
     }
 
-    static func failed(at date: Date) -> Self {
-        .retryAfter(date.addingTimeInterval(failureRetryDelay))
+    static func failed(
+        at date: Date,
+        preserving presentation: HomeThreadPullRequestPresentation? = nil
+    ) -> Self {
+        .retryAfter(
+            date.addingTimeInterval(failureRetryDelay),
+            previous: presentation
+        )
     }
 
     var presentation: HomeThreadPullRequestPresentation? {
-        guard case let .resolved(presentation, _) = self else { return nil }
-        return presentation
+        switch self {
+        case let .resolved(presentation, _), let .retryAfter(_, presentation):
+            return presentation
+        }
     }
 
     func needsLoad(at date: Date) -> Bool {
         switch self {
         case let .resolved(_, expiresAt): expiresAt <= date
-        case let .retryAfter(retryAfter): retryAfter <= date
+        case let .retryAfter(retryAfter, _): retryAfter <= date
         }
     }
 }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -809,6 +809,45 @@ struct HomeThreadRowContext: Equatable {
     }
 }
 
+struct HomeThreadPullRequestPresentation: Equatable {
+    let number: Int
+    let state: String
+    let destination: URL
+
+    var shortLabel: String { "#\(number)" }
+    var accessibilityLabel: String { "Pull request \(number), \(state)" }
+    var accessibilityActionName: String { "Open pull request \(number), \(state)" }
+    func accessibilityValue(appending baseValue: String) -> String {
+        "\(baseValue). \(accessibilityLabel)."
+    }
+
+    init?(
+        thread: FeatureThread,
+        status: FeatureSourceControlStatus
+    ) {
+        guard let threadBranch = Self.normalizedBranch(thread.branch),
+              let statusBranch = Self.normalizedBranch(status.branch),
+              threadBranch == statusBranch,
+              let pullRequest = status.pullRequest,
+              pullRequest.number > 0,
+              let destination = pullRequest.safeExternalURL else {
+            return nil
+        }
+        let normalizedState = pullRequest.state.trimmingCharacters(in: .whitespacesAndNewlines)
+        number = pullRequest.number
+        state = normalizedState.isEmpty ? "unknown state" : normalizedState
+        self.destination = destination
+    }
+
+    private static func normalizedBranch(_ branch: String?) -> String? {
+        guard let branch = branch?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !branch.isEmpty else {
+            return nil
+        }
+        return branch
+    }
+}
+
 struct FeatureThreadRow: View {
     enum Style: Equatable {
         case rich
@@ -822,6 +861,7 @@ struct FeatureThreadRow: View {
     let style: Style
     let now: Date
     let allowsMultilineTitle: Bool
+    let pullRequest: HomeThreadPullRequestPresentation?
 
     init(
         thread: FeatureThread,
@@ -830,7 +870,8 @@ struct FeatureThreadRow: View {
         isSelected: Bool = false,
         style: Style = .rich,
         now: Date = .now,
-        allowsMultilineTitle: Bool = false
+        allowsMultilineTitle: Bool = false,
+        pullRequest: HomeThreadPullRequestPresentation? = nil
     ) {
         self.thread = thread
         self.context = context
@@ -839,6 +880,7 @@ struct FeatureThreadRow: View {
         self.style = style
         self.now = now
         self.allowsMultilineTitle = allowsMultilineTitle
+        self.pullRequest = pullRequest
     }
 
     var body: some View {
@@ -893,6 +935,7 @@ struct FeatureThreadRow: View {
                         .foregroundStyle(T3Colors.syntaxProperty)
                 }
                 Spacer(minLength: 8)
+                pullRequestLink
                 if let environmentLabel {
                     HStack(spacing: 4) {
                         Image(systemName: environmentIcon)
@@ -934,6 +977,7 @@ struct FeatureThreadRow: View {
                 .foregroundStyle(T3Colors.textSecondary)
                 .lineLimit(allowsMultilineTitle ? 2 : 1)
             Spacer(minLength: 8)
+            pullRequestLink
             if thread.pinnedAt != nil {
                 Image(systemName: "pin.fill")
                     .font(.system(size: 9, weight: .semibold))
@@ -951,6 +995,35 @@ struct FeatureThreadRow: View {
             isSelected ? T3Colors.subtleStrong : Color.clear,
             in: RoundedRectangle(cornerRadius: 7)
         )
+    }
+
+    @ViewBuilder
+    private var pullRequestLink: some View {
+        if let pullRequest {
+            Link(destination: pullRequest.destination) {
+                HStack(spacing: 3) {
+                    Text(pullRequest.shortLabel)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                    Image(systemName: "arrow.up.right")
+                        .font(.system(size: 8, weight: .bold))
+                }
+                .font(T3Typography.homeMetadata.weight(.semibold))
+                .foregroundStyle(T3Colors.accent)
+                .contentShape(Rectangle())
+            }
+            .padding(.horizontal, 7)
+            .padding(.vertical, 15)
+            .contentShape(Rectangle())
+            .padding(.horizontal, -7)
+            .padding(.vertical, -15)
+            .buttonStyle(.plain)
+            .layoutPriority(1)
+            .accessibilityLabel(pullRequest.accessibilityLabel)
+            .accessibilityHint("Opens pull request in the browser")
+            .accessibilityIdentifier("thread-\(thread.id)-pull-request")
+        }
     }
 
     @ViewBuilder

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -780,9 +780,12 @@ struct HomeThreadRowContext: Equatable {
             let explicitProvider = thread.providerName?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let configuredProvider = thread.providerID.flatMap { providerID in
-                environmentID.flatMap {
-                    snapshot.providersByEnvironment?[$0]?.first(where: { $0.id == providerID })
-                } ?? snapshot.providers.first(where: { $0.id == providerID })
+                if let providersByEnvironment = snapshot.providersByEnvironment {
+                    return environmentID.flatMap {
+                        providersByEnvironment[$0]?.first(where: { $0.id == providerID })
+                    }
+                }
+                return snapshot.providers.first(where: { $0.id == providerID })
             }
             let providerName = (explicitProvider?.isEmpty == false ? explicitProvider : nil)
                 ?? configuredProvider?.name

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -782,7 +782,7 @@ struct HomeThreadRowContext: Equatable {
             let configuredProvider = thread.providerID.flatMap { providerID in
                 environmentID.flatMap {
                     snapshot.providersByEnvironment?[$0]?.first(where: { $0.id == providerID })
-                }
+                } ?? snapshot.providers.first(where: { $0.id == providerID })
             }
             let providerName = (explicitProvider?.isEmpty == false ? explicitProvider : nil)
                 ?? configuredProvider?.name

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -195,4 +195,190 @@ struct HomeThreadMetadataTests {
             ) == nil
         )
     }
+
+    @Test
+    func pullRequestPresentationCarriesSafeDestinationNumberStateAndAccessibility() throws {
+        let thread = pullRequestThread(branch: " feature/pr-links ")
+        let destination = try #require(URL(string: "https://github.com/pingdotgg/t3code/pull/5804"))
+        let presentation = try #require(HomeThreadPullRequestPresentation(
+            thread: thread,
+            status: FeatureSourceControlStatus(
+                branch: "feature/pr-links",
+                pullRequest: FeaturePullRequest(
+                    number: 5804,
+                    title: "Link thread rows",
+                    state: " open ",
+                    url: destination
+                )
+            )
+        ))
+
+        #expect(presentation.number == 5804)
+        #expect(presentation.state == "open")
+        #expect(presentation.destination == destination)
+        #expect(presentation.shortLabel == "#5804")
+        #expect(presentation.accessibilityLabel == "Pull request 5804, open")
+        #expect(presentation.accessibilityActionName == "Open pull request 5804, open")
+        #expect(
+            presentation.accessibilityValue(appending: "Ready. Project t3code")
+                == "Ready. Project t3code. Pull request 5804, open."
+        )
+    }
+
+    @Test
+    func pullRequestPresentationRejectsMissingMismatchedOrMalformedRemoteData() {
+        let thread = pullRequestThread(branch: "feature/pr-links")
+        let validPullRequest = FeaturePullRequest(
+            number: 5804,
+            title: "Link thread rows",
+            state: "open",
+            url: URL(string: "https://github.com/pingdotgg/t3code/pull/5804")
+        )
+
+        #expect(HomeThreadPullRequestPresentation(
+            thread: thread,
+            status: FeatureSourceControlStatus(branch: "feature/other", pullRequest: validPullRequest)
+        ) == nil)
+        #expect(HomeThreadPullRequestPresentation(
+            thread: thread,
+            status: FeatureSourceControlStatus(branch: nil, pullRequest: validPullRequest)
+        ) == nil)
+        #expect(HomeThreadPullRequestPresentation(
+            thread: thread,
+            status: FeatureSourceControlStatus(branch: "feature/pr-links", pullRequest: nil)
+        ) == nil)
+
+        for unsafeURL in [
+            nil,
+            URL(string: "t3code-swiftui://pull/5804"),
+            URL(string: "https://token@example.com/pull/5804"),
+            URL(string: "https:///pull/5804"),
+            URL(string: "not a remote URL"),
+        ] {
+            var pullRequest = validPullRequest
+            pullRequest.url = unsafeURL
+            #expect(HomeThreadPullRequestPresentation(
+                thread: thread,
+                status: FeatureSourceControlStatus(
+                    branch: "feature/pr-links",
+                    pullRequest: pullRequest
+                )
+            ) == nil)
+        }
+
+        var invalidNumber = validPullRequest
+        invalidNumber.number = 0
+        #expect(HomeThreadPullRequestPresentation(
+            thread: thread,
+            status: FeatureSourceControlStatus(
+                branch: "feature/pr-links",
+                pullRequest: invalidNumber
+            )
+        ) == nil)
+
+        var missingBranch = thread
+        missingBranch.branch = "  "
+        #expect(HomeThreadPullRequestPresentation(
+            thread: missingBranch,
+            status: FeatureSourceControlStatus(
+                branch: "feature/pr-links",
+                pullRequest: validPullRequest
+            )
+        ) == nil)
+    }
+
+    @Test
+    func pullRequestLookupKeysAndDestinationsDoNotFollowRecycledThreadIDs() throws {
+        let first = pullRequestThread(
+            id: "first-row",
+            environmentID: "mac",
+            branch: " feature/pr-links ",
+            worktreePath: " /worktrees/pr-links "
+        )
+        let recycled = pullRequestThread(
+            id: "recycled-row",
+            environmentID: "mac",
+            branch: "feature/pr-links",
+            worktreePath: "/worktrees/pr-links"
+        )
+        let otherCheckout = pullRequestThread(
+            id: "other-row",
+            environmentID: "mac",
+            branch: "feature/other",
+            worktreePath: "/worktrees/other"
+        )
+        let firstKey = try #require(HomeThreadPullRequestLookupKey(thread: first))
+        let recycledKey = try #require(HomeThreadPullRequestLookupKey(thread: recycled))
+        let otherKey = try #require(HomeThreadPullRequestLookupKey(thread: otherCheckout))
+
+        #expect(firstKey == recycledKey)
+        #expect(firstKey != otherKey)
+
+        let firstDestination = URL(string: "https://github.com/pingdotgg/t3code/pull/5804")
+        let otherDestination = URL(string: "https://github.com/pingdotgg/t3code/pull/5999")
+        let firstPresentation = try #require(HomeThreadPullRequestPresentation(
+            thread: first,
+            status: FeatureSourceControlStatus(
+                branch: "feature/pr-links",
+                pullRequest: FeaturePullRequest(
+                    number: 5804,
+                    title: "First",
+                    state: "open",
+                    url: firstDestination
+                )
+            )
+        ))
+        let otherPresentation = try #require(HomeThreadPullRequestPresentation(
+            thread: otherCheckout,
+            status: FeatureSourceControlStatus(
+                branch: "feature/other",
+                pullRequest: FeaturePullRequest(
+                    number: 5999,
+                    title: "Other",
+                    state: "merged",
+                    url: otherDestination
+                )
+            )
+        ))
+
+        #expect(firstPresentation.destination == firstDestination)
+        #expect(otherPresentation.destination == otherDestination)
+        #expect(firstPresentation.accessibilityActionName != otherPresentation.accessibilityActionName)
+        #expect(HomeThreadPullRequestLookupKey(thread: pullRequestThread(branch: nil)) == nil)
+    }
+
+    @Test
+    func blankPullRequestStateHasATruthfulAccessibilityFallback() throws {
+        let presentation = try #require(HomeThreadPullRequestPresentation(
+            thread: pullRequestThread(branch: "feature/pr-links"),
+            status: FeatureSourceControlStatus(
+                branch: "feature/pr-links",
+                pullRequest: FeaturePullRequest(
+                    number: 5804,
+                    title: "Link thread rows",
+                    state: "   ",
+                    url: URL(string: "http://127.0.0.1/pull/5804")
+                )
+            )
+        ))
+
+        #expect(presentation.state == "unknown state")
+        #expect(presentation.accessibilityLabel == "Pull request 5804, unknown state")
+    }
+
+    private func pullRequestThread(
+        id: String = "thread",
+        environmentID: String? = "environment",
+        branch: String?,
+        worktreePath: String? = "/worktrees/pr-links"
+    ) -> FeatureThread {
+        FeatureThread(
+            id: id,
+            projectID: "project",
+            environmentID: environmentID,
+            title: "Build",
+            branch: branch,
+            worktreePath: worktreePath
+        )
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -348,6 +348,21 @@ struct HomeThreadMetadataTests {
     }
 
     @Test
+    func pullRequestLookupCacheExpiresResultsAndThrottlesFailures() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let cachedMissingPullRequest = HomeThreadPullRequestResolution.cached(nil, at: now)
+        let failedLookup = HomeThreadPullRequestResolution.failed(at: now)
+
+        #expect(
+            cachedMissingPullRequest.needsLoad(at: now.addingTimeInterval(5 * 60 - 1))
+                == false
+        )
+        #expect(cachedMissingPullRequest.needsLoad(at: now.addingTimeInterval(5 * 60)))
+        #expect(failedLookup.needsLoad(at: now.addingTimeInterval(9)) == false)
+        #expect(failedLookup.needsLoad(at: now.addingTimeInterval(10)))
+    }
+
+    @Test
     func blankPullRequestStateHasATruthfulAccessibilityFallback() throws {
         let presentation = try #require(HomeThreadPullRequestPresentation(
             thread: pullRequestThread(branch: "feature/pr-links"),

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -348,7 +348,7 @@ struct HomeThreadMetadataTests {
     }
 
     @Test
-    func pullRequestLookupCacheExpiresResultsAndThrottlesFailures() {
+    func pullRequestLookupCacheExpiresResultsAndThrottlesFailures() throws {
         let now = Date(timeIntervalSince1970: 1_000)
         let cachedMissingPullRequest = HomeThreadPullRequestResolution.cached(nil, at: now)
         let failedLookup = HomeThreadPullRequestResolution.failed(at: now)
@@ -360,6 +360,25 @@ struct HomeThreadMetadataTests {
         #expect(cachedMissingPullRequest.needsLoad(at: now.addingTimeInterval(5 * 60)))
         #expect(failedLookup.needsLoad(at: now.addingTimeInterval(9)) == false)
         #expect(failedLookup.needsLoad(at: now.addingTimeInterval(10)))
+
+        let presentation = try #require(HomeThreadPullRequestPresentation(
+            thread: pullRequestThread(branch: "feature/cache"),
+            status: FeatureSourceControlStatus(
+                branch: "feature/cache",
+                pullRequest: FeaturePullRequest(
+                    number: 42,
+                    title: "Keep visible",
+                    state: "OPEN",
+                    url: URL(string: "https://github.com/example/repo/pull/42")!
+                )
+            )
+        ))
+        let failedRefresh = HomeThreadPullRequestResolution.failed(
+            at: now,
+            preserving: presentation
+        )
+        #expect(failedRefresh.presentation == presentation)
+        #expect(!failedRefresh.needsLoad(at: now.addingTimeInterval(9)))
     }
 
     @Test
@@ -395,5 +414,37 @@ struct HomeThreadMetadataTests {
             branch: branch,
             worktreePath: worktreePath
         )
+    }
+
+    @Test
+    func environmentCatalogMissDoesNotUseLegacyProviders() throws {
+        let thread = FeatureThread(
+            id: "thread",
+            projectID: "project",
+            title: "Use provider",
+            providerID: "shared-id"
+        )
+        let snapshot = FeatureSnapshot(
+            projects: [
+                FeatureProject(
+                    id: "project",
+                    environmentID: "remote",
+                    name: "Remote",
+                    path: "/remote"
+                ),
+            ],
+            threads: [thread],
+            providers: [
+                FeatureProvider(id: "shared-id", name: "Wrong environment", driver: "codex"),
+            ],
+            providersByEnvironment: ["local": [
+                FeatureProvider(id: "shared-id", name: "Local only", driver: "codex"),
+            ]]
+        )
+
+        #expect(thread.homeProviderLabel(in: snapshot) == "shared-id")
+        let context = try #require(HomeThreadRowContext.index(snapshot: snapshot)[thread.id])
+        #expect(context.providerName == "shared-id")
+        #expect(context.providerDriver == "shared-id")
     }
 }


### PR DESCRIPTION
## What changed

- Resolve each visible SwiftUI thread row's related pull request from the existing cached VCS status stream.
- Show the matching PR as a native SwiftUI `Link` with the short `#<number>` label.
- Accept only credential-free HTTP(S) destinations, preserve row selection for the row itself, and expose a separate accessibility action for the PR.

## Why

The server already publishes pull-request metadata, but the SwiftUI thread list did not surface it. A manual VCS refresh invalidates the backend PR cache, so list rows use the existing status subscription instead; the source-control screen keeps its explicit refresh behavior.

## Scope

This is one native SwiftUI change. Every changed file is under `apps/swift-ios` or its native tests. There are no `apps/mobile`, Expo, React Native, or bridge changes.

## UI evidence

Owner baseline `0d0c77431c851ff31181fb5f1708f351e0c5e80c`:

![Thread row before the PR link](https://alexs-macbook-pro-1.tail4e5636.ts.net:10009/pr-5804-before-owner-base-0d0c77431.jpg)

UI capture at `fba2518d76761185499935255b74d1e725936dfd`:

![Thread row with the short PR link](https://alexs-macbook-pro-1.tail4e5636.ts.net:10009/pr-5804-after-fba2518d7.jpg)

[Integrated simulator safe-destination smoke video](https://alexs-macbook-pro-1.tail4e5636.ts.net:10009/pr-5804-safe-open-fba2518d7.mp4) — starts on the row and verifies the sanitized destination opens PR #5804 in Safari. The destination launch in this recording was invoked at the simulator OS level because the hosted cell hides nested SwiftUI controls from the semantic automation tree; it is not presented as coordinate-tap evidence.

Final head `d56c1dcf937285609ca31b1c2462d14e9fdb47b9` changes only the cache-expiry behavior and its test after this capture; it does not alter the rendered row or link destination.

Evidence is Tailnet-only. The downloaded MP4 matched the source byte-for-byte (`f9d14dbf581f6934b4833c39fcaa2ece0e32f11d7c5ccbca63b83afe32f2fa0f`, 3,514,304 bytes, `video/mp4`).

## Verification

- [x] Focused native tests: 25 passed, 0 failed, 0 skipped on iPhone 17 Pro simulator `4401D856-DE6C-4769-A649-468778C929F6`.
- [x] `apps/swift-ios/Scripts/ci-test.sh`: 222 passed across 27 suites; `TEST SUCCEEDED`.
- [x] Integrated SwiftUI simulator pass against a disposable copied backend: `#5804` rendered on the matching thread and the sanitized URL opened the actual PR.
- [x] Before/after screenshots and an interaction smoke video are linked above.
- [x] The diff is limited to `apps/swift-ios` and native Swift tests.

Macroscope's valid stale-cache finding was addressed by expiring successful lookup results after five minutes; the focused cache test now covers both success expiry and failure retry.

Independent cross-provider review was attempted with Claude Code 2.1.224 / Claude Opus 5 high, but Claude returned HTTP 429 before inference because the weekly quota was exhausted. No independent-model review is claimed.

Built with GPT-5.6 Sol high in T3 Code's Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pull request links to thread rows in the iOS home view
> - Thread rows in the home collection view now display a tappable pull request badge that opens the PR in the system browser, with full accessibility labeling and a custom accessibility action.
> - The coordinator in [HomeThreadCollectionView.swift](https://github.com/pingdotgg/t3code/pull/5804/files#diff-71b51c44b9cda4172685b500cb742a05438cef1aff0cbb3ae51526305da7fbb7) asynchronously resolves source control status per thread, caches results for 5 minutes, and throttles failed lookups for 10 seconds.
> - `HomeThreadPullRequestPresentation` in [WorkspaceView.swift](https://github.com/pingdotgg/t3code/pull/5804/files#diff-06a43c1b27d1a4bc0456aef6f149417250cdee6930e57b06458c76f9c606b644) validates PR data before surfacing it: branch must match, PR number must be positive, and the URL must be a credential-free `http`/`https` link with a host.
> - Provider resolution in `homeProviderLabel` and `HomeThreadRowContext.index` now falls back to the global providers list when `providersByEnvironment` is absent, fixing cases where the provider ID was shown instead of its name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b499d83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SwiftUI-only home list UX with URL sanitization and tests; provider fallback change is a targeted correctness fix with no auth or data-path changes.
> 
> **Overview**
> Home thread rows now **asynchronously resolve and show a tappable PR badge** (`#<number>`) when source-control status matches the thread’s branch.
> 
> The home collection coordinator loads status via `sourceControlStatus`, keys lookups by checkout (not thread id), caches successes for five minutes with failure backoff, and cancels/prunes work when rows scroll off or the view dismantles. `HomeThreadPullRequestPresentation` only surfaces PRs with matching branches and **`safeExternalURL`** (credential-free http/https). Rich and slim rows get a SwiftUI `Link`; VoiceOver gets PR text plus a custom action to open the PR in Safari.
> 
> **Provider resolution** no longer falls back to legacy `snapshot.providers` when `providersByEnvironment` exists but omits the thread’s environment—avoiding wrong harness labels across devices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b499d83efa2c25ed2de5bcc18f1943cb7722f5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable with runnable checks green; requested review changes remain. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
