### PR TITLE
feat(swift-ios): reveal message timestamps on swipe

### DIFF
--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -1293,28 +1293,27 @@ private struct FeatureTimestampRevealMessageView: View {
     @ObservedObject var reveal: FeatureTimestampRevealState
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            FeatureMessageView(message: message)
-
-            if message.createdAt != .distantPast {
-                Text(message.createdAt, format: .dateTime.hour().minute())
-                    .font(T3Typography.supporting.monospacedDigit())
-                    .foregroundStyle(T3Colors.textTertiary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-                    .dynamicTypeSize(.small ... .accessibility1)
-                    .frame(
-                        width: TranscriptTimestampRevealGeometry.maximumWidth,
-                        alignment: .trailing
-                    )
-                    .padding(.vertical, 5)
-                    .background(T3Colors.surface, in: Capsule())
-                    .frame(width: reveal.width, alignment: .trailing)
-                    .clipped()
-                    .opacity(reveal.width > 0 ? 1 : 0)
-                    .accessibilityHidden(true)
+        FeatureMessageView(message: message)
+            .overlay(alignment: .topTrailing) {
+                if message.createdAt != .distantPast {
+                    Text(message.createdAt, format: .dateTime.hour().minute())
+                        .font(T3Typography.supporting.monospacedDigit())
+                        .foregroundStyle(T3Colors.textTertiary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .dynamicTypeSize(.small ... .accessibility1)
+                        .frame(
+                            width: TranscriptTimestampRevealGeometry.maximumWidth,
+                            alignment: .trailing
+                        )
+                        .padding(.vertical, 5)
+                        .background(T3Colors.surface, in: Capsule())
+                        .frame(width: reveal.width, alignment: .trailing)
+                        .clipped()
+                        .opacity(reveal.width > 0 ? 1 : 0)
+                        .accessibilityHidden(true)
+                }
             }
-        }
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -657,7 +657,6 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         )
         collectionView.backgroundColor = T3Colors.uiBackground
         collectionView.alwaysBounceVertical = true
-        collectionView.keyboardDismissMode = .onDrag
         collectionView.delaysContentTouches = false
         collectionView.contentInsetAdjustmentBehavior = .never
         collectionView.isPrefetchingEnabled = true
@@ -710,7 +709,9 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
     }
 
     @MainActor
-    final class Coordinator: NSObject, UICollectionViewDataSourcePrefetching, UICollectionViewDelegate {
+    final class Coordinator: NSObject, UICollectionViewDataSourcePrefetching,
+        UICollectionViewDelegate, UIGestureRecognizerDelegate
+    {
         private struct MarkdownPrefetch {
             let revision: MarkdownContentRevision
             let task: Task<Void, Never>
@@ -731,12 +732,22 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         private var markdownPrefetches: [String: MarkdownPrefetch] = [:]
         private var onLoadEarlier: (() -> Void)?
         private var onDismissKeyboard: (() -> Void)?
+        private let timestampReveal = FeatureTimestampRevealState()
+        private var verticalDragStartOffset: CGFloat?
+        private lazy var timestampPanGesture = UIPanGestureRecognizer(
+            target: self,
+            action: #selector(handleTimestampPan(_:))
+        )
 
         deinit {
             markdownPrefetches.values.forEach { $0.task.cancel() }
         }
 
         func connect(to collectionView: UICollectionView) {
+            timestampPanGesture.cancelsTouchesInView = false
+            timestampPanGesture.delegate = self
+            collectionView.addGestureRecognizer(timestampPanGesture)
+
             let registration = UICollectionView.CellRegistration<UICollectionViewCell, String> {
                 [weak self] cell, _, messageID in
                 if messageID == FeatureTranscriptCollectionView.loadEarlierID {
@@ -770,7 +781,10 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 }
 
                 cell.contentConfiguration = UIHostingConfiguration {
-                    FeatureMessageView(message: message)
+                    FeatureTimestampRevealMessageView(
+                        message: message,
+                        reveal: self?.timestampReveal ?? FeatureTimestampRevealState()
+                    )
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .margins(.all, 0)
@@ -789,6 +803,63 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             }
             collectionView.prefetchDataSource = self
             collectionView.delegate = self
+        }
+
+        @objc private func handleTimestampPan(_ gesture: UIPanGestureRecognizer) {
+            switch gesture.state {
+            case .changed:
+                timestampReveal.width = TranscriptTimestampRevealGeometry.width(
+                    translationX: gesture.translation(in: gesture.view).x
+                )
+            case .ended, .cancelled, .failed:
+                guard timestampReveal.width > 0 else { return }
+                let duration = UIAccessibility.isReduceMotionEnabled ? 0 : 0.22
+                withAnimation(.easeOut(duration: duration)) {
+                    timestampReveal.width = 0
+                }
+            default:
+                break
+            }
+        }
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard gestureRecognizer === timestampPanGesture,
+                  let collectionView = gestureRecognizer.view as? UICollectionView,
+                  let pan = gestureRecognizer as? UIPanGestureRecognizer else {
+                return true
+            }
+            let velocity = pan.velocity(in: collectionView)
+            return TranscriptTimestampRevealGeometry.shouldBegin(
+                velocityX: velocity.x,
+                velocityY: velocity.y
+            ) && !isNestedHorizontalScroller(
+                at: pan.location(in: collectionView),
+                in: collectionView
+            )
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            gestureRecognizer === timestampPanGesture
+                || otherGestureRecognizer === timestampPanGesture
+        }
+
+        private func isNestedHorizontalScroller(
+            at point: CGPoint,
+            in collectionView: UICollectionView
+        ) -> Bool {
+            var candidate = collectionView.hitTest(point, with: nil)
+            while let view = candidate, view !== collectionView {
+                if let scrollView = view as? UIScrollView,
+                   scrollView.alwaysBounceHorizontal
+                    || scrollView.contentSize.width > scrollView.bounds.width + 1 {
+                    return true
+                }
+                candidate = view.superview
+            }
+            return false
         }
 
         func update(
@@ -1154,12 +1225,22 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         }
 
         func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+            verticalDragStartOffset = scrollView.contentOffset.y
+        }
+
+        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            guard let startOffset = verticalDragStartOffset,
+                  abs(scrollView.contentOffset.y - startOffset) > 0.5 else {
+                return
+            }
+            verticalDragStartOffset = nil
             (scrollView as? BottomAnchoredTranscriptCollectionView)?.maintainsBottomAnchor = false
             scrollView.window?.endEditing(false)
             onDismissKeyboard?()
         }
 
         func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+            verticalDragStartOffset = nil
             guard !decelerate else { return }
             updateBottomAnchor(for: scrollView)
         }
@@ -1173,6 +1254,51 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 return
             }
             collectionView.maintainsBottomAnchor = isNearBottom(collectionView)
