### PR TITLE
perf(desktop): probe the Windows shell environment concurrently

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -379,10 +379,18 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
   function* (
     config: ShellEnvironmentConfig,
   ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner> {
-    const noProfile = yield* readWindowsEnvironment(["PATH"], { loadProfile: false });
-    const profile = yield* readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, {
-      loadProfile: true,
-    });
+    // Concurrent, not sequential: these two probes are independent (only their
+    // results are combined below) and each spawns its own PowerShell. Run in
+    // series they sit at offset 0 of desktop.startup, before anything else, and
+    // launch traces measured them at 2718ms then 2066ms — the entire 4.8s
+    // startup span, of which desktop.bootstrap is ~30ms.
+    const [noProfile, profile] = yield* Effect.all(
+      [
+        readWindowsEnvironment(["PATH"], { loadProfile: false }),
+        readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
+      ],
+      { concurrency: 2 },
+    );
     const mergedPath = mergePaths("win32", [
       trimNonEmpty(profile.PATH),
       trimNonEmpty(knownWindowsCliDirs(config.env).join(";")),


### PR DESCRIPTION
Fixes the second issue in #5876. Independent of #5877 — either can merge alone.

## What Changed

`installWindowsEnvironment` spawned PowerShell twice in series:

```ts
const noProfile = yield* readWindowsEnvironment(["PATH"], { loadProfile: false });
const profile = yield* readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true });
```

They now run under `Effect.all(..., { concurrency: 2 })`.

## Why

The two probes are independent — one reads `PATH` without the profile, the other reads the profile environment — and only their results are combined, a few lines below. They sit at offset 0 of `desktop.startup`, before anything else runs.

Traces over this code path measured the two spawns at **2718ms** and **2066ms**: the entire 4.8s startup span, of which `desktop.bootstrap` itself is ~30ms. Running them concurrently takes the second spawn off the critical path.

This does not address the larger cold-start cost — window creation still blocks on backend HTTP readiness, which is what #5877 targets. It only removes work that was serialized for no reason.

On provenance: those trace numbers come from a downstream fork of this codebase. I verified `installWindowsEnvironment` is byte-identical here before quoting them. The change is structural — two independent spawns stop being serialized — so it doesn't depend on the exact figures.

## Verification

`apps/desktop/src/shell/DesktopShellEnvironment.test.ts` (9) passes. `vp lint` and `@t3tools/desktop` typecheck are clean.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a — no UI change)
- [x] I included a video for animation/interaction changes (n/a — no motion change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only performance change on Windows; PATH/FNM merge behavior is unchanged and existing tests cover the module.
> 
> **Overview**
> On Windows, **`installWindowsEnvironment`** no longer runs its two PowerShell probes one after the other. The no-profile `PATH` read and the profile probe (`PATH`, `FNM_*`) now run together via **`Effect.all(..., { concurrency: 2 })`**, then the same merge into `config.env` as before.
> 
> That removes roughly one full probe from the critical path at the start of **`desktop.startup`**, where the two spawns were previously serialized despite being independent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f912be6e7f170f22d7f39987140967389d4a01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Probe Windows shell environment concurrently in `installWindowsEnvironment`
> The two `readWindowsEnvironment` calls (one without a profile for `PATH`, one with a profile for other env vars) previously ran sequentially. They now run concurrently using `Effect.all` with `concurrency: 2`, reducing the total time by one PowerShell invocation wait. The merging logic for `PATH` and `FNM_*` variables is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3f912b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->