### PR TITLE
fix(usage): usage no longer misses custom provider-instance homes

### DIFF
--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -14,6 +14,8 @@
 import * as NodeOS from "node:os";
 
 import {
+  ClaudeSettings,
+  CodexSettings,
   USAGE_CONTRACT_VERSION,
   type UsageProviderKind,
   type UsageSource,
@@ -37,6 +39,7 @@ import { ServerConfig } from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
+import { listProviderHomeCandidates, scanHomePath } from "./usageHomes.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
@@ -84,6 +87,9 @@ const encodeRatesCache = Schema.encodeEffect(
 const ScanCacheJson = Schema.fromJsonString(Schema.Unknown as unknown as Schema.Codec<unknown>);
 const decodeScanCacheFile = Schema.decodeUnknownEffect(ScanCacheJson);
 const encodeScanCacheFile = Schema.encodeEffect(ScanCacheJson);
+
+const decodeClaudeSettings = Schema.decodeUnknownEffect(ClaudeSettings);
+const decodeCodexSettings = Schema.decodeUnknownEffect(CodexSettings);
 
 export class UsageService extends Context.Service<
   UsageService,
@@ -196,7 +202,11 @@ export const make = Effect.gen(function* () {
       return nestedExists ? nested : path.join(homePath, "projects");
     });
 
-  /** Resolves the transcript directory for each provider. */
+  /**
+   * Resolves the transcript directories for each provider, one per configured
+   * provider instance. Instances that share a home (shadow homes symlink
+   * `sessions` back into the shared home) collapse to a single directory.
+   */
   const resolveTranscriptDirs = Effect.fn("UsageService.resolveTranscriptDirs")(function* () {
     // A settings failure must surface as an error: swallowing it here would
     // present "zero usage from every provider" as a valid answer.
@@ -214,14 +224,54 @@ export const make = Effect.gen(function* () {
       ),
     );
 
-    const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
-    const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
-    const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
+    const dirs: { provider: UsageProviderKind; dir: string }[] = [];
+    const seen = new Set<string>();
+    // Two instances can point at one physical directory through symlinks
+    // (or macOS's /tmp → /private/tmp). Canonicalising before de-duplication
+    // stops the same transcripts being counted once per alias. A directory
+    // that does not resolve (typically: does not exist) keeps its configured
+    // path and is reported as missing further down.
+    const push = (provider: UsageProviderKind, dir: string) =>
+      Effect.gen(function* () {
+        const canonical = yield* fileSystem
+          .realPath(dir)
+          .pipe(Effect.catchCause(() => Effect.succeed(dir)));
+        const key = `${provider}\0${canonical}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        dirs.push({ provider, dir: canonical });
+      });
 
-    return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
-    ];
+    for (const candidate of listProviderHomeCandidates(settings, "claude")) {
+      // A blob that fails to decode belongs to an instance the registry
+      // already reports as unavailable; the scan skips it.
+      const config = yield* decodeClaudeSettings(candidate.config).pipe(
+        Effect.catchCause(() => Effect.succeed(null)),
+      );
+      if (config === null) continue;
+      const claudeHome = yield* resolveClaudeHomePath({
+        homePath: scanHomePath(config.homePath, candidate.homeEnvValue, false),
+      });
+      yield* push("claude", yield* resolveClaudeTranscriptDir(claudeHome));
+    }
+
+    for (const candidate of listProviderHomeCandidates(settings, "codex")) {
+      const config = yield* decodeCodexSettings(candidate.config).pipe(
+        Effect.catchCause(() => Effect.succeed(null)),
+      );
+      if (config === null) continue;
+      const layout = yield* resolveCodexHomeLayout({
+        ...config,
+        homePath: scanHomePath(
+          config.homePath,
+          candidate.homeEnvValue,
+          config.shadowHomePath.trim().length > 0,
+        ),
+      });
+      yield* push("codex", path.join(layout.sharedHomePath, "sessions"));
+    }
+
+    return dirs;
   });
 
   /**

--- a/apps/server/src/usage/usageHomes.test.ts
+++ b/apps/server/src/usage/usageHomes.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "@effect/vitest";
+import { ServerSettings } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+import { listProviderHomeCandidates, scanHomePath } from "./usageHomes.ts";
+
+const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
+
+describe("listProviderHomeCandidates", () => {
+  it("falls back to the legacy provider blob when no instance claims the default slot", () => {
+    const settings = decodeServerSettings({
+      providers: { codex: { homePath: "~/.codex-legacy" } },
+    });
+
+    const codex = listProviderHomeCandidates(settings, "codex", {});
+    expect(codex).toHaveLength(1);
+    expect(codex[0]?.config).toMatchObject({ homePath: "~/.codex-legacy" });
+
+    const claude = listProviderHomeCandidates(settings, "claude", {});
+    expect(claude).toHaveLength(1);
+    expect(claude[0]?.config).toMatchObject({ homePath: "" });
+  });
+
+  it("prefers an explicit default-slot instance over the legacy blob", () => {
+    const settings = decodeServerSettings({
+      providers: { codex: { homePath: "~/.codex-legacy" } },
+      providerInstances: {
+        codex: { driver: "codex", config: { homePath: "~/.codex-t3/work" } },
+      },
+    });
+
+    const codex = listProviderHomeCandidates(settings, "codex", {});
+    expect(codex).toHaveLength(1);
+    expect(codex[0]?.config).toMatchObject({ homePath: "~/.codex-t3/work" });
+  });
+
+  it("returns every instance of the driver and ignores other drivers", () => {
+    const settings = decodeServerSettings({
+      providerInstances: {
+        codex: { driver: "codex", config: { homePath: "~/.codex-t3/work" } },
+        codex_personal: { driver: "codex", config: { homePath: "~/.codex-t3/personal" } },
+        codex_work_overlay: {
+          driver: "codex",
+          config: { homePath: "~/.codex-t3/work", shadowHomePath: "~/.codex-t3/overlay" },
+        },
+        cursor: { driver: "cursor", config: { binaryPath: "cursor-agent" } },
+      },
+    });
+
+    const codex = listProviderHomeCandidates(settings, "codex", {});
+    expect(codex).toHaveLength(3);
+    expect(codex.map((candidate) => (candidate.config as { homePath?: string }).homePath)).toEqual([
+      "~/.codex-t3/work",
+      "~/.codex-t3/personal",
+      "~/.codex-t3/work",
+    ]);
+
+    // No explicit claudeAgent instance: the legacy default still applies.
+    expect(listProviderHomeCandidates(settings, "claude", {})).toHaveLength(1);
+  });
+
+  it("treats an instance without a config payload as driver defaults", () => {
+    const settings = decodeServerSettings({
+      providerInstances: {
+        codex_extra: { driver: "codex" },
+      },
+    });
+
+    const codex = listProviderHomeCandidates(settings, "codex", {});
+    // The config-less instance plus the legacy default slot.
+    expect(codex).toHaveLength(2);
+    expect(codex[0]).toEqual({ config: {}, homeEnvValue: null });
+  });
+
+  it("suppresses the legacy blob when another driver claims the default slot", () => {
+    // The registry keys default-slot suppression on the instance id alone, so
+    // an id claimed by a different driver still hides the legacy blob.
+    const settings = decodeServerSettings({
+      providers: { codex: { homePath: "~/.codex-legacy" } },
+      providerInstances: {
+        codex: { driver: "claudeAgent", config: { homePath: "~/.claude-in-codex-slot" } },
+      },
+    });
+
+    expect(listProviderHomeCandidates(settings, "codex", {})).toHaveLength(0);
+  });
+
+  it("extracts the provider's home variable from the environment entries", () => {
+    const settings = decodeServerSettings({
+      providerInstances: {
+        codex_env: {
+          driver: "codex",
+          environment: [
+            { name: "OPENAI_API_KEY", value: "sk-test", sensitive: true },
+            // Later entries win, mirroring mergeProviderInstanceEnvironment.
+            { name: "CODEX_HOME", value: "/ignored" },
+            { name: "CODEX_HOME", value: "/homes/codex-alt" },
+          ],
+        },
+        claude_env: {
+          driver: "claudeAgent",
+          environment: [{ name: "CLAUDE_CONFIG_DIR", value: "/homes/claude-alt" }],
+        },
+        claude_blank: {
+          driver: "claudeAgent",
+          environment: [{ name: "CLAUDE_CONFIG_DIR", value: "   " }],
+        },
+      },
+    });
+
+    const codex = listProviderHomeCandidates(settings, "codex", {});
+    expect(codex[0]?.homeEnvValue).toBe("/homes/codex-alt");
+
+    const claude = listProviderHomeCandidates(settings, "claude", {});
+    expect(claude[0]?.homeEnvValue).toBe("/homes/claude-alt");
+    // A blank value is unset, like an absent entry.
+    expect(claude[1]?.homeEnvValue).toBeNull();
+  });
+
+  it("inherits the server's own home variable like the spawn environment does", () => {
+    const settings = decodeServerSettings({
+      providerInstances: {
+        codex_plain: { driver: "codex" },
+        codex_override: {
+          driver: "codex",
+          environment: [{ name: "CODEX_HOME", value: "/homes/override" }],
+        },
+        codex_cleared: {
+          driver: "codex",
+          environment: [{ name: "CODEX_HOME", value: "" }],
+        },
+      },
+    });
+
+    const codex = listProviderHomeCandidates(settings, "codex", {
+      CODEX_HOME: "/homes/inherited",
+    });
+    // No per-instance entry: the CLI inherits the server's variable.
+    expect(codex[0]?.homeEnvValue).toBe("/homes/inherited");
+    // A per-instance entry overrides the inherited value...
+    expect(codex[1]?.homeEnvValue).toBe("/homes/override");
+    // ...even to unset: the merge writes the blank into the spawn env.
+    expect(codex[2]?.homeEnvValue).toBeNull();
+    // The legacy default slot inherits too.
+    expect(codex[3]?.homeEnvValue).toBe("/homes/inherited");
+  });
+
+  it("ignores home variable values the scan cannot locate", () => {
+    const settings = decodeServerSettings({
+      providerInstances: {
+        codex_relative: {
+          driver: "codex",
+          // Relative paths resolve against each workspace's cwd at runtime,
+          // so no single directory represents them.
+          environment: [{ name: "CODEX_HOME", value: "codex-home" }],
+        },
+        codex_tilde: {
+          driver: "codex",
+          // The spawn does not shell-expand `~`; the CLI rejects it verbatim.
+          environment: [{ name: "CODEX_HOME", value: "~/codex-home" }],
+        },
+      },
+    });
+
+    const codex = listProviderHomeCandidates(settings, "codex", { CODEX_HOME: "relative-too" });
+    expect(codex[0]?.homeEnvValue).toBeNull();
+    expect(codex[1]?.homeEnvValue).toBeNull();
+  });
+});
+
+describe("scanHomePath", () => {
+  it("uses the environment value only when no home path is configured", () => {
+    expect(scanHomePath("", "/homes/alt", false)).toBe("/homes/alt");
+    expect(scanHomePath("~/.codex-t3/work", "/homes/alt", false)).toBe("~/.codex-t3/work");
+    expect(scanHomePath("", null, false)).toBe("");
+  });
+
+  it("ignores the environment value for a shadowed home", () => {
+    // With a shadow home the server always sets the home variable itself and
+    // sessions flow through the symlink into the shared home.
+    expect(scanHomePath("", "/homes/alt", true)).toBe("");
+  });
+});

--- a/apps/server/src/usage/usageHomes.ts
+++ b/apps/server/src/usage/usageHomes.ts
@@ -1,0 +1,125 @@
+// @effect-diagnostics nodeBuiltinImport:off
+/**
+ * Enumerates the provider home configurations the usage scan must cover.
+ *
+ * A user can configure several instances of the same driver through
+ * `settings.providerInstances` (e.g. `codex_work` + `codex_personal`), each
+ * with its own home directory. The scan must read every one of those homes,
+ * not just the legacy single-instance `settings.providers.<kind>` blob.
+ *
+ * Precedence mirrors `deriveProviderInstanceConfigMap`: explicit
+ * `providerInstances` entries always win, and the legacy blob only fills the
+ * default slot (instance id === driver kind) when no explicit entry claims it
+ * — regardless of that entry's driver, so an id claimed by another driver
+ * still suppresses the legacy blob exactly as the registry does.
+ *
+ * @module usageHomes
+ */
+import * as NodePath from "node:path";
+
+import type { ServerSettings, UsageProviderKind } from "@t3tools/contracts";
+
+const DRIVER_BY_PROVIDER = {
+  claude: "claudeAgent",
+  codex: "codex",
+} as const satisfies Record<UsageProviderKind, keyof ServerSettings["providers"]>;
+
+/**
+ * The provider's home environment variable. An instance can configure its
+ * home purely through an environment entry; the spawned CLI honours it
+ * whenever the server does not override the variable from `config.homePath`.
+ */
+const HOME_VARIABLE_BY_PROVIDER = {
+  claude: "CLAUDE_CONFIG_DIR",
+  codex: "CODEX_HOME",
+} as const satisfies Record<UsageProviderKind, string>;
+
+export interface UsageHomeCandidate {
+  /** Raw (undecoded) driver config blob for one configured instance. */
+  readonly config: unknown;
+  /**
+   * Effective value of the provider's home variable in the instance's spawn
+   * environment, or `null`. Mirrors `mergeProviderInstanceEnvironment`: the
+   * server's own environment is the base and per-instance entries override it,
+   * last entry winning. Only absolute paths count — the spawn does not expand
+   * `~`, and a relative path resolves against each workspace's cwd at runtime,
+   * so no single directory represents it.
+   */
+  readonly homeEnvValue: string | null;
+}
+
+/** A home variable value the scan can actually locate on disk. */
+function usableHomePath(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 && NodePath.isAbsolute(trimmed) ? trimmed : null;
+}
+
+/**
+ * Candidate configs for every configured instance of the given provider.
+ * Callers decode each through the driver's settings schema; blobs that fail to
+ * decode belong to instances the registry already surfaces as unavailable and
+ * are simply skipped by the scan.
+ */
+export function listProviderHomeCandidates(
+  settings: ServerSettings,
+  provider: UsageProviderKind,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): ReadonlyArray<UsageHomeCandidate> {
+  const driver = DRIVER_BY_PROVIDER[provider];
+  const homeVariable = HOME_VARIABLE_BY_PROVIDER[provider];
+  // Spawned CLIs inherit the server's environment, so a server-level home
+  // variable applies to every instance that does not override it.
+  const inheritedHome = usableHomePath(baseEnv[homeVariable]);
+  const candidates: UsageHomeCandidate[] = [];
+  let defaultSlotClaimed = false;
+
+  for (const [instanceId, envelope] of Object.entries(settings.providerInstances)) {
+    // Any entry occupying the default slot claims it, even one for another
+    // driver: the registry suppresses the legacy blob in that case too.
+    if (instanceId === driver) defaultSlotClaimed = true;
+    if (envelope.driver !== driver) continue;
+
+    let homeEnvValue = inheritedHome;
+    for (const variable of envelope.environment ?? []) {
+      if (variable.name !== homeVariable) continue;
+      // An entry always overrides the inherited value, even to unusable: the
+      // merge writes it into the spawn env verbatim.
+      homeEnvValue = usableHomePath(variable.value);
+    }
+
+    candidates.push({
+      // An envelope without a config payload is an instance running on driver
+      // defaults; the settings schemas fill those in when the blob decodes.
+      // `??`, not an `undefined` check: the registry coalesces an explicit
+      // `null` payload into driver defaults the same way.
+      config: envelope.config ?? {},
+      homeEnvValue,
+    });
+  }
+
+  if (!defaultSlotClaimed) {
+    candidates.push({ config: settings.providers[driver], homeEnvValue: inheritedHome });
+  }
+  return candidates;
+}
+
+/**
+ * The home path the scan should resolve for one candidate, mirroring the
+ * runtime's precedence exactly:
+ *
+ *   - A configured `homePath` wins — the server overrides the home variable
+ *     in the spawn environment whenever it is set.
+ *   - With a shadow home, the server always sets the variable to the shadow
+ *     path and sessions flow through the symlink into the shared home, so an
+ *     environment entry never takes effect.
+ *   - Only an instance with neither reaches the CLI with its own environment
+ *     entry intact.
+ */
+export function scanHomePath(
+  configHomePath: string,
+  homeEnvValue: string | null,
+  shadowed: boolean,
+): string {
+  if (configHomePath.trim().length > 0 || shadowed) return configHomePath;
+  return homeEnvValue ?? "";
+}


### PR DESCRIPTION
## What Changed

The usage scan now enumerates every configured provider instance instead of only the legacy `settings.providers.<kind>` blobs:

- A new `usageHomes.ts` lists each instance's config with the same precedence the provider registry uses (`deriveProviderInstanceConfigMap`): explicit `providerInstances` entries win, and the legacy blob only fills the default slot while no entry claims that id.
- Each instance's home resolves with the runtime's exact rules: a configured `homePath` wins; otherwise the provider's home variable from the instance's spawn environment applies (server environment as base, per-instance entries overriding, absolute paths only); never for shadowed homes, where the server always sets the variable itself.
- Resolved directories are canonicalised (`realPath`) and de-duplicated, so instances sharing a home — shadow overlays symlink `sessions` into the shared home — are scanned exactly once.

Server-only. No contract change (`sources` already carries several directories per provider) and no UI code change.

## Why

Configuring Codex through `providerInstances` (e.g. work + personal instances, each with its own `CODEX_HOME`) leaves the legacy `providers.codex` blob empty, so the scan read `~/.codex/sessions` — a directory those instances never write to — and the usage page reported no Codex usage at all.

Closes #5805.

One known edge is left for a follow-up (#5738): buckets are still keyed per provider kind, so two environments whose *partially* overlapping directory sets get de-duplicated client-side can still over-count in the overlap. Fixing that needs per-directory bucket attribution, which is a contract change and deliberately out of scope here.

## UI Changes

No UI code changes, but the visible effect on an instance-based setup (four Codex instances across two homes):

| Before | After |
| --- | --- |
| Codex missing entirely | Codex usage reported |
| ![Usage page with Claude only](https://raw.githubusercontent.com/zenDevNomad/t3code/pr-assets/usage-before.png) | ![Usage page with Codex and Claude](https://raw.githubusercontent.com/zenDevNomad/t3code/pr-assets/usage-after-pr1.png) |

## Testing

- New unit tests for the instance enumeration (legacy fallback, default-slot precedence including cross-driver claims, spawn-environment inheritance/override, absolute-path gating) and the home-path precedence.
- `vp test run src/usage/`: 40 passed; `tsgo --noEmit` and `vp lint` clean.
- Verified live against a real four-instance setup (two homes, two shadow overlays, legacy blob empty): both screenshots above are from the same state directory and transcripts, before/after only differing by this change on top of current `main`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes — not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which transcript directories are scanned and aggregated usage totals for multi-instance setups; logic is server-only with tests but mis-resolved paths could still skew reported usage.
> 
> **Overview**
> **Usage scanning** no longer relies only on legacy `settings.providers` blobs. It walks every Claude/Codex **provider instance**, resolves each home with the same rules as spawn (`homePath`, `CODEX_HOME` / `CLAUDE_CONFIG_DIR`, shadow homes), and **dedupes** transcript dirs via `realPath` so shared/shadow homes are counted once.
> 
> Adds **`usageHomes.ts`** (`listProviderHomeCandidates`, `scanHomePath`) aligned with provider registry precedence, plus unit tests. **`resolveTranscriptDirs`** in `UsageService` loops instances, skips invalid configs, and can return multiple dirs per provider (fixes missing Codex usage when instances live only under `providerInstances`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed33dde6edc90f2f90052a50238181340989a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveTranscriptDirs` to scan transcript homes for every configured provider instance
> - Previously, `resolveTranscriptDirs` resolved a single transcript directory per provider. It now enumerates all configured Claude and Codex instances via the new `listProviderHomeCandidates` utility in [usageHomes.ts](https://github.com/pingdotgg/t3code/pull/5806/files#diff-37f9e7f04c437ed2bf12f56af3a05c2d1ed664cb845a2317bd015de3168c4d1a).
> - For each instance, the home path is derived using `scanHomePath`, which mirrors runtime precedence between configured `homePath` and environment-variable-provided home paths.
> - Instances with undecodable configs are skipped; results are de-duplicated by provider and canonical real path to avoid counting the same transcripts twice.
> - A legacy provider blob fallback is included when no instance claims the default slot, preserving backward compatibility.
> - Behavioral Change: `resolveTranscriptDirs` now returns zero or more entries per provider (instead of exactly one), so usage counts may change for users with multiple configured instances or non-default home paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ed33dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->