### PR TITLE
fix(mobile): long-pressing a thread row no longer navigates into the thread

### DIFF
--- a/apps/mobile/src/components/ControlPill.tsx
+++ b/apps/mobile/src/components/ControlPill.tsx
@@ -133,9 +133,25 @@ export function ControlPillMenu(
   }
 
   const { className: _className, ...menuProps } = props;
+  let children = menuProps.children;
+  // In long-press mode the wrapped pressable still receives the touch (the
+  // patched MenuView button is touch-transparent) and RN's Fabric touch
+  // handler is never cancelled by the in-tree UIContextMenuInteraction, so a
+  // bare onPress would fire on finger-up even after the menu opened — and
+  // also on a long press released just under the menu threshold. A dispatched
+  // onLongPress makes Pressability swallow the release, so holds past 350ms
+  // (below the ~500ms context-menu threshold) can only open the menu, never
+  // tap through.
+  if (props.shouldOpenOnLongPress && isValidElement(children)) {
+    const child = children as ReactElement<{ onLongPress?: () => void; delayLongPress?: number }>;
+    children = cloneElement(child, {
+      onLongPress: child.props.onLongPress ?? (() => undefined),
+      delayLongPress: child.props.delayLongPress ?? 350,
+    });
+  }
   return (
     <MenuView {...menuProps} themeVariant={isDarkMode ? "dark" : "light"}>
-      {menuProps.children}
+      {children}
     </MenuView>
   );
 }


### PR DESCRIPTION
Fixes the bug phil5034 reported on Discord: long-pressing a thread row in the overview to open the context menu could also navigate into the thread. Long press now only opens the menu; taps still navigate.

## Why it happened

Two stacked issues, both iOS-only in our setup (Android already injects a guard):

1. **A `Pressable` with only `onPress` fires on finger-up after *any* hold duration.** The thread-row pressables have no `onLongPress` on iOS, so a long press released just under the ~500 ms native context-menu threshold read as a tap and navigated. Same class of bug as [react-native-context-menu-view#60](https://github.com/mpiannucci/react-native-context-menu-view/issues/60).

2. **The real double-fire: RN's Fabric touch handler is never cancelled when the menu opens.** Our `@react-native-menu/menu` patch makes the native button touch-transparent (so row taps reach the `Pressable`) and hosts the `UIContextMenuInteraction` on the host component view — i.e. *inside* the RN view tree. `RCTSurfaceTouchHandler.canBePreventedByGestureRecognizer:` returns `NO` for any recognizer attached inside the RN hierarchy, and `cancelsTouchesInView` only cancels view-level delivery, not un-prevented gesture recognizers. So RN kept tracking the touch after the menu appeared; on finger-up Pressability fired `onPress` and navigated with the menu already showing. Documented ecosystem-wide in [zeego#145](https://github.com/nandorojo/zeego/issues/145).

## The fix

Mirror the Android branch of `ControlPillMenu` on iOS: in `shouldOpenOnLongPress` mode, clone the child with a no-op `onLongPress` and `delayLongPress: 350` (below the ~500 ms menu threshold). Once `onLongPress` dispatches, Pressability suppresses `onPress` on release (`isPressCanceledByLongPress`), which closes both holes — short taps still navigate, holds past 350 ms can only open the menu. A child's own `onLongPress`/`delayLongPress` are preserved if ever passed. Covers all four long-press menu call sites (v1 + v2 thread rows, both pending-task rows), which all pass a `Pressable` as the direct child.

## Verification

Verified in the dev client on an iPhone 17 Pro simulator against a seeded showcase environment, driving real touch events:

- 1.2 s long press → context menu (Settle/Snooze/Pin/Delete) opens, dismissing it lands back on the overview, no navigation
- 0.6 s press (releasing right at the menu threshold — the raciest timing and the reported repro) → menu only, no navigation
- Normal tap → still navigates into the thread

Typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized touch-handling change on iOS menu wrappers; behavior aligns with the existing Android branch and only affects long-press menu rows.
> 
> **Overview**
> Fixes an iOS-only bug where long-pressing a thread row to open the context menu could also fire the row’s `onPress` and navigate into the thread.
> 
> **`ControlPillMenu` (iOS)** now mirrors the existing Android long-press path: when `shouldOpenOnLongPress` is set, it clones the direct child `Pressable` with a no-op `onLongPress` and `delayLongPress: 350` (under the ~500ms native menu threshold). That lets React Native’s Pressability cancel `onPress` on finger-up after a hold, so opens the menu without tap-through. Short taps still navigate; existing child `onLongPress` / `delayLongPress` props are left unchanged if present.
> 
> Applies to all long-press menu usages (v1/v2 thread rows and pending-task rows) without changing those call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad735a7e884ee0ed45eac58a575d58a1c40dbe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix long-press on thread rows to prevent navigation on iOS
> In [ControlPill.tsx](https://github.com/pingdotgg/t3code/pull/5901/files#diff-399d916fedf786f62149bf81f4839236f5389657a810489f04807d53fde21a4f), when `shouldOpenOnLongPress` is enabled on iOS, the wrapped child is cloned to inject a no-op `onLongPress` handler and a 350ms `delayLongPress` if neither is already set. This prevents the child's tap/navigation from firing after a long-press that opens the menu.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ad735a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->