### PR TITLE
feat(web): humanize tool-call rows with dynamic strings

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1785,6 +1785,21 @@ describe("work entry row chrome", () => {
     expect(body!.length).toBeLessThan(1000);
   });
 
+  it("bounds a tool input dictionary with many keys", () => {
+    const metadata = Object.fromEntries(
+      Array.from({ length: 500 }, (_, index) => [`file-${index}.ts`, `sha-${index}`]),
+    );
+    const body = buildToolCallExpandedBody(
+      makeWorkEntry({ toolName: "Catalog", toolInput: metadata }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(body).toContain("file-19.ts");
+    expect(body).not.toContain("file-20.ts");
+    expect(body).toContain("(+480 more entries)");
+    expect(body!.length).toBeLessThan(1500);
+  });
+
   it("bounds long arrays and deep nesting in tool input", () => {
     const body = buildToolCallExpandedBody(
       makeWorkEntry({

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  buildToolCallExpandedBody,
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
+  describeToolCallWorkEntry,
+  hasToolCallExpandedBody,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  workEntryIconName,
 } from "./MessagesTimeline.logic";
+import { type WorkLogEntry } from "../../session-logic";
 
 describe("computeMessageDurationStart", () => {
   it("returns message createdAt when there is no preceding user message", () => {
@@ -1169,5 +1174,626 @@ describe("computeStableMessagesTimelineRows", () => {
 
     expect(reordered).not.toBe(initial);
     expect(reordered.result).toEqual([initial.result[1], initial.result[0]]);
+  });
+});
+
+describe("describeToolCallWorkEntry", () => {
+  const WORKSPACE_ROOT = "/Users/dev/t3code";
+
+  function makeWorkEntry(overrides: Partial<WorkLogEntry>): WorkLogEntry {
+    return {
+      id: "work-1",
+      createdAt: "2026-03-17T19:12:28.000Z",
+      label: "Tool call",
+      tone: "tool",
+      ...overrides,
+    };
+  }
+
+  it("names Claude read calls after the file they read", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolTitle: "Tool call",
+        itemType: "dynamic_tool_call",
+        detail: 'Read: {"file_path":"/Users/dev/t3code/apps/web/src/app.ts"}',
+        toolName: "Read",
+        toolInput: { file_path: "/Users/dev/t3code/apps/web/src/app.ts" },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({
+      heading: "Read file",
+      preview: "t3code/apps/web/src/app.ts",
+    });
+  });
+
+  it("prefers the structured command over the prefixed detail Claude echoes", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Command run",
+        toolTitle: "Command run",
+        itemType: "command_execution",
+        detail: "Bash: git status",
+        command: "Bash: git status",
+        toolName: "Bash",
+        toolInput: { command: "git status", description: "Check the working tree" },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Ran command", preview: "git status" });
+  });
+
+  it("previews grep calls with their pattern", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolTitle: "Tool call",
+        itemType: "dynamic_tool_call",
+        toolName: "Grep",
+        toolInput: { pattern: "useEffect\\(", path: "/Users/dev/t3code/apps/web" },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Searched code", preview: "useEffect\\(" });
+  });
+
+  it("previews web search calls with their query", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolTitle: "Web search",
+        itemType: "web_search",
+        toolName: "WebSearch",
+        toolInput: { query: "react useEffect cleanup" },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Searched the web", preview: "react useEffect cleanup" });
+  });
+
+  it("previews web fetch calls with their url", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolTitle: "Tool call",
+        itemType: "dynamic_tool_call",
+        toolName: "WebFetch",
+        toolInput: { url: "https://example.com/docs", prompt: "Summarize the page" },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Fetched page", preview: "https://example.com/docs" });
+  });
+
+  it("keeps MCP identity when the adapter misclassified the item type", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "File change",
+        toolTitle: "File change",
+        itemType: "file_change",
+        toolName: "create_pr",
+        toolServer: "github",
+        toolInput: { title: "Fix login bug", body: "Resets the session on 401" },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "github · create_pr", preview: "Fix login bug" });
+  });
+
+  it("falls back to the row detail for MCP calls without arguments", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "t3-code · preview_status",
+        toolTitle: "t3-code · preview_status",
+        itemType: "mcp_tool_call",
+        detail: "19 files",
+        toolName: "preview_status",
+        toolServer: "t3-code",
+        toolInput: {},
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "t3-code · preview_status", preview: "19 files" });
+  });
+
+  it("recovers the tool from legacy '<Tool>: <json>' details", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Tool call completed",
+        toolTitle: "Tool call",
+        itemType: "dynamic_tool_call",
+        detail: 'Read: {"file_path":"/tmp/app.ts"}',
+        command: "sed -n 1,40p /tmp/app.ts",
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Read file", preview: "/tmp/app.ts" });
+  });
+
+  it("recovers the command from a legacy shell-prefixed detail", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Command run",
+        toolTitle: "Command run",
+        itemType: "command_execution",
+        detail: "Bash: git status",
+        command: "Bash: git status",
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Ran command", preview: "git status" });
+  });
+
+  it("humanizes unknown dynamic tool names", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolTitle: "Tool call",
+        itemType: "dynamic_tool_call",
+        toolName: "preview_status",
+        toolInput: { target: "web" },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Preview status", preview: "web" });
+  });
+
+  it("prefers the changed-files summary for edits", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "File change",
+        toolTitle: "File change",
+        itemType: "file_change",
+        toolName: "Edit",
+        toolInput: { file_path: "/Users/dev/t3code/apps/web/src/a.ts" },
+        changedFiles: [
+          "/Users/dev/t3code/apps/web/src/a.ts",
+          "/Users/dev/t3code/apps/web/src/b.ts",
+        ],
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({
+      heading: "Edited file",
+      preview: "t3code/apps/web/src/a.ts +1 more",
+    });
+  });
+
+  it("describes subagent calls with their description", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Subagent task",
+        toolTitle: "Subagent task",
+        itemType: "collab_agent_tool_call",
+        detail: "Explore the auth module",
+        toolName: "Task",
+        toolInput: {
+          description: "Explore the auth module",
+          prompt: "Read every file under apps/server/src/auth and report the entry points.",
+          subagent_type: "explore",
+        },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Ran subagent", preview: "Explore the auth module" });
+  });
+
+  it("drops the preview for to-do updates", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolTitle: "Tool call",
+        itemType: "dynamic_tool_call",
+        toolName: "TodoWrite",
+        toolInput: { todos: [{ content: "Ship it" }] },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Updated to-do list", preview: null });
+  });
+
+  it("truncates long previews", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolName: "Bash",
+        toolInput: { command: `echo ${"x".repeat(200)}` },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display.preview).toHaveLength(120);
+    expect(display.preview?.endsWith("…")).toBe(true);
+  });
+
+  it("leaves prose details alone", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Ran command",
+        toolTitle: "Ran command",
+        itemType: "command_execution",
+        command: "grep -R nope .",
+        detail: "grep: command not found",
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Ran command", preview: "grep -R nope ." });
+  });
+
+  it("reproduces the legacy heading and preview when nothing identifies the tool", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Glob",
+        detail: "No files found",
+        toolLifecycleStatus: "failed",
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Glob", preview: "No files found" });
+  });
+
+  it("falls back to the changed-files summary when there is no detail", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Changed files",
+        toolTitle: "Changed files",
+        itemType: "file_change",
+        changedFiles: ["/Users/dev/t3code/a.ts", "/Users/dev/t3code/b.ts"],
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Changed files", preview: "t3code/a.ts +1 more" });
+  });
+});
+
+describe("describeToolCallWorkEntry legacy shell prefixes", () => {
+  it("does not read a shell error in the output as the command that ran", () => {
+    const display = describeToolCallWorkEntry(
+      {
+        id: "work-1",
+        createdAt: "2026-03-17T19:12:28.000Z",
+        label: "Ran command",
+        tone: "tool",
+        toolTitle: "Ran command",
+        itemType: "command_execution",
+        command: "foo --bar",
+        detail: "bash: foo: command not found",
+      },
+      "/Users/dev/t3code",
+    );
+
+    expect(display).toEqual({ heading: "Ran command", preview: "foo --bar" });
+  });
+});
+
+describe("describeToolCallWorkEntry does not invent tool calls", () => {
+  const WORKSPACE_ROOT = "/Users/dev/t3code";
+
+  function makeWorkEntry(overrides: Partial<WorkLogEntry>): WorkLogEntry {
+    return {
+      id: "work-1",
+      createdAt: "2026-03-17T19:12:28.000Z",
+      label: "Tool call",
+      tone: "tool",
+      ...overrides,
+    };
+  }
+
+  it("keeps error prose that merely opens with a shell word", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Provider error",
+        tone: "error",
+        detail: "sh: permission denied while starting the agent",
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({
+      heading: "Provider error",
+      preview: "sh: permission denied while starting the agent",
+    });
+  });
+
+  it("keeps reasoning prose that opens with a command word", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Thinking",
+        tone: "thinking",
+        detail: "Command: run the migration",
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Thinking", preview: "Command: run the migration" });
+  });
+
+  it("keeps a shell-prefixed label as the row heading", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({ label: "Shell: exited with code 1", tone: "error" }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display.heading).toBe("Shell: exited with code 1");
+  });
+
+  it("keeps prose that quotes JSON instead of turning the word into a tool", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({ detail: 'Result: {"ok":true}' }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Tool call", preview: 'Result: {"ok":true}' });
+  });
+
+  it("still recovers an MCP call from a legacy prefixed detail", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({ detail: 'mcp__github__create_pr: {"title":"Fix login bug"}' }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "github · create_pr", preview: "Fix login bug" });
+  });
+
+  it("phrases a pending command approval as the request, not as a finished call", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "Command approval requested",
+        tone: "info",
+        requestKind: "command",
+        detail: "Bash: rm -rf /tmp/build",
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({
+      heading: "Command approval requested",
+      preview: "Bash: rm -rf /tmp/build",
+    });
+  });
+
+  it("phrases a pending file approval as the request, not as a finished read", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        label: "File read approval requested",
+        tone: "info",
+        requestKind: "file-read",
+        detail: 'Read: {"file_path":"/etc/passwd"}',
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({
+      heading: "File read approval requested",
+      preview: 'Read: {"file_path":"/etc/passwd"}',
+    });
+  });
+});
+
+describe("describeToolCallWorkEntry argument handling", () => {
+  const WORKSPACE_ROOT = "/Users/dev/t3code";
+
+  function makeWorkEntry(overrides: Partial<WorkLogEntry>): WorkLogEntry {
+    return {
+      id: "work-1",
+      createdAt: "2026-03-17T19:12:28.000Z",
+      label: "Tool call",
+      tone: "tool",
+      ...overrides,
+    };
+  }
+
+  it("names OpenCode reads after their camelCase filePath instead of the output", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolTitle: "read",
+        itemType: "dynamic_tool_call",
+        toolName: "read",
+        toolInput: { filePath: "/Users/dev/t3code/apps/web/src/a.ts" },
+        detail: "<file>\n00001| import x from 'y';\n</file>",
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Read file", preview: "t3code/apps/web/src/a.ts" });
+  });
+
+  it("names OpenCode edits after their camelCase filePath instead of the diff", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolTitle: "edit",
+        itemType: "file_change",
+        toolName: "edit",
+        toolInput: { filePath: "/Users/dev/t3code/apps/web/src/a.ts" },
+        detail: "diff --git a/x b/x\n+added",
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Edited file", preview: "t3code/apps/web/src/a.ts" });
+  });
+
+  it("normalizes argv-array commands the way the row command is normalized", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({ toolName: "Bash", toolInput: { command: ["bash", "-lc", "git status"] } }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "Ran command", preview: "git status" });
+  });
+
+  it("leaves MCP arguments unrewritten — they address the server, not the checkout", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({
+        toolName: "get_file_contents",
+        toolServer: "github",
+        toolInput: { owner: "o", repo: "r", path: "src/index.ts" },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display).toEqual({ heading: "github · get_file_contents", preview: "src/index.ts" });
+  });
+
+  it("does not turn slash-bearing arguments into workspace files", () => {
+    for (const [input, expected] of [
+      [{ repository: "t3-tools/t3code" }, "t3-tools/t3code"],
+      [{ branch: "feature/login-fix" }, "feature/login-fix"],
+      [{ ref: "refs/heads/main" }, "refs/heads/main"],
+      [{ module: "@scope/pkg" }, "@scope/pkg"],
+    ] as const) {
+      const display = describeToolCallWorkEntry(
+        makeWorkEntry({ toolName: "list_commits", toolInput: input }),
+        WORKSPACE_ROOT,
+      );
+
+      expect(display.preview).toBe(expected);
+    }
+  });
+
+  it("does not rewrite a URL passed under a path-shaped argument", () => {
+    for (const entry of [
+      makeWorkEntry({
+        toolName: "open",
+        toolServer: "browser",
+        toolInput: { path: "https://example.com/docs/page" },
+      }),
+      makeWorkEntry({
+        toolName: "open_page",
+        toolInput: { path: "https://example.com/docs/page" },
+      }),
+    ]) {
+      expect(describeToolCallWorkEntry(entry, WORKSPACE_ROOT).preview).toBe(
+        "https://example.com/docs/page",
+      );
+    }
+  });
+
+  it("still resolves real relative file paths against the workspace", () => {
+    const display = describeToolCallWorkEntry(
+      makeWorkEntry({ toolName: "Read", toolInput: { file_path: "apps/web/src/a.ts" } }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(display.preview).toBe("t3code/apps/web/src/a.ts");
+  });
+});
+
+describe("work entry row chrome", () => {
+  const WORKSPACE_ROOT = "/Users/dev/t3code";
+
+  function makeWorkEntry(overrides: Partial<WorkLogEntry>): WorkLogEntry {
+    return {
+      id: "work-1",
+      createdAt: "2026-03-17T19:12:28.000Z",
+      label: "Tool call",
+      tone: "tool",
+      ...overrides,
+    };
+  }
+
+  it("marks MCP rows with the wrench even when the adapter misclassified them", () => {
+    expect(
+      workEntryIconName(
+        makeWorkEntry({
+          itemType: "file_change",
+          toolName: "create_pr",
+          toolServer: "github",
+          changedFiles: ["/Users/dev/t3code/a.ts"],
+        }),
+      ),
+    ).toBe("wrench");
+  });
+
+  it("keeps the pre-existing icon precedence for non-MCP rows", () => {
+    expect(workEntryIconName(makeWorkEntry({ requestKind: "command" }))).toBe("terminal");
+    expect(workEntryIconName(makeWorkEntry({ itemType: "command_execution" }))).toBe("terminal");
+    expect(workEntryIconName(makeWorkEntry({ itemType: "file_change" }))).toBe("square-pen");
+    expect(workEntryIconName(makeWorkEntry({ itemType: "web_search" }))).toBe("globe");
+    expect(workEntryIconName(makeWorkEntry({ itemType: "mcp_tool_call" }))).toBe("wrench");
+    expect(workEntryIconName(makeWorkEntry({ itemType: "dynamic_tool_call" }))).toBe("hammer");
+    expect(workEntryIconName(makeWorkEntry({ tone: "error" }))).toBe("circle-alert");
+    expect(workEntryIconName(makeWorkEntry({ tone: "tool" }))).toBe("zap");
+  });
+
+  it("agrees with the expanded body it guards", () => {
+    const entries: WorkLogEntry[] = [
+      makeWorkEntry({}),
+      makeWorkEntry({ detail: "   " }),
+      makeWorkEntry({ detail: "19 files" }),
+      makeWorkEntry({ command: "git status" }),
+      makeWorkEntry({ command: "git status", rawCommand: 'pwsh -Command "git status"' }),
+      makeWorkEntry({ rawCommand: 'pwsh -Command "git status"' }),
+      makeWorkEntry({ changedFiles: ["/Users/dev/t3code/a.ts"] }),
+      makeWorkEntry({ toolInput: {} }),
+      makeWorkEntry({ toolInput: { pattern: "useEffect" } }),
+      makeWorkEntry({ itemType: "mcp_tool_call", toolData: { server: "t3-code" } }),
+    ];
+
+    for (const entry of entries) {
+      expect(hasToolCallExpandedBody(entry)).toBe(
+        buildToolCallExpandedBody(entry, WORKSPACE_ROOT) !== null,
+      );
+    }
+  });
+
+  it("appends the tool input for non-MCP rows", () => {
+    const body = buildToolCallExpandedBody(
+      makeWorkEntry({ toolName: "Grep", toolInput: { pattern: "useEffect" } }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(body).toBe('Input\n{\n  "pattern": "useEffect"\n}');
+  });
+
+  it("leaves the input out of MCP rows, which already show the whole call", () => {
+    const body = buildToolCallExpandedBody(
+      makeWorkEntry({
+        itemType: "mcp_tool_call",
+        toolData: { tool: "preview_status" },
+        toolInput: { interactiveOnly: true },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(body).toContain("MCP call");
+    expect(body).not.toContain("Input");
+  });
+
+  it("bounds a tool input that carries a whole file", () => {
+    const content = "const x = 1;\n".repeat(2000);
+    const body = buildToolCallExpandedBody(
+      makeWorkEntry({
+        toolName: "Write",
+        toolInput: { file_path: "/Users/dev/t3code/a.ts", content },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(body).toContain("/Users/dev/t3code/a.ts");
+    expect(body).toContain(`(+${content.length - 400} more characters)`);
+    expect(body!.length).toBeLessThan(1000);
+  });
+
+  it("bounds long arrays and deep nesting in tool input", () => {
+    const body = buildToolCallExpandedBody(
+      makeWorkEntry({
+        toolName: "MultiEdit",
+        toolInput: { edits: Array.from({ length: 50 }, (_, index) => ({ old: `line ${index}` })) },
+      }),
+      WORKSPACE_ROOT,
+    );
+
+    expect(body).toContain("(+30 more items)");
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -1,6 +1,8 @@
 import * as Equal from "effect/Equal";
 import {
   formatDuration,
+  normalizeCommandValue,
+  splitMcpToolName,
   workEntryIndicatesToolNeutralStatus,
   workLogEntryIsToolLike,
   type TimelineEntry,
@@ -8,6 +10,7 @@ import {
   type WorkLogEntry,
 } from "../../session-logic";
 import { type ChatMessage, type ProposedPlan, type TurnDiffSummary } from "../../types";
+import { formatWorkspaceRelativePath } from "../../filePathDisplay";
 import { type MessageId, type OrchestrationLatestTurn, type TurnId } from "@t3tools/contracts";
 
 export const MAX_VISIBLE_WORK_LOG_ENTRIES = 1;
@@ -236,6 +239,734 @@ export function computeMessageDurationStart(
 
 export function normalizeCompactToolLabel(value: string): string {
   return value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
+}
+
+// ---------------------------------------------------------------------------
+// Tool-call phrasing — turns provider payloads into a human row
+// ---------------------------------------------------------------------------
+
+export interface ToolCallDisplay {
+  heading: string;
+  preview: string | null;
+}
+
+const TOOL_PREVIEW_MAX_LENGTH = 120;
+/** `Read: {"file_path":"/x.ts"}` / `Bash: git status` — how legacy activities persisted the call. */
+const LEGACY_TOOL_PREFIX_PATTERN = /^([A-Za-z][\w-]*):\s*([\s\S]+)$/;
+
+type ToolIdentityKind =
+  | "read"
+  | "write"
+  | "edit"
+  | "command"
+  | "grep"
+  | "glob"
+  | "web-search"
+  | "web-fetch"
+  | "subagent"
+  | "skill"
+  | "todo";
+
+interface ToolIdentity {
+  heading: string;
+  kind: ToolIdentityKind;
+}
+
+function toolIdentities(
+  kind: ToolIdentityKind,
+  heading: string,
+  names: ReadonlyArray<string>,
+): ReadonlyArray<readonly [string, ToolIdentity]> {
+  return names.map((name) => [name, { heading, kind }] as const);
+}
+
+/** Provider tool names (lowercased) mapped to the sentence the row should read as. */
+const TOOL_IDENTITIES: ReadonlyMap<string, ToolIdentity> = new Map([
+  ...toolIdentities("read", "Read file", ["read", "read_file", "readfile", "view"]),
+  ...toolIdentities("write", "Wrote file", ["write", "write_file", "writefile"]),
+  ...toolIdentities("edit", "Edited file", [
+    "edit",
+    "multiedit",
+    "multi_edit",
+    "notebookedit",
+    "notebook_edit",
+    "str_replace_editor",
+  ]),
+  ...toolIdentities("command", "Ran command", [
+    "bash",
+    "sh",
+    "shell",
+    "zsh",
+    "terminal",
+    "command",
+    "exec",
+    "execute_command",
+    "local_shell",
+    "run_command",
+    "run_terminal_cmd",
+  ]),
+  ...toolIdentities("grep", "Searched code", ["grep", "ripgrep"]),
+  ...toolIdentities("glob", "Listed files", ["glob", "list"]),
+  ...toolIdentities("web-search", "Searched the web", ["websearch", "web_search"]),
+  ...toolIdentities("web-fetch", "Fetched page", ["webfetch", "web_fetch", "fetch"]),
+  ...toolIdentities("subagent", "Ran subagent", ["task", "agent"]),
+  ...toolIdentities("skill", "Ran skill", ["skill"]),
+  ...toolIdentities("todo", "Updated to-do list", ["todowrite", "todo_write"]),
+]);
+
+const PRIMARY_TOOL_ARG_KEYS = [
+  "command",
+  "cmd",
+  "file_path",
+  "filePath",
+  "path",
+  "notebook_path",
+  "notebookPath",
+  "url",
+  "query",
+  "pattern",
+  "prompt",
+  "description",
+  "name",
+  "title",
+  "skill",
+] as const;
+
+/**
+ * Argument names that address a file. OpenCode (and the ACP `rawInput`
+ * passthrough) spell these camelCase, Claude and Codex snake_case, so both have
+ * to be listed or the row falls back to dumping the whole tool output.
+ */
+const FILE_PATH_TOOL_ARG_KEYS = [
+  "file_path",
+  "filePath",
+  "notebook_path",
+  "notebookPath",
+  "path",
+] as const;
+
+const PATH_TOOL_ARG_KEYS = new Set<string>(FILE_PATH_TOOL_ARG_KEYS);
+
+function toolIdentityFor(toolName: string): ToolIdentity | undefined {
+  return TOOL_IDENTITIES.get(toolName.toLowerCase());
+}
+
+function collapseInlineWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncateToolPreview(value: string, maxLength = TOOL_PREVIEW_MAX_LENGTH): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function hasUriScheme(value: string): boolean {
+  return /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(value);
+}
+
+/** `/a/b.ts`, `~/a`, `./a`, `../a`, `C:\a`, `\\host\share` — rooted somewhere real. */
+function isAnchoredFilePath(value: string): boolean {
+  return (
+    value.startsWith("/") ||
+    value.startsWith("~/") ||
+    value.startsWith("\\\\") ||
+    /^\.{1,2}[/\\]/.test(value) ||
+    /^[A-Za-z]:[/\\]/.test(value)
+  );
+}
+
+/**
+ * Only consulted for arguments that are *not* named after a path, so it has to
+ * stay conservative: `refs/heads/main`, `owner/repo` and `@scope/pkg` all carry
+ * a slash and none of them may be rewritten as a workspace file.
+ */
+function looksLikeFilePath(value: string): boolean {
+  if (hasUriScheme(value) || /\s/.test(value) || !/[/\\]/.test(value)) {
+    return false;
+  }
+  return isAnchoredFilePath(value) || /\.[A-Za-z0-9]{1,10}$/.test(value);
+}
+
+function capitalizePhrase(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return value;
+  }
+  return `${trimmed.charAt(0).toUpperCase()}${trimmed.slice(1)}`;
+}
+
+/** `preview_status` / `previewStatus` → `Preview status`. */
+function humanizeToolName(toolName: string): string {
+  const words = toolName
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_\-.]+/g, " ")
+    .split(/\s+/)
+    .filter((word) => word.length > 0)
+    .map((word) => word.toLowerCase());
+  const [first, ...rest] = words;
+  if (!first) {
+    return toolName;
+  }
+  return [capitalizePhrase(first), ...rest].join(" ");
+}
+
+function toolArgText(input: Record<string, unknown> | undefined, key: string): string | null {
+  if (!input) {
+    return null;
+  }
+  const value = input[key];
+  if (typeof value === "string") {
+    const collapsed = collapseInlineWhitespace(value);
+    return collapsed.length > 0 ? collapsed : null;
+  }
+  if (Array.isArray(value)) {
+    const joined = collapseInlineWhitespace(
+      value.filter((part): part is string => typeof part === "string").join(" "),
+    );
+    return joined.length > 0 ? joined : null;
+  }
+  return null;
+}
+
+function toolArgPath(
+  input: Record<string, unknown> | undefined,
+  keys: ReadonlyArray<string>,
+  workspaceRoot: string | undefined,
+): string | null {
+  for (const key of keys) {
+    const value = toolArgText(input, key);
+    if (value) {
+      return formatToolArgPreview(key, value, workspaceRoot);
+    }
+  }
+  return null;
+}
+
+/**
+ * Command arguments arrive as strings *and* as argv arrays
+ * (`["bash","-lc","git status"]`), so they get the same normalization that
+ * produced `entry.command` instead of a raw space-join.
+ */
+function toolArgCommand(input: Record<string, unknown> | undefined): string | null {
+  if (!input) {
+    return null;
+  }
+  for (const key of ["command", "cmd"] as const) {
+    const normalized = normalizeCommandValue(input[key]);
+    if (normalized === null) {
+      continue;
+    }
+    const collapsed = collapseInlineWhitespace(normalized);
+    if (collapsed.length > 0) {
+      return truncateToolPreview(collapsed);
+    }
+  }
+  return null;
+}
+
+function toolArgPlain(
+  input: Record<string, unknown> | undefined,
+  keys: ReadonlyArray<string>,
+): string | null {
+  for (const key of keys) {
+    const value = toolArgText(input, key);
+    if (value) {
+      return truncateToolPreview(value);
+    }
+  }
+  return null;
+}
+
+function isWorkspacePathArg(key: string, value: string): boolean {
+  // A URL is never a workspace file, whatever the argument happens to be named.
+  if (hasUriScheme(value)) {
+    return false;
+  }
+  if (PATH_TOOL_ARG_KEYS.has(key)) {
+    return true;
+  }
+  if ((PRIMARY_TOOL_ARG_KEYS as ReadonlyArray<string>).includes(key)) {
+    return false;
+  }
+  return looksLikeFilePath(value);
+}
+
+/**
+ * `workspaceRoot === undefined` means "do not rewrite": callers pass it for
+ * arguments that address a remote system (MCP servers), where a workspace
+ * prefix would invent a local file that does not exist.
+ */
+function formatToolArgPreview(
+  key: string,
+  value: string,
+  workspaceRoot: string | undefined,
+): string {
+  return truncateToolPreview(
+    workspaceRoot !== undefined && isWorkspacePathArg(key, value)
+      ? formatWorkspaceRelativePath(value, workspaceRoot)
+      : value,
+  );
+}
+
+/** Best single argument to show beside the heading for tools with no bespoke phrasing. */
+function primaryToolArg(
+  input: Record<string, unknown> | undefined,
+  workspaceRoot: string | undefined,
+): string | null {
+  if (!input) {
+    return null;
+  }
+  for (const key of PRIMARY_TOOL_ARG_KEYS) {
+    const value = toolArgText(input, key);
+    if (value) {
+      return formatToolArgPreview(key, value, workspaceRoot);
+    }
+  }
+  for (const [key, rawValue] of Object.entries(input)) {
+    if (typeof rawValue !== "string") {
+      continue;
+    }
+    const value = collapseInlineWhitespace(rawValue);
+    if (value.length > 0) {
+      return formatToolArgPreview(key, value, workspaceRoot);
+    }
+  }
+  return null;
+}
+
+function changedFilesPreview(
+  entry: Pick<WorkLogEntry, "changedFiles">,
+  workspaceRoot: string | undefined,
+): string | null {
+  const changedFiles = entry.changedFiles ?? [];
+  const [firstPath] = changedFiles;
+  if (!firstPath) {
+    return null;
+  }
+  const displayPath = formatWorkspaceRelativePath(firstPath, workspaceRoot);
+  return changedFiles.length === 1
+    ? displayPath
+    : `${displayPath} +${changedFiles.length - 1} more`;
+}
+
+/** The pre-existing row preview: command, then detail, then the changed-file summary. */
+function fallbackWorkEntryPreview(
+  entry: Pick<WorkLogEntry, "detail" | "command" | "changedFiles">,
+  workspaceRoot: string | undefined,
+): string | null {
+  if (entry.command) return entry.command;
+  if (entry.detail) return entry.detail;
+  return changedFilesPreview(entry, workspaceRoot);
+}
+
+export function fallbackWorkEntryDisplay(
+  entry: WorkLogEntry,
+  workspaceRoot: string | undefined,
+): ToolCallDisplay {
+  return {
+    heading: capitalizePhrase(normalizeCompactToolLabel(entry.toolTitle ?? entry.label)),
+    preview: fallbackWorkEntryPreview(entry, workspaceRoot),
+  };
+}
+
+interface ToolCallSubject {
+  toolName: string;
+  toolServer?: string;
+  input?: Record<string, unknown>;
+  /** True when the identity came from `detail`, which must then not be echoed as the preview. */
+  fromDetail: boolean;
+}
+
+function parseJsonObject(value: string): Record<string, unknown> | null {
+  if (!value.startsWith("{") || !value.endsWith("}")) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+interface LegacyToolCallParse {
+  subject: Omit<ToolCallSubject, "fromDetail">;
+  /** True when `<rest>` was a JSON object rather than a bare command string. */
+  structured: boolean;
+}
+
+function parseLegacyToolCallText(
+  entry: WorkLogEntry,
+  value: string | undefined,
+): LegacyToolCallParse | null {
+  if (!value) {
+    return null;
+  }
+  const match = LEGACY_TOOL_PREFIX_PATTERN.exec(value.trim());
+  const rawName = match?.[1];
+  const rest = match?.[2]?.trim();
+  if (!rawName || !rest) {
+    return null;
+  }
+  const { server, name } = splitMcpToolName(rawName);
+  const input = parseJsonObject(rest);
+  if (input) {
+    // `Result: {"ok":true}` is prose that happens to quote JSON. Letting an
+    // unknown word take over the heading also drops the text (the detail is
+    // suppressed as an echo of the call), so the row would carry nothing.
+    if (!server && !toolIdentityFor(name)) {
+      return null;
+    }
+    return {
+      subject: { toolName: name, ...(server ? { toolServer: server } : {}), input },
+      structured: true,
+    };
+  }
+  // Only a shell prefix is safe to read as free text ("Bash: git status").
+  // Anything else with a colon is ordinary prose ("Error: ENOENT ...").
+  if (toolIdentityFor(name)?.kind !== "command") {
+    return null;
+  }
+  // Plenty of prose opens with a shell word and a colon — command output
+  // ("bash: foo: command not found"), runtime errors ("sh: permission
+  // denied"), pending approvals ("Bash: rm -rf /tmp/build"). Claiming a
+  // command *ran* is only safe when the row carries a derived command that
+  // corroborates this very text.
+  const command = entry.command?.trim();
+  if (!command || (command !== value.trim() && command !== rest)) {
+    return null;
+  }
+  return { subject: { toolName: name, input: { command: rest } }, structured: false };
+}
+
+/** OpenCode titled its rows with the bare tool name (`bash`, `edit`, `webfetch`). */
+function toolNameFromTitle(title: string | undefined): string | null {
+  if (!title) {
+    return null;
+  }
+  const normalized = normalizeCompactToolLabel(title);
+  if (normalized.length === 0 || /\s/.test(normalized)) {
+    return null;
+  }
+  return toolIdentityFor(normalized) ? normalized : null;
+}
+
+function resolveToolCallSubject(entry: WorkLogEntry): ToolCallSubject | null {
+  if (entry.toolName) {
+    return {
+      toolName: entry.toolName,
+      ...(entry.toolServer !== undefined ? { toolServer: entry.toolServer } : {}),
+      ...(entry.toolInput !== undefined ? { input: entry.toolInput } : {}),
+      fromDetail: false,
+    };
+  }
+  const fromDetail = parseLegacyToolCallText(entry, entry.detail);
+  if (fromDetail) {
+    return { ...fromDetail.subject, fromDetail: true };
+  }
+  const fromLabel = parseLegacyToolCallText(entry, entry.label);
+  if (fromLabel) {
+    return { ...fromLabel.subject, fromDetail: false };
+  }
+  const fromTitle = toolNameFromTitle(entry.toolTitle);
+  return fromTitle ? { toolName: fromTitle, fromDetail: false } : null;
+}
+
+/** Claude repeats the call as `<Tool>: <json>` in `detail`; never show that back to the user. */
+function detailEchoesToolCall(entry: WorkLogEntry, subject: ToolCallSubject): boolean {
+  if (subject.fromDetail) {
+    return true;
+  }
+  const match = LEGACY_TOOL_PREFIX_PATTERN.exec(entry.detail?.trim() ?? "");
+  const rawName = match?.[1];
+  if (!rawName) {
+    return false;
+  }
+  return splitMcpToolName(rawName).name.toLowerCase() === subject.toolName.toLowerCase();
+}
+
+/**
+ * Approval rows describe a request that has *not* run yet, and the provider
+ * writes the request itself into `detail` ("Bash: rm -rf /tmp/build"). Phrasing
+ * one as a finished call is the single worst thing this module could do, so
+ * they keep the plain request wording.
+ */
+function isPendingRequestEntry(entry: WorkLogEntry): boolean {
+  return entry.requestKind !== undefined;
+}
+
+export function describeToolCallWorkEntry(
+  entry: WorkLogEntry,
+  workspaceRoot: string | undefined,
+): ToolCallDisplay {
+  const subject = isPendingRequestEntry(entry) ? null : resolveToolCallSubject(entry);
+  if (!subject) {
+    return fallbackWorkEntryDisplay(entry, workspaceRoot);
+  }
+
+  const { input } = subject;
+  const skipDetail = detailEchoesToolCall(entry, subject);
+  const fallbackPreview = (): string | null => {
+    if (entry.command) return entry.command;
+    if (!skipDetail && entry.detail) return entry.detail;
+    return changedFilesPreview(entry, workspaceRoot);
+  };
+
+  if (subject.toolServer) {
+    return {
+      heading: `${subject.toolServer} · ${subject.toolName}`,
+      // MCP arguments address the server, not this checkout: a `path` here is a
+      // remote resource, so it is shown exactly as the model sent it.
+      preview: primaryToolArg(input, undefined) ?? fallbackPreview(),
+    };
+  }
+
+  const identity = toolIdentityFor(subject.toolName);
+  if (!identity) {
+    return {
+      heading: humanizeToolName(subject.toolName),
+      preview: primaryToolArg(input, workspaceRoot) ?? fallbackPreview(),
+    };
+  }
+
+  const { heading } = identity;
+  switch (identity.kind) {
+    case "read":
+      return {
+        heading,
+        preview: toolArgPath(input, FILE_PATH_TOOL_ARG_KEYS, workspaceRoot) ?? fallbackPreview(),
+      };
+    case "write":
+    case "edit":
+      return {
+        heading,
+        preview:
+          changedFilesPreview(entry, workspaceRoot) ??
+          toolArgPath(input, FILE_PATH_TOOL_ARG_KEYS, workspaceRoot) ??
+          fallbackPreview(),
+      };
+    case "command":
+      return {
+        heading,
+        preview: toolArgCommand(input) ?? fallbackPreview(),
+      };
+    case "grep":
+      return {
+        heading,
+        preview: toolArgPlain(input, ["pattern", "query"]) ?? fallbackPreview(),
+      };
+    case "glob":
+      return {
+        heading,
+        preview:
+          toolArgPlain(input, ["pattern"]) ??
+          toolArgPath(input, ["path"], workspaceRoot) ??
+          fallbackPreview(),
+      };
+    case "web-search":
+      return {
+        heading,
+        preview: toolArgPlain(input, ["query"]) ?? fallbackPreview(),
+      };
+    case "web-fetch":
+      return {
+        heading,
+        preview: toolArgPlain(input, ["url"]) ?? fallbackPreview(),
+      };
+    case "subagent":
+      return {
+        heading,
+        preview: toolArgPlain(input, ["description", "prompt"]) ?? fallbackPreview(),
+      };
+    case "skill":
+      return {
+        heading,
+        preview: toolArgPlain(input, ["skill", "name", "command"]) ?? fallbackPreview(),
+      };
+    case "todo":
+      return { heading, preview: null };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Work-entry row chrome — icon choice and expanded body
+// ---------------------------------------------------------------------------
+
+export type WorkEntryIconName =
+  | "bot"
+  | "check"
+  | "circle-alert"
+  | "eye"
+  | "globe"
+  | "hammer"
+  | "message-circle"
+  | "square-pen"
+  | "terminal"
+  | "wrench"
+  | "x"
+  | "zap";
+
+export function workToneIconName(tone: WorkLogEntry["tone"]): WorkEntryIconName {
+  if (tone === "error") return "circle-alert";
+  if (tone === "thinking") return "bot";
+  if (tone === "info") return "check";
+  return "zap";
+}
+
+export function workEntryIconName(workEntry: WorkLogEntry): WorkEntryIconName {
+  if (
+    workEntry.sourceActivityKind === "user-input.requested" ||
+    workEntry.sourceActivityKind === "user-input.resolved"
+  ) {
+    return "message-circle";
+  }
+  if (workEntry.requestKind === "command") return "terminal";
+  if (workEntry.requestKind === "file-read") return "eye";
+  if (workEntry.requestKind === "file-change") return "square-pen";
+
+  // Adapters classify itemType by keyword, so `mcp__github__create_pr` lands on
+  // `file_change`. The resolved server name is the reliable MCP signal.
+  if (workEntry.toolServer) return "wrench";
+
+  if (workEntry.itemType === "command_execution" || workEntry.command) {
+    return "terminal";
+  }
+  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
+    return "square-pen";
+  }
+  if (workEntry.itemType === "web_search") return "globe";
+  if (workEntry.itemType === "image_view") return "eye";
+
+  switch (workEntry.itemType) {
+    case "mcp_tool_call":
+      return "wrench";
+    case "dynamic_tool_call":
+      return "hammer";
+    case "collab_agent_tool_call":
+      return "bot";
+  }
+
+  // Subagent lifecycle rows (grouped by taskId) get agent identity chrome.
+  if (workEntry.taskId) {
+    return "bot";
+  }
+
+  return workToneIconName(workEntry.tone);
+}
+
+/**
+ * Tool input is passed through by the adapters verbatim — a Write call carries
+ * the entire file — so it is bounded before it reaches the expanded body.
+ */
+const TOOL_INPUT_STRING_MAX_LENGTH = 400;
+const TOOL_INPUT_ARRAY_MAX_ITEMS = 20;
+const TOOL_INPUT_MAX_DEPTH = 4;
+
+function boundToolInputValue(value: unknown, depth: number): unknown {
+  if (typeof value === "string") {
+    const overflow = value.length - TOOL_INPUT_STRING_MAX_LENGTH;
+    return overflow > 0
+      ? `${value.slice(0, TOOL_INPUT_STRING_MAX_LENGTH)}… (+${overflow} more characters)`
+      : value;
+  }
+  if (Array.isArray(value)) {
+    if (depth >= TOOL_INPUT_MAX_DEPTH) {
+      return `… (${value.length} items)`;
+    }
+    const kept = value
+      .slice(0, TOOL_INPUT_ARRAY_MAX_ITEMS)
+      .map((item) => boundToolInputValue(item, depth + 1));
+    const overflow = value.length - TOOL_INPUT_ARRAY_MAX_ITEMS;
+    return overflow > 0 ? [...kept, `… (+${overflow} more items)`] : kept;
+  }
+  if (value !== null && typeof value === "object") {
+    if (depth >= TOOL_INPUT_MAX_DEPTH) {
+      return "…";
+    }
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+        key,
+        boundToolInputValue(item, depth + 1),
+      ]),
+    );
+  }
+  return value;
+}
+
+export function formatToolInputBlock(input: Record<string, unknown>): string {
+  return `Input\n${JSON.stringify(boundToolInputValue(input, 1), null, 2)}`;
+}
+
+export function workEntryRawCommand(
+  workEntry: Pick<WorkLogEntry, "command" | "rawCommand">,
+): string | null {
+  const rawCommand = workEntry.rawCommand?.trim();
+  if (!rawCommand || !workEntry.command) {
+    return null;
+  }
+  return rawCommand === workEntry.command.trim() ? null : rawCommand;
+}
+
+function hasToolInputBlock(workEntry: WorkLogEntry): boolean {
+  return workEntry.toolInput !== undefined && Object.keys(workEntry.toolInput).length > 0;
+}
+
+function hasMcpBlock(workEntry: WorkLogEntry): boolean {
+  return workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined;
+}
+
+/**
+ * Cheap mirror of `buildToolCallExpandedBody() !== null`, so a collapsed row
+ * never pays for serialising the body it is not showing (tool rows re-render on
+ * every streaming update). Kept in lockstep with the builder below by test.
+ */
+export function hasToolCallExpandedBody(workEntry: WorkLogEntry): boolean {
+  return (
+    hasMcpBlock(workEntry) ||
+    Boolean(workEntryRawCommand(workEntry)?.trim()) ||
+    Boolean(workEntry.command?.trim()) ||
+    Boolean(workEntry.detail?.trim()) ||
+    (workEntry.changedFiles?.length ?? 0) > 0 ||
+    hasToolInputBlock(workEntry)
+  );
+}
+
+export function buildToolCallExpandedBody(
+  workEntry: WorkLogEntry,
+  workspaceRoot: string | undefined,
+): string | null {
+  const blocks: string[] = [];
+  const mcpBlock = hasMcpBlock(workEntry);
+  if (mcpBlock) {
+    blocks.push(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
+  }
+  const raw = workEntryRawCommand(workEntry);
+  if (raw?.trim()) {
+    blocks.push(raw.trim());
+  } else if (workEntry.command?.trim()) {
+    blocks.push(workEntry.command.trim());
+  }
+  if (workEntry.detail?.trim()) {
+    blocks.push(workEntry.detail.trim());
+  }
+  const changedFiles = workEntry.changedFiles ?? [];
+  if (changedFiles.length > 0) {
+    blocks.push(
+      changedFiles
+        .map((filePath) => formatWorkspaceRelativePath(filePath, workspaceRoot))
+        .join("\n"),
+    );
+  }
+  // The row heading only shows one argument; the MCP block already carries the
+  // full call, so the raw input is appended for every other tool.
+  if (!mcpBlock && workEntry.toolInput && hasToolInputBlock(workEntry)) {
+    blocks.push(formatToolInputBlock(workEntry.toolInput));
+  }
+  return blocks.length > 0 ? blocks.join("\n\n") : null;
 }
 
 export function resolveAssistantMessageCopyState({

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -864,6 +864,7 @@ export function workEntryIconName(workEntry: WorkLogEntry): WorkEntryIconName {
  */
 const TOOL_INPUT_STRING_MAX_LENGTH = 400;
 const TOOL_INPUT_ARRAY_MAX_ITEMS = 20;
+const TOOL_INPUT_OBJECT_MAX_ENTRIES = 20;
 const TOOL_INPUT_MAX_DEPTH = 4;
 
 function boundToolInputValue(value: unknown, depth: number): unknown {
@@ -887,12 +888,15 @@ function boundToolInputValue(value: unknown, depth: number): unknown {
     if (depth >= TOOL_INPUT_MAX_DEPTH) {
       return "…";
     }
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([key, item]) => [
-        key,
-        boundToolInputValue(item, depth + 1),
-      ]),
-    );
+    const entries = Object.entries(value as Record<string, unknown>);
+    const kept: Array<[string, unknown]> = entries
+      .slice(0, TOOL_INPUT_OBJECT_MAX_ENTRIES)
+      .map(([key, item]) => [key, boundToolInputValue(item, depth + 1)]);
+    const overflow = entries.length - TOOL_INPUT_OBJECT_MAX_ENTRIES;
+    if (overflow > 0) {
+      kept.push(["…", `(+${overflow} more entries)`]);
+    }
+    return Object.fromEntries(kept);
   }
   return value;
 }

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -682,4 +682,94 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("lucide-x");
     expect(markup).toContain('aria-label="Tool call failed"');
   });
+
+  it("renders a misclassified MCP call as the tool it really is", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "File change",
+              tone: "tool",
+              toolTitle: "File change",
+              itemType: "file_change",
+              toolName: "create_pr",
+              toolServer: "github",
+              toolInput: { title: "Fix login bug" },
+            },
+          },
+        ]}
+        workspaceRoot="/Users/dev/t3code"
+      />,
+    );
+
+    expect(markup).toContain("github · create_pr");
+    expect(markup).toContain("Fix login bug");
+    expect(markup).toContain("lucide-wrench");
+    expect(markup).not.toContain("File change");
+  });
+
+  it("keeps a pending approval phrased as a request", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Command approval requested",
+              tone: "info",
+              requestKind: "command",
+              detail: "Bash: rm -rf /tmp/build",
+            },
+          },
+        ]}
+        workspaceRoot="/Users/dev/t3code"
+      />,
+    );
+
+    expect(markup).toContain("Command approval requested");
+    expect(markup).toContain("Bash: rm -rf /tmp/build");
+    expect(markup).not.toContain("Ran command");
+  });
+
+  it("does not render the expanded body of a collapsed tool row", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Tool call",
+              tone: "tool",
+              itemType: "dynamic_tool_call",
+              toolName: "Grep",
+              toolInput: { pattern: "useEffect" },
+            },
+          },
+        ]}
+        workspaceRoot="/Users/dev/t3code"
+      />,
+    );
+
+    // The row is expandable, but nothing is serialised until it is opened.
+    expect(markup).toContain("Searched code");
+    expect(markup).toContain("lucide-chevron-down");
+    expect(markup).not.toContain("Input\n");
+  });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -72,8 +72,12 @@ import { ChangedFilesCard } from "./ChangedFilesTree";
 import { shouldAutoExpandChangedFiles } from "./changedFilesPresentation";
 import { MessageCopyButton } from "./MessageCopyButton";
 import {
+  buildToolCallExpandedBody,
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
+  describeToolCallWorkEntry,
+  fallbackWorkEntryDisplay,
+  hasToolCallExpandedBody,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
   resolveTimelineIsAtEnd,
@@ -87,6 +91,9 @@ import {
   type MessagesTimelineRow,
   TIMELINE_MINIMAP_MIN_ITEMS,
   type TimelineLatestTurn,
+  type WorkEntryIconName,
+  workEntryIconName,
+  workToneIconName,
 } from "./MessagesTimeline.logic";
 import { TerminalContextInlineChip } from "./TerminalContextInlineChip";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -1939,20 +1946,6 @@ function formatWorkingTimerNow(startIso: string): string {
   return formatWorkingTimer(startIso, new Date().toISOString()) ?? "0s";
 }
 
-type WorkEntryIconName =
-  | "bot"
-  | "check"
-  | "circle-alert"
-  | "eye"
-  | "globe"
-  | "hammer"
-  | "message-circle"
-  | "square-pen"
-  | "terminal"
-  | "wrench"
-  | "x"
-  | "zap";
-
 function WorkEntryIconSvg({ name, className }: { name: WorkEntryIconName; className: string }) {
   switch (name) {
     case "bot":
@@ -1986,133 +1979,10 @@ function workToneIcon(tone: TimelineWorkEntry["tone"]): {
   iconName: WorkEntryIconName;
   className: string;
 } {
-  if (tone === "error") {
-    return {
-      iconName: "circle-alert",
-      className: "text-foreground",
-    };
-  }
-  if (tone === "thinking") {
-    return {
-      iconName: "bot",
-      className: "text-foreground",
-    };
-  }
-  if (tone === "info") {
-    return {
-      iconName: "check",
-      className: "text-icon-muted",
-    };
-  }
   return {
-    iconName: "zap",
-    className: "text-foreground",
+    iconName: workToneIconName(tone),
+    className: tone === "info" ? "text-icon-muted" : "text-foreground",
   };
-}
-
-function workEntryPreview(
-  workEntry: Pick<TimelineWorkEntry, "detail" | "command" | "changedFiles">,
-  workspaceRoot: string | undefined,
-) {
-  if (workEntry.command) return workEntry.command;
-  if (workEntry.detail) return workEntry.detail;
-  if ((workEntry.changedFiles?.length ?? 0) === 0) return null;
-  const [firstPath] = workEntry.changedFiles ?? [];
-  if (!firstPath) return null;
-  const displayPath = formatWorkspaceRelativePath(firstPath, workspaceRoot);
-  return workEntry.changedFiles!.length === 1
-    ? displayPath
-    : `${displayPath} +${workEntry.changedFiles!.length - 1} more`;
-}
-
-function workEntryRawCommand(
-  workEntry: Pick<TimelineWorkEntry, "command" | "rawCommand">,
-): string | null {
-  const rawCommand = workEntry.rawCommand?.trim();
-  if (!rawCommand || !workEntry.command) {
-    return null;
-  }
-  return rawCommand === workEntry.command.trim() ? null : rawCommand;
-}
-
-function buildToolCallExpandedBody(
-  workEntry: TimelineWorkEntry,
-  workspaceRoot: string | undefined,
-): string | null {
-  const blocks: string[] = [];
-  if (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) {
-    blocks.push(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
-  }
-  const raw = workEntryRawCommand(workEntry);
-  if (raw?.trim()) {
-    blocks.push(raw.trim());
-  } else if (workEntry.command?.trim()) {
-    blocks.push(workEntry.command.trim());
-  }
-  if (workEntry.detail?.trim()) {
-    blocks.push(workEntry.detail.trim());
-  }
-  const changedFiles = workEntry.changedFiles ?? [];
-  if (changedFiles.length > 0) {
-    blocks.push(
-      changedFiles
-        .map((filePath) => formatWorkspaceRelativePath(filePath, workspaceRoot))
-        .join("\n"),
-    );
-  }
-  return blocks.length > 0 ? blocks.join("\n\n") : null;
-}
-
-function workEntryIconName(workEntry: TimelineWorkEntry): WorkEntryIconName {
-  if (
-    workEntry.sourceActivityKind === "user-input.requested" ||
-    workEntry.sourceActivityKind === "user-input.resolved"
-  ) {
-    return "message-circle";
-  }
-  if (workEntry.requestKind === "command") return "terminal";
-  if (workEntry.requestKind === "file-read") return "eye";
-  if (workEntry.requestKind === "file-change") return "square-pen";
-
-  if (workEntry.itemType === "command_execution" || workEntry.command) {
-    return "terminal";
-  }
-  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
-    return "square-pen";
-  }
-  if (workEntry.itemType === "web_search") return "globe";
-  if (workEntry.itemType === "image_view") return "eye";
-
-  switch (workEntry.itemType) {
-    case "mcp_tool_call":
-      return "wrench";
-    case "dynamic_tool_call":
-      return "hammer";
-    case "collab_agent_tool_call":
-      return "bot";
-  }
-
-  // Subagent lifecycle rows (grouped by taskId) get agent identity chrome.
-  if (workEntry.taskId) {
-    return "bot";
-  }
-
-  return workToneIcon(workEntry.tone).iconName;
-}
-
-function capitalizePhrase(value: string): string {
-  const trimmed = value.trim();
-  if (trimmed.length === 0) {
-    return value;
-  }
-  return `${trimmed.charAt(0).toUpperCase()}${trimmed.slice(1)}`;
-}
-
-function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
-  if (!workEntry.toolTitle) {
-    return capitalizePhrase(normalizeCompactToolLabel(workEntry.label));
-  }
-  return capitalizePhrase(normalizeCompactToolLabel(workEntry.toolTitle));
 }
 
 const stopRowToggle = (e: { stopPropagation: () => void }) => e.stopPropagation();
@@ -2233,8 +2103,10 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const iconConfig = workToneIcon(workEntry.tone);
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
   const entryIconName = showWarningIndicator ? "x" : workEntryIconName(workEntry);
-  const heading = toolWorkEntryHeading(workEntry);
-  const rawPreview = workEntryPreview(workEntry, workspaceRoot);
+  const { heading, preview: rawPreview } =
+    workLogEntryIsToolLike(workEntry) || workEntry.itemType !== undefined
+      ? describeToolCallWorkEntry(workEntry, workspaceRoot)
+      : fallbackWorkEntryDisplay(workEntry, workspaceRoot);
   const preview =
     rawPreview &&
     normalizeCompactToolLabel(rawPreview).toLowerCase() ===
@@ -2242,8 +2114,13 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       ? null
       : rawPreview;
   const displayText = preview ? `${heading} - ${preview}` : heading;
-  const expandedBody = buildToolCallExpandedBody(workEntry, workspaceRoot);
-  const canExpand = expandedBody !== null;
+  const canExpand = hasToolCallExpandedBody(workEntry);
+  // Tool rows re-render on every streaming update, and the body serialises the
+  // whole tool input — so it is only built for the row the user opened.
+  const expandedBody = useMemo(
+    () => (expanded ? buildToolCallExpandedBody(workEntry, workspaceRoot) : null),
+    [expanded, workEntry, workspaceRoot],
+  );
   const showFailedIndicator = workEntryIndicatesToolFailure(workEntry);
   const showDestructiveRowStyle =
     showFailedIndicator &&

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1026,6 +1026,194 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.toolData).toEqual(item);
   });
 
