### PR TITLE
fix(client-runtime): branch list no longer resets while paging through refs

### DIFF
--- a/packages/client-runtime/src/state/vcs.ts
+++ b/packages/client-runtime/src/state/vcs.ts
@@ -236,29 +236,32 @@ export function cachedVcsRefsChanges(
 export function createVcsEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | EnvironmentCacheStore | R, E>,
 ) {
-  const listRefsByEnvironment = Atom.family((environmentId: EnvironmentId) =>
-    Atom.family((inputKey: string) => {
-      const input = JSON.parse(inputKey) as VcsListRefsInput;
-      return runtime
-        .atom((get) => {
-          const state = get(vcsRefsCacheStateAtom({ environmentId }));
-          return cachedVcsRefsChanges(
-            environmentId,
-            input,
-            state.revision,
-            state.persistedCacheReadable,
-          );
-        })
-        .pipe(
-          Atom.setIdleTTL(VCS_REFS_IDLE_TTL_MS),
-          Atom.withLabel(`environment-data:vcs:list-refs:${environmentId}:${inputKey}`),
+  // Single-level family on purpose: `Atom.family` holds entries via WeakRef,
+  // so with a nested family the inner family (and its whole atom cache) is
+  // only strongly referenced during the call and can be garbage-collected
+  // between lookups — returning fresh valueless atoms for pages that were
+  // already loaded.
+  const listRefsFamily = Atom.family((key: string) => {
+    const [environmentId, input] = JSON.parse(key) as [EnvironmentId, VcsListRefsInput];
+    return runtime
+      .atom((get) => {
+        const state = get(vcsRefsCacheStateAtom({ environmentId }));
+        return cachedVcsRefsChanges(
+          environmentId,
+          input,
+          state.revision,
+          state.persistedCacheReadable,
         );
-    }),
-  );
+      })
+      .pipe(
+        Atom.setIdleTTL(VCS_REFS_IDLE_TTL_MS),
+        Atom.withLabel(`environment-data:vcs:list-refs:${key}`),
+      );
+  });
   const listRefs = (target: {
     readonly environmentId: EnvironmentId;
     readonly input: VcsListRefsInput;
-  }) => listRefsByEnvironment(target.environmentId)(JSON.stringify(target.input));
+  }) => listRefsFamily(JSON.stringify([target.environmentId, target.input]));
   const invalidateRefs = (
     target: { readonly environmentId: EnvironmentId; readonly input: { readonly cwd: string } },
     registry: AtomRegistry.AtomRegistry,


### PR DESCRIPTION
# What Changed

`listRefs` in `createVcsEnvironmentAtoms` was one `Atom.family` nested inside another. It is now a single family keyed by `JSON.stringify([environmentId, input])`, the same pattern `createEnvironmentRpcQueryAtomFamily` uses.

## Why

The cached ref pages live in an `Atom.family`, and it was a family nested inside another family. A family only holds its entries weakly, and nothing held on to the inner one between lookups. So at any random moment the garbage collector could throw the whole cache away. When that happened mid-scroll, every page the picker had loaded was just gone: the list went empty, the scroll jumped to the top, and fetching started over from page 1. That's the reset in the video on the issue.

With one flat family, the pages that are in use keep their cache entries alive, so GC can't wipe them and the scroll stays put. This also fixes in-use ref lists refetching at random, which #4727 tried to stop.

Before:
https://github.com/user-attachments/assets/79ba896d-3f06-4092-ad46-3311380e7499

After:
https://github.com/user-attachments/assets/2714e07e-e10f-47c1-b940-af05dc6fa2fd
