### PR TITLE
feat(threads): add projectless threads

### DIFF
--- a/apps/mobile/src/features/archive/archivedThreadList.ts
+++ b/apps/mobile/src/features/archive/archivedThreadList.ts
@@ -5,7 +5,7 @@ import {
   type EnvironmentProject,
   type EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
-import type { EnvironmentId } from "@t3tools/contracts";
+import { ProjectId, type EnvironmentId } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Order from "effect/Order";
 
@@ -45,12 +45,18 @@ export function buildArchivedThreadGroups(input: {
 
     const environmentLabel = input.environmentLabels[entry.environmentId] ?? null;
     const threadsByProjectId = new Map<string, EnvironmentThreadShell[]>();
+    const projectlessThreads: EnvironmentThreadShell[] = [];
     for (const thread of entry.snapshot.threads) {
       if (thread.archivedAt === null) {
         continue;
       }
+      const scopedThread = scopeThreadShell(entry.environmentId, thread);
+      if (thread.projectId === null) {
+        projectlessThreads.push(scopedThread);
+        continue;
+      }
       const threads = threadsByProjectId.get(thread.projectId) ?? [];
-      threads.push(scopeThreadShell(entry.environmentId, thread));
+      threads.push(scopedThread);
       threadsByProjectId.set(thread.projectId, threads);
     }
 
@@ -80,6 +86,45 @@ export function buildArchivedThreadGroups(input: {
           matchingThreads,
           Order.mapInput(
             Order.Struct({ timestamp: timestampOrder, title: Order.String, id: Order.String }),
+            (thread: EnvironmentThreadShell) => ({
+              timestamp: archiveTimestamp(thread),
+              title: thread.title,
+              id: thread.id,
+            }),
+          ),
+        ),
+      });
+    }
+    const matchingProjectlessThreads =
+      query.length === 0 ||
+      matchesQuery("No project", query) ||
+      matchesQuery(environmentLabel, query)
+        ? projectlessThreads
+        : projectlessThreads.filter((thread) => matchesQuery(thread.title, query));
+    const firstProjectlessThread = matchingProjectlessThreads[0];
+    if (firstProjectlessThread) {
+      const project = {
+        environmentId: entry.environmentId,
+        id: ProjectId.make(`projectless-${entry.environmentId}`),
+        title: "No project",
+        workspaceRoot: firstProjectlessThread.workspaceRoot ?? "",
+        repositoryIdentity: null,
+        defaultModelSelection: null,
+        scripts: [],
+        createdAt: firstProjectlessThread.createdAt,
+        updatedAt: firstProjectlessThread.updatedAt,
+      } satisfies EnvironmentProject;
+      groups.push({
+        key: `projectless:${entry.environmentId}`,
+        project,
+        threads: Arr.sort(
+          matchingProjectlessThreads,
+          Order.mapInput(
+            Order.Struct({
+              timestamp: input.sortOrder === "newest" ? Order.flip(Order.Number) : Order.Number,
+              title: Order.String,
+              id: Order.String,
+            }),
             (thread: EnvironmentThreadShell) => ({
               timestamp: archiveTimestamp(thread),
               title: thread.title,

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -348,8 +348,10 @@ export function HomeScreen(props: HomeScreenProps) {
     () =>
       selectedProjectRefKeys === null
         ? props.threads
-        : props.threads.filter((thread) =>
-            selectedProjectRefKeys.has(scopedProjectKey(thread.environmentId, thread.projectId)),
+        : props.threads.filter(
+            (thread) =>
+              thread.projectId !== null &&
+              selectedProjectRefKeys.has(scopedProjectKey(thread.environmentId, thread.projectId)),
           ),
     [props.threads, selectedProjectRefKeys],
   );
@@ -782,11 +784,17 @@ export function HomeScreen(props: HomeScreenProps) {
           snoozeWakeLabelText={item.snoozeWakeLabelText}
           showTrailingDivider={showTrailingDivider}
           project={
-            projectByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ?? null
+            thread.projectId === null
+              ? null
+              : (projectByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ?? null)
           }
-          projectTitle={v2ProjectTitleByProjectKey.get(
-            scopedProjectKey(thread.environmentId, thread.projectId),
-          )}
+          projectTitle={
+            thread.projectId === null
+              ? "No project"
+              : v2ProjectTitleByProjectKey.get(
+                  scopedProjectKey(thread.environmentId, thread.projectId),
+                )
+          }
           providerDriver={
             serverConfigs
               .get(thread.environmentId)
@@ -829,7 +837,10 @@ export function HomeScreen(props: HomeScreenProps) {
           onMovePinnedThread={handleMovePinnedThread}
           onChangeRequestState={handleChangeRequestState}
           projectCwd={
-            projectCwdByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ?? null
+            thread.projectId === null
+              ? (thread.workspaceRoot ?? null)
+              : (projectCwdByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ??
+                null)
           }
           onSwipeableClose={handleSwipeableClose}
           onSwipeableWillOpen={handleSwipeableWillOpen}
@@ -954,8 +965,11 @@ export function HomeScreen(props: HomeScreenProps) {
                 props.savedConnectionsById[thread.environmentId]?.environmentLabel ?? null
               }
               projectCwd={
-                projectCwdByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ??
-                null
+                thread.projectId === null
+                  ? (thread.workspaceRoot ?? null)
+                  : (projectCwdByKey.get(
+                      scopedProjectKey(thread.environmentId, thread.projectId),
+                    ) ?? null)
               }
               isLast={item.isLast}
               searchMatch={threadSearchMatchByKey.get(

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -20,6 +20,7 @@ import type {
   SidebarProjectSortOrder,
   SidebarThreadSortOrder,
 } from "@t3tools/contracts";
+import { ProjectId } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Option from "effect/Option";
 import * as Order from "effect/Order";
@@ -98,6 +99,7 @@ export function sortHomeProjectScopes(input: {
 
   for (const thread of input.threads) {
     if (thread.archivedAt !== null) continue;
+    if (thread.projectId === null) continue;
     recordActivity(
       scopeKeyByProjectRef.get(scopedProjectKey(thread.environmentId, thread.projectId)),
       getThreadSortTimestamp(thread, input.projectSortOrder),
@@ -281,6 +283,32 @@ export function buildHomeThreadGroups(input: {
       continue;
     }
 
+    if (thread.projectId === null) {
+      const groupKey = `projectless:${thread.environmentId}`;
+      if (!groups.has(groupKey)) {
+        groupTitleByKey.set(groupKey, "No project");
+        groups.set(groupKey, {
+          key: groupKey,
+          projects: [
+            {
+              environmentId: thread.environmentId,
+              id: ProjectId.make(`projectless-${thread.environmentId}`),
+              title: "No project",
+              workspaceRoot: thread.workspaceRoot ?? "",
+              repositoryIdentity: null,
+              defaultModelSelection: null,
+              scripts: [],
+              createdAt: thread.createdAt,
+              updatedAt: thread.updatedAt,
+            },
+          ],
+          pendingTasks: [],
+          threads: [],
+        });
+      }
+      groups.get(groupKey)?.threads.push(thread);
+      continue;
+    }
     const physicalKey = scopedProjectKey(thread.environmentId, thread.projectId);
     const groupKey = groupKeyByProjectKey.get(physicalKey);
     if (!groupKey) {
@@ -363,9 +391,10 @@ export function buildHomeThreadGroups(input: {
       pendingTasks: matchingPendingTasks,
       threads: sortedThreads,
       recentThreads,
-      newThreadTarget: group.key.startsWith("pending-project:")
-        ? null
-        : (lastActiveProject ?? representative),
+      newThreadTarget:
+        group.key.startsWith("pending-project:") || group.key.startsWith("projectless:")
+          ? null
+          : (lastActiveProject ?? representative),
     });
   }
 

--- a/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
@@ -10,6 +10,7 @@ type NewTaskDraftRouteParams = {
   readonly title?: string | string[];
   readonly pendingTaskId?: string | string[];
   readonly incomingShareId?: string | string[];
+  readonly projectless?: string | string[];
 };
 
 export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraftRouteParams>) {
@@ -37,6 +38,10 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
       />
       <NewTaskDraftScreen
         initialProjectRef={initialProjectRef}
+        projectless={
+          (Array.isArray(params.projectless) ? params.projectless[0] : params.projectless) ===
+          "true"
+        }
         incomingShareId={
           Array.isArray(params.incomingShareId) ? params.incomingShareId[0] : params.incomingShareId
         }

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -71,6 +71,7 @@ export function NewTaskDraftScreen(props: {
   readonly pendingTaskId?: string;
   /** Durable native share inbox item to merge into this project draft. */
   readonly incomingShareId?: string;
+  readonly projectless?: boolean;
 }) {
   const projects = useProjects();
   const createProjectThread = useCreateProjectThread();
@@ -87,15 +88,13 @@ export function NewTaskDraftScreen(props: {
   const colorScheme = useColorScheme();
   const isKeyboardVisible = useKeyboardState((state) => state.isVisible);
   const controlsBottomPadding = isKeyboardVisible ? 8 : Math.max(insets.bottom, 10);
-  const { projectScopes, selectedProject, selectedProjectKey, setProject } = flow;
+  const { projectScopes, selectedProject, selectedProjectKey, setProject, setProjectless } = flow;
   const { connectedEnvironments } = useRemoteConnectionStatus();
-  const selectedEnvironmentServerConfig = useEnvironmentServerConfig(
-    selectedProject?.environmentId ?? null,
-  );
+  const selectedEnvironmentServerConfig = useEnvironmentServerConfig(flow.selectedEnvironmentId);
   const environmentConnected =
-    selectedProject !== null &&
+    flow.selectedEnvironmentId !== null &&
     connectedEnvironments.find(
-      (environment) => environment.environmentId === selectedProject.environmentId,
+      (environment) => environment.environmentId === flow.selectedEnvironmentId,
     )?.connectionState === "connected";
   const promptInputRef = useRef<ComposerEditorHandle>(null);
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
@@ -244,6 +243,10 @@ export function NewTaskDraftScreen(props: {
       appliedInitialProjectKeyRef.current = null;
     }
     const initialEnvironmentId = props.initialProjectRef?.environmentId;
+    if (props.projectless && initialEnvironmentId) {
+      setProjectless(EnvironmentId.make(initialEnvironmentId));
+      return;
+    }
     const initialProjectId = props.initialProjectRef?.projectId;
     if (initialEnvironmentId && initialProjectId) {
       const directProject =
@@ -295,10 +298,12 @@ export function NewTaskDraftScreen(props: {
     props.initialProjectRef,
     props.incomingShareId,
     props.pendingTaskId,
+    props.projectless,
     navigation,
     selectedProject,
     selectedProjectKey,
     setProject,
+    setProjectless,
   ]);
 
   useEffect(() => {
@@ -516,7 +521,7 @@ export function NewTaskDraftScreen(props: {
   useEffect(() => {
     // Android starts with the collapsed composer pill (like an open thread)
     // and only expands/focuses when tapped.
-    if (!selectedProject || Platform.OS === "android") {
+    if ((!selectedProject && !flow.isProjectless) || Platform.OS === "android") {
       return;
     }
 
@@ -540,6 +545,7 @@ export function NewTaskDraftScreen(props: {
       }
     };
   }, [
+    flow.isProjectless,
     selectedProject,
     settingsSheetPresentation.isActiveRef,
     settingsSheetPresentation.restoreFocusAfterSave,
@@ -710,8 +716,9 @@ export function NewTaskDraftScreen(props: {
 
   async function handleStart(): Promise<void> {
     const selectedProject = flow.selectedProject;
+    const selectedEnvironmentId = flow.selectedEnvironmentId;
     const draftKey = flow.draftKey;
-    if (!selectedProject || !draftKey) {
+    if ((!selectedProject && !flow.isProjectless) || !selectedEnvironmentId || !draftKey) {
       return;
     }
     const draft = getComposerDraftSnapshot(draftKey);
@@ -744,6 +751,13 @@ export function NewTaskDraftScreen(props: {
     const editingPendingTask = flow.editingPendingTask;
 
     if (!environmentConnected) {
+      if (flow.isProjectless) {
+        Alert.alert(
+          "Environment unavailable",
+          "Connect to the environment before starting a thread without a project.",
+        );
+        return;
+      }
       // Offline: park the task in the outbox; the drain sends it when the
       // environment reconnects. Editing an existing pending task re-queues it
       // under its original identifiers.
@@ -790,14 +804,15 @@ export function NewTaskDraftScreen(props: {
     // finds no work and ends the card within seconds.
     armAgentAwarenessLiveActivityForLocalWork({
       threadTitle: deriveThreadTitleFromPrompt(initialMessageText),
-      projectTitle: selectedProject.title,
+      projectTitle: selectedProject?.title ?? "No project",
     });
     const result = await createProjectThread({
       project: selectedProject,
+      environmentId: selectedEnvironmentId,
       modelSelection,
-      envMode: workspaceMode,
-      branch: selectedBranchName,
-      worktreePath: workspaceMode === "worktree" ? null : selectedWorktreePath,
+      envMode: selectedProject ? workspaceMode : "local",
+      branch: selectedProject ? selectedBranchName : null,
+      worktreePath: selectedProject && workspaceMode !== "worktree" ? selectedWorktreePath : null,
       startFromOrigin,
       runtimeMode,
       interactionMode,
@@ -845,7 +860,7 @@ export function NewTaskDraftScreen(props: {
     );
   }
 
-  if (!selectedProject) {
+  if (!selectedProject && !flow.isProjectless) {
     return (
       <View className="flex-1 bg-sheet">
         {Platform.OS === "android" ? (
@@ -868,13 +883,15 @@ export function NewTaskDraftScreen(props: {
   // draft composer expanded through the blur (mirrors ThreadComposer).
   const isExpanded = !isAndroid || isComposerFocused || settingsSheetPresentation.isActive;
   const canStart =
-    Boolean(flow.selectedProject) &&
+    Boolean(flow.selectedProject || flow.isProjectless) &&
     Boolean(flow.selectedModel) &&
     flow.prompt.trim().length > 0 &&
     isIncomingShareReady &&
     !isImportingShare &&
     !flow.submitting &&
-    !(flow.workspaceMode === "worktree" && !flow.selectedBranchName);
+    (!flow.isProjectless || environmentConnected) &&
+    !(!flow.isProjectless && flow.workspaceMode === "worktree" && !flow.selectedBranchName);
+  const targetTitle = selectedProject?.title ?? "No project";
   const promptEditor = (
     <ComposerEditor
       ref={promptInputRef}
@@ -892,7 +909,9 @@ export function NewTaskDraftScreen(props: {
       onFocus={() => setIsComposerFocused(true)}
       onBlur={() => setIsComposerFocused(false)}
       onPasteImages={(uris) => void handleNativePasteImages(uris)}
-      placeholder={`Describe a coding task in ${selectedProject.title}`}
+      placeholder={
+        flow.isProjectless ? "Describe a coding task" : `Describe a coding task in ${targetTitle}`
+      }
       // Same collapsed centering as ThreadComposer: native vertical gravity
       // in a pill-height box.
       singleLineCentered={!isExpanded}
@@ -939,17 +958,19 @@ export function NewTaskDraftScreen(props: {
           label={selectedEnvironmentLabel}
         />
       </ControlPillMenu>
-      <ControlPillMenu
-        actions={workspaceMenuActions}
-        onPressAction={({ nativeEvent }) => handleWorkspaceMenuAction(nativeEvent.event)}
-      >
-        <ComposerToolbarTrigger
-          accessibilityLabel="Workspace"
-          disabled={isIncomingShareTransferPending}
-          icon="point.topleft.down.curvedto.point.bottomright.up"
-          label={workspaceLabel}
-        />
-      </ControlPillMenu>
+      {!flow.isProjectless ? (
+        <ControlPillMenu
+          actions={workspaceMenuActions}
+          onPressAction={({ nativeEvent }) => handleWorkspaceMenuAction(nativeEvent.event)}
+        >
+          <ComposerToolbarTrigger
+            accessibilityLabel="Workspace"
+            disabled={isIncomingShareTransferPending}
+            icon="point.topleft.down.curvedto.point.bottomright.up"
+            label={workspaceLabel}
+          />
+        </ControlPillMenu>
+      ) : null}
     </>
   );
 
@@ -971,9 +992,15 @@ export function NewTaskDraftScreen(props: {
   const startButton = (
     <ComposerToolbarButton
       accessibilityLabel={
-        flow.submitting ? "Starting task" : environmentConnected ? "Start task" : "Queue task"
+        flow.submitting
+          ? "Starting task"
+          : environmentConnected
+            ? "Start task"
+            : flow.isProjectless
+              ? "Environment unavailable"
+              : "Queue task"
       }
-      icon={environmentConnected ? "arrow.up" : "tray.and.arrow.up"}
+      icon={environmentConnected || flow.isProjectless ? "arrow.up" : "tray.and.arrow.up"}
       onPress={() => void handleStart()}
       variant="primary"
       showChevron={false}
@@ -1064,7 +1091,7 @@ export function NewTaskDraftScreen(props: {
 
   return (
     <View className="flex-1 bg-sheet">
-      <NativeStackScreenOptions options={{ title: selectedProject.title }} />
+      <NativeStackScreenOptions options={{ title: targetTitle }} />
 
       <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
         <View className="min-h-0 flex-1 px-5 pt-2">{promptEditor}</View>

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -244,6 +244,11 @@ export function NewTaskDraftScreen(props: {
     }
     const initialEnvironmentId = props.initialProjectRef?.environmentId;
     if (props.projectless && initialEnvironmentId) {
+      const projectlessKey = `projectless:${initialEnvironmentId}`;
+      if (appliedInitialProjectKeyRef.current === projectlessKey) {
+        return;
+      }
+      appliedInitialProjectKeyRef.current = projectlessKey;
       setProjectless(EnvironmentId.make(initialEnvironmentId));
       return;
     }

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -11,7 +11,8 @@ import { cn } from "../../lib/cn";
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { AppText as Text } from "../../components/AppText";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
-import { useProjects } from "../../state/entities";
+import { useProjects, useServerConfigs } from "../../state/entities";
+import { useEnvironments } from "../../state/environments";
 import type { WorkspaceState } from "../../state/workspaceModel";
 import { useWorkspaceState } from "../../state/workspace";
 import { scopedProjectKey } from "../../lib/scopedEntities";
@@ -80,6 +81,8 @@ function deriveProjectEmptyState(catalogState: WorkspaceState): {
 
 export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRouteParams | undefined>) {
   const projects = useProjects();
+  const serverConfigs = useServerConfigs();
+  const { environments } = useEnvironments();
   const { projectScopes } = useNewTaskFlow();
   const { state: catalogState } = useWorkspaceState();
   const navigation = useNavigation();
@@ -103,6 +106,9 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
     : null;
   const screenTitle = incomingShare ? "Start a task" : "Choose project";
   const projectEmptyState = deriveProjectEmptyState(catalogState);
+  const projectlessEnvironment = environments.find(
+    (environment) => serverConfigs.get(environment.environmentId)?.projectlessThreads === true,
+  );
   const resumedDestinationKeyRef = useRef<string | null>(null);
   const reservedDestinationProject = incomingShare?.destination
     ? (projects.find(
@@ -133,6 +139,18 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
         projectId: project.id,
         title: project.title,
         incomingShareId: incomingShare?.id,
+      },
+    });
+  }
+
+  function selectProjectless(): void {
+    if (!projectlessEnvironment) return;
+    navigation.navigate("NewTaskSheet", {
+      screen: "NewTaskDraft",
+      params: {
+        environmentId: projectlessEnvironment.environmentId,
+        title: "No project",
+        projectless: "true",
       },
     });
   }
@@ -242,6 +260,27 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           paddingTop: 8,
         }}
       >
+        {!incomingShare && projectlessEnvironment ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Don't work in a project"
+            onPress={selectProjectless}
+            className="flex-row items-center gap-3 rounded-[24px] bg-card px-4 py-3.5 active:opacity-70"
+          >
+            <View className="h-7 w-7 items-center justify-center">
+              <SymbolView name="xmark" size={18} tintColor={accentColor} />
+            </View>
+            <View className="min-w-0 flex-1">
+              <Text className="text-base leading-snug font-t3-bold">
+                Don&apos;t work in a project
+              </Text>
+              <Text className="text-xs leading-snug text-foreground-muted">
+                Start in {projectlessEnvironment.label}
+              </Text>
+            </View>
+            <SymbolView name="chevron.right" size={14} tintColor={chevronColor} />
+          </Pressable>
+        ) : null}
         {projectScopes.length === 0 ? (
           <View collapsable={false} className="items-center gap-3 rounded-[24px] bg-card px-6 py-8">
             {projectEmptyState.loading ? <ActivityIndicator color={accentColor} /> : null}

--- a/apps/mobile/src/features/threads/ThreadGitControls.tsx
+++ b/apps/mobile/src/features/threads/ThreadGitControls.tsx
@@ -97,6 +97,7 @@ type ThreadGitControlsProps = ThreadGitMenuProps & {
   };
   readonly canOpenTerminal: boolean;
   readonly canOpenFiles: boolean;
+  readonly canOpenGit: boolean;
   readonly projectScripts: ReadonlyArray<ProjectScript>;
   readonly terminalSessions: ReadonlyArray<TerminalMenuSession>;
   readonly showActionControls?: boolean;
@@ -393,16 +394,26 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
 export function useThreadGitRightHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
   return useMemo(
-    () => [actionItems.git, actionItems.files, actionItems.terminal] as HeaderItems,
-    [actionItems],
+    () =>
+      [
+        ...(props.canOpenGit ? [actionItems.git] : []),
+        actionItems.files,
+        actionItems.terminal,
+      ] as HeaderItems,
+    [actionItems, props.canOpenGit],
   );
 }
 
 export function useThreadGitCenterHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
   return useMemo(
-    () => [actionItems.files, actionItems.git, actionItems.terminal] as HeaderItems,
-    [actionItems],
+    () =>
+      [
+        actionItems.files,
+        ...(props.canOpenGit ? [actionItems.git] : []),
+        actionItems.terminal,
+      ] as HeaderItems,
+    [actionItems, props.canOpenGit],
   );
 }
 
@@ -489,7 +500,7 @@ export function ThreadGitControls(props: ThreadGitControlsProps) {
           separateBackground
         />
       ) : null}
-      {showActionControls ? <ThreadGitMenu {...props} /> : null}
+      {showActionControls && props.canOpenGit ? <ThreadGitMenu {...props} /> : null}
     </NativeHeaderToolbar>
   );
 }

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -332,8 +332,10 @@ function ThreadNavigationSidebarPane(
     () =>
       selectedProjectRefs === null
         ? threads
-        : threads.filter((thread) =>
-            selectedProjectRefs.has(scopedProjectKey(thread.environmentId, thread.projectId)),
+        : threads.filter(
+            (thread) =>
+              thread.projectId !== null &&
+              selectedProjectRefs.has(scopedProjectKey(thread.environmentId, thread.projectId)),
           ),
     [selectedProjectRefs, threads],
   );
@@ -910,7 +912,10 @@ function ThreadNavigationSidebarPane(
         }
         case "v2-thread": {
           const thread = item.item.thread;
-          const scopeKey = scopedProjectKey(thread.environmentId, thread.projectId);
+          const scopeKey =
+            thread.projectId === null
+              ? `projectless:${thread.environmentId}`
+              : scopedProjectKey(thread.environmentId, thread.projectId);
           return (
             <ThreadListV2Row
               thread={thread}
@@ -1050,8 +1055,11 @@ function ThreadNavigationSidebarPane(
                 savedConnectionsById[thread.environmentId]?.environmentLabel ?? null
               }
               projectCwd={
-                projectCwdByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ??
-                null
+                thread.projectId === null
+                  ? (thread.workspaceRoot ?? null)
+                  : (projectCwdByKey.get(
+                      scopedProjectKey(thread.environmentId, thread.projectId),
+                    ) ?? null)
               }
               isLast={item.isLast}
               searchMatch={threadSearchMatchByKey.get(

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -306,7 +306,7 @@ function ThreadRouteContent(
     .join(" · ");
   /* ─── Git status for native header trigger ───────────────────────── */
   const gitStatus = useEnvironmentQuery(
-    selectedThread !== null && selectedThreadCwd !== null
+    selectedThread !== null && selectedThreadProject !== null && selectedThreadCwd !== null
       ? vcsEnvironment.status({
           environmentId: selectedThread.environmentId,
           input: { cwd: selectedThreadCwd },
@@ -321,9 +321,9 @@ function ThreadRouteContent(
     () =>
       buildTerminalMenuSessions({
         knownSessions: knownTerminalSessions,
-        workspaceRoot: selectedThreadProject?.workspaceRoot ?? null,
+        workspaceRoot: selectedThreadCwd,
       }),
-    [knownTerminalSessions, selectedThreadProject?.workspaceRoot],
+    [knownTerminalSessions, selectedThreadCwd],
   );
   const selectedThreadDetailWorktreePath = selectedThreadDetail?.worktreePath ?? null;
   const handleReconnectEnvironment = useCallback(() => {
@@ -502,10 +502,10 @@ function ThreadRouteContent(
       terminalDebugLog("terminal-menu:open-existing", {
         terminalId: nextTerminalId ?? null,
         hasThread: Boolean(selectedThread),
-        hasWorkspaceRoot: Boolean(selectedThreadProject?.workspaceRoot),
+        hasWorkspaceRoot: Boolean(selectedThreadCwd),
       });
 
-      if (!selectedThread || !selectedThreadProject?.workspaceRoot) {
+      if (!selectedThread || !selectedThreadCwd) {
         return;
       }
 
@@ -515,17 +515,17 @@ function ThreadRouteContent(
         ...(nextTerminalId ? { terminalId: nextTerminalId } : {}),
       });
     },
-    [navigation, selectedThread, selectedThreadProject?.workspaceRoot],
+    [navigation, selectedThread, selectedThreadCwd],
   );
 
   const handleOpenNewTerminal = useCallback(() => {
     terminalDebugLog("terminal-menu:open-new", {
       hasThread: Boolean(selectedThread),
-      hasWorkspaceRoot: Boolean(selectedThreadProject?.workspaceRoot),
+      hasWorkspaceRoot: Boolean(selectedThreadCwd),
       listedTerminalIds: terminalMenuSessions.map((session) => session.terminalId),
     });
 
-    if (!selectedThread || !selectedThreadProject?.workspaceRoot) {
+    if (!selectedThread || !selectedThreadCwd) {
       return;
     }
 
@@ -537,7 +537,7 @@ function ThreadRouteContent(
       threadId: String(selectedThread.id),
       terminalId: nextId,
     });
-  }, [navigation, selectedThread, selectedThreadProject?.workspaceRoot, terminalMenuSessions]);
+  }, [navigation, selectedThread, selectedThreadCwd, terminalMenuSessions]);
 
   const handleRunProjectScript = useCallback(
     async (script: ProjectScript) => {
@@ -624,8 +624,9 @@ function ThreadRouteContent(
     currentBranch: selectedThread?.branch ?? null,
     gitStatus: gitStatus.data,
     gitOperationLabel: gitState.gitOperationLabel,
-    canOpenTerminal: Boolean(selectedThreadProject?.workspaceRoot),
-    canOpenFiles: Boolean(selectedThreadProject?.workspaceRoot),
+    canOpenTerminal: Boolean(selectedThreadCwd),
+    canOpenFiles: Boolean(selectedThreadCwd),
+    canOpenGit: selectedThreadProject !== null,
     projectScripts: selectedThreadProject?.scripts ?? [],
     terminalSessions: terminalMenuSessions,
     showDirectFileControl: layout.usesSplitView,
@@ -696,18 +697,20 @@ function ThreadRouteContent(
         onPress: handleOpenFilesInspector,
       });
     }
-    if (selectedThreadProject?.workspaceRoot) {
+    if (selectedThreadCwd) {
       actions.push({
         accessibilityLabel: "Open terminal",
         icon: "terminal",
         onPress: () => handleOpenTerminal(null),
       });
     }
-    actions.push({
-      accessibilityLabel: "Open git controls",
-      icon: "point.topleft.down.curvedto.point.bottomright.up",
-      onPress: handleOpenGitInspector,
-    });
+    if (selectedThreadProject) {
+      actions.push({
+        accessibilityLabel: "Open git controls",
+        icon: "point.topleft.down.curvedto.point.bottomright.up",
+        onPress: handleOpenGitInspector,
+      });
+    }
     if (fileInspector.supported && selectedThreadCwd !== null) {
       actions.push({
         accessibilityLabel: "Toggle inspector",
@@ -724,7 +727,8 @@ function ThreadRouteContent(
     handleToggleInspector,
     props.onReturnToThread,
     selectedThreadCwd,
-    selectedThreadProject?.workspaceRoot,
+    selectedThreadProject,
+    selectedThreadCwd,
   ]);
 
   // Deep links / cold starts land with Thread as the ONLY route, where the

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -25,7 +25,12 @@ import {
 import * as Arr from "effect/Array";
 import { pipe } from "effect/Function";
 
-import { useEnvironmentServerConfig, useProjects, useThreadShells } from "../../state/entities";
+import {
+  useEnvironmentServerConfig,
+  useProjects,
+  useServerConfigs,
+  useThreadShells,
+} from "../../state/entities";
 import type { TurnCommandMetadata } from "../../lib/commandMetadata";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import type { ModelOption, ProviderGroup } from "../../lib/modelOptions";
@@ -148,6 +153,7 @@ type NewTaskFlowContextValue = {
     readonly environmentLabel: string;
   }>;
   readonly selectedProject: EnvironmentProject | null;
+  readonly isProjectless: boolean;
   readonly modelOptions: ReadonlyArray<ModelOption>;
   readonly selectedModel: ModelSelection | null;
   readonly selectedModelOption: ModelOption | null;
@@ -156,6 +162,7 @@ type NewTaskFlowContextValue = {
   readonly filteredBranches: ReadonlyArray<VcsRef>;
   readonly reset: () => void;
   readonly setProject: (project: EnvironmentProject) => void;
+  readonly setProjectless: (environmentId: EnvironmentId) => void;
   readonly selectEnvironment: (environmentId: EnvironmentId) => void;
   readonly setSelectedModelKey: (
     key: string | null,
@@ -189,6 +196,7 @@ const NewTaskFlowContext = React.createContext<NewTaskFlowContextValue | null>(n
 export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const projects = useProjects();
   const threads = useThreadShells();
+  const serverConfigs = useServerConfigs();
   const { savedConnectionsById } = useSavedRemoteConnections();
   const groupingSettings = useMobileProjectGroupingSettings();
   const projectScopes = useMemo(
@@ -211,10 +219,14 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   );
   const selectedEnvironmentId =
     selectedEnvironmentIdOverride !== null &&
-    projects.some((project) => project.environmentId === selectedEnvironmentIdOverride)
+    savedConnectionsById[selectedEnvironmentIdOverride] !== undefined
       ? selectedEnvironmentIdOverride
-      : (projects[0]?.environmentId ?? null);
+      : (projects[0]?.environmentId ??
+        (Object.keys(savedConnectionsById)[0] as EnvironmentId | undefined) ??
+        null);
   const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(null);
+  const isProjectless =
+    selectedEnvironmentId !== null && selectedProjectKey === `projectless:${selectedEnvironmentId}`;
   const [submitting, setSubmitting] = useState(false);
   const [branchQuery, setBranchQuery] = useState("");
   const [expandedProvider, setExpandedProvider] = useState<string | null>(null);
@@ -284,7 +296,9 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     selectedProjectKey ===
       scopedProjectKey(editingPendingProject.environmentId, editingPendingProject.id)
       ? editingPendingProject
-      : (projectsForEnvironment[0] ?? null));
+      : isProjectless
+        ? null
+        : (projectsForEnvironment[0] ?? null));
 
   // Only offer machines that actually host the currently selected repository, so
   // switching computers moves the same repo across machines instead of jumping to
@@ -315,6 +329,17 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         (selectedProjectTitle !== null && project.title === selectedProjectTitle)
       );
     };
+    if (isProjectless) {
+      return Object.values(savedConnectionsById)
+        .filter(
+          (environment) =>
+            serverConfigs.get(environment.environmentId)?.projectlessThreads === true,
+        )
+        .map((environment) => ({
+          environmentId: environment.environmentId,
+          environmentLabel: environment.environmentLabel,
+        }));
+    }
     for (const project of projects) {
       if (!hostsSelectedRepository(project)) {
         continue;
@@ -336,21 +361,23 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   }, [
     projects,
     savedConnectionsById,
+    serverConfigs,
     selectedRepositoryKey,
     selectedWorkspaceBasename,
     selectedProjectTitle,
+    isProjectless,
   ]);
 
-  const selectedEnvironmentServerConfig = useEnvironmentServerConfig(
-    selectedProject?.environmentId ?? null,
-  );
+  const selectedEnvironmentServerConfig = useEnvironmentServerConfig(selectedEnvironmentId);
   // While a queued pending task is being edited its draft lives under a key
   // scoped to the queued message, so per-project new-task drafts stay intact.
   const selectedProjectDraftKey = editingPendingTask
     ? pendingTaskDraftKey(editingPendingTask.messageId)
-    : selectedProject
-      ? `new-task:${scopedProjectKey(selectedProject.environmentId, selectedProject.id)}`
-      : null;
+    : isProjectless && selectedEnvironmentId
+      ? `new-task:projectless:${selectedEnvironmentId}`
+      : selectedProject
+        ? `new-task:${scopedProjectKey(selectedProject.environmentId, selectedProject.id)}`
+        : null;
   const selectedProjectDraft = useComposerDraft(selectedProjectDraftKey);
   const prompt = selectedProjectDraft.text;
   const attachments = selectedProjectDraft.attachments;
@@ -370,11 +397,13 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     if (t3ProjectFileData === null || t3ProjectFileData.truncated) return null;
     return parseT3ProjectFile(t3ProjectFileData.contents)?.defaultThreadEnvMode ?? null;
   }, [t3ProjectFileData]);
-  const defaultWorkspaceMode: WorkspaceMode = resolveDefaultThreadEnvMode({
-    projectSetting: selectedProject?.defaultThreadEnvMode,
-    projectFile: t3ProjectFileDefaultMode,
-    globalDefault: selectedEnvironmentServerConfig?.settings.defaultThreadEnvMode ?? "local",
-  });
+  const defaultWorkspaceMode: WorkspaceMode = isProjectless
+    ? "local"
+    : resolveDefaultThreadEnvMode({
+        projectSetting: selectedProject?.defaultThreadEnvMode,
+        projectFile: t3ProjectFileDefaultMode,
+        globalDefault: selectedEnvironmentServerConfig?.settings.defaultThreadEnvMode ?? "local",
+      });
   // While unsettled the resolved default is provisional. Nothing may write
   // it into the draft during that window (the auto-branch effect does), or
   // the frozen interim value beats the t3.json default once it loads.
@@ -560,8 +589,18 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     setSelectedProjectKey(nextProjectKey);
   }, []);
 
+  const setProjectless = useCallback((environmentId: EnvironmentId) => {
+    setSelectedEnvironmentId(environmentId);
+    setSelectedProjectKey(`projectless:${environmentId}`);
+  }, []);
+
   const selectEnvironment = useCallback(
     (environmentId: EnvironmentId) => {
+      if (isProjectless) {
+        setSelectedEnvironmentId(environmentId);
+        setSelectedProjectKey(`projectless:${environmentId}`);
+        return;
+      }
       const projectsOnTarget = projects.filter(
         (project) => project.environmentId === environmentId,
       );
@@ -588,7 +627,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       setSelectedEnvironmentId(environmentId);
       setSelectedProjectKey(match ? scopedProjectKey(match.environmentId, match.id) : null);
     },
-    [projects, selectedProject],
+    [isProjectless, projects, selectedProject],
   );
 
   const setWorkspaceMode = useCallback(
@@ -791,6 +830,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       selectedEnvironmentServerConfig,
       selectedModel,
       selectedProject,
+      isProjectless,
       selectedProjectDraftKey,
       startFromOrigin,
       workspaceMode,
@@ -910,6 +950,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       expandedProvider,
       environments,
       selectedProject,
+      isProjectless,
       modelOptions,
       selectedModel,
       selectedModelOption,
@@ -918,6 +959,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       filteredBranches,
       reset,
       setProject,
+      setProjectless,
       selectEnvironment,
       setSelectedModelKey,
       setWorkspaceMode,
@@ -971,9 +1013,11 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       selectedProviderSkills,
       setSelectedModelOptions,
       selectedProject,
+      isProjectless,
       selectedProjectKey,
       selectedWorktreePath,
       setProject,
+      setProjectless,
       selectBranch,
       selectEnvironment,
       setInteractionMode,

--- a/apps/mobile/src/features/threads/use-project-actions.ts
+++ b/apps/mobile/src/features/threads/use-project-actions.ts
@@ -27,7 +27,8 @@ export function useCreateProjectThread() {
 
   return useCallback(
     async (input: {
-      readonly project: EnvironmentProject;
+      readonly project: EnvironmentProject | null;
+      readonly environmentId: EnvironmentProject["environmentId"];
       readonly modelSelection: ModelSelection;
       readonly envMode: "local" | "worktree";
       readonly branch: string | null;
@@ -44,23 +45,27 @@ export function useCreateProjectThread() {
       const threadId = ThreadId.make(metadata.threadId);
       const initialMessageText = input.initialMessageText.trim();
 
-      const validationError = validateProjectThreadCreation({
-        environmentId: input.project.environmentId,
-        projectId: input.project.id,
-        environmentMode: input.envMode,
-        branch: input.branch,
-        initialMessageText,
-      });
+      const validationError = input.project
+        ? validateProjectThreadCreation({
+            environmentId: input.project.environmentId,
+            projectId: input.project.id,
+            environmentMode: input.envMode,
+            branch: input.branch,
+            initialMessageText,
+          })
+        : initialMessageText.length === 0
+          ? new Error("Enter a task before starting the thread.")
+          : null;
       if (validationError !== null) {
         setPendingConnectionError(validationError.message);
         return AsyncResult.failure(Cause.fail(validationError));
       }
 
       const result = await startTurn({
-        environmentId: input.project.environmentId,
+        environmentId: input.environmentId,
         input: buildProjectThreadStartTurnInput({
-          projectId: input.project.id,
-          projectCwd: input.project.workspaceRoot,
+          projectId: input.project?.id ?? null,
+          projectCwd: input.project?.workspaceRoot ?? null,
           threadId: metadata.threadId,
           commandId: metadata.commandId,
           messageId: metadata.messageId,
@@ -70,9 +75,9 @@ export function useCreateProjectThread() {
           modelSelection: input.modelSelection,
           runtimeMode: input.runtimeMode,
           interactionMode: input.interactionMode,
-          workspaceMode: input.envMode,
-          branch: input.branch,
-          worktreePath: input.worktreePath,
+          workspaceMode: input.project ? input.envMode : "local",
+          branch: input.project ? input.branch : null,
+          worktreePath: input.project ? input.worktreePath : null,
           startFromOrigin: input.startFromOrigin ?? false,
           worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
         }),
@@ -86,9 +91,7 @@ export function useCreateProjectThread() {
       }
       setPendingConnectionError(null);
 
-      return mapAtomCommandResult(result, () =>
-        scopeThreadRef(input.project.environmentId, threadId),
-      );
+      return mapAtomCommandResult(result, () => scopeThreadRef(input.environmentId, threadId));
     },
     [startTurn],
   );

--- a/apps/mobile/src/lib/projectThreadStartTurn.ts
+++ b/apps/mobile/src/lib/projectThreadStartTurn.ts
@@ -21,8 +21,8 @@ export function deriveThreadTitleFromPrompt(value: string): string {
 }
 
 export interface ProjectThreadStartTurnSpec {
-  readonly projectId: ProjectId;
-  readonly projectCwd: string;
+  readonly projectId: ProjectId | null;
+  readonly projectCwd: string | null;
   readonly threadId: string;
   readonly commandId: string;
   readonly messageId: string;
@@ -47,7 +47,7 @@ export interface ProjectThreadStartTurnSpec {
  */
 export function buildProjectThreadStartTurnInput(spec: ProjectThreadStartTurnSpec) {
   const title = deriveThreadTitleFromPrompt(spec.text);
-  const isWorktree = spec.workspaceMode === "worktree";
+  const isWorktree = spec.projectId !== null && spec.workspaceMode === "worktree";
   return {
     commandId: CommandId.make(spec.commandId),
     threadId: ThreadId.make(spec.threadId),
@@ -64,18 +64,19 @@ export function buildProjectThreadStartTurnInput(spec: ProjectThreadStartTurnSpe
     bootstrap: {
       createThread: {
         projectId: spec.projectId,
+        workspaceRoot: null,
         title,
         modelSelection: spec.modelSelection,
         runtimeMode: spec.runtimeMode,
         interactionMode: spec.interactionMode,
-        branch: spec.branch,
-        worktreePath: isWorktree ? null : spec.worktreePath,
+        branch: spec.projectId === null ? null : spec.branch,
+        worktreePath: spec.projectId === null || isWorktree ? null : spec.worktreePath,
         createdAt: spec.createdAt,
       },
       ...(isWorktree
         ? {
             prepareWorktree: {
-              projectCwd: spec.projectCwd,
+              projectCwd: spec.projectCwd!,
               baseBranch: spec.branch!,
               branch: spec.worktreeBranchName,
               ...(spec.startFromOrigin ? { startFromOrigin: true } : {}),

--- a/apps/mobile/src/state/use-selected-thread-git-state.ts
+++ b/apps/mobile/src/state/use-selected-thread-git-state.ts
@@ -16,13 +16,13 @@ export function useSelectedThreadGitState() {
   const selectedThreadGitTarget = useMemo(
     () => ({
       environmentId: selectedThread?.environmentId ?? null,
-      cwd: selectedThreadCwd,
+      cwd: selectedThreadProject === null ? null : selectedThreadCwd,
     }),
-    [selectedThread?.environmentId, selectedThreadCwd],
+    [selectedThread?.environmentId, selectedThreadCwd, selectedThreadProject],
   );
   const gitActionState = useVcsActionState(selectedThreadGitTarget);
   const sourceControlDiscovery = useEnvironmentQuery(
-    selectedThread === null
+    selectedThread === null || selectedThreadProject === null
       ? null
       : sourceControlEnvironment.discovery({
           environmentId: selectedThread.environmentId,

--- a/apps/mobile/src/state/use-thread-selection.ts
+++ b/apps/mobile/src/state/use-thread-selection.ts
@@ -105,7 +105,7 @@ function useResolvedThreadSelection(params: ThreadSelectionRouteParams | undefin
   );
   const selectedProjectRef = useMemo<ScopedProjectRef | null>(
     () =>
-      selectedThread === null
+      selectedThread === null || selectedThread.projectId === null
         ? null
         : {
             environmentId: selectedThread.environmentId,

--- a/apps/server/src/checkpointing/Utils.ts
+++ b/apps/server/src/checkpointing/Utils.ts
@@ -11,7 +11,8 @@ export function checkpointRefForThreadTurn(threadId: ThreadId, turnCount: number
 
 export function resolveThreadWorkspaceCwd(input: {
   readonly thread: {
-    readonly projectId: ProjectId;
+    readonly projectId: ProjectId | null;
+    readonly workspaceRoot?: string | null;
     readonly worktreePath: string | null;
   };
   readonly projects: ReadonlyArray<{
@@ -22,6 +23,10 @@ export function resolveThreadWorkspaceCwd(input: {
   const worktreeCwd = input.thread.worktreePath ?? undefined;
   if (worktreeCwd) {
     return worktreeCwd;
+  }
+
+  if (input.thread.projectId === null) {
+    return input.thread.workspaceRoot ?? undefined;
   }
 
   return input.projects.find((project) => project.id === input.thread.projectId)?.workspaceRoot;

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -169,8 +169,9 @@ const make = Effect.gen(function* () {
   });
 
   const resolveThreadProjects = Effect.fn("resolveThreadProjects")(function* (
-    projectId: ProjectId,
+    projectId: ProjectId | null,
   ) {
+    if (projectId === null) return [];
     const project = yield* projectionSnapshotQuery
       .getProjectShellById(projectId)
       .pipe(Effect.map(Option.getOrUndefined));
@@ -185,10 +186,15 @@ const make = Effect.gen(function* () {
   // a git repository.
   const resolveCheckpointCwd = Effect.fn("resolveCheckpointCwd")(function* (input: {
     readonly threadId: ThreadId;
-    readonly thread: { readonly projectId: ProjectId; readonly worktreePath: string | null };
+    readonly thread: {
+      readonly projectId: ProjectId | null;
+      readonly workspaceRoot?: string | null;
+      readonly worktreePath: string | null;
+    };
     readonly projects: ReadonlyArray<{ readonly id: ProjectId; readonly workspaceRoot: string }>;
     readonly preferSessionRuntime: boolean;
   }): Effect.fn.Return<string | undefined> {
+    if (input.thread.projectId === null) return undefined;
     const fromSession = yield* resolveSessionRuntimeForThread(input.threadId);
     const fromThread = resolveThreadWorkspaceCwd({
       thread: input.thread,

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -605,6 +605,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           yield* projectionThreadRepository.upsert({
             threadId: event.payload.threadId,
             projectId: event.payload.projectId,
+            workspaceRoot: event.payload.workspaceRoot ?? null,
             title: event.payload.title,
             modelSelection: event.payload.modelSelection,
             runtimeMode: event.payload.runtimeMode,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -1689,6 +1689,25 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
             '2026-05-01T00:00:07.000Z',
             '2026-05-01T00:00:08.000Z',
             NULL
+          ),
+          (
+            'thread-orphaned',
+            'project-missing',
+            'Orphaned search',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            '2026-05-01T00:00:09.000Z',
+            '2026-05-01T00:00:10.000Z',
+            NULL,
+            NULL
           )
       `;
 
@@ -1773,6 +1792,16 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
             0,
             '2026-05-01T00:00:16.000Z',
             '2026-05-01T00:00:16.000Z'
+          ),
+          (
+            'message-orphaned',
+            'thread-orphaned',
+            NULL,
+            'user',
+            'Orphaned needle must not be searchable.',
+            0,
+            '2026-05-01T00:00:17.000Z',
+            '2026-05-01T00:00:17.000Z'
           )
       `;
 
@@ -1830,6 +1859,10 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
       );
       assert.deepStrictEqual(
         (yield* snapshotQuery.searchThreads({ query: "hidden needle" })).matches,
+        [],
+      );
+      assert.deepStrictEqual(
+        (yield* snapshotQuery.searchThreads({ query: "orphaned needle" })).matches,
         [],
       );
       yield* sql`

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -295,6 +295,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
         {
           id: ThreadId.make("thread-1"),
           projectId: asProjectId("project-1"),
+          workspaceRoot: null,
           title: "Thread 1",
           modelSelection: {
             instanceId: ProviderInstanceId.make("codex"),
@@ -414,6 +415,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
         {
           id: ThreadId.make("thread-1"),
           projectId: asProjectId("project-1"),
+          workspaceRoot: null,
           title: "Thread 1",
           modelSelection: {
             instanceId: ProviderInstanceId.make("codex"),
@@ -1184,6 +1186,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
         INSERT INTO projection_threads (
           thread_id,
           project_id,
+          workspace_root,
           title,
           model_selection_json,
           runtime_mode,
@@ -1202,7 +1205,8 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
         )
         VALUES (
           'thread-1',
-          'project-1',
+          NULL,
+          '/tmp/projectless',
           'Thread 1',
           '{"provider":"codex","model":"gpt-5-codex"}',
           'full-access',
@@ -1276,6 +1280,8 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
       const threadShell = yield* snapshotQuery.getThreadShellById(ThreadId.make("thread-1"));
       assert.equal(threadShell._tag, "Some");
       if (threadShell._tag === "Some") {
+        assert.equal(threadShell.value.projectId, null);
+        assert.equal(threadShell.value.workspaceRoot, "/tmp/projectless");
         assert.equal(threadShell.value.latestTurn?.turnId, asTurnId("turn-running"));
         assert.equal(threadShell.value.latestTurn?.state, "running");
         assert.equal(threadShell.value.latestTurn?.startedAt, "2026-04-02T00:00:30.000Z");
@@ -1284,6 +1290,8 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
       const threadDetail = yield* snapshotQuery.getThreadDetailById(ThreadId.make("thread-1"));
       assert.equal(threadDetail._tag, "Some");
       if (threadDetail._tag === "Some") {
+        assert.equal(threadDetail.value.projectId, null);
+        assert.equal(threadDetail.value.workspaceRoot, "/tmp/projectless");
         assert.equal(threadDetail.value.latestTurn?.turnId, asTurnId("turn-running"));
         assert.equal(threadDetail.value.latestTurn?.state, "running");
         assert.equal(threadDetail.value.latestTurn?.startedAt, "2026-04-02T00:00:30.000Z");

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -121,7 +121,7 @@ const ProjectionThreadSearchRequest = Schema.Struct({
 });
 const ProjectionThreadSearchRow = Schema.Struct({
   threadId: ThreadId,
-  projectId: ProjectId,
+  projectId: Schema.NullOr(ProjectId),
   source: OrchestrationThreadSearchSource,
   matchText: Schema.String,
   messageCreatedAt: Schema.NullOr(IsoDateTime),
@@ -412,6 +412,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          workspace_root AS "workspaceRoot",
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",
@@ -448,6 +449,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          workspace_root AS "workspaceRoot",
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",
@@ -486,6 +488,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          workspace_root AS "workspaceRoot",
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",
@@ -803,11 +806,11 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           FROM projection_thread_messages AS messages
           INNER JOIN projection_threads AS threads
             ON threads.thread_id = messages.thread_id
-          INNER JOIN projection_projects AS projects
+          LEFT JOIN projection_projects AS projects
             ON projects.project_id = threads.project_id
           WHERE threads.deleted_at IS NULL
             AND threads.archived_at IS NULL
-            AND projects.deleted_at IS NULL
+            AND (threads.project_id IS NULL OR projects.deleted_at IS NULL)
             AND messages.is_streaming = 0
             AND (
               messages.role = 'user'
@@ -928,6 +931,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          workspace_root AS "workspaceRoot",
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",
@@ -1561,6 +1565,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
               const threads: ReadonlyArray<OrchestrationThread> = threadRows.map((row) => ({
                 id: row.threadId,
                 projectId: row.projectId,
+                workspaceRoot: row.workspaceRoot,
                 title: row.title,
                 modelSelection: row.modelSelection,
                 runtimeMode: row.runtimeMode,
@@ -1768,6 +1773,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 threads.push({
                   id: row.threadId,
                   projectId: row.projectId,
+                  workspaceRoot: row.workspaceRoot,
                   title: row.title,
                   modelSelection: row.modelSelection,
                   runtimeMode: row.runtimeMode,
@@ -1904,6 +1910,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   ? Result.succeed({
                       id: row.threadId,
                       projectId: row.projectId,
+                      workspaceRoot: row.workspaceRoot,
                       title: row.title,
                       modelSelection: row.modelSelection,
                       runtimeMode: row.runtimeMode,
@@ -2049,6 +2056,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 (row): OrchestrationThreadShell => ({
                   id: row.threadId,
                   projectId: row.projectId,
+                  workspaceRoot: row.workspaceRoot,
                   title: row.title,
                   modelSelection: row.modelSelection,
                   runtimeMode: row.runtimeMode,
@@ -2328,6 +2336,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       return Option.some({
         id: threadRow.value.threadId,
         projectId: threadRow.value.projectId,
+        workspaceRoot: threadRow.value.workspaceRoot,
         title: threadRow.value.title,
         modelSelection: threadRow.value.modelSelection,
         runtimeMode: threadRow.value.runtimeMode,
@@ -2449,6 +2458,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       const thread = {
         id: threadRow.value.threadId,
         projectId: threadRow.value.projectId,
+        workspaceRoot: threadRow.value.workspaceRoot,
         title: threadRow.value.title,
         modelSelection: threadRow.value.modelSelection,
         runtimeMode: threadRow.value.runtimeMode,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -810,7 +810,10 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             ON projects.project_id = threads.project_id
           WHERE threads.deleted_at IS NULL
             AND threads.archived_at IS NULL
-            AND (threads.project_id IS NULL OR projects.deleted_at IS NULL)
+            AND (
+              threads.project_id IS NULL
+              OR (projects.project_id IS NOT NULL AND projects.deleted_at IS NULL)
+            )
             AND messages.is_streaming = 0
             AND (
               messages.role = 'user'

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -434,7 +434,8 @@ const make = Effect.gen(function* () {
     });
   });
 
-  const resolveProject = Effect.fnUntraced(function* (projectId: ProjectId) {
+  const resolveProject = Effect.fnUntraced(function* (projectId: ProjectId | null) {
+    if (projectId === null) return undefined;
     return yield* projectionSnapshotQuery
       .getProjectShellById(projectId)
       .pipe(Effect.map(Option.getOrUndefined));

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -100,8 +100,26 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
       } satisfies OrchestrationCommand;
     }
 
+    if (canonicalCommand.type === "thread.create") {
+      return {
+        ...canonicalCommand,
+        workspaceRoot: canonicalCommand.projectId === null ? serverConfig.cwd : null,
+        ...(canonicalCommand.projectId === null ? { branch: null, worktreePath: null } : {}),
+      } satisfies OrchestrationCommand;
+    }
+
     if (canonicalCommand.type !== "thread.turn.start") {
       return canonicalCommand as OrchestrationCommand;
+    }
+
+    const bootstrap = canonicalCommand.bootstrap;
+    if (
+      bootstrap?.createThread?.projectId === null &&
+      (bootstrap.prepareWorktree !== undefined || bootstrap.runSetupScript === true)
+    ) {
+      return yield* new OrchestrationDispatchCommandError({
+        message: "Projectless threads cannot create worktrees or run project setup scripts.",
+      });
     }
 
     const normalizedAttachments = yield* Effect.forEach(
@@ -169,8 +187,22 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
       { concurrency: 1 },
     );
 
+    const normalizedBootstrap = bootstrap?.createThread
+      ? {
+          ...bootstrap,
+          createThread: {
+            ...bootstrap.createThread,
+            workspaceRoot: bootstrap.createThread.projectId === null ? serverConfig.cwd : null,
+            ...(bootstrap.createThread.projectId === null
+              ? { branch: null, worktreePath: null }
+              : {}),
+          },
+        }
+      : bootstrap;
+
     return {
       ...canonicalCommand,
+      ...(normalizedBootstrap ? { bootstrap: normalizedBootstrap } : {}),
       message: {
         ...canonicalCommand.message,
         attachments: normalizedAttachments,

--- a/apps/server/src/orchestration/decider.projectlessThread.test.ts
+++ b/apps/server/src/orchestration/decider.projectlessThread.test.ts
@@ -1,0 +1,56 @@
+import { CommandId, ThreadId, ProviderInstanceId } from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+import { createEmptyReadModel } from "./projector.ts";
+
+const now = "2026-01-01T00:00:00.000Z";
+
+const projectlessCreate = (workspaceRoot: string | null) => ({
+  type: "thread.create" as const,
+  commandId: CommandId.make(`cmd-projectless-${workspaceRoot ?? "missing"}`),
+  threadId: ThreadId.make(`thread-projectless-${workspaceRoot ?? "missing"}`),
+  projectId: null,
+  workspaceRoot,
+  title: "No project",
+  modelSelection: {
+    instanceId: ProviderInstanceId.make("codex"),
+    model: "gpt-5.4",
+  },
+  runtimeMode: "full-access" as const,
+  interactionMode: "default" as const,
+  branch: null,
+  worktreePath: null,
+  createdAt: now,
+});
+
+it.layer(NodeServices.layer)("decider projectless threads", (it) => {
+  it.effect("creates a thread with an explicit environment workspace root", () =>
+    Effect.gen(function* () {
+      const result = yield* decideOrchestrationCommand({
+        command: projectlessCreate("/tmp/environment-root"),
+        readModel: createEmptyReadModel(now),
+      });
+      const event = Array.isArray(result) ? result[0] : result;
+
+      expect(event.type).toBe("thread.created");
+      expect(event.payload.projectId).toBeNull();
+      expect(event.payload.workspaceRoot).toBe("/tmp/environment-root");
+    }),
+  );
+
+  it.effect("rejects a thread with neither a project nor workspace root", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.exit(
+        decideOrchestrationCommand({
+          command: projectlessCreate(null),
+          readModel: createEmptyReadModel(now),
+        }),
+      );
+
+      expect(result._tag).toBe("Failure");
+    }),
+  );
+});

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -350,11 +350,18 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.create": {
-      yield* requireProject({
-        readModel,
-        command,
-        projectId: command.projectId,
-      });
+      const hasProject = command.projectId !== null;
+      const hasProjectlessRoot = command.workspaceRoot != null;
+      if (hasProject === hasProjectlessRoot) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail:
+            "A thread must target either a project or an environment workspace root, but not both.",
+        });
+      }
+      if (command.projectId !== null) {
+        yield* requireProject({ readModel, command, projectId: command.projectId });
+      }
       yield* requireThreadAbsent({
         readModel,
         command,
@@ -371,6 +378,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           projectId: command.projectId,
+          workspaceRoot: command.workspaceRoot,
           title: command.title,
           modelSelection: command.modelSelection,
           runtimeMode: command.runtimeMode,

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -76,6 +76,7 @@ describe("orchestration projector", () => {
       {
         id: "thread-1",
         projectId: "project-1",
+        workspaceRoot: null,
         title: "demo",
         modelSelection: {
           instanceId: "codex",

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -291,6 +291,7 @@ export function projectEvent(
           {
             id: payload.threadId,
             projectId: payload.projectId,
+            workspaceRoot: payload.workspaceRoot ?? null,
             title: payload.title,
             modelSelection: payload.modelSelection,
             runtimeMode: payload.runtimeMode,

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -79,6 +79,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
       yield* threads.upsert({
         threadId: ThreadId.make("thread-null-options"),
         projectId: ProjectId.make("project-null-options"),
+        workspaceRoot: null,
         title: "Null options thread",
         modelSelection: {
           instanceId: ProviderInstanceId.make("claudeAgent"),
@@ -142,6 +143,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
       yield* threads.upsert({
         threadId: ThreadId.make("thread-settled"),
         projectId: ProjectId.make("project-1"),
+        workspaceRoot: null,
         title: "Settled thread",
         modelSelection: {
           instanceId: ProviderInstanceId.make("codex"),

--- a/apps/server/src/persistence/Layers/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreads.ts
@@ -33,6 +33,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         INSERT INTO projection_threads (
           thread_id,
           project_id,
+          workspace_root,
           title,
           model_selection_json,
           runtime_mode,
@@ -60,6 +61,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         VALUES (
           ${row.threadId},
           ${row.projectId},
+          ${row.workspaceRoot},
           ${row.title},
           ${JSON.stringify(row.modelSelection)},
           ${row.runtimeMode},
@@ -87,6 +89,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         ON CONFLICT (thread_id)
         DO UPDATE SET
           project_id = excluded.project_id,
+          workspace_root = excluded.workspace_root,
           title = excluded.title,
           model_selection_json = excluded.model_selection_json,
           runtime_mode = excluded.runtime_mode,
@@ -121,6 +124,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          workspace_root AS "workspaceRoot",
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",
@@ -157,6 +161,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          workspace_root AS "workspaceRoot",
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -53,6 +53,7 @@ import Migration0037 from "./Migrations/037_ProjectionTurnsKeysetIndex.ts";
 import Migration0038 from "./Migrations/038_ProjectionThreadsPinOrderKey.ts";
 import Migration0039 from "./Migrations/039_ProjectionProjectsDefaultThreadEnvMode.ts";
 import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
+import Migration0041 from "./Migrations/041_ProjectlessThreads.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -105,6 +106,7 @@ export const migrationEntries = [
   [38, "ProjectionThreadsPinOrderKey", Migration0038],
   [39, "ProjectionProjectsDefaultThreadEnvMode", Migration0039],
   [40, "ProjectionProjectFaviconPath", Migration0040],
+  [41, "ProjectlessThreads", Migration0041],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/041_ProjectlessThreads.test.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectlessThreads.test.ts
@@ -1,0 +1,59 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("041_ProjectlessThreads", (it) => {
+  it.effect("makes project ownership nullable and preserves thread indexes", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 40 });
+      yield* runMigrations({ toMigrationInclusive: 41 });
+
+      const columns = yield* sql<{
+        readonly name: string;
+        readonly notnull: number;
+        readonly dflt_value: string | null;
+      }>`
+        PRAGMA table_info(projection_threads)
+      `;
+      assert.equal(columns.find((column) => column.name === "project_id")?.notnull, 0);
+      assert.equal(columns.find((column) => column.name === "workspace_root")?.notnull, 0);
+      assert.equal(
+        columns.find((column) => column.name === "runtime_mode")?.dflt_value,
+        "'full-access'",
+      );
+      assert.equal(
+        columns.find((column) => column.name === "interaction_mode")?.dflt_value,
+        "'default'",
+      );
+      for (const columnName of [
+        "pending_approval_count",
+        "pending_user_input_count",
+        "has_actionable_proposed_plan",
+      ]) {
+        assert.equal(columns.find((column) => column.name === columnName)?.dflt_value, "0");
+      }
+
+      const indexes = yield* sql<{ readonly name: string }>`
+        PRAGMA index_list(projection_threads)
+      `;
+      const indexNames = new Set(indexes.map((index) => index.name));
+      for (const expectedIndex of [
+        "idx_projection_threads_project_id",
+        "idx_projection_threads_project_archived_at",
+        "idx_projection_threads_project_deleted_created",
+        "idx_projection_threads_shell_active",
+        "idx_projection_threads_shell_archived",
+      ]) {
+        assert.ok(indexNames.has(expectedIndex), `missing ${expectedIndex}`);
+      }
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/041_ProjectlessThreads.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectlessThreads.ts
@@ -1,0 +1,55 @@
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as Effect from "effect/Effect";
+
+/** Makes thread ownership optional and stores the concrete execution root. */
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  yield* sql`ALTER TABLE projection_threads RENAME TO projection_threads_040`;
+  yield* sql`
+    CREATE TABLE projection_threads (
+      thread_id TEXT PRIMARY KEY, project_id TEXT, workspace_root TEXT,
+      title TEXT NOT NULL, model_selection_json TEXT NOT NULL,
+      runtime_mode TEXT NOT NULL DEFAULT 'full-access',
+      interaction_mode TEXT NOT NULL DEFAULT 'default',
+      branch TEXT, worktree_path TEXT, latest_turn_id TEXT,
+      created_at TEXT NOT NULL, updated_at TEXT NOT NULL, archived_at TEXT,
+      settled_override TEXT, settled_at TEXT, snoozed_until TEXT, snoozed_at TEXT,
+      pinned_at TEXT, pin_order_key TEXT, title_regeneration_request_id TEXT,
+      title_regeneration_started_at TEXT, latest_user_message_at TEXT,
+      pending_approval_count INTEGER NOT NULL DEFAULT 0,
+      pending_user_input_count INTEGER NOT NULL DEFAULT 0,
+      has_actionable_proposed_plan INTEGER NOT NULL DEFAULT 0,
+      deleted_at TEXT
+    )
+  `;
+  yield* sql`
+    INSERT INTO projection_threads SELECT thread_id, project_id, NULL, title,
+      model_selection_json, runtime_mode, interaction_mode, branch, worktree_path,
+      latest_turn_id, created_at, updated_at, archived_at, settled_override, settled_at,
+      snoozed_until, snoozed_at, pinned_at, pin_order_key, title_regeneration_request_id,
+      title_regeneration_started_at, latest_user_message_at, pending_approval_count,
+      pending_user_input_count, has_actionable_proposed_plan, deleted_at
+    FROM projection_threads_040
+  `;
+  yield* sql`DROP TABLE projection_threads_040`;
+  yield* sql`
+    CREATE INDEX idx_projection_threads_project_id
+    ON projection_threads(project_id)
+  `;
+  yield* sql`
+    CREATE INDEX idx_projection_threads_project_archived_at
+    ON projection_threads(project_id, archived_at)
+  `;
+  yield* sql`
+    CREATE INDEX idx_projection_threads_project_deleted_created
+    ON projection_threads(project_id, deleted_at, created_at)
+  `;
+  yield* sql`
+    CREATE INDEX idx_projection_threads_shell_active
+    ON projection_threads(deleted_at, archived_at, project_id, created_at, thread_id)
+  `;
+  yield* sql`
+    CREATE INDEX idx_projection_threads_shell_archived
+    ON projection_threads(deleted_at, archived_at, project_id, thread_id)
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreads.ts
@@ -26,7 +26,8 @@ import type { ProjectionRepositoryError } from "../Errors.ts";
 
 export const ProjectionThread = Schema.Struct({
   threadId: ThreadId,
-  projectId: ProjectId,
+  projectId: Schema.NullOr(ProjectId),
+  workspaceRoot: Schema.NullOr(Schema.String),
   title: Schema.String,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,

--- a/apps/server/src/relay/AgentAwarenessRelay.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.ts
@@ -234,7 +234,7 @@ export function resolveAgentAwarenessRelayPublishSnapshot(input: {
   readonly environmentId: EnvironmentId;
   readonly threadId: ThreadId;
   readonly thread: Option.Option<OrchestrationThreadShell>;
-  readonly project: Option.Option<OrchestrationProjectShell>;
+  readonly project: Option.Option<Pick<OrchestrationProjectShell, "title">>;
 }): {
   readonly projectId: string | null;
   readonly state: RelayAgentActivityState | null;
@@ -248,6 +248,19 @@ export function resolveAgentAwarenessRelayPublishSnapshot(input: {
     };
   }
   if (Option.isNone(input.project)) {
+    if (input.thread.value.projectId === null) {
+      return {
+        projectId: null,
+        state: sanitizeRelayAgentActivityState(
+          projectThreadAwareness({
+            environmentId: input.environmentId,
+            project: { title: "No project" },
+            thread: input.thread.value,
+          }),
+        ),
+        reason: "snapshot",
+      };
+    }
     return {
       projectId: input.thread.value.projectId,
       state: null,
@@ -275,7 +288,8 @@ export function resolveAgentAwarenessRelayActiveThreadIds(input: {
   const projectById = new Map(input.projects.map((project) => [project.id, project]));
   return input.threads
     .filter((thread) => {
-      const project = projectById.get(thread.projectId);
+      const project =
+        thread.projectId === null ? { title: "No project" } : projectById.get(thread.projectId);
       if (!project) {
         return false;
       }
@@ -405,9 +419,10 @@ export const make = Effect.gen(function* () {
       });
 
     const thread = yield* snapshotQuery.getThreadShellById(threadId);
-    const project = Option.isSome(thread)
-      ? yield* snapshotQuery.getProjectShellById(thread.value.projectId)
-      : Option.none<OrchestrationProjectShell>();
+    const project =
+      Option.isSome(thread) && thread.value.projectId !== null
+        ? yield* snapshotQuery.getProjectShellById(thread.value.projectId)
+        : Option.none<OrchestrationProjectShell>();
     const snapshot = resolveAgentAwarenessRelayPublishSnapshot({
       environmentId,
       threadId,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -897,6 +897,7 @@ const makeWsRpcLayer = (
                 commandId: yield* serverCommandId("bootstrap-thread-create"),
                 threadId: command.threadId,
                 projectId: bootstrap.createThread.projectId,
+                workspaceRoot: bootstrap.createThread.workspaceRoot ?? null,
                 title: bootstrap.createThread.title,
                 modelSelection: bootstrap.createThread.modelSelection,
                 runtimeMode: bootstrap.createThread.runtimeMode,
@@ -1001,6 +1002,7 @@ const makeWsRpcLayer = (
           environment,
           auth,
           cwd: config.cwd,
+          projectlessThreads: true,
           keybindingsConfigPath: config.keybindingsConfigPath,
           keybindings: keybindingsConfig.keybindings,
           issues: keybindingsConfig.issues,
@@ -1806,25 +1808,34 @@ const makeWsRpcLayer = (
                   resource: input.resource,
                 });
               }
-              const project = yield* projectionSnapshotQuery
-                .getProjectShellById(thread.value.projectId)
-                .pipe(
-                  Effect.mapError(
-                    (cause) =>
-                      new AssetWorkspaceContextResolutionError({
-                        resource: input.resource,
-                        cause,
-                      }),
-                  ),
-                );
-              if (Option.isNone(project)) {
+              const project =
+                thread.value.projectId === null
+                  ? Option.none()
+                  : yield* projectionSnapshotQuery.getProjectShellById(thread.value.projectId).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new AssetWorkspaceContextResolutionError({
+                            resource: input.resource,
+                            cause,
+                          }),
+                      ),
+                    );
+              if (thread.value.projectId !== null && Option.isNone(project)) {
+                return yield* new AssetWorkspaceContextNotFoundError({
+                  resource: input.resource,
+                });
+              }
+              const workspaceRoot =
+                thread.value.worktreePath ??
+                (Option.isSome(project) ? project.value.workspaceRoot : thread.value.workspaceRoot);
+              if (!workspaceRoot) {
                 return yield* new AssetWorkspaceContextNotFoundError({
                   resource: input.resource,
                 });
               }
               return yield* issueAssetUrl({
                 resource: input.resource,
-                workspaceRoot: thread.value.worktreePath ?? project.value.workspaceRoot,
+                workspaceRoot,
               });
             }),
             { "rpc.aggregate": "workspace" },

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -333,9 +333,9 @@ export const BranchToolbar = memo(function BranchToolbar({
   );
   const serverThread = useThread(threadRef, { waitForShell: draftThread !== null });
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
-  const activeProjectRef = serverThread
+  const activeProjectRef = serverThread?.projectId
     ? scopeProjectRef(serverThread.environmentId, serverThread.projectId)
-    : draftThread
+    : draftThread?.projectId
       ? scopeProjectRef(draftThread.environmentId, draftThread.projectId)
       : null;
   const activeProject = useProject(activeProjectRef);

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -123,9 +123,9 @@ export function BranchToolbarBranchSelector({
   const serverSession = serverThread?.session ?? null;
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
 
-  const activeProjectRef = serverThread
+  const activeProjectRef = serverThread?.projectId
     ? scopeProjectRef(serverThread.environmentId, serverThread.projectId)
-    : draftThread
+    : draftThread?.projectId
       ? scopeProjectRef(draftThread.environmentId, draftThread.projectId)
       : null;
   const activeProject = useProject(activeProjectRef);

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -538,7 +538,7 @@ describe("shouldWriteThreadErrorToCurrentServerThread", () => {
 
 describe("startNewThreadForProject", () => {
   it("starts a thread through the supplied shared handler for the active project", () => {
-    const calls: Array<{ environmentId: EnvironmentId; projectId: ProjectId }> = [];
+    const calls: Array<{ environmentId: EnvironmentId; projectId: ProjectId | null }> = [];
     const projectRef = { environmentId, projectId };
 
     expect(

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -26,6 +26,7 @@ import {
   isBranchMismatchDismissedForSession,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
+  resolveThreadWorkspaceRoot,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
   scheduleEnvironmentReconnectWarning,
@@ -38,6 +39,37 @@ const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");
 const threadId = ThreadId.make("thread-1");
 const now = "2026-03-29T00:00:00.000Z";
+
+describe("resolveThreadWorkspaceRoot", () => {
+  it("prefers worktrees and project roots for project-backed threads", () => {
+    expect(
+      resolveThreadWorkspaceRoot({
+        worktreePath: "/repo/worktree",
+        projectCwd: "/repo",
+        threadWorkspaceRoot: null,
+      }),
+    ).toBe("/repo/worktree");
+  });
+
+  it("falls back to the durable projectless root and then the environment cwd", () => {
+    expect(
+      resolveThreadWorkspaceRoot({
+        worktreePath: null,
+        projectCwd: null,
+        threadWorkspaceRoot: "/durable/root",
+        environmentCwd: "/environment/root",
+      }),
+    ).toBe("/durable/root");
+    expect(
+      resolveThreadWorkspaceRoot({
+        worktreePath: null,
+        projectCwd: null,
+        threadWorkspaceRoot: null,
+        environmentCwd: "/environment/root",
+      }),
+    ).toBe("/environment/root");
+  });
+});
 
 describe("environment reconnect warning grace", () => {
   afterEach(() => vi.useRealTimers());

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -51,6 +51,21 @@ export function startNewThreadForProject(
   return true;
 }
 
+export function resolveThreadWorkspaceRoot(input: {
+  readonly worktreePath: string | null | undefined;
+  readonly projectCwd: string | null | undefined;
+  readonly threadWorkspaceRoot: string | null | undefined;
+  readonly environmentCwd?: string | null | undefined;
+}): string | undefined {
+  return (
+    input.worktreePath ??
+    input.projectCwd ??
+    input.threadWorkspaceRoot ??
+    input.environmentCwd ??
+    undefined
+  );
+}
+
 export function resolveThreadMetadataUpdateForNextTurn(input: {
   currentModelSelection: ModelSelection;
   nextModelSelection?: ModelSelection;

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -5,13 +5,13 @@ import {
   type ModelSelection,
   type ProviderDriverKind,
   type ServerProvider,
-  type ScopedProjectRef,
   type ScopedThreadRef,
   type ThreadId,
   type TurnId,
 } from "@t3tools/contracts";
 import { type ChatMessage, type SessionPhase, type Thread, type ThreadShell } from "../types";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
+import type { DraftThreadTargetRef } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentThreadDetails } from "../state/threads";
@@ -42,8 +42,8 @@ export function hasEnvironmentReconnectWarningGraceElapsed(
 }
 
 export function startNewThreadForProject(
-  projectRef: ScopedProjectRef | null,
-  handleNewThread: (projectRef: ScopedProjectRef) => Promise<void>,
+  projectRef: DraftThreadTargetRef | null,
+  handleNewThread: (projectRef: DraftThreadTargetRef) => Promise<void>,
 ): boolean {
   if (projectRef === null) return false;
   void handleNewThread(projectRef);
@@ -87,6 +87,7 @@ export function buildLocalDraftThread(
     id: threadId,
     environmentId: draftThread.environmentId,
     projectId: draftThread.projectId,
+    workspaceRoot: null,
     title: "New thread",
     modelSelection: fallbackModelSelection,
     runtimeMode: draftThread.runtimeMode,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -234,6 +234,7 @@ import { useEnvironments, usePrimaryEnvironment } from "../state/environments";
 import {
   useProject,
   useProjects,
+  useServerConfigs,
   useThread,
   useThreadRefs,
   useThreadShell,
@@ -299,6 +300,7 @@ import {
   reconcileMountedTerminalThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
+  resolveThreadWorkspaceRoot,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
   shouldWriteThreadErrorToCurrentServerThread,
@@ -653,12 +655,18 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const closeTerminalMutation = useAtomCommand(terminalEnvironment.close, "terminal close");
   const draftThread = useComposerDraftStore((store) => store.getDraftThreadByRef(threadRef));
   const serverThread = useThread(threadRef, { waitForShell: draftThread !== null });
+  const serverConfigs = useServerConfigs();
   const projectRef = serverThread?.projectId
     ? scopeProjectRef(serverThread.environmentId, serverThread.projectId)
     : draftThread?.projectId
       ? scopeProjectRef(draftThread.environmentId, draftThread.projectId)
       : null;
   const project = useProject(projectRef);
+  const projectlessWorkspaceRoot =
+    serverThread?.workspaceRoot ??
+    (serverThread?.projectId === null || draftThread?.projectId === null
+      ? (serverConfigs.get(threadRef.environmentId)?.cwd ?? null)
+      : null);
   const terminalUiState = useTerminalUiStateStore((state) =>
     selectThreadTerminalUiState(state.terminalUiStateByThreadKey, threadRef),
   );
@@ -702,10 +710,6 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         readonly runtimeEnv: Record<string, string>;
       }
     >();
-    if (!project) {
-      return next;
-    }
-
     for (const session of drawerTerminalSessions) {
       const summary = session.state.summary;
       if (!summary) {
@@ -716,10 +720,12 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
       next.set(session.target.terminalId, {
         cwd: launchContext?.cwd ?? summary.cwd,
         worktreePath: worktreePathForLaunch,
-        runtimeEnv: projectScriptRuntimeEnv({
-          project: { cwd: project.workspaceRoot },
-          worktreePath: worktreePathForLaunch,
-        }),
+        runtimeEnv: project
+          ? projectScriptRuntimeEnv({
+              project: { cwd: project.workspaceRoot },
+              worktreePath: worktreePathForLaunch,
+            })
+          : {},
       });
     }
 
@@ -779,8 +785,8 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
             project: { cwd: project.workspaceRoot },
             worktreePath: effectiveWorktreePath,
           })
-        : null),
-    [effectiveWorktreePath, launchContext?.cwd, project],
+        : projectlessWorkspaceRoot),
+    [effectiveWorktreePath, launchContext?.cwd, project, projectlessWorkspaceRoot],
   );
   const runtimeEnv = useMemo(
     () =>
@@ -946,7 +952,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     [onAddTerminalContext, visible],
   );
 
-  if (!project || !terminalUiState.terminalOpen || !cwd) {
+  if (!terminalUiState.terminalOpen || !cwd) {
     return null;
   }
 
@@ -1022,12 +1028,18 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
 }: PersistentThreadTerminalPanelProps) {
   const draftThread = useComposerDraftStore((store) => store.getDraftThreadByRef(threadRef));
   const serverThread = useThread(threadRef, { waitForShell: draftThread !== null });
+  const serverConfigs = useServerConfigs();
   const projectRef = serverThread?.projectId
     ? scopeProjectRef(serverThread.environmentId, serverThread.projectId)
     : draftThread?.projectId
       ? scopeProjectRef(draftThread.environmentId, draftThread.projectId)
       : null;
   const project = useProject(projectRef);
+  const projectlessWorkspaceRoot =
+    serverThread?.workspaceRoot ??
+    (serverThread?.projectId === null || draftThread?.projectId === null
+      ? (serverConfigs.get(threadRef.environmentId)?.cwd ?? null)
+      : null);
   const knownTerminalSessions = useKnownTerminalSessions({
     environmentId: threadRef.environmentId,
     threadId: threadRef.threadId,
@@ -1047,8 +1059,8 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
             project: { cwd: project.workspaceRoot },
             worktreePath,
           })
-        : null),
-    [activeSummary?.cwd, launchContext?.cwd, project, worktreePath],
+        : projectlessWorkspaceRoot),
+    [activeSummary?.cwd, launchContext?.cwd, project, projectlessWorkspaceRoot, worktreePath],
   );
   const runtimeEnv = useMemo(
     () =>
@@ -1093,15 +1105,17 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
               project: { cwd: project.workspaceRoot },
               worktreePath: terminalWorktreePath,
             })
-          : null);
-      if (!terminalCwd || !project) continue;
+          : projectlessWorkspaceRoot);
+      if (!terminalCwd) continue;
       locations.set(terminalId, {
         cwd: terminalCwd,
         worktreePath: terminalWorktreePath,
-        runtimeEnv: projectScriptRuntimeEnv({
-          project: { cwd: project.workspaceRoot },
-          worktreePath: terminalWorktreePath,
-        }),
+        runtimeEnv: project
+          ? projectScriptRuntimeEnv({
+              project: { cwd: project.workspaceRoot },
+              worktreePath: terminalWorktreePath,
+            })
+          : {},
       });
     }
     return locations;
@@ -1110,11 +1124,12 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
     launchContext?.cwd,
     launchContext?.worktreePath,
     project,
+    projectlessWorkspaceRoot,
     surface.terminalIds,
     threadWorktreePath,
   ]);
 
-  if (!project || !cwd) return null;
+  if (!cwd) return null;
 
   return (
     <ThreadTerminalDrawer
@@ -1220,6 +1235,7 @@ function ChatViewContent(props: ChatViewProps) {
   const closePreview = useAtomCommand(previewEnvironment.close, "preview close");
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
+  const serverConfigs = useServerConfigs();
   const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, { reportFailure: false });
   const environmentById = useMemo(
     () => new Map(environments.map((environment) => [environment.environmentId, environment])),
@@ -1665,34 +1681,44 @@ function ChatViewContent(props: ChatViewProps) {
     activeThread ? environmentShell.stateAtom(activeThread.environmentId) : null,
   );
   const activeEnvironmentBootstrapComplete = activeEnvironmentShell.data?.snapshot._tag === "Some";
-  const activeProjectKey = activeProject
-    ? `${activeProject.environmentId}:${activeProject.workspaceRoot}`
-    : null;
+  const activeWorkspaceKeyRoot = resolveThreadWorkspaceRoot({
+    worktreePath: activeThread?.worktreePath,
+    projectCwd: activeProject?.workspaceRoot,
+    threadWorkspaceRoot: activeThread?.workspaceRoot,
+    environmentCwd:
+      activeThread?.projectId === null
+        ? serverConfigs.get(activeThread.environmentId)?.cwd
+        : undefined,
+  });
+  const activeWorkspaceKey =
+    activeThread && activeWorkspaceKeyRoot
+      ? `${activeThread.environmentId}:${activeWorkspaceKeyRoot}`
+      : null;
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const clientSettingsHydrated = useClientSettingsHydrated();
   const [pendingFileSurfaceIdsByProject, setPendingFileSurfaceIdsByProject] = useState<
     ReadonlyMap<string, ReadonlySet<string>>
   >(() => new Map());
-  const pendingFileSurfaceIds = activeProjectKey
-    ? (pendingFileSurfaceIdsByProject.get(activeProjectKey) ?? EMPTY_PENDING_FILE_SURFACE_IDS)
+  const pendingFileSurfaceIds = activeWorkspaceKey
+    ? (pendingFileSurfaceIdsByProject.get(activeWorkspaceKey) ?? EMPTY_PENDING_FILE_SURFACE_IDS)
     : EMPTY_PENDING_FILE_SURFACE_IDS;
   const handleFilePendingChange = useCallback(
     (relativePath: string, pending: boolean) => {
-      if (!activeProjectKey) return;
+      if (!activeWorkspaceKey) return;
       setPendingFileSurfaceIdsByProject((currentByProject) => {
-        const current = currentByProject.get(activeProjectKey) ?? EMPTY_PENDING_FILE_SURFACE_IDS;
+        const current = currentByProject.get(activeWorkspaceKey) ?? EMPTY_PENDING_FILE_SURFACE_IDS;
         const surfaceId = `file:${relativePath}`;
         if (current.has(surfaceId) === pending) return currentByProject;
         const next = new Set(current);
         if (pending) next.add(surfaceId);
         else next.delete(surfaceId);
         const nextByProject = new Map(currentByProject);
-        if (next.size === 0) nextByProject.delete(activeProjectKey);
-        else nextByProject.set(activeProjectKey, next);
+        if (next.size === 0) nextByProject.delete(activeWorkspaceKey);
+        else nextByProject.set(activeWorkspaceKey, next);
         return nextByProject;
       });
     },
-    [activeProjectKey],
+    [activeWorkspaceKey],
   );
   const configuredPreviewUrls = useMemo(
     () => getConfiguredPreviewUrls(activeProject?.scripts),
@@ -2607,7 +2633,15 @@ function ChatViewContent(props: ChatViewProps) {
   const hasTimelineTopBanner = Boolean(threadError) || visibleProviderStatus !== null;
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
-  const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
+  const activeWorkspaceRoot = resolveThreadWorkspaceRoot({
+    worktreePath: activeThreadWorktreePath,
+    projectCwd: activeProjectCwd,
+    threadWorkspaceRoot: activeThread?.workspaceRoot,
+    environmentCwd:
+      activeThread?.projectId === null && activeThread.environmentId
+        ? serverConfigs.get(activeThread.environmentId)?.cwd
+        : undefined,
+  });
   const activeTerminalLaunchContext =
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.
@@ -5992,14 +6026,14 @@ function ChatViewContent(props: ChatViewProps) {
         threadId={activeThreadRef?.threadId ?? null}
       />
     ) : (activeRightPanelSurface?.kind === "files" || activeRightPanelSurface?.kind === "file") &&
-      activeProject &&
+      activeThread &&
       activeWorkspaceRoot ? (
       <Suspense fallback={null}>
         <FilePreviewPanel
-          key={`${activeProject.environmentId}:${activeWorkspaceRoot}`}
-          environmentId={activeProject.environmentId}
+          key={`${activeThread.environmentId}:${activeWorkspaceRoot}`}
+          environmentId={activeThread.environmentId}
           cwd={activeWorkspaceRoot}
-          projectName={activeProject.title}
+          projectName={activeProject?.title ?? "No project"}
           threadRef={activeThreadRef}
           composerDraftTarget={composerDraftTarget}
           keybindings={keybindings}
@@ -6432,7 +6466,7 @@ function ChatViewContent(props: ChatViewProps) {
           onAddAgents={addAgentsSurface}
           browserAvailable={isPreviewSupportedInRuntime()}
           diffAvailable={isServerThread && isGitRepo}
-          filesAvailable={activeProject !== null}
+          filesAvailable={activeWorkspaceRoot !== undefined}
           liveAgentCount={agentPanelModel.liveCount}
         >
           {rightPanelContent}
@@ -6461,7 +6495,7 @@ function ChatViewContent(props: ChatViewProps) {
             onAddAgents={addAgentsSurface}
             browserAvailable={isPreviewSupportedInRuntime()}
             diffAvailable={isServerThread && isGitRepo}
-            filesAvailable={activeProject !== null}
+            filesAvailable={activeWorkspaceRoot !== undefined}
             liveAgentCount={agentPanelModel.liveCount}
           >
             {rightPanelContent}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -653,9 +653,9 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const closeTerminalMutation = useAtomCommand(terminalEnvironment.close, "terminal close");
   const draftThread = useComposerDraftStore((store) => store.getDraftThreadByRef(threadRef));
   const serverThread = useThread(threadRef, { waitForShell: draftThread !== null });
-  const projectRef = serverThread
+  const projectRef = serverThread?.projectId
     ? scopeProjectRef(serverThread.environmentId, serverThread.projectId)
-    : draftThread
+    : draftThread?.projectId
       ? scopeProjectRef(draftThread.environmentId, draftThread.projectId)
       : null;
   const project = useProject(projectRef);
@@ -1022,9 +1022,9 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
 }: PersistentThreadTerminalPanelProps) {
   const draftThread = useComposerDraftStore((store) => store.getDraftThreadByRef(threadRef));
   const serverThread = useThread(threadRef, { waitForShell: draftThread !== null });
-  const projectRef = serverThread
+  const projectRef = serverThread?.projectId
     ? scopeProjectRef(serverThread.environmentId, serverThread.projectId)
-    : draftThread
+    : draftThread?.projectId
       ? scopeProjectRef(draftThread.environmentId, draftThread.projectId)
       : null;
   const project = useProject(projectRef);
@@ -1427,7 +1427,7 @@ function ChatViewContent(props: ChatViewProps) {
     [mountedTerminalThreadKeys],
   );
 
-  const fallbackDraftProjectRef = draftThread
+  const fallbackDraftProjectRef = draftThread?.projectId
     ? scopeProjectRef(draftThread.environmentId, draftThread.projectId)
     : null;
   const fallbackDraftProject = useProject(fallbackDraftProjectRef);
@@ -1651,13 +1651,16 @@ function ChatViewContent(props: ChatViewProps) {
     });
   }, [activeThreadKey, existingOpenTerminalThreadKeys, terminalUiState.terminalOpen]);
   const latestTurnSettled = isLatestTurnSettled(activeLatestTurn, activeThread?.session ?? null);
-  const activeProjectRef = activeThread
+  const activeThreadTargetRef = activeThread
+    ? { environmentId: activeThread.environmentId, projectId: activeThread.projectId }
+    : null;
+  const activeProjectRef = activeThread?.projectId
     ? scopeProjectRef(activeThread.environmentId, activeThread.projectId)
     : null;
   const activeProject = useProject(activeProjectRef);
   const handleNewThreadInActiveProject = useCallback(() => {
-    startNewThreadForProject(activeProjectRef, handleNewThread);
-  }, [activeProjectRef, handleNewThread]);
+    startNewThreadForProject(activeThreadTargetRef, handleNewThread);
+  }, [activeThreadTargetRef, handleNewThread]);
   const activeEnvironmentShell = useEnvironmentQuery(
     activeThread ? environmentShell.stateAtom(activeThread.environmentId) : null,
   );
@@ -4928,7 +4931,7 @@ function ChatViewContent(props: ChatViewProps) {
       }
       return;
     }
-    if (!activeProject) {
+    if (activeThread.projectId !== null && !activeProject) {
       toastManager.add(
         stackedThreadToast({
           type: "warning",
@@ -5083,7 +5086,7 @@ function ChatViewContent(props: ChatViewProps) {
     const title = truncate(titleSeed);
     const threadCreateModelSelection = createModelSelection(
       ctxSelectedModelSelection.instanceId,
-      ctxSelectedModel || activeProject.defaultModelSelection?.model || DEFAULT_MODEL,
+      ctxSelectedModel || activeProject?.defaultModelSelection?.model || DEFAULT_MODEL,
       ctxSelectedModelSelection.options,
     );
 
@@ -5131,7 +5134,8 @@ function ChatViewContent(props: ChatViewProps) {
               ...(isLocalDraftThread
                 ? {
                     createThread: {
-                      projectId: activeProject.id,
+                      projectId: activeThread.projectId,
+                      workspaceRoot: null,
                       title,
                       modelSelection: threadCreateModelSelection,
                       runtimeMode,
@@ -5142,7 +5146,7 @@ function ChatViewContent(props: ChatViewProps) {
                     },
                   }
                 : {}),
-              ...(baseBranchForWorktree
+              ...(baseBranchForWorktree && activeProject
                 ? {
                     prepareWorktree: {
                       projectCwd: activeProject.workspaceRoot,
@@ -6172,7 +6176,7 @@ function ChatViewContent(props: ChatViewProps) {
                         }
                       >
                         <DraftHeroHeadline
-                          activeProjectRef={activeProjectRef}
+                          activeProjectRef={activeThreadTargetRef}
                           activeProjectTitle={activeProject?.title ?? null}
                         />
                       </div>
@@ -6213,7 +6217,11 @@ function ChatViewContent(props: ChatViewProps) {
                             isServerThread={isServerThread}
                             isLocalDraftThread={isLocalDraftThread}
                             forceExpandedOnMobile={forceExpandedMobileComposer && isDraftHeroState}
-                            projectSelectionRequired={isLocalDraftThread && activeProject === null}
+                            projectSelectionRequired={
+                              isLocalDraftThread &&
+                              activeThread?.projectId !== null &&
+                              activeProject === null
+                            }
                             phase={phase}
                             isConnecting={isConnecting}
                             isSendBusy={isSendBusy}

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -7,6 +7,7 @@ import {
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
   reduceCommandPaletteUiState,
+  shouldOpenNewThreadTargetPicker,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -105,6 +106,42 @@ describe("enumerateCommandPaletteItems", () => {
       "thread.jump.9",
       undefined,
     ]);
+  });
+});
+
+describe("shouldOpenNewThreadTargetPicker", () => {
+  it("opens the picker whenever projectless threads are supported", () => {
+    expect(
+      shouldOpenNewThreadTargetPicker({
+        legacySidebarEnabled: true,
+        projectGroupCount: 0,
+        supportsProjectlessThreads: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldOpenNewThreadTargetPicker({
+        legacySidebarEnabled: false,
+        projectGroupCount: 1,
+        supportsProjectlessThreads: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves the existing multi-project behavior on older servers", () => {
+    expect(
+      shouldOpenNewThreadTargetPicker({
+        legacySidebarEnabled: false,
+        projectGroupCount: 2,
+        supportsProjectlessThreads: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldOpenNewThreadTargetPicker({
+        legacySidebarEnabled: true,
+        projectGroupCount: 2,
+        supportsProjectlessThreads: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -124,6 +124,16 @@ export function enumerateCommandPaletteItems(
   });
 }
 
+export function shouldOpenNewThreadTargetPicker(input: {
+  readonly legacySidebarEnabled: boolean;
+  readonly projectGroupCount: number;
+  readonly supportsProjectlessThreads: boolean;
+}): boolean {
+  return (
+    input.supportsProjectlessThreads || (!input.legacySidebarEnabled && input.projectGroupCount > 1)
+  );
+}
+
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
 
 export function normalizeSearchText(value: string): string {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -182,7 +182,8 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
     input.limit === undefined ? sortedThreads : sortedThreads.slice(0, input.limit);
 
   return visibleThreads.map((thread) => {
-    const projectTitle = input.projectTitleById.get(thread.projectId);
+    const projectTitle =
+      thread.projectId === null ? "No project" : input.projectTitleById.get(thread.projectId);
     const descriptionParts: string[] = [];
 
     if (projectTitle) {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -68,7 +68,7 @@ import { sourceControlEnvironment } from "../state/sourceControl";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
-import { useProjects, useThreadShells } from "../state/entities";
+import { useProjects, useServerConfigs, useThreadShells } from "../state/entities";
 import { useThreadSearch } from "../state/queries";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
@@ -579,6 +579,7 @@ function OpenCommandPaletteDialog(props: {
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
   const projects = useProjects();
+  const serverConfigs = useServerConfigs();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
@@ -686,7 +687,10 @@ function OpenCommandPaletteDialog(props: {
     () =>
       buildSidebarProjectPickerEntries({
         groups: projectGroups,
-        preferredProjectRef: contextualProjectRef,
+        preferredProjectRef:
+          contextualProjectRef?.projectId == null
+            ? null
+            : scopeProjectRef(contextualProjectRef.environmentId, contextualProjectRef.projectId),
       }),
     [contextualProjectRef, projectGroups],
   );
@@ -1405,6 +1409,23 @@ function OpenCommandPaletteDialog(props: {
       icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
       groups: [{ value: "projects", label: "Projects", items: projectThreadItems }],
+    });
+  }
+
+  const projectlessEnvironmentId = contextualProjectRef?.environmentId ?? primaryEnvironmentId;
+  if (
+    projectlessEnvironmentId !== null &&
+    serverConfigs.get(projectlessEnvironmentId)?.projectlessThreads === true
+  ) {
+    actionItems.push({
+      kind: "action",
+      value: "action:new-thread-without-project",
+      searchTerms: ["new thread", "without project", "no project", "chat"],
+      title: "New thread without a project",
+      icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
+      run: async () => {
+        await handleNewThread({ environmentId: projectlessEnvironmentId, projectId: null });
+      },
     });
   }
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -687,6 +687,21 @@ function OpenCommandPaletteDialog(props: {
   const supportsProjectlessThreads =
     projectlessEnvironmentId !== null &&
     serverConfigs.get(projectlessEnvironmentId)?.projectlessThreads === true;
+  const projectlessTargets = useMemo(
+    () =>
+      [...serverConfigs.entries()]
+        .filter(([, config]) => config.projectlessThreads === true)
+        .map(([environmentId]) => ({
+          environmentId,
+          environmentLabel: environmentLabelById.get(environmentId) ?? "Environment",
+        }))
+        .sort((left, right) => {
+          if (left.environmentId === primaryEnvironmentId) return -1;
+          if (right.environmentId === primaryEnvironmentId) return 1;
+          return left.environmentLabel.localeCompare(right.environmentLabel);
+        }),
+    [environmentLabelById, primaryEnvironmentId, serverConfigs],
+  );
   const projectPickerEntries = useMemo(
     () =>
       buildSidebarProjectPickerEntries({
@@ -992,24 +1007,20 @@ function OpenCommandPaletteDialog(props: {
         );
       },
     });
-    const projectlessItems: CommandPaletteActionItem[] =
-      supportsProjectlessThreads && projectlessEnvironmentId !== null
-        ? [
-            {
-              kind: "action",
-              value: `new-thread-in:${projectlessEnvironmentId}:projectless`,
-              searchTerms: ["new thread", "without project", "no project", "chat"],
-              title: "Don't work in a project",
-              icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
-              run: async () => {
-                await handleNewThread({
-                  environmentId: projectlessEnvironmentId,
-                  projectId: null,
-                });
-              },
-            },
-          ]
-        : [];
+    const showEnvironmentLabel = projectlessTargets.length > 1;
+    const projectlessItems: CommandPaletteActionItem[] = projectlessTargets.map(
+      ({ environmentId, environmentLabel }) => ({
+        kind: "action",
+        value: `new-thread-in:${environmentId}:projectless`,
+        searchTerms: ["new thread", "without project", "no project", "chat", environmentLabel],
+        title: "Don't work in a project",
+        ...(showEnvironmentLabel ? { description: environmentLabel } : {}),
+        icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
+        run: async () => {
+          await handleNewThread({ environmentId, projectId: null });
+        },
+      }),
+    );
 
     return enumerateCommandPaletteItems([...projectItems, ...projectlessItems]);
   }, [
@@ -1017,8 +1028,7 @@ function OpenCommandPaletteDialog(props: {
     handleNewThread,
     pickerProjects,
     projectGroupByTargetKey,
-    projectlessEnvironmentId,
-    supportsProjectlessThreads,
+    projectlessTargets,
   ]);
 
   const allThreadItems = useMemo(
@@ -1430,7 +1440,9 @@ function OpenCommandPaletteDialog(props: {
         },
       });
     }
+  }
 
+  if (projectThreadItems.length > 0) {
     actionItems.push({
       kind: "submenu",
       value: "action:new-thread-in",

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -683,6 +683,10 @@ function OpenCommandPaletteDialog(props: {
       }),
     [activeDraftThread, activeThread, defaultProjectRef, handleNewThread],
   );
+  const projectlessEnvironmentId = contextualProjectRef?.environmentId ?? primaryEnvironmentId;
+  const supportsProjectlessThreads =
+    projectlessEnvironmentId !== null &&
+    serverConfigs.get(projectlessEnvironmentId)?.projectlessThreads === true;
   const projectPickerEntries = useMemo(
     () =>
       buildSidebarProjectPickerEntries({
@@ -961,38 +965,61 @@ function OpenCommandPaletteDialog(props: {
     [openProjectFromSearch, pickerProjects, projectGroupByTargetKey],
   );
 
-  const projectThreadItems = useMemo(
-    () =>
-      enumerateCommandPaletteItems(
-        buildProjectActionItems({
-          projects: pickerProjects,
-          valuePrefix: "new-thread-in",
-          searchTerms: (project) => {
-            const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
-            return (
-              group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
-            );
-          },
-          icon: projectFavicon,
-          runProject: async (project) => {
-            const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
-            const contextualRefBelongsToGroup =
-              contextualProjectRef !== null &&
-              group?.memberProjectRefs.some(
-                (projectRef) =>
-                  projectRef.environmentId === contextualProjectRef.environmentId &&
-                  projectRef.projectId === contextualProjectRef.projectId,
-              );
-            await handleNewThread(
-              contextualRefBelongsToGroup
-                ? contextualProjectRef
-                : scopeProjectRef(project.environmentId, project.id),
-            );
-          },
-        }),
-      ),
-    [contextualProjectRef, handleNewThread, pickerProjects, projectGroupByTargetKey],
-  );
+  const projectThreadItems = useMemo(() => {
+    const projectItems = buildProjectActionItems({
+      projects: pickerProjects,
+      valuePrefix: "new-thread-in",
+      searchTerms: (project) => {
+        const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
+        return (
+          group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
+        );
+      },
+      icon: projectFavicon,
+      runProject: async (project) => {
+        const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
+        const contextualRefBelongsToGroup =
+          contextualProjectRef !== null &&
+          group?.memberProjectRefs.some(
+            (projectRef) =>
+              projectRef.environmentId === contextualProjectRef.environmentId &&
+              projectRef.projectId === contextualProjectRef.projectId,
+          );
+        await handleNewThread(
+          contextualRefBelongsToGroup
+            ? contextualProjectRef
+            : scopeProjectRef(project.environmentId, project.id),
+        );
+      },
+    });
+    const projectlessItems: CommandPaletteActionItem[] =
+      supportsProjectlessThreads && projectlessEnvironmentId !== null
+        ? [
+            {
+              kind: "action",
+              value: `new-thread-in:${projectlessEnvironmentId}:projectless`,
+              searchTerms: ["new thread", "without project", "no project", "chat"],
+              title: "Don't work in a project",
+              icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
+              run: async () => {
+                await handleNewThread({
+                  environmentId: projectlessEnvironmentId,
+                  projectId: null,
+                });
+              },
+            },
+          ]
+        : [];
+
+    return enumerateCommandPaletteItems([...projectItems, ...projectlessItems]);
+  }, [
+    contextualProjectRef,
+    handleNewThread,
+    pickerProjects,
+    projectGroupByTargetKey,
+    projectlessEnvironmentId,
+    supportsProjectlessThreads,
+  ]);
 
   const allThreadItems = useMemo(
     () =>
@@ -1342,9 +1369,11 @@ function OpenCommandPaletteDialog(props: {
     setViewStack([]);
     setQuery("");
     const currentPrefix =
-      currentProjectEnvironmentId && currentProjectId
-        ? `new-thread-in:${currentProjectEnvironmentId}:${currentProjectId}`
-        : null;
+      contextualProjectRef?.projectId === null
+        ? `new-thread-in:${contextualProjectRef.environmentId}:projectless`
+        : currentProjectEnvironmentId && currentProjectId
+          ? `new-thread-in:${currentProjectEnvironmentId}:${currentProjectId}`
+          : null;
     const prioritized = currentPrefix
       ? [
           ...projectThreadItems.filter((item) => item.value === currentPrefix),
@@ -1366,6 +1395,7 @@ function OpenCommandPaletteDialog(props: {
     browseNavigation,
     currentProjectEnvironmentId,
     currentProjectId,
+    contextualProjectRef,
     openIntent,
     projectThreadItems,
     pushPaletteView,
@@ -1412,16 +1442,12 @@ function OpenCommandPaletteDialog(props: {
     });
   }
 
-  const projectlessEnvironmentId = contextualProjectRef?.environmentId ?? primaryEnvironmentId;
-  if (
-    projectlessEnvironmentId !== null &&
-    serverConfigs.get(projectlessEnvironmentId)?.projectlessThreads === true
-  ) {
+  if (projectlessEnvironmentId !== null && supportsProjectlessThreads) {
     actionItems.push({
       kind: "action",
       value: "action:new-thread-without-project",
       searchTerms: ["new thread", "without project", "no project", "chat"],
-      title: "New thread without a project",
+      title: "Don't work in a project",
       icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
       run: async () => {
         await handleNewThread({ environmentId: projectlessEnvironmentId, projectId: null });

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -336,6 +336,7 @@ interface SidebarThreadRowProps {
   cancelRename: () => void;
   attemptArchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
   openPrLink: (event: React.MouseEvent<HTMLElement>, prUrl: string) => void;
+  selectionEnabled?: boolean;
 }
 
 export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowProps) {
@@ -362,12 +363,15 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     cancelRename,
     attemptArchiveThread,
     openPrLink,
+    selectionEnabled = true,
     thread,
   } = props;
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
   const threadKey = scopedThreadKey(threadRef);
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
-  const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
+  const isSelected = useThreadSelectionStore(
+    (state) => selectionEnabled && state.selectedThreadKeys.has(threadKey),
+  );
   const runningTerminalIds = useThreadRunningTerminalIds({
     environmentId: thread.environmentId,
     threadId: thread.id,
@@ -481,9 +485,13 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   );
   const handleRowClick = useCallback(
     (event: React.MouseEvent) => {
+      if (!selectionEnabled) {
+        navigateToThread(threadRef);
+        return;
+      }
       handleThreadClick(event, threadRef, orderedProjectThreadKeys);
     },
-    [handleThreadClick, orderedProjectThreadKeys, threadRef],
+    [handleThreadClick, navigateToThread, orderedProjectThreadKeys, selectionEnabled, threadRef],
   );
   const handleRowDoubleClick = useCallback(
     (event: React.MouseEvent) => {
@@ -515,7 +523,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     (event: React.MouseEvent) => {
       event.preventDefault();
       const hasSelection = useThreadSelectionStore.getState().hasSelection();
-      if (hasSelection && isSelected) {
+      if (selectionEnabled && hasSelection && isSelected) {
         void (async () => {
           const result = await settlePromise(() =>
             handleMultiSelectContextMenu({
@@ -537,7 +545,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         return;
       }
 
-      if (hasSelection) {
+      if (selectionEnabled && hasSelection) {
         clearSelection();
       }
       void (async () => {
@@ -559,7 +567,14 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         }
       })();
     },
-    [clearSelection, handleMultiSelectContextMenu, handleThreadContextMenu, isSelected, threadRef],
+    [
+      clearSelection,
+      handleMultiSelectContextMenu,
+      handleThreadContextMenu,
+      isSelected,
+      selectionEnabled,
+      threadRef,
+    ],
   );
   const handlePrClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -2775,6 +2790,10 @@ interface SidebarProjectsContentProps {
   projectsLength: number;
 }
 
+function projectlessThreadListKey(environmentId: SidebarThreadSummary["environmentId"]): string {
+  return `projectless:${environmentId}`;
+}
+
 const SidebarProjectsContent = memo(function SidebarProjectsContent(
   props: SidebarProjectsContentProps,
 ) {
@@ -2835,6 +2854,158 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     },
     [updateSettings],
   );
+  const appSettingsConfirmThreadDelete = useClientSettings((settings) =>
+    Boolean(settings.confirmThreadDelete),
+  );
+  const appSettingsConfirmThreadArchive = useClientSettings((settings) =>
+    Boolean(settings.confirmThreadArchive),
+  );
+  const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
+    reportFailure: false,
+  });
+  const markThreadUnread = useUiStateStore((state) => state.markThreadUnread);
+  const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
+  const openPrLink = useOpenPrLink();
+  const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
+  const [renamingTitle, setRenamingTitle] = useState("");
+  const [confirmingArchiveThreadKey, setConfirmingArchiveThreadKey] = useState<string | null>(null);
+  const renamingInputRef = useRef<HTMLInputElement | null>(null);
+  const renamingCommittedRef = useRef(false);
+  const confirmArchiveButtonRefs = useRef(new Map<string, HTMLButtonElement>());
+  const projectlessThreadByKey = useMemo(
+    () =>
+      new Map(
+        projectlessThreadGroups.flatMap((group) =>
+          group.threads.map(
+            (thread) =>
+              [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
+          ),
+        ),
+      ),
+    [projectlessThreadGroups],
+  );
+  const startProjectlessThreadRename = useCallback((threadKey: string, title: string) => {
+    setRenamingThreadKey(threadKey);
+    setRenamingTitle(title);
+    renamingCommittedRef.current = false;
+  }, []);
+  const cancelProjectlessThreadRename = useCallback(() => {
+    setRenamingThreadKey(null);
+    renamingInputRef.current = null;
+  }, []);
+  const commitProjectlessThreadRename = useCallback(
+    async (threadRef: ScopedThreadRef, newTitle: string, originalTitle: string) => {
+      const trimmed = newTitle.trim();
+      if (trimmed.length === 0) {
+        toastManager.add({ type: "warning", title: "Thread title cannot be empty" });
+      } else if (trimmed !== originalTitle) {
+        const result = await updateThreadMetadata({
+          environmentId: threadRef.environmentId,
+          input: { threadId: threadRef.threadId, title: trimmed },
+        });
+        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Failed to rename thread",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        }
+      }
+      setRenamingThreadKey(null);
+      renamingInputRef.current = null;
+    },
+    [updateThreadMetadata],
+  );
+  const attemptArchiveProjectlessThread = useCallback(
+    async (threadRef: ScopedThreadRef) => {
+      const result = await archiveThread(threadRef);
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to archive thread",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      }
+    },
+    [archiveThread],
+  );
+  const handleProjectlessThreadContextMenu = useCallback(
+    async (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
+      const api = readLocalApi();
+      const thread = projectlessThreadByKey.get(scopedThreadKey(threadRef));
+      if (!api || !thread) return;
+      const clicked = await api.contextMenu.show(
+        [
+          { id: "rename", label: "Rename thread" },
+          { id: "mark-unread", label: "Mark unread" },
+          { id: "archive", label: "Archive" },
+          { id: "delete", label: "Delete", destructive: true, icon: "trash" },
+        ] as const,
+        position,
+      );
+      if (clicked === "rename") {
+        startProjectlessThreadRename(scopedThreadKey(threadRef), thread.title);
+        return;
+      }
+      if (clicked === "mark-unread") {
+        markThreadUnread(scopedThreadKey(threadRef), thread.latestTurn?.completedAt);
+        return;
+      }
+      if (clicked === "archive") {
+        if (
+          appSettingsConfirmThreadArchive &&
+          !(await api.dialogs.confirm(`Archive thread "${thread.title}"?`))
+        ) {
+          return;
+        }
+        await attemptArchiveProjectlessThread(threadRef);
+        return;
+      }
+      if (clicked !== "delete") return;
+      if (
+        appSettingsConfirmThreadDelete &&
+        !(await api.dialogs.confirm(
+          [
+            `Delete thread "${thread.title}"?`,
+            "This permanently clears conversation history for this thread.",
+          ].join("\n"),
+        ))
+      ) {
+        return;
+      }
+      const result = await deleteThread(threadRef);
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to delete thread",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      }
+    },
+    [
+      appSettingsConfirmThreadArchive,
+      appSettingsConfirmThreadDelete,
+      attemptArchiveProjectlessThread,
+      deleteThread,
+      markThreadUnread,
+      projectlessThreadByKey,
+      startProjectlessThreadRename,
+    ],
+  );
+  const handleProjectlessThreadClick = useCallback(
+    (_event: React.MouseEvent, threadRef: ScopedThreadRef) => navigateToThread(threadRef),
+    [navigateToThread],
+  );
+  const ignoreProjectlessMultiSelect = useCallback(async () => undefined, []);
 
   return (
     <SidebarContent
@@ -2994,35 +3165,76 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           </SidebarMenu>
         )}
 
-        {projectlessThreadGroups.map((group) => (
-          <div key={group.environmentId} className="mt-2">
-            <div className="px-2 py-1 text-xs font-medium text-sidebar-muted-foreground/80">
-              No project · {group.environmentLabel}
-            </div>
-            <SidebarMenu>
-              {group.threads.map((thread) => {
-                const threadRef = scopeThreadRef(thread.environmentId, thread.id);
-                const threadKey = scopedThreadKey(threadRef);
-                return (
-                  <SidebarMenuItem key={threadKey}>
-                    <SidebarMenuButton
-                      size="sm"
+        {projectlessThreadGroups.map((group) => {
+          const listKey = projectlessThreadListKey(group.environmentId);
+          const isExpanded = expandedThreadListsByProject.has(listKey);
+          const hasOverflowingThreads = group.threads.length > threadPreviewCount;
+          const renderedThreads =
+            isExpanded || !hasOverflowingThreads
+              ? group.threads
+              : group.threads.slice(0, threadPreviewCount);
+          const renderedThreadKeys = renderedThreads.map((thread) =>
+            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+          );
+          return (
+            <div key={group.environmentId} className="mt-2">
+              <div className="px-2 py-1 text-xs font-medium text-sidebar-muted-foreground/80">
+                No project · {group.environmentLabel}
+              </div>
+              <SidebarMenu ref={attachThreadListAutoAnimateRef}>
+                {renderedThreads.map((thread) => {
+                  const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+                  const threadKey = scopedThreadKey(threadRef);
+                  return (
+                    <SidebarThreadRow
+                      key={threadKey}
+                      thread={thread}
+                      projectCwd={thread.workspaceRoot ?? null}
+                      orderedProjectThreadKeys={renderedThreadKeys}
                       isActive={routeThreadKey === threadKey}
-                      onClick={() => navigateToThread(threadRef)}
+                      jumpLabel={threadJumpLabelByKey.get(threadKey) ?? null}
+                      appSettingsConfirmThreadArchive={appSettingsConfirmThreadArchive}
+                      renamingThreadKey={renamingThreadKey}
+                      renamingTitle={renamingTitle}
+                      setRenamingTitle={setRenamingTitle}
+                      startThreadRename={startProjectlessThreadRename}
+                      renamingInputRef={renamingInputRef}
+                      renamingCommittedRef={renamingCommittedRef}
+                      confirmingArchiveThreadKey={confirmingArchiveThreadKey}
+                      setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
+                      confirmArchiveButtonRefs={confirmArchiveButtonRefs}
+                      handleThreadClick={handleProjectlessThreadClick}
+                      navigateToThread={navigateToThread}
+                      handleMultiSelectContextMenu={ignoreProjectlessMultiSelect}
+                      handleThreadContextMenu={handleProjectlessThreadContextMenu}
+                      clearSelection={clearSelection}
+                      commitRename={commitProjectlessThreadRename}
+                      cancelRename={cancelProjectlessThreadRename}
+                      attemptArchiveThread={attemptArchiveProjectlessThread}
+                      openPrLink={openPrLink}
+                      selectionEnabled={false}
+                    />
+                  );
+                })}
+                {hasOverflowingThreads ? (
+                  <SidebarMenuSubItem className="w-full">
+                    <SidebarMenuSubButton
+                      render={<button type="button" />}
+                      size="sm"
+                      className="h-8 w-full translate-x-0 justify-start px-2 text-left text-xs text-sidebar-muted-foreground/75 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+                      onClick={() => {
+                        if (isExpanded) collapseThreadListForProject(listKey);
+                        else expandThreadListForProject(listKey);
+                      }}
                     >
-                      <span className="min-w-0 flex-1 truncate">{thread.title}</span>
-                      {threadJumpLabelByKey.get(threadKey) ? (
-                        <Kbd className="h-4 min-w-0 rounded-sm px-1.5 text-[10px]">
-                          {threadJumpLabelByKey.get(threadKey)}
-                        </Kbd>
-                      ) : null}
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                );
-              })}
-            </SidebarMenu>
-          </div>
-        ))}
+                      <span>{isExpanded ? "Show less" : "Show more"}</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                ) : null}
+              </SidebarMenu>
+            </div>
+          );
+        })}
 
         {projectsLength === 0 && projectlessThreadGroups.length === 0 && (
           <div className="px-2 pt-4 text-center text-secondary-label text-xs">No projects yet</div>
@@ -3360,11 +3572,6 @@ export default function LegacySidebar() {
   }, [environmentLabelById, sidebarThreadSortOrder, visibleThreads]);
   const visibleSidebarThreadKeys = useMemo(
     () => [
-      ...projectlessThreadGroups.flatMap((group) =>
-        group.threads.map((thread) =>
-          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-        ),
-      ),
       ...sortedProjects.flatMap((project) => {
         const projectThreads = sortThreads(
           (threadsByProjectKey.get(project.projectKey) ?? []).filter(
@@ -3396,6 +3603,18 @@ export default function LegacySidebar() {
             ? projectThreads
             : projectThreads.slice(0, sidebarThreadPreviewCount);
         const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
+        return renderedThreads.map((thread) =>
+          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+        );
+      }),
+      ...projectlessThreadGroups.flatMap((group) => {
+        const isExpanded = expandedThreadListsByProject.has(
+          projectlessThreadListKey(group.environmentId),
+        );
+        const renderedThreads =
+          isExpanded || group.threads.length <= sidebarThreadPreviewCount
+            ? group.threads
+            : group.threads.slice(0, sidebarThreadPreviewCount);
         return renderedThreads.map((thread) =>
           scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
         );

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -400,7 +400,8 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   // so git status (and thus PR detection) queries the correct path.
   const threadProject = useProject(
     useMemo(
-      () => scopeProjectRef(thread.environmentId, thread.projectId),
+      () =>
+        thread.projectId === null ? null : scopeProjectRef(thread.environmentId, thread.projectId),
       [thread.environmentId, thread.projectId],
     ),
   );
@@ -1221,6 +1222,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       project.memberProjects.map((member) => [member.physicalProjectKey, 0] as const),
     );
     for (const thread of projectThreads) {
+      if (thread.projectId === null) continue;
       const member = memberProjectByScopedKey.get(
         scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
       );
@@ -2103,14 +2105,17 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       const threadKey = scopedThreadKey(threadRef);
       const thread = sidebarThreadByKeyRef.current.get(threadKey) ?? null;
       if (!thread) return;
-      const threadProject = memberProjectByScopedKey.get(
-        scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
-      );
+      const threadProject =
+        thread.projectId === null
+          ? undefined
+          : memberProjectByScopedKey.get(
+              scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
+            );
       const threadWorkspacePath =
         thread.worktreePath ?? threadProject?.workspaceRoot ?? project.workspaceRoot ?? null;
       const clicked = await api.contextMenu.show(
         [
-          ...(thread.branch
+          ...(thread.branch && thread.projectId !== null
             ? [{ id: "new-thread-on-branch", label: `New thread on ${thread.branch}` }]
             : []),
           { id: "rename", label: "Rename thread" },
@@ -2123,10 +2128,12 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       );
 
       if (clicked === "new-thread-on-branch") {
+        if (thread.projectId === null) return;
+        const projectId = thread.projectId;
         // Explicit branch carry-over: reuse the thread's worktree when it
         // has one, otherwise its branch on the local checkout.
         const result = await settlePromise(() =>
-          handleNewThread(scopeProjectRef(thread.environmentId, thread.projectId), {
+          handleNewThread(scopeProjectRef(thread.environmentId, projectId), {
             branch: thread.branch,
             worktreePath: thread.worktreePath,
             envMode: thread.worktreePath ? "worktree" : "local",
@@ -2746,6 +2753,12 @@ interface SidebarProjectsContentProps {
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   sortedProjects: readonly SidebarProjectSnapshot[];
+  projectlessThreadGroups: ReadonlyArray<{
+    readonly environmentId: SidebarThreadSummary["environmentId"];
+    readonly environmentLabel: string;
+    readonly threads: ReadonlyArray<SidebarThreadSummary>;
+  }>;
+  navigateToThread: (threadRef: ScopedThreadRef) => void;
   expandedThreadListsByProject: ReadonlySet<string>;
   activeRouteProjectKey: string | null;
   routeThreadKey: string | null;
@@ -2786,6 +2799,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     archiveThread,
     deleteThread,
     sortedProjects,
+    projectlessThreadGroups,
+    navigateToThread,
     expandedThreadListsByProject,
     activeRouteProjectKey,
     routeThreadKey,
@@ -2979,7 +2994,37 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           </SidebarMenu>
         )}
 
-        {projectsLength === 0 && (
+        {projectlessThreadGroups.map((group) => (
+          <div key={group.environmentId} className="mt-2">
+            <div className="px-2 py-1 text-xs font-medium text-sidebar-muted-foreground/80">
+              No project · {group.environmentLabel}
+            </div>
+            <SidebarMenu>
+              {group.threads.map((thread) => {
+                const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+                const threadKey = scopedThreadKey(threadRef);
+                return (
+                  <SidebarMenuItem key={threadKey}>
+                    <SidebarMenuButton
+                      size="sm"
+                      isActive={routeThreadKey === threadKey}
+                      onClick={() => navigateToThread(threadRef)}
+                    >
+                      <span className="min-w-0 flex-1 truncate">{thread.title}</span>
+                      {threadJumpLabelByKey.get(threadKey) ? (
+                        <Kbd className="h-4 min-w-0 rounded-sm px-1.5 text-[10px]">
+                          {threadJumpLabelByKey.get(threadKey)}
+                        </Kbd>
+                      ) : null}
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </div>
+        ))}
+
+        {projectsLength === 0 && projectlessThreadGroups.length === 0 && (
           <div className="px-2 pt-4 text-center text-secondary-label text-xs">No projects yet</div>
         )}
       </SidebarGroup>
@@ -3125,6 +3170,7 @@ export default function LegacySidebar() {
     }
     const activeThread = sidebarThreadByKey.get(routeThreadKey);
     if (!activeThread) return null;
+    if (activeThread.projectId === null) return null;
     const physicalKey =
       projectPhysicalKeyByScopedRef.get(
         scopedProjectKey(scopeProjectRef(activeThread.environmentId, activeThread.projectId)),
@@ -3137,6 +3183,7 @@ export default function LegacySidebar() {
   const threadsByProjectKey = useMemo(() => {
     const next = new Map<string, SidebarThreadSummary[]>();
     for (const thread of sidebarThreads) {
+      if (thread.projectId === null) continue;
       const physicalKey =
         projectPhysicalKeyByScopedRef.get(
           scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
@@ -3267,15 +3314,18 @@ export default function LegacySidebar() {
       ...project,
       id: project.projectKey,
     }));
-    const sortableThreads = visibleThreads.map((thread) => {
+    const sortableThreads = visibleThreads.flatMap((thread) => {
+      if (thread.projectId === null) return [];
       const physicalKey =
         projectPhysicalKeyByScopedRef.get(
           scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
         ) ?? scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId));
-      return {
-        ...thread,
-        projectId: (physicalToLogicalKey.get(physicalKey) ?? physicalKey) as ProjectId,
-      };
+      return [
+        {
+          ...thread,
+          projectId: (physicalToLogicalKey.get(physicalKey) ?? physicalKey) as ProjectId,
+        },
+      ];
     });
     return sortProjectsForSidebar(
       sortableProjects,
@@ -3294,9 +3344,28 @@ export default function LegacySidebar() {
     visibleThreads,
   ]);
   const isManualProjectSorting = sidebarProjectSortOrder === "manual";
+  const projectlessThreadGroups = useMemo(() => {
+    const byEnvironment = new Map<SidebarThreadSummary["environmentId"], SidebarThreadSummary[]>();
+    for (const thread of visibleThreads) {
+      if (thread.projectId !== null) continue;
+      const threadsForEnvironment = byEnvironment.get(thread.environmentId) ?? [];
+      threadsForEnvironment.push(thread);
+      byEnvironment.set(thread.environmentId, threadsForEnvironment);
+    }
+    return [...byEnvironment.entries()].map(([environmentId, threads]) => ({
+      environmentId,
+      environmentLabel: environmentLabelById.get(environmentId) ?? "Environment",
+      threads: sortThreads(threads, sidebarThreadSortOrder),
+    }));
+  }, [environmentLabelById, sidebarThreadSortOrder, visibleThreads]);
   const visibleSidebarThreadKeys = useMemo(
-    () =>
-      sortedProjects.flatMap((project) => {
+    () => [
+      ...projectlessThreadGroups.flatMap((group) =>
+        group.threads.map((thread) =>
+          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+        ),
+      ),
+      ...sortedProjects.flatMap((project) => {
         const projectThreads = sortThreads(
           (threadsByProjectKey.get(project.projectKey) ?? []).filter(
             (thread) => thread.archivedAt === null,
@@ -3331,11 +3400,13 @@ export default function LegacySidebar() {
           scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
         );
       }),
+    ],
     [
       sidebarThreadSortOrder,
       sidebarThreadPreviewCount,
       expandedThreadListsByProject,
       projectExpandedById,
+      projectlessThreadGroups,
       routeThreadKey,
       sortedProjects,
       threadsByProjectKey,
@@ -3610,6 +3681,8 @@ export default function LegacySidebar() {
         archiveThread={archiveThread}
         deleteThread={deleteThread}
         sortedProjects={sortedProjects}
+        projectlessThreadGroups={projectlessThreadGroups}
+        navigateToThread={navigateToThread}
         expandedThreadListsByProject={expandedThreadListsByProject}
         activeRouteProjectKey={activeRouteProjectKey}
         routeThreadKey={routeThreadKey}

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -36,7 +36,7 @@ type ScopedSidebarProject = SidebarProject & {
 
 type ScopedSidebarThread = ThreadSortInput & {
   environmentId: string;
-  projectId: string;
+  projectId: string | null;
   archivedAt: string | null;
 };
 
@@ -836,6 +836,7 @@ export function sortProjectsForSidebar<
 ): TProject[] {
   const threadsByProjectId = new Map<string, TThread[]>();
   for (const thread of threads) {
+    if (thread.projectId === null) continue;
     const existing = threadsByProjectId.get(thread.projectId) ?? [];
     existing.push(thread);
     threadsByProjectId.set(thread.projectId, existing);
@@ -904,7 +905,7 @@ export function sortScopedProjectsForSidebar<
     `${environmentId}\u0000${projectId}`;
   const threadsByProject = new Map<string, TThread[]>();
   for (const thread of threads) {
-    if (thread.archivedAt !== null) {
+    if (thread.archivedAt !== null || thread.projectId === null) {
       continue;
     }
     const key = scopedKey(thread.environmentId, thread.projectId);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -97,7 +97,7 @@ import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
-import { startNewThreadFromContext } from "../lib/chatThreadActions";
+import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
@@ -135,6 +135,7 @@ import {
   sortSettledThreadsForSidebar,
   sortThreadsForSidebar,
 } from "./Sidebar.logic";
+import { shouldOpenNewThreadTargetPicker } from "./CommandPalette.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
   prStatusIndicator,
@@ -3131,13 +3132,29 @@ export default function Sidebar() {
     autoAnimate(node, { duration: 150, easing: "ease-out" });
   }, []);
 
+  const newThreadTarget = resolveThreadActionProjectRef({
+    activeDraftThread: newThreadContext.activeDraftThread,
+    activeThread: newThreadContext.activeThread ?? undefined,
+    defaultProjectRef: newThreadContext.defaultProjectRef,
+    handleNewThread: newThreadContext.handleNewThread,
+  });
+  const newThreadEnvironmentId = newThreadTarget?.environmentId ?? primaryEnvironmentId;
+  const supportsProjectlessThreads =
+    newThreadEnvironmentId !== null &&
+    serverConfigs.get(newThreadEnvironmentId)?.projectlessThreads === true;
+
   // New thread defaults to the project you're in (active thread's project,
-  // falling back to the top project) — same resolution the command palette
-  // uses. The command palette already offers a "New thread in..." submenu
-  // for multi-project setups.
+  // falling back to the top project). When the environment supports
+  // projectless threads, the target picker remains useful even with one
+  // project because it also offers "Don't work in a project".
   const handleNewThreadClick = useCallback(() => {
-    // One project: nothing to pick, create immediately.
-    if (projectGroups.length <= 1) {
+    if (
+      !shouldOpenNewThreadTargetPicker({
+        legacySidebarEnabled: false,
+        projectGroupCount: projectGroups.length,
+        supportsProjectlessThreads,
+      })
+    ) {
       if (isMobile) setOpenMobile(false);
       void startNewThreadFromContext({
         activeDraftThread: newThreadContext.activeDraftThread,
@@ -3149,12 +3166,12 @@ export default function Sidebar() {
     }
     if (isMobile) setOpenMobile(false);
     openCommandPalette({ open: "new-thread-in" });
-  }, [isMobile, newThreadContext, projectGroups.length, setOpenMobile]);
+  }, [isMobile, newThreadContext, projectGroups.length, setOpenMobile, supportsProjectlessThreads]);
 
-  // The button mirrors chat.new: in multi-project setups both route through
-  // the command palette's "New thread in..." picker, and in single-project
-  // setups both create immediately. chat.newLocal always creates directly, so
-  // it is only a correct label when chat.new is unbound.
+  // The button mirrors chat.new: both route through the target picker whenever
+  // there is more than one project or projectless threads are available.
+  // chat.newLocal always creates directly, so it is only a correct label when
+  // chat.new is unbound.
   const newThreadShortcutLabel =
     shortcutLabelForCommand(keybindings, "chat.new") ??
     shortcutLabelForCommand(keybindings, "chat.newLocal");

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2303,7 +2303,11 @@ export default function Sidebar() {
         ? () => navigateToThread(scopeThreadRef(nextThread.environmentId, nextThread.id))
         : shell
           ? () =>
-              void handleNewThreadRef.current(scopeProjectRef(shell.environmentId, shell.projectId))
+              void handleNewThreadRef.current(
+                shell.projectId === null
+                  ? { environmentId: shell.environmentId, projectId: null }
+                  : scopeProjectRef(shell.environmentId, shell.projectId),
+              )
           : () => void router.navigate({ to: "/" });
     },
     [navigateToThread, router],
@@ -2923,10 +2927,12 @@ export default function Sidebar() {
         }
         switch (clicked.value) {
           case "new-thread-on-branch": {
+            if (thread.projectId === null) return;
+            const projectId = thread.projectId;
             // Explicit branch carry-over: reuse the thread's worktree when it
             // has one, otherwise its branch on the local checkout.
             const result = await settlePromise(() =>
-              handleNewThreadRef.current(scopeProjectRef(thread.environmentId, thread.projectId), {
+              handleNewThreadRef.current(scopeProjectRef(thread.environmentId, projectId), {
                 branch: thread.branch,
                 worktreePath: thread.worktreePath,
                 envMode: thread.worktreePath ? "worktree" : "local",
@@ -3368,9 +3374,11 @@ export default function Sidebar() {
                           ) ?? null
                         }
                         projectTitle={
-                          projectDisplayNameByKey.get(
-                            `${thread.environmentId}:${thread.projectId}`,
-                          ) ?? null
+                          thread.projectId === null
+                            ? "No project"
+                            : (projectDisplayNameByKey.get(
+                                `${thread.environmentId}:${thread.projectId}`,
+                              ) ?? null)
                         }
                         environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
                         providerEntryByInstanceId={providerEntryByInstanceId}
@@ -3476,9 +3484,11 @@ export default function Sidebar() {
                           ) ?? null
                         }
                         projectTitle={
-                          projectDisplayNameByKey.get(
-                            `${thread.environmentId}:${thread.projectId}`,
-                          ) ?? null
+                          thread.projectId === null
+                            ? "No project"
+                            : (projectDisplayNameByKey.get(
+                                `${thread.environmentId}:${thread.projectId}`,
+                              ) ?? null)
                         }
                         providerEntryByInstanceId={providerEntryByInstanceId}
                         timestampFormat={timestampFormat}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -97,7 +97,7 @@ import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
-import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
+import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
@@ -3132,16 +3132,9 @@ export default function Sidebar() {
     autoAnimate(node, { duration: 150, easing: "ease-out" });
   }, []);
 
-  const newThreadTarget = resolveThreadActionProjectRef({
-    activeDraftThread: newThreadContext.activeDraftThread,
-    activeThread: newThreadContext.activeThread ?? undefined,
-    defaultProjectRef: newThreadContext.defaultProjectRef,
-    handleNewThread: newThreadContext.handleNewThread,
-  });
-  const newThreadEnvironmentId = newThreadTarget?.environmentId ?? primaryEnvironmentId;
-  const supportsProjectlessThreads =
-    newThreadEnvironmentId !== null &&
-    serverConfigs.get(newThreadEnvironmentId)?.projectlessThreads === true;
+  const supportsProjectlessThreads = [...serverConfigs.values()].some(
+    (config) => config.projectlessThreads === true,
+  );
 
   // New thread defaults to the project you're in (active thread's project,
   // falling back to the top project). When the environment supports
@@ -3240,7 +3233,7 @@ export default function Sidebar() {
                         type="button"
                         className="relative focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
                         onClick={handleNewThreadClick}
-                        disabled={projects.length === 0}
+                        disabled={projects.length === 0 && !supportsProjectlessThreads}
                         aria-label="New thread"
                       />
                     }

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -236,7 +236,8 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
   );
   const threadProject = useProject(
     useMemo(
-      () => scopeProjectRef(thread.environmentId, thread.projectId),
+      () =>
+        thread.projectId === null ? null : scopeProjectRef(thread.environmentId, thread.projectId),
       [thread.environmentId, thread.projectId],
     ),
   );

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -101,7 +101,7 @@ export function DraftHeroHeadline({
   const activeProjectKey = activeProjectGroup?.projectKey ?? "";
   const activeProjectDisplayName =
     activeProjectRef?.projectId === null
-      ? "No project"
+      ? "without a project"
       : (activeProjectGroup?.displayName ?? activeProjectTitle);
   const hasResolvedTarget = activeProjectRef !== null;
   const canChooseProject = projectPickerEntries.length > 0;
@@ -179,7 +179,7 @@ export function DraftHeroHeadline({
   return (
     <h1 className="mx-auto w-full max-w-5xl text-center font-normal text-2xl text-foreground tracking-tight sm:text-3xl">
       {activeProjectRef?.projectId === null ? (
-        <>What should we work on?</>
+        <>What should we work on {projectSelector}?</>
       ) : hasResolvedTarget ? (
         <>What should we build in {projectSelector}?</>
       ) : canChooseProject ? (

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -1,17 +1,18 @@
-import type { ScopedProjectRef } from "@t3tools/contracts";
-import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
-import { FolderPlusIcon } from "lucide-react";
+import type { EnvironmentId } from "@t3tools/contracts";
+import { scopeProjectRef } from "@t3tools/client-runtime/environment";
+import { FolderPlusIcon, XIcon } from "lucide-react";
 import { useCallback, useMemo } from "react";
 
 import { openCommandPalette } from "~/commandPaletteBus";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
+import type { DraftThreadTargetRef } from "~/composerDraftStore";
 import { useClientSettings } from "~/hooks/useSettings";
 import { selectProjectGroupingSettings } from "~/logicalProject";
 import {
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
 } from "~/sidebarProjectGrouping";
-import { useProjects, useThreadShells } from "~/state/entities";
+import { useProjects, useServerConfigs, useThreadShells } from "~/state/entities";
 import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
 import { sortLogicalProjectsForSidebar } from "../Sidebar.logic";
 import {
@@ -25,7 +26,7 @@ import {
 } from "../ui/menu";
 
 interface DraftHeroHeadlineProps {
-  readonly activeProjectRef: ScopedProjectRef | null;
+  readonly activeProjectRef: DraftThreadTargetRef | null;
   readonly activeProjectTitle: string | null;
 }
 
@@ -35,6 +36,7 @@ export function DraftHeroHeadline({
 }: DraftHeroHeadlineProps) {
   const projects = useProjects();
   const threads = useThreadShells();
+  const serverConfigs = useServerConfigs();
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
@@ -75,7 +77,10 @@ export function DraftHeroHeadline({
     () =>
       buildSidebarProjectPickerEntries({
         groups: projectGroups,
-        preferredProjectRef: activeProjectRef,
+        preferredProjectRef:
+          activeProjectRef?.projectId == null
+            ? null
+            : scopeProjectRef(activeProjectRef.environmentId, activeProjectRef.projectId),
       }),
     [activeProjectRef, projectGroups],
   );
@@ -84,27 +89,37 @@ export function DraftHeroHeadline({
     [projectPickerEntries],
   );
   const activeProjectGroup =
-    activeProjectRef === null
+    activeProjectRef?.projectId == null
       ? null
       : (projectGroups.find((group) =>
           group.memberProjectRefs.some(
-            (projectRef) => scopedProjectKey(projectRef) === scopedProjectKey(activeProjectRef),
+            (projectRef) =>
+              projectRef.environmentId === activeProjectRef.environmentId &&
+              projectRef.projectId === activeProjectRef.projectId,
           ),
         ) ?? null);
   const activeProjectKey = activeProjectGroup?.projectKey ?? "";
-  const activeProjectDisplayName = activeProjectGroup?.displayName ?? activeProjectTitle;
-  const hasResolvedProject = activeProjectTitle !== null;
+  const activeProjectDisplayName =
+    activeProjectRef?.projectId === null
+      ? "No project"
+      : (activeProjectGroup?.displayName ?? activeProjectTitle);
+  const hasResolvedTarget = activeProjectRef !== null;
   const canChooseProject = projectPickerEntries.length > 0;
-  const shouldShowProjectMenu = canChooseProject;
+  const projectlessEnvironmentId: EnvironmentId | null =
+    activeProjectRef?.environmentId ?? primaryEnvironmentId;
+  const canCreateProjectlessThread =
+    projectlessEnvironmentId !== null &&
+    serverConfigs.get(projectlessEnvironmentId)?.projectlessThreads === true;
+  const shouldShowProjectMenu = projectlessEnvironmentId !== null;
 
   const projectSelector = shouldShowProjectMenu ? (
     <Menu>
       <MenuTrigger
-        aria-label={hasResolvedProject ? "Change project" : "Choose a project"}
+        aria-label={hasResolvedTarget ? "Change workspace" : "Choose a workspace"}
         className="pointer-events-auto inline-block max-w-64 truncate border-foreground/60 border-b border-dotted align-bottom text-foreground transition-colors hover:border-foreground/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
         title={activeProjectDisplayName ?? undefined}
       >
-        {activeProjectDisplayName ?? "Choose a project"}
+        {activeProjectDisplayName ?? "Choose a workspace"}
       </MenuTrigger>
       <MenuPopup align="center" className="max-h-80 min-w-40! w-max max-w-64 overflow-y-auto">
         <MenuRadioGroup
@@ -135,6 +150,20 @@ export function DraftHeroHeadline({
           <FolderPlusIcon />
           New project
         </MenuItem>
+        {canCreateProjectlessThread ? (
+          <MenuItem
+            onClick={() => {
+              if (projectlessEnvironmentId === null) return;
+              void handleNewThread(
+                { environmentId: projectlessEnvironmentId, projectId: null },
+                { replace: true },
+              );
+            }}
+          >
+            <XIcon />
+            Don&apos;t work in a project
+          </MenuItem>
+        ) : null}
       </MenuPopup>
     </Menu>
   ) : (
@@ -149,7 +178,9 @@ export function DraftHeroHeadline({
 
   return (
     <h1 className="mx-auto w-full max-w-5xl text-center font-normal text-2xl text-foreground tracking-tight sm:text-3xl">
-      {hasResolvedProject ? (
+      {activeProjectRef?.projectId === null ? (
+        <>What should we work on?</>
+      ) : hasResolvedTarget ? (
         <>What should we build in {projectSelector}?</>
       ) : canChooseProject ? (
         <>{projectSelector} to start</>

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -207,7 +207,7 @@ type LegacyPersistedComposerDraftStoreState = PersistedComposerDraftStoreState &
 const PersistedDraftThreadState = Schema.Struct({
   threadId: ThreadId,
   environmentId: Schema.String,
-  projectId: ProjectId,
+  projectId: Schema.NullOr(ProjectId),
   logicalProjectKey: Schema.optionalKey(Schema.String),
   createdAt: Schema.String,
   runtimeMode: RuntimeMode,
@@ -311,7 +311,7 @@ export function composerDraftHasUserContent(
 export interface DraftSessionState {
   threadId: ThreadId;
   environmentId: EnvironmentId;
-  projectId: ProjectId;
+  projectId: ProjectId | null;
   logicalProjectKey: string;
   createdAt: string;
   runtimeMode: RuntimeMode;
@@ -324,6 +324,12 @@ export interface DraftSessionState {
 }
 
 export type DraftThreadState = DraftSessionState;
+
+/** The environment and optional project a draft will run in on first send. */
+export interface DraftThreadTargetRef {
+  readonly environmentId: EnvironmentId;
+  readonly projectId: ProjectId | null;
+}
 
 /**
  * Draft session metadata paired with its stable draft-session identity.
@@ -373,7 +379,7 @@ interface ComposerDraftStoreState {
   /** Creates or updates the draft session tracked for a logical project. */
   setLogicalProjectDraftThreadId: (
     logicalProjectKey: string,
-    projectRef: ScopedProjectRef,
+    projectRef: DraftThreadTargetRef,
     draftId: DraftId,
     options?: {
       threadId?: ThreadId;
@@ -407,7 +413,7 @@ interface ComposerDraftStoreState {
     options: {
       branch?: string | null;
       worktreePath?: string | null;
-      projectRef?: ScopedProjectRef;
+      projectRef?: DraftThreadTargetRef;
       createdAt?: string;
       envMode?: DraftThreadEnvMode;
       startFromOrigin?: boolean;
@@ -1225,6 +1231,17 @@ function projectDraftKey(projectRef: ScopedProjectRef): string {
   return scopedProjectKey(projectRef);
 }
 
+export function projectlessDraftKey(environmentId: EnvironmentId): string {
+  return `environment:${environmentId}:projectless`;
+}
+
+function logicalDraftEnvironmentId(logicalKey: string): EnvironmentId | null {
+  const projectRef = parseScopedProjectKey(logicalKey);
+  if (projectRef) return projectRef.environmentId;
+  const match = /^environment:(.+):projectless$/.exec(logicalKey);
+  return match?.[1] ? (match[1] as EnvironmentId) : null;
+}
+
 function logicalProjectDraftKey(logicalProjectKey: string): string {
   return logicalProjectKey.trim();
 }
@@ -1350,7 +1367,7 @@ function toProjectDraftSession(
 }
 
 function createDraftThreadState(
-  projectRef: ScopedProjectRef,
+  projectRef: DraftThreadTargetRef,
   threadId: ThreadId,
   logicalProjectKey: string,
   existingThread: DraftThreadState | undefined,
@@ -1547,21 +1564,26 @@ function normalizePersistedDraftThreads(
               promotedToRecord.threadId as ThreadId,
             )
           : null;
-      if (typeof projectId !== "string" || projectId.length === 0 || environmentId === undefined) {
+      if (
+        (projectId !== null && (typeof projectId !== "string" || projectId.length === 0)) ||
+        environmentId === undefined
+      ) {
         continue;
       }
       const normalizedEnvironmentId = environmentId as EnvironmentId;
       draftThreadsByThreadKey[threadKey] = {
         threadId,
         environmentId: normalizedEnvironmentId,
-        projectId: projectId as ProjectId,
+        projectId: projectId === null ? null : (projectId as ProjectId),
         logicalProjectKey:
           typeof candidateDraftThread.logicalProjectKey === "string" &&
           candidateDraftThread.logicalProjectKey.length > 0
             ? candidateDraftThread.logicalProjectKey
-            : parsedThreadRef
+            : parsedThreadRef && projectId !== null
               ? projectDraftKey(scopeProjectRef(normalizedEnvironmentId, projectId as ProjectId))
-              : threadKeyOrId,
+              : projectId === null
+                ? projectlessDraftKey(normalizedEnvironmentId)
+                : threadKeyOrId,
         createdAt:
           typeof createdAt === "string" && createdAt.length > 0
             ? createdAt
@@ -2214,12 +2236,14 @@ function toHydratedDraftThreadState(
     projectId: persistedDraftThread.projectId,
     logicalProjectKey:
       persistedDraftThread.logicalProjectKey ??
-      projectDraftKey(
-        scopeProjectRef(
-          persistedDraftThread.environmentId as EnvironmentId,
-          persistedDraftThread.projectId,
-        ),
-      ),
+      (persistedDraftThread.projectId === null
+        ? projectlessDraftKey(persistedDraftThread.environmentId as EnvironmentId)
+        : projectDraftKey(
+            scopeProjectRef(
+              persistedDraftThread.environmentId as EnvironmentId,
+              persistedDraftThread.projectId,
+            ),
+          )),
     createdAt: persistedDraftThread.createdAt,
     runtimeMode: persistedDraftThread.runtimeMode,
     interactionMode: persistedDraftThread.interactionMode,
@@ -2418,7 +2442,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               projectId: existing.projectId,
             };
             if (
-              nextProjectRef.projectId.length === 0 ||
+              (nextProjectRef.projectId !== null && nextProjectRef.projectId.length === 0) ||
               nextProjectRef.environmentId.length === 0
             ) {
               return state;
@@ -3529,7 +3553,7 @@ export function clearComposerDraftsEnvironment(environmentId: EnvironmentId): vo
     for (const [logicalProjectKey, threadKey] of Object.entries(
       state.logicalProjectDraftThreadKeyByLogicalProjectKey,
     )) {
-      if (parseScopedProjectKey(logicalProjectKey)?.environmentId === environmentId) {
+      if (logicalDraftEnvironmentId(logicalProjectKey) === environmentId) {
         removedThreadKeys.add(threadKey);
       }
     }
@@ -3537,7 +3561,7 @@ export function clearComposerDraftsEnvironment(environmentId: EnvironmentId): vo
     const nextLogicalMappings = Object.fromEntries(
       Object.entries(state.logicalProjectDraftThreadKeyByLogicalProjectKey).filter(
         ([logicalProjectKey, threadKey]) =>
-          parseScopedProjectKey(logicalProjectKey)?.environmentId !== environmentId &&
+          logicalDraftEnvironmentId(logicalProjectKey) !== environmentId &&
           !removedThreadKeys.has(threadKey),
       ),
     ) as Record<string, string>;

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -10,6 +10,8 @@ import { useCallback, useMemo } from "react";
 import {
   composerDraftHasUserContent,
   markPromotedDraftThreadByRef,
+  projectlessDraftKey,
+  type DraftThreadTargetRef,
   type DraftThreadEnvMode,
   type DraftThreadState,
   useComposerDraftStore,
@@ -66,7 +68,7 @@ export function useNewThreadHandler() {
 
   return useCallback(
     (
-      projectRef: ScopedProjectRef,
+      projectRef: DraftThreadTargetRef,
       options?: {
         branch?: string | null;
         worktreePath?: string | null;
@@ -131,6 +133,7 @@ export function useNewThreadHandler() {
       // skipped entirely when a higher-priority source decides, and its
       // query atom caches per project after the first call.
       const resolveDefaultEnvMode = async (): Promise<DraftThreadEnvMode> => {
+        if (projectRef.projectId === null) return "local";
         const consultProjectFile = project !== undefined && project.defaultThreadEnvMode == null;
         return resolveDefaultThreadEnvMode({
           projectSetting: project?.defaultThreadEnvMode,
@@ -143,9 +146,12 @@ export function useNewThreadHandler() {
           globalDefault: primaryServerSettings.defaultThreadEnvMode,
         });
       };
-      const logicalProjectKey = project
-        ? deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings)
-        : scopedProjectKey(projectRef);
+      const logicalProjectKey =
+        projectRef.projectId === null
+          ? projectlessDraftKey(projectRef.environmentId)
+          : project
+            ? deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings)
+            : scopedProjectKey(projectRef as ScopedProjectRef);
       const hasBranchOption = options?.branch !== undefined;
       const hasWorktreePathOption = options?.worktreePath !== undefined;
       const hasEnvModeOption = options?.envMode !== undefined;

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -177,10 +177,12 @@ export function useThreadActionMenu(input: {
         };
         switch (action) {
           case "new-thread-on-branch": {
+            if (thread.projectId === null) return;
+            const projectId = thread.projectId;
             // Explicit branch carry-over: reuse the thread's worktree when it
             // has one, otherwise its branch on the local checkout.
             const result = await settlePromise(() =>
-              handleNewThread(scopeProjectRef(threadRef.environmentId, thread.projectId), {
+              handleNewThread(scopeProjectRef(threadRef.environmentId, projectId), {
                 branch: thread.branch,
                 worktreePath: thread.worktreePath,
                 envMode: thread.worktreePath ? "worktree" : "local",

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -242,7 +242,11 @@ export function useThreadActions() {
 
       if (shouldNavigateToDraft) {
         const navigationResult = await settlePromise(() =>
-          handleNewThreadRef.current(scopeProjectRef(thread.environmentId, thread.projectId)),
+          handleNewThreadRef.current(
+            thread.projectId === null
+              ? { environmentId: thread.environmentId, projectId: null }
+              : scopeProjectRef(thread.environmentId, thread.projectId),
+          ),
         );
         if (navigationResult._tag === "Failure") {
           return navigationResult;
@@ -288,10 +292,13 @@ export function useThreadActions() {
         const shell = readThreadShell(ref);
         return shell === null ? [] : [shell];
       });
-      const threadProject = readProject({
-        environmentId: threadRef.environmentId,
-        projectId: thread.projectId,
-      });
+      const threadProject =
+        thread.projectId === null
+          ? null
+          : readProject({
+              environmentId: threadRef.environmentId,
+              projectId: thread.projectId,
+            });
       const deletedIds =
         opts.deletedThreadKeys && opts.deletedThreadKeys.size > 0
           ? new Set<ThreadId>(
@@ -364,10 +371,12 @@ export function useThreadActions() {
       }
       refreshArchivedThreadsForEnvironment(threadRef.environmentId);
       clearComposerDraftForThread(threadRef);
-      clearProjectDraftThreadById(
-        scopeProjectRef(threadRef.environmentId, thread.projectId),
-        threadRef,
-      );
+      if (thread.projectId !== null) {
+        clearProjectDraftThreadById(
+          scopeProjectRef(threadRef.environmentId, thread.projectId),
+          threadRef,
+        );
+      }
       clearTerminalUiState(threadRef);
 
       if (shouldNavigateToFallback) {

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -1,15 +1,15 @@
 import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentId, ProjectId, ScopedProjectRef } from "@t3tools/contracts";
-import type { DraftThreadEnvMode } from "../composerDraftStore";
+import type { DraftThreadEnvMode, DraftThreadTargetRef } from "../composerDraftStore";
 
 interface ThreadContextLike {
   environmentId: EnvironmentId;
-  projectId: ProjectId;
+  projectId: ProjectId | null;
 }
 
 interface NewThreadHandler {
   (
-    projectRef: ScopedProjectRef,
+    projectRef: DraftThreadTargetRef,
     options?: {
       branch?: string | null;
       worktreePath?: string | null;
@@ -35,15 +35,19 @@ export function resolveNewDraftStartFromOrigin(input: {
 
 export function resolveThreadActionProjectRef(
   context: ChatThreadActionContext,
-): ScopedProjectRef | null {
+): DraftThreadTargetRef | null {
   if (context.activeThread) {
-    return scopeProjectRef(context.activeThread.environmentId, context.activeThread.projectId);
+    return context.activeThread.projectId === null
+      ? { environmentId: context.activeThread.environmentId, projectId: null }
+      : scopeProjectRef(context.activeThread.environmentId, context.activeThread.projectId);
   }
   if (context.activeDraftThread) {
-    return scopeProjectRef(
-      context.activeDraftThread.environmentId,
-      context.activeDraftThread.projectId,
-    );
+    return context.activeDraftThread.projectId === null
+      ? { environmentId: context.activeDraftThread.environmentId, projectId: null }
+      : scopeProjectRef(
+          context.activeDraftThread.environmentId,
+          context.activeDraftThread.projectId,
+        );
   }
   return context.defaultProjectRef;
 }

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -12,9 +12,10 @@ import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import {
   useAllEnvironmentShellsBootstrapped,
   useProjects,
+  useServerConfigs,
   useThreadShells,
 } from "../state/entities";
-import { useEnvironments } from "../state/environments";
+import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { APP_DISPLAY_NAME } from "~/branding";
 import { hasCloudPublicConfig } from "~/cloud/publicConfig";
 import { cn } from "~/lib/utils";
@@ -41,6 +42,8 @@ function IndexDraftLanding() {
   const threads = useThreadShells();
   const bootstrapped = useAllEnvironmentShellsBootstrapped();
   const handleNewThread = useNewThreadHandler();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const serverConfigs = useServerConfigs();
   const startingRef = useRef(false);
   const [startState, setStartState] = useState({ failed: false, retryRequest: 0 });
 
@@ -80,7 +83,19 @@ function IndexDraftLanding() {
       />
     ) : null;
   }
-  return <NoProjectsHero />;
+  return (
+    <NoProjectsHero
+      onStartWithoutProject={
+        primaryEnvironmentId && serverConfigs.get(primaryEnvironmentId)?.projectlessThreads === true
+          ? () =>
+              handleNewThread(
+                { environmentId: primaryEnvironmentId, projectId: null },
+                { replace: true },
+              )
+          : null
+      }
+    />
+  );
 }
 
 function DraftStartError({ onRetry }: { readonly onRetry: () => void }) {
@@ -104,7 +119,11 @@ function DraftStartError({ onRetry }: { readonly onRetry: () => void }) {
   );
 }
 
-function NoProjectsHero() {
+function NoProjectsHero({
+  onStartWithoutProject,
+}: {
+  readonly onStartWithoutProject: (() => Promise<void>) | null;
+}) {
   const openAddProject = useCallback(() => openCommandPalette({ open: "add-project" }), []);
 
   return (
@@ -117,13 +136,18 @@ function NoProjectsHero() {
                 What should we work on?
               </EmptyTitle>
               <EmptyDescription className="mt-2 text-sm text-muted-foreground/78">
-                Add a project to start your first thread.
+                Add a project, or start a thread without one.
               </EmptyDescription>
-              <div className="mt-6 flex justify-center">
+              <div className="mt-6 flex flex-wrap justify-center gap-2">
                 <Button size="sm" onClick={openAddProject}>
                   <PlusIcon className="size-4" />
                   Add project
                 </Button>
+                {onStartWithoutProject ? (
+                  <Button size="sm" variant="outline" onClick={() => void onStartWithoutProject()}>
+                    Start without a project
+                  </Button>
+                ) : null}
               </div>
             </EmptyHeader>
           </div>

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -11,7 +11,7 @@ import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
+import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { resolveShortcutCommand } from "../keybindings";
@@ -44,16 +44,9 @@ function ChatRouteGlobalShortcuts() {
       }).length,
     [primaryEnvironmentId, projectGroupingSettings, projects],
   );
-  const contextualTarget = resolveThreadActionProjectRef({
-    activeDraftThread,
-    activeThread: activeThread ?? undefined,
-    defaultProjectRef,
-    handleNewThread,
-  });
-  const newThreadEnvironmentId = contextualTarget?.environmentId ?? primaryEnvironmentId;
-  const supportsProjectlessThreads =
-    newThreadEnvironmentId !== null &&
-    serverConfigs.get(newThreadEnvironmentId)?.projectlessThreads === true;
+  const supportsProjectlessThreads = [...serverConfigs.values()].some(
+    (config) => config.projectlessThreads === true,
+  );
   const terminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -5,13 +5,13 @@ import { useEffect, useMemo } from "react";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useLegacySidebarEnabled } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
-import { useProjects } from "../state/entities";
+import { useProjects, useServerConfigs } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import { startNewThreadFromContext } from "../lib/chatThreadActions";
+import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { resolveShortcutCommand } from "../keybindings";
@@ -21,6 +21,7 @@ import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { stackedThreadToast, toastManager } from "~/components/ui/toast";
 import { primaryServerKeybindingsAtom } from "~/state/server";
+import { shouldOpenNewThreadTargetPicker } from "../components/CommandPalette.logic";
 
 function ChatRouteGlobalShortcuts() {
   const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
@@ -31,6 +32,7 @@ function ChatRouteGlobalShortcuts() {
   const legacySidebarEnabled = useLegacySidebarEnabled();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();
+  const serverConfigs = useServerConfigs();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const projectGroupCount = useMemo(
     () =>
@@ -42,6 +44,16 @@ function ChatRouteGlobalShortcuts() {
       }).length,
     [primaryEnvironmentId, projectGroupingSettings, projects],
   );
+  const contextualTarget = resolveThreadActionProjectRef({
+    activeDraftThread,
+    activeThread: activeThread ?? undefined,
+    defaultProjectRef,
+    handleNewThread,
+  });
+  const newThreadEnvironmentId = contextualTarget?.environmentId ?? primaryEnvironmentId;
+  const supportsProjectlessThreads =
+    newThreadEnvironmentId !== null &&
+    serverConfigs.get(newThreadEnvironmentId)?.projectlessThreads === true;
   const terminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
@@ -92,10 +104,13 @@ function ChatRouteGlobalShortcuts() {
       if (command === "chat.new") {
         event.preventDefault();
         event.stopPropagation();
-        // The default sidebar routes creation through the command palette
-        // whenever there is a real choice to make; the legacy sidebar (and
-        // single-project setups) keep the immediate contextual create.
-        if (!legacySidebarEnabled && projectGroupCount > 1) {
+        if (
+          shouldOpenNewThreadTargetPicker({
+            legacySidebarEnabled,
+            projectGroupCount,
+            supportsProjectlessThreads,
+          })
+        ) {
           openCommandPalette({ open: "new-thread-in" });
           return;
         }
@@ -168,6 +183,7 @@ function ChatRouteGlobalShortcuts() {
     routeThreadRef,
     selectedThreadKeysSize,
     legacySidebarEnabled,
+    supportsProjectlessThreads,
     terminalOpen,
   ]);
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -62,6 +62,10 @@ at. To keep a worktree, use the explicit "new thread in this worktree" action in
 toolbar. The only difference between the two commands: with the current sidebar and more than one
 project, `chat.new` opens a project chooser first.
 
+The new-thread picker and Command Palette also offer **Don't work in a project**. This creates an
+environment-scoped thread with no project association; the provider runs from that environment's
+default working directory.
+
 ## `when` Conditions
 
 A `when` expression is evaluated against context keys describing the current UI state. The keys

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -4,6 +4,12 @@ Pin a thread from its context menu to keep it in the pinned section above your a
 Pinned threads are shown independently of their project, including when you connect to more than
 one environment.
 
+## Start without a project
+
+Choose **Don't work in a project** from the new-thread project picker to start a thread in the
+selected environment's default working directory. These threads appear under **No project** and
+do not offer project-only branch, worktree, checkpoint, or source-control controls.
+
 On web and desktop, drag a pinned thread to change its position. On mobile, open the thread's menu
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -80,6 +80,7 @@ export function applyThreadDetailEvent(
         thread: {
           id: event.payload.threadId,
           projectId: event.payload.projectId,
+          workspaceRoot: event.payload.workspaceRoot ?? null,
           title: event.payload.title,
           modelSelection: event.payload.modelSelection,
           runtimeMode: event.payload.runtimeMode,

--- a/packages/client-runtime/src/state/threadShell.ts
+++ b/packages/client-runtime/src/state/threadShell.ts
@@ -75,6 +75,7 @@ export function createEnvironmentThreadShellAtoms(input: {
     return Atom.make((get) => {
       const grouped = new Map<ProjectId, ScopedThreadRef[]>();
       for (const thread of get(environmentThreadsAtom(environmentId))) {
+        if (thread.projectId === null) continue;
         const refs = grouped.get(thread.projectId);
         const ref = { environmentId, threadId: thread.id };
         if (refs === undefined) {

--- a/packages/client-runtime/src/state/threadSort.ts
+++ b/packages/client-runtime/src/state/threadSort.ts
@@ -91,7 +91,7 @@ export function sortThreads<T extends { readonly id: string } & ThreadSortInput>
 export function getLatestThreadForProject<
   T extends {
     readonly id: string;
-    readonly projectId: ProjectId;
+    readonly projectId: ProjectId | null;
     readonly archivedAt: string | null;
   } & ThreadSortInput,
 >(threads: readonly T[], projectId: ProjectId, sortOrder: SidebarThreadSortOrder): T | null {

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -294,6 +294,39 @@ it.effect("accepts bootstrap metadata in thread.turn.start", () =>
   }),
 );
 
+it.effect("accepts a projectless thread bootstrap target", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeThreadTurnStartCommand({
+      type: "thread.turn.start",
+      commandId: "cmd-projectless-bootstrap",
+      threadId: "thread-projectless",
+      message: {
+        messageId: "msg-projectless-bootstrap",
+        role: "user",
+        text: "hello",
+        attachments: [],
+      },
+      bootstrap: {
+        createThread: {
+          projectId: null,
+          workspaceRoot: null,
+          title: "Projectless thread",
+          modelSelection: { provider: "codex", model: "gpt-5.4" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    assert.strictEqual(parsed.bootstrap?.createThread?.projectId, null);
+    assert.strictEqual(parsed.bootstrap?.createThread?.workspaceRoot, null);
+  }),
+);
+
 it.effect("decodes thread.created runtime mode for historical events", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeThreadCreatedPayload({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -363,7 +363,8 @@ export type ThreadTitleRegeneration = typeof ThreadTitleRegeneration.Type;
 
 export const OrchestrationThread = Schema.Struct({
   id: ThreadId,
-  projectId: ProjectId,
+  projectId: Schema.NullOr(ProjectId),
+  workspaceRoot: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
@@ -433,7 +434,8 @@ export type OrchestrationProjectShell = typeof OrchestrationProjectShell.Type;
 
 export const OrchestrationThreadShell = Schema.Struct({
   id: ThreadId,
-  projectId: ProjectId,
+  projectId: Schema.NullOr(ProjectId),
+  workspaceRoot: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
@@ -654,7 +656,8 @@ const ThreadCreateCommand = Schema.Struct({
   type: Schema.Literal("thread.create"),
   commandId: CommandId,
   threadId: ThreadId,
-  projectId: ProjectId,
+  projectId: Schema.NullOr(ProjectId),
+  workspaceRoot: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
@@ -783,7 +786,8 @@ const ThreadInteractionModeSetCommand = Schema.Struct({
 });
 
 const ThreadTurnStartBootstrapCreateThread = Schema.Struct({
-  projectId: ProjectId,
+  projectId: Schema.NullOr(ProjectId),
+  workspaceRoot: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
@@ -1110,7 +1114,8 @@ export const ProjectDeletedPayload = Schema.Struct({
 
 export const ThreadCreatedPayload = Schema.Struct({
   threadId: ThreadId,
-  projectId: ProjectId,
+  projectId: Schema.NullOr(ProjectId),
+  workspaceRoot: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
@@ -1589,7 +1594,7 @@ export type OrchestrationSearchThreadsInput = typeof OrchestrationSearchThreadsI
 
 export const OrchestrationThreadSearchMatch = Schema.Struct({
   threadId: ThreadId,
-  projectId: ProjectId,
+  projectId: Schema.NullOr(ProjectId),
   source: OrchestrationThreadSearchSource,
   snippet: Schema.String.check(Schema.isMaxLength(240)),
   messageCreatedAt: Schema.NullOr(IsoDateTime),

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -421,6 +421,8 @@ export const ServerConfig = Schema.Struct({
   environment: ExecutionEnvironmentDescriptor,
   auth: ServerAuthDescriptor,
   cwd: TrimmedNonEmptyString,
+  /** Server supports durable threads that are not attached to a project. */
+  projectlessThreads: Schema.optionalKey(Schema.Boolean),
   keybindingsConfigPath: TrimmedNonEmptyString,
   keybindings: ResolvedKeybindingsConfig,
   issues: ServerConfigIssues,


### PR DESCRIPTION
## What Changed

Adds a first-class projectless thread target across web, desktop, mobile, and the server.

- Adds **Don't work in a project** to new-thread project pickers and the zero-project landing state.
- Persists projectless threads with `projectId: null` and an environment-local execution directory.
- Keeps project-backed threads on their existing dynamic project/worktree resolution path.
- Shows projectless threads under an environment-scoped **No project** group after reconnect or reload.
- Hides or rejects project-only behavior such as branches, worktrees, setup scripts, Git controls, checkpoints, and reverts.
- Adds capability gating so older remote environments do not receive unsupported commands.
- Adds the SQLite migration, projection/query support, focused tests, and user documentation.

## Why

Starting a thread currently requires creating or selecting a project, even for questions and tasks that are not tied to a repository. This makes lightweight or environment-level work unnecessarily awkward.

Projectless threads are modeled explicitly instead of creating a hidden project record. The server remains authoritative for their working directory, so local, remote, relay, and tunnel clients resolve the correct environment consistently.

## UI Changes

The new-thread workspace menu now offers **Don't work in a project**. Once selected, the composer becomes projectless and removes branch/worktree controls. Created threads remain available under **No project** in the sidebar.

| Before | After |
| --- | --- |
| ![Before: new-thread menu requires a project](https://raw.githubusercontent.com/Bhanu1776/t3code/pr-assets-5822/projectless-thread-before.png) | ![After: new-thread menu includes Don't work in a project](https://raw.githubusercontent.com/Bhanu1776/t3code/pr-assets-5822/projectless-thread-after.png) |

## Verification

- Created a real projectless web thread, sent a prompt, received the provider response, reloaded, and reopened it from **No project**.
- Confirmed the persisted thread has `project_id = NULL` and the environment server's execution directory.
- `181` focused tests across contracts, server orchestration/persistence, and web logic.
- Server, web, and mobile typechecks.
- Changed-file lint and formatting checks.
- `git diff --check`.
- Independent review followed by fixes for historical event replay, point-query hydration, legacy-sidebar visibility, migration defaults/indexes, and rejected attachment persistence.

Mobile visual verification could not run on this host because it has neither an installed iOS Simulator runtime nor an Android AVD. Mobile typechecking and focused logic validation passed.

## Checklist

- [x] This PR is focused on projectless thread creation and lifecycle support.
- [x] I explained what changed and why.
- [x] Before/after screenshots attached to the PR.
- [x] Web interaction verified in a real client.
- [x] Focused tests and relevant typechecks pass.

Built with GPT-5.6-Sol via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add projectless thread support across web, mobile, and server
> - Threads can now be created without a project association, using an environment's default working directory as their workspace root instead of a project-scoped path.
> - Schema changes across contracts, orchestration, and persistence allow `projectId` to be null and add an optional `workspaceRoot` field to threads, events, and projections; a new DB migration (041) makes `project_id` nullable in `projection_threads`.
> - Web sidebar, command palette, draft hero, and chat view are updated to show 'No project' for projectless threads and offer a 'Don't work in a project' action when the server advertises `projectlessThreads: true` in its config.
> - Mobile home screen, archive list, new-task flow, and thread route screen are updated to group and label projectless threads, hide git/branch controls for them, and support navigating to a projectless draft.
> - Server-side orchestration (decider, normalizer, checkpoint reactor, provider reactor, awareness relay) skips project lookups for projectless threads and rejects invalid combinations like worktree setup without a project.
> - Risk: existing threads with a project are unaffected, but the DB migration rebuilds `projection_threads` in place; any deployment rollback would need to handle the now-nullable `project_id` column.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5566cfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
