### PR TITLE
fix(web): rotate stale draft thread ids after bootstrap failure

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1264,6 +1264,7 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const clearComposerDraftContent = useComposerDraftStore((store) => store.clearComposerContent);
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
+  const replaceDraftThreadId = useComposerDraftStore((store) => store.replaceDraftThreadId);
   const getDraftSessionByLogicalProjectKey = useComposerDraftStore(
     (store) => store.getDraftSessionByLogicalProjectKey,
   );
@@ -4840,6 +4841,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
 
     let turnStartSucceeded = false;
+    let draftBootstrapAttempted = false;
     if (failure === null && turnAttachmentsResult._tag === "Success") {
       const bootstrap =
         isLocalDraftThread || baseBranchForWorktree
@@ -4871,6 +4873,7 @@ function ChatViewContent(props: ChatViewProps) {
                 : {}),
             }
           : undefined;
+      draftBootstrapAttempted = bootstrap?.createThread !== undefined;
       beginLocalDispatch({ preparingWorktree: false });
       const startResult = await startThreadTurn({
         environmentId,
@@ -4898,6 +4901,11 @@ function ChatViewContent(props: ChatViewProps) {
     }
 
     if (failure !== null) {
+      if (draftBootstrapAttempted && draftId !== null) {
+        // A failed bootstrap may have already created and tombstoned this id.
+        // Keep the draft content, but reserve a fresh server thread id for retry.
+        replaceDraftThreadId(draftId, newThreadId());
+      }
       if (
         promptRef.current.length === 0 &&
         composerImagesRef.current.length === 0 &&

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -767,6 +767,30 @@ describe("composerDraftStore project draft thread mapping", () => {
     });
   });
 
+  it("replaces a failed draft thread id without losing draft state", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId, {
+      threadId,
+      branch: "feature/retry",
+      worktreePath: "/tmp/retry-worktree",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    store.setPrompt(draftId, "retry this draft");
+    store.markDraftThreadPromoting(draftId);
+
+    store.replaceDraftThreadId(draftId, otherThreadId);
+
+    expect(store.getDraftThreadByProjectRef(projectRef)).toMatchObject({
+      threadId: otherThreadId,
+      branch: "feature/retry",
+      worktreePath: "/tmp/retry-worktree",
+      promotedTo: null,
+    });
+    expect(useComposerDraftStore.getState().getComposerDraft(draftId)?.prompt).toBe(
+      "retry this draft",
+    );
+  });
+
   it("clears only matching project draft mapping entries", () => {
     const store = useComposerDraftStore.getState();
     store.setProjectDraftThreadId(projectRef, draftId, { threadId });

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -390,6 +390,8 @@ interface ComposerDraftStoreState {
       interactionMode?: ProviderInteractionMode;
     },
   ) => void;
+  /** Replaces a draft's reserved server thread id after a failed bootstrap. */
+  replaceDraftThreadId: (threadRef: ComposerThreadTarget, threadId: ThreadId) => void;
   clearProjectDraftThreadId: (projectRef: ScopedProjectRef) => void;
   clearProjectDraftThreadById: (
     projectRef: ScopedProjectRef,
@@ -2399,6 +2401,28 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               draftThreadsByThreadKey: {
                 ...state.draftThreadsByThreadKey,
                 [threadKey]: nextDraftThread,
+              },
+            };
+          });
+        },
+        replaceDraftThreadId: (threadRef, threadId) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
+          if (threadKey.length === 0 || threadId.length === 0) {
+            return;
+          }
+          set((state) => {
+            const existing = state.draftThreadsByThreadKey[threadKey];
+            if (!existing || (existing.threadId === threadId && existing.promotedTo === null)) {
+              return state;
+            }
+            return {
+              draftThreadsByThreadKey: {
+                ...state.draftThreadsByThreadKey,
+                [threadKey]: {
+                  ...existing,
+                  threadId,
+                  promotedTo: null,
+                },
               },
             };
           });


### PR DESCRIPTION
## Problem

A failed first-turn bootstrap can create and then tombstone a draft's preallocated thread ID. The persisted draft retries with that same ID, so the server rejects the next `thread.create` command.

## Fix

- Rotate only after a draft bootstrap create was actually attempted and failed.
- Preserve the draft ID, composer content, model, and workspace context.
- Clear stale promotion metadata before retrying.
- Add regression coverage for state preservation.

## Verification

- `pnpm exec vp test run apps/web/src/composerDraftStore.test.ts` (75 passed)
- `pnpm --filter @t3tools/web typecheck`
- Targeted `vp lint`
- Targeted `vp fmt --check`