### PR TITLE
fix(server): report incomplete usage scans

### DIFF
--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -1,0 +1,295 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import { UsageDay } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+
+import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
+import * as UsageService from "./UsageService.ts";
+import { listTranscriptFiles } from "./usageTranscriptReader.ts";
+
+const TestHttpClientLive = Layer.succeed(
+  HttpClient.HttpClient,
+  HttpClient.make((request) =>
+    Effect.succeed(HttpClientResponse.fromWeb(request, Response.json({}))),
+  ),
+);
+
+const AUGUST_WINDOW = {
+  sinceDay: UsageDay.make("2026-08-01"),
+  untilDay: UsageDay.make("2026-08-31"),
+  timeZone: "UTC",
+} as const;
+
+function makeUsageLayer(input: {
+  readonly baseDir: string;
+  readonly claudeHome: string;
+  readonly codexHome: string;
+  readonly fileSystem?: FileSystem.FileSystem;
+}) {
+  const platformLayer =
+    input.fileSystem === undefined
+      ? NodeServices.layer
+      : Layer.merge(NodeServices.layer, Layer.succeed(FileSystem.FileSystem, input.fileSystem));
+  return UsageService.layer.pipe(
+    Layer.provide(ServerConfig.layerTest(process.cwd(), input.baseDir)),
+    Layer.provide(
+      ServerSettings.layerTest({
+        providers: {
+          claudeAgent: { homePath: input.claudeHome },
+          codex: { homePath: input.codexHome },
+        },
+      }),
+    ),
+    Layer.provide(TestHttpClientLive),
+    Layer.provideMerge(platformLayer),
+  );
+}
+
+function claudeUsageLine(outputTokens: number): string {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-08-08T12:00:00.000Z",
+    sessionId: "session-a",
+    message: {
+      id: `msg-${outputTokens}`,
+      model: "claude-fable-5",
+      usage: {
+        input_tokens: 10,
+        cache_read_input_tokens: 20,
+        cache_creation_input_tokens: 30,
+        output_tokens: outputTokens,
+      },
+    },
+  });
+}
+
+it.layer(NodeServices.layer)("UsageService", (it) => {
+  it.effect("keeps an unreadable default Claude root instead of using the legacy fallback", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-usage-service-default-root-",
+      });
+      const homePath = path.join(root, "home");
+      const preferred = path.join(homePath, ".claude", "projects");
+      yield* fileSystem.makeDirectory(path.dirname(preferred), { recursive: true });
+      yield* fileSystem.writeFileString(preferred, "not a directory");
+
+      const inspectionError = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "exists",
+        description: "permission denied",
+        pathOrDescriptor: preferred,
+      });
+      const failingFileSystem = {
+        ...fileSystem,
+        exists: (candidate: string) =>
+          candidate === preferred ? Effect.fail(inspectionError) : fileSystem.exists(candidate),
+      } satisfies FileSystem.FileSystem;
+
+      const resolved = yield* UsageService.resolveClaudeTranscriptDir({
+        homePath,
+        explicitHome: false,
+      }).pipe(Effect.provideService(FileSystem.FileSystem, failingFileSystem));
+      const listing = yield* Effect.promise(() => listTranscriptFiles(resolved, 0));
+
+      expect(resolved).toBe(preferred);
+      expect(listing.rootStatus).toBe("failed");
+    }),
+  );
+
+  it.effect("uses the legacy default-home layout only when the preferred root is absent", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-usage-service-legacy-root-",
+      });
+      const homePath = path.join(root, "home");
+
+      const resolved = yield* UsageService.resolveClaudeTranscriptDir({
+        homePath,
+        explicitHome: false,
+      });
+
+      expect(resolved).toBe(path.join(homePath, "projects"));
+    }),
+  );
+
+  it.effect("reads an explicit Claude home directly without probing the default layout", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-usage-service-preferred-root-",
+      });
+      const baseDir = path.join(root, "t3-home");
+      const claudeHome = path.join(root, "claude");
+      const codexHome = path.join(root, "codex");
+      const direct = path.join(claudeHome, "projects");
+      const defaultLayout = path.join(claudeHome, ".claude", "projects");
+      yield* fileSystem.makeDirectory(direct, { recursive: true });
+      yield* fileSystem.writeFileString(path.join(direct, "usage.jsonl"), claudeUsageLine(40));
+      yield* fileSystem.makeDirectory(path.dirname(defaultLayout), { recursive: true });
+      yield* fileSystem.writeFileString(defaultLayout, "not a directory");
+
+      const inspectionError = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "exists",
+        description: "permission denied",
+        pathOrDescriptor: defaultLayout,
+      });
+      const failingFileSystem = {
+        ...fileSystem,
+        exists: (candidate: string) =>
+          candidate === defaultLayout ? Effect.fail(inspectionError) : fileSystem.exists(candidate),
+      } satisfies FileSystem.FileSystem;
+
+      const summary = yield* Effect.gen(function* () {
+        const usage = yield* UsageService.UsageService;
+        return yield* usage.readSummary(AUGUST_WINDOW);
+      }).pipe(
+        Effect.provide(
+          makeUsageLayer({ baseDir, claudeHome, codexHome, fileSystem: failingFileSystem }),
+        ),
+      );
+
+      expect(
+        summary.sources.find(({ fingerprint }) => fingerprint.provider === "claude"),
+      ).toMatchObject({
+        fingerprint: { resolvedHomePath: direct },
+        status: "ok",
+        scannedFiles: 1,
+        message: null,
+      });
+      expect(summary.buckets[0]?.totals.outputTokens).toBe(40);
+    }),
+  );
+
+  it.effect("reports partial coverage while retaining readable transcript usage", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-usage-service-partial-",
+      });
+      const baseDir = path.join(root, "t3-home");
+      const claudeHome = path.join(root, "claude");
+      const codexHome = path.join(root, "codex");
+      const transcriptDir = path.join(claudeHome, "projects");
+      const readablePath = path.join(transcriptDir, "readable.jsonl");
+      const unreadablePath = path.join(transcriptDir, "unreadable.jsonl");
+
+      yield* fileSystem.makeDirectory(transcriptDir, { recursive: true });
+      yield* fileSystem.writeFileString(readablePath, claudeUsageLine(40));
+      yield* fileSystem.writeFileString(unreadablePath, claudeUsageLine(900));
+      yield* fileSystem.chmod(unreadablePath, 0o000);
+      yield* Effect.addFinalizer(() => fileSystem.chmod(unreadablePath, 0o600).pipe(Effect.ignore));
+
+      const summary = yield* Effect.gen(function* () {
+        const usage = yield* UsageService.UsageService;
+        return yield* usage.readSummary(AUGUST_WINDOW);
+      }).pipe(Effect.provide(makeUsageLayer({ baseDir, claudeHome, codexHome })));
+
+      const source = summary.sources.find(({ fingerprint }) => fingerprint.provider === "claude");
+      expect(source).toMatchObject({
+        status: "partial",
+        scannedFiles: 1,
+        skippedFiles: 1,
+        message: "Usage may be incomplete: 1 transcript file could not be read.",
+      });
+      expect(summary.buckets).toHaveLength(1);
+      expect(summary.buckets[0]?.totals.outputTokens).toBe(40);
+    }),
+  );
+
+  it.effect("reports failed coverage when an existing transcript root cannot be listed", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-usage-service-failed-",
+      });
+      const baseDir = path.join(root, "t3-home");
+      const claudeHome = path.join(root, "claude");
+      const codexHome = path.join(root, "codex");
+      const transcriptDir = path.join(claudeHome, "projects");
+
+      yield* fileSystem.makeDirectory(path.dirname(transcriptDir), { recursive: true });
+      yield* fileSystem.writeFileString(transcriptDir, "not a directory");
+
+      const summary = yield* Effect.gen(function* () {
+        const usage = yield* UsageService.UsageService;
+        return yield* usage.readSummary(AUGUST_WINDOW);
+      }).pipe(Effect.provide(makeUsageLayer({ baseDir, claudeHome, codexHome })));
+
+      expect(
+        summary.sources.find(({ fingerprint }) => fingerprint.provider === "claude"),
+      ).toMatchObject({
+        status: "failed",
+        scannedFiles: 0,
+        skippedFiles: 0,
+        message: "Transcript directory could not be read.",
+      });
+      expect(
+        summary.sources.find(({ fingerprint }) => fingerprint.provider === "codex"),
+      ).toMatchObject({
+        status: "missing",
+        message: "No transcript directory on this environment.",
+      });
+      expect(summary.buckets).toHaveLength(0);
+    }),
+  );
+
+  it.effect("reports partial coverage when a nested transcript directory cannot be listed", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-usage-service-nested-partial-",
+      });
+      const baseDir = path.join(root, "t3-home");
+      const claudeHome = path.join(root, "claude");
+      const codexHome = path.join(root, "codex");
+      const transcriptDir = path.join(claudeHome, "projects");
+      const unreadableDir = path.join(transcriptDir, "unreadable-session");
+
+      yield* fileSystem.makeDirectory(unreadableDir, { recursive: true });
+      yield* fileSystem.writeFileString(
+        path.join(transcriptDir, "readable.jsonl"),
+        claudeUsageLine(40),
+      );
+      yield* fileSystem.writeFileString(
+        path.join(unreadableDir, "hidden.jsonl"),
+        claudeUsageLine(900),
+      );
+      yield* fileSystem.chmod(unreadableDir, 0o000);
+      yield* Effect.addFinalizer(() => fileSystem.chmod(unreadableDir, 0o700).pipe(Effect.ignore));
+
+      const summary = yield* Effect.gen(function* () {
+        const usage = yield* UsageService.UsageService;
+        return yield* usage.readSummary(AUGUST_WINDOW);
+      }).pipe(Effect.provide(makeUsageLayer({ baseDir, claudeHome, codexHome })));
+
+      expect(
+        summary.sources.find(({ fingerprint }) => fingerprint.provider === "claude"),
+      ).toMatchObject({
+        status: "partial",
+        scannedFiles: 1,
+        skippedFiles: 0,
+        message: "Usage may be incomplete: 1 transcript path could not be listed or inspected.",
+      });
+      expect(summary.buckets).toHaveLength(1);
+      expect(summary.buckets[0]?.totals.outputTokens).toBe(40);
+    }),
+  );
+});

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -85,12 +85,46 @@ const ScanCacheJson = Schema.fromJsonString(Schema.Unknown as unknown as Schema.
 const decodeScanCacheFile = Schema.decodeUnknownEffect(ScanCacheJson);
 const encodeScanCacheFile = Schema.encodeEffect(ScanCacheJson);
 
+function incompleteScanMessage(scanIssues: number, failedFiles: number): string | null {
+  const details: string[] = [];
+  if (scanIssues > 0) {
+    details.push(
+      `${scanIssues} transcript ${scanIssues === 1 ? "path" : "paths"} could not be listed or inspected`,
+    );
+  }
+  if (failedFiles > 0) {
+    details.push(
+      `${failedFiles} transcript ${failedFiles === 1 ? "file" : "files"} could not be read`,
+    );
+  }
+  return details.length === 0 ? null : `Usage may be incomplete: ${details.join("; ")}.`;
+}
+
 export class UsageService extends Context.Service<
   UsageService,
   {
     readonly readSummary: (input: UsageSummaryInput) => Effect.Effect<UsageSummary, UsageReadError>;
   }
 >()("t3/usage/UsageService") {}
+
+/** Resolves Claude's transcript layout without losing explicit-home semantics. */
+export const resolveClaudeTranscriptDir = Effect.fn("UsageService.resolveClaudeTranscriptDir")(
+  function* (input: { readonly homePath: string; readonly explicitHome: boolean }) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const direct = path.join(input.homePath, "projects");
+    if (input.explicitHome) return direct;
+
+    const nested = path.join(input.homePath, ".claude", "projects");
+    const nestedExists = yield* fileSystem
+      .exists(nested)
+      // Fall back only when the preferred path is genuinely absent. If the
+      // probe itself fails, scan that path so coverage reports `failed` rather
+      // than making an unreadable source look `missing` at the legacy path.
+      .pipe(Effect.catchCause(() => Effect.succeed(true)));
+    return nestedExists ? nested : direct;
+  },
+);
 
 /** Empty summary, for suites that only need the RPC surface to resolve. */
 export const layerTest = Layer.succeed(
@@ -183,19 +217,6 @@ export const make = Effect.gen(function* () {
     );
   });
 
