### PR TITLE
fix(web): thread title button no longer eats the drag area

### DIFF
--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -266,7 +266,7 @@ export const ChatHeader = memo(function ChatHeader({
                   aria-label={`Thread actions for ${activeThreadTitle}`}
                   aria-haspopup="menu"
                   onClick={openMenuFromTitle}
-                  className="group/thread-title inline-flex min-w-0 flex-1 cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                  className="group/thread-title inline-flex min-w-0 cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                 />
               }
             >


### PR DESCRIPTION
## What Changed

Remove `flex-1` from the server-thread title button in `ChatHeader`.

This keeps the button's clickable area limited to the title and chevron instead of stretching across the remaining header space.

## Why

The title button introduced in #5592 inherited `flex-1` from the previous non-interactive `<h2>`.

As a result, its invisible clickable area extended toward the right-side controls, preventing that part of the title bar from being used to drag the desktop window.

`min-w-0` remains on the button and the inner `<h2>` still uses `truncate`, so long thread titles continue to ellipsize.

Fixes #5631

## UI Changes

### Before

<img width="2554" height="1259" alt="image" src="https://github.com/user-attachments/assets/72bf9025-f861-4fea-8d5a-b45820b41b35" />

### After

<img width="2557" height="1265" alt="image" src="https://github.com/user-attachments/assets/4fee901a-895e-4713-9814-e89a422e7bd6" />


https://github.com/user-attachments/assets/cebb4b5d-69f9-4e4a-bd39-4728cdedbad4


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class removal on a header button; no auth, data, or API changes.
> 
> **Overview**
> **Restores window dragging** on the chat header for server threads by shrinking the thread-title action button’s hit target.
> 
> The server-thread title `<button>` no longer uses `flex-1`, so it only covers the title text and chevron instead of stretching toward the right-side controls. **`min-w-0`** on the button and **`truncate`** on the inner `<h2>` are unchanged, so long titles still ellipsize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db45048186be8ea55bc69f427013fa15e13cb80d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread title button in `ChatHeader` to stop consuming drag area
> Removes `flex-1` from the thread title button's className in [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/5857/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c), so the button no longer stretches to fill remaining horizontal space. The button now sizes to its content, freeing the drag area alongside it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db45048.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->