### PR TITLE
fix(web): make usage titlebar draggable

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,7 +1,8 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 import { RefreshCwIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 
+import { isElectron } from "../../env";
 import { cn } from "../../lib/utils";
 import { useUsage } from "../../state/usage";
 import {
@@ -14,6 +15,7 @@ import {
   makeWindow,
 } from "../../usage/usageFormat";
 import { ScrollArea } from "../ui/scroll-area";
+import { SidebarInset } from "../ui/sidebar";
 import { UsageChartLegend, UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
 import { PROVIDER_COLOR, PROVIDER_LABEL, PROVIDER_MARK, PROVIDER_ORDER } from "./usageProviders";
 
@@ -53,8 +55,8 @@ export function UsagePage() {
   const observedInput = merged.uncachedInputTokens + merged.cachedInputTokens;
   const cachedShare = observedInput === 0 ? 0 : merged.cachedInputTokens / observedInput;
 
-  return (
-    <ScrollArea className="h-full">
+  const content = (
+    <ScrollArea className="min-h-0 flex-1">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-6">
         <header className="flex flex-wrap items-start justify-between gap-4">
           <div className="flex flex-col gap-1">
@@ -361,6 +363,22 @@ export function UsagePage() {
         )}
       </div>
     </ScrollArea>
+  );
+
+  return <UsagePageFrame>{content}</UsagePageFrame>;
+}
+
+function UsagePageFrame({ children }: { readonly children: ReactNode }) {
+  return (
+    <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none text-foreground">
+      {isElectron ? (
+        <div
+          className="drag-region h-[52px] shrink-0 w-full wco:h-[env(titlebar-area-height)]"
+          aria-hidden
+        />
+      ) : null}
+      {children}
+    </SidebarInset>
   );
 }
 


### PR DESCRIPTION
## What Changed

- Add a desktop-only drag region above the Usage page.
- Keep Usage content in the standard sidebar inset and scroll it within the remaining viewport.

## Why

The Usage page rendered directly into the frameless desktop titlebar. Its heading and controls overlapped the native window-control row, while the empty-looking titlebar area was not draggable.

The new desktop-only spacer matches the existing 52px titlebar geometry (and the Window Controls Overlay height when available), so web behavior remains unchanged.

## UI Changes

Before
<img width="1351" height="272" alt="image" src="https://github.com/user-attachments/assets/14c0f00b-5316-4092-95e5-ff202f068da4" />


After
<img width="1115" height="215" alt="image" src="https://github.com/user-attachments/assets/57590d14-55f5-4062-8fa1-eac4e36a1c84" />



Manually verified in an isolated Windows Electron dev build: the Usage content begins below the native titlebar and the exposed titlebar strip can move the window.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Created with gpt-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only layout/CSS for the Usage route; no auth, data, or API changes.
> 
> **Overview**
> On **frameless Electron**, the Usage page no longer draws its header and controls under the native window buttons. Content is wrapped in **`SidebarInset`** with a new **`UsagePageFrame`** that reserves a **desktop-only `drag-region` spacer** (52px, or Window Controls Overlay height when available), aligned with other panels like **`DiffPanelShell`**.
> 
> The scrollable body uses **`min-h-0 flex-1`** instead of **`h-full`** so usage charts and tables scroll in the remaining viewport. **Web** layout is unchanged (no spacer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe4fd4ba7cfc7a4f20cb3a9eba41c13d58f0c5f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the usage page titlebar draggable in Electron
> Wraps the usage page in a new `UsagePageFrame` component that, when running under Electron, inserts a 52px draggable title bar region above the page content. The `ScrollArea` sizing is also updated from `h-full` to `min-h-0 flex-1` and the page is now nested inside a `SidebarInset`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe4fd4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->