### PR TITLE
fix(desktop): use unique identifier for window focus restoration

### DIFF
--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3008,6 +3008,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       () => webContents.getFocusedWebContents(),
     );
     let keyDownAttempted = false;
+    const focusRestoreId = `__t3_focus_${Math.random().toString(36).slice(2)}`;
     const releaseInput = Effect.gen(function* () {
       if (keyDownAttempted) {
         yield* sendCleanup("Input.dispatchKeyEvent", keySequence.keyUp).pipe(Effect.ignore);
@@ -3024,6 +3025,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           },
           () => previouslyFocused.focus(),
         ).pipe(Effect.ignore);
+        yield* attemptPromise(
+          {
+            operation: "automationPress.restoreActiveElement",
+            tabId,
+            webContentsId: previouslyFocused.id,
+          },
+          () =>
+            previouslyFocused.executeJavaScript(
+              `if (window['${focusRestoreId}'] && typeof window['${focusRestoreId}'].focus === 'function') { window['${focusRestoreId}'].focus(); } delete window['${focusRestoreId}'];`,
+            ),
+        ).pipe(Effect.ignore);
       }
     });
 
@@ -3032,6 +3044,19 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     // changing which thread is mounted in the UI. Restore the previous renderer
     // after dispatch so automation never leaves the app's input focus behind.
     yield* Effect.gen(function* () {
+      if (previouslyFocused && previouslyFocused.id !== wc.id && !previouslyFocused.isDestroyed()) {
+        yield* attemptPromise(
+          {
+            operation: "automationPress.saveActiveElement",
+            tabId,
+            webContentsId: previouslyFocused.id,
+          },
+          () =>
+            previouslyFocused.executeJavaScript(
+              `if (document.activeElement && document.activeElement !== document.body) { window['${focusRestoreId}'] = document.activeElement; }`,
+            ),
+        ).pipe(Effect.ignore);
+      }
       yield* attempt(
         { operation: "automationPress.focusWebContents", tabId, webContentsId: wc.id },
         () => wc.focus(),


### PR DESCRIPTION
Fixes #5792c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches focus handling during agent keyboard automation with injected page scripts; bugs could leave stale window properties or wrong focus, but scope is limited to the press cleanup path.
> 
> **Overview**
> **Preview automation `press`** now restores in-page focus after simulated key events, not only the previously focused `WebContents`.
> 
> Before dispatching keys to the preview guest, the flow stores `document.activeElement` on the prior renderer under a **random per-press** `window['__t3_focus_…']` id. Cleanup refocuses that `WebContents`, calls `.focus()` on the saved element if present, then deletes the property. That addresses collisions from a shared restore slot (#5792) and keeps keyboard focus on inputs in the main UI after agent key automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15b2a4bd2937b373b60f2b98f32519143f620105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore active element focus after automation key press in desktop preview
> During `automationPress` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/5898/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53), focus is temporarily moved to a target `WebContents`. The previously focused renderer's active element is now saved to a unique `window[focusRestoreId]` before the shift, then refocused and cleaned up after the automation completes. Save/restore steps use `attemptPromise` and are silently ignored on failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15b2a4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->