### PR TITLE
fix(web): trait menu closes after you pick a level

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -323,6 +323,9 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                     key={option.id}
                     value={option.id}
                     hideIndicator
+                    // Base UI keeps radio menus open by default. Close on pick so
+                    // the traits menu behaves like the model picker.
+                    closeOnClick
                     disabled={ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id}
                   >
                     <span className="flex w-full min-w-0 items-center justify-between gap-3">
@@ -362,7 +365,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                 }}
               >
                 {(["on", "off"] as const).map((value) => (
-                  <MenuRadioItem key={value} value={value} hideIndicator>
+                  <MenuRadioItem key={value} value={value} hideIndicator closeOnClick>
                     <span className="flex w-full min-w-0 items-center justify-between gap-3">
                       <span>{value === "on" ? "On" : "Off"}</span>
                     </span>


### PR DESCRIPTION
Picking an effort level left the menu sitting open. You had to hit Escape or click away to get rid of it. The model picker closes itself on select, so the two menus behaved differently for no reason.

Base UI's `Menu.RadioItem` defaults `closeOnClick` to `false`, which is why. Turned it on for the trait rows.

This applies to every row in that menu, not just effort. It also holds Context window, Agent, Thinking, and Fast mode. Closing on effort but staying open on context window would be worse than either consistent option. Trade-off: setting two traits now takes two menu opens, same as the model picker.

Verified with typecheck, lint, and format check on `@t3tools/web`. Not run in the browser.

---
Made by Claude Opus 5 (1M context) in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX-only change to menu dismiss behavior in the composer; no auth, data, or API impact.
> 
> **Overview**
> The traits composer menu now **closes when you pick a value**, matching the model picker and other radio menus that already use `closeOnClick`.
> 
> `MenuRadioItem` in `TraitsPicker` gets **`closeOnClick`** on every row: select traits (effort, context window, agent, etc.) and boolean On/Off traits (thinking, fast mode). Base UI radio items default to staying open; without this prop the menu stayed up until Escape or an outside click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bfba4c0692e1b179aee765e982ea3d4b0d0316b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close traits menu immediately after selecting a level
> Adds `closeOnClick` to `MenuRadioItem` components in [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/5879/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45) so the menu closes on selection instead of remaining open.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bfba4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->