### PR TITLE
feat(usage): filter dashboard by device

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -1,5 +1,7 @@
 import { useNavigation } from "@react-navigation/native";
-import type { MergedUsage } from "@t3tools/shared/usageMerge";
+import type { MenuAction } from "@react-native-menu/menu";
+import type { EnvironmentId } from "@t3tools/contracts";
+import type { DeviceUsageOption, MergedUsage } from "@t3tools/shared/usageMerge";
 import {
   enumerateDays,
   formatCount,
@@ -9,12 +11,13 @@ import {
   formatUsd,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Platform, Pressable, RefreshControl, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { AppText as Text } from "../../components/AppText";
+import { ControlPill, ControlPillMenu } from "../../components/ControlPill";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
 import { SettingsSection } from "../settings/components/SettingsSection";
@@ -29,17 +32,34 @@ const WINDOW_OPTIONS = [
 ] as const;
 
 const CHART_HEIGHT = 180;
+const ALL_DEVICES_VALUE = "all-devices";
 
 export function UsageRouteScreen() {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
   const [windowDays, setWindowDays] = useState<number>(30);
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
+  const [requestedEnvironmentId, setRequestedEnvironmentId] = useState<EnvironmentId | null>(null);
 
   // Recomputed only when the window length changes, so a re-render does not
   // shift the range and refetch every environment.
   const window = useMemo(() => makeWindow(windowDays), [windowDays]);
-  const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
+  const {
+    merged,
+    environments,
+    selectedEnvironmentId,
+    shouldResetRequestedEnvironment,
+    deviceOptions,
+    isPending,
+    isPartial,
+    refresh,
+  } = useUsage(window, requestedEnvironmentId);
+
+  // Persist the derived fallback so a device that later reconnects does not
+  // silently reselect itself after it disappeared or returned stale data.
+  if (shouldResetRequestedEnvironment) {
+    setRequestedEnvironmentId(null);
+  }
 
   const days = useMemo(
     () => enumerateDays(window.sinceDay, window.untilDay),
@@ -67,6 +87,16 @@ export function UsageRouteScreen() {
         contentContainerStyle={{ paddingBottom: Math.max(insets.bottom, 18) + 18 }}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refresh} />}
       >
+        {!isPending &&
+        deviceOptions.length > 0 &&
+        (environments.length > 1 || selectedEnvironmentId !== null) ? (
+          <UsageDeviceMenu
+            options={deviceOptions}
+            selectedEnvironmentId={selectedEnvironmentId}
+            onSelect={setRequestedEnvironmentId}
+          />
+        ) : null}
+
         <SegmentedControl
           options={WINDOW_OPTIONS.map((option) => ({ value: option.days, label: option.label }))}
           selected={windowDays}
@@ -99,6 +129,60 @@ export function UsageRouteScreen() {
           </>
         )}
       </ScrollView>
+    </View>
+  );
+}
+
+function UsageDeviceMenu(props: {
+  readonly options: readonly DeviceUsageOption[];
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly onSelect: (environmentId: EnvironmentId | null) => void;
+}) {
+  const selectedLabel =
+    props.options.find((option) => option.environmentId === props.selectedEnvironmentId)?.label ??
+    "All devices";
+  const actions = useMemo<MenuAction[]>(
+    () => [
+      {
+        id: ALL_DEVICES_VALUE,
+        title: "All devices",
+        state: props.selectedEnvironmentId === null ? "on" : "off",
+      },
+      ...props.options.map((option) => ({
+        id: `device:${option.environmentId}`,
+        title: option.label,
+        state:
+          props.selectedEnvironmentId === option.environmentId ? ("on" as const) : ("off" as const),
+      })),
+    ],
+    [props.options, props.selectedEnvironmentId],
+  );
+  const handleAction = useCallback(
+    (event: { nativeEvent: { event: string } }) => {
+      const id = event.nativeEvent.event;
+      if (id === ALL_DEVICES_VALUE) {
+        props.onSelect(null);
+        return;
+      }
+      if (!id.startsWith("device:")) return;
+      const environmentId = id.slice("device:".length);
+      const selected = props.options.find((option) => option.environmentId === environmentId);
+      if (selected) props.onSelect(selected.environmentId);
+    },
+    [props],
+  );
+
+  return (
+    <View className="flex-row items-center justify-between gap-3">
+      <Text className="text-sm text-foreground-muted">Device</Text>
+      <ControlPillMenu actions={actions} isAnchoredToRight onPressAction={handleAction}>
+        <ControlPill
+          accessibilityLabel={`Usage device: ${selectedLabel}`}
+          icon="desktopcomputer"
+          label={selectedLabel}
+          variant="pill"
+        />
+      </ControlPillMenu>
     </View>
   );
 }

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -13,10 +13,14 @@ import { useAtomValue } from "@effect/atom-react";
 import {
   USAGE_CONTRACT_VERSION,
   type EnvironmentId,
-  type UsageSummary,
   type UsageSummaryInput,
 } from "@t3tools/contracts";
