### PR TITLE
feat(web): show a color swatch next to color literals in chat

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -72,6 +72,7 @@ import {
   serializeTableElementToCsv,
   serializeTableElementToMarkdown,
 } from "../markdown-clipboard";
+import { resolveInlineCodeColor } from "../markdown-colors";
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
   normalizeMarkdownLinkDestination,
@@ -1638,6 +1639,17 @@ function ChatMarkdown({
             resolveInlineCodeFileLinkMeta(codeText, cwd);
           if (fileLinkMeta) {
             return fileLinkChip(fileLinkMeta, `\`${codeText}\``);
+          }
+          const color = resolveInlineCodeColor(codeText);
+          if (color) {
+            return (
+              <code {...props} className={className}>
+                <span className="chat-markdown-color-swatch" aria-hidden>
+                  <span style={{ background: color }} />
+                </span>
+                {children}
+              </code>
+            );
           }
         }
         return (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1746,9 +1746,6 @@ code {
   margin-inline-end: 0.35em;
   vertical-align: -0.075em;
   border-radius: 0.25em;
-  /* An inset ring rather than a border: white and near-background swatches still
-     read as a shape, without the border eating into a swatch this small. */
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--foreground) 25%, transparent);
   background-color: #fff;
   background-image:
     linear-gradient(45deg, #c8c8c8 25%, transparent 25%, transparent 75%, #c8c8c8 75%),
@@ -1759,10 +1756,17 @@ code {
   background-size: 0.5em 0.5em;
 }
 
+/*
+ * The ring rides on the fill, not the wrapper: an inset shadow paints below
+ * descendants, so a wrapper ring would sit under this element and white swatches
+ * would lose their edge. A ring rather than a border keeps the fill full-size.
+ */
 .chat-markdown .chat-markdown-color-swatch > span {
   display: block;
   width: 100%;
   height: 100%;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--foreground) 25%, transparent);
 }
 
 .chat-markdown a.chat-markdown-file-link,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1732,6 +1732,39 @@ code {
   font-size: 0.75rem;
 }
 
