### PR TITLE
feat(web): show pull request ci status in the sidebar

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -11,6 +11,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
+import * as Result from "effect/Result";
 import * as Scope from "effect/Scope";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { expect } from "vite-plus/test";
@@ -28,6 +29,7 @@ import {
   TextGenerationError,
 } from "@t3tools/contracts";
 import * as GitHubCli from "../sourceControl/GitHubCli.ts";
+import { decodeGitHubCheckRollupJson } from "../sourceControl/gitHubPullRequests.ts";
 import * as TextGeneration from "../textGeneration/TextGeneration.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
@@ -56,6 +58,8 @@ interface FakeGhScenario {
     headRepositoryNameWithOwner?: string | null;
     headRepositoryOwnerLogin?: string | null;
   };
+  /** Raw projected statusCheckRollup JSON returned by `pr view --json statusCheckRollup`. */
+  checkRollup?: string;
   repositoryCloneUrls?: Record<string, { url: string; sshUrl: string }>;
   failWith?: GitHubCli.GitHubCliError;
   /** Let this many gh calls succeed before failWith kicks in (default 0 = fail immediately). */
@@ -391,6 +395,12 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
       );
     }
 
+    // Must precede the general `pr view` branch: the checks lookup is also a
+    // `pr view`, but returns a rollup array rather than a PR object.
+    if (args[0] === "pr" && args[1] === "view" && args.includes("statusCheckRollup")) {
+      return Effect.succeed(fakeGhOutput((scenario.checkRollup ?? "[]") + "\n"));
+    }
+
     if (args[0] === "pr" && args[1] === "view") {
       const pullRequest: FakePullRequest = scenario.pullRequest ?? {
         number: 101,
@@ -555,6 +565,18 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
         }).pipe(
           Effect.map((result) => JSON.parse(result.stdout) as GitHubCli.GitHubPullRequestSummary),
         ),
+      getPullRequestChecks: (input) =>
+        execute({
+          cwd: input.cwd,
+          args: ["pr", "view", input.reference, "--json", "statusCheckRollup", "--jq", "<rollup>"],
+        }).pipe(
+          Effect.map((result) => {
+            const raw = result.stdout.trim();
+            if (raw.length === 0) return null;
+            const decoded = decodeGitHubCheckRollupJson(raw);
+            return Result.isSuccess(decoded) ? decoded.success : null;
+          }),
+        ),
       getRepositoryCloneUrls: (input) =>
         execute({
           cwd: input.cwd,
@@ -715,7 +737,85 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         baseRef: "main",
         headRef: "feature/status-open-pr",
         state: "open",
+        checks: null,
       });
+    }),
+  );
+
+  it.effect("status carries the rolled-up CI state for an open PR", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/status-pr-checks"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/status-pr-checks"]);
+
+      const { manager } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 55,
+                title: "PR with failing checks",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/55",
+                baseRefName: "main",
+                headRefName: "feature/status-pr-checks",
+              },
+            ]),
+          ],
+          // @effect-diagnostics-next-line preferSchemaOverJson:off
+          checkRollup: JSON.stringify([
+            { typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS", state: null },
+            { typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE", state: null },
+          ]),
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+      expect(status.pr?.checks).toEqual({
+        state: "failure",
+        total: 2,
+        passed: 1,
+        failed: 1,
+        pending: 0,
+      });
+    }),
+  );
+
+  it.effect("status leaves checks null for a settled PR without asking the provider", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/status-merged-no-checks"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/status-merged-no-checks"]);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 56,
+                title: "Merged PR",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/56",
+                baseRefName: "main",
+                headRefName: "feature/status-merged-no-checks",
+                state: "MERGED",
+              },
+            ]),
+          ],
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+      expect(status.pr?.state).toBe("merged");
+      expect(status.pr?.checks).toBeNull();
+      // CI on a settled PR isn't actionable, so it must not cost a provider call.
+      expect(ghCalls.some((call) => call.includes("statusCheckRollup"))).toBe(false);
     }),
   );
 
@@ -754,6 +854,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         baseRef: "main",
         headRef: "feature/status-trimmed-pr",
         state: "open",
+        checks: null,
       });
     }),
   );
@@ -806,6 +907,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         baseRef: "main",
         headRef: "feature/status-valid-pr-entry",
         state: "open",
+        checks: null,
       });
     }),
   );
@@ -856,6 +958,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         baseRef: "main",
         headRef: "feature/status-lowercase-state",
         state: "merged",
+        checks: null,
       });
     }),
   );
@@ -1119,6 +1222,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           baseRef: "main",
           headRef: "statemachine",
           state: "open",
+          checks: null,
         });
         expect(ghCalls).toContain(
           "pr list --head jasonLaster:statemachine --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -1227,6 +1331,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           baseRef: "main",
           headRef: "effect-atom",
           state: "open",
+          checks: null,
         });
         expect(ghCalls.some((call) => call.includes("pr list --head upstream/effect-atom "))).toBe(
           false,
@@ -1278,6 +1383,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         baseRef: "main",
         headRef: "feature/status-merged-pr",
         state: "merged",
+        checks: null,
       });
     }),
   );
@@ -1357,6 +1463,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         baseRef: "main",
         headRef: "feature/status-open-over-merged",
         state: "open",
