### PR TITLE
feat(mobile): auto-start new task flow in most recently active project

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -112,6 +112,39 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
       ) ?? null)
     : null;
 
+  const defaultSelectionNavigatedRef = useRef(false);
+
+  useEffect(() => {
+    if (defaultSelectionNavigatedRef.current) {
+      return;
+    }
+
+    if (incomingShare || reservedDestinationProject) {
+      // Incoming shares have their own auto-navigation path; don't fight it.
+      defaultSelectionNavigatedRef.current = true;
+      return;
+    }
+
+    if (projectScopes.length > 0) {
+      defaultSelectionNavigatedRef.current = true;
+      const defaultProject = projectScopes[0]?.projects[0];
+      if (defaultProject) {
+        navigation.navigate("NewTaskSheet", {
+          screen: "NewTaskDraft",
+          params: {
+            environmentId: defaultProject.environmentId,
+            projectId: defaultProject.id,
+            title: defaultProject.title,
+          },
+        });
+      }
+    } else if (!projectEmptyState.loading) {
+      // If we finished loading and there are truly no projects, we shouldn't
+      // keep waiting to auto-navigate. Let the user see the empty state.
+      defaultSelectionNavigatedRef.current = true;
+    }
+  }, [projectScopes, navigation, incomingShare, reservedDestinationProject, projectEmptyState.loading]);
+
   async function selectProject(project: EnvironmentProject): Promise<void> {
     if (incomingShare?.destination && !reservedDestinationProject) {
       try {


### PR DESCRIPTION
Fixes #5785

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only UX change in the new-task flow with explicit guards for share flows and empty catalog states.
> 
> **Overview**
> Opening **Choose project** for a normal new task now **auto-navigates** into `NewTaskDraft` for the default project (`projectScopes[0].projects[0]`, ordered by recent activity via the new-task flow provider) instead of leaving users on the picker.
> 
> A **one-shot** `useEffect` plus ref ensures navigation runs only once. **Incoming shares** and reserved share destinations are skipped so existing share auto-navigation is unchanged. If loading finishes with **no projects**, the ref is set without navigating so the empty state stays visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bff2b9756b5dcc331b0fb69903faa97104c9745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-navigate to the most recently active project when opening the new task flow
> In [NewTaskRouteScreen](https://github.com/pingdotgg/t3code/pull/5875/files#diff-ff6990d7f3ffc05e93955c8a5c7bf5a3b77e8139e45c8b63e3a296596cd2d29e), adds a one-time auto-navigation effect that sends the user directly to `NewTaskDraft` for the first available project when the screen loads without an incoming share or reserved destination project. A ref guard (`defaultSelectionNavigatedRef`) ensures the effect fires only once per screen mount. If loading completes with no projects, the empty state is shown instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bff2b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->