-  /**
-   * Claude's config dir is the home itself when overridden, but a default
-   * install nests transcripts under `~/.claude/projects`. Probe both.
-   */
-  const resolveClaudeTranscriptDir = (homePath: string) =>
-    Effect.gen(function* () {
-      const nested = path.join(homePath, ".claude", "projects");
-      const nestedExists = yield* fileSystem
-        .exists(nested)
-        .pipe(Effect.catchCause(() => Effect.succeed(false)));
-      return nestedExists ? nested : path.join(homePath, "projects");
-    });
-
   /** Resolves the transcript directory for each provider. */
   const resolveTranscriptDirs = Effect.fn("UsageService.resolveTranscriptDirs")(function* () {
     // A settings failure must surface as an error: swallowing it here would
@@ -214,8 +235,15 @@ export const make = Effect.gen(function* () {
       ),
     );
 
-    const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
-    const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
+    const claudeConfig = settings.providers.claudeAgent;
+    const claudeHome = yield* resolveClaudeHomePath(claudeConfig);
+    const claudeDir = yield* resolveClaudeTranscriptDir({
+      homePath: claudeHome,
+      explicitHome: claudeConfig.homePath.trim().length > 0,
+    }).pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(Path.Path, path),
+    );
     const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
 
     return [
@@ -262,7 +290,7 @@ export const make = Effect.gen(function* () {
     size: number,
     mtimeMs: number,
     provider: UsageProviderKind,
-  ): Effect.Effect<readonly UsageRecord[]> =>
+  ): Effect.Effect<readonly UsageRecord[] | null> =>
     Effect.gen(function* () {
       const cached = fileCache.get(filePath);
       // Provider is part of the identity: if both providers were ever pointed
@@ -279,7 +307,7 @@ export const make = Effect.gen(function* () {
       const parsed = yield* Effect.promise(() => readTranscriptRecords(filePath, provider));
       // A read failure is not an empty transcript: caching it under this
       // (size, mtime) would silently drop the file's usage until it changes.
-      if (parsed === null) return [];
+      if (parsed === null) return null;
       // Stored already de-duplicated within the file, which is 99% of all
       // duplicates. The aggregator still runs the cross-file dedupe pass.
       const records = dedupeWithinFile(parsed);
@@ -327,11 +355,9 @@ export const make = Effect.gen(function* () {
 
     for (const { provider, dir } of dirs) {
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
-      const exists = yield* fileSystem
-        .exists(dir)
-        .pipe(Effect.catchCause(() => Effect.succeed(false)));
+      const listing = yield* Effect.promise(() => listTranscriptFiles(dir, windowStartMs));
 
-      if (!exists) {
+      if (listing.rootStatus === "missing") {
         sources.push({
           fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
           status: "missing",
@@ -344,17 +370,37 @@ export const make = Effect.gen(function* () {
         continue;
       }
 
-      walkedRoots.push(dir);
-      const files = yield* Effect.promise(() => listTranscriptFiles(dir, windowStartMs));
+      if (listing.rootStatus === "failed") {
+        sources.push({
+          fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
+          status: "failed",
+          scannedFiles: 0,
+          skippedFiles: 0,
+          malformedRecords: 0,
+          distinctSessions: 0,
+          message: "Transcript directory could not be read.",
+        });
+        continue;
+      }
+
+      // Absence from a partial walk does not prove a cached file disappeared.
+      // Only a complete walk may evict paths that were not seen this pass.
+      if (listing.failedPaths === 0) walkedRoots.push(dir);
       let scannedFiles = 0;
       let skippedFiles = 0;
+      let failedFiles = 0;
       // Distinct per directory. Buckets carry per-cell session counts, but a
       // session spans days and models, so clients total this figure instead.
       const sessionIds = new Set<string>();
 
-      for (const file of files) {
+      for (const file of listing.files) {
         livePaths.add(file.path);
         const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
+        if (records === null) {
+          failedFiles += 1;
+          skippedFiles += 1;
+          continue;
+        }
         if (records.length === 0) {
           skippedFiles += 1;
           continue;
@@ -369,14 +415,15 @@ export const make = Effect.gen(function* () {
         }
       }
 
+      const message = incompleteScanMessage(listing.failedPaths, failedFiles);
       sources.push({
         fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
-        status: "ok",
+        status: message === null ? "ok" : "partial",
         scannedFiles,
         skippedFiles,
         malformedRecords: 0,
         distinctSessions: sessionIds.size,
-        message: null,
+        message,
       });
     }
 

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -31,24 +31,37 @@ export interface TranscriptFile {
   readonly mtimeMs: number;
 }
 
+export interface TranscriptFileListing {
+  readonly files: readonly TranscriptFile[];
+  readonly rootStatus: "ok" | "missing" | "failed";
+  readonly failedPaths: number;
+}
+
 /**
  * Lists `.jsonl` transcripts under `root` last modified at or after `sinceMs`.
  *
- * Errors on individual entries are swallowed: session files rotate and get
- * removed while the walk is in flight, and a partial listing is far better than
- * failing the page.
+ * A missing root is distinct from a root that exists but cannot be read.
+ * Nested directory and entry failures are counted so callers can keep the
+ * files that were found without claiming complete coverage.
  */
 export async function listTranscriptFiles(
   root: string,
   sinceMs: number,
-): Promise<readonly TranscriptFile[]> {
+): Promise<TranscriptFileListing> {
   const found: TranscriptFile[] = [];
+  let failedPaths = 0;
+  let rootStatus: TranscriptFileListing["rootStatus"] = "ok";
 
   const walk = async (dir: string): Promise<void> => {
     let entries;
     try {
       entries = await NodeFSP.readdir(dir, { withFileTypes: true });
-    } catch {
+    } catch (error) {
+      if (dir === root) {
+        rootStatus = (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "failed";
+      } else {
+        failedPaths += 1;
+      }
       return;
     }
     for (const entry of entries) {
@@ -64,13 +77,13 @@ export async function listTranscriptFiles(
           found.push({ path: child, size: stats.size, mtimeMs: stats.mtimeMs });
         }
       } catch {
-        // Vanished between readdir and stat.
+        failedPaths += 1;
       }
     }
   };
 
   await walk(root);
-  return found;
+  return { files: found, rootStatus, failedPaths };
 }
 
 /**

--- a/apps/web/src/usage/usageMerge.test.ts
+++ b/apps/web/src/usage/usageMerge.test.ts
@@ -4,6 +4,7 @@ import {
   type UsageBucket,
   type UsageDay,
   type UsageProviderKind,
+  type UsageSourceStatus,
   type UsageSummary,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
@@ -40,6 +41,7 @@ function summary(
     homePath: string;
     volumeId?: string;
     distinctSessions?: number;
+    status?: UsageSourceStatus;
   }[],
   contractVersion: number = USAGE_CONTRACT_VERSION,
 ): UsageSummary {
@@ -57,7 +59,7 @@ function summary(
         resolvedHomePath: source.homePath,
         volumeId: source.volumeId ?? `vol-${source.hostId}`,
       },
-      status: "ok" as const,
+      status: source.status ?? "ok",
       scannedFiles: 1,
       skippedFiles: 0,
       malformedRecords: 0,
@@ -110,6 +112,74 @@ describe("mergeUsage", () => {
     expect(merged.sessions).toBe(1);
     expect(merged.duplicateSources).toHaveLength(1);
     expect(merged.contributingEnvironments).toEqual(["env-a"]);
+  });
+
+  it("prefers complete coverage for a shared source even when its environment sorts later", () => {
+    const shared = {
+      provider: "claude" as const,
+      hostId: "mac",
+      homePath: "/home/theo/.claude",
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket({ costUsd: 4, records: 2 })],
+            [{ ...shared, status: "partial", distinctSessions: 2 }],
+          ),
+        ),
+        environment(
+          "env-b",
+          summary(
+            [bucket({ costUsd: 10, records: 5 })],
+            [{ ...shared, status: "ok", distinctSessions: 7 }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(10);
+    expect(merged.records).toBe(5);
+    expect(merged.sessions).toBe(7);
+    expect(merged.contributingEnvironments).toEqual(["env-b"]);
+    expect(merged.duplicateSources).toEqual(["env-a: /home/theo/.claude"]);
+  });
+
+  it("prefers partial coverage over failed and missing copies of a shared source", () => {
+    const shared = {
+      provider: "claude" as const,
+      hostId: "mac",
+      homePath: "/home/theo/.claude",
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary([bucket({ costUsd: 1 })], [{ ...shared, status: "failed", distinctSessions: 1 }]),
+        ),
+        environment(
+          "env-b",
+          summary(
+            [bucket({ costUsd: 2 })],
+            [{ ...shared, status: "missing", distinctSessions: 2 }],
+          ),
+        ),
+        environment(
+          "env-c",
+          summary(
+            [bucket({ costUsd: 6 })],
+            [{ ...shared, status: "partial", distinctSessions: 6 }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(6);
+    expect(merged.sessions).toBe(6);
+    expect(merged.contributingEnvironments).toEqual(["env-c"]);
   });
 
   it("drops only the duplicated provider, keeping the environment's other one", () => {

--- a/apps/web/src/usage/usageMerge.ts
+++ b/apps/web/src/usage/usageMerge.ts
@@ -11,6 +11,7 @@ import type {
   UsageBucket,
   UsageProviderKind,
   UsageSourceFingerprint,
+  UsageSourceStatus,
   UsageSummary,
 } from "@t3tools/contracts";
 
@@ -89,20 +90,35 @@ function fingerprintKey(fingerprint: UsageSourceFingerprint): string {
   ].join(" ");
 }
 
+const SOURCE_COVERAGE_RANK: Readonly<Record<UsageSourceStatus, number>> = {
+  missing: 0,
+  failed: 1,
+  partial: 2,
+  ok: 3,
+};
+
 /**
  * Decides which environment owns each physical transcript directory.
  *
  * Several environments on one machine (worktree servers, for instance) resolve
  * the same provider home and would otherwise double count every token. The
- * first environment in a stable order claims a fingerprint; the rest have that
- * provider's buckets dropped. Environments are sorted by id so the winner does
- * not change between renders.
+ * The environment with the best coverage claims a fingerprint; ties break by
+ * stable environment id. This prevents an earlier failed or partial scan from
+ * hiding a later complete scan of the same directory.
  */
 function claimSources(environments: readonly EnvironmentUsage[]): {
   readonly ownerByFingerprint: ReadonlyMap<string, EnvironmentId>;
   readonly duplicates: readonly string[];
 } {
-  const ownerByFingerprint = new Map<string, EnvironmentId>();
+  const claims = new Map<
+    string,
+    {
+      readonly environmentId: EnvironmentId;
+      readonly label: string;
+      readonly resolvedHomePath: string;
+      readonly coverageRank: number;
+    }
+  >();
   const duplicates: string[] = [];
 
   const ordered = [...environments].sort((a, b) => a.environmentId.localeCompare(b.environmentId));
@@ -111,14 +127,29 @@ function claimSources(environments: readonly EnvironmentUsage[]): {
     for (const source of environment.summary.sources) {
       if (source.status === "missing") continue;
       const key = fingerprintKey(source.fingerprint);
-      if (ownerByFingerprint.has(key)) {
-        duplicates.push(`${environment.label}: ${source.fingerprint.resolvedHomePath}`);
+      const existing = claims.get(key);
+      const candidate = {
+        environmentId: environment.environmentId,
+        label: environment.label,
+        resolvedHomePath: source.fingerprint.resolvedHomePath,
+        coverageRank: SOURCE_COVERAGE_RANK[source.status],
+      };
+      if (existing === undefined) {
+        claims.set(key, candidate);
         continue;
       }
-      ownerByFingerprint.set(key, environment.environmentId);
+      if (candidate.coverageRank > existing.coverageRank) {
+        duplicates.push(`${existing.label}: ${existing.resolvedHomePath}`);
+        claims.set(key, candidate);
+      } else {
+        duplicates.push(`${environment.label}: ${source.fingerprint.resolvedHomePath}`);
+      }
     }
   }
 
+  const ownerByFingerprint = new Map(
+    [...claims].map(([key, claim]) => [key, claim.environmentId] as const),
+  );
   return { ownerByFingerprint, duplicates };
 }
 


### PR DESCRIPTION
## What Changed

- Distinguish missing transcript roots from roots that cannot be read.
- Report nested listing/stat/file-read failures as partial coverage while retaining readable buckets.
- Keep failed reads out of the durable cache and avoid pruning unseen cache entries after partial walks.
- Preserve Claude's explicit-config, default nested, and legacy fallback layouts.
- Prefer the healthiest shared source across environments (`ok > partial > failed`) before deduplicating buckets.

## Why

The scanner currently converts I/O failures into empty results and still reports `status: "ok"`. That silently undercounts tokens and cost while claiming complete coverage; a weaker environment can also displace a healthy copy of the same source.

Closes #5798

## Verification

- 47 focused server/web tests passed after review fixes.
- Targeted formatting and lint passed.
- Server and web typechecks passed; only pre-existing unrelated Effect suggestions remain.
- Branch rebased on current `upstream/main`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Implemented with gpt-5.6-sol in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report incomplete usage scans with partial, failed, and missing source statuses
> - `listTranscriptFiles` in [usageTranscriptReader.ts](https://github.com/pingdotgg/t3code/pull/5812/files#diff-abfb6e6193baf30b1461a91349257b617fc266915d75b17a73ca21ccd1041d08) now returns a structured `TranscriptFileListing` with `rootStatus` (`ok` | `missing` | `failed`) and a count of `failedPaths` instead of a plain array.
> - `readSummary` in [UsageService.ts](https://github.com/pingdotgg/t3code/pull/5812/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70) uses this richer result to set source status to `missing`, `failed`, or `partial` with descriptive messages; previously all error cases silently produced empty results.
> - `readFileRecords` now returns `null` on read failure instead of an empty array, so unreadable files are counted as failed rather than appearing as empty transcripts.
> - `claimSources` in [usageMerge.ts](https://github.com/pingdotgg/t3code/pull/5812/files#diff-1fa547b68afc750e6b9b85a52d69d633e237a6fc4fa9242b64c6f37ef1094813) now assigns shared physical transcript directories to the environment with the best coverage (`ok > partial > failed > missing`) rather than the first by environment ID.
> - Behavioral Change: sources that previously appeared as empty or were silently skipped now surface as `partial` or `failed` with explicit messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dd5bc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes usage aggregation and multi-environment deduplication logic; incorrect status or merge rules could still misreport totals, but behavior is heavily covered by new server and web tests.
> 
> **Overview**
> Usage scanning no longer treats I/O failures as empty transcripts with **`status: "ok"`**. **`listTranscriptFiles`** returns a structured listing with **`missing`** vs **`failed`** roots and a count of paths that could not be walked or stat’d; **`readSummary`** maps those to source statuses and **`partial`** when some files read but others fail, with explicit “usage may be incomplete” messages.
> 
> Failed file reads return **`null`** instead of an empty record list so they are not cached as zero usage, and scan-cache pruning only runs after a **complete** directory walk so partial listings do not evict unseen cached paths. **Claude** transcript resolution is extracted as **`resolveClaudeTranscriptDir`**: explicit homes use **`projects`** directly; default installs probe **`.claude/projects`** and only fall back to legacy **`projects`** when the nested path is absent—probe errors keep the preferred path so unreadable roots surface as **`failed`** rather than **`missing`** at the legacy location.
> 
> On the web side, **`mergeUsage`** assigns duplicate physical sources to the environment with the best coverage (**`ok` > `partial` > `failed` > `missing`**) instead of the first environment by id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd5bc2eb17225d2c9c8d48ed44ef144c7db086a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->