### PR TITLE
fix(server): avoid grok browser auth during provider check

### DIFF
--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -86,7 +86,9 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
     Effect.gen(function* () {
       const crypto = yield* Crypto.Crypto;
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
       const httpClient = yield* HttpClient.HttpClient;
+      const path = yield* Path.Path;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const processEnv = mergeProviderInstanceEnvironment(environment);
@@ -117,6 +119,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
       );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -69,6 +69,7 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
 
           return yield* checkGrokProviderStatus(
             decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+            { HOME: dir },
           );
         }),
       );
@@ -81,14 +82,66 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
     }),
   );
 
-  it.effect("reports an error when ACP model discovery is unavailable", () =>
+  it.effect("does not start ACP discovery when Grok has no usable cached auth", () =>
     Effect.gen(function* () {
       const snapshot = yield* Effect.scoped(
         Effect.gen(function* () {
           const fs = yield* FileSystem.FileSystem;
           const path = yield* Path.Path;
-          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-success-" });
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-no-auth-" });
           const grokPath = path.join(dir, "grok");
+          const grokHomePath = path.join(dir, ".grok");
+          const acpMarkerPath = path.join(dir, "acp-started");
+          yield* fs.makeDirectory(grokHomePath);
+          yield* fs.writeFileString(path.join(grokHomePath, "auth.json"), "{}\n");
+          yield* fs.writeFileString(
+            grokPath,
+            [
+              "#!/bin/sh",
+              'if [ "$1" = "--version" ]; then',
+              '  printf "grok-cli 0.0.99\\n"',
+              "  exit 0",
+              "fi",
+              `printf "unexpected ACP startup\\n" > "${acpMarkerPath}"`,
+              "exit 0",
+              "",
+            ].join("\n"),
+          );
+          yield* fs.chmod(grokPath, 0o755);
+
+          const checked = yield* checkGrokProviderStatus(
+            decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+            { HOME: dir },
+          );
+          const acpStarted = yield* fs.exists(acpMarkerPath);
+          return { checked, acpStarted };
+        }),
+      );
+
+      expect(snapshot.checked.status).toBe("error");
+      expect(snapshot.checked.installed).toBe(true);
+      expect(snapshot.checked.auth.status).toBe("unauthenticated");
+      expect(snapshot.checked.message).toBe(
+        "Grok CLI is installed but not authenticated. Run `grok login` and try again.",
+      );
+      expect(snapshot.acpStarted).toBe(false);
+    }),
+  );
+
+  it.effect("checks the Windows user profile for cached Grok auth", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-windows-auth-" });
+          const grokPath = path.join(dir, "grok");
+          const grokHomePath = path.join(dir, ".grok");
+          yield* fs.makeDirectory(grokHomePath);
+          yield* fs.writeFileString(
+            path.join(grokHomePath, "auth.json"),
+            '{"refresh_token":"valid-refresh-token-value"}\n',
+          );
           yield* fs.writeFileString(
             grokPath,
             ["#!/bin/sh", 'printf "grok-cli 0.0.99\\n"', "exit 0", ""].join("\n"),
@@ -97,6 +150,39 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
 
           return yield* checkGrokProviderStatus(
             decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+            { USERPROFILE: dir },
+          );
+        }),
+      );
+
+      expect(snapshot.auth.status).toBe("unknown");
+      expect(snapshot.message).toContain("ACP startup failed");
+    }),
+  );
+
+  it.effect("reports an error when ACP model discovery is unavailable", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-success-" });
+          const grokPath = path.join(dir, "grok");
+          const grokHomePath = path.join(dir, ".grok");
+          yield* fs.makeDirectory(grokHomePath);
+          yield* fs.writeFileString(
+            path.join(grokHomePath, "auth.json"),
+            '{"refresh_token":"valid-refresh-token-value"}\n',
+          );
+          yield* fs.writeFileString(
+            grokPath,
+            ["#!/bin/sh", 'printf "grok-cli 0.0.99\\n"', "exit 0", ""].join("\n"),
+          );
+          yield* fs.chmod(grokPath, 0o755);
+
+          return yield* checkGrokProviderStatus(
+            decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+            { HOME: dir },
           );
         }),
       );

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -10,7 +10,9 @@ import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Result from "effect/Result";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -43,6 +45,9 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
 
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+const GROK_API_KEY_ENV = "XAI_API_KEY";
+const GROK_HOME_ENV = "GROK_HOME";
+const GROK_AUTH_TOKEN_MIN_LENGTH = 16;
 
 const GROK_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   {
@@ -158,13 +163,84 @@ const runGrokVersionCommand = (
     );
   });
 
