### PR TITLE
fix(mobile): forward native content size change to JS composer

### DIFF
--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -45,6 +45,11 @@ type NativePasteImagesEvent = NativeSyntheticEvent<{
   readonly uris: ReadonlyArray<string>;
 }>;
 
+type NativeContentSizeChangeEvent = NativeSyntheticEvent<{
+  readonly width: number;
+  readonly height: number;
+}>;
+
 interface NativeComposerEditorRef {
   focus: () => Promise<void>;
   blur: () => Promise<void>;
@@ -71,6 +76,7 @@ interface NativeComposerEditorProps extends ViewProps {
   readonly onComposerFocus?: () => void;
   readonly onComposerBlur?: () => void;
   readonly onComposerSubmit?: () => void;
+  readonly onComposerContentSizeChange?: (event: NativeContentSizeChangeEvent) => void;
 }
 
 const NativeView = requireNativeView<NativeComposerEditorProps>(NATIVE_MODULE_NAME);
@@ -96,6 +102,7 @@ export function ComposerEditor({
   onFocus,
   onBlur,
   onSubmit,
+  onContentSizeChange,
   contentInsetVertical = 0,
   ...props
 }: ComposerEditorProps) {
@@ -274,6 +281,9 @@ export function ComposerEditor({
       onComposerFocus={onFocus}
       onComposerBlur={onBlur}
       onComposerSubmit={onSubmit}
+      onComposerContentSizeChange={(event) =>
+        onContentSizeChange?.(event.nativeEvent.width, event.nativeEvent.height)
+      }
     />
   );
 }

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -47,6 +47,11 @@ type NativePasteImagesEvent = NativeSyntheticEvent<{
   readonly uris: ReadonlyArray<string>;
 }>;
 
+type NativeContentSizeChangeEvent = NativeSyntheticEvent<{
+  readonly width: number;
+  readonly height: number;
+}>;
+
 interface NativeComposerEditorRef {
   focus: () => Promise<void>;
   blur: () => Promise<void>;
@@ -73,6 +78,7 @@ interface NativeComposerEditorProps extends ViewProps {
   readonly onComposerPasteImages?: (event: NativePasteImagesEvent) => void;
   readonly onComposerFocus?: () => void;
   readonly onComposerBlur?: () => void;
+  readonly onComposerContentSizeChange?: (event: NativeContentSizeChangeEvent) => void;
 }
 
 const NativeView = requireNativeView<NativeComposerEditorProps>(NATIVE_MODULE_NAME);
@@ -97,6 +103,7 @@ export function ComposerEditor({
   onPasteImages,
   onFocus,
   onBlur,
+  onContentSizeChange,
   contentInsetVertical = 0,
   ...props
 }: ComposerEditorProps) {
@@ -279,6 +286,9 @@ export function ComposerEditor({
         onComposerPasteImages={(event) => onPasteImages?.(event.nativeEvent.uris)}
         onComposerFocus={onFocus}
         onComposerBlur={onBlur}
+        onComposerContentSizeChange={(event) =>
+          onContentSizeChange?.(event.nativeEvent.width, event.nativeEvent.height)
+        }
       />
     </TextInputWrapper>
   );


### PR DESCRIPTION
Fixes #5783c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bridge-layer change with optional callback forwarding; no auth, data, or business-logic changes.
> 
> **Overview**
> The native **T3ComposerEditor** already emits `onComposerContentSizeChange`, but the iOS and Android React wrappers never subscribed to it, so JS parents could not react when the editor’s measured size changed.
> 
> This PR threads **`onContentSizeChange`** from `ComposerEditorProps` through both `T3ComposerEditor.ios.tsx` and `T3ComposerEditor.native.tsx`, mapping native `{ width, height }` into the existing callback signature. That lets composer UI (e.g. auto-growing input height) stay in sync with native layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aed4f37d6154cffaa8e016b9eca6ca8fac4c7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward native content size change events to JS `ComposerEditor` on mobile
> Adds an `onContentSizeChange` prop to `ComposerEditor` that fires with `width` and `height` when the native editor reports a content size change. A new `NativeContentSizeChangeEvent` type and `onComposerContentSizeChange` prop are added to the native view interfaces in both [T3ComposerEditor.ios.tsx](https://github.com/pingdotgg/t3code/pull/5886/files#diff-69d4d5095272f78042959f979b5bdb8cec908152e8d1461903770acd5e76c7df) and [T3ComposerEditor.native.tsx](https://github.com/pingdotgg/t3code/pull/5886/files#diff-713805a2470d470287c4d2a11eafef4c6b9d4d8397caf53923053dd64462f0a7).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9aed4f3. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->