### PR TITLE
fix(mobile): apply height state for composer auto-grow

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -279,6 +279,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const { onExpandedChange } = props;
 
   const [previewImageUri, setPreviewImageUri] = useState<string | null>(null);
+  const [contentHeight, setContentHeight] = useState(80);
   const hasContent = props.draftMessage.trim().length > 0 || props.draftAttachments.length > 0;
   // Opening and closing count as active so the composer stays expanded while
   // focus moves between its native editor and the settings modal.
@@ -719,6 +720,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               onFocus={handleFocus}
               onBlur={handleBlur}
               onSubmit={handleSend}
+              onContentSizeChange={(width, height) => setContentHeight(height)}
               scrollEnabled={isExpanded}
               // Android: collapsed single line centers natively (gravity) in
               // a pill-height box matching the send button; iOS keeps insets.
@@ -727,6 +729,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               style={
                 isExpanded
                   ? {
+                      height: Math.min(Math.max(contentHeight, 80), 160),
                       minHeight: 80,
                       maxHeight: 160,
                       paddingHorizontal: 4,


### PR DESCRIPTION
Fixes #5783b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile composer layout change with no auth, data, or API impact.
> 
> **Overview**
> Fixes **expanded thread composer auto-grow** by driving the editor container height from native content-size events instead of relying only on static `minHeight` / `maxHeight`.
> 
> `ThreadComposer` tracks `contentHeight` (default 80) via `ComposerEditor`'s `onContentSizeChange` and sets expanded `height` to `clamp(contentHeight, 80, 160)`, so the field grows with multiline input up to the existing cap while scrolling still applies above that limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f2723b2e163e8ccc373bad7d9f87e47f80470f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer auto-grow by applying clamped height state in `ThreadComposer`
> Adds a `contentHeight` state (initial value 80) to [ThreadComposer.tsx](https://github.com/pingdotgg/t3code/pull/5884/files#diff-4c62d895b68dd46f4d2858321c8942fde0d3ddd37c5e4253cba04c18c21a6024) and wires an `onContentSizeChange` handler to the editor. When expanded, the editor's height is set to `contentHeight` clamped between 80 and 160px, replacing the previous behavior where measured height was tracked but never applied.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8f2723b. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->