### PR TITLE
fix(web): reliably follow latest thread content

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -92,7 +92,14 @@ import {
   isLatestTurnSettled,
 } from "../session-logic";
 import { type LegendListRef } from "@legendapp/list/react";
-import { getAnchoredTurnMetrics, type TimelineScrollMode } from "./chat/timelineScrollAnchoring";
+import {
+  clearTimelineAnchor,
+  getAnchoredTurnEndRevealOffset,
+  resolveTimelineLiveFollowEnabled,
+  resolveTimelineRouteEpoch,
+  updateTimelineLiveFollowState,
+  type TimelineScrollMode,
+} from "./chat/timelineScrollAnchoring";
 import {
   buildPendingUserInputAnswers,
   derivePendingUserInputProgress,
@@ -3584,12 +3591,33 @@ function ChatViewContent(props: ChatViewProps) {
   const timelineScrollModeRef = useRef<TimelineScrollMode>("following-end");
   // State mirror of the follow mode refs. LegendList's maintainScrollAtEnd
   // re-pins on its own (independent of the refs), so the timeline needs a
-  // render-visible flag to switch it off once the user scrolls away.
-  const [timelineLiveFollowEnabled, setTimelineLiveFollowEnabled] = useState(true);
+  // render-visible flag to switch it off once the user scrolls away. Scope
+  // that flag to the route so a new thread follows on its very first render,
+  // before the route reset effect has a chance to commit.
+  const timelineRouteEpochRef = useRef({ threadKey: routeThreadKey });
+  timelineRouteEpochRef.current = resolveTimelineRouteEpoch(
+    timelineRouteEpochRef.current,
+    routeThreadKey,
+  );
+  const timelineRouteEpoch = timelineRouteEpochRef.current;
+  const [timelineLiveFollowState, setTimelineLiveFollowState] = useState(() => ({
+    threadKey: routeThreadKey,
+    enabled: true,
+  }));
+  const timelineLiveFollowEnabled = resolveTimelineLiveFollowEnabled(
+    timelineLiveFollowState,
+    routeThreadKey,
+  );
+  const setTimelineLiveFollowEnabled = useCallback((enabled: boolean) => {
+    setTimelineLiveFollowState((current) =>
+      updateTimelineLiveFollowState(current, timelineRouteEpochRef.current.threadKey, enabled),
+    );
+  }, []);
   const pendingTimelineAnchorRef = useRef<MessageId | null>(null);
   const positionedTimelineAnchorRef = useRef<MessageId | null>(null);
   const settledTimelineAnchorRef = useRef<MessageId | null>(null);
   const activeTimelineAnchorIndexRef = useRef<number | null>(null);
+  const timelineItemSizeFollowFrameRef = useRef<number | null>(null);
   const anchorUserScrollGenerationRef = useRef(0);
   const liveFollowUserScrollGenerationRef = useRef<number | null>(0);
   // Manual navigation stops live-follow without removing anchored end space.
@@ -3611,7 +3639,7 @@ function ChatViewContent(props: ChatViewProps) {
     cancelTimelineLiveFollowForUserNavigationRef.current =
       cancelTimelineLiveFollowForUserNavigation;
   }, [cancelTimelineLiveFollowForUserNavigation]);
-  const getActiveTimelineTurnMetrics = useCallback(
+  const getActiveTimelineTurnRevealOffset = useCallback(
     (list?: LegendListRef | null) => {
       const resolvedList = list ?? legendListRef.current;
       const anchorIndex = activeTimelineAnchorIndexRef.current;
@@ -3620,7 +3648,7 @@ function ChatViewContent(props: ChatViewProps) {
         return null;
       }
 
-      return getAnchoredTurnMetrics({
+      return getAnchoredTurnEndRevealOffset({
         state,
         anchorIndex,
         composerOverlayHeight,
@@ -3658,6 +3686,54 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [composerOverlayHeight],
   );
+  const revealActiveTimelineTurnEnd = useCallback(() => {
+    if (timelineRouteEpochRef.current !== timelineRouteEpoch) {
+      return;
+    }
+    if (liveFollowUserScrollGenerationRef.current !== anchorUserScrollGenerationRef.current) {
+      return;
+    }
+    if (timelineScrollModeRef.current !== "anchoring-new-turn") {
+      return;
+    }
+    if (pendingTimelineAnchorRef.current !== null) {
+      return;
+    }
+    if (
+      positionedTimelineAnchorRef.current !== null &&
+      settledTimelineAnchorRef.current !== positionedTimelineAnchorRef.current
+    ) {
+      return;
+    }
+
+    const list = legendListRef.current;
+    if (!list) {
+      return;
+    }
+    const nextOffset = getActiveTimelineTurnRevealOffset(list);
+    if (nextOffset === null) {
+      return;
+    }
+    void list.scrollToOffset({ offset: nextOffset, animated: false });
+  }, [getActiveTimelineTurnRevealOffset, timelineRouteEpoch]);
+  const onTimelineItemSizeChanged = useCallback(() => {
+    if (timelineItemSizeFollowFrameRef.current !== null) {
+      return;
+    }
+    timelineItemSizeFollowFrameRef.current = requestAnimationFrame(() => {
+      timelineItemSizeFollowFrameRef.current = null;
+      revealActiveTimelineTurnEnd();
+    });
+  }, [revealActiveTimelineTurnEnd]);
+  useEffect(
+    () => () => {
+      if (timelineItemSizeFollowFrameRef.current !== null) {
+        cancelAnimationFrame(timelineItemSizeFollowFrameRef.current);
+        timelineItemSizeFollowFrameRef.current = null;
+      }
+    },
+    [routeThreadKey],
+  );
   // Live-follow stays active after send/thread-open until an actual list scroll
   // gesture opts out.
   const scrollToEnd = useCallback((animated = false) => {
@@ -3669,9 +3745,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeTimelineAnchorIndexRef.current = null;
     showScrollDebouncer.current.cancel();
     setShowScrollToBottom(false);
-    setTimelineAnchor((current) =>
-      current.messageId === null ? current : { ...current, messageId: null },
-    );
+    setTimelineAnchor(clearTimelineAnchor);
     requestAnimationFrame(() => {
       void legendListRef.current?.scrollToEnd?.({ animated });
     });
@@ -3783,7 +3857,7 @@ function ChatViewContent(props: ChatViewProps) {
       }
       removeListeners?.();
     };
-  }, [activeThread?.id, composerOverlayHeight, timelineRealContentOverflowsViewport]);
+  }, [composerOverlayHeight, routeThreadKey, timelineRealContentOverflowsViewport]);
 
   const onTimelineAnchorReady = useCallback((messageId: MessageId, anchorIndex: number) => {
     // Anchored-end space can be remeasured when the turn completes. Once the
@@ -3846,6 +3920,11 @@ function ChatViewContent(props: ChatViewProps) {
       timelineScrollModeRef.current = "following-end";
       liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
       setTimelineLiveFollowEnabled(true);
+      pendingTimelineAnchorRef.current = null;
+      positionedTimelineAnchorRef.current = null;
+      settledTimelineAnchorRef.current = null;
+      activeTimelineAnchorIndexRef.current = null;
+      setTimelineAnchor(clearTimelineAnchor);
       showScrollDebouncer.current.cancel();
       setShowScrollToBottom(false);
     } else {
@@ -3872,30 +3951,7 @@ function ChatViewContent(props: ChatViewProps) {
     let secondFrame: number | null = null;
     const frame = requestAnimationFrame(() => {
       secondFrame = requestAnimationFrame(() => {
-        if (liveFollowUserScrollGenerationRef.current !== anchorUserScrollGenerationRef.current) {
-          return;
-        }
-        if (pendingTimelineAnchorRef.current !== null) {
-          return;
-        }
-        if (
-          positionedTimelineAnchorRef.current !== null &&
-          settledTimelineAnchorRef.current !== positionedTimelineAnchorRef.current
-        ) {
-          return;
-        }
-        const list = legendListRef.current;
-        if (!list) {
-          return;
-        }
-
-        const metrics = getActiveTimelineTurnMetrics(list);
-        if (!metrics || metrics.scrollDeltaToRevealEnd <= 1) {
-          return;
-        }
-
-        const nextOffset = list.getState().scroll + metrics.scrollDeltaToRevealEnd;
-        void list.scrollToOffset({ offset: nextOffset, animated: false });
+        revealActiveTimelineTurnEnd();
       });
     });
 
@@ -3905,7 +3961,7 @@ function ChatViewContent(props: ChatViewProps) {
         cancelAnimationFrame(secondFrame);
       }
     };
-  }, [activeThread?.id, timelineEntries, getActiveTimelineTurnMetrics]);
+  }, [routeThreadKey, timelineEntries, revealActiveTimelineTurnEnd]);
 
   useEffect(() => {
     setPullRequestDialogState(null);
@@ -3920,7 +3976,7 @@ function ChatViewContent(props: ChatViewProps) {
     showScrollDebouncer.current.cancel();
     setShowScrollToBottom(false);
     // activeThreadRef resets transitively with the active thread.
-  }, [activeThread?.id]);
+  }, [routeThreadKey]);
 
   useEffect(() => {
     setIsRevertingCheckpoint(false);
@@ -6087,7 +6143,7 @@ function ChatViewContent(props: ChatViewProps) {
               <MessagesTimeline
                 agentPanelModel={agentPanelModel}
                 onOpenAgents={addAgentsSurface}
-                key={activeThread.id}
+                key={routeThreadKey}
                 isWorking={isWorking}
                 workingStepLabel={workingStepLabel}
                 activeTurnInProgress={isWorking || !latestTurnSettled}
@@ -6118,6 +6174,7 @@ function ChatViewContent(props: ChatViewProps) {
                 contentInsetEndAdjustment={composerOverlayHeight}
                 liveFollowEnabled={timelineLiveFollowEnabled}
                 onIsAtEndChange={onIsAtEndChange}
+                onItemSizeChanged={onTimelineItemSizeChanged}
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
                 hideEmptyPlaceholder={isDraftHeroState || threadDetailLoading}
                 topFadeEnabled={!hasTimelineTopBanner}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -3,6 +3,7 @@ import { createRef, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import type { LegendListRef } from "@legendapp/list/react";
+import { resolveTimelineLiveFollowEnabled } from "./timelineScrollAnchoring";
 
 vi.mock("@legendapp/list/react", async () => {
   const legendListTestId = "legend-list";
@@ -38,10 +39,27 @@ vi.mock("@legendapp/list/react", async () => {
           size?: boolean;
           shouldRestorePosition?: (item: { id: string }) => boolean;
         };
+    onItemSizeChanged?: (info: {
+      index: number;
+      itemData: { id: string };
+      itemKey: string;
+      previous: number;
+      size: number;
+    }) => void;
     ref?: Ref<LegendListRef>;
   }) => {
     if (props.anchoredEndSpace) {
       props.anchoredEndSpace.onReady?.({ anchorIndex: props.anchoredEndSpace.anchorIndex });
+    }
+    const lastItem = props.data.at(-1);
+    if (lastItem) {
+      props.onItemSizeChanged?.({
+        index: props.data.length - 1,
+        itemData: lastItem,
+        itemKey: props.keyExtractor(lastItem),
+        previous: 90,
+        size: 1_800,
+      });
     }
     return (
       <div
@@ -195,6 +213,7 @@ function buildProps() {
     workspaceRoot: undefined,
     anchorMessageId: null,
     onAnchorReady: () => {},
+    onItemSizeChanged: () => {},
     contentInsetEndAdjustment: 0,
     liveFollowEnabled: true,
     onIsAtEndChange: () => {},
@@ -221,6 +240,23 @@ function buildUserTimelineEntry(text: string) {
       createdAt: MESSAGE_CREATED_AT,
       updatedAt: MESSAGE_CREATED_AT,
       streaming: false,
+    },
+  };
+}
+
+function buildStreamingAssistantTimelineEntry() {
+  return {
+    id: "entry-streaming-assistant",
+    kind: "message" as const,
+    createdAt: MESSAGE_CREATED_AT,
+    message: {
+      id: MessageId.make("message-streaming-assistant"),
+      role: "assistant" as const,
+      text: "Streaming response content.",
+      turnId: TurnId.make("turn-streaming"),
+      createdAt: MESSAGE_CREATED_AT,
+      updatedAt: MESSAGE_CREATED_AT,
+      streaming: true,
     },
   };
 }
@@ -430,6 +466,65 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('data-maintain-visible-content-position-restore="true"');
     expect(onAnchorReady).toHaveBeenCalledOnce();
     expect(onAnchorReady).toHaveBeenCalledWith(secondEntry.message.id, 1);
+  });
+
+  it("keeps streamed content following after switching from a thread scrolled into history", () => {
+    const previousThreadState = {
+      threadKey: "environment-local:thread-a",
+      enabled: false,
+    };
+    const nextThreadKey = "environment-local:thread-b";
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        routeThreadKey={nextThreadKey}
+        liveFollowEnabled={resolveTimelineLiveFollowEnabled(previousThreadState, nextThreadKey)}
+        timelineEntries={[buildStreamingAssistantTimelineEntry()]}
+      />,
+    );
+
+    expect(markup).toContain('data-maintain-scroll-at-end="enabled"');
+    expect(markup).toContain('data-maintain-scroll-at-end-data-change="true"');
+    expect(markup).toContain('data-maintain-scroll-at-end-item-layout="true"');
+    expect(markup).toContain('data-maintain-scroll-at-end-layout="true"');
+  });
+
+  it("reports late row measurements so a buffered completion can settle at the live edge", () => {
+    const onItemSizeChanged = vi.fn();
+    const userEntry = buildUserTimelineEntry("Generate a response longer than the viewport.");
+
+    renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        anchorMessageId={userEntry.message.id}
+        onItemSizeChanged={onItemSizeChanged}
+        timelineEntries={[userEntry, buildStreamingAssistantTimelineEntry()]}
+      />,
+    );
+
+    expect(onItemSizeChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ previous: 90, size: 1_800 }),
+    );
+  });
+
+  it("disables streamed-content follow while reading history and restores it at the live edge", () => {
+    const timelineEntries = [buildStreamingAssistantTimelineEntry()];
+    const readingMarkup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        liveFollowEnabled={false}
+        timelineEntries={timelineEntries}
+      />,
+    );
+    const followingMarkup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} liveFollowEnabled timelineEntries={timelineEntries} />,
+    );
+
+    expect(readingMarkup).not.toContain('data-maintain-scroll-at-end="enabled"');
+    expect(followingMarkup).toContain('data-maintain-scroll-at-end="enabled"');
+    expect(followingMarkup).toContain('data-maintain-scroll-at-end-data-change="true"');
+    expect(followingMarkup).toContain('data-maintain-scroll-at-end-item-layout="true"');
+    expect(followingMarkup).toContain('data-maintain-scroll-at-end-layout="true"');
   });
 
   it("renders collapse controls for long user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -236,6 +236,8 @@ interface MessagesTimelineProps {
    */
   liveFollowEnabled: boolean;
   onIsAtEndChange: (isAtEnd: boolean) => void;
+  /** Reports authoritative row height changes so anchored follow can settle after late layout. */
+  onItemSizeChanged: () => void;
   onManualNavigation: () => void;
   hideEmptyPlaceholder?: boolean;
   topFadeEnabled?: boolean;
@@ -276,6 +278,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   contentInsetEndAdjustment,
   liveFollowEnabled,
   onIsAtEndChange,
+  onItemSizeChanged,
   onManualNavigation,
   hideEmptyPlaceholder = false,
   topFadeEnabled = false,
@@ -588,6 +591,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                 : TIMELINE_MAINTAIN_SCROLL_AT_END
             }
             maintainVisibleContentPosition={maintainVisibleContentPosition}
