### PR TITLE
feat(web): render color swatches next to color literals in chat markdown

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -145,6 +145,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     ...defaultSchema.attributes,
     "*": (defaultSchema.attributes?.["*"] ?? []).filter((attribute) => attribute !== "title"),
     code: [...(defaultSchema.attributes?.code ?? []), "dataCodeMeta", "dataInlineCode"],
+    span: [...(defaultSchema.attributes?.span ?? []), "dataColorSwatch", "className", "style"],
   },
   protocols: {
     ...defaultSchema.protocols,
@@ -157,6 +158,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS = [
   remarkNormalizeListItemIndentation,
   remarkPreserveCodeMeta,
   remarkTagInlineCode,
+  remarkColorSwatches,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
 
 const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
@@ -165,6 +167,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
   remarkBreaks,
   remarkPreserveCodeMeta,
   remarkTagInlineCode,
+  remarkColorSwatches,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
 
 const CHAT_MARKDOWN_REHYPE_PLUGINS = [
@@ -261,6 +264,53 @@ function remarkTagInlineCode() {
     };
 
     visit(tree, false);
+  };
+}
+
+const COLOR_LITERAL_REGEX = /(#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b|(?:rgb|rgba|hsl|hsla)\([^)]+\))/gi;
+
+function remarkColorSwatches() {
+  return (tree: MarkdownAstNode) => {
+    const visit = (node: MarkdownAstNode) => {
+      if (!node.children) return;
+      for (let i = 0; i < node.children.length; i++) {
+        const child = node.children[i];
+        if (child && child.type === "text" && typeof (child as any).value === "string") {
+          const textValue = (child as any).value as string;
+          const matches = [...textValue.matchAll(COLOR_LITERAL_REGEX)];
+          if (matches.length > 0) {
+            const newChildren: MarkdownAstNode[] = [];
+            let lastIndex = 0;
+            for (const match of matches) {
+              const start = match.index!;
+              const end = start + match[0].length;
+              if (start > lastIndex) {
+                newChildren.push({ type: "text", value: textValue.slice(lastIndex, start) } as any);
+              }
+              newChildren.push({
+                type: "colorSwatch",
+                data: {
+                  hName: "span",
+                  hProperties: {
+                    dataColorSwatch: match[0],
+                  },
+                },
+                children: [{ type: "text", value: match[0] } as any],
+              });
+              lastIndex = end;
+            }
+            if (lastIndex < textValue.length) {
+              newChildren.push({ type: "text", value: textValue.slice(lastIndex) } as any);
+            }
+            node.children.splice(i, 1, ...newChildren);
+            i += newChildren.length - 1;
+          }
+        } else {
+          visit(child as MarkdownAstNode);
+        }
+      }
+    };
+    visit(tree);
   };
 }
 
@@ -1413,6 +1463,21 @@ function ChatMarkdown({
     };
 
     return {
+      span({ node, className, children, ...props }) {
+        if ("data-color-swatch" in props) {
+          const colorValue = String(props["data-color-swatch"]);
+          return (
+            <span className="inline-flex items-center gap-1">
+              <span
+                className="inline-block size-3 shrink-0 rounded-[3px] border border-border"
+                style={{ backgroundColor: colorValue }}
+              />
+              <span {...props} className={className}>{children}</span>
+            </span>
+          );
+        }
+        return <span {...props} className={className}>{children}</span>;
+      },
       p({ node: _node, children, ...props }) {
         return <p {...props}>{renderSkillInlineMarkdownChildren(children, skills)}</p>;
       },


### PR DESCRIPTION
Fixes #5815

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only chat markdown change; swatch colors come from regex-matched literals, with no auth or data-path impact.
> 
> **Overview**
> Chat messages now show a small **color preview chip** beside recognized color literals (hex, `rgb`/`rgba`, `hsl`/`hsla`) in rendered markdown.
> 
> A new **`remarkColorSwatches`** remark plugin walks text nodes, splits out matches, and emits spans tagged with `data-color-swatch`. The sanitize schema allows those span attributes (plus `className`/`style`), and a custom **`span`** renderer paints a bordered swatch using `backgroundColor` while keeping the literal text visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb7fc0e3450a8a55347ed0ce88fe00c0b068f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render color swatches next to color literals in chat markdown
> - Adds a `remarkColorSwatches` remark plugin to [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/5871/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) that detects hex and functional color literals (e.g. `#fff`, `rgb()`, `hsl()`) in markdown text nodes and wraps them in annotated `colorSwatch` span nodes.
> - A custom `span` renderer displays a small inline colored square next to the color text when the `data-color-swatch` attribute is present.
> - The sanitize schema is extended to allow `span` elements to retain `className`, `style`, and `dataColorSwatch` attributes so the swatches survive sanitization.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3cb7fc0. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->