### PR TITLE
fix(web): match create theme and import theme buttons to the standard outline style

### DIFF
--- a/apps/web/src/components/settings/ThemeSettings.tsx
+++ b/apps/web/src/components/settings/ThemeSettings.tsx
@@ -555,9 +555,8 @@ export function ThemeLibrary({
         <h3 className="text-sm font-medium tracking-[-0.005em] text-foreground">Themes</h3>
         <div className="flex flex-wrap items-center justify-end gap-3">
           <Button
-            className="h-7 rounded-md border border-border/70 bg-muted/30 px-2 text-xs font-medium text-foreground shadow-none hover:bg-accent/40"
             size="xs"
-            variant="ghost"
+            variant="outline"
             onClick={() =>
               openThemeEditor({
                 editingThemeId: null,
@@ -570,7 +569,7 @@ export function ThemeLibrary({
             <PlusIcon />
             Create theme
           </Button>
-          <Button size="xs" variant="ghost" onClick={() => onImportOpenChange(true)}>
+          <Button size="xs" variant="outline" onClick={() => onImportOpenChange(true)}>
             <UploadIcon />
             Import theme
           </Button>


### PR DESCRIPTION
## What Changed

Changed both theme buttons on Settings > Appearance to use the standard settings outline style. Previously, "Create theme" had a custom chip-like style (extra padding, muted background, custom border) and "Import theme" was a bare ghost button. Now both use the same size="xs" variant="outline" look as every other button on the Settings pages.

## Why

The styling was inconsistent.

1. Both buttons looked different from each other.
2. "Create theme" button had a custom style different from all others, and hence looked different. The custom style also pinned a fixed height and padding at all screen sizes, while the standard buttons shrink on smaller screens.
3. "Import theme" had the ghost variant, which is used for icon-only buttons or buttons with less importance.

Removing the overrides makes the row match the rest of Settings and fixes the sizing behavior.

## UI Changes

Before:
<img width="325" height="36" alt="image" src="https://github.com/user-attachments/assets/2b68e1ce-f034-4b0e-87b6-fb83f65f1f73" />

After:
<img width="322" height="36" alt="image" src="https://github.com/user-attachments/assets/8e224ac3-c0e2-4146-9a4e-86611eba09fe" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic button styling only in theme settings; no logic or data changes.
> 
> **Overview**
> **Appearance > Themes** row buttons are aligned with the rest of Settings.
> 
> **Create theme** drops its custom chip styling (fixed height, muted background, extra border/padding) and uses `size="xs"` with `variant="outline"`. **Import theme** switches from `ghost` to the same outline variant. Behavior and click handlers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f3572f4a3559e492e6ecda1aec2bb950ed738c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Match 'Create theme' and 'Import theme' buttons to outline style in ThemeSettings
> Changes the variant of both buttons in [ThemeSettings.tsx](https://github.com/pingdotgg/t3code/pull/5860/files#diff-4cc84a2ea71f7b5fef270e04a72f0110c8530ee83377e432642907950560b408) from `ghost` to `outline` for visual consistency. Also removes the custom `className` previously applied to the 'Create theme' button.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7f3572.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->