### PR TITLE
fix(server): keep usage pricing aliases distinct

### DIFF
--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -38,7 +38,12 @@ import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
-import { parseRateTable, type RateTable } from "./usagePricing.ts";
+import {
+  emptyRateTable,
+  parseRateTable,
+  rateTableModelCount,
+  type RateTable,
+} from "./usagePricing.ts";
 import {
   listTranscriptFiles,
   readDirectoryVolumeId,
@@ -128,7 +133,7 @@ export const make = Effect.gen(function* () {
 
   const ratesCachePath = path.join(config.stateDir, "usage-model-rates.json");
   const scanCachePath = path.join(config.stateDir, "usage-scan-cache.json");
-  let rates: RateTable = new Map();
+  let rates: RateTable = emptyRateTable();
   let ratesFetchedAtMs: number | null = null;
   let ratesStatus: UsageSummary["pricing"]["status"] = "unavailable";
 
@@ -148,7 +153,7 @@ export const make = Effect.gen(function* () {
       );
       if (fromDisk !== null) {
         const parsed = parseRateTable(fromDisk.document);
-        if (parsed.size > 0) {
+        if (rateTableModelCount(parsed) > 0) {
           rates = parsed;
           ratesFetchedAtMs = fromDisk.fetchedAtMs;
           ratesStatus = "cached";
@@ -166,12 +171,12 @@ export const make = Effect.gen(function* () {
     if (fetched === null) {
       // The refresh failed; whatever we are serving is now past its TTL and
       // must not keep claiming to be fresh.
-      if (rates.size > 0) ratesStatus = "cached";
+      if (rateTableModelCount(rates) > 0) ratesStatus = "cached";
       return;
     }
 
     const parsed = parseRateTable(fetched);
-    if (parsed.size === 0) return;
+    if (rateTableModelCount(parsed) === 0) return;
 
     rates = parsed;
     ratesFetchedAtMs = now;
@@ -408,7 +413,7 @@ export const make = Effect.gen(function* () {
           ratesFetchedAtMs === null
             ? null
             : DateTime.formatIso(DateTime.makeUnsafe(ratesFetchedAtMs)),
-        knownModels: rates.size,
+        knownModels: rateTableModelCount(rates),
       },
       scanDurationMs: Math.max(0, finishedAtMs - startedAtMs),
     } satisfies UsageSummary;

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -1,20 +1,17 @@
 import { describe, expect, it } from "@effect/vitest";
 
 import { UsageAggregator } from "./usageAggregation.ts";
-import type { RateTable } from "./usagePricing.ts";
+import { parseRateTable } from "./usagePricing.ts";
 import type { UsageRecord } from "./usageTranscripts.ts";
 
-const rates: RateTable = new Map([
-  [
-    "claude-fable-5",
-    {
-      inputCostPerToken: 1e-5,
-      outputCostPerToken: 5e-5,
-      cacheReadCostPerToken: 1e-6,
-      cacheCreationCostPerToken: 1.25e-5,
-    },
-  ],
-]);
+const rates = parseRateTable({
+  "claude-fable-5": {
+    input_cost_per_token: 1e-5,
+    output_cost_per_token: 5e-5,
+    cache_read_input_token_cost: 1e-6,
+    cache_creation_input_token_cost: 1.25e-5,
+  },
+});
 
 function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
   return {

--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { lookupRate, parseRateTable, rateTableModelCount } from "./usagePricing.ts";
+
+const rate = (input: number, output = input * 2, cacheRead = input, cacheCreation = input) => ({
+  input_cost_per_token: input,
+  output_cost_per_token: output,
+  cache_read_input_token_cost: cacheRead,
+  cache_creation_input_token_cost: cacheCreation,
+});
+
+describe("usage pricing", () => {
+  it("prefers a canonical model rate over provider-qualified aliases regardless of entry order", () => {
+    const canonical = {
+      input_cost_per_token: 1,
+      output_cost_per_token: 2,
+      cache_read_input_token_cost: 0.1,
+      cache_creation_input_token_cost: 1.25,
+    };
+    const providerQualified = {
+      input_cost_per_token: 10,
+      output_cost_per_token: 20,
+    };
+
+    const canonicalFirst = parseRateTable({
+      "gpt-5": canonical,
+      "replicate/openai/gpt-5": providerQualified,
+    });
+    const providerFirst = parseRateTable({
+      "replicate/openai/gpt-5": providerQualified,
+      "gpt-5": canonical,
+    });
+
+    expect(lookupRate(canonicalFirst, "gpt-5")).toEqual({
+      inputCostPerToken: 1,
+      outputCostPerToken: 2,
+      cacheReadCostPerToken: 0.1,
+      cacheCreationCostPerToken: 1.25,
+    });
+    expect(lookupRate(providerFirst, "gpt-5")).toEqual(lookupRate(canonicalFirst, "gpt-5"));
+  });
+
+  it("keeps provider-qualified rates distinct instead of guessing an ambiguous bare rate", () => {
+    const table = parseRateTable({
+      "provider-a/example-model": {
+        input_cost_per_token: 1,
+        output_cost_per_token: 2,
+      },
+      "provider-b/example-model": {
+        input_cost_per_token: 3,
+        output_cost_per_token: 4,
+      },
+    });
+
+    expect(lookupRate(table, "provider-a/example-model")?.inputCostPerToken).toBe(1);
+    expect(lookupRate(table, "provider-b/example-model")?.inputCostPerToken).toBe(3);
+    expect(lookupRate(table, "example-model")).toBeNull();
+  });
+
+  it("keeps a unique provider-qualified entry available through its bare alias", () => {
+    const table = parseRateTable({
+      "provider-a/example-model": {
+        input_cost_per_token: 1,
+        output_cost_per_token: 2,
+      },
+    });
+
+    expect(lookupRate(table, "example-model")).toEqual(
+      lookupRate(table, "provider-a/example-model"),
+    );
+    expect(rateTableModelCount(table)).toBe(1);
+  });
+
+  it("does not fall back to a bare alias when a provider-qualified lookup misses", () => {
+    const table = parseRateTable({
+      "example-model": rate(1),
+      "provider-a/example-model": rate(3),
+    });
+
+    expect(lookupRate(table, "provider-b/example-model")).toBeNull();
+  });
+
+  it("prefers the canonical raw spelling for normalized bare-key duplicates in either order", () => {
+    const canonical = ["example-model", rate(1, 2, 0.1, 1.25)] as const;
+    const variant = [" Example-Model ", rate(10, 20, 5, 15)] as const;
+
+    for (const entries of [
+      [canonical, variant],
+      [variant, canonical],
+    ]) {
+      const table = parseRateTable(Object.fromEntries(entries));
+      expect(lookupRate(table, "example-model")).toEqual({
+        inputCostPerToken: 1,
+        outputCostPerToken: 2,
+        cacheReadCostPerToken: 0.1,
+        cacheCreationCostPerToken: 1.25,
+      });
+      expect(rateTableModelCount(table)).toBe(1);
+    }
+  });
+
+  it("prefers the canonical raw spelling for normalized qualified-key duplicates in either order", () => {
+    const canonical = ["provider-a/example-model", rate(1, 2, 0.1, 1.25)] as const;
+    const variant = [" Provider-A/Example-Model ", rate(10, 20, 5, 15)] as const;
+
+    for (const entries of [
+      [canonical, variant],
+      [variant, canonical],
+    ]) {
+      const table = parseRateTable(Object.fromEntries(entries));
+      expect(lookupRate(table, "provider-a/example-model")).toEqual({
+        inputCostPerToken: 1,
+        outputCostPerToken: 2,
+        cacheReadCostPerToken: 0.1,
+        cacheCreationCostPerToken: 1.25,
+      });
+      expect(lookupRate(table, "example-model")).toEqual(
+        lookupRate(table, "provider-a/example-model"),
+      );
+      expect(rateTableModelCount(table)).toBe(1);
+    }
+  });
+
+  it("drops ambiguous normalized duplicates when neither has canonical provenance", () => {
+    const cases = [
+      ["Example-Model", " EXAMPLE-MODEL ", "example-model"],
+      ["Provider-A/Example-Model", " PROVIDER-A/EXAMPLE-MODEL ", "provider-a/example-model"],
+    ] as const;
+
+    for (const [firstName, secondName, lookup] of cases) {
+      const first = [firstName, rate(1)] as const;
+      const second = [secondName, rate(10)] as const;
+      for (const entries of [
+        [first, second],
+        [second, first],
+      ]) {
+        const table = parseRateTable(Object.fromEntries(entries));
+        expect(lookupRate(table, lookup)).toBeNull();
+        expect(rateTableModelCount(table)).toBe(0);
+      }
+    }
+  });
+});

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -24,7 +24,21 @@ export interface ModelRate {
   readonly cacheCreationCostPerToken: number;
 }
 
-export type RateTable = ReadonlyMap<string, ModelRate>;
+/**
+ * Parsed pricing data with source models kept separate from derived aliases.
+ *
+ * Keeping these indexes distinct prevents a convenience alias from inflating
+ * the model count or being mistaken for an exact provider-qualified entry.
+ */
+export interface RateTable {
+  readonly exactRates: ReadonlyMap<string, ModelRate>;
+  readonly bareAliases: ReadonlyMap<string, ModelRate>;
+  readonly modelCount: number;
+}
+
+export function emptyRateTable(): RateTable {
+  return { exactRates: new Map(), bareAliases: new Map(), modelCount: 0 };
+}
 
 /** Raw shape of one LiteLLM entry, narrowed to the fields we read. */
 interface LiteLlmEntry {
@@ -43,11 +57,15 @@ function finiteNumber(value: unknown): number | null {
  *
  * Entries without both an input and an output rate are dropped: a half-priced
  * model would silently under-report cost, which is worse than reporting the
- * model as unpriced.
+ * model as unpriced. Provider-qualified keys remain distinct. A bare alias is
+ * added only for a canonical entry or one unambiguous provider candidate.
  */
 export function parseRateTable(document: unknown): RateTable {
-  const table = new Map<string, ModelRate>();
-  if (typeof document !== "object" || document === null) return table;
+  const candidatesByKey = new Map<
+    string,
+    Array<{ readonly rawName: string; readonly rate: ModelRate }>
+  >();
+  if (typeof document !== "object" || document === null) return emptyRateTable();
 
   for (const [name, raw] of Object.entries(document as Record<string, unknown>)) {
     if (typeof raw !== "object" || raw === null) continue;
@@ -56,7 +74,9 @@ export function parseRateTable(document: unknown): RateTable {
     const output = finiteNumber(entry.output_cost_per_token);
     if (input === null || output === null) continue;
 
-    table.set(normalizeModelName(name), {
+    const key = normalizeRateKey(name);
+    if (key.length === 0) continue;
+    const rate = {
       inputCostPerToken: input,
       outputCostPerToken: output,
       // Anthropic bills cache reads at a discount and cache writes at a
@@ -64,20 +84,72 @@ export function parseRateTable(document: unknown): RateTable {
       // input rather than as free.
       cacheReadCostPerToken: finiteNumber(entry.cache_read_input_token_cost) ?? input,
       cacheCreationCostPerToken: finiteNumber(entry.cache_creation_input_token_cost) ?? input,
-    });
+    };
+    const candidates = candidatesByKey.get(key) ?? [];
+    candidates.push({ rawName: name, rate });
+    candidatesByKey.set(key, candidates);
   }
-  return table;
+
+  const exactRates = new Map<string, ModelRate>();
+  for (const [key, candidates] of candidatesByKey) {
+    const selected = selectExactCandidate(key, candidates);
+    if (selected !== null) exactRates.set(key, selected.rate);
+  }
+
+  const candidatesByAlias = new Map<
+    string,
+    Array<{ readonly key: string; readonly rate: ModelRate }>
+  >();
+  for (const [key, rate] of exactRates) {
+    const alias = normalizeModelName(key);
+    const candidates = candidatesByAlias.get(alias) ?? [];
+    candidates.push({ key, rate });
+    candidatesByAlias.set(alias, candidates);
+  }
+
+  const bareAliases = new Map<string, ModelRate>();
+  for (const [alias, candidates] of candidatesByAlias) {
+    const canonical = candidates.find((candidate) => candidate.key === alias);
+    if (canonical === undefined && candidates.length === 1) {
+      const [candidate] = candidates;
+      if (candidate !== undefined) bareAliases.set(alias, candidate.rate);
+    }
+  }
+
+  return { exactRates, bareAliases, modelCount: exactRates.size };
+}
+
+/**
+ * Selects one source entry after normalization.
+ *
+ * A collision is only resolved when one entry has the canonical normalized
+ * spelling verbatim. Otherwise neither variant has trustworthy provenance, so
+ * dropping the key is safer than making pricing depend on document order.
+ */
+function selectExactCandidate(
+  key: string,
+  candidates: readonly { readonly rawName: string; readonly rate: ModelRate }[],
+): { readonly rawName: string; readonly rate: ModelRate } | null {
+  if (candidates.length === 1) return candidates[0] ?? null;
+  return candidates.find((candidate) => candidate.rawName === key) ?? null;
+}
+
+export function rateTableModelCount(table: RateTable): number {
+  return table.modelCount;
+}
+
+function normalizeRateKey(model: string): string {
+  return model.trim().toLowerCase();
 }
 
 /**
  * Canonicalises a model name for lookup.
  *
- * Strips a `provider/` prefix (LiteLLM publishes both `claude-opus-5` and
- * `anthropic/claude-opus-5`) and lowercases, since transcripts are inconsistent
- * about casing.
+ * Strips a `provider/` prefix and lowercases. This derives a candidate bare
+ * alias; exact provider-qualified lookup uses the normalized full key first.
  */
 export function normalizeModelName(model: string): string {
-  const trimmed = model.trim().toLowerCase();
+  const trimmed = normalizeRateKey(model);
   const slash = trimmed.lastIndexOf("/");
   return slash === -1 ? trimmed : trimmed.slice(slash + 1);
 }
@@ -99,9 +171,11 @@ const UNPRICEABLE_MODELS = new Set([
 ]);
 
 export function lookupRate(table: RateTable, model: string): ModelRate | null {
+  const exact = normalizeRateKey(model);
   const normalized = normalizeModelName(model);
   if (normalized.length === 0 || UNPRICEABLE_MODELS.has(normalized)) return null;
-  return table.get(normalized) ?? null;
+  if (exact.includes("/")) return table.exactRates.get(exact) ?? null;
+  return table.exactRates.get(exact) ?? table.bareAliases.get(exact) ?? null;
 }
 
 export interface PricedUsage {


### PR DESCRIPTION
## What Changed

- Separate exact provider-qualified rates, bare aliases, and the public model count.
- Resolve qualified model names only through their exact provider key.
- Prefer a canonical bare rate, allow one unambiguous provider fallback, and leave ambiguous collisions unpriced.
- Make case/whitespace-normalized collisions deterministic instead of document-order dependent.
- Keep aliases from inflating `pricing.knownModels`.

## Why

The rate parser currently strips provider prefixes before insertion, so LiteLLM entries ending in the same model name overwrite one another. JSON order can change base and cache pricing, including replacing a canonical cache-read rate with full input price.

Closes #5797

## Verification

- 16 focused pricing and aggregation tests passed after review fixes.
- Targeted formatting and lint passed.
- Server typecheck passed; only pre-existing unrelated Effect suggestions remain.
- Branch rebased on current `upstream/main`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Implemented with gpt-5.6-sol in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `lookupRate` to keep provider-qualified and bare alias entries distinct in `RateTable`
> - Restructures `RateTable` in [usagePricing.ts](https://github.com/pingdotgg/t3code/pull/5810/files#diff-fe836a76687342f066ff2679d4edcb42b28156a016ba013085092c27fc826c66) from a flat `Map<string, ModelRate>` into an object with `exactRates`, `bareAliases`, and `modelCount`, so provider-qualified and bare alias entries are stored separately.
> - `parseRateTable` now drops ambiguous normalized duplicates (no canonical provenance) and only creates bare aliases for canonical or unambiguous entries.
> - `lookupRate` no longer falls back from a missing provider-qualified key to a bare alias; bare lookups still resolve via `exactRates` then `bareAliases`.
> - `UsageService` switches from `Map.size` to `rateTableModelCount()` so alias-only entries are excluded from model counts and rate-status decisions.
> - Behavioral Change: provider-qualified model lookups that previously matched a bare alias will now return null if no exact entry exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3b1d5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how transcript model names map to LiteLLM rates, so some costs may shift from priced to unpriced (or vice versa) for ambiguous or provider-qualified names.
> 
> **Overview**
> Fixes LiteLLM usage pricing so provider-qualified model keys no longer overwrite each other when normalized to the same bare name.
> 
> **`RateTable`** is no longer a single `Map`; it now holds **`exactRates`**, optional **`bareAliases`**, and **`modelCount`**. **`parseRateTable`** indexes entries by the full normalized key, resolves duplicate spellings only when one row matches the canonical key (otherwise drops the key), and adds a bare alias only for a canonical bare entry or a single unambiguous provider-qualified candidate. **`lookupRate`** uses exact keys for `provider/model` lookups (no bare fallback on miss); bare names still resolve via exact then alias. **`UsageService`** uses **`emptyRateTable`**, **`rateTableModelCount`**, and reports **`knownModels`** from exact entries only.
> 
> Adds **`usagePricing.test.ts`** for alias/collision behavior; aggregation tests build rates via **`parseRateTable`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b1d5c4530cf702e25fdf3f0bd82022eaa7687d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->