+/*
+ * The code element stays inline: as an atomic inline (inline-flex) its padding
+ * and line-height would count toward the line box, making every line holding a
+ * color taller than its neighbours.
+ * Checkerboard under the fill so translucent colors read as translucent.
+ */
+.chat-markdown .chat-markdown-color-swatch {
+  display: inline-block;
+  overflow: hidden;
+  width: 0.9em;
+  height: 0.9em;
+  margin-inline-end: 0.35em;
+  vertical-align: -0.075em;
+  border-radius: 0.25em;
+  /* An inset ring rather than a border: white and near-background swatches still
+     read as a shape, without the border eating into a swatch this small. */
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--foreground) 25%, transparent);
+  background-color: #fff;
+  background-image:
+    linear-gradient(45deg, #c8c8c8 25%, transparent 25%, transparent 75%, #c8c8c8 75%),
+    linear-gradient(45deg, #c8c8c8 25%, transparent 25%, transparent 75%, #c8c8c8 75%);
+  background-position:
+    0 0,
+    0.25em 0.25em;
+  background-size: 0.5em 0.5em;
+}
+
+.chat-markdown .chat-markdown-color-swatch > span {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .chat-markdown a.chat-markdown-file-link,
 .chat-markdown a.chat-markdown-file-link:hover {
   color: var(--foreground);

--- a/apps/web/src/markdown-colors.test.ts
+++ b/apps/web/src/markdown-colors.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveInlineCodeColor } from "./markdown-colors";
+
+describe("resolveInlineCodeColor", () => {
+  it("resolves hex literals of every length", () => {
+    expect(resolveInlineCodeColor("#FFB3C6")).toBe("#FFB3C6");
+    expect(resolveInlineCodeColor("#fdf6e3")).toBe("#fdf6e3");
+    expect(resolveInlineCodeColor("#abc")).toBe("#abc");
+    expect(resolveInlineCodeColor("#abcd")).toBe("#abcd");
+    expect(resolveInlineCodeColor("#ff00aa80")).toBe("#ff00aa80");
+  });
+
+  it("resolves functional color notations", () => {
+    expect(resolveInlineCodeColor("rgb(255, 179, 198)")).toBe("rgb(255, 179, 198)");
+    expect(resolveInlineCodeColor("rgba(255 179 198 / 0.5)")).toBe("rgba(255 179 198 / 0.5)");
+    expect(resolveInlineCodeColor("hsl(340 100% 85%)")).toBe("hsl(340 100% 85%)");
+    expect(resolveInlineCodeColor("oklch(0.86 0.09 5.2)")).toBe("oklch(0.86 0.09 5.2)");
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(resolveInlineCodeColor("  #FFB3C6 ")).toBe("#FFB3C6");
+  });
+
+  it("rejects text that merely contains a color", () => {
+    expect(resolveInlineCodeColor("color: #FFB3C6")).toBeNull();
+    expect(resolveInlineCodeColor("#FFB3C6 on cream")).toBeNull();
+  });
+
+  it("rejects hex-shaped values that aren't colors", () => {
+    expect(resolveInlineCodeColor("#ff")).toBeNull();
+    expect(resolveInlineCodeColor("#fffffff")).toBeNull();
+    expect(resolveInlineCodeColor("#zzzzzz")).toBeNull();
+    expect(resolveInlineCodeColor("a1b2c3")).toBeNull();
+  });
+
+  it("rejects bare color keywords, which read as prose far more often than as colors", () => {
+    expect(resolveInlineCodeColor("red")).toBeNull();
+    expect(resolveInlineCodeColor("tan")).toBeNull();
+  });
+
+  it("rejects unknown or injection-shaped function calls", () => {
+    expect(resolveInlineCodeColor("url(evil.png)")).toBeNull();
+    expect(resolveInlineCodeColor("rgb(0,0,0); background: url(x)")).toBeNull();
+    expect(resolveInlineCodeColor("rgb(var(--x))")).toBeNull();
+  });
+
+  it("rejects empty and oversized spans", () => {
+    expect(resolveInlineCodeColor("")).toBeNull();
+    expect(resolveInlineCodeColor(`rgb(${"0".repeat(80)})`)).toBeNull();
+  });
+});

--- a/apps/web/src/markdown-colors.ts
+++ b/apps/web/src/markdown-colors.ts
@@ -1,0 +1,58 @@
+/**
+ * Inline code that is *only* a CSS color literal gets a swatch rendered next to
+ * it, the way editors decorate color literals in source. Prose keeps its meaning
+ * when the swatch is stripped, so the match has to be exact — a span containing
+ * a color plus anything else stays plain code.
+ */
+
+const HEX_COLOR_PATTERN = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+// Numbers, percentages, angles, `none`, separators, and the alpha slash — the
+// full argument grammar these functions share, and nothing that could close the
+// declaration this value ends up in.
+const COLOR_FUNCTION_ARGUMENTS_PATTERN = /^[0-9a-z%.,/\s+-]*$/i;
+const COLOR_FUNCTION_PATTERN = /^([a-z]+)\(([^()]*)\)$/i;
+const COLOR_FUNCTION_NAMES = new Set([
+  "rgb",
+  "rgba",
+  "hsl",
+  "hsla",
+  "hwb",
+  "lab",
+  "lch",
+  "oklab",
+  "oklch",
+]);
+
+function supportsColorValue(value: string): boolean {
+  // jsdom has no CSS.supports; the patterns above already bound what can reach
+  // a style attribute, so shape validation stands on its own there.
+  if (typeof CSS === "undefined" || typeof CSS.supports !== "function") return true;
+  return CSS.supports("color", value);
+}
+
+/**
+ * Returns the color to paint a swatch with, or null when the text isn't a
+ * standalone color literal.
+ */
+export function resolveInlineCodeColor(text: string): string | null {
+  const value = text.trim();
+  if (value.length === 0 || value.length > 64) return null;
+
+  if (HEX_COLOR_PATTERN.test(value)) {
+    return supportsColorValue(value) ? value : null;
+  }
+
+  const functionMatch = COLOR_FUNCTION_PATTERN.exec(value);
+  const functionName = functionMatch?.[1]?.toLowerCase();
+  const functionArguments = functionMatch?.[2];
+  if (
+    functionName == null ||
+    functionArguments == null ||
+    !COLOR_FUNCTION_NAMES.has(functionName) ||
+    !COLOR_FUNCTION_ARGUMENTS_PATTERN.test(functionArguments)
+  ) {
+    return null;
+  }
+
+  return supportsColorValue(value) ? value : null;
+}


### PR DESCRIPTION
## What Changed

Inline code in a chat message that is *exactly* a CSS color literal now renders a small swatch before the text, the way editors decorate color literals in source.

- Matches 3/4/6/8-digit hex and `rgb() / rgba() / hsl() / hsla() / hwb() / lab() / lch() / oklab() / oklch()`.
- Translucent colors (`#FFB3C680`, `rgba(20 24 40 / 0.35)`) sit on a checkerboard so the alpha reads.
- Spans that merely *contain* a color stay plain: `#FFB3C6 on cream`, `abcdef`. Bare keywords (`red`, `tan`) are deliberately excluded — they read as prose far more often than as colors.
- File-path chips keep precedence, so `apps/web/src/index.css` is unaffected.
- The swatch is `aria-hidden` and contributes no text, so copying a message out is unchanged.

Web only. `apps/mobile` renders markdown through a separate native pipeline (`modules/t3-markdown-text`) and would need its own change.

## Why

When a thread discusses colors, the values arrive as bare inline code. "`#FFB3C6` on cream `#FDF6E3` is a small step in value" tells you nothing about what either color looks like, so reviewing a palette or a set of theme tokens means copying each literal into a separate tool one at a time.

Two details worth calling out:

- **The matched value ends up in a style attribute**, so it is shape-validated by regex first — the argument grammar cannot contain anything that would close the declaration — and then confirmed with `CSS.supports` where available.
- **The swatch is an inline-block inside a still-inline `<code>`**, matching how `.chat-markdown-link-favicon` already works. Making the `<code>` an atomic inline (`inline-flex`) pulls its padding and line-height into the line box, which measurably grows every line holding a color: chips went 19.19px → 24.69px and list rows 22.75px → 24.69px. The shipped version measures identical to a plain code chip.

## UI Changes

Before:
<img width="1520" height="550" alt="Image" src="https://github.com/user-attachments/assets/6b05084a-9475-41d4-bfe0-78bce3b03ef3" />

After:
<img width="1520" height="550" alt="Image" src="https://github.com/user-attachments/assets/2cff8705-c587-40ac-b6b7-c5ad8c5e3a36" />

## Verification

- `apps/web/src/markdown-colors.test.ts` — 8 new tests, passing.
- `pnpm typecheck` clean; `pnpm lint` clean (the one `ThemeEditorPanel.tsx` warning predates this branch).
- Rendered in a local dev environment against a seeded thread; heights measured in-browser as above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show color swatches next to color literals in chat markdown inline code
> - Adds a `resolveInlineCodeColor` utility in [markdown-colors.ts](https://github.com/pingdotgg/t3code/pull/5816/files#diff-a997c14a6b12bb8a1262ffb3b026d7379d08a4a0fe16b156ce61fb19457cb09b) that validates whether a string is a standalone CSS color literal (hex or named color functions like `rgb`, `hsl`, `oklch`, etc.), using `CSS.supports` when available.
> - Extends the `markdownComponents.code` renderer in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/5816/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to detect color literals in inline code and prepend a small color swatch span before the code text.
> - Adds CSS in [index.css](https://github.com/pingdotgg/t3code/pull/5816/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) for `.chat-markdown-color-swatch` with a checkerboard background (for transparency indication) and an inset ring for contrast.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68204c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Color values are regex-constrained and checked with CSS.supports before a single background style attribute; scope is limited to chat markdown rendering with file-link precedence unchanged.
> 
> **Overview**
> **Chat markdown** now shows a small color preview before inline code when the span is *only* a CSS color literal (hex or `rgb`/`hsl`/`oklch`-style functions), similar to editor color decorations. File-path inline chips still win, so paths like `apps/web/src/index.css` are unchanged.
> 
> A new **`resolveInlineCodeColor`** helper decides matches with strict whole-string rules (no bare keywords like `red`, no embedded colors in prose), regex bounds on function arguments, length limits, and **`CSS.supports`** when the browser provides it—because the resolved value is applied as an inline **`background`** style.
> 
> **Styling** adds `.chat-markdown-color-swatch`: inline-block inside the existing `<code>` (to avoid line-height growth), checkerboard behind translucent fills, and an inset ring on the inner fill for contrast. The swatch is **`aria-hidden`** so copied text stays the literal only.
> 
> **Tests** cover accepted formats, rejection cases, and injection-shaped inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68204c774e8fee47f1641e95396a5cadf2959bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->