### PR TITLE
perf(server): poll VCS remote status every 5 minutes on the balanced profile

### DIFF
--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -25,6 +25,11 @@ import { mergeGitStatusParts } from "@t3tools/shared/git";
 import * as BackgroundPolicy from "../background/BackgroundPolicy.ts";
 import * as GitWorkflowService from "../git/GitWorkflowService.ts";
 
+// Wake cadence used only when automatic fetching is disabled (configured
+// interval zero). The loop skips the actual refresh in that case, so this
+// decides how often the setting is re-checked, not how often we poll the
+// remote. The polling cadence is automaticGitFetchInterval, resolved from the
+// background activity profile.
 const DEFAULT_VCS_STATUS_REFRESH_INTERVAL = Duration.seconds(30);
 const VCS_STATUS_REFRESH_FAILURE_BASE_DELAY = Duration.seconds(30);
 const VCS_STATUS_REFRESH_FAILURE_MAX_DELAY = Duration.minutes(15);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -499,7 +499,24 @@ export const SourceControlWritingStyleSettings = Schema.Struct({
 });
 export type SourceControlWritingStyleSettings = typeof SourceControlWritingStyleSettings.Type;
 
-export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
+/**
+ * Balanced-profile cadence for the per-cwd remote status poller: git fetch,
+ * ahead/behind counts, and the PR lookup.
+ *
+ * At 30s this was an ~18% duty cycle per open repo. Traces measured
+ * refreshRemoteStatus at 5382ms average and 9507ms worst case, so the server
+ * spent five-plus seconds shelling out to git and gh every half minute, forever,
+ * for every open repo — 530 subprocess spawns in 12.8 minutes.
+ *
+ * Nothing on that path is latency-sensitive. Ahead/behind counts and PR state do
+ * not change on a 30-second cadence, and local status (dirty files, branch
+ * changes) refreshes on its own path via refreshLocalStatus, so the UI stays
+ * responsive to the user's own work regardless of this value.
+ *
+ * This is the `balanced` preset only. `performance` keeps its own 15s cadence
+ * for anyone who wants tighter polling, and `battery-saver` disables it.
+ */
+export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.minutes(5);
 export const DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL = Duration.minutes(5);
 
 export const BackgroundActivityProfile = Schema.Literals([

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -495,7 +495,24 @@ export const SourceControlWritingStyleSettings = Schema.Struct({
 });
 export type SourceControlWritingStyleSettings = typeof SourceControlWritingStyleSettings.Type;
 
-export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
+/**
+ * Balanced-profile cadence for the per-cwd remote status poller: git fetch,
+ * ahead/behind counts, and the PR lookup.
+ *
+ * At 30s this was an ~18% duty cycle per open repo. Traces measured
+ * refreshRemoteStatus at 5382ms average and 9507ms worst case, so the server
+ * spent five-plus seconds shelling out to git and gh every half minute, forever,
+ * for every open repo — 530 subprocess spawns in 12.8 minutes.
+ *
+ * Nothing on that path is latency-sensitive. Ahead/behind counts and PR state do
+ * not change on a 30-second cadence, and local status (dirty files, branch
+ * changes) refreshes on its own path via refreshLocalStatus, so the UI stays
+ * responsive to the user's own work regardless of this value.
+ *
+ * This is the `balanced` preset only. `performance` keeps its own 15s cadence
+ * for anyone who wants tighter polling, and `battery-saver` disables it.
+ */
+export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.minutes(5);
 export const DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL = Duration.minutes(5);
 
 export const BackgroundActivityProfile = Schema.Literals([

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL,
   DEFAULT_SERVER_SETTINGS,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -417,8 +418,11 @@ describe("serverSettings helpers", () => {
     const custom = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
       automaticGitFetchInterval: Duration.seconds(15),
     });
+    // Pinned to the constant, not a literal: this asserts "an override equal to
+    // the balanced preset reconciles back to the preset", which is about the
+    // reconciliation, not about the preset's particular value.
     const next = applyServerSettingsPatch(custom, {
-      automaticGitFetchInterval: Duration.seconds(30),
+      automaticGitFetchInterval: DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL,
     });
 
     expect(next.backgroundActivity).toEqual({
@@ -427,7 +431,9 @@ describe("serverSettings helpers", () => {
       overrides: {},
     });
     expect(next.backgroundActivityProfile).toBe("balanced");
-    expect(Duration.toMillis(next.automaticGitFetchInterval)).toBe(30_000);
+    expect(Duration.toMillis(next.automaticGitFetchInterval)).toBe(
+      Duration.toMillis(DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL),
+    );
   });
 
   it("drops custom overrides that duplicate the base profile", () => {
@@ -437,7 +443,9 @@ describe("serverSettings helpers", () => {
         profile: "custom",
         baseProfile: "balanced",
         overrides: {
-          automaticGitFetchInterval: Duration.seconds(30),
+          // Equal to the balanced preset by construction, so the override is
+          // redundant and should be dropped.
+          automaticGitFetchInterval: DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL,
         },
       },
     });


### PR DESCRIPTION
## What Changed

`DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL` moves from 30 seconds to 5 minutes. That constant is the `balanced` preset's remote-poll cadence, so this changes the default profile only.

Unaffected:

- `performance` keeps its own explicit `Duration.seconds(15)`.
- `battery-saver` still disables remote fetching entirely.
- An explicit `automaticGitFetchInterval` override still wins.

## Why

The balanced profile fetches remote git status every 30 seconds, per open repo, forever. Traces measured `refreshRemoteStatus` at **5382ms average and 9507ms worst case** — an **~18% duty cycle per repo**: 530 git subprocess spawns in 12.8 minutes at ~179ms each, plus `gh` network round trips (`lookupStatusPr` 1276ms average, `computeAheadCountAgainstBase` 2239ms).

Nothing on that path is latency-sensitive. Ahead/behind counts and PR state don't change on a 30-second cadence. The things that *do* need to react to what the user just did — dirty files, branch changes — refresh on a separate path via `refreshLocalStatus`, so the UI stays responsive regardless of this value.

At 5 minutes, balanced also lines up with `DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL`, which is already 5 minutes.

Provenance: those trace numbers come from a downstream fork of this codebase, measured before the background-activity profiles existed. I checked the current resolution path here — `balanced` reads this constant directly through `resolveServerBackgroundActivitySettings` — so the constant is still what drives the cadence.

## Notes

`DEFAULT_VCS_STATUS_REFRESH_INTERVAL` in `VcsStatusBroadcaster` is deliberately left at 30s. It is the wake cadence for re-checking the setting when automatic fetching is disabled, not a polling interval — the loop skips the refresh entirely in that mode. I added a comment saying so, because the two constants read alike and the next person will wonder.

Two tests in `packages/shared/src/serverSettings.test.ts` pinned the balanced value as a literal 30s while actually asserting something else: that an override equal to the preset reconciles back to the preset. They now reference `DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL`, so they test the reconciliation rather than the constant, and won't need touching next time it moves.

## Verification

`packages/shared/src/serverSettings.test.ts`, `packages/shared/src/backgroundActivitySettings.test.ts`, `apps/server/src/serverSettings.test.ts` — 57 tests, all passing. `vp lint` clean; `@t3tools/contracts` and `@t3tools/shared` typecheck clean.

`apps/server/src/vcs/VcsStatusBroadcaster.test.ts` has one failure on my machine — `EPERM: operation not permitted, symlink` in "normalizes symlinked CWDs". I confirmed it fails identically on unmodified `main`: it needs Windows symlink privileges, and is unrelated to this change. The other 12 pass.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a — no UI change)
- [x] I included a video for animation/interaction changes (n/a — no motion change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default cadence change only affects balanced-profile background polling; local status and other presets are unchanged, with no auth or data-path changes.
> 
> **Overview**
> On the **balanced** background activity profile, remote VCS polling (`git fetch`, ahead/behind, PR lookup) now defaults to **5 minutes** instead of **30 seconds** via `DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL`. **Performance** (15s) and **battery-saver** (disabled) presets are unchanged; explicit `automaticGitFetchInterval` overrides still win.
> 
> `VcsStatusBroadcaster` gains a comment clarifying that `DEFAULT_VCS_STATUS_REFRESH_INTERVAL` (still 30s) is only the wake cadence when automatic fetching is off—not the remote poll interval, which comes from `automaticGitFetchInterval`.
> 
> `serverSettings.test.ts` reconciliation tests now pin expectations to `DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL` instead of a hardcoded 30s so they assert preset reconciliation, not a specific interval value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6cc55009dd595f845146b76ca36b7696608b8d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL` from 30 seconds to 5 minutes on the balanced profile
> The previous 30-second interval was too aggressive for the balanced background activity profile. The new default of 5 minutes reduces unnecessary VCS polling load. Tests in [serverSettings.test.ts](https://github.com/pingdotgg/t3code/pull/5890/files#diff-7e40ca4f652952527cffdd29ffa9e492fa97dfacff250aa1889c5b7aaa1b235e) are updated to use the imported constant instead of a hardcoded literal. Behavioral Change: any server using the balanced profile default will now poll remote VCS status every 5 minutes instead of every 30 seconds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6cc550.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->