+            onItemSizeChanged={onItemSizeChanged}
             onScroll={handleScroll}
             className={cn(
               "scrollbar-gutter-both h-full min-h-0 overflow-x-hidden overscroll-y-contain px-3 [overflow-anchor:none] sm:px-5",

--- a/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "vite-plus/test";
-import { getAnchoredTurnMetrics, getRowBottom } from "./timelineScrollAnchoring";
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  clearTimelineAnchor,
+  getAnchoredTurnEndRevealOffset,
+  getAnchoredTurnMetrics,
+  getRowBottom,
+  resolveTimelineRouteEpoch,
+  resolveTimelineLiveFollowEnabled,
+  updateTimelineLiveFollowState,
+} from "./timelineScrollAnchoring";
 
 function buildState({
   positions,
@@ -22,6 +30,62 @@ function buildState({
 }
 
 describe("timeline scroll anchoring", () => {
+  it("invalidates a deferred reveal when switching routes, including switching back", () => {
+    const threadA = "environment-local:thread-a";
+    const threadB = "environment-local:thread-b";
+    const firstThreadAEpoch = { threadKey: threadA };
+    let currentEpoch = firstThreadAEpoch;
+    const reveal = vi.fn();
+    const deferredReveal = () => {
+      if (currentEpoch === firstThreadAEpoch) {
+        reveal();
+      }
+    };
+
+    expect(resolveTimelineRouteEpoch(currentEpoch, threadA)).toBe(firstThreadAEpoch);
+    currentEpoch = resolveTimelineRouteEpoch(currentEpoch, threadB);
+    deferredReveal();
+    currentEpoch = resolveTimelineRouteEpoch(currentEpoch, threadA);
+    deferredReveal();
+
+    expect(reveal).not.toHaveBeenCalled();
+    expect(currentEpoch).not.toBe(firstThreadAEpoch);
+  });
+
+  it("clears send-time anchoring when ordinary bottom-follow resumes", () => {
+    const anchored = {
+      threadKey: "environment-local:thread-a",
+      messageId: "message-a",
+    };
+    const alreadyCleared = {
+      threadKey: anchored.threadKey,
+      messageId: null,
+    };
+
+    expect(clearTimelineAnchor(anchored)).toEqual({
+      threadKey: anchored.threadKey,
+      messageId: null,
+    });
+    expect(clearTimelineAnchor(alreadyCleared)).toBe(alreadyCleared);
+  });
+
+  it("starts a different thread at the live edge before its reset effect runs", () => {
+    const previousThreadState = {
+      threadKey: "environment-local:thread-a",
+      enabled: false,
+    };
+    const nextThreadKey = "environment-local:thread-b";
+
+    expect(
+      resolveTimelineLiveFollowEnabled(previousThreadState, previousThreadState.threadKey),
+    ).toBe(false);
+    expect(resolveTimelineLiveFollowEnabled(previousThreadState, nextThreadKey)).toBe(true);
+    expect(updateTimelineLiveFollowState(previousThreadState, nextThreadKey, true)).toEqual({
+      threadKey: nextThreadKey,
+      enabled: true,
+    });
+  });
+
   it("measures row bottoms from LegendList row position and size", () => {
     const state = buildState({
       positions: [0, 120],
@@ -110,6 +174,29 @@ describe("timeline scroll anchoring", () => {
     expect(metrics?.lastBottom).toBe(1540);
     expect(metrics?.visibleUsableBottom).toBe(1464);
     expect(metrics?.scrollDeltaToRevealEnd).toBe(76);
+  });
+
+  it("recomputes the reveal target after a buffered assistant row receives its real height", () => {
+    const estimatedState = buildState({
+      positions: [0, 120],
+      sizes: [80, 90],
+      scroll: 0,
+      scrollLength: 700,
+    });
+    const measuredState = buildState({
+      positions: [0, 120],
+      sizes: [80, 1_800],
+      scroll: 0,
+      scrollLength: 700,
+    });
+    const input = {
+      anchorIndex: 0,
+      composerOverlayHeight: 180,
+      anchorOffset: 16,
+    };
+
+    expect(getAnchoredTurnEndRevealOffset({ ...input, state: estimatedState })).toBeNull();
+    expect(getAnchoredTurnEndRevealOffset({ ...input, state: measuredState })).toBe(1_416);
   });
 
   it("subtracts composer height from usable viewport height", () => {

--- a/apps/web/src/components/chat/timelineScrollAnchoring.ts
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.ts
@@ -1,5 +1,49 @@
 export type TimelineScrollMode = "following-end" | "anchoring-new-turn" | "free-scrolling";
 
+export interface TimelineLiveFollowState {
+  readonly threadKey: string;
+  readonly enabled: boolean;
+}
+
+export interface TimelineRouteEpoch {
+  readonly threadKey: string;
+}
+
+export interface TimelineAnchorState<Message> {
+  readonly threadKey: string | null;
+  readonly messageId: Message | null;
+}
+
+export function clearTimelineAnchor<Message>(
+  state: TimelineAnchorState<Message>,
+): TimelineAnchorState<Message> {
+  return state.messageId === null ? state : { ...state, messageId: null };
+}
+
+export function resolveTimelineRouteEpoch(
+  current: TimelineRouteEpoch,
+  threadKey: string,
+): TimelineRouteEpoch {
+  return current.threadKey === threadKey ? current : { threadKey };
+}
+
+export function resolveTimelineLiveFollowEnabled(
+  state: TimelineLiveFollowState,
+  threadKey: string,
+): boolean {
+  return state.threadKey === threadKey ? state.enabled : true;
+}
+
+export function updateTimelineLiveFollowState(
+  state: TimelineLiveFollowState,
+  threadKey: string,
+  enabled: boolean,
+): TimelineLiveFollowState {
+  return state.threadKey === threadKey && state.enabled === enabled
+    ? state
+    : { threadKey, enabled };
+}
+
 export interface TimelineListMeasurementState {
   readonly data: readonly unknown[];
   readonly scroll: number;
@@ -75,4 +119,13 @@ export function getAnchoredTurnMetrics({
     targetScrollToRevealEnd,
     scrollDeltaToRevealEnd,
   };
+}
+
+export function getAnchoredTurnEndRevealOffset(
+  input: Parameters<typeof getAnchoredTurnMetrics>[0],
+): number | null {
+  const metrics = getAnchoredTurnMetrics(input);
+  return metrics && metrics.scrollDeltaToRevealEnd > 1
+    ? input.state.scroll + metrics.scrollDeltaToRevealEnd
+    : null;
 }


### PR DESCRIPTION
## What Changed

- Scope live-follow state to the full environment/thread route so a newly selected thread follows from its first render.
- Settle send-time anchoring when LegendList reports authoritative row-height changes from markdown, images, and tool output.
- Return control to normal end-following when the reader reaches the live edge.
- Invalidate deferred follow callbacks across route changes, including rapid A → B → A switches.
- Preserve the existing scroll-away affordance and history-prepend viewport behavior.
- Add focused regressions for thread switching, delayed layout, live follow, scroll-away, follow restoration, and route-switch races.

## Why

Initial positioning depended on LegendList's one-shot `initialScrollAtEnd`, while live-follow state survived SPA route changes until a post-render reset. A thread could therefore render once with stale follow state, and delayed row measurement could occur after the initial correction had already finished.

The fix keeps the existing virtualization architecture and only follows while the reader remains at the live edge. It does not add persisted scroll state, timers, or render-time `scrollToBottom()` calls.

Closes #5903

## UI Changes

This is a timing and interaction change. Before/after screenshots and a short recording will be added while the PR is in draft.

## Verification

- `pnpm exec vp test run apps/web/src/components/chat/timelineScrollAnchoring.test.tsx apps/web/src/components/chat/MessagesTimeline.test.tsx packages/client-runtime/src/state/threads-pagination.test.ts` — 38 passed
- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/client-runtime typecheck`
- Focused lint and format checks
- `git diff --check`
- Independent review: PASS

Manual verification:

- A long buffered response settled with its final line visible.
- A 19,011px-long existing thread opened within 0.5px of the live edge.
- Scrolling upward preserved the reading position while content grew.
- Returning to the bottom restored normal follow behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Built with GPT-5.6-Sol in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread chat view to reliably follow latest content across route changes and size updates
> - Live-follow state is now scoped per route/thread so opening a new thread always starts in follow mode, even if the previous thread was paused.
> - Late row height measurements (e.g. buffered completions) now trigger a deferred single-frame scroll via a new `onTimelineItemSizeChanged` handler to keep the live edge visible.
> - Anchor state is fully cleared when the user returns to the end of a thread, preventing residual anchor space or stale offsets from persisting.
> - New helpers in [timelineScrollAnchoring.ts](https://github.com/pingdotgg/t3code/pull/5905/files#diff-7d5bb365d2e39e9337a3a31436884ed0c0df1127c2033e30a6c027826c46de67) (`resolveTimelineRouteEpoch`, `clearTimelineAnchor`, `getAnchoredTurnEndRevealOffset`) centralize route- and thread-aware scroll logic.
> - Behavioral Change: scroll reveal after anchoring a new turn now uses absolute offset arithmetic instead of delta-based math, and fires without animation.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 87be81e. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat scroll state, LegendList integration, and thread-switch timing; behavior is heavily regression-tested but wrong scroll logic is user-visible.
> 
> **Overview**
> Fixes chat timeline scroll/follow so new threads start at the live edge and streaming content stays visible after late layout.
> 
> **Live-follow is keyed by route/thread** (`routeThreadKey` instead of `activeThread?.id` for resets and list remount). A thread you open while another had follow disabled still gets `liveFollowEnabled` on the first paint via `resolveTimelineLiveFollowEnabled`, before the route reset effect runs.
> 
> **Send-time anchoring reacts to real row heights**: `MessagesTimeline` forwards LegendList `onItemSizeChanged`; `ChatView` debounces with `requestAnimationFrame` and calls `revealActiveTimelineTurnEnd`, which uses new `getAnchoredTurnEndRevealOffset` (absolute scroll target) instead of inlined delta scroll math. **Route epochs** drop stale deferred reveals on fast A→B→A switches.
> 
> **Returning to the live edge** clears pending/positioned/settled anchor refs and applies `clearTimelineAnchor` so send-time anchor space does not linger after ordinary bottom-follow resumes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87be81ef6417ff9d477de772d361e6230bb20a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->