### PR TITLE
fix(mobile): resolve stale project refs for project sorting

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -422,6 +422,7 @@ export function HomeScreen(props: HomeScreenProps) {
   const v2ScopeProjects = useMemo(
     () =>
       sortHomeProjectScopes({
+        projects: props.projects,
         scopes: projectScopes,
         threads: props.threads,
         pendingTasks: props.pendingTasks,

--- a/apps/mobile/src/features/home/homeThreadList.test.ts
+++ b/apps/mobile/src/features/home/homeThreadList.test.ts
@@ -247,7 +247,7 @@ describe("buildHomeThreadGroups", () => {
     });
 
     expect(
-      sortHomeProjectScopes({
+      sortHomeProjectScopes({ projects,
         scopes,
         threads: [
           makeThread({
@@ -292,7 +292,7 @@ describe("buildHomeThreadGroups", () => {
     });
 
     expect(
-      sortHomeProjectScopes({
+      sortHomeProjectScopes({ projects,
         scopes,
         threads: [],
         pendingTasks: [],
@@ -339,7 +339,7 @@ describe("buildHomeThreadGroups", () => {
     });
 
     expect(
-      sortHomeProjectScopes({
+      sortHomeProjectScopes({ projects,
         scopes,
         threads: [],
         pendingTasks: [],

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -74,6 +74,7 @@ export function buildHomeProjectScopes(input: {
 }
 
 export function sortHomeProjectScopes(input: {
+  readonly projects: ReadonlyArray<EnvironmentProject>;
   readonly scopes: ReadonlyArray<HomeProjectScope>;
   readonly threads: ReadonlyArray<EnvironmentThreadShell>;
   readonly pendingTasks: ReadonlyArray<PendingNewTask>;
@@ -87,32 +88,52 @@ export function sortHomeProjectScopes(input: {
       ),
     ),
   );
+  const physicalProjectKeyByProjectRefKey = new Map(
+    input.projects.map((project) => [
+      scopedProjectKey(project.environmentId, project.id),
+      derivePhysicalProjectKey(project),
+    ] as const),
+  );
   const latestActivityByScope = new Map<string, number>();
-  const recordActivity = (scopeKey: string | undefined, timestamp: number) => {
-    if (!scopeKey || !Number.isFinite(timestamp)) return;
-    latestActivityByScope.set(
-      scopeKey,
-      Math.max(latestActivityByScope.get(scopeKey) ?? Number.NEGATIVE_INFINITY, timestamp),
-    );
+  const latestActivityByProjectKey = new Map<string, number>();
+  const recordActivity = (scopeKey: string | undefined, projectKey: string | undefined, timestamp: number) => {
+    if (!Number.isFinite(timestamp)) return;
+    if (scopeKey) {
+      latestActivityByScope.set(
+        scopeKey,
+        Math.max(latestActivityByScope.get(scopeKey) ?? Number.NEGATIVE_INFINITY, timestamp),
+      );
+    }
+    if (projectKey) {
+      latestActivityByProjectKey.set(
+        projectKey,
+        Math.max(latestActivityByProjectKey.get(projectKey) ?? Number.NEGATIVE_INFINITY, timestamp),
+      );
+    }
   };
 
   for (const thread of input.threads) {
     if (thread.archivedAt !== null) continue;
+    const projectRefKey = scopedProjectKey(thread.environmentId, thread.projectId);
     recordActivity(
-      scopeKeyByProjectRef.get(scopedProjectKey(thread.environmentId, thread.projectId)),
+      scopeKeyByProjectRef.get(projectRefKey),
+      physicalProjectKeyByProjectRefKey.get(projectRefKey),
       getThreadSortTimestamp(thread, input.projectSortOrder),
     );
   }
   for (const pendingTask of input.pendingTasks) {
+    const projectRefKey = scopedProjectKey(
+      pendingTask.message.environmentId,
+      pendingTask.creation.projectId,
+    );
     recordActivity(
-      scopeKeyByProjectRef.get(
-        scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
-      ),
+      scopeKeyByProjectRef.get(projectRefKey),
+      physicalProjectKeyByProjectRefKey.get(projectRefKey),
       Date.parse(pendingTask.message.createdAt),
     );
   }
 
-  return Arr.sort(
+  const sortedScopes = Arr.sort(
     input.scopes,
     Order.mapInput(
       Order.Struct({
@@ -133,6 +154,17 @@ export function sortHomeProjectScopes(input: {
       }),
     ),
   );
+
+  return sortedScopes.map((scope) => ({
+    ...scope,
+    projects: Arr.sort(
+      scope.projects,
+      Order.mapInput(Order.flip(Order.Number), (project) =>
+        latestActivityByProjectKey.get(derivePhysicalProjectKey(project)) ??
+        getProjectSortTimestamp(project, input.projectSortOrder),
+      ),
+    ),
+  }));
 }
 
 /**

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -194,6 +194,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const projectScopes = useMemo(
     () =>
       sortHomeProjectScopes({
+        projects,
         scopes: buildHomeProjectScopes({
           projects,
           environmentId: null,


### PR DESCRIPTION
Fixes #5785d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to mobile home list sorting logic with existing test coverage; no auth, persistence, or API surface changes.
> 
> **Overview**
> **`sortHomeProjectScopes`** now takes the full **`projects`** list and attributes thread/pending activity using **`derivePhysicalProjectKey`**, not only scoped project IDs on **`projectRefs`**. That way threads tied to stale duplicate project shells still move scope order and in-group project order the same as activity on the canonical member.
> 
> Call sites (**`HomeScreen`**, **`NewTaskFlowProvider`**) pass **`projects`** into the sorter; tests were updated for the new argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d131228c0e07c46168e3114910dbe93db4a41bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale project refs in `sortHomeProjectScopes` to sort projects by latest activity
> - `sortHomeProjectScopes` in [homeThreadList.ts](https://github.com/pingdotgg/t3code/pull/5906/files#diff-1f36b630d8d39dd1ca1be5a84d64ea082a69ffdf26be6759d3e6c9b705473796) now accepts a `projects` array and sorts member projects within each scope by latest activity (threads and pending tasks), falling back to `getProjectSortTimestamp` when no activity exists.
> - [HomeScreen](https://github.com/pingdotgg/t3code/pull/5906/files#diff-b6e075b3065ae370669290cbaa8476a852399968002468571cd914d06a32fd40) and [NewTaskFlowProvider](https://github.com/pingdotgg/t3code/pull/5906/files#diff-70cedfb5c403f777ceda2ca120dd7f822b033acf06053841f85a63b7d0cd3192) are updated to pass `projects` to `sortHomeProjectScopes`.
> - Behavioral Change: `sortHomeProjectScopes` now requires a `projects` argument; callers omitting it will not get correctly sorted project members.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d13122.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->