### PR TITLE
feat(web): configure compact sidebar thread sorting

### DIFF
--- a/apps/mobile/src/features/home/home-list-options.ts
+++ b/apps/mobile/src/features/home/home-list-options.ts
@@ -45,6 +45,7 @@ export const THREAD_SORT_OPTIONS: ReadonlyArray<{
 }> = [
   { value: "updated_at", label: "Last user message" },
   { value: "created_at", label: "Created at" },
+  { value: "activity", label: "Latest activity" },
 ];
 
 function defaultHomeListOptions(): HomeListOptions {

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -212,6 +212,7 @@ const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
 const SIDEBAR_THREAD_SORT_LABELS: Record<SidebarThreadSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
+  activity: "Latest activity",
 };
 const SIDEBAR_LIST_ANIMATION_OPTIONS = {
   duration: 180,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -741,6 +741,30 @@ describe("sortThreadsForSidebar", () => {
 
     expect(sorted.map((thread) => thread.id)).toEqual(["a", "b"]);
   });
+
+  it("can order by the latest user message or completed agent turn", () => {
+    const sorted = sortThreadsForSidebar(
+      [
+        {
+          id: "user-message-later",
+          createdAt: "2026-03-09T08:00:00.000Z",
+          updatedAt: "2026-03-09T09:00:00.000Z",
+          latestUserMessageAt: "2026-03-09T12:00:00.000Z",
+          latestTurn: { completedAt: "2026-03-09T10:00:00.000Z" },
+        },
+        {
+          id: "agent-turn-later",
+          createdAt: "2026-03-09T09:00:00.000Z",
+          updatedAt: "2026-03-09T10:00:00.000Z",
+          latestUserMessageAt: "2026-03-09T11:00:00.000Z",
+          latestTurn: { completedAt: "2026-03-09T13:00:00.000Z" },
+        },
+      ],
+      "activity",
+    );
+
+    expect(sorted.map((thread) => thread.id)).toEqual(["agent-turn-later", "user-message-later"]);
+  });
 });
 
 describe("pinOrderKeyBetween", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -502,16 +502,15 @@ export function firstValidTimestamp(
   return null;
 }
 
-// Sidebar sort: static creation order, newest thread on top. Activity NEVER
-// reorders the list — a row holds its position from open until settled, so
-// the screen only moves at lifecycle transitions. Status (including pending
+// Sidebar sort is selected in General settings. Status (including pending
 // approval) is carried by each card's edge strip, not by position.
 export function sortThreadsForSidebar<
   T extends { readonly id: string; readonly createdAt: string },
->(threads: readonly T[]): T[] {
+>(threads: readonly T[], sortOrder: SidebarThreadSortOrder = "created_at"): T[] {
   return [...threads].toSorted(
     (left, right) =>
-      parseTimestampMs(right.createdAt) - parseTimestampMs(left.createdAt) ||
+      getThreadSortTimestamp(right as T & ThreadSortInput, sortOrder) -
+        getThreadSortTimestamp(left as T & ThreadSortInput, sortOrder) ||
       left.id.localeCompare(right.id),
   );
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1575,6 +1575,7 @@ export default function Sidebar() {
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
+  const sidebarThreadSortOrder = useClientSettings((s) => s.sidebarThreadSortOrder);
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const {
@@ -1932,7 +1933,7 @@ export default function Sidebar() {
           )
           .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
       ),
-      activeThreads: sortThreadsForSidebar(active),
+      activeThreads: sortThreadsForSidebar(active, sidebarThreadSortOrder),
       // Soonest wake first: "what comes back next" is the shelf's question.
       snoozedThreads: snoozed.toSorted(
         (left, right) =>
@@ -1948,6 +1949,7 @@ export default function Sidebar() {
     nowMinute,
     scopedProjectKeys,
     serverConfigs,
+    sidebarThreadSortOrder,
     snoozeWakeTick,
     threads,
   ]);

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE,
   DEFAULT_UNIFIED_SETTINGS,
   type EnvironmentIdentificationMode,
+  type SidebarThreadSortOrder,
   MAX_CODE_FONT_SIZE,
   MAX_GLASS_OPACITY,
   MAX_INTERFACE_FONT_SIZE,
@@ -153,6 +154,12 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const SIDEBAR_THREAD_SORT_LABELS: Record<SidebarThreadSortOrder, string> = {
+  updated_at: "Last user message",
+  created_at: "Created at",
+  activity: "Latest activity",
+};
 
 const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<BackgroundActivityProfile, string> = {
   balanced: "Balanced",
@@ -1755,6 +1762,45 @@ export function GeneralSettingsPanel() {
               }}
               aria-label="Project grouping"
             />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("sidebar-thread-order")}
+          description="Choose how the compact sidebar orders active threads. Latest activity uses whichever is newer: your latest message or the latest completed agent turn."
+          resetAction={
+            settings.sidebarThreadSortOrder !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadSortOrder ? (
+              <SettingResetButton
+                label="sidebar thread order"
+                onClick={() =>
+                  updateSettings({
+                    sidebarThreadSortOrder: DEFAULT_UNIFIED_SETTINGS.sidebarThreadSortOrder,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.sidebarThreadSortOrder}
+              onValueChange={(value) => {
+                if (value === null) return;
+                updateSettings({ sidebarThreadSortOrder: value as SidebarThreadSortOrder });
+              }}
+            >
+              <SelectTrigger className="w-44" aria-label="Sidebar thread order">
+                <SelectValue>
+                  {SIDEBAR_THREAD_SORT_LABELS[settings.sidebarThreadSortOrder]}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                {Object.entries(SIDEBAR_THREAD_SORT_LABELS).map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
           }
         />
 

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -101,6 +101,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "sidebar-thread-order",
+    title: "Sidebar thread order",
+    to: "/settings/general",
+  },
+  {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
     to: "/settings/general",

--- a/packages/client-runtime/src/state/threadSort.test.ts
+++ b/packages/client-runtime/src/state/threadSort.test.ts
@@ -21,6 +21,26 @@ function makeThread(overrides: Partial<TestThread> = {}): TestThread {
 }
 
 describe("sortThreads", () => {
+  it("sorts by whichever is newer: the latest user message or completed agent turn", () => {
+    const sorted = sortThreads(
+      [
+        makeThread({
+          id: "user-message-newer",
+          latestUserMessageAt: "2026-03-09T10:20:00.000Z",
+          latestTurn: { completedAt: "2026-03-09T10:10:00.000Z" },
+        }),
+        makeThread({
+          id: "agent-turn-newer",
+          latestUserMessageAt: "2026-03-09T10:00:00.000Z",
+          latestTurn: { completedAt: "2026-03-09T10:30:00.000Z" },
+        }),
+      ],
+      "activity",
+    );
+
+    expect(sorted.map((thread) => thread.id)).toEqual(["agent-turn-newer", "user-message-newer"]);
+  });
+
   it("falls back to updatedAt and createdAt when latestUserMessageAt is invalid and there are no messages", () => {
     const sorted = sortThreads(
       [

--- a/packages/client-runtime/src/state/threadSort.ts
+++ b/packages/client-runtime/src/state/threadSort.ts
@@ -7,6 +7,9 @@ export interface ThreadSortInput {
   readonly createdAt: string;
   readonly updatedAt: string;
   readonly latestUserMessageAt?: string | null;
+  readonly latestTurn?: {
+    readonly completedAt?: string | null;
+  } | null;
   readonly messages?: ReadonlyArray<{
     readonly createdAt: string;
     readonly role: string;
@@ -65,6 +68,10 @@ export function getThreadSortTimestamp(
     return (
       getFirstSortableTimestamp(thread.createdAt, thread.updatedAt) ?? Number.NEGATIVE_INFINITY
     );
+  }
+  if (sortOrder === "activity") {
+    const completedAt = toSortableTimestamp(thread.latestTurn?.completedAt ?? undefined);
+    return Math.max(getLatestUserMessageTimestamp(thread), completedAt ?? Number.NEGATIVE_INFINITY);
   }
   return getLatestUserMessageTimestamp(thread);
 }

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -22,7 +22,7 @@ export const SidebarProjectSortOrder = Schema.Literals(["updated_at", "created_a
 export type SidebarProjectSortOrder = typeof SidebarProjectSortOrder.Type;
 export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "updated_at";
 
-export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
+export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at", "activity"]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 


### PR DESCRIPTION
## Summary

- Add a General setting for compact sidebar thread ordering.
- Support Last user message, Created at, and Latest activity.
- Define Latest activity as the newer of the latest user message and latest completed agent turn.
- Keep the persisted sort compatible with the legacy sidebar and mobile surface.

## Verification

- `vp test run apps/web/src/components/Sidebar.logic.test.ts packages/client-runtime/src/state/threadSort.test.ts` — 105 tests passed
- `vp run --filter @t3tools/web typecheck` — passed
- `pnpm --filter @t3tools/contracts typecheck` — passed
- `pnpm --filter @t3tools/client-runtime typecheck` — passed
- `pnpm --filter @t3tools/mobile typecheck` — passed
- Verified with realistic isolated data and screenshots in the dev-loop artifact

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how active threads are ordered in the compact sidebar when users change the setting, and extends shared sort contracts used by web and mobile; defaults stay on last user message.
> 
> **Overview**
> Adds a **Sidebar thread order** control under General settings so the compact sidebar can sort active threads by **Last user message**, **Created at**, or **Latest activity** (the newer of the latest user message and the latest **completed** agent turn).
> 
> Shared sort logic in `client-runtime` gains the `activity` mode and `latestTurn.completedAt` on thread sort input; the compact `Sidebar` applies the persisted `sidebarThreadSortOrder` when ordering active threads. Legacy sidebar and mobile pick up the new label/option for the same setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d84d5439e1741001cb3af5954470fe5ee80148e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Latest activity' thread sort order to the compact sidebar
> - Adds `'activity'` as a new `SidebarThreadSortOrder` value that sorts threads by the most recent of the latest user message or completed agent turn.
> - Exposes a sort order selector in General Settings so users can switch between creation time and latest activity ordering.
> - The `sortThreadsForSidebar` function in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/5904/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) now accepts a `sortOrder` parameter (defaulting to `'created_at'`) and the sidebar reads this from client settings.
> - The `'activity'` sort option is also added to the mobile home list in [home-list-options.ts](https://github.com/pingdotgg/t3code/pull/5904/files#diff-9c8d937dff6c056fa183e790cac4efc40bda9492809565dd83fd2fc799b152e8).
> - Behavioral Change: when `sortOrder` is `'created_at'`, threads with missing creation timestamps now fall back to another valid timestamp via `getThreadSortTimestamp` rather than treating the timestamp as absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d84d543.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->