### PR TITLE
fix(client-runtime): stop counting the workflow coordinator as a working agent

### DIFF
--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -568,10 +568,8 @@ export function AgentsPanel({
       </ScrollArea>
       <footer className="flex items-center justify-between border-t border-border/60 px-3 py-1.5 font-mono text-[.7rem] text-muted-foreground">
         <span className="flex items-center gap-2">
-          {model.runningCount + model.waitingCount > 0 ? (
-            <span className="text-info-foreground">
-              ● {model.runningCount + model.waitingCount} working
-            </span>
+          {model.liveCount > 0 ? (
+            <span className="text-info-foreground">● {model.liveCount} working</span>
           ) : null}
           {model.idleCount > 0 ? <span>{model.idleCount} idle</span> : null}
           {model.settledCount > 0 ? <span>{model.settledCount} settled</span> : null}

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -390,6 +390,28 @@ describe("deriveAgentPanelModel", () => {
     );
   });
 
+  it("excludes the workflow coordinator from the live count", () => {
+    // The composer banner and the panel footer read liveCount. A workflow
+    // running one member must read "1 agent working", not 2 — the
+    // coordinator is the workflow itself, not a worker.
+    const model = deriveAgentPanelModel({ agents: roster });
+    // wf-1 (coordinator) + wf-1:wf:1 (member) are both live in the tally...
+    expect(model.runningCount).toBe(2);
+    // ...but only the member is an agent doing work.
+    expect(model.liveCount).toBe(1);
+  });
+
+  it("counts a memberless workflow coordinator as its own live work", () => {
+    // Dynamic spawns mean a coordinator can be live before its first member
+    // exists; dropping it outright would report zero agents mid-run.
+    const model = deriveAgentPanelModel({
+      agents: fold([
+        activity("task.started", { taskId: "wf-2", taskType: "local_workflow", title: "solo" }),
+      ]),
+    });
+    expect(model.liveCount).toBe(1);
+  });
+
   it("keeps direct spawns in first-seen order as their activity changes", () => {
     const directRoster = fold([
       activity("task.started", { taskId: "direct-a", title: "First" }, "2026-08-01T11:00:00.000Z"),

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -825,11 +825,21 @@ export function deriveAgentPanelModel({
   let idleCount = 0;
   let settledCount = 0;
   let totalTokens = 0;
+  let liveCount = 0;
   for (const agent of source) {
+    const live =
+      agent.status === "running" || agent.status === "pending" || agent.status === "waiting";
     if (agent.status === "running" || agent.status === "pending") runningCount += 1;
     else if (agent.status === "waiting") waitingCount += 1;
     else if (agent.status === "idle") idleCount += 1;
     else settledCount += 1;
+    // A coordinator is the workflow itself, not a worker: counting it would
+    // report one more agent than is doing work ("2 agents working" for a
+    // single running member). Same exclusion rule as totalTokens below —
+    // a coordinator with no members is still its own unit of live work.
+    if (live && (agent.kind !== "workflow" || (members.get(agent.id) ?? []).length === 0)) {
+      liveCount += 1;
+    }
     // Workflow coordinators aggregate member usage upstream in some providers;
     // avoid double counting by only summing leaf agents when members exist.
     if (agent.kind !== "workflow" || (members.get(agent.id) ?? []).length === 0) {
@@ -850,7 +860,7 @@ export function deriveAgentPanelModel({
     settledCount,
     totalTokens,
     hasAgents: true,
-    liveCount: runningCount + waitingCount,
+    liveCount,
   };
 }
 


### PR DESCRIPTION
Closes #5807

## What changed

`deriveAgentPanelModel` counted the workflow coordinator as one of the agents doing work. A workflow running a single member reported two:

- composer banner: **"2 agents working in the background"**
- Agents panel footer: **"2 working · 1 settled"**
- inline spawn card: **"Spine · 1 working"** ← the only correct one

The tally loop in `packages/client-runtime/src/state/subagentRuntime.ts` iterated every roster entry, including the coordinator (`kind === "workflow"`), which stays `running` for the whole run. So `liveCount = runningCount + waitingCount` was always one higher than the number of agents actually working.

`liveCount` now applies the same coordinator-exclusion rule the `totalTokens` sum four lines below already used: skip a coordinator that has members. A memberless coordinator still counts, so a workflow that has not spawned its first member — or is between phases — does not read as zero agents.

`runningCount` / `waitingCount` still count every roster entry, preserving the existing bucket-sum invariant (`idle + running + waiting + settled === roster.length`). `AgentsPanel`'s footer switches to `liveCount` so both surfaces agree with the inline card.

## Why it should exist

The banner is the only visible Stop affordance for background work, so its count is what a user reads to decide whether anything is still running. It disagreed with the two other surfaces in the same view. With N concurrent workflows the banner is off by N, and a workflow whose members have all settled between phases reads "1 agent working" when zero are.

Note the inline card is unaffected and stays correct: "Kicked off 2 subagents" is the batch size (how many were spawned), not a live count.

## Before / after

Identical fixture, one member running and one settled. Only the two counts differ.

<!-- BEFORE / AFTER screenshots attached below -->

| | Banner | Panel footer |
|---|---|---|
| Before | `2 agents working in the background` | `● 2 working · 1 settled` |
| After | `1 agent working in the background` | `● 1 working · 1 settled` |

Unchanged in both: inline card `Kicked off 2 subagents · ride-shelf-v2 — Spine · 1 working`, panel header `1/2 settled`, `RECON 1 done`, `SPINE 1 active · 0 done`.

Before:
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/3dcdf658-acbb-4d30-a3f0-4141a8fd4a59" />

After:
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/f43b90c8-6689-4d10-be53-f5922aad16fe" />



## Tests

Two cases added to `subagentRuntime.test.ts`:

- coordinator excluded — `liveCount` is 1 while `runningCount` is 2
- memberless coordinator still counts as 1, so a mid-spawn workflow does not read as zero

Verified red/green: with the source change reverted the first test fails `expected 2 to be 1`; with it applied 48/48 pass. `vp lint` and `tsgo --noEmit` clean for both packages.

## Scope

3 files, +35 / −5. No behavior change outside the two count readouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only count logic in client-runtime with targeted tests; no auth, data, or server behavior changes.
> 
> **Overview**
> **`liveCount` no longer treats workflow coordinators as working agents** when they already have member rows, so the composer banner, panel footer, and inline cards agree (e.g. one running member reads as **1 working**, not 2).
> 
> In `deriveAgentPanelModel`, `liveCount` is computed in the roster loop instead of `runningCount + waitingCount`. Live agents (`running`, `pending`, `waiting`) count toward `liveCount` unless they are a **workflow coordinator with members**—the same rule already used for `totalTokens`. A coordinator with **no** members still counts, so mid-spawn or between-phase runs do not show zero.
> 
> The **Agents panel** footer now displays `model.liveCount` directly. **`runningCount` / `waitingCount`** are unchanged and still sum to roster size with idle and settled.
> 
> Tests cover coordinator exclusion vs `runningCount`, and memberless coordinators still contributing `liveCount` of 1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a1a6feb9b76910e8d3fa7f0da29b72a8c9e59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `liveCount` in `deriveAgentPanelModel` to exclude workflow coordinators that have members
> - `liveCount` previously equaled `runningCount + waitingCount`, which included workflow coordinators even when they duplicate work already counted via their members.
> - `deriveAgentPanelModel` now computes `liveCount` independently: non-workflow agents count if running, pending, or waiting; coordinators only count when they have no members.
> - The `AgentsPanel` footer now uses `model.liveCount` directly instead of summing `runningCount + waitingCount`.
> - Behavioral Change: the working-agents count shown in the UI will be lower in workflows where coordinators have active members.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17a1a6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
