### PR TITLE
fix(server): reconcile Codex cumulative usage

### DIFF
--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -1,0 +1,178 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { UsageSummaryInput } from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+
+import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
+import * as UsageService from "./UsageService.ts";
+
+const summaryInput = Schema.decodeSync(UsageSummaryInput)({
+  sinceDay: "2026-08-01",
+  untilDay: "2026-08-31",
+  timeZone: "UTC",
+});
+const decodeUnknownJson = Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Unknown));
+
+function codexUsageLine(options: {
+  readonly timestamp: string;
+  readonly total: readonly [number, number, number, number, number, number];
+  readonly last: readonly [number, number, number, number, number, number];
+}): string {
+  const counters = (usage: typeof options.total) => ({
+    input_tokens: usage[0],
+    cached_input_tokens: usage[1],
+    cache_write_input_tokens: usage[2],
+    output_tokens: usage[3],
+    reasoning_output_tokens: usage[4],
+    total_tokens: usage[5],
+  });
+
+  return JSON.stringify({
+    timestamp: options.timestamp,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: counters(options.total),
+        last_token_usage: counters(options.last),
+      },
+    },
+  });
+}
+
+function codexTranscript(): string {
+  return [
+    JSON.stringify({
+      timestamp: "2026-08-07T12:00:00.000Z",
+      type: "session_meta",
+      payload: { id: "codex-session" },
+    }),
+    JSON.stringify({
+      timestamp: "2026-08-07T12:00:00.000Z",
+      type: "turn_context",
+      payload: { model: "gpt-5.4" },
+    }),
+    codexUsageLine({
+      timestamp: "2026-08-07T12:00:01.000Z",
+      total: [100, 0, 0, 10, 2, 110],
+      last: [100, 0, 0, 10, 2, 110],
+    }),
+    // Cached input is a subset of input. This impossible per-request value is
+    // rejected, while its plausible cumulative checkpoint becomes the resync.
+    codexUsageLine({
+      timestamp: "2026-08-07T12:00:02.000Z",
+      total: [150, 60, 0, 15, 2, 165],
+      last: [50, 60, 0, 5, 0, 55],
+    }),
+  ].join("\n");
+}
+
+const noRatesHttpLayer = Layer.succeed(
+  HttpClient.HttpClient,
+  HttpClient.make((request) =>
+    Effect.succeed(HttpClientResponse.fromWeb(request, Response.json({}))),
+  ),
+);
+
+it.layer(NodeServices.layer)("UsageService parser diagnostics", (it) => {
+  it.effect("reports rejected Codex counters on cold and warm cache reads", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-usage-service-",
+        });
+        const codexHome = path.join(baseDir, "codex-home");
+        const codexSessions = path.join(codexHome, "sessions", "2026", "08", "07");
+        const claudeHome = path.join(baseDir, "claude-home");
+        const claudeProjects = path.join(claudeHome, "projects");
+        const transcriptPaths = [
+          path.join(codexSessions, "rollout-a.jsonl"),
+          path.join(codexSessions, "rollout-b.jsonl"),
+        ] as const;
+        const transcript = codexTranscript();
+
+        yield* fileSystem.makeDirectory(codexSessions, { recursive: true });
+        yield* fileSystem.makeDirectory(claudeProjects, { recursive: true });
+        yield* Effect.forEach(transcriptPaths, (transcriptPath) =>
+          fileSystem.writeFileString(transcriptPath, transcript),
+        );
+
+        const dependencies = Layer.mergeAll(
+          ServerConfig.layerTest(process.cwd(), baseDir),
+          ServerSettings.layerTest({
+            providers: {
+              claudeAgent: { homePath: claudeHome },
+              codex: { homePath: codexHome },
+            },
+          }),
+          noRatesHttpLayer,
+        ).pipe(Layer.provideMerge(NodeServices.layer));
+
+        const coldService = yield* UsageService.make.pipe(Effect.provide(dependencies));
+        const coldSummary = yield* coldService.readSummary(summaryInput);
+        const coldCodex = coldSummary.sources.find(
+          (source) => source.fingerprint.provider === "codex",
+        );
+
+        expect(coldCodex).toMatchObject({
+          status: "partial",
+          scannedFiles: 2,
+          malformedRecords: 2,
+          message: "Skipped 2 malformed or inconsistent usage records.",
+        });
+        expect(coldSummary.buckets).toHaveLength(1);
+
+        const cacheDocument = (yield* decodeUnknownJson(
+          yield* fileSystem.readFileString(path.join(baseDir, "userdata", "usage-scan-cache.json")),
+        )) as { readonly files: Readonly<Record<string, { readonly e?: number }>> };
+        expect(
+          transcriptPaths.map((transcriptPath) => cacheDocument.files[transcriptPath]?.e),
+        ).toEqual([1, 1]);
+
+        // Preserve the cache identity but erase every usage marker. A cold
+        // parse would now return no records or diagnostics; the second service
+        // must restore both from its durable cache.
+        const originalStats = yield* Effect.forEach(transcriptPaths, (transcriptPath) =>
+          Effect.promise(() => NodeFSP.stat(transcriptPath)),
+        );
+        yield* Effect.forEach(transcriptPaths, (transcriptPath, index) =>
+          Effect.gen(function* () {
+            const original = originalStats[index]!;
+            yield* fileSystem.writeFileString(transcriptPath, " ".repeat(transcript.length));
+            yield* Effect.promise(() =>
+              NodeFSP.utimes(transcriptPath, original.atimeMs / 1000, original.mtimeMs / 1000),
+            );
+            const restored = yield* Effect.promise(() => NodeFSP.stat(transcriptPath));
+            expect(restored.size).toBe(original.size);
+            expect(restored.mtimeMs).toBe(original.mtimeMs);
+          }),
+        );
+
+        const warmService = yield* UsageService.make.pipe(Effect.provide(dependencies));
+        const warmSummary = yield* warmService.readSummary(summaryInput);
+        const warmCodex = warmSummary.sources.find(
+          (source) => source.fingerprint.provider === "codex",
+        );
+
+        expect(warmCodex).toMatchObject({
+          status: "partial",
+          scannedFiles: 2,
+          malformedRecords: 2,
+          message: "Skipped 2 malformed or inconsistent usage records.",
+        });
+        expect(warmSummary.buckets).toHaveLength(1);
+      }),
+    ),
+  );
+});

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -43,6 +43,7 @@ import {
   listTranscriptFiles,
   readDirectoryVolumeId,
   readTranscriptRecords,
+  type TranscriptReadResult,
 } from "./usageTranscriptReader.ts";
 import {
   decodeScanCache,
@@ -51,7 +52,6 @@ import {
   pruneScanCache,
   type ScanCache,
 } from "./usageScanCache.ts";
-import type { UsageRecord } from "./usageTranscripts.ts";
 
 const LITELLM_RATES_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
@@ -257,12 +257,12 @@ export const make = Effect.gen(function* () {
   });
 
   /** Parses one transcript, reusing the cached result when it is unchanged. */
-  const readFileRecords = (
+  const readFileUsage = (
     filePath: string,
     size: number,
     mtimeMs: number,
     provider: UsageProviderKind,
-  ): Effect.Effect<readonly UsageRecord[]> =>
+  ): Effect.Effect<TranscriptReadResult> =>
     Effect.gen(function* () {
       const cached = fileCache.get(filePath);
       // Provider is part of the identity: if both providers were ever pointed
@@ -273,20 +273,29 @@ export const make = Effect.gen(function* () {
         cached.mtimeMs === mtimeMs &&
         cached.provider === provider
       ) {
-        return cached.records;
+        return {
+          records: cached.records,
+          malformedRecords: cached.malformedRecords,
+        };
       }
 
       const parsed = yield* Effect.promise(() => readTranscriptRecords(filePath, provider));
       // A read failure is not an empty transcript: caching it under this
       // (size, mtime) would silently drop the file's usage until it changes.
-      if (parsed === null) return [];
+      if (parsed === null) return { records: [], malformedRecords: 0 };
       // Stored already de-duplicated within the file, which is 99% of all
       // duplicates. The aggregator still runs the cross-file dedupe pass.
-      const records = dedupeWithinFile(parsed);
+      const records = dedupeWithinFile(parsed.records);
 
-      fileCache.set(filePath, { size, mtimeMs, provider, records });
+      fileCache.set(filePath, {
+        size,
+        mtimeMs,
+        provider,
+        records,
+        malformedRecords: parsed.malformedRecords,
+      });
       cacheDirty = true;
-      return records;
+      return { records, malformedRecords: parsed.malformedRecords };
     });
 
   const readSummary = Effect.fn("UsageService.readSummary")(function* (input: UsageSummaryInput) {
@@ -348,13 +357,16 @@ export const make = Effect.gen(function* () {
       const files = yield* Effect.promise(() => listTranscriptFiles(dir, windowStartMs));
       let scannedFiles = 0;
       let skippedFiles = 0;
+      let malformedRecords = 0;
       // Distinct per directory. Buckets carry per-cell session counts, but a
       // session spans days and models, so clients total this figure instead.
       const sessionIds = new Set<string>();
 
       for (const file of files) {
         livePaths.add(file.path);
-        const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
+        const fileUsage = yield* readFileUsage(file.path, file.size, file.mtimeMs, provider);
+        malformedRecords += fileUsage.malformedRecords;
+        const { records } = fileUsage;
         if (records.length === 0) {
           skippedFiles += 1;
           continue;
@@ -369,14 +381,18 @@ export const make = Effect.gen(function* () {
         }
       }
 
+      const hasMalformedRecords = malformedRecords > 0;
+
       sources.push({
         fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
-        status: "ok",
+        status: hasMalformedRecords ? "partial" : "ok",
         scannedFiles,
         skippedFiles,
-        malformedRecords: 0,
+        malformedRecords,
         distinctSessions: sessionIds.size,
-        message: null,
+        message: hasMalformedRecords
+          ? `Skipped ${malformedRecords} malformed or inconsistent usage ${malformedRecords === 1 ? "record" : "records"}.`
+          : null,
       });
     }
 

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -28,10 +28,18 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
   };
 }
 
-function cacheWith(entries: readonly [string, number, readonly UsageRecord[]][]): ScanCache {
+function cacheWith(
+  entries: readonly [string, number, readonly UsageRecord[], malformedRecords?: number][],
+): ScanCache {
   const cache: ScanCache = new Map();
-  for (const [path, mtimeMs, records] of entries) {
-    cache.set(path, { size: records.length * 10, mtimeMs, provider: "claude", records });
+  for (const [path, mtimeMs, records, malformedRecords = 0] of entries) {
+    cache.set(path, {
+      size: records.length * 10,
+      mtimeMs,
+      provider: "claude",
+      records,
+      malformedRecords,
+    });
   }
   return cache;
 }
@@ -50,6 +58,25 @@ describe("scan cache round trip", () => {
     expect(restored.get("/b.jsonl")).toEqual(original.get("/b.jsonl"));
   });
 
+  it("restores per-file malformed record diagnostics", () => {
+    const original: ScanCache = new Map([
+      [
+        "/codex.jsonl",
+        {
+          size: 10,
+          mtimeMs: 100,
+          provider: "codex",
+          records: [record({ provider: "codex" })],
+          malformedRecords: 2,
+        },
+      ],
+    ]);
+
+    const restored = decodeScanCache(JSON.parse(JSON.stringify(encodeScanCache(original))));
+
+    expect(restored.get("/codex.jsonl")?.malformedRecords).toBe(2);
+  });
+
   it("interns repeated model and session strings", () => {
     const encoded = encodeScanCache(
       cacheWith([["/a.jsonl", 100, [record(), record({ dedupeKey: "msg_2:" }), record()]]]),
@@ -66,6 +93,19 @@ describe("scan cache round trip", () => {
     expect(decodeScanCache({ version: 999, models: [], sessions: [], files: {} }).size).toBe(0);
   });
 
+  it("uses a distinct cache revision for Codex reconciliation diagnostics", () => {
+    const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]]));
+
+    expect(encoded.version).toBe(4);
+  });
+
+  it("invalidates v2 and v3 caches that lack reconciliation diagnostics", () => {
+    const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]]));
+
+    expect(decodeScanCache({ ...encoded, version: 2 }).size).toBe(0);
+    expect(decodeScanCache({ ...encoded, version: 3 }).size).toBe(0);
+  });
+
   it("skips malformed file entries but keeps good ones", () => {
     const encoded = encodeScanCache(cacheWith([["/good.jsonl", 100, [record()]]]));
     const withJunk = {
@@ -75,6 +115,24 @@ describe("scan cache round trip", () => {
 
     const restored = decodeScanCache(JSON.parse(JSON.stringify(withJunk)));
     expect([...restored.keys()]).toEqual(["/good.jsonl"]);
+  });
+
+  it("invalidates a file entry whose diagnostic count is missing or malformed", () => {
+    const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]])) as {
+      readonly version: number;
+      readonly models: readonly string[];
+      readonly sessions: readonly string[];
+      readonly files: Readonly<Record<string, object>>;
+    };
+    const entry = encoded.files["/a.jsonl"]!;
+
+    const missing = { ...encoded, files: { "/a.jsonl": { ...entry, e: undefined } } };
+    const negative = { ...encoded, files: { "/a.jsonl": { ...entry, e: -1 } } };
+    const fractional = { ...encoded, files: { "/a.jsonl": { ...entry, e: 0.5 } } };
+
+    expect(decodeScanCache(JSON.parse(JSON.stringify(missing))).has("/a.jsonl")).toBe(false);
+    expect(decodeScanCache(JSON.parse(JSON.stringify(negative))).has("/a.jsonl")).toBe(false);
+    expect(decodeScanCache(JSON.parse(JSON.stringify(fractional))).has("/a.jsonl")).toBe(false);
   });
 
   it("rejects the whole cache when an intern table holds a non-string", () => {

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -18,13 +18,14 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 
 import type { UsageRecord } from "./usageTranscripts.ts";
 
-export const USAGE_SCAN_CACHE_VERSION = 1 as const;
+export const USAGE_SCAN_CACHE_VERSION = 4 as const;
 
 export interface CachedFile {
   readonly size: number;
   readonly mtimeMs: number;
   readonly provider: UsageProviderKind;
   readonly records: readonly UsageRecord[];
+  readonly malformedRecords: number;
 }
 
 export type ScanCache = Map<string, CachedFile>;
@@ -51,6 +52,8 @@ interface SerializedFile {
   readonly s: number;
   readonly m: number;
   readonly p: UsageProviderKind;
+  /** Number of parser-rejected counter records in this file. */
+  readonly e: number;
   readonly r: readonly SerializedRecord[];
 }
 
@@ -83,6 +86,7 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
       s: entry.size,
       m: entry.mtimeMs,
       p: entry.provider,
+      e: entry.malformedRecords,
       r: entry.records.map((record) => [
         record.timestampMs,
         intern(models, modelIndex, record.model),
@@ -133,6 +137,7 @@ export function decodeScanCache(document: unknown): ScanCache {
     const entry = raw as Partial<SerializedFile>;
     if (typeof entry.s !== "number" || typeof entry.m !== "number") continue;
     if (entry.p !== "claude" && entry.p !== "codex") continue;
+    if (typeof entry.e !== "number" || !Number.isSafeInteger(entry.e) || entry.e < 0) continue;
     if (!isRecordArray(entry.r)) continue;
 
     const provider: UsageProviderKind = entry.p;
@@ -192,7 +197,13 @@ export function decodeScanCache(document: unknown): ScanCache {
     }
 
     if (corrupt) continue;
-    cache.set(path, { size: entry.s, mtimeMs: entry.m, provider, records });
+    cache.set(path, {
+      size: entry.s,
+      mtimeMs: entry.m,
+      provider,
+      records,
+      malformedRecords: entry.e,
+    });
   }
 
   return cache;

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -1,0 +1,160 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { readTranscriptRecords } from "./usageTranscriptReader.ts";
+
+function codexUsageLine(options: {
+  readonly timestamp: string;
+  readonly total: {
+    readonly input: number;
+    readonly cached: number;
+    readonly cacheWrite: number;
+    readonly output: number;
+    readonly reasoning: number;
+    readonly all: number;
+  };
+  readonly last: {
+    readonly input: number;
+    readonly cached: number;
+    readonly cacheWrite: number;
+    readonly output: number;
+    readonly reasoning: number;
+    readonly all: number;
+  };
+}): string {
+  const counters = (usage: typeof options.total) => ({
+    input_tokens: usage.input,
+    cached_input_tokens: usage.cached,
+    cache_write_input_tokens: usage.cacheWrite,
+    output_tokens: usage.output,
+    reasoning_output_tokens: usage.reasoning,
+    total_tokens: usage.all,
+  });
+
+  return JSON.stringify({
+    timestamp: options.timestamp,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: counters(options.total),
+        last_token_usage: counters(options.last),
+      },
+    },
+  });
+}
+
+it.layer(NodeServices.layer)("usage transcript reader", (it) => {
+  it.effect("returns Codex records with rejected counter diagnostics", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-usage-reader-codex-",
+        });
+        const transcriptPath = path.join(directory, "rollout.jsonl");
+
+        yield* fileSystem.writeFileString(
+          transcriptPath,
+          [
+            // @effect-diagnostics-next-line preferSchemaOverJson:off -- Raw provider JSONL fixture.
+            JSON.stringify({
+              timestamp: "2026-08-07T12:00:00.000Z",
+              type: "turn_context",
+              payload: { model: "gpt-5.4" },
+            }),
+            codexUsageLine({
+              timestamp: "2026-08-07T12:00:01.000Z",
+              total: {
+                input: 100,
+                cached: 0,
+                cacheWrite: 0,
+                output: 10,
+                reasoning: 2,
+                all: 110,
+              },
+              last: {
+                input: 100,
+                cached: 0,
+                cacheWrite: 0,
+                output: 10,
+                reasoning: 2,
+                all: 110,
+              },
+            }),
+            // The cumulative checkpoint is plausible, but the per-request
+            // cached subset exceeds its input total and must be rejected.
+            codexUsageLine({
+              timestamp: "2026-08-07T12:00:02.000Z",
+              total: {
+                input: 150,
+                cached: 60,
+                cacheWrite: 0,
+                output: 15,
+                reasoning: 2,
+                all: 165,
+              },
+              last: {
+                input: 50,
+                cached: 60,
+                cacheWrite: 0,
+                output: 5,
+                reasoning: 0,
+                all: 55,
+              },
+            }),
+          ].join("\n"),
+        );
+
+        const result = yield* Effect.promise(() => readTranscriptRecords(transcriptPath, "codex"));
+
+        expect(result).not.toBeNull();
+        expect(result?.records).toHaveLength(1);
+        expect(result?.malformedRecords).toBe(1);
+      }),
+    ),
+  );
+
+  it.effect("returns zero counter diagnostics for Claude transcripts", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-usage-reader-claude-",
+        });
+        const transcriptPath = path.join(directory, "session.jsonl");
+
+        yield* fileSystem.writeFileString(
+          transcriptPath,
+          // @effect-diagnostics-next-line preferSchemaOverJson:off -- Raw provider JSONL fixture.
+          JSON.stringify({
+            timestamp: "2026-08-07T12:00:00.000Z",
+            type: "assistant",
+            sessionId: "claude-session",
+            message: {
+              id: "msg_1",
+              model: "claude-opus-4-1",
+              usage: {
+                input_tokens: 10,
+                cache_read_input_tokens: 2,
+                cache_creation_input_tokens: 1,
+                output_tokens: 5,
+              },
+            },
+          }),
+        );
+
+        const result = yield* Effect.promise(() => readTranscriptRecords(transcriptPath, "claude"));
+
+        expect(result).not.toBeNull();
+        expect(result?.records).toHaveLength(1);
+        expect(result?.malformedRecords).toBe(0);
+      }),
+    ),
+  );
+});

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -31,6 +31,11 @@ export interface TranscriptFile {
   readonly mtimeMs: number;
 }
 
