### PR TITLE
fix(server): usage no longer double-counts forked Codex sessions

### DIFF
--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -18,7 +18,9 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 
 import type { UsageRecord } from "./usageTranscripts.ts";
 
-export const USAGE_SCAN_CACHE_VERSION = 1 as const;
+// v2: Codex fork-copy suppression changed what a file parses to, so v1
+// entries would keep serving double-counted records forever.
+export const USAGE_SCAN_CACHE_VERSION = 2 as const;
 
 export interface CachedFile {
   readonly size: number;

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -134,6 +134,106 @@ describe("parseCodexLine", () => {
     parseCodexLine(turnContext, state);
     expect(parseCodexLine(tokenCount(100, 0, 10, 0), state)).not.toBeNull();
   });
+
+  // A forked/subagent rollout opens with the parent's history copied in and
+  // every line re-stamped to the fork instant, then the ancestors' session
+  // metas. Counting those again multiplied usage ~1.85x on real data (#5758).
+  describe("forked rollouts", () => {
+    const meta = (overrides: {
+      id: string;
+      timestamp: string;
+      forkedFromId?: string;
+      spawnParentId?: string;
+    }) =>
+      JSON.stringify({
+        type: "session_meta",
+        timestamp: overrides.timestamp,
+        payload: {
+          type: "session_meta",
+          id: overrides.id,
+          ...(overrides.forkedFromId === undefined
+            ? {}
+            : { forked_from_id: overrides.forkedFromId }),
+          ...(overrides.spawnParentId === undefined
+            ? {}
+            : {
+                source: {
+                  subagent: { thread_spawn: { parent_thread_id: overrides.spawnParentId } },
+                },
+              }),
+        },
+      });
+    const stamped = (timestamp: string, line: string) => {
+      const parsed = JSON.parse(line) as { timestamp: string };
+      parsed.timestamp = timestamp;
+      return JSON.stringify(parsed);
+    };
+
+    it("keeps the child session id over copied ancestor metas", () => {
+      const state = initialCodexScanState();
+      parseCodexLine(meta({ id: "child", timestamp: "2026-08-01T05:00:00.000Z" }), state);
+      parseCodexLine(meta({ id: "parent", timestamp: "2026-08-01T05:00:00.000Z" }), state);
+      parseCodexLine(turnContext, state);
+      const record = parseCodexLine(tokenCount(100, 0, 10, 0), state);
+
+      expect(record?.sessionId).toBe("child");
+    });
+
+    it("drops the re-stamped copied burst and keeps the first real event", () => {
+      const state = initialCodexScanState();
+      const forkInstant = "2026-08-01T05:00:00.000Z";
+      parseCodexLine(meta({ id: "child", timestamp: forkInstant, forkedFromId: "parent" }), state);
+      parseCodexLine(meta({ id: "parent", timestamp: forkInstant }), state);
+      parseCodexLine(stamped(forkInstant, turnContext), state);
+
+      // Copied history: written in one burst at the fork instant.
+      expect(
+        parseCodexLine(stamped("2026-08-01T05:00:00.001Z", tokenCount(100, 0, 10, 0)), state),
+      ).toBeNull();
+      expect(
+        parseCodexLine(stamped("2026-08-01T05:00:00.002Z", tokenCount(200, 0, 20, 0)), state),
+      ).toBeNull();
+
+      // The child's first genuine turn lands seconds later and must count.
+      const real = parseCodexLine(
+        stamped("2026-08-01T05:00:06.000Z", tokenCount(300, 0, 30, 0)),
+        state,
+      );
+      expect(real).not.toBeNull();
+      expect(real?.totals.outputTokens).toBe(30);
+
+      // Suppression never restarts, even for closely spaced later events.
+      const next = parseCodexLine(
+        stamped("2026-08-01T05:00:06.100Z", tokenCount(400, 0, 40, 0)),
+        state,
+      );
+      expect(next).not.toBeNull();
+    });
+
+    it("recognizes subagent spawns without forked_from_id", () => {
+      const state = initialCodexScanState();
+      const spawnInstant = "2026-08-01T05:00:00.000Z";
+      parseCodexLine(
+        meta({ id: "child", timestamp: spawnInstant, spawnParentId: "parent" }),
+        state,
+      );
+      parseCodexLine(stamped(spawnInstant, turnContext), state);
+      expect(
+        parseCodexLine(stamped("2026-08-01T05:00:00.001Z", tokenCount(100, 0, 10, 0)), state),
+      ).toBeNull();
+    });
+
+    it("does not suppress anything in a rollout that is not a fork", () => {
+      const state = initialCodexScanState();
+      parseCodexLine(meta({ id: "root", timestamp: "2026-08-01T05:00:00.000Z" }), state);
+      parseCodexLine(stamped("2026-08-01T05:00:00.100Z", turnContext), state);
+      const record = parseCodexLine(
+        stamped("2026-08-01T05:00:00.200Z", tokenCount(100, 0, 10, 0)),
+        state,
+      );
+      expect(record).not.toBeNull();
+    });
+  });
 });
 
 describe("totalTokens", () => {

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -151,10 +151,42 @@ export interface CodexScanState {
   model: string;
   sessionId: string;
   lastUsageSignature: string | null;
+  sawSessionMeta: boolean;
+  /** While true, leading usage events are re-stamped copies of parent history. */
+  suppressingForkCopies: boolean;
+  forkCopyAnchorMs: number;
 }
 
 export function initialCodexScanState(): CodexScanState {
-  return { model: "", sessionId: "", lastUsageSignature: null };
+  return {
+    model: "",
+    sessionId: "",
+    lastUsageSignature: null,
+    sawSessionMeta: false,
+    suppressingForkCopies: false,
+    forkCopyAnchorMs: 0,
+  };
+}
+
+/**
+ * A forked or subagent rollout opens with the parent's full history copied in,
+ * every line re-stamped to the fork instant. Those copies are written in one
+ * synchronous burst (observed gaps 0-40ms), while the child's first genuine
+ * usage event only lands after a real model turn (observed 5s+). One second of
+ * separation splits the two cleanly; `ccusage` uses the same threshold.
+ */
+const FORK_COPY_MAX_GAP_MS = 1000;
+
+/** Whether a `session_meta` payload marks the rollout as a fork or subagent. */
+function isForkedSessionMeta(payload: Record<string, unknown>): boolean {
+  if (typeof payload["forked_from_id"] === "string") return true;
+  const source = payload["source"];
+  if (typeof source !== "object" || source === null) return false;
+  const subagent = (source as Record<string, unknown>)["subagent"];
+  if (typeof subagent !== "object" || subagent === null) return false;
+  const spawn = (subagent as Record<string, unknown>)["thread_spawn"];
+  if (typeof spawn !== "object" || spawn === null) return false;
+  return typeof (spawn as Record<string, unknown>)["parent_thread_id"] === "string";
 }
 
 /**
@@ -181,8 +213,18 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
   const payloadType = payloadRecord["type"];
 
   if (record["type"] === "session_meta") {
+    // Only the first meta describes this file's own session. A forked rollout
+    // repeats the ancestors' metas right after it; letting those through would
+    // reassign every subsequent record to an ancestor session.
+    if (state.sawSessionMeta) return null;
+    state.sawSessionMeta = true;
     const id = payloadRecord["id"] ?? payloadRecord["session_id"];
     if (typeof id === "string") state.sessionId = id;
+    const metaTimestampMs = parseTimestampMs(record["timestamp"]);
+    if (metaTimestampMs !== null && isForkedSessionMeta(payloadRecord)) {
+      state.suppressingForkCopies = true;
+      state.forkCopyAnchorMs = metaTimestampMs;
+    }
     return null;
   }
 
@@ -213,6 +255,17 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
   if (signature === state.lastUsageSignature) return null;
   state.lastUsageSignature = signature;
 
+  // In a forked rollout the copied parent history was already counted from the
+  // parent's own file. Drop the leading burst; the first usage event separated
+  // from its predecessor by a real turn's worth of time ends it for good.
+  if (state.suppressingForkCopies) {
+    if (timestampMs - state.forkCopyAnchorMs < FORK_COPY_MAX_GAP_MS) {
+      state.forkCopyAnchorMs = timestampMs;
+      return null;
+    }
+    state.suppressingForkCopies = false;
+  }
+
   const inputTokens = int(lastRecord["input_tokens"]);
   const cachedInputTokens = int(lastRecord["cached_input_tokens"]);
   const cacheCreationTokens = int(lastRecord["cache_write_input_tokens"]);
@@ -238,7 +291,8 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     totals,
     // Codex does not report cost in the rollout.
     reportedCostUsd: null,
-    // Rollout files are unique per session, so events need no global dedup.
+    // Events surviving the fork-copy suppression above are unique to this
+    // rollout, so they need no global dedup.
     dedupeKey: null,
   };
 }


### PR DESCRIPTION
Fixes #5758.

The Usage page could wildly overstate Codex totals (886B tokens / \$600K in the report; 1.85x inflation on my own transcript set). Forked and subagent Codex rollouts open with the parent's full history copied in, with every copied line re-stamped to the fork instant, so each fork counted its parent's entire history again and piled it onto the fork date. Multi-agent swarms made this compound fast: one local file carries 5 generations of copied ancestor history.

The fix, verified against ~/.codex/sessions (710 files, 333 forks):

- In rollouts whose first `session_meta` carries a fork marker (`forked_from_id`, or the subagent `thread_spawn` parent), the parser drops the leading burst of usage events. Copied history is written in one synchronous burst (0-40ms gaps); the child's first genuine turn lands seconds later. A 1s gap ends suppression for good, the same threshold `ccusage` uses for this case.
- Copied ancestor `session_meta` lines no longer overwrite the child's session id (the issue's secondary finding).
- Scan cache version bumped so previously cached inflated records re-parse once.

Two independent checks agree: a content-based dedup of copied events and the patched parser land within 0.03% of each other (10.88B -> 5.89B tokens on my data), consistent with the reporter's fork-aware recalculation matching `ccusage` exactly.

---
Change authored by Claude Fable 5 via Claude Code.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes usage aggregation logic for Codex transcripts (billing-adjacent reporting); behavior is well-tested but mis-tuned fork detection could under-count real usage.
> 
> **Overview**
> Fixes inflated Codex usage totals (#5758) by teaching **`parseCodexLine`** to ignore re-stamped parent history at the start of forked and subagent rollout files.
> 
> Fork/subagent rollouts are detected from the first **`session_meta`** (`forked_from_id` or subagent **`thread_spawn`**). The parser then **drops leading `token_count` events** written in a tight burst at the fork instant and **stops suppressing** once a usage event is **≥1s** after the previous anchor (aligned with `ccusage`). **Later `session_meta` lines** from copied ancestor history are ignored so **`sessionId`** stays on the child session.
> 
> **`USAGE_SCAN_CACHE_VERSION`** is bumped to **2** so v1 cached parses are discarded and files re-scan with the new logic. Tests cover session id retention, burst suppression, subagent spawns, and non-fork rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1264696608f24726cc581f2edb9959fb4277899c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix double-counting of forked Codex sessions in usage tracking
> - Adds fork detection in `parseCodexLine` via a new `isForkedSessionMeta` helper that identifies forked or subagent sessions from `session_meta` payloads.
> - Suppresses re-stamped parent history `token_count` events within a 1-second window (`FORK_COPY_MAX_GAP_MS`) after a fork, then resumes normal counting on the first genuinely new event.
> - Processes only the first `session_meta` per rollout file; subsequent metas are dropped to prevent ancestor session data from polluting counts.
> - Bumps `USAGE_SCAN_CACHE_VERSION` from 1 to 2 so previously cached v1 scan results are invalidated and rescanned with the new logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1264696. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->