### PR TITLE
fix(mobile): sort projects by recent activity to fix new task default

### DIFF
--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -88,31 +88,45 @@ export function sortHomeProjectScopes(input: {
     ),
   );
   const latestActivityByScope = new Map<string, number>();
-  const recordActivity = (scopeKey: string | undefined, timestamp: number) => {
-    if (!scopeKey || !Number.isFinite(timestamp)) return;
-    latestActivityByScope.set(
-      scopeKey,
-      Math.max(latestActivityByScope.get(scopeKey) ?? Number.NEGATIVE_INFINITY, timestamp),
-    );
+  const latestActivityByProjectKey = new Map<string, number>();
+  const recordActivity = (scopeKey: string | undefined, projectKey: string | undefined, timestamp: number) => {
+    if (!Number.isFinite(timestamp)) return;
+    if (scopeKey) {
+      latestActivityByScope.set(
+        scopeKey,
+        Math.max(latestActivityByScope.get(scopeKey) ?? Number.NEGATIVE_INFINITY, timestamp),
+      );
+    }
+    if (projectKey) {
+      latestActivityByProjectKey.set(
+        projectKey,
+        Math.max(latestActivityByProjectKey.get(projectKey) ?? Number.NEGATIVE_INFINITY, timestamp),
+      );
+    }
   };
 
   for (const thread of input.threads) {
     if (thread.archivedAt !== null) continue;
+    const projectKey = scopedProjectKey(thread.environmentId, thread.projectId);
     recordActivity(
-      scopeKeyByProjectRef.get(scopedProjectKey(thread.environmentId, thread.projectId)),
+      scopeKeyByProjectRef.get(projectKey),
+      projectKey,
       getThreadSortTimestamp(thread, input.projectSortOrder),
     );
   }
   for (const pendingTask of input.pendingTasks) {
+    const projectKey = scopedProjectKey(
+      pendingTask.message.environmentId,
+      pendingTask.creation.projectId,
+    );
     recordActivity(
-      scopeKeyByProjectRef.get(
-        scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
-      ),
+      scopeKeyByProjectRef.get(projectKey),
+      projectKey,
       Date.parse(pendingTask.message.createdAt),
     );
   }
 
-  return Arr.sort(
+  const sortedScopes = Arr.sort(
     input.scopes,
     Order.mapInput(
       Order.Struct({
@@ -133,6 +147,20 @@ export function sortHomeProjectScopes(input: {
       }),
     ),
   );
+
+  return sortedScopes.map((scope) => ({
+    ...scope,
+    projects: Arr.sort(
+      scope.projects,
+      Order.mapInput(Order.flip(Order.Number), (project) =>
+        Math.max(
+          latestActivityByProjectKey.get(scopedProjectKey(project.environmentId, project.id)) ??
+            Number.NEGATIVE_INFINITY,
+          getProjectSortTimestamp(project, input.projectSortOrder),
+        ),
+      ),
+    ),
+  }));
 }
 
 /**


### PR DESCRIPTION
Fixes #5785b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile home list ordering only; no changes to auth, networking, or persistence.
> 
> **Overview**
> **`sortHomeProjectScopes`** now tracks **per-project** latest activity (from non-archived threads and pending tasks) in addition to scope-level activity, and **re-sorts each scope’s `projects` array** by that activity (newest first), falling back to existing project `created_at` / `updated_at` sort rules when there is no thread activity.
> 
> Scope ordering is unchanged; only **member order inside grouped scopes** (e.g. same repo on multiple machines) is updated so the project you last used surfaces first—addressing incorrect **new task** defaults that relied on an arbitrary first member.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c37be6158ec031c05e129c658441f65cd81ade2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort projects by recent activity to fix new task default project ordering
> Updates `sortHomeProjectScopes` in [homeThreadList.ts](https://github.com/pingdotgg/t3code/pull/5892/files#diff-1f36b630d8d39dd1ca1be5a84d64ea082a69ffdf26be6759d3e6c9b705473796) to sort projects within each scope by their most recent activity, in addition to the existing scope-level sorting. Tracks per-project activity using a `latestActivityByProjectKey` map, populated from both thread activity and pending task timestamps, then orders projects by the maximum of their activity timestamp and sort timestamp.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2c37be6. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->