### PR TITLE
fix(mobile): fix composer command popover legibility

### DIFF
--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -59,7 +59,7 @@ function PopoverSurface(props: {
   if (isLiquidGlassSupported) {
     return (
       <LiquidGlassView
-        effect="clear"
+        effect="regular"
         interactive={false}
         tintColor={props.isDarkMode ? "rgba(30,30,32,0.95)" : "rgba(255,255,255,0.92)"}
         colorScheme={props.isDarkMode ? "dark" : "light"}
@@ -113,7 +113,7 @@ function groupLabel(triggerKind: ComposerTriggerKind | null): string | null {
 
 function emptyText(triggerKind: ComposerTriggerKind | null, isLoading: boolean): string {
   if (isLoading) {
-    return triggerKind === "path" ? "Searching files…" : "Loading…";
+    return triggerKind === "path" ? "Searching filesÔÇª" : "LoadingÔÇª";
   }
   switch (triggerKind) {
     case "path":
@@ -131,6 +131,7 @@ const CommandRow = memo(function CommandRow(props: {
   readonly item: ComposerCommandItem;
   readonly onPress: () => void;
   readonly isLast: boolean;
+  readonly isDarkMode: boolean;
 }) {
   const iconName = itemIcon(props.item);
   const iconColor = "#a1a1aa";
@@ -146,7 +147,7 @@ const CommandRow = memo(function CommandRow(props: {
         gap: 10,
         opacity: pressed ? 0.6 : 1,
         borderBottomWidth: props.isLast ? 0 : 0.5,
-        borderBottomColor: "rgba(255,255,255,0.1)",
+        borderBottomColor: props.isDarkMode ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)",
       })}
     >
       {props.item.type === "path" ? (
@@ -193,6 +194,7 @@ export const ComposerCommandPopover = memo(function ComposerCommandPopover(
               item={item}
               onPress={() => props.onSelect(item)}
               isLast={index === props.items.length - 1}
+              isDarkMode={isDarkMode}
             />
           ))}
         </ScrollView>

--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -7,6 +7,7 @@ import { Pressable, ScrollView, useColorScheme, View, type ViewStyle } from "rea
 
 import { AppText as Text } from "../../components/AppText";
 import { PierreEntryIcon } from "../../components/PierreEntryIcon";
+import { composerCommandEmptyText } from "./composerCommandPopoverText";
 export type ComposerCommandItem =
   | {
       readonly id: string;
@@ -111,22 +112,6 @@ function groupLabel(triggerKind: ComposerTriggerKind | null): string | null {
   }
 }
 
-function emptyText(triggerKind: ComposerTriggerKind | null, isLoading: boolean): string {
-  if (isLoading) {
-    return triggerKind === "path" ? "Searching filesÔÇª" : "LoadingÔÇª";
-  }
-  switch (triggerKind) {
-    case "path":
-      return "No matching files or folders.";
-    case "skill":
-      return "No skills found.";
-    case "slash-command":
-      return "No matching commands.";
-    default:
-      return "No results.";
-  }
-}
-
 const CommandRow = memo(function CommandRow(props: {
   readonly item: ComposerCommandItem;
   readonly onPress: () => void;
@@ -201,7 +186,7 @@ export const ComposerCommandPopover = memo(function ComposerCommandPopover(
       ) : (
         <View className="px-3.5 py-2.5">
           <Text className="text-xs text-foreground-tertiary">
-            {emptyText(props.triggerKind, props.isLoading)}
+            {composerCommandEmptyText(props.triggerKind, props.isLoading)}
           </Text>
         </View>
       )}

--- a/apps/mobile/src/features/threads/composerCommandPopoverText.test.ts
+++ b/apps/mobile/src/features/threads/composerCommandPopoverText.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { composerCommandEmptyText } from "./composerCommandPopoverText";
+
+describe("composerCommandEmptyText", () => {
+  it("uses legible loading copy for path and command searches", () => {
+    expect(composerCommandEmptyText("path", true)).toBe("Searching files…");
+    expect(composerCommandEmptyText("slash-command", true)).toBe("Loading…");
+  });
+
+  it("uses trigger-specific empty copy", () => {
+    expect(composerCommandEmptyText("path", false)).toBe("No matching files or folders.");
+    expect(composerCommandEmptyText("skill", false)).toBe("No skills found.");
+    expect(composerCommandEmptyText("slash-command", false)).toBe("No matching commands.");
+    expect(composerCommandEmptyText(null, false)).toBe("No results.");
+  });
+});

--- a/apps/mobile/src/features/threads/composerCommandPopoverText.ts
+++ b/apps/mobile/src/features/threads/composerCommandPopoverText.ts
@@ -1,0 +1,21 @@
+import type { ComposerTriggerKind } from "@t3tools/shared/composerTrigger";
+
+export function composerCommandEmptyText(
+  triggerKind: ComposerTriggerKind | null,
+  isLoading: boolean,
+): string {
+  if (isLoading) {
+    return triggerKind === "path" ? "Searching files…" : "Loading…";
+  }
+
+  switch (triggerKind) {
+    case "path":
+      return "No matching files or folders.";
+    case "skill":
+      return "No skills found.";
+    case "slash-command":
+      return "No matching commands.";
+    default:
+      return "No results.";
+  }
+}


### PR DESCRIPTION
This PR resolves legibility issues on the mobile command popover where the list options blended into the background lines.

- Changed `LiquidGlassView` effect from `clear` to `regular` to correctly blur the background behind the popover.
- Updated the row's bottom border color so it adjusts for light/dark modes instead of being invisible in light mode.

Fixes #5859

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile UI-only styling and a small string helper extraction with tests; no auth, data, or API changes.
> 
> **Overview**
> Improves contrast and row separation on the mobile **composer command popover** so list items don’t blend into the background.
> 
> On devices with Liquid Glass, `PopoverSurface` now uses `effect="regular"` instead of `"clear"` so the backdrop blurs correctly behind the popover. **Command row** dividers take `isDarkMode` and use a light border in dark mode and a dark border in light mode, replacing a fixed semi-transparent white line that was hard to see in light mode.
> 
> Empty/loading placeholder strings are unchanged in behavior but moved to `composerCommandEmptyText` in `composerCommandPopoverText.ts`, with unit tests covering trigger-specific copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e231018aa199a88e780f8e24c504a7218272b37c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer command popover legibility in light and dark mode
> - Changes the `LiquidGlassView` effect in `ComposerCommandPopover` from `"clear"` to `"regular"` to improve popover surface legibility.
> - Fixes the `CommandRow` divider color to use a dark alpha (`rgba(0,0,0,0.1)`) in light mode instead of always using a white alpha, making separators visible on light backgrounds.
> - Extracts the `emptyText` helper into a standalone `composerCommandEmptyText` function in [`composerCommandPopoverText.ts`](https://github.com/pingdotgg/t3code/pull/5865/files#diff-18ec180bd6b6f4ac5c556f990f49c4893a401709fd7d975260d088212bf22dfd) with accompanying tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e231018.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->