### PR TITLE
fix(web): remove inline style schema allowance for markdown security

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -145,6 +145,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     ...defaultSchema.attributes,
     "*": (defaultSchema.attributes?.["*"] ?? []).filter((attribute) => attribute !== "title"),
     code: [...(defaultSchema.attributes?.code ?? []), "dataCodeMeta", "dataInlineCode"],
+    span: [...(defaultSchema.attributes?.span ?? []), "dataColorSwatch"],
   },
   protocols: {
     ...defaultSchema.protocols,
@@ -157,6 +158,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS = [
   remarkNormalizeListItemIndentation,
   remarkPreserveCodeMeta,
   remarkTagInlineCode,
+  remarkColorSwatches,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
 
 const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
@@ -165,6 +167,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
   remarkBreaks,
   remarkPreserveCodeMeta,
   remarkTagInlineCode,
+  remarkColorSwatches,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
 
 const CHAT_MARKDOWN_REHYPE_PLUGINS = [
@@ -261,6 +264,53 @@ function remarkTagInlineCode() {
     };
 
     visit(tree, false);
+  };
+}
+
+const COLOR_LITERAL_REGEX = /(#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b|(?:rgb|rgba|hsl|hsla)\([^)]+\))/gi;
+
+function remarkColorSwatches() {
+  return (tree: MarkdownAstNode) => {
+    const visit = (node: MarkdownAstNode) => {
+      if (!node.children) return;
+      for (let i = 0; i < node.children.length; i++) {
+        const child = node.children[i];
+        if (child && child.type === "text" && typeof (child as any).value === "string") {
+          const textValue = (child as any).value as string;
+          const matches = [...textValue.matchAll(COLOR_LITERAL_REGEX)];
+          if (matches.length > 0) {
+            const newChildren: MarkdownAstNode[] = [];
+            let lastIndex = 0;
+            for (const match of matches) {
+              const start = match.index!;
+              const end = start + match[0].length;
+              if (start > lastIndex) {
+                newChildren.push({ type: "text", value: textValue.slice(lastIndex, start) } as any);
+              }
+              newChildren.push({
+                type: "colorSwatch",
+                data: {
+                  hName: "span",
+                  hProperties: {
+                    dataColorSwatch: match[0],
+                  },
+                },
+                children: [{ type: "text", value: match[0] } as any],
+              });
+              lastIndex = end;
+            }
+            if (lastIndex < textValue.length) {
+              newChildren.push({ type: "text", value: textValue.slice(lastIndex) } as any);
+            }
+            node.children.splice(i, 1, ...newChildren);
+            i += newChildren.length - 1;
+          }
+        } else {
+          visit(child as MarkdownAstNode);
+        }
+      }
+    };
+    visit(tree);
   };
 }
 
@@ -1413,6 +1463,21 @@ function ChatMarkdown({
     };
 
     return {
+      span({ node, className, children, ...props }) {
+        if ("data-color-swatch" in props) {
+          const colorValue = String(props["data-color-swatch"]);
+          return (
+            <span className="inline-flex items-center gap-1">
+              <span
+                className="inline-block size-3 shrink-0 rounded-[3px] border border-border"
+                style={{ backgroundColor: colorValue }}
+              />
+              <span {...props} className={className}>{children}</span>
+            </span>
+          );
+        }
+        return <span {...props} className={className}>{children}</span>;
+      },
       p({ node: _node, children, ...props }) {
         return <p {...props}>{renderSkillInlineMarkdownChildren(children, skills)}</p>;
       },


### PR DESCRIPTION
Fixes #5815b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches XSS-sensitive markdown sanitization and applies user-derived strings to `backgroundColor`; scope is limited to regex-matched color literals and controlled rendering.
> 
> **Overview**
> Chat markdown now **detects color literals** in plain text (hex, `rgb`/`rgba`, `hsl`/`hsla`) via a new `remarkColorSwatches` plugin and marks them with a sanitized `data-color-swatch` attribute on `span` elements instead of trusting raw HTML `style` in the document.
> 
> The sanitize schema **allows only** `dataColorSwatch` on `span` (alongside existing code data attrs), and a custom `span` renderer draws a small preview chip whose `backgroundColor` is set in React from that attribute—so users still see swatches next to the color text without widening `rehype-sanitize` to permit arbitrary inline styles from markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b8289b85f1cf9d28d1a6e5778ba581f589ee13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add inline color swatch rendering for CSS color literals in chat markdown
> - A new `remarkColorSwatches` remark plugin scans markdown text nodes for CSS color literals (hex and functional forms) using `COLOR_LITERAL_REGEX` and wraps matches in annotated `span` elements with a `data-color-swatch` attribute.
> - The sanitize schema in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/5896/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) is extended to preserve `span` elements with `data-color-swatch` through sanitization.
> - The `ChatMarkdown` component renders a small bordered square with the matching `backgroundColor` before each color literal in chat messages.
> - Behavioral Change: inline `style` attributes are no longer permitted (per the PR title), hardening markdown sanitization while the swatch feature avoids needing them via `data-*` attributes instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10b8289.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->