+        checks: null,
       });
     }),
   );

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -28,6 +28,7 @@ import {
   type VcsStatusRemoteResult,
   VcsStatusResult,
   ModelSelection,
+  type ChangeRequestChecks,
   type SourceControlWritingStyleSettings,
 } from "@t3tools/contracts";
 import {
@@ -527,13 +528,17 @@ function appendUnique(values: string[], next: string | null | undefined): void {
   values.push(trimmed);
 }
 
-function toStatusPr(pr: PullRequestInfo): {
+function toStatusPr(
+  pr: PullRequestInfo,
+  checks: ChangeRequestChecks | null = null,
+): {
   number: number;
   title: string;
   url: string;
   baseRef: string;
   headRef: string;
   state: "open" | "closed" | "merged";
+  checks: ChangeRequestChecks | null;
 } {
   return {
     number: pr.number,
@@ -542,6 +547,7 @@ function toStatusPr(pr: PullRequestInfo): {
     baseRef: pr.baseRefName,
     headRef: pr.headRefName,
     state: pr.state,
+    checks,
   };
 }
 
@@ -923,6 +929,29 @@ export const make = Effect.gen(function* () {
     prLookupFailureStreakByKey.set(key, streak);
     return prLookupFailureTtl(streak);
   };
+  /**
+   * CI status for a resolved PR. Only open PRs are asked about: checks on a
+   * merged or closed PR aren't actionable, and skipping them keeps settled
+   * threads from costing an extra provider call on every lookup refresh.
+   *
+   * Never fails. A checks lookup that errors (rate limit, provider without
+   * check support, malformed output) degrades to "no CI signal" rather than
+   * taking down the PR association the badge itself depends on.
+   */
+  const lookupPrChecks = Effect.fn("lookupPrChecks")(function* (
+    cwd: string,
+    pr: Pick<PullRequestInfo, "number" | "state">,
+  ) {
+    if (pr.state !== "open") {
+      return null;
+    }
+    return yield* sourceControlProvider(cwd).pipe(
+      Effect.flatMap((provider) =>
+        provider.getChangeRequestChecks({ cwd, reference: String(pr.number) }),
+      ),
+      Effect.orElseSucceed(() => null),
+    );
+  });
   const prLookupCache = yield* Cache.makeWith(
     (key: string) => {
       const [cwd = "", branch = "", upstreamRef = ""] = key.split("\u0000");
@@ -935,10 +964,11 @@ export const make = Effect.gen(function* () {
         // Only skip when the branch is untracked as well: anything carrying an
         // upstream keeps the old behaviour.
         if (details.upstreamRef === null && (yield* isUnpublishedBranch(cwd, headContext))) {
-          return { latest: null, headContext };
+          return { latest: null, checks: null, headContext };
         }
         const latest = yield* findLatestPrForHeadContext(cwd, headContext);
-        return { latest, headContext };
+        const checks = latest === null ? null : yield* lookupPrChecks(cwd, latest);
+        return { latest, checks, headContext };
       });
     },
     {
@@ -1018,14 +1048,14 @@ export const make = Effect.gen(function* () {
     // `push -u`) must not orphan the fallback value for the same branch.
     const branchKey = `${cwd}\u0000${details.branch}`;
     return yield* Cache.get(prLookupCache, prLookupCacheKey(cwd, details)).pipe(
-      Effect.map(({ latest, headContext }) => {
+      Effect.map(({ latest, checks, headContext }) => {
         if (!latest) return { pr: null, headContext };
         // On the default branch, only surface open PRs.
         // Merged/closed matches are usually reverse-merge history, not the thread's PR context.
         if (details.isDefaultBranch && latest.state !== "open") {
           return { pr: null, headContext };
         }
-        return { pr: toStatusPr(latest), headContext };
+        return { pr: toStatusPr(latest, checks), headContext };
       }),
       Effect.tap(({ pr, headContext }) =>
         Effect.sync(() =>

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
@@ -123,6 +123,8 @@ export const make = Effect.gen(function* () {
             }),
         ),
       ),
+    // Build status is not wired up for Azure DevOps yet; null renders no indicator.
+    getChangeRequestChecks: () => Effect.succeed(null),
     createChangeRequest: (input) => {
       const source = SourceControlProvider.sourceControlRefFromInput(input);
       return azure

--- a/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
@@ -80,6 +80,8 @@ export const make = Effect.gen(function* () {
             }),
         ),
       ),
+    // Build status is not wired up for Bitbucket yet; null renders no indicator.
+    getChangeRequestChecks: () => Effect.succeed(null),
     createChangeRequest: (input) => {
       const source = SourceControlProvider.sourceControlRefFromInput(input);
       return bitbucket

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -1,5 +1,6 @@
 import { assert, it, afterEach, describe, expect, vi } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -108,6 +109,60 @@ describe("GitHubCli.layer", () => {
         cwd: "/repo",
         timeoutMs: 30_000,
       });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("rolls up check status and projects the rollup server-side", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              { typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS", state: null },
+              { typename: "CheckRun", status: "IN_PROGRESS", conclusion: null, state: null },
+              { typename: "StatusContext", status: null, conclusion: null, state: "SUCCESS" },
+            ]),
+          ),
+        ),
+      );
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const result = yield* gh.getPullRequestChecks({ cwd: "/repo", reference: "42" });
+
+      assert.deepStrictEqual(result, {
+        state: "pending",
+        total: 3,
+        passed: 2,
+        failed: 0,
+        pending: 1,
+      });
+      // The --jq projection is what keeps a busy PR's rollup from crossing the
+      // process boundary at full size, so assert it is actually sent.
+      const call = mockRun.mock.calls[0]?.[0];
+      assert.include(call?.args ?? [], "--jq");
+      assert.include(call?.args ?? [], "statusCheckRollup");
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("reports no check signal when a PR has an empty rollup", () =>
+    Effect.gen(function* () {
+      // `gh` prints nothing when the PR has no rollup at all.
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      assert.isNull(yield* gh.getPullRequestChecks({ cwd: "/repo", reference: "42" }));
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("surfaces a tagged error when the rollup payload is malformed", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("{not json")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const exit = yield* Effect.exit(gh.getPullRequestChecks({ cwd: "/repo", reference: "42" }));
+
+      assert.isTrue(Exit.isFailure(exit));
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -7,17 +7,28 @@ import * as Schema from "effect/Schema";
 
 import {
   TrimmedNonEmptyString,
+  type ChangeRequestChecks,
   type SourceControlRepositoryVisibility,
   type VcsError,
 } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import {
+  decodeGitHubCheckRollupJson,
   decodeGitHubPullRequestJson,
   decodeGitHubPullRequestListJson,
 } from "./gitHubPullRequests.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Projects `statusCheckRollup` down to the fields that decide a verdict.
+ * `CheckRun` entries carry status/conclusion, `StatusContext` entries carry
+ * state; keeping `__typename` lets the decoder tell an in-progress run from a
+ * completed one with no conclusion.
+ */
+const CHECK_ROLLUP_JQ =
+  "[.statusCheckRollup[]? | {typename: .__typename, status: .status, conclusion: .conclusion, state: .state}]";
 
 const gitHubCliFailureFields = {
   command: Schema.Literal("gh"),
@@ -122,6 +133,19 @@ export class GitHubPullRequestDecodeError extends Schema.TaggedErrorClass<GitHub
   }
 }
 
+export class GitHubPullRequestChecksDecodeError extends Schema.TaggedErrorClass<GitHubPullRequestChecksDecodeError>()(
+  "GitHubPullRequestChecksDecodeError",
+  gitHubCliDecodeFields,
+) {
+  get detail(): string {
+    return "GitHub CLI returned invalid check status JSON.";
+  }
+
+  override get message(): string {
+    return `GitHub CLI failed in getPullRequestChecks: ${this.detail}`;
+  }
+}
+
 export class GitHubRepositoryDecodeError extends Schema.TaggedErrorClass<GitHubRepositoryDecodeError>()(
   "GitHubRepositoryDecodeError",
   gitHubCliDecodeFields,
@@ -143,6 +167,7 @@ export const GitHubCliError = Schema.Union([
   GitHubPullRequestListDecodeError,
   GitHubChangeRequestListDecodeError,
   GitHubPullRequestDecodeError,
+  GitHubPullRequestChecksDecodeError,
   GitHubRepositoryDecodeError,
 ]);
 export type GitHubCliError = typeof GitHubCliError.Type;
@@ -215,6 +240,12 @@ export class GitHubCli extends Context.Service<
       readonly cwd: string;
       readonly reference: string;
     }) => Effect.Effect<GitHubPullRequestSummary, GitHubCliError>;
+
+    /** Rolled-up CI state for one PR, or null when the repo reports no checks. */
+    readonly getPullRequestChecks: (input: {
+      readonly cwd: string;
+      readonly reference: string;
+    }) => Effect.Effect<ChangeRequestChecks | null, GitHubCliError>;
 
     readonly getRepositoryCloneUrls: (input: {
       readonly cwd: string;
@@ -388,6 +419,42 @@ export const make = Effect.gen(function* () {
               );
             }),
           ),
+        ),
+      ),
+    getPullRequestChecks: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: [
+          "pr",
+          "view",
+          input.reference,
+          "--json",
+          "statusCheckRollup",
+          // Project server-side: the raw rollup carries names, URLs, and
+          // timestamps for every check (~8 KB on a busy PR) and we only need
+          // the four fields that discriminate a verdict.
+          "--jq",
+          CHECK_ROLLUP_JQ,
+        ],
+      }).pipe(
+        Effect.map((result) => result.stdout.trim()),
+        Effect.flatMap((raw) =>
+          // A PR with no rollup at all prints nothing rather than "[]".
+          raw.length === 0
+            ? Effect.succeed(null)
+            : Effect.sync(() => decodeGitHubCheckRollupJson(raw)).pipe(
+                Effect.flatMap((decoded) =>
+                  Result.isSuccess(decoded)
+                    ? Effect.succeed(decoded.success)
+                    : Effect.fail(
+                        new GitHubPullRequestChecksDecodeError({
+                          command: "gh",
+                          cwd: input.cwd,
+                          cause: decoded.failure,
+                        }),
+                      ),
+                ),
+              ),
         ),
       ),
     getRepositoryCloneUrls: (input) =>

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -205,6 +205,23 @@ export const make = Effect.gen(function* () {
             }),
         ),
       ),
+    getChangeRequestChecks: (input) =>
+      github.getPullRequestChecks(input).pipe(
+        Effect.mapError(
+          (error) =>
+            new SourceControlProviderError({
+              provider: "github",
+              operation: "getChangeRequestChecks",
+              command: error.command,
+              cwd: input.cwd,
+              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                input.reference,
+              ),
+              detail: error.detail,
+              cause: error,
+            }),
+        ),
+      ),
     createChangeRequest: (input) =>
       github
         .createPullRequest({

--- a/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
@@ -151,6 +151,8 @@ export const make = Effect.gen(function* () {
             }),
         ),
       ),
+    // Pipeline status is not wired up for GitLab yet; null renders no indicator.
+    getChangeRequestChecks: () => Effect.succeed(null),
     createChangeRequest: (input) => {
       const source = SourceControlProvider.sourceControlRefFromInput(input);
       return gitlab

--- a/apps/server/src/sourceControl/SourceControlProvider.ts
+++ b/apps/server/src/sourceControl/SourceControlProvider.ts
@@ -2,6 +2,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import type {
   ChangeRequest,
+  ChangeRequestChecks,
   ChangeRequestState,
   SourceControlProviderError,
   SourceControlProviderInfo,
@@ -96,6 +97,15 @@ export class SourceControlProvider extends Context.Service<
       readonly context?: SourceControlProviderContext;
       readonly reference: string;
     }) => Effect.Effect<ChangeRequest, SourceControlProviderError>;
+    /**
+     * Rolled-up CI state for a change request. Providers that cannot report
+     * checks return null, which renders as no indicator at all.
+     */
+    readonly getChangeRequestChecks: (input: {
+      readonly cwd: string;
+      readonly context?: SourceControlProviderContext;
+      readonly reference: string;
+    }) => Effect.Effect<ChangeRequestChecks | null, SourceControlProviderError>;
     readonly createChangeRequest: (input: {
       readonly cwd: string;
       readonly context?: SourceControlProviderContext;

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -81,6 +81,9 @@ function unsupportedProvider(
         reference: SourceControlProvider.transportSafeSourceControlErrorValue(input.reference),
         detail: `No ${kind} source control provider is registered.`,
       }),
+    // Absent CI status is a normal state (see the provider stubs), so an
+    // unregistered provider reports "no checks" rather than failing the lookup.
+    getChangeRequestChecks: () => Effect.succeed(null),
     createChangeRequest: (input) =>
       new SourceControlProviderError({
         provider: kind,
@@ -166,6 +169,11 @@ function bindProviderContext(
       }),
     getChangeRequest: (input) =>
       provider.getChangeRequest({
+        ...input,
+        context: input.context ?? context,
+      }),
+    getChangeRequestChecks: (input) =>
+      provider.getChangeRequestChecks({
         ...input,
         context: input.context ?? context,
       }),

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -34,6 +34,7 @@ function makeProvider(
     kind: "github",
     listChangeRequests: () => unsupported("listChangeRequests"),
     getChangeRequest: () => unsupported("getChangeRequest"),
+    getChangeRequestChecks: () => Effect.succeed(null),
     createChangeRequest: () => unsupported("createChangeRequest"),
     getRepositoryCloneUrls: () => Effect.succeed(CLONE_URLS),
     createRepository: () => Effect.succeed(CLONE_URLS),

--- a/apps/server/src/sourceControl/gitHubPullRequests.test.ts
+++ b/apps/server/src/sourceControl/gitHubPullRequests.test.ts
@@ -1,0 +1,123 @@
+import * as Result from "effect/Result";
+import { describe, expect, it } from "vite-plus/test";
+
+import { decodeGitHubCheckRollupJson, summarizeGitHubCheckRollup } from "./gitHubPullRequests.ts";
+
+const checkRun = (fields: { status?: string; conclusion?: string | null }) => ({
+  typename: "CheckRun",
+  status: fields.status ?? "COMPLETED",
+  conclusion: fields.conclusion ?? null,
+  state: null,
+});
+
+const statusContext = (state: string | null) => ({
+  typename: "StatusContext",
+  status: null,
+  conclusion: null,
+  state,
+});
+
+describe("summarizeGitHubCheckRollup", () => {
+  it("reports success only when every conclusive check passed", () => {
+    expect(
+      summarizeGitHubCheckRollup([
+        checkRun({ conclusion: "SUCCESS" }),
+        statusContext("SUCCESS"),
+        checkRun({ conclusion: "SUCCESS" }),
+      ]),
+    ).toEqual({ state: "success", total: 3, passed: 3, failed: 0, pending: 0 });
+  });
+
+  it("lets a single failure outrank passing and in-flight checks", () => {
+    // The failure is the actionable signal: a red dot must win over amber even
+    // while the rest of the suite is still running.
+    expect(
+      summarizeGitHubCheckRollup([
+        checkRun({ conclusion: "SUCCESS" }),
+        checkRun({ status: "IN_PROGRESS" }),
+        statusContext("FAILURE"),
+      ]),
+    ).toEqual({ state: "failure", total: 3, passed: 1, failed: 1, pending: 1 });
+  });
+
+  it("treats an incomplete CheckRun as pending regardless of conclusion", () => {
+    expect(
+      summarizeGitHubCheckRollup([
+        checkRun({ status: "QUEUED" }),
+        checkRun({ conclusion: "SUCCESS" }),
+      ]),
+    ).toEqual({ state: "pending", total: 2, passed: 1, failed: 0, pending: 1 });
+  });
+
+  it("counts skipped and neutral checks toward the total but not the verdict", () => {
+    // An all-skipped suite is not an endorsement, so it must not read green
+    // off the back of checks that never ran.
+    expect(
+      summarizeGitHubCheckRollup([
+        checkRun({ conclusion: "SKIPPED" }),
+        checkRun({ conclusion: "NEUTRAL" }),
+        checkRun({ conclusion: "SUCCESS" }),
+      ]),
+    ).toEqual({ state: "success", total: 3, passed: 1, failed: 0, pending: 0 });
+  });
+
+  it("maps every terminal failure conclusion to failed", () => {
+    for (const conclusion of ["FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"]) {
+      expect(summarizeGitHubCheckRollup([checkRun({ conclusion })])?.state).toBe("failure");
+    }
+  });
+
+  it("does not turn an unrecognized conclusion into a failure", () => {
+    // A conclusion GitHub adds later must never light the indicator red on
+    // its own; it lands in the neutral bucket instead.
+    expect(summarizeGitHubCheckRollup([checkRun({ conclusion: "SOMETHING_NEW" })])).toEqual({
+      state: "success",
+      total: 1,
+      passed: 0,
+      failed: 0,
+      pending: 0,
+    });
+  });
+
+  it("returns null when the rollup is empty so no indicator renders", () => {
+    expect(summarizeGitHubCheckRollup([])).toBeNull();
+  });
+});
+
+describe("decodeGitHubCheckRollupJson", () => {
+  it("decodes the projected rollup payload", () => {
+    const decoded = decodeGitHubCheckRollupJson(
+      JSON.stringify([
+        { typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS", state: null },
+        { typename: "StatusContext", status: null, conclusion: null, state: "FAILURE" },
+      ]),
+    );
+
+    expect(Result.isSuccess(decoded)).toBe(true);
+    expect(Result.isSuccess(decoded) ? decoded.success : null).toEqual({
+      state: "failure",
+      total: 2,
+      passed: 1,
+      failed: 1,
+      pending: 0,
+    });
+  });
+
+  it("skips entries it cannot decode rather than failing the batch", () => {
+    const decoded = decodeGitHubCheckRollupJson(
+      JSON.stringify([42, { typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }]),
+    );
+
+    expect(Result.isSuccess(decoded) ? decoded.success : null).toEqual({
+      state: "failure",
+      total: 1,
+      passed: 0,
+      failed: 1,
+      pending: 0,
+    });
+  });
+
+  it("fails when the payload is not an array", () => {
+    expect(Result.isSuccess(decodeGitHubCheckRollupJson("{}"))).toBe(false);
+  });
+});

--- a/apps/server/src/sourceControl/gitHubPullRequests.test.ts
+++ b/apps/server/src/sourceControl/gitHubPullRequests.test.ts
@@ -83,9 +83,28 @@ describe("summarizeGitHubCheckRollup", () => {
   });
 
   it("maps every terminal failure conclusion to failed", () => {
-    for (const conclusion of ["FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"]) {
+    for (const conclusion of [
+      "FAILURE",
+      "ERROR",
+      "TIMED_OUT",
+      "CANCELLED",
+      "STARTUP_FAILURE",
+      "ACTION_REQUIRED",
+      "STALE",
+    ]) {
       expect(summarizeGitHubCheckRollup([checkRun({ conclusion })])?.state).toBe("failure");
     }
+  });
+
+  it("does not let a stale check hide behind passing ones", () => {
+    // GitHub marks stuck runs stale. That is not a success and can block merge,
+    // so a suite carrying one must not render green.
+    expect(
+      summarizeGitHubCheckRollup([
+        checkRun({ conclusion: "SUCCESS" }),
+        checkRun({ conclusion: "STALE" }),
+      ]),
+    ).toEqual({ state: "failure", total: 2, passed: 1, failed: 1, pending: 0 });
   });
 
   it("does not turn an unrecognized conclusion into a failure or a pass", () => {

--- a/apps/server/src/sourceControl/gitHubPullRequests.test.ts
+++ b/apps/server/src/sourceControl/gitHubPullRequests.test.ts
@@ -50,8 +50,6 @@ describe("summarizeGitHubCheckRollup", () => {
   });
 
   it("counts skipped and neutral checks toward the total but not the verdict", () => {
-    // An all-skipped suite is not an endorsement, so it must not read green
-    // off the back of checks that never ran.
     expect(
       summarizeGitHubCheckRollup([
         checkRun({ conclusion: "SKIPPED" }),
@@ -61,22 +59,46 @@ describe("summarizeGitHubCheckRollup", () => {
     ).toEqual({ state: "success", total: 3, passed: 1, failed: 0, pending: 0 });
   });
 
+  it("reports no signal when nothing passed, failed, or is pending", () => {
+    // An all-skipped suite is not an endorsement: green here would claim the
+    // work is verified when no check actually ran.
+    expect(
+      summarizeGitHubCheckRollup([
+        checkRun({ conclusion: "SKIPPED" }),
+        checkRun({ conclusion: "NEUTRAL" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("does not strand the indicator on pending for a stateless status context", () => {
+    // A StatusContext with no state never resolves, so treating it as pending
+    // would leave an amber dot up forever.
+    expect(summarizeGitHubCheckRollup([statusContext(null)])).toBeNull();
+  });
+
+  it("keeps a real verdict when a stateless entry sits alongside it", () => {
+    expect(
+      summarizeGitHubCheckRollup([statusContext(null), checkRun({ conclusion: "SUCCESS" })]),
+    ).toEqual({ state: "success", total: 2, passed: 1, failed: 0, pending: 0 });
+  });
+
   it("maps every terminal failure conclusion to failed", () => {
     for (const conclusion of ["FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"]) {
       expect(summarizeGitHubCheckRollup([checkRun({ conclusion })])?.state).toBe("failure");
     }
   });
 
-  it("does not turn an unrecognized conclusion into a failure", () => {
-    // A conclusion GitHub adds later must never light the indicator red on
-    // its own; it lands in the neutral bucket instead.
-    expect(summarizeGitHubCheckRollup([checkRun({ conclusion: "SOMETHING_NEW" })])).toEqual({
-      state: "success",
-      total: 1,
-      passed: 0,
-      failed: 0,
-      pending: 0,
-    });
+  it("does not turn an unrecognized conclusion into a failure or a pass", () => {
+    // A conclusion GitHub adds later must never light the indicator red on its
+    // own, and must not read green either: it lands in the neutral bucket, so
+    // on its own it produces no signal at all.
+    expect(summarizeGitHubCheckRollup([checkRun({ conclusion: "SOMETHING_NEW" })])).toBeNull();
+    expect(
+      summarizeGitHubCheckRollup([
+        checkRun({ conclusion: "SOMETHING_NEW" }),
+        checkRun({ conclusion: "FAILURE" }),
+      ])?.state,
+    ).toBe("failure");
   });
 
   it("returns null when the rollup is empty so no indicator renders", () => {

--- a/apps/server/src/sourceControl/gitHubPullRequests.ts
+++ b/apps/server/src/sourceControl/gitHubPullRequests.ts
@@ -4,7 +4,12 @@ import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
-import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
+import {
+  PositiveInt,
+  TrimmedNonEmptyString,
+  type ChangeRequestChecks,
+  type ChangeRequestChecksState,
+} from "@t3tools/contracts";
 import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
 
 export interface NormalizedGitHubPullRequestRecord {
@@ -102,9 +107,108 @@ function normalizeGitHubPullRequestRecord(
   };
 }
 
+/**
+ * `gh` returns a heterogeneous rollup: GitHub Actions and most apps report as
+ * `CheckRun` (status + conclusion), while older commit statuses report as
+ * `StatusContext` (state only). Every field is optional so an unrecognized
+ * entry shape degrades to "neutral" instead of failing the whole decode and
+ * costing us the indicator.
+ */
+const GitHubCheckRollupEntrySchema = Schema.Struct({
+  typename: Schema.optional(Schema.NullOr(Schema.String)),
+  status: Schema.optional(Schema.NullOr(Schema.String)),
+  conclusion: Schema.optional(Schema.NullOr(Schema.String)),
+  state: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+type GitHubCheckRollupEntry = Schema.Schema.Type<typeof GitHubCheckRollupEntrySchema>;
+
+/** Conclusions and states that mean the check is done and unhappy. */
+const FAILED_CHECK_RESULTS = new Set([
+  "FAILURE",
+  "ERROR",
+  "TIMED_OUT",
+  "CANCELLED",
+  "STARTUP_FAILURE",
+  "ACTION_REQUIRED",
+]);
+/** States that mean the check has not reached a verdict yet. */
+const PENDING_CHECK_RESULTS = new Set(["PENDING", "EXPECTED", "QUEUED", "IN_PROGRESS", "WAITING"]);
+
+type CheckBucket = "passed" | "failed" | "pending" | "neutral";
+
+/**
+ * Buckets one rollup entry. `SKIPPED` and `NEUTRAL` are deliberately neutral
+ * rather than passing: a repo whose checks all skip should not read as green.
+ * Anything unrecognized is neutral too, so a new GitHub conclusion string
+ * can never turn the indicator red on its own.
+ */
+function bucketCheckRollupEntry(entry: GitHubCheckRollupEntry): CheckBucket {
+  // CheckRun carries the verdict in `conclusion`, but only once `status` says
+  // it is COMPLETED; before that the conclusion is null and it is still running.
+  const isCheckRun = entry.typename?.trim() === "CheckRun";
+  if (isCheckRun) {
+    const status = entry.status?.trim().toUpperCase();
+    if (status !== undefined && status !== "COMPLETED") {
+      return "pending";
+    }
+  }
+
+  const result = (entry.conclusion ?? entry.state)?.trim().toUpperCase();
+  if (result === undefined || result.length === 0) {
+    // A StatusContext with no state, or a completed CheckRun with no
+    // conclusion, tells us nothing actionable.
+    return isCheckRun ? "neutral" : "pending";
+  }
+  if (FAILED_CHECK_RESULTS.has(result)) return "failed";
+  if (PENDING_CHECK_RESULTS.has(result)) return "pending";
+  if (result === "SUCCESS") return "passed";
+  return "neutral";
+}
+
+/**
+ * Rolls check entries into the single state the sidebar renders. Returns null
+ * when there is nothing to say (no CI configured on the repo), which the UI
+ * reads as "draw no dot".
+ */
+export function summarizeGitHubCheckRollup(
+  entries: ReadonlyArray<GitHubCheckRollupEntry>,
+): ChangeRequestChecks | null {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+  for (const entry of entries) {
+    switch (bucketCheckRollupEntry(entry)) {
+      case "passed":
+        passed += 1;
+        break;
+      case "failed":
+        failed += 1;
+        break;
+      case "pending":
+        pending += 1;
+        break;
+      case "neutral":
+        break;
+    }
+  }
+
+  // A failure is the actionable signal, so it outranks work still in flight.
+  const state: ChangeRequestChecksState =
+    failed > 0 ? "failure" : pending > 0 ? "pending" : "success";
+
+  return { state, total: entries.length, passed, failed, pending };
+}
+
 const decodeGitHubPullRequestList = decodeJsonResult(Schema.Array(Schema.Unknown));
 const decodeGitHubPullRequest = decodeJsonResult(GitHubPullRequestSchema);
 const decodeGitHubPullRequestEntry = Schema.decodeUnknownExit(GitHubPullRequestSchema);
+const decodeGitHubCheckRollupList = decodeJsonResult(Schema.Array(Schema.Unknown));
+const decodeGitHubCheckRollupEntry = Schema.decodeUnknownExit(GitHubCheckRollupEntrySchema);
 
 export const formatGitHubJsonDecodeError = formatSchemaError;
 
@@ -137,4 +241,28 @@ export function decodeGitHubPullRequestJson(
     return Result.succeed(normalizeGitHubPullRequestRecord(result.success));
   }
   return Result.fail(result.failure);
+}
+
+/**
+ * Decodes the projected `statusCheckRollup` array (see GitHubCli's --jq filter)
+ * into a rolled-up summary. Individual entries that fail to decode are skipped
+ * rather than failing the batch, matching how the PR list decode degrades.
+ */
+export function decodeGitHubCheckRollupJson(
+  raw: string,
+): Result.Result<ChangeRequestChecks | null, Cause.Cause<Schema.SchemaError>> {
+  const result = decodeGitHubCheckRollupList(raw);
+  if (!Result.isSuccess(result)) {
+    return Result.fail(result.failure);
+  }
+
+  const entries: GitHubCheckRollupEntry[] = [];
+  for (const entry of result.success) {
+    const decodedEntry = decodeGitHubCheckRollupEntry(entry);
+    if (Exit.isFailure(decodedEntry)) {
+      continue;
+    }
+    entries.push(decodedEntry.value);
+  }
+  return Result.succeed(summarizeGitHubCheckRollup(entries));
 }

--- a/apps/server/src/sourceControl/gitHubPullRequests.ts
+++ b/apps/server/src/sourceControl/gitHubPullRequests.ts
@@ -123,7 +123,13 @@ const GitHubCheckRollupEntrySchema = Schema.Struct({
 
 type GitHubCheckRollupEntry = Schema.Schema.Type<typeof GitHubCheckRollupEntrySchema>;
 
-/** Conclusions and states that mean the check is done and unhappy. */
+/**
+ * Conclusions and states that mean the check is done and unhappy. This covers
+ * every non-success `CheckConclusionState` except the two GitHub treats as
+ * "no opinion" (NEUTRAL, SKIPPED). STALE belongs here: GitHub marks a stuck run
+ * stale, it is not a success, and it can block merge — so it must not read as
+ * green.
+ */
 const FAILED_CHECK_RESULTS = new Set([
   "FAILURE",
   "ERROR",
@@ -131,6 +137,7 @@ const FAILED_CHECK_RESULTS = new Set([
   "CANCELLED",
   "STARTUP_FAILURE",
   "ACTION_REQUIRED",
+  "STALE",
 ]);
 /** States that mean the check has not reached a verdict yet. */
 const PENDING_CHECK_RESULTS = new Set(["PENDING", "EXPECTED", "QUEUED", "IN_PROGRESS", "WAITING"]);

--- a/apps/server/src/sourceControl/gitHubPullRequests.ts
+++ b/apps/server/src/sourceControl/gitHubPullRequests.ts
@@ -156,9 +156,10 @@ function bucketCheckRollupEntry(entry: GitHubCheckRollupEntry): CheckBucket {
 
   const result = (entry.conclusion ?? entry.state)?.trim().toUpperCase();
   if (result === undefined || result.length === 0) {
-    // A StatusContext with no state, or a completed CheckRun with no
-    // conclusion, tells us nothing actionable.
-    return isCheckRun ? "neutral" : "pending";
+    // Nothing actionable: a StatusContext with no state, a completed CheckRun
+    // with no conclusion, or an entry shape we don't recognize at all. Reading
+    // these as pending would strand the indicator on amber indefinitely.
+    return "neutral";
   }
   if (FAILED_CHECK_RESULTS.has(result)) return "failed";
   if (PENDING_CHECK_RESULTS.has(result)) return "pending";
@@ -168,8 +169,10 @@ function bucketCheckRollupEntry(entry: GitHubCheckRollupEntry): CheckBucket {
 
 /**
  * Rolls check entries into the single state the sidebar renders. Returns null
- * when there is nothing to say (no CI configured on the repo), which the UI
- * reads as "draw no dot".
+ * when there is nothing to say — no CI configured, or a suite that reached no
+ * verdict at all (every check skipped, neutral, or an unrecognized shape) —
+ * which the UI reads as "draw no dot". A suite that nothing passed must not
+ * render green just because nothing failed either.
  */
 export function summarizeGitHubCheckRollup(
   entries: ReadonlyArray<GitHubCheckRollupEntry>,
@@ -195,6 +198,10 @@ export function summarizeGitHubCheckRollup(
       case "neutral":
         break;
     }
+  }
+
+  if (failed === 0 && pending === 0 && passed === 0) {
+    return null;
   }
 
   // A failure is the actionable signal, so it outranks work still in flight.

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -695,11 +695,15 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                       checks={prChecks}
                       className="size-3"
                       // Mirrors resolveThreadRowClassName's surfaces so the
-                      // dot's ring matches whatever the row is painting.
+                      // dot's ring matches whatever the row is painting. A
+                      // selected-but-inactive row uses row-selected, which is a
+                      // different color from row-active on several themes.
                       ringClass={
-                        isActive || isSelected
+                        isActive
                           ? "ring-sidebar-row-active"
-                          : "ring-sidebar group-hover/menu-sub-item:ring-sidebar-row-hover"
+                          : isSelected
+                            ? "ring-sidebar-row-selected group-hover/menu-sub-item:ring-sidebar-row-active"
+                            : "ring-sidebar group-hover/menu-sub-item:ring-sidebar-row-hover"
                       }
                     />
                   </button>

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -13,7 +13,8 @@ import {
   TriangleAlertIcon,
 } from "lucide-react";
 import {
-  ChangeRequestStatusIcon,
+  ChangeRequestStatusIconWithChecks,
+  prChecksIndicator,
   prStatusIndicator,
   PrStatusTooltipContent,
   resolveThreadPr,
@@ -453,6 +454,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     gitStatus: gitStatus.data,
   });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
+  const prChecks = prChecksIndicator(pr);
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
   const isConfirmingArchive = confirmingArchiveThreadKey === threadKey && !isThreadRunning;
   const threadMetaClassName = isConfirmingArchive
@@ -683,16 +685,28 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                 render={
                   <button
                     type="button"
-                    aria-label={prStatus.tooltip}
+                    aria-label={
+                      prChecks ? `${prStatus.tooltip}. ${prChecks.label}` : prStatus.tooltip
+                    }
                     className={`inline-flex items-center justify-center ${prStatus.colorClass} cursor-pointer rounded-sm outline-hidden focus-visible:ring-1 focus-visible:ring-ring`}
                     onClick={handlePrClick}
                   >
-                    <ChangeRequestStatusIcon className="size-3" />
+                    <ChangeRequestStatusIconWithChecks
+                      checks={prChecks}
+                      className="size-3"
+                      // Mirrors resolveThreadRowClassName's surfaces so the
+                      // dot's ring matches whatever the row is painting.
+                      ringClass={
+                        isActive || isSelected
+                          ? "ring-sidebar-row-active"
+                          : "ring-sidebar group-hover/menu-sub-item:ring-sidebar-row-hover"
+                      }
+                    />
                   </button>
                 }
               />
               <TooltipPopup side="top">
-                <PrStatusTooltipContent status={prStatus} />
+                <PrStatusTooltipContent status={prStatus} checks={prChecks} />
               </TooltipPopup>
             </Tooltip>
           )}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -137,6 +137,8 @@ import {
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
+  ChangeRequestStatusIconWithChecks,
+  prChecksIndicator,
   prStatusIndicator,
   resolveThreadPr,
   settledPrHoverColorClass,
@@ -840,6 +842,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     currentGitBranch: gitStatus.data?.refName ?? null,
   });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
+  const prChecks = prChecksIndicator(pr);
   const settledPrHoverClass = pr ? settledPrHoverColorClass(pr.state) : undefined;
   // Report the PR state up: the parent partitions rows with effectiveSettled,
   // and a merged/closed PR auto-settles a thread — data only rows have.
@@ -1022,6 +1025,17 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       "opacity-70 transition-opacity hover:opacity-100",
   );
 
+  // The CI dot punches out of whatever surface the row is currently painting,
+  // so the ring has to follow the same branches as rowSurfaceClassName above —
+  // otherwise the dot smears into the PR glyph on hover and selection.
+  const prChecksRingClass = cn(
+    props.isActive
+      ? "ring-sidebar-row-active"
+      : isSelected
+        ? "ring-sidebar-row-selected"
+        : "ring-sidebar group-hover/sidebar-row:ring-sidebar-row-hover",
+  );
+
   const title = isRenaming ? (
     <input
       autoFocus
@@ -1074,16 +1088,21 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         className={cn(
           // Sidebar chrome follows the interface font; tabular digits keep the
           // number from reflowing as PR states stream in.
-          "shrink-0 text-xs tabular-nums hover:underline",
+          "inline-flex shrink-0 items-center gap-1 text-xs tabular-nums hover:underline",
           variant === "slim" && variantAction === "unsettle"
             ? props.isActive
               ? "text-secondary-label"
               : cn("text-secondary-label transition-colors", settledPrHoverClass)
             : prStatus.colorClass,
         )}
-        aria-label={prStatus.tooltip}
+        aria-label={prChecks ? `${prStatus.tooltip}. ${prChecks.label}` : prStatus.tooltip}
       >
-        #{pr.number}
+        <ChangeRequestStatusIconWithChecks
+          checks={prChecks}
+          className="size-3"
+          ringClass={prChecksRingClass}
+        />
+        <span>#{pr.number}</span>
       </button>
     ) : null;
   const terminalStatusIcon = terminalStatus ? (

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -2,6 +2,7 @@ import type { VcsStatusResult } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  prChecksIndicator,
   prStatusIndicator,
   resolveThreadPr,
   settledPrHoverColorClass,
@@ -86,6 +87,50 @@ describe("prStatusIndicator", () => {
     expect(prStatusIndicator({ ...closedPr, state: "closed" }, undefined)?.colorClass).toContain(
       "text-red-600",
     );
+  });
+});
+
+describe("prChecksIndicator", () => {
+  function prWithChecks(checks: NonNullable<VcsStatusResult["pr"]>["checks"]) {
+    const pr = status().pr;
+    if (!pr) throw new Error("Expected pull request fixture");
+    return { ...pr, checks };
+  }
+
+  it.each([
+    ["success", "bg-emerald-500", "Checks passing"],
+    ["failure", "bg-red-500", "Checks failing"],
+    ["pending", "bg-amber-500", "Checks running"],
+  ] as const)("maps %s to its dot color and label", (state, dotClass, label) => {
+    const indicator = prChecksIndicator(
+      prWithChecks({ state, total: 4, passed: 2, failed: 1, pending: 1 }),
+    );
+
+    expect(indicator?.dotClass).toContain(dotClass);
+    expect(indicator?.label).toBe(label);
+  });
+
+  it("summarizes counts against the total for the tooltip", () => {
+    expect(
+      prChecksIndicator(
+        prWithChecks({ state: "failure", total: 12, passed: 9, failed: 3, pending: 0 }),
+      )?.summary,
+    ).toBe("3 of 12 failed");
+  });
+
+  it("shows nothing when the server reports no check signal", () => {
+    expect(prChecksIndicator(prWithChecks(null))).toBeNull();
+  });
+
+  it("shows nothing when talking to a server that predates check status", () => {
+    // `checks` is an optional contract field, so an older server simply omits it.
+    const pr = status().pr;
+    if (!pr) throw new Error("Expected pull request fixture");
+    expect(prChecksIndicator(pr)).toBeNull();
+  });
+
+  it("shows nothing when there is no PR at all", () => {
+    expect(prChecksIndicator(null)).toBeNull();
   });
 });
 

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -96,16 +96,102 @@ export function prStatusIndicator(
   return null;
 }
 
-export function ChangeRequestStatusIcon({ className }: { className?: string }) {
+export interface PrChecksIndicator {
+  /** Background class for the dot itself. */
+  dotClass: string;
+  /** Short state description, e.g. "Checks failing". */
+  label: string;
+  /** Count breakdown for the tooltip, e.g. "3 failed of 12". */
+  summary: string;
+}
+
+/**
+ * CI rollup for a thread's PR, or null when there is no signal to show:
+ * a server that predates check status, a provider that cannot report it,
+ * a repo with no CI, or a settled PR (checks are only fetched while open).
+ */
+export function prChecksIndicator(pr: ThreadPr): PrChecksIndicator | null {
+  const checks = pr?.checks;
+  if (!checks) return null;
+
+  switch (checks.state) {
+    case "success":
+      return {
+        dotClass: "bg-emerald-500 dark:bg-emerald-400",
+        label: "Checks passing",
+        summary: `${checks.passed} of ${checks.total} passed`,
+      };
+    case "failure":
+      return {
+        dotClass: "bg-red-500 dark:bg-red-400",
+        label: "Checks failing",
+        summary: `${checks.failed} of ${checks.total} failed`,
+      };
+    case "pending":
+      // No animation: a dot that repaints forever in a list of them is noise,
+      // and it pegs the GPU on high-refresh displays.
+      return {
+        dotClass: "bg-amber-500 dark:bg-amber-400",
+        label: "Checks running",
+        summary: `${checks.pending} of ${checks.total} running`,
+      };
+  }
+}
+
+export function ChangeRequestStatusIcon({ className }: { className?: string | undefined }) {
   return <GitPullRequestIcon className={className} />;
 }
 
-export function PrStatusTooltipContent({ status }: { status: PrStatusIndicator }) {
+/**
+ * PR glyph with the CI rollup overlaid at its lower right. The dot carries a
+ * ring in the row's own background so it stays legible against the glyph
+ * strokes — callers pass the surface class matching the row state they render
+ * (see `Sidebar.tsx`'s rowSurfaceClassName), defaulting to the sidebar surface.
+ */
+export function ChangeRequestStatusIconWithChecks({
+  checks,
+  className,
+  ringClass = "ring-sidebar",
+}: {
+  checks: PrChecksIndicator | null;
+  className?: string | undefined;
+  ringClass?: string | undefined;
+}) {
+  if (checks === null) {
+    return <ChangeRequestStatusIcon className={className} />;
+  }
+
+  return (
+    <span className="relative inline-flex shrink-0">
+      <ChangeRequestStatusIcon className={className} />
+      <span
+        aria-hidden
+        className={`-right-px -bottom-px absolute size-[7px] rounded-full ring-2 ${checks.dotClass} ${ringClass}`}
+      />
+    </span>
+  );
+}
+
+export function PrStatusTooltipContent({
+  status,
+  checks = null,
+}: {
+  status: PrStatusIndicator;
+  checks?: PrChecksIndicator | null;
+}) {
   return (
     <span className="flex max-w-[min(34rem,calc(100vw-2rem))] items-stretch overflow-hidden whitespace-nowrap">
       <span className="shrink-0 pr-2 font-medium">{status.tooltipLead}</span>
       <span className="min-h-4 shrink-0 border-border/70 border-l" aria-hidden="true" />
       <span className="min-w-0 truncate pl-2">{status.tooltipTitle}</span>
+      {checks ? (
+        <>
+          <span className="min-h-4 shrink-0 border-border/70 border-l" aria-hidden="true" />
+          <span className="shrink-0 pl-2">
+            {checks.label} ({checks.summary})
+          </span>
+        </>
+      ) : null}
     </span>
   );
 }
@@ -255,6 +341,7 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
     gitStatus: gitStatus.data,
   });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
+  const prChecks = prChecksIndicator(pr);
   const threadStatus = resolveThreadStatusPill({
     thread: {
       ...thread,
@@ -273,15 +360,20 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
           <TooltipTrigger
             render={
               <span
-                aria-label={prStatus.tooltip}
+                aria-label={prChecks ? `${prStatus.tooltip}. ${prChecks.label}` : prStatus.tooltip}
                 className={`inline-flex items-center justify-center ${prStatus.colorClass}`}
               />
             }
           >
-            <ChangeRequestStatusIcon className="size-3" />
+            {/* Command palette rows sit on the popover surface, not a sidebar row. */}
+            <ChangeRequestStatusIconWithChecks
+              checks={prChecks}
+              className="size-3"
+              ringClass="ring-popover"
+            />
           </TooltipTrigger>
           <TooltipPopup side="top">
-            <PrStatusTooltipContent status={prStatus} />
+            <PrStatusTooltipContent status={prStatus} checks={prChecks} />
           </TooltipPopup>
         </Tooltip>
       ) : null}

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -1,6 +1,10 @@
 import * as Schema from "effect/Schema";
 import { NonNegativeInt, PositiveInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
-import { SourceControlProviderError, SourceControlProviderInfo } from "./sourceControl.ts";
+import {
+  ChangeRequestChecks,
+  SourceControlProviderError,
+  SourceControlProviderInfo,
+} from "./sourceControl.ts";
 import { VcsDriverKind } from "./vcs.ts";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
@@ -197,6 +201,11 @@ const VcsStatusChangeRequest = Schema.Struct({
   baseRef: TrimmedNonEmptyStringSchema,
   headRef: TrimmedNonEmptyStringSchema,
   state: VcsStatusChangeRequestState,
+  // Optional so a client can talk to a server that predates check status (and
+  // vice versa): an absent field must decode, never drop the whole PR badge.
+  // Null means "no CI signal" — provider can't report checks, none are
+  // configured, or the lookup failed.
+  checks: Schema.optional(Schema.NullOr(ChangeRequestChecks)),
 });
 
 const VcsStatusLocalShape = {

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -1,5 +1,5 @@
 import * as Schema from "effect/Schema";
-import { PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { NonNegativeInt, PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { VcsDriverKind } from "./vcs.ts";
 
 export const SourceControlProviderKind = Schema.Literals([
@@ -20,6 +20,27 @@ export type SourceControlProviderInfo = typeof SourceControlProviderInfo.Type;
 
 export const ChangeRequestState = Schema.Literals(["open", "closed", "merged"]);
 export type ChangeRequestState = typeof ChangeRequestState.Type;
+
+/**
+ * Rolled-up CI state for a change request. `pending` covers anything still
+ * running or queued; a single failure outranks any number of successes.
+ */
+export const ChangeRequestChecksState = Schema.Literals(["pending", "success", "failure"]);
+export type ChangeRequestChecksState = typeof ChangeRequestChecksState.Type;
+
+/**
+ * Counts are for the tooltip only; `state` is what the indicator renders.
+ * `total` includes neutral checks (skipped, neutral conclusions) that land in
+ * none of the three buckets, so passed + failed + pending can be under total.
+ */
+export const ChangeRequestChecks = Schema.Struct({
+  state: ChangeRequestChecksState,
+  total: NonNegativeInt,
+  passed: NonNegativeInt,
+  failed: NonNegativeInt,
+  pending: NonNegativeInt,
+});
+export type ChangeRequestChecks = typeof ChangeRequestChecks.Type;
 
 export const ChangeRequest = Schema.Struct({
   provider: SourceControlProviderKind,


### PR DESCRIPTION
## What Changed

Sidebar thread rows now show the pull request's CI state as a colored dot on the PR badge: green when checks pass, red when any check fails, amber while checks are still running. The badge also gains the PR glyph in the card row, matching the slim row and legacy sidebar.

Check status is fetched alongside the PR association that the badge already resolves, inside the same two-minute lookup cache. Only open PRs are asked about, and only GitHub reports check state today; other providers return no signal and render exactly as they do now.

## Why

The sidebar already tells you a thread has an open PR, but not whether it is green. Finding out meant opening the PR in a browser, which is a lot of friction for a signal you want to scan for across a list of threads.

Deliberately scoped so the indicator can only ever add information:

- `checks` is an optional contract field, so a client and server on different versions still decode.
- A failing checks lookup (rate limit, provider without check support, malformed output) degrades to "no dot" rather than taking down the PR association the badge depends on.
- The raw `statusCheckRollup` is ~8 KB on a busy PR, so it is projected server-side with `--jq` down to the four fields that decide a verdict.
- Cost is one extra `gh` call per open-PR branch per two minutes, bounded by the existing cache, epoch invalidation, and failure backoff. Nothing new polls.

## UI Changes

Before:

<img src="https://raw.githubusercontent.com/AadiJo/t3code/07ba782f100fb584c3213cbefea08704e6f98e89/sidebar-ci-before.png" width="500" alt="Sidebar rows showing PR numbers with no CI indicator" />

After:

<img src="https://raw.githubusercontent.com/AadiJo/t3code/07ba782f100fb584c3213cbefea08704e6f98e89/sidebar-ci-after.png" width="500" alt="Sidebar rows showing PR glyph with a red dot for failing checks and a green dot for passing checks" />

Both captures are the same two threads against live GitHub data: #5780 has two failing checks in its rollup, #5828 is fully green.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI and optional contract fields with graceful degradation; extra `gh` calls are limited to open PRs and existing cache TTL.
> 
> **Overview**
> **Adds rolled-up CI status to VCS/git status for open PRs**, exposed as optional `checks` on change requests and wired through `getChangeRequestChecks` on source-control providers.
> 
> On **GitHub**, `gh pr view` fetches `statusCheckRollup` with a server-side `--jq` projection, then decodes and summarizes into `pending` / `success` / `failure` plus pass/fail/pending counts. **GitManager** loads checks only for **open** PRs inside the existing PR lookup cache; failures degrade to `null` so PR association still works. **Azure DevOps, Bitbucket, and GitLab** return `null` for now.
> 
> **Sidebar and legacy sidebar** show a green/red/amber dot on the PR badge via `ChangeRequestStatusIconWithChecks`, with tooltips and aria-labels extended for check summaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a89227ad6f6837ee048f52880e2bd430e9d817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show pull request CI check status in the sidebar
> - Adds a `ChangeRequestChecks` contract type (state, total/passed/failed/pending counts) and an optional `checks` field to `VcsStatusChangeRequest`.
> - GitHub provider fetches `statusCheckRollup` via `gh pr view --json statusCheckRollup`, decodes it, and returns a rolled-up verdict; merged/closed PRs skip the fetch. Azure DevOps, Bitbucket, and GitLab providers return null.
> - Sidebar rows (`Sidebar.tsx`, `LegacySidebar.tsx`) render a colored CI dot overlaid on the PR icon via the new `ChangeRequestStatusIconWithChecks` component, with check counts in tooltips and aria-labels.
> - Risk: the checks fetch is a new network call per open PR status lookup; failures degrade gracefully to null.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67a8922.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->