### PR TITLE
fix(web): narrow thread action menu hit area

### DIFF
--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -200,12 +200,9 @@ export const ChatHeader = memo(function ChatHeader({
     if (!rect) return;
     openMenu({ x: rect.left, y: rect.bottom + 4 });
   }, [openMenu]);
-  const handleHeaderContextMenu = useCallback(
+  const handleTitleContextMenu = useCallback(
     (event: ReactMouseEvent) => {
       if (!isServerThread || renamingTitle !== null) return;
-      // The right-side controls (git, scripts, open-in) keep their own
-      // behavior; only the breadcrumb area opens the thread menu.
-      if ((event.target as HTMLElement).closest("[data-chat-header-actions]")) return;
       event.preventDefault();
       openMenu({ x: event.clientX, y: event.clientY });
     },
@@ -225,10 +222,7 @@ export const ChatHeader = memo(function ChatHeader({
     [commitRename],
   );
   return (
-    <div
-      className="@container/header-actions flex min-w-0 flex-1 items-center gap-2 sm:gap-3"
-      onContextMenu={handleHeaderContextMenu}
-    >
+    <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
       <WorkspaceBreadcrumb ariaLabel="Thread breadcrumb" className="flex-1">
         {/* The project always leads the header: knowing which project a
             thread lives in is priority zero, and the thread title alone
@@ -285,6 +279,7 @@ export const ChatHeader = memo(function ChatHeader({
                     aria-label={`Thread actions for ${activeThreadTitle}`}
                     aria-haspopup="menu"
                     onClick={openMenuFromTitle}
+                    onContextMenu={handleTitleContextMenu}
                     className="group/thread-title inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 }


### PR DESCRIPTION
## Problem

Existing thread headers opened the thread action menu from the full flex-width header area, making empty header space behave like the title control.

## Fix

Move the context-menu handler onto the existing thread title button. Both click and right-click now use the same narrow hit target, while the rest of the header keeps its normal behavior.

## Impact

This is an interaction-only adjustment with no visual change. Existing thread actions remain available from the title and sidebar.

## Validation

- `vp test run apps/web/src/components/chat/ChatHeader.test.ts` (7 passed)
- `vp run --filter @t3tools/web typecheck`
- `vp fmt --check apps/web/src/components/chat/ChatHeader.tsx`

Implemented with GPT-5.6 Sol through the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Narrow thread action menu hit area to the title button in ChatHeader
> Right-clicking anywhere in the chat header previously opened the thread action context menu. The `onContextMenu` handler is moved from the outer header `<div>` to the thread title button in [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/5895/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c), so right-clicks elsewhere in the header no longer trigger the menu.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1416ea3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interaction-only change in ChatHeader with no API, data, or visual impact.
> 
> **Overview**
> **Thread actions context menu** no longer opens from the full chat header flex area. The handler moves from the outer header wrapper onto the existing **thread title** button, so **click** and **right-click** share the same narrow target.
> 
> The `[data-chat-header-actions]` guard is removed because the menu is no longer registered on a parent that spans the action controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1416ea3f222260df75d78ba7e45a72e304ec4187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->