+        }
+    }
+}
+
+enum TranscriptTimestampRevealGeometry {
+    static let maximumWidth: CGFloat = 76
+
+    static func shouldBegin(velocityX: CGFloat, velocityY: CGFloat) -> Bool {
+        velocityX < 0 && abs(velocityX) > abs(velocityY)
+    }
+
+    static func width(translationX: CGFloat) -> CGFloat {
+        min(maximumWidth, max(0, -translationX))
+    }
+}
+
+@MainActor
+private final class FeatureTimestampRevealState: ObservableObject {
+    @Published var width: CGFloat = 0
+}
+
+private struct FeatureTimestampRevealMessageView: View {
+    let message: FeatureMessage
+    @ObservedObject var reveal: FeatureTimestampRevealState
+
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            if message.createdAt != .distantPast {
+                Text(message.createdAt, format: .dateTime.hour().minute())
+                    .font(T3Typography.supporting.monospacedDigit())
+                    .foregroundStyle(T3Colors.textTertiary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .dynamicTypeSize(.small ... .accessibility1)
+                    .frame(
+                        width: TranscriptTimestampRevealGeometry.maximumWidth,
+                        alignment: .trailing
+                    )
+                    .offset(x: TranscriptTimestampRevealGeometry.maximumWidth - reveal.width)
+                    .opacity(reveal.width > 0 ? 1 : 0)
+                    .accessibilityHidden(true)
+            }
+
+            FeatureMessageView(message: message)
+                .offset(x: -reveal.width)
         }
     }
 }