+export interface TranscriptReadResult {
+  readonly records: readonly UsageRecord[];
+  readonly malformedRecords: number;
+}
+
 /**
  * Lists `.jsonl` transcripts under `root` last modified at or after `sinceMs`.
  *
@@ -90,8 +95,8 @@ export async function readDirectoryVolumeId(path: string): Promise<string> {
 }
 
 /**
- * Streams one transcript and returns the usage records it contains, or `null`
- * when the file could not be read.
+ * Streams one transcript and returns its usage records and parser diagnostics,
+ * or `null` when the file could not be read.
  *
  * The distinction matters to the caller's cache: a genuinely empty transcript
  * is a stable fact worth memoising, while a transient read failure memoised
@@ -105,7 +110,7 @@ export async function readDirectoryVolumeId(path: string): Promise<string> {
 export async function readTranscriptRecords(
   filePath: string,
   provider: UsageProviderKind,
-): Promise<readonly UsageRecord[] | null> {
+): Promise<TranscriptReadResult | null> {
   const records: UsageRecord[] = [];
   const codexState = initialCodexScanState();
 
@@ -137,5 +142,10 @@ export async function readTranscriptRecords(
     return null;
   }
 
-  return records;
+  return {
+    records,
+    // Claude reports independent per-request counters, so this cumulative
+    // integrity diagnostic only applies to Codex token-count checkpoints.
+    malformedRecords: provider === "codex" ? codexState.malformedRecords : 0,
+  };
 }

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -78,19 +78,41 @@ describe("parseCodexLine", () => {
     timestamp: "2026-08-01T05:17:42.694Z",
     payload: { type: "turn_context", model: "gpt-5.6-sol" },
   });
-  const tokenCount = (inputTokens: number, cached: number, output: number, reasoning: number) =>
+  interface TokenUsageFixture {
+    readonly inputTokens: number;
+    readonly cached: number;
+    readonly output: number;
+    readonly reasoning: number;
+  }
+
+  const tokenCount = (
+    inputTokens: number,
+    cached: number,
+    output: number,
+    reasoning: number,
+    total: TokenUsageFixture = { inputTokens, cached, output, reasoning },
+  ) =>
     JSON.stringify({
       type: "event_msg",
       timestamp: "2026-08-01T05:17:49.919Z",
       payload: {
         type: "token_count",
         info: {
+          total_token_usage: {
+            input_tokens: total.inputTokens,
+            cached_input_tokens: total.cached,
+            cache_write_input_tokens: 0,
+            output_tokens: total.output,
+            reasoning_output_tokens: total.reasoning,
+            total_tokens: total.inputTokens + total.output,
+          },
           last_token_usage: {
             input_tokens: inputTokens,
             cached_input_tokens: cached,
             cache_write_input_tokens: 0,
             output_tokens: output,
             reasoning_output_tokens: reasoning,
+            total_tokens: inputTokens + output,
           },
         },
       },
@@ -121,14 +143,373 @@ describe("parseCodexLine", () => {
     expect(repeat).toBeNull();
   });
 
+  it("skips usage when the cumulative counter did not advance", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const total = { inputTokens: 100, cached: 0, output: 10, reasoning: 0 };
+    const first = parseCodexLine(tokenCount(100, 0, 10, 0, total), state);
+    const rebroadcast = parseCodexLine(tokenCount(50, 0, 5, 0, total), state);
+
+    expect(first).not.toBeNull();
+    expect(rebroadcast).toBeNull();
+    expect(state.malformedRecords).toBe(0);
+  });
+
+  it("keeps identical per-request usage when the cumulative counter advances", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const first = parseCodexLine(tokenCount(100, 0, 10, 0), state);
+    const second = parseCodexLine(
+      tokenCount(100, 0, 10, 0, {
+        inputTokens: 200,
+        cached: 0,
+        output: 20,
+        reasoning: 0,
+      }),
+      state,
+    );
+
+    expect(first).not.toBeNull();
+    expect(state.malformedRecords).toBe(0);
+    expect(second).not.toBeNull();
+  });
+
+  it("rejects and reports usage that disagrees with the cumulative advance", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    parseCodexLine(tokenCount(100, 0, 10, 0), state);
+    const inconsistent = parseCodexLine(
+      tokenCount(70, 0, 7, 0, {
+        inputTokens: 150,
+        cached: 0,
+        output: 15,
+        reasoning: 0,
+      }),
+      state,
+    );
+
+    expect(inconsistent).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("rejects a first usage event larger than its cumulative counter", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const inconsistent = parseCodexLine(
+      tokenCount(100, 0, 10, 0, {
+        inputTokens: 90,
+        cached: 0,
+        output: 10,
+        reasoning: 0,
+      }),
+      state,
+    );
+
+    expect(inconsistent).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("accepts a first event when its cumulative counter includes prior usage", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const record = parseCodexLine(
+      tokenCount(50, 0, 5, 0, {
+        inputTokens: 150,
+        cached: 0,
+        output: 15,
+        reasoning: 0,
+      }),
+      state,
+    );
+
+    expect(record?.totals.uncachedInputTokens).toBe(50);
+    expect(record?.totals.outputTokens).toBe(5);
+    expect(state.malformedRecords).toBe(0);
+  });
+
+  it("rejects a first checkpoint whose implied prior usage has impossible subsets", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const impossiblePrior = parseCodexLine(
+      tokenCount(0, 0, 100, 0, {
+        inputTokens: 0,
+        cached: 0,
+        output: 100,
+        reasoning: 100,
+      }),
+      state,
+    );
+
+    expect(impossiblePrior).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+
+    const afterResync = parseCodexLine(
+      tokenCount(10, 0, 5, 0, {
+        inputTokens: 10,
+        cached: 0,
+        output: 105,
+        reasoning: 100,
+      }),
+      state,
+    );
+    expect(afterResync).not.toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("accepts a first checkpoint with legitimate total-only context-window residue", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const afterUnseenReset = JSON.parse(tokenCount(50, 0, 5, 0)) as {
+      payload: { info: { total_token_usage: { total_tokens: number } } };
+    };
+    afterUnseenReset.payload.info.total_token_usage.total_tokens = 258_455;
+
+    expect(parseCodexLine(JSON.stringify(afterUnseenReset), state)).not.toBeNull();
+    expect(state.malformedRecords).toBe(0);
+  });
+
+  it("resynchronizes after one inconsistent cumulative checkpoint", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    parseCodexLine(tokenCount(100, 0, 10, 0), state);
+    expect(
+      parseCodexLine(
+        tokenCount(70, 0, 7, 0, {
+          inputTokens: 150,
+          cached: 0,
+          output: 15,
+          reasoning: 0,
+        }),
+        state,
+      ),
+    ).toBeNull();
+
+    const next = parseCodexLine(
+      tokenCount(50, 0, 5, 0, {
+        inputTokens: 200,
+        cached: 0,
+        output: 20,
+        reasoning: 0,
+      }),
+      state,
+    );
+
+    expect(next).not.toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("accepts a corrected re-emission after a structurally invalid last usage", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    parseCodexLine(tokenCount(100, 0, 10, 0), state);
+    const cumulative = {
+      inputTokens: 150,
+      cached: 0,
+      output: 15,
+      reasoning: 0,
+    };
+
+    expect(parseCodexLine(tokenCount(50, 60, 5, 0, cumulative), state)).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+
+    const corrected = tokenCount(50, 0, 5, 0, cumulative);
+    expect(parseCodexLine(corrected, state)).not.toBeNull();
+    expect(parseCodexLine(corrected, state)).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("keeps a backward checkpoint as the resync baseline", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    parseCodexLine(tokenCount(100, 0, 10, 0), state);
+
+    expect(
+      parseCodexLine(
+        tokenCount(10, 0, 1, 0, {
+          inputTokens: 80,
+          cached: 0,
+          output: 8,
+          reasoning: 0,
+        }),
+        state,
+      ),
+    ).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+
+    expect(
+      parseCodexLine(
+        tokenCount(20, 0, 2, 0, {
+          inputTokens: 100,
+          cached: 0,
+          output: 10,
+          reasoning: 0,
+        }),
+        state,
+      ),
+    ).not.toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("resynchronizes a context-window checkpoint without reporting it as malformed", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    parseCodexLine(tokenCount(100, 0, 10, 0), state);
+    const contextFull = JSON.parse(tokenCount(0, 0, 0, 0)) as {
+      payload: {
+        info: {
+          last_token_usage: { total_tokens: number };
+          total_token_usage: { total_tokens: number };
+        };
+      };
+    };
+    contextFull.payload.info.last_token_usage.total_tokens = 258_290;
+    contextFull.payload.info.total_token_usage.total_tokens = 258_400;
+
+    expect(parseCodexLine(JSON.stringify(contextFull), state)).toBeNull();
+    expect(state.malformedRecords).toBe(0);
+
+    const afterReset = JSON.parse(tokenCount(50, 0, 5, 0)) as typeof contextFull;
+    afterReset.payload.info.total_token_usage.total_tokens = 258_455;
+    expect(parseCodexLine(JSON.stringify(afterReset), state)).not.toBeNull();
+    expect(state.malformedRecords).toBe(0);
+  });
+
+  it("rejects a total-only reset whose delta does not match the previous total", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    parseCodexLine(tokenCount(100, 0, 10, 0), state);
+    const invalidReset = JSON.parse(tokenCount(0, 0, 0, 0)) as {
+      payload: {
+        info: {
+          last_token_usage: { total_tokens: number };
+          total_token_usage: { total_tokens: number };
+        };
+      };
+    };
+    invalidReset.payload.info.last_token_usage.total_tokens = 1;
+    invalidReset.payload.info.total_token_usage.total_tokens = 500;
+
+    expect(parseCodexLine(JSON.stringify(invalidReset), state)).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+
+    const afterReset = JSON.parse(tokenCount(50, 0, 5, 0)) as typeof invalidReset;
+    afterReset.payload.info.total_token_usage.total_tokens = 555;
+    expect(parseCodexLine(JSON.stringify(afterReset), state)).not.toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("reports a token_count without cumulative usage as malformed", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const withoutTotal = JSON.parse(tokenCount(100, 0, 10, 0)) as {
+      payload: { info: { total_token_usage?: unknown } };
+    };
+    delete withoutTotal.payload.info.total_token_usage;
+
+    expect(parseCodexLine(JSON.stringify(withoutTotal), state)).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("rejects reasoning usage that exceeds output usage", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+
+    expect(parseCodexLine(tokenCount(100, 0, 5, 10), state)).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("rejects cached input subsets that exceed total input", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const invalid = JSON.parse(tokenCount(100, 90, 10, 0)) as {
+      payload: {
+        info: {
+          last_token_usage: { cache_write_input_tokens: number };
+          total_token_usage: { cache_write_input_tokens: number };
+        };
+      };
+    };
+    invalid.payload.info.last_token_usage.cache_write_input_tokens = 20;
+    invalid.payload.info.total_token_usage.cache_write_input_tokens = 20;
+
+    expect(parseCodexLine(JSON.stringify(invalid), state)).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("rejects an impossible cached subset in the cumulative checkpoint", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+
+    expect(
+      parseCodexLine(
+        tokenCount(50, 0, 5, 0, {
+          inputTokens: 100,
+          cached: 110,
+          output: 10,
+          reasoning: 0,
+        }),
+        state,
+      ),
+    ).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("reports non-numeric usage counters as malformed", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const invalid = JSON.parse(tokenCount(100, 0, 10, 0)) as {
+      payload: { info: { last_token_usage: { output_tokens: unknown } } };
+    };
+    invalid.payload.info.last_token_usage.output_tokens = "10";
+
+    expect(parseCodexLine(JSON.stringify(invalid), state)).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("rejects a per-request total that excludes or double-counts tokens", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const invalid = JSON.parse(tokenCount(100, 0, 10, 0)) as {
+      payload: {
+        info: {
+          last_token_usage: { total_tokens: number };
+          total_token_usage: { total_tokens: number };
+        };
+      };
+    };
+    invalid.payload.info.last_token_usage.total_tokens = 999;
+    invalid.payload.info.total_token_usage.total_tokens = 999;
+
+    expect(parseCodexLine(JSON.stringify(invalid), state)).toBeNull();
+    expect(state.malformedRecords).toBe(1);
+  });
+
+  it("accepts older counters that predate cache-write reporting", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(turnContext, state);
+    const legacy = JSON.parse(tokenCount(100, 0, 10, 0)) as {
+      payload: {
+        info: {
+          last_token_usage: { cache_write_input_tokens?: number };
+          total_token_usage: { cache_write_input_tokens?: number };
+        };
+      };
+    };
+    delete legacy.payload.info.last_token_usage.cache_write_input_tokens;
+    delete legacy.payload.info.total_token_usage.cache_write_input_tokens;
+
+    expect(parseCodexLine(JSON.stringify(legacy), state)).not.toBeNull();
+    expect(state.malformedRecords).toBe(0);
+  });
+
   it("drops usage that arrives before any model is known", () => {
     const state = initialCodexScanState();
     expect(parseCodexLine(tokenCount(100, 0, 10, 0), state)).toBeNull();
   });
 
-  it("does not let a pre-model event poison the duplicate signature", () => {
-    // A token_count before its turn_context is dropped; the identical event
-    // re-emitted once the model is known must still be counted.
+  it("does not let a pre-model event consume the cumulative checkpoint", () => {
+    // A token_count before its turn_context is dropped; its re-emitted copy
+    // after the model is known must still be counted.
     const state = initialCodexScanState();
     expect(parseCodexLine(tokenCount(100, 0, 10, 0), state)).toBeNull();
     parseCodexLine(turnContext, state);

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -150,20 +150,137 @@ export function parseClaudeLine(line: string): UsageRecord | null {
 export interface CodexScanState {
   model: string;
   sessionId: string;
-  lastUsageSignature: string | null;
+  /** Last cumulative checkpoint, used to validate the next per-request increment. */
+  cumulativeUsage: CodexUsageCounters | null;
+  /** Counter sequences that could not be reconciled without guessing. */
+  malformedRecords: number;
 }
 
 export function initialCodexScanState(): CodexScanState {
-  return { model: "", sessionId: "", lastUsageSignature: null };
+  return { model: "", sessionId: "", cumulativeUsage: null, malformedRecords: 0 };
+}
+
+type CodexUsageCounters = readonly [
+  inputTokens: number,
+  cachedInputTokens: number,
+  cacheWriteInputTokens: number,
+  outputTokens: number,
+  reasoningOutputTokens: number,
+  totalTokens: number,
+];
+
+function codexCounter(
+  record: Record<string, unknown>,
+  key: string,
+  optional = false,
+): number | null {
+  const value = record[key];
+  if (optional && value === undefined) return 0;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function codexUsageCounters(record: Record<string, unknown>): CodexUsageCounters | null {
+  const inputTokens = codexCounter(record, "input_tokens");
+  const cachedInputTokens = codexCounter(record, "cached_input_tokens");
+  // Older Codex rollouts predate this counter; Serde defaults it to zero.
+  const cacheWriteInputTokens = codexCounter(record, "cache_write_input_tokens", true);
+  const outputTokens = codexCounter(record, "output_tokens");
+  const reasoningOutputTokens = codexCounter(record, "reasoning_output_tokens");
+  const totalTokens = codexCounter(record, "total_tokens");
+  if (
+    inputTokens === null ||
+    cachedInputTokens === null ||
+    cacheWriteInputTokens === null ||
+    outputTokens === null ||
+    reasoningOutputTokens === null ||
+    totalTokens === null
+  ) {
+    return null;
+  }
+  return [
+    inputTokens,
+    cachedInputTokens,
+    cacheWriteInputTokens,
+    outputTokens,
+    reasoningOutputTokens,
+    totalTokens,
+  ];
+}
+
+function sameCounters(a: CodexUsageCounters, b: CodexUsageCounters): boolean {
+  return a.every((value, index) => value === b[index]);
+}
+
+function advancesBy(
+  previous: CodexUsageCounters,
+  current: CodexUsageCounters,
+  increment: CodexUsageCounters,
+): boolean {
+  return current.every((value, index) => value - (previous[index] ?? 0) === increment[index]);
+}
+
+function containsAtLeast(total: CodexUsageCounters, part: CodexUsageCounters): boolean {
+  return total.every((value, index) => value >= (part[index] ?? 0));
+}
+
+function hasValidSubsets(counters: CodexUsageCounters): boolean {
+  const [inputTokens, cachedInputTokens, cacheWriteInputTokens, outputTokens, reasoningTokens] =
+    counters;
+  return (
+    cachedInputTokens + cacheWriteInputTokens <= inputTokens && reasoningTokens <= outputTokens
+  );
+}
+
+function hasValidFirstCheckpoint(total: CodexUsageCounters, last: CodexUsageCounters): boolean {
+  if (!containsAtLeast(total, last)) return false;
+  const impliedPrior: CodexUsageCounters = [
+    total[0] - last[0],
+    total[1] - last[1],
+    total[2] - last[2],
+    total[3] - last[3],
+    total[4] - last[4],
+    total[5] - last[5],
+  ];
+  // The first visible checkpoint may include earlier requests (including a
+  // total-only context-window residue), but its measured residue must still
+  // obey the same subset relationships as every other usage vector.
+  return hasValidSubsets(impliedPrior);
+}
+
+function hasValidLastTotal(counters: CodexUsageCounters): boolean {
+  const [
+    inputTokens,
+    cachedInputTokens,
+    cacheWriteInputTokens,
+    outputTokens,
+    reasoningTokens,
+    total,
+  ] = counters;
+  const hasMeasuredUsage =
+    inputTokens + cachedInputTokens + cacheWriteInputTokens + outputTokens + reasoningTokens > 0;
+  return !hasMeasuredUsage || total === inputTokens + outputTokens;
+}
+
+function isContextWindowCheckpoint(
+  previous: CodexUsageCounters,
+  total: CodexUsageCounters,
+  last: CodexUsageCounters,
+): boolean {
+  return (
+    total.slice(0, 5).every((value) => value === 0) &&
+    last.slice(0, 5).every((value) => value === 0) &&
+    last[5] === Math.max(total[5] - previous[5], 0)
+  );
 }
 
 /**
  * Feeds one line of a Codex rollout into `state`, returning a record when the
  * line was a usage event.
  *
- * Deltas come from `last_token_usage`. Summing those across a session
- * reconciles with the session's final `total_token_usage`, provided
- * consecutive duplicate events are dropped, which this does.
+ * Codex constructs `total_token_usage` by adding each real
+ * `last_token_usage` element-wise. An unchanged cumulative checkpoint is a
+ * re-emission, while an advancing checkpoint must advance by exactly the last
+ * usage. Ambiguous events are skipped and counted in `malformedRecords`.
  */
 export function parseCodexLine(line: string, state: CodexScanState): UsageRecord | null {
   let parsed: unknown;
@@ -195,28 +312,61 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
 
   const info = payloadRecord["info"];
   if (typeof info !== "object" || info === null) return null;
-  const last = (info as Record<string, unknown>)["last_token_usage"];
-  if (typeof last !== "object" || last === null) return null;
+  const infoRecord = info as Record<string, unknown>;
+  const total = infoRecord["total_token_usage"];
+  const last = infoRecord["last_token_usage"];
+  if (typeof total !== "object" || total === null || typeof last !== "object" || last === null) {
+    state.malformedRecords += 1;
+    return null;
+  }
+  const totalRecord = total as Record<string, unknown>;
   const lastRecord = last as Record<string, unknown>;
 
-  // Only an event that is otherwise eligible may consume the duplicate
-  // signature. A token_count arriving before its turn_context (no model yet)
-  // must not poison it, or the re-emitted copy after the model is known would
-  // be skipped as a duplicate and those tokens never counted.
+  // Only an otherwise eligible event may advance the checkpoint. A
+  // token_count before its turn_context must not hide the re-emitted copy that
+  // arrives after its model is known.
   const timestampMs = parseTimestampMs(record["timestamp"]);
   if (timestampMs === null) return null;
   if (state.model.length === 0) return null;
 
-  // Codex re-emits an unchanged token_count on some stream boundaries. Summing
-  // those would double count, so identical consecutive payloads are skipped.
-  const signature = JSON.stringify(lastRecord);
-  if (signature === state.lastUsageSignature) return null;
-  state.lastUsageSignature = signature;
-
-  const inputTokens = int(lastRecord["input_tokens"]);
-  const cachedInputTokens = int(lastRecord["cached_input_tokens"]);
-  const cacheCreationTokens = int(lastRecord["cache_write_input_tokens"]);
-  const outputTokens = int(lastRecord["output_tokens"]);
+  const cumulativeUsage = codexUsageCounters(totalRecord);
+  const lastUsage = codexUsageCounters(lastRecord);
+  if (cumulativeUsage === null || lastUsage === null) {
+    state.malformedRecords += 1;
+    return null;
+  }
+  if (
+    !hasValidSubsets(cumulativeUsage) ||
+    !hasValidSubsets(lastUsage) ||
+    !hasValidLastTotal(lastUsage)
+  ) {
+    state.malformedRecords += 1;
+    return null;
+  }
+  if (state.cumulativeUsage !== null && sameCounters(cumulativeUsage, state.cumulativeUsage)) {
+    return null;
+  }
+  const previousCumulativeUsage = state.cumulativeUsage;
+  state.cumulativeUsage = cumulativeUsage;
+  if (
+    (previousCumulativeUsage === null && !hasValidFirstCheckpoint(cumulativeUsage, lastUsage)) ||
+    (previousCumulativeUsage !== null &&
+      !advancesBy(previousCumulativeUsage, cumulativeUsage, lastUsage))
+  ) {
+    // `fill_to_context_window` deliberately replaces the component totals
+    // with a total-only checkpoint. It carries no billable usage but is the
+    // correct baseline for the next request.
+    if (
+      previousCumulativeUsage !== null &&
+      isContextWindowCheckpoint(previousCumulativeUsage, cumulativeUsage, lastUsage)
+    ) {
+      return null;
+    }
+    state.malformedRecords += 1;
+    return null;
+  }
+  const [inputTokens, cachedInputTokens, cacheCreationTokens, outputTokens, reasoningTokens] =
+    lastUsage;
 
   const totals: UsageTokenTotals = {
     // Codex reports `input_tokens` inclusive of the cached portion.
@@ -225,7 +375,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     cacheCreationTokens,
     outputTokens,
     // Reported inside output_tokens, surfaced separately for the token mix.
-    reasoningTokens: Math.min(outputTokens, int(lastRecord["reasoning_output_tokens"])),
+    reasoningTokens,
   };
 
   if (totalTokens(totals) === 0) return null;


### PR DESCRIPTION
## What Changed

- Reconcile each Codex `last_token_usage` against the element-wise cumulative `total_token_usage`.
- Suppress unchanged cumulative checkpoints while preserving identical legitimate requests when the cumulative total advances.
- Reject, count, and resynchronize mismatched/backward/unsafe counters instead of guessing.
- Enforce input-cache and output-reasoning subset invariants, including the implied history at the first checkpoint.
- Validate Codex's total-only context-window reset relationship exactly.
- Carry malformed counts through the transcript reader and v4 durable cache into partial source coverage.

## Why

The previous parser ignored `total_token_usage` and deduplicated only by the JSON signature of `last_token_usage`. It could count stale recomputation events, discard two legitimate identical requests, and accept counters that inflate processed tokens.

Closes #5800

## Verification

- 56 focused usage tests passed after review fixes; 45 directly touched tests passed after the final upstream rebase.
- Targeted formatting and lint passed.
- Server typecheck passed; only pre-existing unrelated Effect suggestions remain.
- A 90-day live corpus scan covered 822 files and 222,254 accepted records with 0 malformed records and 0 read failures.
- All required upstream CI and automated convention/correctness checks passed on the final SHA.
- Branch rebased on current `upstream/main`.

## Integration Note

This PR intentionally uses scan-cache revision 4. Open PR #5700 reserves revision 2 and #5811 reserves revision 3, preventing silent stale-cache reuse. Its narrow reader/cache/source diagnostic plumbing is complementary to #5812's I/O coverage and may require a mechanical rebase if either lands first.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Implemented with gpt-5.6-sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex token accounting and durable cache format, which can shift reported usage totals, but the goal is fixing over/under-counting and the change is heavily tested.
> 
> **Overview**
> Replaces Codex usage parsing that deduped only on **`last_token_usage` JSON** with reconciliation against element-wise **`total_token_usage`**: unchanged cumulative checkpoints are ignored, each advance must match **`last_token_usage`**, and inconsistent, backward, or structurally invalid counters are **skipped and counted** rather than guessed. The parser also handles **context-window total-only resets** and enforces cache/reasoning subset invariants.
> 
> **Malformed counts** flow from the transcript reader through **scan-cache v4** (field `e`) into **`UsageService`**, which marks affected Codex sources **`partial`** with a skip message. Older cache revisions without diagnostics are invalidated. Coverage is expanded with focused unit and integration tests for cold/warm cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d06d91106fcb1ce7588f85c04a2f9de4f56e7e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex cumulative usage reconciliation to detect and report inconsistent token records
> - Rewrites `parseCodexLine` in [usageTranscripts.ts](https://github.com/pingdotgg/t3code/pull/5814/files#diff-639e969b22f50fb1c28800a8caacb40faa709fb5b829f6c1e0a06a1be5fd5871) to reconcile `last_token_usage` against `total_token_usage` checkpoints, rejecting events where the cumulative advance does not match the per-request usage.
> - Introduces `TranscriptReadResult` in [usageTranscriptReader.ts](https://github.com/pingdotgg/t3code/pull/5814/files#diff-abfb6e6193baf30b1461a91349257b617fc266915d75b17a73ca21ccd1041d08) so callers receive a `malformedRecords` count alongside parsed records.
> - Propagates malformed record counts through `UsageService.readSummary`, setting source status to `'partial'` with a descriptive message when any records are rejected.
> - Bumps the scan cache schema to version 4 in [usageScanCache.ts](https://github.com/pingdotgg/t3code/pull/5814/files#diff-ca3f710ebaf0cd708cedab20134ea19de9a81237223250d0402fa68c37498806), adding a per-file `malformedRecords` field (`'e'`) — caches at older versions are dropped on decode.
> - Behavioral Change: sources that previously reported `'ok'` may now report `'partial'` if their transcripts contain inconsistent token counts; v2/v3 caches are invalidated on upgrade.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d06d91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->