### PR TITLE
fix(usage): distinguish unpriced usage from zero cost

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -18,6 +18,7 @@ import { AppText as Text } from "../../components/AppText";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
 import { SettingsSection } from "../settings/components/SettingsSection";
+import { presentUsageCost, presentUsageCostShare, USAGE_COST_GUIDE } from "./usageCostPresentation";
 import { UsageDailyChart } from "./UsageDailyChart";
 import type { UsageChartMetric } from "./usageChartData";
 import { PROVIDER_LABEL, useProviderColors } from "./usageProviders";
@@ -150,20 +151,21 @@ function ChartCard(props: {
   const { merged, metric } = props;
   const colors = useProviderColors();
   const hasActivity = merged.daily.some((day) => day.totalTokens > 0);
+  const cost = presentUsageCost(merged.costUsd, merged.costQuality.unpricedShare, 1);
 
   return (
     <View className="gap-4 rounded-[24px] border-continuous bg-card p-4">
       <View className="flex-row items-start justify-between gap-3">
         <View className="min-w-0 flex-1 gap-0.5">
           <Text className="text-sm text-foreground-muted">
-            {metric === "cost" ? "Raw token cost" : "Processed tokens"}
+            {metric === "cost" ? cost.chartLabel : "Processed tokens"}
           </Text>
           <Text className="text-4xl font-t3-bold tabular-nums text-foreground">
-            {metric === "cost" ? `${formatUsd(merged.costUsd)}*` : formatTokens(merged.totalTokens)}
+            {metric === "cost" ? cost.headline : formatTokens(merged.totalTokens)}
           </Text>
           <Text className="text-sm text-foreground-muted">
             {metric === "cost"
-              ? "* if billed at full API rate"
+              ? cost.headlineDetail
               : `Across ${formatCount(merged.sessions)} sessions`}
           </Text>
         </View>
@@ -200,6 +202,10 @@ function ChartCard(props: {
         </View>
         <Text className="text-xs text-foreground-tertiary">{formatDayShort(props.untilDay)}</Text>
       </View>
+
+      {cost.hasUnpriced ? (
+        <Text className="text-xs leading-5 text-foreground-tertiary">{USAGE_COST_GUIDE}</Text>
+      ) : null}
     </View>
   );
 }
@@ -254,6 +260,11 @@ function ProviderSection(props: {
     <SettingsSection title="Providers" card>
       {ordered.map((provider, index) => {
         const share = metric === "cost" ? provider.costShare : provider.tokenShare;
+        const providerCost = presentUsageCost(
+          provider.costUsd,
+          provider.unpricedShare,
+          provider.costShare,
+        );
         return (
           <View
             key={provider.provider}
@@ -268,9 +279,7 @@ function ProviderSection(props: {
                 <Text className="text-lg text-foreground">{PROVIDER_LABEL[provider.provider]}</Text>
               </View>
               <Text className="text-lg tabular-nums text-foreground">
-                {metric === "cost"
-                  ? formatUsd(provider.costUsd)
-                  : formatTokens(provider.totalTokens)}
+                {metric === "cost" ? providerCost.amount : formatTokens(provider.totalTokens)}
               </Text>
             </View>
             <View className="h-1 flex-row overflow-hidden rounded-full bg-subtle">
@@ -282,8 +291,8 @@ function ProviderSection(props: {
             </View>
             <Text className="text-sm text-foreground-muted">
               {metric === "cost"
-                ? `${formatPercent(share)} of cost · ${formatTokens(provider.totalTokens)} tokens`
-                : `${formatPercent(share)} of tokens · ${formatUsd(provider.costUsd)}`}
+                ? `${presentUsageCostShare(providerCost, merged.costQuality.unpricedShare)} · ${formatTokens(provider.totalTokens)} tokens`
+                : `${formatPercent(share)} of tokens · ${providerCost.amount}`}
             </Text>
           </View>
         );
@@ -362,30 +371,34 @@ function ModelsSection(props: { readonly merged: MergedUsage }) {
 
   return (
     <SettingsSection title="By model" card>
-      {merged.models.map((model, index) => (
-        <View
-          key={`${model.provider}:${model.model}`}
-          className={
-            index === 0
-              ? "flex-row items-center gap-3 p-4"
-              : "flex-row items-center gap-3 border-t border-border-subtle p-4"
-          }
-        >
+      {merged.models.map((model, index) => {
+        const modelCost = presentUsageCost(model.costUsd, model.unpricedShare, model.costShare);
+        return (
           <View
-            className="size-2.5 shrink-0 rounded-full"
-            style={{ backgroundColor: colors[model.provider] }}
-          />
-          <View className="min-w-0 flex-1 gap-0.5">
-            <Text className="text-base text-foreground" numberOfLines={1}>
-              {model.model}
-            </Text>
-            <Text className="text-sm text-foreground-muted">
-              {formatPercent(model.costShare)} of cost · {formatTokens(model.totalTokens)} tokens
-            </Text>
+            key={`${model.provider}:${model.model}`}
+            className={
+              index === 0
+                ? "flex-row items-center gap-3 p-4"
+                : "flex-row items-center gap-3 border-t border-border-subtle p-4"
+            }
+          >
+            <View
+              className="size-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: colors[model.provider] }}
+            />
+            <View className="min-w-0 flex-1 gap-0.5">
+              <Text className="text-base text-foreground" numberOfLines={1}>
+                {model.model}
+              </Text>
+              <Text className="text-sm text-foreground-muted">
+                {presentUsageCostShare(modelCost, merged.costQuality.unpricedShare)} ·{" "}
+                {formatTokens(model.totalTokens)} tokens
+              </Text>
+            </View>
+            <Text className="text-base tabular-nums text-foreground">{modelCost.amount}</Text>
           </View>
-          <Text className="text-base tabular-nums text-foreground">{formatUsd(model.costUsd)}</Text>
-        </View>
-      ))}
+        );
+      })}
     </SettingsSection>
   );
 }

--- a/apps/mobile/src/features/usage/usageCostPresentation.test.ts
+++ b/apps/mobile/src/features/usage/usageCostPresentation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { presentUsageCost, presentUsageCostShare } from "./usageCostPresentation";
+
+describe("presentUsageCost", () => {
+  it("does not present fully unpriced mobile usage as free", () => {
+    const cost = presentUsageCost(0, 1, 0);
+
+    expect(cost).toEqual({
+      amount: "—",
+      headline: "—",
+      headlineDetail: "No matching API rates; token totals are still complete.",
+      chartLabel: "Raw token cost (partial)",
+      costShare: "—",
+      unpricedDetail: "100.0% unpriced",
+      hasUnpriced: true,
+    });
+    expect(presentUsageCostShare(cost, 0.5)).toBe("No priced-cost share · 100.0% unpriced");
+  });
+
+  it("marks mixed mobile usage as a lower-bound priced-cost estimate", () => {
+    const cost = presentUsageCost(12.34, 0.25, 0.4);
+
+    expect(cost).toEqual({
+      amount: "≥$12.34",
+      headline: "≥$12.34*",
+      headlineDetail: "* Partial API-rate estimate; 25.0% of requests have no matching rate.",
+      chartLabel: "Raw token cost (partial)",
+      costShare: "40.0%",
+      unpricedDetail: "25.0% unpriced",
+      hasUnpriced: true,
+    });
+    expect(presentUsageCostShare(cost, 0.5)).toBe("40.0% of priced cost · 25.0% unpriced");
+  });
+
+  it("preserves the existing mobile wording when every request is priced", () => {
+    const cost = presentUsageCost(12.34, 0, 0.4);
+
+    expect(cost).toEqual({
+      amount: "$12.34",
+      headline: "$12.34*",
+      headlineDetail: "* if billed at full API rate",
+      chartLabel: "Raw token cost",
+      costShare: "40.0%",
+      unpricedDetail: null,
+      hasUnpriced: false,
+    });
+    expect(presentUsageCostShare(cost, 0)).toBe("40.0% of cost");
+  });
+});

--- a/apps/mobile/src/features/usage/usageCostPresentation.ts
+++ b/apps/mobile/src/features/usage/usageCostPresentation.ts
@@ -1,0 +1,50 @@
+import { formatCostEstimate, formatPercent } from "@t3tools/shared/usageFormat";
+
+export const USAGE_COST_GUIDE =
+  "Cost guide: ≥ means a lower-bound estimate from matching API rates; — means no matching rate. Token totals remain complete.";
+
+export interface UsageCostPresentation {
+  readonly amount: string;
+  readonly headline: string;
+  readonly headlineDetail: string;
+  readonly chartLabel: string;
+  readonly costShare: string;
+  readonly unpricedDetail: string | null;
+  readonly hasUnpriced: boolean;
+}
+
+/** User-facing cost language shared by the mobile headline and breakdown rows. */
+export function presentUsageCost(
+  costUsd: number,
+  unpricedShare: number,
+  costShare: number,
+): UsageCostPresentation {
+  const estimate = formatCostEstimate(costUsd, unpricedShare);
+  const hasUnpriced = unpricedShare > 0;
+
+  return {
+    amount: estimate.value,
+    headline: estimate.value === "—" ? estimate.value : `${estimate.value}*`,
+    headlineDetail: !hasUnpriced
+      ? "* if billed at full API rate"
+      : estimate.value === "—"
+        ? estimate.detail
+        : `* ${estimate.detail}`,
+    chartLabel: hasUnpriced ? "Raw token cost (partial)" : "Raw token cost",
+    costShare: unpricedShare >= 1 ? "—" : formatPercent(costShare),
+    unpricedDetail: hasUnpriced ? `${formatPercent(unpricedShare)} unpriced` : null,
+    hasUnpriced,
+  };
+}
+
+/** Describes one provider/model's share without treating unpriced records as free. */
+export function presentUsageCostShare(
+  cost: UsageCostPresentation,
+  totalUnpricedShare: number,
+): string {
+  if (cost.costShare === "—") {
+    return `No priced-cost share${cost.unpricedDetail === null ? "" : ` · ${cost.unpricedDetail}`}`;
+  }
+  const label = totalUnpricedShare > 0 ? "priced cost" : "cost";
+  return `${cost.costShare} of ${label}${cost.unpricedDetail === null ? "" : ` · ${cost.unpricedDetail}`}`;
+}

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -1,0 +1,163 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import type { DailyTotals, ModelTotals, ProviderTotals } from "@t3tools/shared/usageMerge";
+import { formatUsageMetricLabel, UsageBreakdownTable, UsageProviderRows } from "./UsagePage";
+
+function provider(overrides: Partial<ProviderTotals> = {}): ProviderTotals {
+  return {
+    provider: "codex",
+    costUsd: 0,
+    totalTokens: 10_000,
+    records: 1,
+    costShare: 0,
+    tokenShare: 1,
+    unpricedShare: 1,
+    ...overrides,
+  };
+}
+
+function model(overrides: Partial<ModelTotals> = {}): ModelTotals {
+  return {
+    provider: "codex",
+    model: "gpt-5.6-sol",
+    costUsd: 12.34,
+    totalTokens: 10_000,
+    records: 4,
+    costShare: 0.6,
+    unpricedShare: 0.25,
+    ...overrides,
+  };
+}
+
+function day(overrides: Partial<DailyTotals> = {}): DailyTotals {
+  return {
+    day: "2026-08-01",
+    costUsd: 0,
+    totalTokens: 10_000,
+    unpricedShare: 1,
+    byProvider: new Map([["codex", { costUsd: 0, totalTokens: 10_000, unpricedShare: 1 }]]),
+    ...overrides,
+  };
+}
+
+describe("formatUsageMetricLabel", () => {
+  it("marks the web cost headline partial when pricing coverage is incomplete", () => {
+    expect(formatUsageMetricLabel("cost", 0.25)).toBe("Raw token cost (partial)");
+    expect(formatUsageMetricLabel("cost", 0)).toBe("Raw token cost");
+    expect(formatUsageMetricLabel("tokens", 1)).toBe("Processed tokens");
+  });
+});
+
+describe("UsageProviderRows", () => {
+  it("does not assign a priced-cost share to a fully unpriced provider", () => {
+    const markup = renderToStaticMarkup(
+      <UsageProviderRows providers={[provider()]} metric="cost" totalUnpricedShare={1} />,
+    );
+
+    expect(markup).toContain("No priced-cost share · 100.0% unpriced · 10K tokens");
+    expect(markup).not.toContain("0.0% of priced cost");
+  });
+
+  it("does not call fully unpriced provider usage free in token mode", () => {
+    const markup = renderToStaticMarkup(
+      <UsageProviderRows providers={[provider()]} metric="tokens" totalUnpricedShare={1} />,
+    );
+
+    expect(markup).toContain("100.0% of tokens · —");
+    expect(markup).not.toContain("$0.00");
+  });
+
+  it("labels partial bars against priced cost", () => {
+    const markup = renderToStaticMarkup(
+      <UsageProviderRows
+        providers={[provider({ costUsd: 12.34, costShare: 0.6, unpricedShare: 0.25 })]}
+        metric="cost"
+        totalUnpricedShare={0.25}
+      />,
+    );
+
+    expect(markup).toContain("≥$12.34");
+    expect(markup).toContain("60.0% of priced cost · 25.0% unpriced");
+  });
+
+  it("keeps the ordinary cost-share wording when every record is priced", () => {
+    const markup = renderToStaticMarkup(
+      <UsageProviderRows
+        providers={[provider({ costUsd: 12.34, costShare: 0.6, unpricedShare: 0 })]}
+        metric="cost"
+        totalUnpricedShare={0}
+      />,
+    );
+
+    expect(markup).toContain("$12.34");
+    expect(markup).toContain("60.0% of cost · 10K tokens");
+    expect(markup).not.toContain("priced cost");
+    expect(markup).not.toContain("unpriced");
+  });
+});
+
+describe("UsageBreakdownTable", () => {
+  it("visibly explains partial estimates and describes the model table", () => {
+    const markup = renderToStaticMarkup(
+      <UsageBreakdownTable
+        breakdown="model"
+        models={[model()]}
+        recentDays={[]}
+        totalUnpricedShare={0.25}
+      />,
+    );
+
+    expect(markup).toContain("≥ means a lower-bound estimate from matching API rates");
+    expect(markup).toContain("— means no matching rate");
+    expect(markup).toContain('aria-describedby="usage-cost-guidance"');
+    expect(markup).toContain("Share of priced cost");
+    expect(markup).toContain("≥$12.34");
+  });
+
+  it("describes all-unpriced day values without calling them zero cost", () => {
+    const markup = renderToStaticMarkup(
+      <UsageBreakdownTable
+        breakdown="day"
+        models={[]}
+        recentDays={[day()]}
+        totalUnpricedShare={1}
+      />,
+    );
+
+    expect(markup).toContain('aria-describedby="usage-cost-guidance"');
+    expect(markup).toContain("— means no matching rate");
+    expect(markup).toContain("No matching API rates; token totals are still complete.");
+  });
+
+  it("labels an absent provider-day as no activity rather than priced zero", () => {
+    const markup = renderToStaticMarkup(
+      <UsageBreakdownTable
+        breakdown="day"
+        models={[]}
+        recentDays={[day()]}
+        totalUnpricedShare={1}
+      />,
+    );
+
+    expect(markup).toContain('title="No activity">—</span>');
+    expect(markup).not.toContain("If billed at full API rate.");
+    expect(markup).not.toContain("$0.00");
+  });
+
+  it("keeps all-priced model details free of partial-estimate guidance", () => {
+    const markup = renderToStaticMarkup(
+      <UsageBreakdownTable
+        breakdown="model"
+        models={[model({ unpricedShare: 0 })]}
+        recentDays={[]}
+        totalUnpricedShare={0}
+      />,
+    );
+
+    expect(markup).toContain(">Share</th>");
+    expect(markup).not.toContain("Share of priced cost");
+    expect(markup).not.toContain("usage-cost-guidance");
+    expect(markup).not.toContain("lower-bound estimate");
+  });
+});

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -5,8 +5,10 @@ import { useMemo, useState } from "react";
 
 import { cn } from "../../lib/utils";
 import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
+import type { DailyTotals, ModelTotals, ProviderTotals } from "@t3tools/shared/usageMerge";
 import {
   enumerateDays,
+  formatCostEstimate,
   formatCount,
   formatDayShort,
   formatPercent,
@@ -23,6 +25,11 @@ const WINDOW_OPTIONS = [
   { days: 30, label: "30 days" },
   { days: 90, label: "90 days" },
 ] as const;
+
+export function formatUsageMetricLabel(metric: UsageChartMetric, unpricedShare: number): string {
+  if (metric === "tokens") return "Processed tokens";
+  return unpricedShare > 0 ? "Raw token cost (partial)" : "Raw token cost";
+}
 
 export function UsagePage() {
   const [windowDays, setWindowDays] = useState<number>(30);
@@ -61,6 +68,7 @@ export function UsagePage() {
   const dailyAverage = activeDays === 0 ? 0 : merged.totalTokens / activeDays;
   const observedInput = merged.uncachedInputTokens + merged.cachedInputTokens;
   const cachedShare = observedInput === 0 ? 0 : merged.cachedInputTokens / observedInput;
+  const costEstimate = formatCostEstimate(merged.costUsd, merged.costQuality.unpricedShare);
 
   return (
     <ScrollArea className="h-full">
@@ -137,58 +145,40 @@ export function UsagePage() {
               <div className="flex flex-col gap-5">
                 <div className="flex flex-col gap-1">
                   <span className="text-xs tracking-wide text-muted-foreground uppercase">
-                    {metric === "cost" ? "Raw token cost" : "Processed tokens"}
+                    {formatUsageMetricLabel(metric, merged.costQuality.unpricedShare)}
                   </span>
                   <span className="text-4xl font-semibold text-foreground tabular-nums">
                     {metric === "cost"
-                      ? `${formatUsd(merged.costUsd)}*`
+                      ? costEstimate.value === "—"
+                        ? costEstimate.value
+                        : `${costEstimate.value}*`
                       : formatTokens(merged.totalTokens)}
                   </span>
                   <span className="text-xs text-muted-foreground">
                     {metric === "cost"
-                      ? "* if billed at full API rate"
+                      ? costEstimate.value === "—"
+                        ? costEstimate.detail
+                        : `* ${costEstimate.detail}`
                       : `Input, cache reads and output across ${formatCount(merged.sessions)} sessions.`}
                   </span>
                 </div>
 
-                {orderedProviders.map((provider) => {
-                  const share = metric === "cost" ? provider.costShare : provider.tokenShare;
-                  return (
-                    <div key={provider.provider} className="flex flex-col gap-1.5">
-                      <div className="flex items-baseline justify-between">
-                        <span className="flex items-center gap-2 text-sm text-foreground">
-                          <ProviderMark provider={provider.provider} className="size-4" />
-                          {PROVIDER_LABEL[provider.provider]}
-                        </span>
-                        <span className="text-sm text-foreground tabular-nums">
-                          {metric === "cost"
-                            ? formatUsd(provider.costUsd)
-                            : formatTokens(provider.totalTokens)}
-                        </span>
-                      </div>
-                      <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
-                        <div
-                          className="h-full"
-                          style={{
-                            width: `${(share * 100).toFixed(1)}%`,
-                            backgroundColor: PROVIDER_COLOR[provider.provider],
-                          }}
-                        />
-                      </div>
-                      <span className="text-xs text-muted-foreground">
-                        {metric === "cost"
-                          ? `${formatPercent(share)} of cost · ${formatTokens(provider.totalTokens)} tokens`
-                          : `${formatPercent(share)} of tokens · ${formatUsd(provider.costUsd)}`}
-                      </span>
-                    </div>
-                  );
-                })}
+                <UsageProviderRows
+                  providers={orderedProviders}
+                  metric={metric}
+                  totalUnpricedShare={merged.costQuality.unpricedShare}
+                />
               </div>
 
               <div className="flex flex-col gap-3">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <h2 className="text-sm font-medium text-foreground">
-                    Daily {metric === "tokens" ? "processed tokens" : "cost"}
+                    Daily{" "}
+                    {metric === "tokens"
+                      ? "processed tokens"
+                      : merged.costQuality.unpricedShare > 0
+                        ? "cost (partial)"
+                        : "cost"}
                   </h2>
                   <div className="flex items-center gap-4">
                     <div className="flex overflow-hidden rounded-md border border-border">
@@ -269,99 +259,201 @@ export function UsagePage() {
                 </div>
               </div>
 
-              {breakdown === "model" ? (
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-border text-left text-xs text-muted-foreground">
-                      <th className="py-2 font-normal">Model</th>
-                      <th className="py-2 text-right font-normal">Cost</th>
-                      <th className="py-2 text-right font-normal">Share</th>
-                      <th className="py-2 text-right font-normal">Tokens</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {merged.models.length === 0 ? (
-                      <tr>
-                        <td colSpan={4} className="py-6 text-center text-muted-foreground">
-                          No activity in this window.
-                        </td>
-                      </tr>
-                    ) : (
-                      merged.models.map((model) => (
-                        <tr
-                          key={`${model.provider}:${model.model}`}
-                          className="border-b border-border/50"
-                        >
-                          <td className="py-2 text-foreground">
-                            <span className="flex items-center gap-2">
-                              <ProviderMark provider={model.provider} className="size-3.5" />
-                              {model.model}
-                            </span>
-                          </td>
-                          <td className="py-2 text-right text-foreground tabular-nums">
-                            {formatUsd(model.costUsd)}
-                          </td>
-                          <td className="py-2 text-right text-muted-foreground tabular-nums">
-                            {formatPercent(model.costShare)}
-                          </td>
-                          <td className="py-2 text-right text-muted-foreground tabular-nums">
-                            {formatTokens(model.totalTokens)}
-                          </td>
-                        </tr>
-                      ))
-                    )}
-                  </tbody>
-                </table>
-              ) : (
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-border text-left text-xs text-muted-foreground">
-                      <th className="py-2 font-normal">Day</th>
-                      {PROVIDER_ORDER.map((provider) => (
-                        <th key={provider} className="py-2 text-right font-normal">
-                          {PROVIDER_LABEL[provider]}
-                        </th>
-                      ))}
-                      <th className="py-2 text-right font-normal">Total</th>
-                      <th className="py-2 text-right font-normal">Tokens</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {recentDays.length === 0 ? (
-                      <tr>
-                        <td colSpan={5} className="py-6 text-center text-muted-foreground">
-                          No activity in this window.
-                        </td>
-                      </tr>
-                    ) : (
-                      recentDays.map((day) => (
-                        <tr key={day.day} className="border-b border-border/50">
-                          <td className="py-2 text-foreground">{formatDayShort(day.day)}</td>
-                          {PROVIDER_ORDER.map((provider) => (
-                            <td
-                              key={provider}
-                              className="py-2 text-right text-muted-foreground tabular-nums"
-                            >
-                              {formatUsd(day.byProvider.get(provider)?.costUsd ?? 0)}
-                            </td>
-                          ))}
-                          <td className="py-2 text-right text-foreground tabular-nums">
-                            {formatUsd(day.costUsd)}
-                          </td>
-                          <td className="py-2 text-right text-muted-foreground tabular-nums">
-                            {formatTokens(day.totalTokens)}
-                          </td>
-                        </tr>
-                      ))
-                    )}
-                  </tbody>
-                </table>
-              )}
+              <UsageBreakdownTable
+                breakdown={breakdown}
+                models={merged.models}
+                recentDays={recentDays}
+                totalUnpricedShare={merged.costQuality.unpricedShare}
+              />
             </section>
           </>
         )}
       </div>
     </ScrollArea>
+  );
+}
+
+/** Provider totals and share bars for the selected chart metric. */
+export function UsageProviderRows({
+  providers,
+  metric,
+  totalUnpricedShare,
+}: {
+  readonly providers: readonly ProviderTotals[];
+  readonly metric: UsageChartMetric;
+  readonly totalUnpricedShare: number;
+}) {
+  return providers.map((provider) => {
+    const share = metric === "cost" ? provider.costShare : provider.tokenShare;
+    const providerCost = formatCostEstimate(provider.costUsd, provider.unpricedShare);
+    const costShareLabel = totalUnpricedShare > 0 ? "priced cost" : "cost";
+    const costShareText =
+      provider.unpricedShare >= 1
+        ? "No priced-cost share"
+        : `${formatPercent(share)} of ${costShareLabel}`;
+    return (
+      <div key={provider.provider} className="flex flex-col gap-1.5">
+        <div className="flex items-baseline justify-between">
+          <span className="flex items-center gap-2 text-sm text-foreground">
+            <ProviderMark provider={provider.provider} className="size-4" />
+            {PROVIDER_LABEL[provider.provider]}
+          </span>
+          <span className="text-sm text-foreground tabular-nums">
+            {metric === "cost" ? providerCost.value : formatTokens(provider.totalTokens)}
+          </span>
+        </div>
+        <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full"
+            style={{
+              width: `${(share * 100).toFixed(1)}%`,
+              backgroundColor: PROVIDER_COLOR[provider.provider],
+            }}
+          />
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {metric === "cost"
+            ? `${costShareText}${provider.unpricedShare > 0 ? ` · ${formatPercent(provider.unpricedShare)} unpriced` : ""} · ${formatTokens(provider.totalTokens)} tokens`
+            : `${formatPercent(share)} of tokens · ${providerCost.value}`}
+        </span>
+      </div>
+    );
+  });
+}
+
+const COST_GUIDANCE_ID = "usage-cost-guidance";
+
+/** Model/day details with a shared, screen-reader-addressable pricing guide. */
+export function UsageBreakdownTable({
+  breakdown,
+  models,
+  recentDays,
+  totalUnpricedShare,
+}: {
+  readonly breakdown: "model" | "day";
+  readonly models: readonly ModelTotals[];
+  readonly recentDays: readonly DailyTotals[];
+  readonly totalUnpricedShare: number;
+}) {
+  const hasUnpriced = totalUnpricedShare > 0;
+  const describedBy = hasUnpriced ? COST_GUIDANCE_ID : undefined;
+
+  return (
+    <>
+      {hasUnpriced ? (
+        <p id={COST_GUIDANCE_ID} className="text-xs text-muted-foreground">
+          Cost guide: ≥ means a lower-bound estimate from matching API rates; — means no matching
+          rate. Token totals remain complete.
+        </p>
+      ) : null}
+
+      {breakdown === "model" ? (
+        <table className="w-full text-sm" aria-describedby={describedBy}>
+          <thead>
+            <tr className="border-b border-border text-left text-xs text-muted-foreground">
+              <th className="py-2 font-normal">Model</th>
+              <th className="py-2 text-right font-normal">Cost</th>
+              <th className="py-2 text-right font-normal">
+                {hasUnpriced ? "Share of priced cost" : "Share"}
+              </th>
+              <th className="py-2 text-right font-normal">Tokens</th>
+            </tr>
+          </thead>
+          <tbody>
+            {models.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                  No activity in this window.
+                </td>
+              </tr>
+            ) : (
+              models.map((model) => {
+                const modelCost = formatCostEstimate(model.costUsd, model.unpricedShare);
+                return (
+                  <tr
+                    key={`${model.provider}:${model.model}`}
+                    className="border-b border-border/50"
+                  >
+                    <td className="py-2 text-foreground">
+                      <span className="flex items-center gap-2">
+                        <ProviderMark provider={model.provider} className="size-3.5" />
+                        {model.model}
+                      </span>
+                    </td>
+                    <td
+                      className="py-2 text-right text-foreground tabular-nums"
+                      title={modelCost.detail}
+                    >
+                      {modelCost.value}
+                    </td>
+                    <td className="py-2 text-right text-muted-foreground tabular-nums">
+                      {model.unpricedShare >= 1 ? "—" : formatPercent(model.costShare)}
+                    </td>
+                    <td className="py-2 text-right text-muted-foreground tabular-nums">
+                      {formatTokens(model.totalTokens)}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      ) : (
+        <table className="w-full text-sm" aria-describedby={describedBy}>
+          <thead>
+            <tr className="border-b border-border text-left text-xs text-muted-foreground">
+              <th className="py-2 font-normal">Day</th>
+              {PROVIDER_ORDER.map((provider) => (
+                <th key={provider} className="py-2 text-right font-normal">
+                  {PROVIDER_LABEL[provider]}
+                </th>
+              ))}
+              <th className="py-2 text-right font-normal">Total</th>
+              <th className="py-2 text-right font-normal">Tokens</th>
+            </tr>
+          </thead>
+          <tbody>
+            {recentDays.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                  No activity in this window.
+                </td>
+              </tr>
+            ) : (
+              recentDays.map((day) => (
+                <tr key={day.day} className="border-b border-border/50">
+                  <td className="py-2 text-foreground">{formatDayShort(day.day)}</td>
+                  {PROVIDER_ORDER.map((provider) => {
+                    const providerDay = day.byProvider.get(provider);
+                    return (
+                      <td
+                        key={provider}
+                        className="py-2 text-right text-muted-foreground tabular-nums"
+                      >
+                        {providerDay === undefined ? (
+                          <span title="No activity">—</span>
+                        ) : (
+                          <CostAmount
+                            costUsd={providerDay.costUsd}
+                            unpricedShare={providerDay.unpricedShare}
+                          />
+                        )}
+                      </td>
+                    );
+                  })}
+                  <td className="py-2 text-right text-foreground tabular-nums">
+                    <CostAmount costUsd={day.costUsd} unpricedShare={day.unpricedShare} />
+                  </td>
+                  <td className="py-2 text-right text-muted-foreground tabular-nums">
+                    {formatTokens(day.totalTokens)}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      )}
+    </>
   );
 }
 
@@ -393,6 +485,17 @@ function Metric({
       <span className="text-xs text-muted-foreground">{detail}</span>
     </div>
   );
+}
+
+function CostAmount({
+  costUsd,
+  unpricedShare,
+}: {
+  readonly costUsd: number;
+  readonly unpricedShare: number;
+}) {
+  const estimate = formatCostEstimate(costUsd, unpricedShare);
+  return <span title={estimate.detail}>{estimate.value}</span>;
 }
 
 /**

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildDayColumns, niceScale } from "./UsageProviderChart";
+import { buildDayColumns, formatChartValue, niceScale } from "./UsageProviderChart";
 
 describe("niceScale", () => {
   it("never puts the peak above the top of the scale", () => {
@@ -49,9 +49,10 @@ describe("buildDayColumns", () => {
         day: "2026-08-01",
         costUsd: 30,
         totalTokens: 300,
+        unpricedShare: 0.5,
         byProvider: new Map([
-          ["codex" as const, { costUsd: 10, totalTokens: 100 }],
-          ["claude" as const, { costUsd: 20, totalTokens: 200 }],
+          ["codex" as const, { costUsd: 10, totalTokens: 100, unpricedShare: 1 }],
+          ["claude" as const, { costUsd: 20, totalTokens: 200, unpricedShare: 0.25 }],
         ]),
       },
     ],
@@ -62,7 +63,10 @@ describe("buildDayColumns", () => {
         day: "2026-08-03",
         costUsd: 5,
         totalTokens: 50,
-        byProvider: new Map([["claude" as const, { costUsd: 5, totalTokens: 50 }]]),
+        unpricedShare: 0,
+        byProvider: new Map([
+          ["claude" as const, { costUsd: 5, totalTokens: 50, unpricedShare: 0 }],
+        ]),
       },
     ],
   ]);
@@ -77,14 +81,45 @@ describe("buildDayColumns", () => {
     ]);
   });
 
+  it("retains pricing coverage for cost hover values", () => {
+    const [first] = buildDayColumns(days, byDay, "cost");
+
+    expect(first).toMatchObject({
+      unpricedShare: 0.5,
+      bands: [
+        { provider: "codex", unpricedShare: 1 },
+        { provider: "claude", unpricedShare: 0.25 },
+      ],
+    });
+  });
+
+  it("retains whether sparse provider-day columns have activity", () => {
+    const columns = buildDayColumns(days, byDay, "cost");
+
+    expect(columns[1]).toMatchObject({
+      hasActivity: false,
+      bands: [
+        { provider: "codex", hasActivity: false },
+        { provider: "claude", hasActivity: false },
+      ],
+    });
+    expect(columns[2]).toMatchObject({
+      hasActivity: true,
+      bands: [
+        { provider: "codex", hasActivity: false },
+        { provider: "claude", hasActivity: true },
+      ],
+    });
+  });
+
   it("keeps band values absolute rather than cumulative", () => {
     // Regression: the bands were once stack offsets, which drew Claude Code
     // permanently above Codex regardless of which provider spent more.
     const [first] = buildDayColumns(days, byDay, "cost");
 
     expect(first?.bands).toEqual([
-      { provider: "codex", value: 10 },
-      { provider: "claude", value: 20 },
+      { provider: "codex", value: 10, unpricedShare: 1, hasActivity: true },
+      { provider: "claude", value: 20, unpricedShare: 0.25, hasActivity: true },
     ]);
   });
 
@@ -93,5 +128,22 @@ describe("buildDayColumns", () => {
       const sum = column.bands.reduce((running, band) => running + band.value, 0);
       expect(column.total).toBeCloseTo(sum, 9);
     }
+  });
+});
+
+describe("formatChartValue", () => {
+  it("labels an inactive provider-day as no activity rather than priced zero", () => {
+    expect(formatChartValue("cost", 0, 0, false)).toBe("—");
+    expect(formatChartValue("cost", 0, 0, true)).toBe("$0.00");
+  });
+
+  it("does not show missing or partial cost rates as exact hover values", () => {
+    expect(formatChartValue("cost", 0, 1, true)).toBe("—");
+    expect(formatChartValue("cost", 20, 0.25, true)).toBe("≥$20.00");
+    expect(formatChartValue("cost", 20, 0, true)).toBe("$20.00");
+  });
+
+  it("keeps token hover values independent of pricing coverage", () => {
+    expect(formatChartValue("tokens", 20_000, 1, true)).toBe("20K");
   });
 });

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -2,7 +2,12 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import type { DailyTotals } from "@t3tools/shared/usageMerge";
-import { formatDayShort, formatTokens, formatUsd } from "@t3tools/shared/usageFormat";
+import {
+  formatCostEstimate,
+  formatDayShort,
+  formatTokens,
+  formatUsd,
+} from "@t3tools/shared/usageFormat";
 import { PROVIDER_COLOR, PROVIDER_LABEL, PROVIDER_MARK, PROVIDER_ORDER } from "./usageProviders";
 
 const VIEW_WIDTH = 960;
@@ -11,6 +16,17 @@ const TICK_COUNT = 4;
 const PLOT_TOP = 8;
 
 export type UsageChartMetric = "tokens" | "cost";
+
+/** Formats a plotted value with the pricing coverage carried by its day column. */
+export function formatChartValue(
+  metric: UsageChartMetric,
+  value: number,
+  unpricedShare: number,
+  hasActivity: boolean,
+): string {
+  if (metric === "cost" && !hasActivity) return "—";
+  return metric === "tokens" ? formatTokens(value) : formatCostEstimate(value, unpricedShare).value;
+}
 
 interface UsageProviderChartProps {
   readonly days: readonly string[];
@@ -23,8 +39,12 @@ export interface DayColumn {
   readonly bands: readonly {
     readonly provider: UsageProviderKind;
     readonly value: number;
+    readonly unpricedShare: number;
+    readonly hasActivity: boolean;
   }[];
   readonly total: number;
+  readonly unpricedShare: number;
+  readonly hasActivity: boolean;
 }
 
 interface Point {
@@ -172,8 +192,15 @@ export function buildDayColumns(
     const bands = PROVIDER_ORDER.map((provider) => ({
       provider,
       value: valueFor(entry, provider, metric),
+      unpricedShare: entry?.byProvider.get(provider)?.unpricedShare ?? 0,
+      hasActivity: entry?.byProvider.has(provider) ?? false,
     }));
-    return { bands, total: bands.reduce((sum, band) => sum + band.value, 0) };
+    return {
+      bands,
+      total: bands.reduce((sum, band) => sum + band.value, 0),
+      unpricedShare: entry?.unpricedShare ?? 0,
+      hasActivity: entry !== undefined,
+    };
   });
 }
 
@@ -336,6 +363,7 @@ export function UsageProviderChart({ days, daily, metric }: UsageProviderChartPr
               <div className="mb-1 text-muted-foreground">{formatDayShort(hoveredDay)}</div>
               {PROVIDER_ORDER.map((provider) => {
                 const Mark = PROVIDER_MARK[provider];
+                const band = hoveredColumn?.bands.find((entry) => entry.provider === provider);
                 return (
                   <div key={provider} className="flex items-center justify-between gap-3">
                     <span className="flex items-center gap-1.5 text-muted-foreground">
@@ -343,8 +371,11 @@ export function UsageProviderChart({ days, daily, metric }: UsageProviderChartPr
                       {PROVIDER_LABEL[provider]}
                     </span>
                     <span className="text-foreground tabular-nums">
-                      {format(
-                        hoveredColumn?.bands.find((band) => band.provider === provider)?.value ?? 0,
+                      {formatChartValue(
+                        metric,
+                        band?.value ?? 0,
+                        band?.unpricedShare ?? 0,
+                        band?.hasActivity ?? false,
                       )}
                     </span>
                   </div>
@@ -353,7 +384,12 @@ export function UsageProviderChart({ days, daily, metric }: UsageProviderChartPr
               <div className="mt-1 flex items-center justify-between gap-3 border-t border-border pt-1">
                 <span className="text-muted-foreground">Total</span>
                 <span className="text-foreground tabular-nums">
-                  {format(hoveredColumn?.total ?? 0)}
+                  {formatChartValue(
+                    metric,
+                    hoveredColumn?.total ?? 0,
+                    hoveredColumn?.unpricedShare ?? 0,
+                    hoveredColumn?.hasActivity ?? false,
+                  )}
                 </span>
               </div>
             </div>

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatCostEstimate } from "./usageFormat.js";
+
+describe("formatCostEstimate", () => {
+  it("does not present fully unpriced usage as zero cost", () => {
+    expect(formatCostEstimate(0, 1)).toEqual({
+      value: "—",
+      detail: "No matching API rates; token totals are still complete.",
+    });
+  });
+
+  it("marks a mixed priced and unpriced total as a lower bound", () => {
+    expect(formatCostEstimate(12.34, 0.25)).toEqual({
+      value: "≥$12.34",
+      detail: "Partial API-rate estimate; 25.0% of requests have no matching rate.",
+    });
+  });
+
+  it("keeps the existing API-rate label when every request is priced", () => {
+    expect(formatCostEstimate(12.34, 0)).toEqual({
+      value: "$12.34",
+      detail: "If billed at full API rate.",
+    });
+  });
+});

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -19,6 +19,29 @@ export function formatUsd(value: number): string {
   return CURRENCY.format(value);
 }
 
+/** Marks incomplete API-rate estimates without making missing prices look free. */
+export function formatCostEstimate(
+  costUsd: number,
+  unpricedShare: number,
+): { readonly value: string; readonly detail: string } {
+  if (unpricedShare >= 1) {
+    return {
+      value: "—",
+      detail: "No matching API rates; token totals are still complete.",
+    };
+  }
+  if (unpricedShare > 0) {
+    return {
+      value: `≥${formatUsd(costUsd)}`,
+      detail: `Partial API-rate estimate; ${formatPercent(unpricedShare)} of requests have no matching rate.`,
+    };
+  }
+  return {
+    value: formatUsd(costUsd),
+    detail: "If billed at full API rate.",
+  };
+}
+
 export function formatCount(value: number): string {
   return INTEGER.format(Math.round(value));
 }

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -187,6 +187,12 @@ describe("mergeUsage", () => {
     expect(merged.providers[0]?.costShare).toBeCloseTo(0.75, 5);
     expect(merged.costQuality.unpricedShare).toBeCloseTo(0.5, 5);
     expect(merged.costQuality.cacheSavingsUsd).toBe(4);
+    expect(merged.providers.find((provider) => provider.provider === "codex")?.unpricedShare).toBe(
+      1,
+    );
+    expect(merged.models.find((model) => model.model === "gpt-5.6-sol")?.unpricedShare).toBe(1);
+    expect(merged.daily[0]?.unpricedShare).toBeCloseTo(0.5, 5);
+    expect(merged.daily[0]?.byProvider.get("codex")?.unpricedShare).toBe(1);
   });
 
   it("keeps two machines apart when hostname and home path collide", () => {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -27,6 +27,7 @@ export interface ProviderTotals {
   readonly records: number;
   readonly costShare: number;
   readonly tokenShare: number;
+  readonly unpricedShare: number;
 }
 
 export interface ModelTotals {
@@ -36,13 +37,18 @@ export interface ModelTotals {
   readonly totalTokens: number;
   readonly records: number;
   readonly costShare: number;
+  readonly unpricedShare: number;
 }
 
 export interface DailyTotals {
   readonly day: string;
   readonly costUsd: number;
   readonly totalTokens: number;
-  readonly byProvider: ReadonlyMap<UsageProviderKind, { costUsd: number; totalTokens: number }>;
+  readonly unpricedShare: number;
+  readonly byProvider: ReadonlyMap<
+    UsageProviderKind,
+    { readonly costUsd: number; readonly totalTokens: number; readonly unpricedShare: number }
+  >;
 }
 
 export interface CostQuality {
@@ -218,18 +224,29 @@ export function mergeUsage(
 
   const providerAccumulator = new Map<
     UsageProviderKind,
-    { costUsd: number; totalTokens: number; records: number }
+    { costUsd: number; totalTokens: number; records: number; unpricedRecords: number }
   >();
   const modelAccumulator = new Map<
     string,
-    { provider: UsageProviderKind; costUsd: number; totalTokens: number; records: number }
+    {
+      provider: UsageProviderKind;
+      costUsd: number;
+      totalTokens: number;
+      records: number;
+      unpricedRecords: number;
+    }
   >();
   const dailyAccumulator = new Map<
     string,
     {
       costUsd: number;
       totalTokens: number;
-      byProvider: Map<UsageProviderKind, { costUsd: number; totalTokens: number }>;
+      records: number;
+      unpricedRecords: number;
+      byProvider: Map<
+        UsageProviderKind,
+        { costUsd: number; totalTokens: number; records: number; unpricedRecords: number }
+      >;
     }
   >();
   const contributingEnvironments: EnvironmentId[] = [];
@@ -260,10 +277,12 @@ export function mergeUsage(
         costUsd: 0,
         totalTokens: 0,
         records: 0,
+        unpricedRecords: 0,
       };
       provider.costUsd += bucket.costUsd;
       provider.totalTokens += tokens;
       provider.records += bucket.records;
+      provider.unpricedRecords += bucket.unpricedRecords;
       providerAccumulator.set(bucket.provider, provider);
 
       const modelKey = `${bucket.provider} ${bucket.model}`;
@@ -272,22 +291,38 @@ export function mergeUsage(
         costUsd: 0,
         totalTokens: 0,
         records: 0,
+        unpricedRecords: 0,
       };
       model.costUsd += bucket.costUsd;
       model.totalTokens += tokens;
       model.records += bucket.records;
+      model.unpricedRecords += bucket.unpricedRecords;
       modelAccumulator.set(modelKey, model);
 
       const day = dailyAccumulator.get(bucket.day) ?? {
         costUsd: 0,
         totalTokens: 0,
-        byProvider: new Map<UsageProviderKind, { costUsd: number; totalTokens: number }>(),
+        records: 0,
+        unpricedRecords: 0,
+        byProvider: new Map<
+          UsageProviderKind,
+          { costUsd: number; totalTokens: number; records: number; unpricedRecords: number }
+        >(),
       };
       day.costUsd += bucket.costUsd;
       day.totalTokens += tokens;
-      const dayProvider = day.byProvider.get(bucket.provider) ?? { costUsd: 0, totalTokens: 0 };
+      day.records += bucket.records;
+      day.unpricedRecords += bucket.unpricedRecords;
+      const dayProvider = day.byProvider.get(bucket.provider) ?? {
+        costUsd: 0,
+        totalTokens: 0,
+        records: 0,
+        unpricedRecords: 0,
+      };
       dayProvider.costUsd += bucket.costUsd;
       dayProvider.totalTokens += tokens;
+      dayProvider.records += bucket.records;
+      dayProvider.unpricedRecords += bucket.unpricedRecords;
       day.byProvider.set(bucket.provider, dayProvider);
       dailyAccumulator.set(bucket.day, day);
     }
@@ -303,6 +338,7 @@ export function mergeUsage(
       records: totals.records,
       costShare: costUsd === 0 ? 0 : totals.costUsd / costUsd,
       tokenShare: totalTokens === 0 ? 0 : totals.totalTokens / totalTokens,
+      unpricedShare: totals.records === 0 ? 0 : totals.unpricedRecords / totals.records,
     }))
     .sort((a, b) => b.costUsd - a.costUsd);
 
@@ -314,6 +350,7 @@ export function mergeUsage(
       totalTokens: totals.totalTokens,
       records: totals.records,
       costShare: costUsd === 0 ? 0 : totals.costUsd / costUsd,
+      unpricedShare: totals.records === 0 ? 0 : totals.unpricedRecords / totals.records,
     }))
     .sort((a, b) => b.costUsd - a.costUsd || b.totalTokens - a.totalTokens);
 
@@ -322,7 +359,20 @@ export function mergeUsage(
       day,
       costUsd: totals.costUsd,
       totalTokens: totals.totalTokens,
-      byProvider: totals.byProvider,
+      unpricedShare: totals.records === 0 ? 0 : totals.unpricedRecords / totals.records,
+      byProvider: new Map(
+        [...totals.byProvider].map(([provider, providerTotals]) => [
+          provider,
+          {
+            costUsd: providerTotals.costUsd,
+            totalTokens: providerTotals.totalTokens,
+            unpricedShare:
+              providerTotals.records === 0
+                ? 0
+                : providerTotals.unpricedRecords / providerTotals.records,
+          },
+        ]),
+      ),
     }))
     .sort((a, b) => a.day.localeCompare(b.day));
 


### PR DESCRIPTION
## What Changed

- Render fully unpriced usage as `—` and mixed priced/unpriced usage as a lower bound (`≥$X`) instead of an exact `$0.00` or `$X`.
- Surface unpriced coverage consistently across the web/desktop and mobile headline, provider, model, chart, and day breakdowns while keeping token totals complete.
- Share the cost presentation rules between clients and add focused all-priced, mixed, and fully-unpriced regression coverage.

## Why

The aggregation layer already knows when a model has no matching API rate, but the UI formatted that missing price as zero. That made unknown cost look like a genuine free result and made mixed totals look exact. This keeps the existing API-rate estimate model while making its coverage honest.

Fixes #5799.

Focused verification:

- 33 shared/web/mobile usage tests
- targeted format and lint checks
- `@t3tools/web` and `@t3tools/mobile` typechecks
- independent standards/spec review

## UI Changes

All screenshots use isolated synthetic transcripts and rates.

### Web / desktop

| Before | After |
| --- | --- |
| ![Web before](https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-unpriced-visibility/.github/pr-assets/usage-unpriced-visibility/before.png) | ![Web after](https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-unpriced-visibility/.github/pr-assets/usage-unpriced-visibility/after.png) |

### Mobile summary and providers

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-unpriced-visibility/.github/pr-assets/usage-unpriced-visibility/mobile-before-summary.png" width="360" alt="Mobile usage summary before"> | <img src="https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-unpriced-visibility/.github/pr-assets/usage-unpriced-visibility/mobile-after-summary.png" width="360" alt="Mobile usage summary after"> |

### Mobile model breakdown

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-unpriced-visibility/.github/pr-assets/usage-unpriced-visibility/mobile-before-models.png" width="360" alt="Mobile model breakdown before"> | <img src="https://raw.githubusercontent.com/caezium/t3code/pr-assets-usage-unpriced-visibility/.github/pr-assets/usage-unpriced-visibility/mobile-after-models.png" width="360" alt="Mobile model breakdown after"> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] No animation or interaction changed, so a video is not applicable


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distinguish unpriced usage from zero cost across web and mobile usage views
> - Adds `unpricedShare` to provider, model, day, and per-provider-day totals in [`usageMerge.ts`](https://github.com/pingdotgg/t3code/pull/5827/files#diff-143d7ed21cccd3774754bd4f261d302d61b7997008db82ed56a3920e176a57b3), tracking the fraction of records with no matching API rate.
> - Adds `formatCostEstimate` in [`usageFormat.ts`](https://github.com/pingdotgg/t3code/pull/5827/files#diff-fe92f08893f2c1ba1424fe730fd95fbb0ef2269ab3266b4e47c98aa5ea918552) to render `—` for fully unpriced, `≥$` for partial, and plain USD for fully priced costs.
> - Updates web ([`UsagePage.tsx`](https://github.com/pingdotgg/t3code/pull/5827/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead), [`UsageProviderChart.tsx`](https://github.com/pingdotgg/t3code/pull/5827/files#diff-52c28becdc9ddcf01c41d61d218f83687038f2efea310911245393fc696d5c56)) and mobile ([`UsageRouteScreen.tsx`](https://github.com/pingdotgg/t3code/pull/5827/files#diff-488a6bd45cb7af1278effc53880b4af38118aedbf2b167549e1011124f850058)) to use coverage-aware formatting throughout headlines, chart tooltips, provider rows, and breakdown tables.
> - Adds guidance text (e.g. `≥` and `—` explanations) inline when any unpriced records are present.
> - Behavioral Change: any cost previously shown as `$0.00` for unpriced models or providers now displays `—` or `≥$X.XX` depending on pricing coverage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9920f0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to usage cost formatting with shared helpers and broad test coverage; no auth, billing, or aggregation logic beyond exposing existing unpriced record counts.
> 
> **Overview**
> Usage cost UI no longer treats missing API rates as **$0.00** or exact totals when coverage is incomplete.
> 
> **Shared:** `formatCostEstimate` returns `—` when everything is unpriced, `≥$…` when only part of usage has rates, and unchanged dollar amounts when fully priced. `mergeUsage` now surfaces **`unpricedShare`** on providers, models, daily rows, and per-provider day cells so clients can format honestly.
> 
> **Web:** Headlines, provider rows, model/day breakdowns, and chart hovers use those rules; partial windows get **(partial)** labels, a short cost guide, and **“share of priced cost”** where relevant. Missing provider-days show **—** (no activity), not priced zero.
> 
> **Mobile:** `presentUsageCost` / `presentUsageCostShare` mirror the same copy for the chart card, providers, and models, including the cost guide when any usage is unpriced.
> 
> Regression tests cover all-priced, mixed, and fully-unpriced cases on shared, web, mobile, and chart helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9920f0ea42713f841eee5ae6d32fe082355525fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->