@@ -1532,6 +1658,7 @@ struct FeatureMessageView: View {
             .accessibilityLabel("You")
             .accessibilityValue(accessibilityValue)
             .accessibilityIdentifier("message-\(message.id)")
+            .modifier(FeatureMessageTimestampAccessibilityModifier(message: message))
         case .assistant:
             VStack(alignment: .leading, spacing: 10) {
                 if message.state == .streaming {
@@ -1553,6 +1680,7 @@ struct FeatureMessageView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityIdentifier("message-\(message.id)")
+            .modifier(FeatureMessageTimestampAccessibilityModifier(message: message))
         case .tool:
             DisclosureGroup {
                 Text(message.text)
@@ -1569,12 +1697,14 @@ struct FeatureMessageView: View {
             .padding(.vertical, 6)
             .frame(minHeight: T3Metrics.minimumTapTarget)
             .accessibilityIdentifier("message-\(message.id)")
+            .modifier(FeatureMessageTimestampAccessibilityModifier(message: message))
         case .system:
             Text(message.text)
                 .font(T3Typography.supporting)
                 .foregroundStyle(T3Colors.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .center)
                 .accessibilityIdentifier("message-\(message.id)")
+                .modifier(FeatureMessageTimestampAccessibilityModifier(message: message))
         }
     }
 
@@ -1586,6 +1716,31 @@ struct FeatureMessageView: View {
         return [message.text, attachmentSummary]
             .filter { !$0.isEmpty }
             .joined(separator: ", ")
+    }
+}
+
+private struct FeatureMessageTimestampAccessibilityModifier: ViewModifier {
+    let message: FeatureMessage
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if message.createdAt == .distantPast {
+            content
+        } else {
+            content.accessibilityCustomContent(
+                Text(accessibilityLabel),
+                Text(message.createdAt.formatted(date: .omitted, time: .shortened)),
+                importance: .default
+            )
+        }
+    }
+
+    private var accessibilityLabel: String {
+        switch message.role {
+        case .user: "Sent"
+        case .assistant: "Received"
+        case .tool, .system: "Timestamp"
+        }
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -1233,7 +1233,11 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         }
 
         func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-            verticalDragStartOffset = scrollView.contentOffset.y
+            let velocity = scrollView.panGestureRecognizer.velocity(in: scrollView)
+            verticalDragStartOffset = TranscriptTimestampRevealGeometry.hasVerticalIntent(
+                velocityX: velocity.x,
+                velocityY: velocity.y
+            ) ? scrollView.contentOffset.y : nil
         }
 
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -1280,6 +1284,10 @@ enum TranscriptTimestampRevealGeometry {
 
     static func width(translationX: CGFloat) -> CGFloat {
         min(maximumWidth, max(0, -translationX))
+    }
+
+    static func hasVerticalIntent(velocityX: CGFloat, velocityY: CGFloat) -> Bool {
+        abs(velocityY) > abs(velocityX)
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -829,6 +829,9 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 return true
             }
             let velocity = pan.velocity(in: collectionView)
+            guard collectionView.effectiveUserInterfaceLayoutDirection == .leftToRight else {
+                return false
+            }
             return TranscriptTimestampRevealGeometry.shouldBegin(
                 velocityX: velocity.x,
                 velocityY: velocity.y
@@ -842,8 +845,13 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
         ) -> Bool {
-            gestureRecognizer === timestampPanGesture
-                || otherGestureRecognizer === timestampPanGesture
+            guard let collectionView = timestampPanGesture.view as? UICollectionView else {
+                return false
+            }
+            return (gestureRecognizer === timestampPanGesture
+                    && otherGestureRecognizer === collectionView.panGestureRecognizer)
+                || (otherGestureRecognizer === timestampPanGesture
+                    && gestureRecognizer === collectionView.panGestureRecognizer)
         }
 
         private func isNestedHorizontalScroller(
@@ -1260,9 +1268,14 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
 
 enum TranscriptTimestampRevealGeometry {
     static let maximumWidth: CGFloat = 76
+    static let minimumHorizontalVelocity: CGFloat = 120
+    static let horizontalIntentRatio: CGFloat = 1.35
 
     static func shouldBegin(velocityX: CGFloat, velocityY: CGFloat) -> Bool {
-        velocityX < 0 && abs(velocityX) > abs(velocityY)
+        let horizontalSpeed = abs(velocityX)
+        return velocityX < 0
+            && horizontalSpeed >= minimumHorizontalVelocity
+            && horizontalSpeed >= abs(velocityY) * horizontalIntentRatio
     }
 
     static func width(translationX: CGFloat) -> CGFloat {
@@ -1280,7 +1293,9 @@ private struct FeatureTimestampRevealMessageView: View {
     @ObservedObject var reveal: FeatureTimestampRevealState
 
     var body: some View {
-        ZStack(alignment: .trailing) {
+        ZStack(alignment: .topTrailing) {
+            FeatureMessageView(message: message)
+
             if message.createdAt != .distantPast {
                 Text(message.createdAt, format: .dateTime.hour().minute())
                     .font(T3Typography.supporting.monospacedDigit())
@@ -1292,13 +1307,13 @@ private struct FeatureTimestampRevealMessageView: View {
                         width: TranscriptTimestampRevealGeometry.maximumWidth,
                         alignment: .trailing
                     )
-                    .offset(x: TranscriptTimestampRevealGeometry.maximumWidth - reveal.width)
+                    .padding(.vertical, 5)
+                    .background(T3Colors.surface, in: Capsule())
+                    .frame(width: reveal.width, alignment: .trailing)
+                    .clipped()
                     .opacity(reveal.width > 0 ? 1 : 0)
                     .accessibilityHidden(true)
             }
-
-            FeatureMessageView(message: message)
-                .offset(x: -reveal.width)
         }
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 

--- a/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
@@ -1,8 +1,35 @@
 import Testing
 @testable import T3Code
 
-@Suite("Transcript viewport anchoring")
+@Suite("Transcript viewport and timestamp gestures")
 struct TranscriptViewportGeometryTests {
+    @Test
+    func timestampRevealTracksLeftwardDragWithinBounds() {
+        #expect(TranscriptTimestampRevealGeometry.width(translationX: -32) == 32)
+    }
+
+    @Test
+    func timestampRevealClampsAtRestAndMaximumWidth() {
+        #expect(TranscriptTimestampRevealGeometry.width(translationX: 24) == 0)
+        #expect(
+            TranscriptTimestampRevealGeometry.width(translationX: -200)
+                == TranscriptTimestampRevealGeometry.maximumWidth
+        )
+    }
+
+    @Test
+    func timestampRevealClaimsOnlyDeliberateLeftwardHorizontalPans() {
+        #expect(
+            TranscriptTimestampRevealGeometry.shouldBegin(velocityX: -24, velocityY: 4)
+        )
+        #expect(
+            !TranscriptTimestampRevealGeometry.shouldBegin(velocityX: -4, velocityY: 24)
+        )
+        #expect(
+            !TranscriptTimestampRevealGeometry.shouldBegin(velocityX: 24, velocityY: 4)
+        )
+    }
+
     @Test
     func firstLoadedTranscriptAnchorsToLatestMessage() {
         let empty = TranscriptViewportGeometry(

--- a/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
@@ -37,6 +37,22 @@ struct TranscriptViewportGeometryTests {
     }
 
     @Test
+    func keyboardDismissalTracksOnlyVerticalTranscriptPans() {
+        #expect(
+            TranscriptTimestampRevealGeometry.hasVerticalIntent(
+                velocityX: -40,
+                velocityY: 240
+            )
+        )
+        #expect(
+            !TranscriptTimestampRevealGeometry.hasVerticalIntent(
+                velocityX: -240,
+                velocityY: 40
+            )
+        )
+    }
+
+    @Test
     func firstLoadedTranscriptAnchorsToLatestMessage() {
         let empty = TranscriptViewportGeometry(
             contentHeight: 0,

--- a/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
@@ -20,13 +20,19 @@ struct TranscriptViewportGeometryTests {
     @Test
     func timestampRevealClaimsOnlyDeliberateLeftwardHorizontalPans() {
         #expect(
-            TranscriptTimestampRevealGeometry.shouldBegin(velocityX: -24, velocityY: 4)
+            TranscriptTimestampRevealGeometry.shouldBegin(velocityX: -240, velocityY: 40)
         )
         #expect(
-            !TranscriptTimestampRevealGeometry.shouldBegin(velocityX: -4, velocityY: 24)
+            !TranscriptTimestampRevealGeometry.shouldBegin(velocityX: -40, velocityY: 240)
         )
         #expect(
-            !TranscriptTimestampRevealGeometry.shouldBegin(velocityX: 24, velocityY: 4)
+            !TranscriptTimestampRevealGeometry.shouldBegin(velocityX: 240, velocityY: 40)
+        )
+        #expect(
+            !TranscriptTimestampRevealGeometry.shouldBegin(velocityX: -40, velocityY: 2)
+        )
+        #expect(
+            !TranscriptTimestampRevealGeometry.shouldBegin(velocityX: -120, velocityY: 100)
         )
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
 - [Organizing threads](./user/thread-sidebar.md)
+- [Native iPhone thread transcript](./user/swiftui-thread-transcript.md)
 - [Customize a project icon](./user/project-settings.md)
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)

--- a/docs/user/swiftui-thread-transcript.md
+++ b/docs/user/swiftui-thread-transcript.md
@@ -1,0 +1,6 @@
+# Native iPhone thread transcript
+
+In the native iPhone app, swipe left across the transcript to reveal the time on each message.
+The gesture requires a deliberate horizontal swipe so ordinary vertical scrolling and text
+selection keep their normal behavior. VoiceOver exposes the same time as custom content on each
+message without requiring the gesture.


### PR DESCRIPTION
## What Changed

- Reveal each visible SwiftUI transcript message's local sent or received time while the user drags the transcript left.
- Drive all visible rows from one bounded reveal distance, then return the thread to rest on release or cancellation.
- Preserve vertical scrolling, keyboard dismissal, and nested horizontal Markdown scrollers; respect Reduce Motion and expose the timestamps to VoiceOver.

This is intentionally SwiftUI-only. It does not change the server, wire contracts, web/desktop client, or React Native mobile client.

## Why

Conversation timestamps currently require opening individual message details. This gives the native iOS client the familiar iMessage interaction: a deliberate leftward drag reveals several message times in context without leaving the thread.

The implementation stays at the transcript's existing `UICollectionView` ownership seam. A dedicated pan recognizer publishes one small observable reveal value to the virtualized visible cells, while gesture arbitration leaves vertical transcript scrolling and nested horizontal content intact.

Base: `t3code/rebuild-mobile-app-swift` at `f98cab553546558e28d6e22f3dbe9807ecc3325f`.

## UI Changes

| Before | During left drag |
| --- | --- |
| ![Thread before timestamp reveal](https://raw.githubusercontent.com/saphid/t3code/agent/pr-media-swiftui-message-timestamps/pr-media/swiftui-message-timestamps/before.jpg) | ![Five message times revealed](https://raw.githubusercontent.com/saphid/t3code/agent/pr-media-swiftui-message-timestamps/pr-media/swiftui-message-timestamps/after.jpg) |

### Interaction

![Two message times revealed on the final head](https://raw.githubusercontent.com/saphid/t3code/agent/pr-media-swiftui-message-timestamps/pr-media/swiftui-message-timestamps/final-head-reveal.jpg)

[Play the 7-second final-head MP4](https://github.com/saphid/t3code/blob/agent/pr-media-swiftui-message-timestamps/pr-media/swiftui-message-timestamps/final-head-interaction.mp4)

The recording uses a real 1.5-second swipe against the integrated app on commit `c4bb0cf8d`, with two message times visible together; it is not a staged animation.

## Verification

- Current-head `Contract fixtures and native tests` CI job — passed on `c4bb0cf8d`, including the previously failing environment-scoped provider fixtures.
- Focused native suites on iPhone 17 Pro / iOS 26.5 — 13 tests passed, zero failures: all five `HomeThreadMetadataTests` and all eight `TranscriptViewportGeometryTests`.
- Exact-head build, install, and launch — passed for `com.t3tools.t3code.swiftui.dev` on iOS 26.5.
- Integrated SwiftUI simulator pass on iOS 26.5 — a real left drag revealed two distinct timestamps (`11:47 pm` and `11:49 pm`) together and they disappeared at rest. LLDB measured translation x = `-94` and velocity = `(-207.29, 0)` on the timestamp pan; the vertical-dismissal guard evaluated `false`.
- `git diff --check` — passed.
- The fixture repair is test-only and patch-identical to direct upstream PR #6130; it updates stale fixtures to the environment-scoped provider catalog introduced by Theo's target without changing timestamp-swipe production behavior.
- Independent Claude Opus 5 high review found one real layout issue: the hidden timestamp could enlarge short rows. Replacing the sizing `ZStack` with a non-sizing overlay preserves the approved reveal appearance and fixes the resting row height; the already-required user doc is now indexed.
- Cursor's valid ready-state finding that a noisy horizontal pan could arm keyboard dismissal is fixed on `c4bb0cf8d`; the focused regression and exact-head gesture both verify horizontal intent does not enter that path, and the review thread is resolved with evidence.
- A fresh frozen-head Claude Opus 5 high review was launched for `c4bb0cf8d`, but exited 1 before producing a verdict because the Anthropic session limit was reached; no current-head Opus verdict is claimed. The earlier successful Opus review remains recorded above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with GPT-5.6 Sol in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add swipe-to-reveal message timestamps in the iOS chat transcript view
> - Adds a leftward pan gesture on the chat transcript that slides messages left to reveal a trailing timestamp label, animating closed when the gesture ends.
> - Introduces `FeatureTimestampRevealState`, `FeatureTimestampRevealMessageView`, and `TranscriptTimestampRevealGeometry` in [ThreadDetailView.swift](https://github.com/pingdotgg/t3code/pull/5820/files#diff-c987f84bf3746c99e23dc49057c113592bca2c0bce299b9dd80fe73c9495af30) to manage reveal state, geometry clamping, and gesture gating.
> - Gesture only activates on deliberate leftward horizontal pans and yields to nested horizontal scrollers via `UIGestureRecognizerDelegate`.
> - Adds `FeatureMessageTimestampAccessibilityModifier` so VoiceOver users receive timestamp information as custom accessibility content on all message types.
> - Keyboard dismissal and bottom-anchor release are deferred until meaningful vertical scroll movement is detected, replacing the previous `keyboardDismissMode = .onDrag` approach.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad0b3dd. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SwiftUI/UIKit transcript interaction only; no server or data changes, with geometry covered by unit tests.
> 
> **Overview**
> Adds **iMessage-style swipe-to-reveal timestamps** on the native iOS chat transcript: a leftward pan drives one shared reveal distance so visible rows slide left and show trailing hour/minute labels, then animate closed on release (honoring Reduce Motion).
> 
> The transcript `UICollectionView` coordinator owns a non-cancelling pan recognizer with **gesture arbitration**—only deliberate leftward horizontal pans, simultaneous recognition with scrolling, and deferral when the touch hits nested horizontal scrollers (e.g. wide Markdown). Collection cells wrap messages in `FeatureTimestampRevealMessageView` backed by shared `FeatureTimestampRevealState` and `TranscriptTimestampRevealGeometry` for clamping.
> 
> **Keyboard and scroll behavior** changes: `keyboardDismissMode = .onDrag` is removed; keyboard dismissal and releasing the bottom anchor now run only after meaningful vertical movement in `scrollViewDidScroll`. **VoiceOver** gets sent/received timestamp custom content on all message roles via `FeatureMessageTimestampAccessibilityModifier`.
> 
> Unit tests cover reveal width bounds and pan direction gating in `TranscriptViewportGeometryTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0b3ddfb8c935834e6e5aed92f9c8828ffac094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Ready for human review. Current-head actionable CI, Cursor, Macroscope correctness, focused native tests, and integrated Simulator validation pass; zero unresolved threads. Macroscope approvability is neutral because new features require human review. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
