### PR TITLE
fix(web): match settings search shortcut styling to command palette's

### DIFF
--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -234,9 +234,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
                 <XIcon className="size-3" />
               </Button>
             ) : (
-              <Kbd className="mr-px h-4 min-w-0 rounded-sm bg-sidebar-control-surface px-1.5 text-[10px] text-sidebar-muted-foreground ring-1 ring-sidebar-border">
-                /
-              </Kbd>
+              <Kbd className="h-4 min-w-0 rounded-sm px-1.5 text-[10px]">/</Kbd>
             )}
           </div>
           {isSearching && results.length === 0 ? (


### PR DESCRIPTION
## What Changed

The "/" shortcut badge in the settings sidebar search box now uses the same subtle keycap style as the command palette shortcut badge in the legacy sidebar, so the two look consistent.

## Why

The "/" settings badge previously looked weird and was not consistent with the existing style. It rendered as a bordered, outlined pill, which stood out against the plain keycap used for the command palette hint. This change makes the settings search shortcut match the existing style.

Existing Style (command palette shortcut badge in the legacy sidebar): 
<img width="316" height="48" alt="image" src="https://github.com/user-attachments/assets/710c9907-b1fc-4c2b-b626-8481b34f86ac" />
The "/" shortcut didn't match this, and looked weird.

## UI Changes

Before:
<img width="316" height="48" alt="image" src="https://github.com/user-attachments/assets/0c38510b-3cd4-4f8d-be55-a273d5db0894" />

After:
<img width="316" height="48" alt="image" src="https://github.com/user-attachments/assets/9a2533ed-1b89-4288-a7f3-dc3ee6c3dbab" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only className change on a keyboard hint with no behavior or data impact.
> 
> **Overview**
> The **/** keyboard hint in the settings sidebar search field no longer uses sidebar-specific pill styling (extra background, border ring, muted text color, and right margin). It now relies on the shared `Kbd` defaults with the same compact sizing classes as the legacy sidebar command palette shortcut badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 124ffcf3c93a9fcff099dcfa89267c649895cb22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Match settings search `Kbd` shortcut styling to command palette
> Removes sidebar-specific styles (background color, ring/border, muted-foreground text color, right margin) from the `/` keyboard hint in [SettingsSidebarNav.tsx](https://github.com/pingdotgg/t3code/pull/5841/files#diff-0c64e545aee60962b27c61f412d1b564c5896199b9538212702b7da60246d134), aligning it visually with the command palette shortcut badge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 124ffcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->