-import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
+import {
+  deriveUsageDisplay,
+  type DeviceUsageOption,
+  type EnvironmentUsageStatus,
+  type MergedUsage,
+} from "@t3tools/shared/usageMerge";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { useCallback, useMemo } from "react";
@@ -25,13 +29,7 @@ import { appAtomRegistry } from "./atom-registry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
 
-export interface EnvironmentUsageStatus {
-  readonly environmentId: EnvironmentId;
-  readonly label: string;
-  readonly isPending: boolean;
-  readonly error: string | null;
-  readonly summary: UsageSummary | null;
-}
+export type { EnvironmentUsageStatus } from "@t3tools/shared/usageMerge";
 
 /**
  * Reads every environment's summary for one window.
@@ -51,6 +49,7 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
       statuses.push({
         environmentId,
         label: presentation.entry.target.label,
+        isConnected: presentation.connection.phase === "connected",
         isPending: result.waiting,
         error: result._tag === "Failure" ? "This environment could not report usage." : null,
         summary: Option.getOrNull(AsyncResult.value(result)),
@@ -63,6 +62,9 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
 export interface UsageView {
   readonly merged: MergedUsage;
   readonly environments: readonly EnvironmentUsageStatus[];
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly shouldResetRequestedEnvironment: boolean;
+  readonly deviceOptions: readonly DeviceUsageOption[];
   /** True until at least one environment has answered. */
   readonly isPending: boolean;
   /**
@@ -74,7 +76,10 @@ export interface UsageView {
   readonly refresh: () => void;
 }
 
-export function useUsage(input: UsageSummaryInput): UsageView {
+export function useUsage(
+  input: UsageSummaryInput,
+  requestedEnvironmentId: EnvironmentId | null = null,
+): UsageView {
   const windowKey = useMemo(
     () =>
       JSON.stringify({
@@ -99,31 +104,19 @@ export function useUsage(input: UsageSummaryInput): UsageView {
     }
   }, [environments, windowKey]);
 
-  const merged = useMemo(() => {
-    const answered: EnvironmentUsage[] = environments.flatMap((environment) =>
-      environment.summary === null
-        ? []
-        : [
-            {
-              environmentId: environment.environmentId,
-              label: environment.label,
-              summary: environment.summary,
-            },
-          ],
-    );
-    return mergeUsage(answered, USAGE_CONTRACT_VERSION);
-  }, [environments]);
-
-  const answeredCount = environments.filter((environment) => environment.summary !== null).length;
-  const stillReporting = environments.filter(
-    (environment) => environment.summary === null && environment.error === null,
-  ).length;
+  const display = useMemo(
+    () => deriveUsageDisplay(environments, requestedEnvironmentId, USAGE_CONTRACT_VERSION),
+    [environments, requestedEnvironmentId],
+  );
 
   return {
-    merged,
+    merged: display.merged,
     environments,
-    isPending: answeredCount === 0 && stillReporting > 0,
-    isPartial: answeredCount > 0 && stillReporting > 0,
+    selectedEnvironmentId: display.selectedEnvironmentId,
+    shouldResetRequestedEnvironment: display.shouldResetRequestedEnvironment,
+    deviceOptions: display.deviceOptions,
+    isPending: display.isPending,
+    isPartial: display.isPartial,
     refresh,
   };
 }

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,6 +1,7 @@
-import type { UsageProviderKind } from "@t3tools/contracts";
+import type { EnvironmentId, UsageProviderKind } from "@t3tools/contracts";
+import type { DeviceUsageOption } from "@t3tools/shared/usageMerge";
 import { useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router";
-import { ArrowLeftIcon, CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
+import { ArrowLeftIcon, CheckIcon, MonitorIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { cn } from "../../lib/utils";
@@ -15,6 +16,7 @@ import {
   makeWindow,
 } from "@t3tools/shared/usageFormat";
 import { ScrollArea } from "../ui/scroll-area";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { UsageChartLegend, UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
 import { PROVIDER_COLOR, PROVIDER_LABEL, PROVIDER_MARK, PROVIDER_ORDER } from "./usageProviders";
 
@@ -24,10 +26,14 @@ const WINDOW_OPTIONS = [
   { days: 90, label: "90 days" },
 ] as const;
 
+const ALL_DEVICES_VALUE = "all-devices";
+const DEVICE_VALUE_PREFIX = "device:";
+
 export function UsagePage() {
   const [windowDays, setWindowDays] = useState<number>(30);
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
   const [breakdown, setBreakdown] = useState<"model" | "day">("model");
+  const [requestedEnvironmentId, setRequestedEnvironmentId] = useState<EnvironmentId | null>(null);
   const canGoBack = useCanGoBack();
   const navigate = useNavigate();
   const router = useRouter();
@@ -35,7 +41,22 @@ export function UsagePage() {
   // Recomputed only when the window length changes, so a re-render does not
   // shift the range and refetch every environment.
   const window = useMemo(() => makeWindow(windowDays), [windowDays]);
-  const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
+  const {
+    merged,
+    environments,
+    selectedEnvironmentId,
+    shouldResetRequestedEnvironment,
+    deviceOptions,
+    isPending,
+    isPartial,
+    refresh,
+  } = useUsage(window, requestedEnvironmentId);
+
+  // Persist the derived fallback so a device that later reconnects does not
+  // silently reselect itself after it disappeared or returned stale data.
+  if (shouldResetRequestedEnvironment) {
+    setRequestedEnvironmentId(null);
+  }
 
   // Hold the content until every environment is terminal. Rendering merged
   // totals while devices are still answering makes every number on the page
@@ -89,6 +110,15 @@ export function UsagePage() {
             </div>
           </div>
           <div className="flex items-center gap-2">
+            {!settling &&
+            deviceOptions.length > 0 &&
+            (environments.length > 1 || selectedEnvironmentId !== null) ? (
+              <UsageDeviceSelect
+                options={deviceOptions}
+                selectedEnvironmentId={selectedEnvironmentId}
+                onSelect={setRequestedEnvironmentId}
+              />
+            ) : null}
             <div className="flex overflow-hidden rounded-md border border-border">
               {WINDOW_OPTIONS.map((option) => (
                 <button
@@ -362,6 +392,60 @@ export function UsagePage() {
         )}
       </div>
     </ScrollArea>
+  );
+}
+
+function UsageDeviceSelect(props: {
+  readonly options: readonly DeviceUsageOption[];
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly onSelect: (environmentId: EnvironmentId | null) => void;
+}) {
+  const items = [
+    { value: ALL_DEVICES_VALUE, label: "All devices" },
+    ...props.options.map((option) => ({
+      value: `${DEVICE_VALUE_PREFIX}${option.environmentId}`,
+      label: option.label,
+    })),
+  ];
+
+  return (
+    <Select
+      modal={false}
+      value={
+        props.selectedEnvironmentId === null
+          ? ALL_DEVICES_VALUE
+          : `${DEVICE_VALUE_PREFIX}${props.selectedEnvironmentId}`
+      }
+      onValueChange={(value) => {
+        if (value === null) return;
+        if (value === ALL_DEVICES_VALUE) {
+          props.onSelect(null);
+          return;
+        }
+        if (!value.startsWith(DEVICE_VALUE_PREFIX)) return;
+        const environmentId = value.slice(DEVICE_VALUE_PREFIX.length);
+        const selected = props.options.find((option) => option.environmentId === environmentId);
+        if (selected) props.onSelect(selected.environmentId);
+      }}
+      items={items}
+    >
+      <SelectTrigger size="sm" className="w-52" aria-label="Usage device">
+        <MonitorIcon className="size-3.5" />
+        <span className="text-muted-foreground">Device:</span>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectPopup>
+        <SelectItem value={ALL_DEVICES_VALUE}>All devices</SelectItem>
+        {props.options.map((option) => (
+          <SelectItem
+            key={option.environmentId}
+            value={`${DEVICE_VALUE_PREFIX}${option.environmentId}`}
+          >
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
   );
 }
 

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -10,25 +10,23 @@ import { useAtomValue } from "@effect/atom-react";
 import {
   USAGE_CONTRACT_VERSION,
   type EnvironmentId,
-  type UsageSummary,
   type UsageSummaryInput,
 } from "@t3tools/contracts";
+import {
+  deriveUsageDisplay,
+  type DeviceUsageOption,
+  type EnvironmentUsageStatus,
+  type MergedUsage,
+} from "@t3tools/shared/usageMerge";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { useCallback, useMemo } from "react";
 
-import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
 
-export interface EnvironmentUsageStatus {
-  readonly environmentId: EnvironmentId;
-  readonly label: string;
-  readonly isPending: boolean;
-  readonly error: string | null;
-  readonly summary: UsageSummary | null;
-}
+export type { EnvironmentUsageStatus } from "@t3tools/shared/usageMerge";
 
 /**
  * Reads every environment's summary for one window.
@@ -48,6 +46,7 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
       statuses.push({
         environmentId,
         label: presentation.entry.target.label,
+        isConnected: presentation.connection.phase === "connected",
         isPending: result.waiting,
         error: result._tag === "Failure" ? "This environment could not report usage." : null,
         summary: Option.getOrNull(AsyncResult.value(result)),
@@ -60,6 +59,9 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
 export interface UsageView {
   readonly merged: MergedUsage;
   readonly environments: readonly EnvironmentUsageStatus[];
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly shouldResetRequestedEnvironment: boolean;
+  readonly deviceOptions: readonly DeviceUsageOption[];
   /** True until at least one environment has answered. */
   readonly isPending: boolean;
   /**
@@ -71,7 +73,10 @@ export interface UsageView {
   readonly refresh: () => void;
 }
 
-export function useUsage(input: UsageSummaryInput): UsageView {
+export function useUsage(
+  input: UsageSummaryInput,
+  requestedEnvironmentId: EnvironmentId | null = null,
+): UsageView {
   const windowKey = useMemo(
     () =>
       JSON.stringify({
@@ -96,31 +101,19 @@ export function useUsage(input: UsageSummaryInput): UsageView {
     }
   }, [environments, windowKey]);
 
-  const merged = useMemo(() => {
-    const answered: EnvironmentUsage[] = environments.flatMap((environment) =>
-      environment.summary === null
-        ? []
-        : [
-            {
-              environmentId: environment.environmentId,
-              label: environment.label,
-              summary: environment.summary,
-            },
-          ],
-    );
-    return mergeUsage(answered, USAGE_CONTRACT_VERSION);
-  }, [environments]);
-
-  const answeredCount = environments.filter((environment) => environment.summary !== null).length;
-  const stillReporting = environments.filter(
-    (environment) => environment.summary === null && environment.error === null,
-  ).length;
+  const display = useMemo(
+    () => deriveUsageDisplay(environments, requestedEnvironmentId, USAGE_CONTRACT_VERSION),
+    [environments, requestedEnvironmentId],
+  );
 
   return {
-    merged,
+    merged: display.merged,
     environments,
-    isPending: answeredCount === 0 && stillReporting > 0,
-    isPartial: answeredCount > 0 && stillReporting > 0,
+    selectedEnvironmentId: display.selectedEnvironmentId,
+    shouldResetRequestedEnvironment: display.shouldResetRequestedEnvironment,
+    deviceOptions: display.deviceOptions,
+    isPending: display.isPending,
+    isPartial: display.isPartial,
     refresh,
   };
 }

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,0 +1,19 @@
+# Reviewing usage
+
+Open **Usage** from the sidebar on web and desktop, or from **Settings** on mobile. Choose a
+7-, 30-, or 90-day window to review estimated cost, processed tokens, cache activity, provider
+shares, and model totals.
+
+T3 Code reads usage from provider transcripts on each connected environment. The raw transcripts
+stay on the machine that owns them.
+
+## Viewing one device
+
+Usage shows **All devices** by default. When more than one environment is connected and at least
+one has a current summary, use the **Device** menu to show the same dashboard for one device. The
+active device stays visible in the menu while that view is selected.
+
+The **All devices** view combines compatible environment summaries and counts a shared transcript
+directory only once. Only devices with a finished, compatible summary are offered as individual
+views. If the selected device disconnects, starts scanning again, fails to report, or becomes
+incompatible, Usage returns to **All devices**.

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -8,7 +8,12 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { mergeUsage, type EnvironmentUsage } from "./usageMerge.ts";
+import {
+  deriveUsageDisplay,
+  mergeUsage,
+  type EnvironmentUsage,
+  type EnvironmentUsageStatus,
+} from "./usageMerge.ts";
 
 function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
   return {
@@ -254,5 +259,241 @@ describe("mergeUsage", () => {
     const merged = mergeUsage([], USAGE_CONTRACT_VERSION);
     expect(merged.costUsd).toBe(0);
     expect(merged.daily).toHaveLength(0);
+  });
+});
+
+describe("deriveUsageDisplay", () => {
+  it("keeps the existing merged and deduplicated totals for All devices", () => {
+    const sharedSource = {
+      provider: "claude" as const,
+      hostId: "mac",
+      homePath: "/Users/theo/.claude",
+    };
+    const answered = [
+      environment("env-a", summary([bucket()], [sharedSource])),
+      environment("env-b", summary([bucket()], [sharedSource])),
+    ];
+    const environments: EnvironmentUsageStatus[] = answered.map((environmentUsage) => ({
+      ...environmentUsage,
+      isConnected: true,
+      isPending: false,
+      error: null,
+    }));
+
+    const display = deriveUsageDisplay(environments, null, USAGE_CONTRACT_VERSION);
+    const existingAggregate = mergeUsage(answered, USAGE_CONTRACT_VERSION);
+
+    expect(display.selectedEnvironmentId).toBeNull();
+    expect(display.merged).toEqual(existingAggregate);
+    expect(display.merged.costUsd).toBe(10);
+    expect(display.merged.duplicateSources).toHaveLength(1);
+  });
+
+  it("filters totals, models, days, and providers to one selected device", () => {
+    const environments: EnvironmentUsageStatus[] = [
+      {
+        ...environment(
+          "env-a",
+          summary(
+            [bucket({ day: "2026-08-06" as UsageDay })],
+            [{ provider: "claude", hostId: "mac-a", homePath: "/a/.claude" }],
+          ),
+        ),
+        isConnected: true,
+        isPending: false,
+        error: null,
+      },
+      {
+        ...environment(
+          "env-b",
+          summary(
+            [
+              bucket({
+                day: "2026-08-07" as UsageDay,
+                provider: "codex",
+                model: "gpt-5.6-sol",
+                costUsd: 4,
+              }),
+            ],
+            [{ provider: "codex", hostId: "mac-b", homePath: "/b/.codex" }],
+          ),
+        ),
+        isConnected: true,
+        isPending: false,
+        error: null,
+      },
+    ];
+
+    const display = deriveUsageDisplay(
+      environments,
+      "env-b" as EnvironmentId,
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(display.selectedEnvironmentId).toBe("env-b");
+    expect(display.merged.costUsd).toBe(4);
+    expect(display.merged.models.map((model) => model.model)).toEqual(["gpt-5.6-sol"]);
+    expect(display.merged.daily.map((day) => day.day)).toEqual(["2026-08-07"]);
+    expect(display.merged.providers.map((provider) => provider.provider)).toEqual(["codex"]);
+  });
+
+  it("falls back to All devices and offers only successful current summaries", () => {
+    const current = summary(
+      [bucket()],
+      [{ provider: "claude", hostId: "mac", homePath: "/current/.claude" }],
+    );
+    const environments: EnvironmentUsageStatus[] = [
+      {
+        ...environment("env-current", current),
+        isConnected: true,
+        isPending: false,
+        error: null,
+      },
+      {
+        ...environment(
+          "env-failed",
+          summary(
+            [bucket()],
+            [{ provider: "claude", hostId: "linux", homePath: "/failed/.claude" }],
+          ),
+        ),
+        isConnected: true,
+        isPending: false,
+        error: "This environment could not report usage.",
+      },
+      {
+        ...environment(
+          "env-old-server",
+          summary(
+            [bucket()],
+            [{ provider: "claude", hostId: "old", homePath: "/old/.claude" }],
+            USAGE_CONTRACT_VERSION - 1,
+          ),
+        ),
+        isConnected: true,
+        isPending: false,
+        error: null,
+      },
+      {
+        environmentId: "env-pending" as EnvironmentId,
+        label: "env-pending",
+        isConnected: true,
+        isPending: true,
+        error: null,
+        summary: null,
+      },
+      {
+        ...environment(
+          "env-refreshing",
+          summary(
+            [bucket()],
+            [{ provider: "claude", hostId: "refreshing", homePath: "/refreshing/.claude" }],
+          ),
+        ),
+        isConnected: true,
+        isPending: true,
+        error: null,
+      },
+      {
+        ...environment(
+          "env-disconnected",
+          summary(
+            [bucket()],
+            [{ provider: "claude", hostId: "offline", homePath: "/offline/.claude" }],
+          ),
+        ),
+        isConnected: false,
+        isPending: false,
+        error: null,
+      },
+    ];
+
+    const display = deriveUsageDisplay(
+      environments,
+      "env-failed" as EnvironmentId,
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(display.selectedEnvironmentId).toBeNull();
+    expect(display.shouldResetRequestedEnvironment).toBe(true);
+    expect(display.deviceOptions).toEqual([{ environmentId: "env-current", label: "env-current" }]);
+    expect(display.merged.costUsd).toBe(40);
+
+    const refreshingSelection = deriveUsageDisplay(
+      environments,
+      "env-refreshing" as EnvironmentId,
+      USAGE_CONTRACT_VERSION,
+    );
+    expect(refreshingSelection.selectedEnvironmentId).toBeNull();
+
+    const disconnectedSelection = deriveUsageDisplay(
+      environments,
+      "env-disconnected" as EnvironmentId,
+      USAGE_CONTRACT_VERSION,
+    );
+    expect(disconnectedSelection.selectedEnvironmentId).toBeNull();
+  });
+
+  it("keeps the global wait-for-all loading state when one device is selected", () => {
+    const environments: EnvironmentUsageStatus[] = [
+      {
+        ...environment(
+          "env-ready",
+          summary(
+            [bucket()],
+            [{ provider: "claude", hostId: "ready", homePath: "/ready/.claude" }],
+          ),
+        ),
+        isConnected: true,
+        isPending: false,
+        error: null,
+      },
+      {
+        environmentId: "env-scanning" as EnvironmentId,
+        label: "env-scanning",
+        isConnected: true,
+        isPending: true,
+        error: null,
+        summary: null,
+      },
+    ];
+
+    const display = deriveUsageDisplay(
+      environments,
+      "env-ready" as EnvironmentId,
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(display.isPending).toBe(false);
+    expect(display.isPartial).toBe(true);
+  });
+
+  it("preserves a requested device scope while that device refreshes", () => {
+    const ready: EnvironmentUsageStatus = {
+      ...environment(
+        "env-selected",
+        summary(
+          [bucket()],
+          [{ provider: "claude", hostId: "selected", homePath: "/selected/.claude" }],
+        ),
+      ),
+      isConnected: true,
+      isPending: false,
+      error: null,
+    };
+    const requestedEnvironmentId = "env-selected" as EnvironmentId;
+
+    const refreshing = deriveUsageDisplay(
+      [{ ...ready, isPending: true }],
+      requestedEnvironmentId,
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(refreshing.selectedEnvironmentId).toBeNull();
+    expect(refreshing.shouldResetRequestedEnvironment).toBe(false);
+    expect(
+      deriveUsageDisplay([ready], requestedEnvironmentId, USAGE_CONTRACT_VERSION)
+        .selectedEnvironmentId,
+    ).toBe(requestedEnvironmentId);
   });
 });

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -20,6 +20,32 @@ export interface EnvironmentUsage {
   readonly summary: UsageSummary;
 }
 
+/** One environment's query state, shared by the web and mobile usage views. */
+export interface EnvironmentUsageStatus {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly isConnected: boolean;
+  readonly isPending: boolean;
+  readonly error: string | null;
+  readonly summary: UsageSummary | null;
+}
+
+/** A device whose successful, current summary can be selected on its own. */
+export interface DeviceUsageOption {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+}
+
+export interface UsageDisplay {
+  readonly merged: MergedUsage;
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  /** True only when a requested device cannot become selectable without a new user choice. */
+  readonly shouldResetRequestedEnvironment: boolean;
+  readonly deviceOptions: readonly DeviceUsageOption[];
+  readonly isPending: boolean;
+  readonly isPartial: boolean;
+}
+
 export interface ProviderTotals {
   readonly provider: UsageProviderKind;
   readonly costUsd: number;
@@ -349,5 +375,73 @@ export function mergeUsage(
     duplicateSources: duplicates,
     contributingEnvironments,
     staleEnvironments,
+  };
+}
+
+/**
+ * Resolves the effective device scope without changing global query progress.
+ * Invalid selections fall back to the existing all-environment merge.
+ */
+export function deriveUsageDisplay(
+  environments: readonly EnvironmentUsageStatus[],
+  requestedEnvironmentId: EnvironmentId | null,
+  expectedContractVersion: number,
+): UsageDisplay {
+  const answered: EnvironmentUsage[] = environments.flatMap((environment) =>
+    environment.summary === null
+      ? []
+      : [
+          {
+            environmentId: environment.environmentId,
+            label: environment.label,
+            summary: environment.summary,
+          },
+        ],
+  );
+  // AsyncResult can retain its previous summary while a refresh is waiting.
+  // Preserve that value in All devices, but do not present it as current data
+  // for an individually selectable device.
+  const available = environments.filter(
+    (environment): environment is EnvironmentUsageStatus & { readonly summary: UsageSummary } =>
+      environment.error === null &&
+      environment.isConnected &&
+      !environment.isPending &&
+      environment.summary !== null &&
+      environment.summary.contractVersion === expectedContractVersion,
+  );
+  const selectedStatus =
+    requestedEnvironmentId === null
+      ? undefined
+      : available.find((environment) => environment.environmentId === requestedEnvironmentId);
+  const requestedStatus =
+    requestedEnvironmentId === null
+      ? undefined
+      : environments.find((environment) => environment.environmentId === requestedEnvironmentId);
+  const shouldResetRequestedEnvironment =
+    requestedEnvironmentId !== null &&
+    (requestedStatus === undefined ||
+      !requestedStatus.isConnected ||
+      requestedStatus.error !== null ||
+      (!requestedStatus.isPending &&
+        (requestedStatus.summary === null ||
+          requestedStatus.summary.contractVersion !== expectedContractVersion)));
+  const selected = selectedStatus
+    ? {
+        environmentId: selectedStatus.environmentId,
+        label: selectedStatus.label,
+        summary: selectedStatus.summary,
+      }
+    : undefined;
+  const answeredCount = environments.filter((environment) => environment.summary !== null).length;
+  const stillReporting = environments.filter(
+    (environment) => environment.summary === null && environment.error === null,
+  ).length;
+  return {
+    merged: mergeUsage(selected ? [selected] : answered, expectedContractVersion),
+    selectedEnvironmentId: selected?.environmentId ?? null,
+    shouldResetRequestedEnvironment,
+    deviceOptions: available.map(({ environmentId, label }) => ({ environmentId, label })),
+    isPending: answeredCount === 0 && stillReporting > 0,
+    isPartial: answeredCount > 0 && stillReporting > 0,
   };
 }


