### PR TITLE
fix(web): wait for usage refresh completion

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -449,22 +449,11 @@ function UsageDeviceStrip({
   readonly environments: readonly EnvironmentUsageStatus[];
 }) {
   const scanning = environments.filter(
-    (environment) => environment.summary === null && environment.error === null,
+    (environment) => environment.isPending && environment.error === null,
   );
   return (
     <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 border border-border px-3 py-2 text-xs">
       {environments.map((environment) => {
-        if (environment.summary !== null) {
-          return (
-            <span
-              key={environment.environmentId}
-              className="flex items-center gap-1 text-foreground"
-            >
-              <CheckIcon className="size-3 text-emerald-600 dark:text-emerald-300/90" aria-hidden />
-              {environment.label}
-            </span>
-          );
-        }
         if (environment.error !== null) {
           return (
             <span
@@ -472,6 +461,17 @@ function UsageDeviceStrip({
               className="flex items-center gap-1 text-destructive"
             >
               <XIcon className="size-3" aria-hidden />
+              {environment.label}
+            </span>
+          );
+        }
+        if (!environment.isPending && environment.summary !== null) {
+          return (
+            <span
+              key={environment.environmentId}
+              className="flex items-center gap-1 text-foreground"
+            >
+              <CheckIcon className="size-3 text-emerald-600 dark:text-emerald-300/90" aria-hidden />
               {environment.label}
             </span>
           );

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -7,28 +7,21 @@
  * @module state/usage
  */
 import { useAtomValue } from "@effect/atom-react";
-import {
-  USAGE_CONTRACT_VERSION,
-  type EnvironmentId,
-  type UsageSummary,
-  type UsageSummaryInput,
-} from "@t3tools/contracts";
-import * as Option from "effect/Option";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
+import { USAGE_CONTRACT_VERSION, type UsageSummaryInput } from "@t3tools/contracts";
+import { Atom } from "effect/unstable/reactivity";
 import { useCallback, useMemo } from "react";
 
 import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
+import {
+  deriveEnvironmentUsageStatus,
+  deriveUsageSettlingState,
+  type EnvironmentUsageStatus,
+} from "./usageStatus";
 
-export interface EnvironmentUsageStatus {
-  readonly environmentId: EnvironmentId;
-  readonly label: string;
-  readonly isPending: boolean;
-  readonly error: string | null;
-  readonly summary: UsageSummary | null;
-}
+export type { EnvironmentUsageStatus } from "./usageStatus";
 
 /**
  * Reads every environment's summary for one window.
@@ -45,13 +38,14 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
     const statuses: EnvironmentUsageStatus[] = [];
     for (const [environmentId, presentation] of presentations) {
       const result = get(serverEnvironment.usageSummary({ environmentId, input }));
-      statuses.push({
-        environmentId,
-        label: presentation.entry.target.label,
-        isPending: result.waiting,
-        error: result._tag === "Failure" ? "This environment could not report usage." : null,
-        summary: Option.getOrNull(AsyncResult.value(result)),
-      });
+      statuses.push(
+        deriveEnvironmentUsageStatus({
+          connectionPhase: presentation.connection.phase,
+          result,
+          environmentId,
+          label: presentation.entry.target.label,
+        }),
+      );
     }
     return statuses;
   }).pipe(Atom.withLabel(`web-usage:window:${windowKey}`)),
@@ -111,16 +105,13 @@ export function useUsage(input: UsageSummaryInput): UsageView {
     return mergeUsage(answered, USAGE_CONTRACT_VERSION);
   }, [environments]);
 
-  const answeredCount = environments.filter((environment) => environment.summary !== null).length;
-  const stillReporting = environments.filter(
-    (environment) => environment.summary === null && environment.error === null,
-  ).length;
+  const settling = deriveUsageSettlingState(environments);
 
   return {
     merged,
     environments,
-    isPending: answeredCount === 0 && stillReporting > 0,
-    isPartial: answeredCount > 0 && stillReporting > 0,
+    isPending: settling.isPending,
+    isPartial: settling.isPartial,
     refresh,
   };
 }

--- a/apps/web/src/state/usageStatus.test.ts
+++ b/apps/web/src/state/usageStatus.test.ts
@@ -1,0 +1,157 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
+import {
+  USAGE_CONTRACT_VERSION,
+  type EnvironmentId,
+  type UsageDay,
+  type UsageSummary,
+} from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import { describe, expect, it } from "vite-plus/test";
+
+import { deriveEnvironmentUsageStatus, deriveUsageSettlingState } from "./usageStatus";
+
+const summary: UsageSummary = {
+  contractVersion: USAGE_CONTRACT_VERSION,
+  readAt: "2026-08-09T00:00:00.000Z",
+  timeZone: "UTC",
+  sinceDay: "2026-08-01" as UsageDay,
+  untilDay: "2026-08-09" as UsageDay,
+  buckets: [],
+  sources: [],
+  pricing: { status: "fresh", source: "litellm", fetchedAt: null, knownModels: 0 },
+  scanDurationMs: 1,
+};
+
+const freshSummary: UsageSummary = {
+  ...summary,
+  readAt: "2026-08-09T00:01:00.000Z",
+  scanDurationMs: 2,
+};
+
+function status(
+  environmentId: string,
+  connectionPhase: EnvironmentConnectionPhase,
+  result: AsyncResult.AsyncResult<UsageSummary, string>,
+) {
+  return deriveEnvironmentUsageStatus({
+    environmentId: environmentId as EnvironmentId,
+    label: environmentId,
+    connectionPhase,
+    result,
+  });
+}
+
+describe("usage status", () => {
+  it("settles a refresh only after every environment answers the new request", () => {
+    const macRefreshing = status(
+      "mac",
+      "connected",
+      AsyncResult.success<UsageSummary, string>(summary, { waiting: true }),
+    );
+    const linuxRefreshing = status(
+      "linux",
+      "connected",
+      AsyncResult.success<UsageSummary, string>(summary, { waiting: true }),
+    );
+
+    expect(macRefreshing.summary).toBe(summary);
+    expect(deriveUsageSettlingState([macRefreshing, linuxRefreshing])).toEqual({
+      isPending: true,
+      isPartial: false,
+    });
+
+    const macFinished = status("mac", "connected", AsyncResult.success(summary));
+    expect(deriveUsageSettlingState([macFinished, linuxRefreshing])).toEqual({
+      isPending: false,
+      isPartial: true,
+    });
+
+    const linuxFinished = status("linux", "connected", AsyncResult.success(summary));
+    expect(deriveUsageSettlingState([macFinished, linuxFinished])).toEqual({
+      isPending: false,
+      isPartial: false,
+    });
+  });
+
+  it("waits while an environment makes its initial connection", () => {
+    expect(
+      status("connecting", "connecting", AsyncResult.initial<UsageSummary, string>(true)),
+    ).toEqual(expect.objectContaining({ isPending: true, error: null, summary: null }));
+  });
+
+  it("waits for a connected environment's first usage result", () => {
+    expect(status("connected", "connected", AsyncResult.initial<UsageSummary, string>())).toEqual(
+      expect.objectContaining({ isPending: true, error: null, summary: null }),
+    );
+  });
+
+  it("waits through reconnect and a fresh scan before completing", () => {
+    const reconnecting = status("laptop", "reconnecting", AsyncResult.success(summary));
+    const refreshing = status(
+      "laptop",
+      "connected",
+      AsyncResult.success<UsageSummary, string>(summary, { waiting: true }),
+    );
+    const refreshed = status("laptop", "connected", AsyncResult.success(freshSummary));
+
+    expect(reconnecting).toEqual(
+      expect.objectContaining({ isPending: true, error: null, summary }),
+    );
+    expect(refreshing).toEqual(expect.objectContaining({ isPending: true, error: null, summary }));
+    expect(refreshed).toEqual(
+      expect.objectContaining({ isPending: false, error: null, summary: freshSummary }),
+    );
+  });
+
+  it("settles terminal connection phases without a completed summary as failures", () => {
+    for (const connectionPhase of ["available", "offline", "error"] as const) {
+      expect(
+        status("offline", connectionPhase, AsyncResult.initial<UsageSummary, string>(true)),
+      ).toEqual(
+        expect.objectContaining({
+          isPending: false,
+          error: "This environment could not report usage.",
+          summary: null,
+        }),
+      );
+    }
+  });
+
+  it("keeps a completed summary when its environment later disconnects", () => {
+    const result = AsyncResult.success<UsageSummary, string>(summary);
+    const connected = status("laptop", "connected", result);
+    const disconnected = status("laptop", "offline", result);
+
+    expect(connected).toEqual(expect.objectContaining({ isPending: false, error: null, summary }));
+    expect(disconnected).toEqual(connected);
+  });
+
+  it("drops a retained previous summary when its refresh fails", () => {
+    const previous = AsyncResult.success<UsageSummary, string>(summary);
+    const retrying = AsyncResult.failWithPrevious("scan failed", {
+      previous: Option.some(previous),
+      waiting: true,
+    });
+    const failed = AsyncResult.failWithPrevious("scan failed", {
+      previous: Option.some(previous),
+    });
+
+    expect(status("desktop", "connected", retrying)).toEqual(
+      expect.objectContaining({ isPending: true, error: null, summary }),
+    );
+
+    const failedStatus = status("desktop", "connected", failed);
+    expect(failedStatus).toEqual(
+      expect.objectContaining({
+        isPending: false,
+        error: "This environment could not report usage.",
+        summary: null,
+      }),
+    );
+    expect(deriveUsageSettlingState([failedStatus])).toEqual({
+      isPending: false,
+      isPartial: false,
+    });
+  });
+});

--- a/apps/web/src/state/usageStatus.ts
+++ b/apps/web/src/state/usageStatus.ts
@@ -1,0 +1,81 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
+import type { EnvironmentId, UsageSummary } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+
+const USAGE_REPORT_ERROR = "This environment could not report usage.";
+
+export interface EnvironmentUsageStatus {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly isPending: boolean;
+  readonly error: string | null;
+  readonly summary: UsageSummary | null;
+}
+
+type UsageConnectionState = "connected" | "transitioning" | "terminal";
+
+/**
+ * Connection phases decide whether a usage request can still make progress.
+ * Keeping this exhaustive makes a newly added phase an explicit product
+ * decision instead of silently treating it as a failure.
+ */
+function classifyUsageConnection(phase: EnvironmentConnectionPhase): UsageConnectionState {
+  switch (phase) {
+    case "connected":
+      return "connected";
+    case "connecting":
+    case "reconnecting":
+      return "transitioning";
+    case "available":
+    case "offline":
+    case "error":
+      return "terminal";
+  }
+}
+
+/** Projects transport and SWR state into the status rendered for one environment. */
+export function deriveEnvironmentUsageStatus<E>(input: {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly connectionPhase: EnvironmentConnectionPhase;
+  readonly result: AsyncResult.AsyncResult<UsageSummary, E>;
+}): EnvironmentUsageStatus {
+  const connection = classifyUsageConnection(input.connectionPhase);
+  const isPending =
+    connection === "transitioning" ||
+    (connection === "connected" && (input.result.waiting || input.result._tag === "Initial"));
+  const summary = Option.getOrNull(AsyncResult.value(input.result));
+  const hasTerminalQueryFailure = input.result._tag === "Failure" && !isPending;
+  return {
+    environmentId: input.environmentId,
+    label: input.label,
+    isPending,
+    error:
+      hasTerminalQueryFailure || (connection === "terminal" && summary === null)
+        ? USAGE_REPORT_ERROR
+        : null,
+    summary: hasTerminalQueryFailure ? null : summary,
+  };
+}
+
+/** Derives the page gate for the current request generation. */
+export function deriveUsageSettlingState(environments: readonly EnvironmentUsageStatus[]): {
+  readonly isPending: boolean;
+  readonly isPartial: boolean;
+} {
+  // SWR preserves the previous summary while a refresh is in flight. A
+  // retained value belongs to the previous request, so it does not count as
+  // this request having answered until `waiting` clears.
+  const answeredCount = environments.filter(
+    (environment) => environment.summary !== null && !environment.isPending,
+  ).length;
+  const stillReporting = environments.filter(
+    (environment) => environment.isPending && environment.error === null,
+  ).length;
+
+  return {
+    isPending: answeredCount === 0 && stillReporting > 0,
+    isPartial: answeredCount > 0 && stillReporting > 0,
+  };
+}


### PR DESCRIPTION
## What Changed

- Treat a retained SWR usage summary as belonging to the previous request until that environment's current refresh finishes.
- Derive each environment's usage state from both its connection phase and its current `AsyncResult`, so retries, terminal failures, and reconnects settle consistently.
- Keep the existing wait-for-all product behavior while making the device strip show the current scan generation truthfully.
- Add focused state tests for retained summaries, refresh failures, connecting/reconnecting environments, and terminal transport states.

## Why

The usage page intentionally waits for every environment before revealing totals, because rendering each response progressively makes every number jump. During a manual refresh, however, SWR retains the old summary; the previous state derivation counted that stale value as a current answer, so the old dashboard could remain visible with no scan indication. A failed refresh with a previous success could also leak that stale summary, while some terminal connection states could leave the gate pending.

This preserves the established loading decision and fixes the refresh-generation issues identified in [review thread 1](https://github.com/pingdotgg/t3code/pull/5772#discussion_r3742298141) and [review thread 2](https://github.com/pingdotgg/t3code/pull/5772#discussion_r3742301096).

Verification:

- `vp test run src/state/usageStatus.test.ts --project unit` — 7 passed
- Targeted `vp lint` and `vp fmt --check` on the four touched files
- `vp run --filter @t3tools/web typecheck`
- `git diff upstream/main...HEAD --check`

## UI Changes

Captured against the same local, synthetic two-environment fixture. Alpha finishes in about 0.9s; Beta finishes in about 3.5s.

| Before: retained totals stay visible during refresh | After: current device progress and skeleton |
| --- | --- |
| ![Before refresh](https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-refresh-gate/.github/pr-assets/usage-refresh-gate/before.png) | ![After refresh](https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-refresh-gate/.github/pr-assets/usage-refresh-gate/after-partial.png) |

[Watch the complete refresh settle from loaded → both scanning → one complete → fully loaded](https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-refresh-gate/.github/pr-assets/usage-refresh-gate/after.mp4)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with GPT-5.6 Sol via the Codex harness in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix usage refresh completion detection to wait for in-flight refreshes
> - Introduces `deriveEnvironmentUsageStatus` and `deriveUsageSettlingState` in [usageStatus.ts](https://github.com/pingdotgg/t3code/pull/5825/files#diff-0b393fc16afe0758a288e74f99bbaf2775d98a40837a9efc032f8a6770d84ab4) to centralize per-environment and page-level pending/partial state logic.
> - Each environment's `isPending`/`error`/`summary` now accounts for transport connection phase (including transitions and terminal states), not just the SWR `AsyncResult` state.
> - The `UsageDeviceStrip` component in [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/5825/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) now shows a check only when the environment is non-pending with a summary, and shows an error immediately when `environment.error` is set.
> - Behavioral Change: the hook's `isPending` and `isPartial` flags now require non-pending answers before settling, so a refresh retaining a previous summary no longer prematurely marks the request as complete.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12e19a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused web usage UI/state change with new unit tests; no auth, security, or data-pipeline impact.
> 
> **Overview**
> Fixes the usage page treating **stale SWR summaries** as finished answers during a manual refresh, which could leave old totals visible with no scan indication.
> 
> **Centralizes status logic** in new `usageStatus.ts`: `deriveEnvironmentUsageStatus` combines **connection phase** (connecting/reconnecting vs terminal offline/error) with **`AsyncResult`** (`waiting`, initial, failure) for each environment; `deriveUsageSettlingState` only counts an environment as answered when it has a summary **and** is not pending.
> 
> `useUsage` wires those helpers instead of inline checks. **`UsageDeviceStrip`** uses `isPending` for the scanning state and shows errors before success vs in-flight rows.
> 
> Adds **unit tests** for refresh generations, reconnect, terminal transport, retained summaries on disconnect, and failed refresh clearing stale data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e19a4bce774b2944bc1168a3edfc547caf2ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->