+  it("extracts the tool name and input from Claude payloads", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "claude-read",
+        kind: "tool.completed",
+        summary: "Tool call",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Tool call",
+          detail: 'Read: {"file_path":"/tmp/app.ts"}',
+          data: {
+            toolName: "Read",
+            input: { file_path: "/tmp/app.ts" },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities);
+    expect(entry?.toolName).toBe("Read");
+    expect(entry?.toolServer).toBeUndefined();
+    expect(entry?.toolInput).toEqual({ file_path: "/tmp/app.ts" });
+  });
+
+  it("splits the MCP server out of prefixed Claude tool names", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "claude-mcp",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          // Adapters classify by keyword, so this MCP call lands on file_change.
+          itemType: "file_change",
+          title: "File change",
+          data: {
+            toolName: "mcp__github__create_pr",
+            input: { title: "Fix login bug" },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities);
+    expect(entry?.toolServer).toBe("github");
+    expect(entry?.toolName).toBe("create_pr");
+    expect(entry?.toolInput).toEqual({ title: "Fix login bug" });
+  });
+
+  it("extracts the tool identity from Codex item payloads", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "codex-mcp",
+        kind: "tool.completed",
+        summary: "t3-code · preview_status",
+        payload: {
+          itemType: "mcp_tool_call",
+          title: "t3-code · preview_status",
+          data: {
+            item: {
+              type: "mcpToolCall",
+              server: "t3-code",
+              tool: "preview_status",
+              arguments: { interactiveOnly: true },
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities);
+    expect(entry?.toolServer).toBe("t3-code");
+    expect(entry?.toolName).toBe("preview_status");
+    expect(entry?.toolInput).toEqual({ interactiveOnly: true });
+  });
+
+  it("extracts the tool identity from OpenCode state payloads", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "opencode-bash",
+        kind: "tool.completed",
+        summary: "bash",
+        payload: {
+          itemType: "command_execution",
+          title: "bash",
+          data: {
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { command: "git status", description: "Check the working tree" },
+              output: "nothing to commit",
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities);
+    expect(entry?.toolName).toBe("bash");
+    expect(entry?.toolServer).toBeUndefined();
+    expect(entry?.toolInput).toEqual({
+      command: "git status",
+      description: "Check the working tree",
+    });
+  });
+
+  it("extracts ACP raw input even though the tool name is not exposed", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "acp-command",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "acp-1",
+            kind: "execute",
+            command: "ls -la",
+            rawInput: { command: "ls -la" },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities);
+    expect(entry?.toolName).toBeUndefined();
+    expect(entry?.toolInput).toEqual({ command: "ls -la" });
+  });
+
+  it("keeps the tool identity while collapsing lifecycle updates", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tool-identity-update",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Tool call",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Tool call",
+          toolCallId: "call-identity",
+          data: {
+            toolCallId: "call-identity",
+            toolName: "Grep",
+            input: { pattern: "useEffect" },
+          },
+        },
+      }),
+      makeActivity({
+        id: "tool-identity-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Tool call completed",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Tool call",
+          toolCallId: "call-identity",
+          data: { toolCallId: "call-identity" },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "tool-identity-complete",
+      toolName: "Grep",
+      toolInput: { pattern: "useEffect" },
+    });
+  });
+
+  it("does not attach a tool identity to subagent task rows", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "task-progress",
+        kind: "task.progress",
+        summary: "Explore the auth module",
+        payload: {
+          taskId: "task-1",
+          data: { tool: "Task", input: { description: "Explore the auth module" } },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities);
+    expect(entry?.toolName).toBeUndefined();
+    expect(entry?.toolInput).toBeUndefined();
+  });
+
   it("unwraps PowerShell command wrappers for displayed command text", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -73,6 +73,12 @@ export interface WorkLogEntry {
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
   toolData?: unknown;
+  /** Provider tool name, `mcp__<server>__` prefix stripped (`Read`, `bash`, `create_issue`). */
+  toolName?: string;
+  /** MCP server name when the call targets an MCP server. */
+  toolServer?: string;
+  /** Raw tool input / arguments when the provider exposes them. */
+  toolInput?: Record<string, unknown>;
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];
   /** From runtime item / task payload `status` when present (e.g. tool.updated). */
@@ -871,6 +877,18 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (itemType) {
     entry.itemType = itemType;
   }
+  if (!isTaskActivity) {
+    const toolMeta = extractToolCallMeta(payload);
+    if (toolMeta.toolName) {
+      entry.toolName = toolMeta.toolName;
+    }
+    if (toolMeta.toolServer) {
+      entry.toolServer = toolMeta.toolServer;
+    }
+    if (toolMeta.toolInput) {
+      entry.toolInput = toolMeta.toolInput;
+    }
+  }
   if (requestKind) {
     entry.requestKind = requestKind;
   }
@@ -1043,6 +1061,9 @@ function mergeDerivedWorkLogEntries(
   const toolCallId = next.toolCallId ?? previous.toolCallId;
   const toolLifecycleStatus = next.toolLifecycleStatus ?? previous.toolLifecycleStatus;
   const toolData = next.toolData ?? previous.toolData;
+  const toolName = next.toolName ?? previous.toolName;
+  const toolServer = next.toolServer ?? previous.toolServer;
+  const toolInput = next.toolInput ?? previous.toolInput;
   return {
     ...previous,
     ...next,
@@ -1057,6 +1078,9 @@ function mergeDerivedWorkLogEntries(
     ...(toolCallId ? { toolCallId } : {}),
     ...(toolLifecycleStatus !== undefined ? { toolLifecycleStatus } : {}),
     ...(toolData !== undefined ? { toolData } : {}),
+    ...(toolName !== undefined ? { toolName } : {}),
+    ...(toolServer !== undefined ? { toolServer } : {}),
+    ...(toolInput !== undefined ? { toolInput } : {}),
   };
 }
 
@@ -1262,7 +1286,13 @@ function formatCommandValue(value: unknown): string | null {
   return parts.map((part) => formatCommandArrayPart(part)).join(" ");
 }
 
-function normalizeCommandValue(value: unknown): string | null {
+/**
+ * Turns a raw provider `command` argument into the text a row should show:
+ * argv arrays are quoted and joined, and known shell wrappers (`bash -lc …`,
+ * `pwsh -Command …`, `cmd /c …`) are unwrapped. This is what `entry.command` is
+ * derived with, so preview code must reuse it rather than read the raw value.
+ */
+export function normalizeCommandValue(value: unknown): string | null {
   const formatted = formatCommandValue(value);
   return formatted ? unwrapKnownShellCommandWrapper(formatted) : null;
 }
@@ -1317,6 +1347,60 @@ function extractToolTitle(payload: Record<string, unknown> | null): string | nul
 function extractToolCallId(payload: Record<string, unknown> | null): string | null {
   const data = asRecord(payload?.data);
   return asTrimmedString(data?.toolCallId);
+}
+
+const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
+
+/** Claude and OpenCode expose MCP calls as one `mcp__<server>__<tool>` name. */
+export function splitMcpToolName(rawName: string): { server: string | null; name: string } {
+  const match = MCP_TOOL_NAME_PATTERN.exec(rawName);
+  const server = match?.[1];
+  const name = match?.[2];
+  return server && name ? { server, name } : { server: null, name: rawName };
+}
+
+type ToolCallMeta = Pick<WorkLogEntry, "toolName" | "toolServer" | "toolInput">;
+
+function asToolInputRecord(value: unknown): Record<string, unknown> | null {
+  return Array.isArray(value) ? null : asRecord(value);
+}
+
+/**
+ * Recovers the concrete tool identity the adapters bury in `payload.data`:
+ * Claude sends `{ toolName, input }`, Codex a typed `item`, OpenCode
+ * `{ tool, state }`, ACP providers only `rawInput`. Titles and itemTypes are
+ * lossy (every Claude Read/Grep/Glob arrives as "Tool call"), so the name and
+ * arguments are the only way the UI can phrase a real sentence.
+ */
+function extractToolCallMeta(payload: Record<string, unknown> | null): ToolCallMeta {
+  const data = asRecord(payload?.data);
+  if (!data) {
+    return {};
+  }
+  const item = asRecord(data.item);
+  const state = asRecord(data.state);
+  const rawName =
+    asTrimmedString(data.toolName) ?? asTrimmedString(item?.tool) ?? asTrimmedString(data.tool);
+  const input =
+    asToolInputRecord(data.input) ??
+    asToolInputRecord(item?.arguments) ??
+    asToolInputRecord(state?.input) ??
+    asToolInputRecord(data.rawInput);
+
+  const meta: ToolCallMeta = {};
+  if (rawName) {
+    const { server: mcpServer, name } = splitMcpToolName(rawName);
+    meta.toolName = name;
+    // Codex splits the MCP identity across `item.server` / `item.tool`.
+    const server = mcpServer ?? asTrimmedString(item?.server);
+    if (server) {
+      meta.toolServer = server;
+    }
+  }
+  if (input) {
+    meta.toolInput = input;
+  }
+  return meta;
 }
 
 function normalizeInlinePreview(value: string): string {


### PR DESCRIPTION
## Summary

Tool-call rows in the chat timeline rendered generic headings like `Tool call - Read: {"file_path":"/x.ts"}`, because provider adapters emit fixed per-itemType titles ("Tool call", "MCP tool call", "File change") and JSON-serialized input summaries. Rows now read as real messages built from each call's dynamic data:

| Before | After |
|---|---|
| `Tool call - Read: {"file_path":"/x/app.ts"}` | `Read file - t3code/apps/web/src/app.ts` |
| `Command run - Bash: git status` | `Ran command - git status` |
| `Tool call - WebSearch: {"query":"react useEffect cleanup"}` | `Searched the web - react useEffect cleanup` |
| `File change - mcp__github__create_pr: {...}` | `github · create_pr - Fix login bug` |
| `Tool call - preview_status: {}` | `Preview status - …` |

## How

- **`session-logic.ts`** — `WorkLogEntry` gains additive `toolName` / `toolServer` / `toolInput`, extracted from all four provider payload shapes (Claude `{toolName, input}`, Codex `item.tool/server/arguments`, OpenCode `{tool, state.input}`, ACP `rawInput`) and carried through lifecycle-collapse merging. MCP identity keys off the `mcp__<server>__<tool>` name (`splitMcpToolName`), so calls the server misclassifies by keyword (e.g. `mcp__github__create_pr` → `file_change`) still display as MCP. Collapse keys and `normalizeCompactToolLabel` are untouched.
- **`MessagesTimeline.logic.ts`** — new pure `describeToolCallWorkEntry()`: tool identity table (read/write/edit/command/grep/glob/web-search/web-fetch/subagent/skill/todo), primary-argument previews (workspace-relative paths, whitespace-collapsed, 120-char ellipsis), a guarded legacy parser so historical `"<Tool>: <json>"` labels also humanize, and a byte-identical fallback for anything unrecognized. Guards prevent prose like `bash: foo: command not found` from being mislabeled as an executed command, and pending-approval rows keep their original presentation.
- **`MessagesTimeline.tsx`** — rows use the new phrasing; MCP calls get the wrench icon by name; expanded body gains a size-capped `Input` JSON block.

Web-only: no server, contract, or mobile changes. Mobile (`threadActivity.ts`) still shows the old headings — parity is a natural follow-up.

## Test plan

- 63 new unit tests across `MessagesTimeline.logic.test.ts`, `session-logic.test.ts`, and `MessagesTimeline.test.tsx` covering all four provider payload shapes, MCP misclassification, legacy-label parsing, merge carry-forward, truncation, and exact-fallback reproduction; no existing assertion changed.
- `bun run test`: 220 files / 2044 tests pass. `bun run typecheck` clean. `vp lint` clean.
- Verified live against a real session database (both fresh and historical entries render humanized; unrecognized entries identical to before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI-only change to timeline labeling and parsing; extensive tests and fallbacks limit regressions, but edge-case mislabeling of prose or approvals remains possible.
> 
> **Overview**
> Chat timeline **work rows** no longer show generic `Tool call` labels and raw JSON; they use **human headings and previews** built from each provider’s tool metadata.
> 
> **`session-logic`** adds `toolName`, `toolServer`, and `toolInput` on `WorkLogEntry`, extracted from Claude/Codex/OpenCode/ACP payloads (including `mcp__server__tool` splitting) and preserved across lifecycle merges. **`MessagesTimeline.logic`** centralizes `describeToolCallWorkEntry` (tool identity table, workspace-relative paths, legacy `Tool: …` parsing with guards for prose/errors/approvals), icon selection (MCP wrench even when misclassified), and expanded bodies with **bounded** tool-input JSON plus `hasToolCallExpandedBody` for cheap expand checks.
> 
> **`MessagesTimeline`** wires the new phrasing and only builds expanded body text when a row is opened (`useMemo`), avoiding serialization on every stream tick.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf23fe20c436d83d40b78747e2e815fe296b15f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Humanize tool-call rows in chat timeline with dynamic headings and previews
> - Adds `describeToolCallWorkEntry` in [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/5847/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) to derive human-friendly headings and previews for tool-call rows, handling MCP, file ops, web ops, grep/glob, subagents, and legacy formats.
> - Extends `WorkLogEntry` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/5847/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) with `toolName`, `toolServer`, and `toolInput` fields extracted from provider payloads (Claude, Codex, OpenCode, ACP) and preserved across lifecycle merges.
> - Replaces inline heading/preview/icon logic in `PlainWorkEntryRow` with the new helpers; defers `buildToolCallExpandedBody` via `useMemo` until a row is expanded to avoid unnecessary serialization.
> - MCP calls are now marked with a wrench icon even when misclassified by the provider, and pending approval entries preserve their request phrasing rather than being converted to finished calls.
> - Risk: Behavioral change — tool row headings, previews, and icons now differ from the previous inline logic for all providers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdf23fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->