+function isUsableGrokTokenValue(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length < GROK_AUTH_TOKEN_MIN_LENGTH) {
+    return false;
+  }
+
+  return !/^(bearer|oauth)$/i.test(trimmed) && !/^https?:\/\//i.test(trimmed);
+}
+
+function hasGrokTokenLikeValue(value: unknown, depth = 0): boolean {
+  if (depth > 8 || value === null || typeof value !== "object") {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasGrokTokenLikeValue(entry, depth + 1));
+  }
+
+  return Object.entries(value).some(([key, entry]) => {
+    const normalizedKey = key.replace(/[-_]/g, "").toLowerCase();
+    const isTokenKey =
+      normalizedKey === "token" ||
+      normalizedKey.endsWith("token") ||
+      normalizedKey.includes("accesstoken") ||
+      normalizedKey.includes("refreshtoken") ||
+      normalizedKey.includes("idtoken") ||
+      normalizedKey.includes("sessiontoken");
+
+    if (isTokenKey && isUsableGrokTokenValue(entry)) {
+      return true;
+    }
+
+    return hasGrokTokenLikeValue(entry, depth + 1);
+  });
+}
+
+function hasUsableGrokAuthJson(contents: string): boolean {
+  try {
+    return hasGrokTokenLikeValue(JSON.parse(contents));
+  } catch {
+    return false;
+  }
+}
+
+const hasGrokCachedAuth = (
+  environment: NodeJS.ProcessEnv = process.env,
+): Effect.Effect<boolean, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    if (environment[GROK_API_KEY_ENV]?.trim()) {
+      return true;
+    }
+
+    const grokHome = environment[GROK_HOME_ENV]?.trim();
+    const home = grokHome || environment.HOME?.trim() || environment.USERPROFILE?.trim();
+    if (!home) {
+      return false;
+    }
+
+    const path = yield* Path.Path;
+    const fs = yield* FileSystem.FileSystem;
+    const authPath = grokHome
+      ? path.join(home, "auth.json")
+      : path.join(home, ".grok", "auth.json");
+    const contents = yield* fs.readFileString(authPath).pipe(Effect.orElseSucceed(() => ""));
+    return hasUsableGrokAuthJson(contents);
+  });
+
 export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(function* (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
-  ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
+  ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto | FileSystem.FileSystem | Path.Path
 > {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const fallbackModels = grokModelsFromSettings(grokSettings.customModels);
@@ -247,6 +323,23 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
         status: "error",
         auth: { status: "unknown" },
         message: "Grok CLI is installed but failed to run.",
+      },
+    });
+  }
+
+  const hasCachedAuth = yield* hasGrokCachedAuth(environment);
+  if (!hasCachedAuth) {
+    return buildServerProvider({
+      presentation: GROK_PRESENTATION,
+      enabled: grokSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: { status: "unauthenticated" },
+        message: "Grok CLI is installed but not authenticated. Run `grok login` and try again.",
       },
     });
   }


### PR DESCRIPTION
Fixes #5852.

T3 Code was starting Grok ACP model discovery during the background provider health check. If Grok CLI was installed but had no saved auth token, that startup could open a browser login window even though the user had not chosen Grok or clicked a sign-in button.

This changes the Grok provider check to stop after `grok --version` when there is no `XAI_API_KEY` and no cached Grok auth file. In that case T3 Code now reports Grok as unauthenticated and tells the user to run `grok login`.

The ACP model discovery path still runs when Grok has cached auth or an API key.

Tested:

- `pnpm exec vp test run apps/server/src/provider/Layers/GrokProvider.test.ts`
- `pnpm --filter t3 typecheck`

Note: the typecheck command printed existing Effect suggestions in unrelated orchestration files, but exited successfully.

Model and harness: GPT-5.6 Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Grok provider health-check behavior and adds file/env-based auth heuristics; impact is limited to Grok but alters when ACP runs during background checks.
> 
> **Overview**
> Fixes background Grok health checks opening a browser when the CLI is installed but not signed in.
> 
> After a successful `grok --version` probe, **`checkGrokProviderStatus`** now runs **`hasGrokCachedAuth`** before ACP model discovery. Cached auth counts as `XAI_API_KEY`, or a usable token in `auth.json` under `GROK_HOME`, `$HOME/.grok`, or **`USERPROFILE`** on Windows. If nothing usable is found, the check returns **`auth.status: unauthenticated`** with a `grok login` message and **does not** start ACP discovery.
> 
> **`GrokDriver`** provides **`FileSystem`** and **`Path`** to the check pipeline. Tests cover the no-auth short-circuit (ACP never starts), Windows profile auth paths, and require valid cached auth before paths that expect ACP to run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200181e693eb51e60ce6109fadace6155664b25c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip Grok ACP discovery when no usable cached auth is detected
> - `checkGrokProviderStatus` in [GrokProvider.ts](https://github.com/pingdotgg/t3code/pull/5853/files#diff-d88edf38a3399863fd884b8deb4f8eb57539ca15d41ce6ea03cad4baf62acf0f) now checks for usable Grok auth before starting ACP discovery, returning an `unauthenticated` error with a `grok login` prompt if none is found.
> - Auth is resolved by checking `XAI_API_KEY`, then `GROK_HOME/auth.json`, then `$HOME/.grok/auth.json`, falling back to `USERPROFILE/.grok/auth.json` on Windows.
> - Auth JSON is validated by recursively searching for token-like keys with non-empty, non-URL string values above a minimum length.
> - `FileSystem` and `Path` services are now provided into `checkGrokProviderStatus` in [GrokDriver.ts](https://github.com/pingdotgg/t3code/pull/5853/files#diff-0b86a3e67f98dbf93f42e8168829458b1cdde63a0486e43e2bebcdaaf32f64e8) to support the new file reads.
> - Behavioral Change: provider status check now returns `status=error, auth.status=unauthenticated` early instead of attempting ACP discovery when no auth is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 200181e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->