### PR TITLE
fix(web): align project name with headline

### DIFF
--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -101,7 +101,7 @@ export function DraftHeroHeadline({
     <Menu>
       <MenuTrigger
         aria-label={hasResolvedProject ? "Change project" : "Choose a project"}
-        className="pointer-events-auto inline-block max-w-64 truncate border-foreground/60 border-b border-dotted align-bottom text-foreground transition-colors hover:border-foreground/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+        className="pointer-events-auto inline-block max-w-64 truncate border-foreground/60 border-b border-dotted align-baseline text-foreground transition-colors hover:border-foreground/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
         title={activeProjectDisplayName ?? undefined}
       >
         {activeProjectDisplayName ?? "Choose a project"}


### PR DESCRIPTION
## What Changed

Aligned the project selector’s text baseline with the surrounding headline text.

## Why

The project name was sitting slightly higher than the other text and looked disjointed.

## UI Changes

Before:
<img width="945" height="289" alt="Screenshot 2026-08-09 at 10 37 08 AM" src="https://github.com/user-attachments/assets/98c2c60d-8a64-4a8a-a9e2-2fa51667a5ff" />

After:
<img width="917" height="305" alt="Screenshot 2026-08-09 at 10 57 13 AM" src="https://github.com/user-attachments/assets/a27d5922-1f2a-444f-8ea9-ac57155192a9" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (n/a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on a UI trigger with no logic or data impact.
> 
> **Overview**
> Fixes a visual misalignment in the draft hero headline by changing the project picker trigger from **`align-bottom`** to **`align-baseline`**, so the dotted project name sits on the same baseline as the surrounding “What should we build in …?” text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a59b6fae089880798d59266f253dcefbd068cc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix vertical alignment of project name in `DraftHeroHeadline`
> Changes the `MenuTrigger` class in [DraftHeroHeadline.tsx](https://github.com/pingdotgg/t3code/pull/5864/files#diff-59395eb8416aacb935e49426b6445ebb8ce3ab54f9d16bd99ed27d0e85a60ec7) from `align-bottom` to `align-baseline` so the project name aligns to the text baseline of the surrounding headline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a59b6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->