### PR TITLE
fix(mobile): report markdown link open failures

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -28,7 +28,6 @@ import {
 import {
   ActivityIndicator,
   Image,
-  Linking,
   Platform,
   type LayoutChangeEvent,
   type NativeScrollEvent,
@@ -49,6 +48,7 @@ import Animated, { FadeIn, FadeInUp, type SharedValue } from "react-native-reani
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useFontFamily } from "../../lib/useFontFamily";
 import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import {
   hasNativeSelectableMarkdownText,
   SelectableMarkdownText,
@@ -271,7 +271,7 @@ const MarkdownExternalLink = memo(function MarkdownExternalLink(props: {
     <NativeText
       className="font-sans"
       onPress={() => {
-        void Linking.openURL(props.href);
+        void tryOpenExternalUrl(props.href, "markdown-link");
       }}
       style={{
         color: props.color,
@@ -601,7 +601,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
             onPress={
               linkHref
                 ? () => {
-                    void Linking.openURL(linkHref);
+                    void tryOpenExternalUrl(linkHref, "markdown-link");
                   }
                 : undefined
             }
@@ -1403,7 +1403,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       }
 
       if (presentation.href) {
-        void Linking.openURL(presentation.href);
+        void tryOpenExternalUrl(presentation.href, "markdown-link");
       }
     },
     [props.environmentId, props.threadId, props.workspaceRoot, navigation],


### PR DESCRIPTION
Resolves #5839

## What Changed

`ThreadFeed.tsx` routes all three markdown link presses through
`tryOpenExternalUrl` with the existing `markdown-link` target. The now unused
`Linking` import goes away. Four lines change, and no behavior changes on a
successful tap.

```diff
-        void Linking.openURL(props.href);
+        void tryOpenExternalUrl(props.href, "markdown-link");
```

## Why

The three call sites called `Linking.openURL` directly:

```ts
// :274 MarkdownExternalLink, :604 link renderer, :1406 onMarkdownLinkPress
void Linking.openURL(props.href);
```

`Linking.openURL` rejects when the device has no handler for the URL. The `void`
operator discards that rejection, so a failed tap produced no log line.

`tryOpenExternalUrl` exists for this case and already declares a
`markdown-link` target. `FileMarkdownPreview.tsx` uses it on lines 60 and 191.
The thread feed was the only markdown renderer that stayed silent, so this
makes the two agree.

## UI Changes

None. The change only adds error reporting on the failure path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

## Verification

- `vp run --filter @t3tools/mobile typecheck` passes.
- `vp run --filter @t3tools/mobile test` passes, 620 tests in 100 files.
- `vp lint --report-unused-disable-directives` reports one pre-existing warning
  in `apps/web/src/components/settings/ThemeEditorPanel.tsx`, untouched here.
- `vp fmt --check` passes.
- Rebased onto `1a003e383`.

Written by Claude Opus 5 in Claude Code.
