### PR TITLE
feat(web): pin the current thread from the command palette

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -195,6 +195,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
 
       assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
       assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
+      assert.equal(defaultsByCommand.get("thread.togglePin"), "mod+alt+shift+p");
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("thread.jump.9"), "mod+9");
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1425,6 +1425,7 @@ function OpenCommandPaletteDialog(props: {
         ? ["unpin thread", "unpin current thread"]
         : ["pin thread", "pin current thread"],
       title: isPinned ? "Unpin current thread" : "Pin current thread",
+      shortcutCommand: "thread.togglePin",
       icon: isPinned ? (
         <PinOffIcon className={ITEM_ICON_CLASS} />
       ) : (

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -36,6 +36,8 @@ import {
   LinkIcon,
   MessageSquareIcon,
   PaletteIcon,
+  PinIcon,
+  PinOffIcon,
   SettingsIcon,
   SquarePenIcon,
   TextSearchIcon,
@@ -59,6 +61,7 @@ import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstra
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { useClientSettings } from "../hooks/useSettings";
 import { useTheme } from "../hooks/useTheme";
+import { useThreadActions } from "../hooks/useThreadActions";
 import { readLocalApi } from "../localApi";
 import { desktopLocalBackendId } from "../connection/desktopLocal";
 import { filesystemEnvironment } from "../state/filesystem";
@@ -68,7 +71,7 @@ import { sourceControlEnvironment } from "../state/sourceControl";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
-import { useProjects, useThreadShells } from "../state/entities";
+import { readEnvironmentSupportsPinning, useProjects, useThreadShells } from "../state/entities";
 import { useThreadSearch } from "../state/queries";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
@@ -578,6 +581,7 @@ function OpenCommandPaletteDialog(props: {
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
+  const { pinThread, unpinThread } = useThreadActions();
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
@@ -1405,6 +1409,40 @@ function OpenCommandPaletteDialog(props: {
       icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
       groups: [{ value: "projects", label: "Projects", items: projectThreadItems }],
+    });
+  }
+
+  // Pin is contextual to the thread being read, and hidden on servers that
+  // predate thread.pin/unpin — same version-skew contract as the sidebar and
+  // chat-header menus. Drafts never get here: activeThread is null for them.
+  if (activeThread && readEnvironmentSupportsPinning(activeThread.environmentId)) {
+    const pinTargetRef = scopeThreadRef(activeThread.environmentId, activeThread.id);
+    const isPinned = activeThread.pinnedAt != null;
+    actionItems.push({
+      kind: "action",
+      value: isPinned ? "action:unpin-thread" : "action:pin-thread",
+      searchTerms: isPinned
+        ? ["unpin thread", "unpin current thread"]
+        : ["pin thread", "pin current thread"],
+      title: isPinned ? "Unpin current thread" : "Pin current thread",
+      icon: isPinned ? (
+        <PinOffIcon className={ITEM_ICON_CLASS} />
+      ) : (
+        <PinIcon className={ITEM_ICON_CLASS} />
+      ),
+      run: async () => {
+        const result = isPinned ? await unpinThread(pinTargetRef) : await pinThread(pinTargetRef);
+        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: isPinned ? "Failed to unpin thread" : "Failed to pin thread",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        }
+      },
     });
   }
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -140,6 +140,11 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("o", { shiftKey: true }), command: "chat.new" },
   { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
+  {
+    shortcut: modShortcut("p", { altKey: true, shiftKey: true }),
+    command: "thread.togglePin",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
   { shortcut: modShortcut("1"), command: "thread.jump.1" },
@@ -567,6 +572,25 @@ describe("chat/editor shortcuts", () => {
         context: { terminalFocus: true },
       }),
       "projectSearch.toggle",
+    );
+  });
+
+  it("matches thread.togglePin outside terminal focus", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "p", metaKey: true, altKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        { platform: "MacIntel", context: { terminalFocus: false } },
+      ),
+      "thread.togglePin",
+    );
+    assert.notStrictEqual(
+      resolveShortcutCommand(
+        event({ key: "p", metaKey: true, altKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        { platform: "MacIntel", context: { terminalFocus: true } },
+      ),
+      "thread.togglePin",
     );
   });
 

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,3 +1,8 @@
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
 import { useEffect, useMemo } from "react";
@@ -5,12 +10,13 @@ import { useEffect, useMemo } from "react";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useLegacySidebarEnabled } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
-import { useProjects } from "../state/entities";
+import { readEnvironmentSupportsPinning, useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useThreadActions } from "../hooks/useThreadActions";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -27,6 +33,7 @@ function ChatRouteGlobalShortcuts() {
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
     useHandleNewThread();
+  const { pinThread, unpinThread } = useThreadActions();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const legacySidebarEnabled = useLegacySidebarEnabled();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
@@ -108,6 +115,32 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
+      if (
+        command === "thread.togglePin" &&
+        !event.repeat &&
+        activeThread &&
+        readEnvironmentSupportsPinning(activeThread.environmentId)
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        const isPinned = activeThread.pinnedAt != null;
+        const threadRef = scopeThreadRef(activeThread.environmentId, activeThread.id);
+        void (async () => {
+          const result = isPinned ? await unpinThread(threadRef) : await pinThread(threadRef);
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: isPinned ? "Failed to unpin thread" : "Failed to pin thread",
+                description: error instanceof Error ? error.message : "An error occurred.",
+              }),
+            );
+          }
+        })();
+        return;
+      }
+
       if (command === "preview.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -168,7 +201,9 @@ function ChatRouteGlobalShortcuts() {
     routeThreadRef,
     selectedThreadKeysSize,
     legacySidebarEnabled,
+    pinThread,
     terminalOpen,
+    unpinThread,
   ]);
 
   return null;

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -40,6 +40,7 @@ Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refre
 `filePicker.toggle` opens file search for the active project and defaults to `mod+p`.
 `projectSearch.toggle` searches inside the active project's files and defaults to `mod+shift+f`.
 Repeating either shortcut closes that search, and switching shortcuts replaces the open search.
