### PR TITLE
fix(mobile): gracefully handle missing width in Android content size events

### DIFF
--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -45,6 +45,11 @@ type NativePasteImagesEvent = NativeSyntheticEvent<{
   readonly uris: ReadonlyArray<string>;
 }>;
 
+type NativeContentSizeChangeEvent = NativeSyntheticEvent<{
+  readonly width?: number;
+  readonly height: number;
+}>;
+
 interface NativeComposerEditorRef {
   focus: () => Promise<void>;
   blur: () => Promise<void>;
@@ -71,6 +76,7 @@ interface NativeComposerEditorProps extends ViewProps {
   readonly onComposerFocus?: () => void;
   readonly onComposerBlur?: () => void;
   readonly onComposerSubmit?: () => void;
+  readonly onComposerContentSizeChange?: (event: NativeContentSizeChangeEvent) => void;
 }
 
 const NativeView = requireNativeView<NativeComposerEditorProps>(NATIVE_MODULE_NAME);
@@ -96,6 +102,7 @@ export function ComposerEditor({
   onFocus,
   onBlur,
   onSubmit,
+  onContentSizeChange,
   contentInsetVertical = 0,
   ...props
 }: ComposerEditorProps) {
@@ -274,6 +281,9 @@ export function ComposerEditor({
       onComposerFocus={onFocus}
       onComposerBlur={onBlur}
       onComposerSubmit={onSubmit}
+      onComposerContentSizeChange={(event) =>
+        onContentSizeChange?.(event.nativeEvent.width ?? 0, event.nativeEvent.height)
+      }
     />
   );
 }

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -47,6 +47,11 @@ type NativePasteImagesEvent = NativeSyntheticEvent<{
   readonly uris: ReadonlyArray<string>;
 }>;
 
+type NativeContentSizeChangeEvent = NativeSyntheticEvent<{
+  readonly width?: number;
+  readonly height: number;
+}>;
+
 interface NativeComposerEditorRef {
   focus: () => Promise<void>;
   blur: () => Promise<void>;
@@ -73,6 +78,7 @@ interface NativeComposerEditorProps extends ViewProps {
   readonly onComposerPasteImages?: (event: NativePasteImagesEvent) => void;
   readonly onComposerFocus?: () => void;
   readonly onComposerBlur?: () => void;
+  readonly onComposerContentSizeChange?: (event: NativeContentSizeChangeEvent) => void;
 }
 
 const NativeView = requireNativeView<NativeComposerEditorProps>(NATIVE_MODULE_NAME);
@@ -97,6 +103,7 @@ export function ComposerEditor({
   onPasteImages,
   onFocus,
   onBlur,
+  onContentSizeChange,
   contentInsetVertical = 0,
   ...props
 }: ComposerEditorProps) {
@@ -279,6 +286,9 @@ export function ComposerEditor({
         onComposerPasteImages={(event) => onPasteImages?.(event.nativeEvent.uris)}
         onComposerFocus={onFocus}
         onComposerBlur={onBlur}
+        onComposerContentSizeChange={(event) =>
+          onContentSizeChange?.(event.nativeEvent.width ?? 0, event.nativeEvent.height)
+        }
       />
     </TextInputWrapper>
   );


### PR DESCRIPTION
Fixes #5783d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bridge-layer change for an optional layout callback; no auth, data, or core business logic.
> 
> **Overview**
> **T3ComposerEditor** on iOS and Android now forwards native `onComposerContentSizeChange` to the existing `onContentSizeChange(width, height)` prop so composer layout can react as the editor grows or shrinks.
> 
> The bridge types **`width` as optional** and uses **`event.nativeEvent.width ?? 0`** when calling the JS callback, so Android events that only include **height** (fixes #5783d) no longer break consumers that expect a numeric width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad78c7c703289fac68cbc1585b95d222dc159153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle missing width in Android `onComposerContentSizeChange` events
> Android content size events sometimes omit the `width` field, which could cause issues in callbacks expecting numeric values. Both [T3ComposerEditor.ios.tsx](https://github.com/pingdotgg/t3code/pull/5888/files#diff-69d4d5095272f78042959f979b5bdb8cec908152e8d1461903770acd5e76c7df) and [T3ComposerEditor.native.tsx](https://github.com/pingdotgg/t3code/pull/5888/files#diff-713805a2470d470287c4d2a11eafef4c6b9d4d8397caf53923053dd64462f0a7) now type `width` as optional and default it to `0` when invoking the `onContentSizeChange` callback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad78c7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->