### PR TITLE
fix(desktop): correctly await executeJavaScript for element focus restoration

### DIFF
--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3024,6 +3024,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           },
           () => previouslyFocused.focus(),
         ).pipe(Effect.ignore);
+        yield* attemptPromise(
+          {
+            operation: "automationPress.restoreActiveElement",
+            tabId,
+            webContentsId: previouslyFocused.id,
+          },
+          () =>
+            previouslyFocused.executeJavaScript(
+              `if (window.__t3_restoreFocus && typeof window.__t3_restoreFocus.focus === 'function') { window.__t3_restoreFocus.focus(); delete window.__t3_restoreFocus; }`,
+            ),
+        ).pipe(Effect.ignore);
       }
     });
 
@@ -3032,6 +3043,19 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     // changing which thread is mounted in the UI. Restore the previous renderer
     // after dispatch so automation never leaves the app's input focus behind.
     yield* Effect.gen(function* () {
+      if (previouslyFocused && previouslyFocused.id !== wc.id && !previouslyFocused.isDestroyed()) {
+        yield* attemptPromise(
+          {
+            operation: "automationPress.saveActiveElement",
+            tabId,
+            webContentsId: previouslyFocused.id,
+          },
+          () =>
+            previouslyFocused.executeJavaScript(
+              `if (document.activeElement && document.activeElement !== document.body) { window.__t3_restoreFocus = document.activeElement; } else { delete window.__t3_restoreFocus; }`,
+            ),
+        ).pipe(Effect.ignore);
+      }
       yield* attempt(
         { operation: "automationPress.focusWebContents", tabId, webContentsId: wc.id },
         () => wc.focus(),


### PR DESCRIPTION
Fixes #5792b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to desktop preview automation cleanup; no auth or data paths, only focus bookkeeping around agent key presses.
> 
> **Overview**
> **Preview key automation** (`performAutomationPress`) now saves and restores the **focused DOM element** in the previously focused renderer, not only that `WebContents`’s OS focus.
> 
> Before dispatching keys to the guest preview, it runs `executeJavaScript` on the prior focus target to stash `document.activeElement` on `window.__t3_restoreFocus` when it isn’t `document.body`. In cleanup (after key-up and focus emulation), it refocuses that `WebContents` and runs JS to call `.focus()` on the stashed element, then deletes the stash.
> 
> Both save and restore use **`attemptPromise`** so the Effect pipeline **awaits** `executeJavaScript` instead of treating it like a synchronous call—addressing focus restoration races (fixes #5792).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46bfa4e52e7b7e451a52266cccf92dab422ed95e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore focused DOM element after automation key dispatch in `PreviewManager`
> When automation temporarily shifts focus to another `WebContents`, the previously focused `WebContents` loses its active DOM element. This fix captures the `activeElement` into a page-global marker before focus shifts away, then re-focuses it and clears the marker after the key dispatch completes. Both steps use `executeJavaScript` with `attemptPromise` and `Effect.ignore` to avoid surfacing errors if the element is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 46bfa4e. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->