+`thread.togglePin` pins or unpins the current thread and defaults to `mod+alt+shift+p`.
 `themeEditor.toggle` opens or closes the floating theme editor and defaults to
 `mod+alt+shift+t`. Select a color label to spotlight the elements that use it; select the label
 again to clear the spotlight. The swatch and hex field keep that color selected while you edit it.

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -101,6 +101,12 @@ it.effect("parses keybinding rules", () =>
       command: "thread.previous",
     });
     assert.strictEqual(parsedThreadPrevious.command, "thread.previous");
+
+    const parsedThreadTogglePin = yield* decode(KeybindingRule, {
+      key: "mod+alt+shift+p",
+      command: "thread.togglePin",
+    });
+    assert.strictEqual(parsedThreadTogglePin.command, "thread.togglePin");
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -35,6 +35,7 @@ export type ModelPickerJumpKeybindingCommand =
   (typeof MODEL_PICKER_JUMP_KEYBINDING_COMMANDS)[number];
 
 export const THREAD_KEYBINDING_COMMANDS = [
+  "thread.togglePin",
   "thread.previous",
   "thread.next",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -44,6 +44,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
+  { key: "mod+alt+shift+p", command: "thread.togglePin", when: "!terminalFocus" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({


### PR DESCRIPTION
## What Changed

Adds a contextual action and configurable shortcut for the active thread: **Pin current thread** (**Unpin current thread** when the thread is already pinned).

- Appears only while a real thread is open — hidden on drafts (`activeThread` is null for them) and on servers that predate `thread.pin`/`thread.unpin`, using the same `threadPinning` capability gate (version-skew contract) as the sidebar and chat-header menus.
- Dispatches through the existing `useThreadActions().pinThread`/`unpinThread` mutations, so top-of-pinned-run placement, `orderKey` handling, and capability guards are the existing code paths — no new pin logic.
- Failures surface through the palette's existing `stackedThreadToast` pattern, ignoring interrupted commands like the other menus do.
- The item reads `pinnedAt` reactively, so title/icon flip between Pin/Unpin and the palette never offers a stale action.
- Adds `thread.togglePin`, defaulting to `mod+alt+shift+p` (`⌥⇧⌘P` on macOS), inactive while a terminal has focus and shown beside the palette action for discoverability.

No new dependencies or server behavior changes.

## Why

Pinning today is mouse-only: hover a sidebar row for its context menu, or open the chat-header menu. But pinning is exactly the kind of mid-flow action you want without leaving the keyboard — you're reading a thread you know you'll come back to: ⌘K, "pin", Enter, done. The palette already models thread-contextual actions ("New thread in &lt;project&gt;"), so this slots into the existing Actions group without any new UI surface. The direct shortcut makes the same toggle available without opening the palette.

## UI Changes

Palette on the current thread, searching "pin" — before, the only hit is "Project settings" (substring of its `grouping` search term); after, the action is first:

| Before | After |
| --- | --- |
| ![before: no pin action in palette](https://raw.githubusercontent.com/Bhanu1776/t3code/media/palette-pin/before-palette-pin-search.png) | ![after: Pin current thread action in palette](https://raw.githubusercontent.com/Bhanu1776/t3code/media/palette-pin/after-palette-pin-search.png) |

After Enter, the thread lands in the sidebar's pinned block (server round-trip, not local state), and the palette then offers the inverse:

| Pinned result | Toggled action |
| --- | --- |
| ![thread in pinned block after action](https://raw.githubusercontent.com/Bhanu1776/t3code/media/palette-pin/pinned-sidebar.png) | ![Unpin current thread action on a pinned thread](https://raw.githubusercontent.com/Bhanu1776/t3code/media/palette-pin/after-palette-unpin.png) |

Full interaction (⌘K → "pin" → Enter → pinned block → ⌘K → "unpin" → Enter), keyboard only:

![pin/unpin from the command palette](https://raw.githubusercontent.com/Bhanu1776/t3code/media/palette-pin/pin-flow.gif)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pin/unpin current thread to the command palette and keyboard shortcut
> - Adds a `thread.togglePin` action to the command palette that shows when the active thread is non-draft and the environment supports pinning; toggles between "Pin current thread" and "Unpin current thread".
> - Binds `mod+alt+shift+p` as the default keyboard shortcut for `thread.togglePin` (outside terminal focus), handled in both the global shortcuts component and the command palette.
> - Surfaces error toasts on pin/unpin failures, excluding user interruptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e407e8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->