### PR TITLE
fix(mobile): strictly prioritize thread activity for project sorting

### DIFF
--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -88,31 +88,45 @@ export function sortHomeProjectScopes(input: {
     ),
   );
   const latestActivityByScope = new Map<string, number>();
-  const recordActivity = (scopeKey: string | undefined, timestamp: number) => {
-    if (!scopeKey || !Number.isFinite(timestamp)) return;
-    latestActivityByScope.set(
-      scopeKey,
-      Math.max(latestActivityByScope.get(scopeKey) ?? Number.NEGATIVE_INFINITY, timestamp),
-    );
+  const latestActivityByProjectKey = new Map<string, number>();
+  const recordActivity = (scopeKey: string | undefined, projectKey: string | undefined, timestamp: number) => {
+    if (!Number.isFinite(timestamp)) return;
+    if (scopeKey) {
+      latestActivityByScope.set(
+        scopeKey,
+        Math.max(latestActivityByScope.get(scopeKey) ?? Number.NEGATIVE_INFINITY, timestamp),
+      );
+    }
+    if (projectKey) {
+      latestActivityByProjectKey.set(
+        projectKey,
+        Math.max(latestActivityByProjectKey.get(projectKey) ?? Number.NEGATIVE_INFINITY, timestamp),
+      );
+    }
   };
 
   for (const thread of input.threads) {
     if (thread.archivedAt !== null) continue;
+    const projectKey = scopedProjectKey(thread.environmentId, thread.projectId);
     recordActivity(
-      scopeKeyByProjectRef.get(scopedProjectKey(thread.environmentId, thread.projectId)),
+      scopeKeyByProjectRef.get(projectKey),
+      projectKey,
       getThreadSortTimestamp(thread, input.projectSortOrder),
     );
   }
   for (const pendingTask of input.pendingTasks) {
+    const projectKey = scopedProjectKey(
+      pendingTask.message.environmentId,
+      pendingTask.creation.projectId,
+    );
     recordActivity(
-      scopeKeyByProjectRef.get(
-        scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
-      ),
+      scopeKeyByProjectRef.get(projectKey),
+      projectKey,
       Date.parse(pendingTask.message.createdAt),
     );
   }
 
-  return Arr.sort(
+  const sortedScopes = Arr.sort(
     input.scopes,
     Order.mapInput(
       Order.Struct({
@@ -133,6 +147,17 @@ export function sortHomeProjectScopes(input: {
       }),
     ),
   );
+
+  return sortedScopes.map((scope) => ({
+    ...scope,
+    projects: Arr.sort(
+      scope.projects,
+      Order.mapInput(Order.flip(Order.Number), (project) =>
+        latestActivityByProjectKey.get(scopedProjectKey(project.environmentId, project.id)) ??
+        getProjectSortTimestamp(project, input.projectSortOrder),
+      ),
+    ),
+  }));
 }
 
 /**


### PR DESCRIPTION
Fixes #5785c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile home list sorting logic with existing unit tests; no auth, data, or API changes.
> 
> **Overview**
> **Home project ordering** in `sortHomeProjectScopes` now tracks **per-project** latest activity from non-archived threads and pending tasks, not only aggregates used to order scopes.
> 
> After scopes are sorted as before, each scope’s **`projects` array is re-sorted** so members with the most recent thread or queued-task activity appear first, using project `created_at` / `updated_at` only when there is no activity for that project.
> 
> Activity recording was extended so timestamps update both the scope bucket and the individual scoped project key, keeping grouped scopes (e.g. same repo on multiple environments) ordered by the machine/project you actually used last.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9e2cba2332914962a66291290297dd03f8ede1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort projects within home thread list scopes by latest thread activity
> Updates `sortHomeProjectScopes` in [homeThreadList.ts](https://github.com/pingdotgg/t3code/pull/5899/files#diff-1f36b630d8d39dd1ca1be5a84d64ea082a69ffdf26be6759d3e6c9b705473796) to sort projects within each scope by their most recent thread or pending task activity, falling back to `getProjectSortTimestamp` when no activity is recorded. Previously, projects preserved their original order regardless of activity.
>
> Behavioral Change: Projects in the home thread list now reorder dynamically based on activity, which may shift project positions users are accustomed to.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6c9e2cb. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->