### PR TITLE
fix(desktop): preserve active element during automation press

### DIFF
--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3024,6 +3024,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           },
           () => previouslyFocused.focus(),
         ).pipe(Effect.ignore);
+        yield* attempt(
+          {
+            operation: "automationPress.restoreActiveElement",
+            tabId,
+            webContentsId: previouslyFocused.id,
+          },
+          () =>
+            previouslyFocused.executeJavaScript(
+              `if (window.__t3_restoreFocus && typeof window.__t3_restoreFocus.focus === 'function') { window.__t3_restoreFocus.focus(); delete window.__t3_restoreFocus; }`,
+            ),
+        ).pipe(Effect.ignore);
       }
     });
 
@@ -3032,6 +3043,19 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     // changing which thread is mounted in the UI. Restore the previous renderer
     // after dispatch so automation never leaves the app's input focus behind.
     yield* Effect.gen(function* () {
+      if (previouslyFocused && previouslyFocused.id !== wc.id && !previouslyFocused.isDestroyed()) {
+        yield* attempt(
+          {
+            operation: "automationPress.saveActiveElement",
+            tabId,
+            webContentsId: previouslyFocused.id,
+          },
+          () =>
+            previouslyFocused.executeJavaScript(
+              `if (document.activeElement && document.activeElement !== document.body) { window.__t3_restoreFocus = document.activeElement; } else { delete window.__t3_restoreFocus; }`,
+            ),
+        ).pipe(Effect.ignore);
+      }
       yield* attempt(
         { operation: "automationPress.focusWebContents", tabId, webContentsId: wc.id },
         () => wc.focus(),


### PR DESCRIPTION
Fixes #5792

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to preview automation press teardown; uses short injected JS on the main renderer with no auth or data-path changes.
> 
> **Overview**
> **Automation key presses** no longer leave the main app UI with the wrong focused control after preview agent input runs.
> 
> `performAutomationPress` already restored the previously focused **WebContents**; it now also snapshots `document.activeElement` in that renderer (via `window.__t3_restoreFocus`) before temporarily focusing the preview guest, and calls `.focus()` on that element during cleanup alongside `previouslyFocused.focus()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025197effed6418c66973fbab27230248eb1b8b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve active element in renderer during automation key dispatch
> During automation key dispatch in [`Manager.ts`](https://github.com/pingdotgg/t3code/pull/5874/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53), focus temporarily moves to a target `WebContents`, which previously caused the previously focused renderer to lose its active element. The fix saves the active element into `window.__t3_restoreFocus` before switching focus and refocuses it afterward via `executeJavaScript`. These steps are guarded to only run when the previously focused `WebContents` exists, differs from the current one, and is not destroyed.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 025197e. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->