### PR DESCRIPTION
## What Changed

- Added an `All devices` / per-device scope selector to the web/desktop and mobile Usage screens.
- Kept `All devices` as the default and preserved the existing cross-environment merge and deduplication behavior.
- Reused the same dashboard for a selected device, deriving totals, models, days, and providers from only that environment's current usage summary.
- Limited device options to connected environments with finished, error-free summaries from the current contract; an invalid or disappearing selection falls back to `All devices`.
- Documented the scope control and added focused behavior coverage for aggregation, filtering, invalid-selection fallback, and unchanged loading derivation.

## Why

Merged totals answer overall usage, but they do not show which environment contributed it. A device scope makes multi-environment usage inspectable without changing the existing wait-for-all gate, skeletons, scan strip, refresh generation, RPC, scanner, or contracts.

Verification:

- `packages/shared/src/usageMerge.test.ts`: 14 tests passed, including refresh-scope retention
- Targeted format and lint checks passed for all touched code and documentation
- Shared, web, and mobile typechecks passed
- Independent standards and spec reviews passed after fixes

## UI Changes

Captured with the same synthetic two-environment fixture. The default `All devices` view retains the aggregate totals:

| Before | After — All devices |
| --- | --- |
| ![Usage page before the device scope control](https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-per-device/.github/pr-assets/usage-per-device/before.png) | ![Usage page with All devices selected](https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-per-device/.github/pr-assets/usage-per-device/after-all.png) |

