### PR TITLE
fix(server): strip positions from file manager targets

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -94,6 +94,53 @@ it.effect("launches the default browser through the platform command", () => {
   );
 });
 
+it.effect("strips file manager positions without changing existing paths", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-file-manager-" });
+    const commandPath = path.join(binDir, "open");
+    const targetPath = path.join(binDir, "CLAUDE.md");
+    const existingColonPath = `${targetPath}:2024`;
+    const missingColonPath = path.join(binDir, "missing:2024");
+    yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(commandPath, 0o755);
+    yield* fileSystem.writeFileString(targetPath, "");
+    yield* fileSystem.writeFileString(existingColonPath, "");
+
+    const spawned: ChildProcess.StandardCommand[] = [];
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      for (const cwd of [targetPath, `${targetPath}:4`, `${targetPath}:12:4`]) {
+        yield* launcher.launchEditor({ editor: "file-manager", cwd });
+      }
+      yield* launcher.launchEditor({ editor: "file-manager", cwd: existingColonPath });
+      yield* launcher.launchEditor({ editor: "file-manager", cwd: missingColonPath });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "darwin",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned.push(command);
+          },
+        }),
+      ),
+    );
+
+    assert.deepEqual(
+      spawned.map(({ command, args }) => ({ command, args })),
+      [
+        { command: "open", args: [targetPath] },
+        { command: "open", args: [targetPath] },
+        { command: "open", args: [targetPath] },
+        { command: "open", args: [existingColonPath] },
+        { command: "open", args: [missingColonPath] },
+      ],
+    );
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
 it.effect("launches an installed editor with platform-safe arguments", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -124,6 +124,19 @@ function parseTargetPathAndPosition(target: string): Option.Option<TargetPathAnd
   });
 }
 
+const resolveFileManagerTarget = Effect.fn("externalLauncher.resolveFileManagerTarget")(function* (
+  target: string,
+): Effect.fn.Return<string, never, FileSystem.FileSystem> {
+  const parsedTarget = parseTargetPathAndPosition(target);
+  if (Option.isNone(parsedTarget)) return target;
+
+  const fileSystem = yield* FileSystem.FileSystem;
+  if (yield* fileSystem.exists(target).pipe(Effect.orElseSucceed(() => false))) return target;
+  return (yield* fileSystem.exists(parsedTarget.value.path).pipe(Effect.orElseSucceed(() => false)))
+    ? parsedTarget.value.path
+    : target;
+});
+
 function resolveCommandEditorArgs(
   editor: (typeof EDITORS)[number],
   target: string,
@@ -376,11 +389,12 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
     return yield* new ExternalLauncherUnsupportedEditorError({ editor: input.editor });
   }
 
+  const target = yield* resolveFileManagerTarget(input.cwd);
   return {
     editor: editorDef.id,
-    target: input.cwd,
+    target,
     command: fileManagerCommandForPlatform(platform),
-    args: [input.cwd],
+    args: [target],
   };
 });
 


### PR DESCRIPTION
## What Changed

- Strip parsed `:line[:column]` positions before launching a target with the file manager when the parsed base path exists.
- Preserve exact existing paths and unresolved targets, including valid POSIX filenames that end in `:digits`.
- Add regression coverage for plain paths, positioned paths, and colon-number filenames on macOS.

## Why

Markdown file links encode editor positions in the launch target. Command editors understand that syntax, but the file-manager path currently passes it unchanged to `open`, `explorer`, or `xdg-open`. The operating system then receives a nonexistent path such as `/Users/tester/.claude/CLAUDE.md:4`, so the click can appear to do nothing.

The normalization is in the server launcher because that is where the selected launch integration is known. It keeps an exact existing path. It removes a parsed position only when the exact target is missing and the parsed base path exists. If neither path exists, it keeps the original target. This avoids changing valid POSIX filenames such as `report:2024`.

This is narrower than #681, which combined suffix stripping with editor fallback behavior. It is also separate from #5366, which adds a new **Open in folder** action. This PR fixes the existing primary **Open in editor** action when File Manager is the preferred integration.

## Verification

- `vp test run apps/server/src/process/externalLauncher.test.ts`
- `vp fmt --check apps/server/src/process/externalLauncher.ts apps/server/src/process/externalLauncher.test.ts`
- `vp lint apps/server/src/process/externalLauncher.ts apps/server/src/process/externalLauncher.test.ts`
- `vp run --filter t3 typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI code changed
- [x] No animation or interaction recording is required

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to file-manager spawn args in externalLauncher with filesystem existence checks; no auth, data, or UI changes.
> 
> **Overview**
> **File manager** launches no longer pass editor-style `:line[:column]` suffixes to `open` / `explorer` / `xdg-open` when the full string is not a real path but the base file path exists—fixing silent failures on markdown links with positions.
> 
> `resolveFileManagerTarget` applies that normalization only for the **file-manager** integration: it keeps the exact `cwd` when it exists on disk (including valid names like `report:2024`), strips the suffix only when the suffixed path is missing and the parsed base path exists, and otherwise leaves the original target unchanged. Command-based editors still receive the full positioned string.
> 
> Regression tests on macOS cover plain paths, positioned paths, existing colon-suffixed filenames, and missing targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b94ea1f1336ee383235a8bb1d381400ba9d16fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->