### PR TITLE
fix: handle markdown links failure correctly

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -48,6 +48,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Animated, { FadeIn, FadeInUp, type SharedValue } from "react-native-reanimated";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useFontFamily } from "../../lib/useFontFamily";
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
 import {
   hasNativeSelectableMarkdownText,
@@ -271,7 +272,7 @@ const MarkdownExternalLink = memo(function MarkdownExternalLink(props: {
     <NativeText
       className="font-sans"
       onPress={() => {
-        void Linking.openURL(props.href);
+        void tryOpenExternalUrl(props.href, "markdown-link");
       }}
       style={{
         color: props.color,
@@ -601,7 +602,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
             onPress={
               linkHref
                 ? () => {
-                    void Linking.openURL(linkHref);
+                    void tryOpenExternalUrl(linkHref, "markdown-link");
                   }
                 : undefined
             }
@@ -1403,7 +1404,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       }
 
       if (presentation.href) {
-        void Linking.openURL(presentation.href);
+        void tryOpenExternalUrl(presentation.href, "markdown-link");
       }
     },
     [props.environmentId, props.threadId, props.workspaceRoot, navigation],


### PR DESCRIPTION
This PR replaces raw calls to Linking.openURL with tryOpenExternalUrl to properly handle links with unsupported schemes, as described in #5839.

Fixes #5839.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to link-open behavior in thread markdown UI with no auth, data, or persistence impact.
> 
> **Overview**
> **Markdown link taps** in the thread feed no longer call `Linking.openURL` directly. External links in `MarkdownExternalLink`, generic link renderers in `useMarkdownStyles`, and `onMarkdownLinkPress` now use **`tryOpenExternalUrl(..., "markdown-link")`**, matching the shared helper used elsewhere on mobile.
> 
> That helper still opens URLs via `Linking`, but **catches failures** (e.g. unsupported schemes), logs structured `ExternalUrlOpenError` metadata, and returns `false` instead of surfacing an unhandled rejection—addressing inconsistent behavior when markdown contains bad or non-http(s) links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d9030a87adabbe613163726d85916eecce6164f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix markdown link failures by routing through `tryOpenExternalUrl`
> Replaces direct `Linking.openURL` calls with `tryOpenExternalUrl` (tagged `"markdown-link"`) in `MarkdownExternalLink`, `useMarkdownStyles`, and `ThreadFeed` so that URL open failures are handled correctly rather than silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d9030a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->