Selecting one environment keeps its scope visible and filters the same dashboard:

![Usage page filtered to the synthetic Usage Beta environment](https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-per-device/.github/pr-assets/usage-per-device/after-selected.png)

Mobile implements the same scope through its existing native menu and passed the focused logic tests and mobile typecheck. A mobile screenshot is not included because the shared emulator, Metro process, and backend were occupied by another isolated evidence run; this PR did not disturb that session.

## Checklist

- [x] I kept the diff small and focused.
- [x] I explained the reasoning behind the change.
- [x] I included before/after screenshots for UI changes.
- [ ] I included a short video for interaction or animation changes. (Not applicable: this adds no motion or timing behavior.)

Built with GPT-5.6 Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how usage totals are derived and when selections reset, but logic is centralized with tests and does not touch RPC or scanners.
> 
> **Overview**
> Adds **All devices** vs single-environment scoping on web and mobile Usage, defaulting to the existing cross-environment merge and deduplication.
> 
> Shared **`deriveUsageDisplay`** in `@t3tools/shared/usageMerge` drives device options (connected, finished, current-contract summaries), filters **`merged`** to one environment when selected, and resets invalid selections (disconnect, error, stale contract) via **`shouldResetRequestedEnvironment`**. Web and mobile **`useUsage`** hooks pass **`requestedEnvironmentId`** and track **`isConnected`** on each environment status.
> 
> User docs describe the Device menu behavior; unit tests cover aggregation parity, per-device filtering, fallback, and loading/refresh edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09e261467b70fef3e79cd0e23bdd03c90c6b3fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add device filter to usage dashboard
> - Adds a device selector (dropdown on web, menu on mobile) to the usage dashboard, allowing users to scope metrics to a specific connected device or view all devices in aggregate.
> - Introduces `deriveUsageDisplay` in [usageMerge.ts](https://github.com/pingdotgg/t3code/pull/5826/files#diff-143d7ed21cccd3774754bd4f261d302d61b7997008db82ed56a3920e176a57b3), a shared utility that resolves the selected environment, computes available device options, and derives `isPending`/`isPartial` flags; both web and mobile `useUsage` hooks now delegate to this function.
> - Automatically resets the device selection to "All devices" if the selected device disconnects or becomes unavailable.
> - Adds a user guide in [usage.md](https://github.com/pingdotgg/t3code/pull/5826/files#diff-d73591feaa8c26e8f16b7467464af0044ee0a9c288ef17901538a61715440e62) documenting the usage page and device selection behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09e2614.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->