### PR TITLE
fix(mobile): align non-git new thread behavior

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -63,6 +63,7 @@ import {
   resolveNewTaskWorkspaceLabel,
 } from "./new-task-context-presentation";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
+import { resolveProjectThreadWorkspaceSelection } from "./projectThreadCreationValidation";
 
 function NewTaskWorkspaceIcon(props: {
   readonly workspaceMode: "local" | "worktree";
@@ -641,10 +642,15 @@ export function NewTaskDraftScreen(props: {
         selectedEnvironmentServerConfig,
         draft.modelSelection ?? null,
       ) ?? flow.selectedModel;
-    const workspaceMode = draft.workspaceSelection?.mode ?? flow.workspaceMode;
-    const selectedBranchName = draft.workspaceSelection?.branch ?? flow.selectedBranchName;
-    const selectedWorktreePath =
-      draft.workspaceSelection?.worktreePath ?? flow.selectedWorktreePath;
+    const workspaceSelection = resolveProjectThreadWorkspaceSelection({
+      isGitRepo: flow.isGitRepo,
+      environmentMode: draft.workspaceSelection?.mode ?? flow.workspaceMode,
+      branch: draft.workspaceSelection?.branch ?? flow.selectedBranchName,
+      worktreePath: draft.workspaceSelection?.worktreePath ?? flow.selectedWorktreePath,
+    });
+    const workspaceMode = workspaceSelection.environmentMode;
+    const selectedBranchName = workspaceSelection.branch;
+    const selectedWorktreePath = workspaceSelection.worktreePath;
     const startFromOrigin = draft.workspaceSelection?.startFromOrigin ?? flow.startFromOrigin;
     const runtimeMode = draft.runtimeMode ?? flow.runtimeMode;
     const interactionMode = flow.planModeEnabled
@@ -909,7 +915,7 @@ export function NewTaskDraftScreen(props: {
     </View>
   );
 
-  const workspaceControls = (
+  const workspaceControls = flow.isGitRepo ? (
     <View className="flex-row items-center gap-1 px-2">
       <ComposerInlineControl
         accessibilityHint={`Switches to ${flow.workspaceMode === "local" ? "a new worktree" : "the current checkout"}`}
@@ -937,11 +943,11 @@ export function NewTaskDraftScreen(props: {
         onPress={() => openContextPicker("NewTaskBranch")}
       />
     </View>
-  );
+  ) : null;
 
   const composerDock = (
     <View className="bg-sheet px-4 pt-1" style={{ paddingBottom: controlsBottomPadding }}>
-      <View className="pb-1">{workspaceControls}</View>
+      {workspaceControls ? <View className="pb-1">{workspaceControls}</View> : null}
 
       <ComposerSurface
         animateLayout={false}

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -67,6 +67,7 @@ import {
   setPendingConnectionError,
   useSavedRemoteConnections,
 } from "../../state/use-remote-environment-registry";
+import { vcsEnvironment } from "../../state/vcs";
 import { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
 import { type VcsRef } from "@t3tools/client-runtime/state/vcs";
 import {
@@ -81,6 +82,7 @@ import {
   resolveNewTaskBranchWorktreePath,
   resolveNewTaskLocalWorkspaceSelection,
 } from "./new-task-context-presentation";
+import { resolveProjectThreadWorkspaceSelection } from "./projectThreadCreationValidation";
 
 type WorkspaceMode = "local" | "worktree";
 
@@ -124,6 +126,7 @@ type NewTaskFlowContextValue = {
   readonly selectedEnvironmentId: EnvironmentId | null;
   readonly selectedProjectKey: string | null;
   readonly selectedModelKey: string | null;
+  readonly isGitRepo: boolean;
   readonly workspaceMode: WorkspaceMode;
   readonly selectedBranchName: string | null;
   readonly selectedWorktreePath: string | null;
@@ -348,6 +351,17 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const selectedEnvironmentServerConfig = useEnvironmentServerConfig(
     selectedProject?.environmentId ?? null,
   );
+  const gitStatus = useEnvironmentQuery(
+    selectedProject !== null && selectedProject.workspaceRoot.length > 0
+      ? vcsEnvironment.status({
+          environmentId: selectedProject.environmentId,
+          input: { cwd: selectedProject.workspaceRoot },
+        })
+      : null,
+  );
+  // Match web/desktop: assume git only while status is unresolved so the
+  // composer controls do not flicker away during the initial query.
+  const isGitRepo = gitStatus.data?.isRepo ?? true;
   // While a queued pending task is being edited its draft lives under a key
   // scoped to the queued message, so per-project new-task drafts stay intact.
   const selectedProjectDraftKey = editingPendingTask
@@ -387,9 +401,15 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     projectSetting: selectedProject?.defaultThreadEnvMode,
     projectFilePending: t3ProjectFileQuery.isPending,
   });
-  const workspaceMode = selectedProjectDraft.workspaceSelection?.mode ?? defaultWorkspaceMode;
-  const selectedBranchName = selectedProjectDraft.workspaceSelection?.branch ?? null;
-  const selectedWorktreePath = selectedProjectDraft.workspaceSelection?.worktreePath ?? null;
+  const workspaceSelection = resolveProjectThreadWorkspaceSelection({
+    isGitRepo,
+    environmentMode: selectedProjectDraft.workspaceSelection?.mode ?? defaultWorkspaceMode,
+    branch: selectedProjectDraft.workspaceSelection?.branch ?? null,
+    worktreePath: selectedProjectDraft.workspaceSelection?.worktreePath ?? null,
+  });
+  const workspaceMode = workspaceSelection.environmentMode;
+  const selectedBranchName = workspaceSelection.branch;
+  const selectedWorktreePath = workspaceSelection.worktreePath;
   // Keep the user's explicit choice separate from the resolved display value:
   // only the explicit flag is ever written back to the draft, so the resolved
   // value keeps tracking the server setting when the config loads late.
@@ -530,12 +550,12 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const debouncedBranchQuery = useDebouncedValue(branchQuery, BRANCH_SEARCH_DEBOUNCE_MS);
   const branchTarget = useMemo(
     () => ({
-      environmentId: selectedProject?.environmentId ?? null,
+      environmentId: isGitRepo ? (selectedProject?.environmentId ?? null) : null,
       // `|| null` also skips the stand-in project's empty workspaceRoot.
-      cwd: selectedProject?.workspaceRoot || null,
+      cwd: isGitRepo ? selectedProject?.workspaceRoot || null : null,
       query: debouncedBranchQuery,
     }),
-    [debouncedBranchQuery, selectedProject?.environmentId, selectedProject?.workspaceRoot],
+    [debouncedBranchQuery, isGitRepo, selectedProject?.environmentId, selectedProject?.workspaceRoot],
   );
   const branchState = usePaginatedBranches(branchTarget);
   const branchSearchIsDebouncing = branchQuery.trim() !== debouncedBranchQuery.trim();
@@ -725,12 +745,12 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const refreshBranches = branchState.refresh;
   const loadMoreBranches = branchState.loadNext;
   const loadBranches = useCallback(() => {
-    if (!selectedProject) {
+    if (!selectedProject || !isGitRepo) {
       return;
     }
     setPendingConnectionError(null);
     refreshBranches();
-  }, [refreshBranches, selectedProject]);
+  }, [isGitRepo, refreshBranches, selectedProject]);
 
   useEffect(() => {
     if (
@@ -824,10 +844,15 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       if (text.length === 0 || !draftModelSelection) {
         return null;
       }
-      const workspaceSelection = draft.workspaceSelection;
-      // Fall back to the resolved mode (server default) so queued tasks drain
+      // Fall back to the resolved default mode so queued tasks drain
       // with the same mode the composer displayed.
-      const mode = workspaceSelection?.mode ?? workspaceMode;
+      const workspaceSelection = resolveProjectThreadWorkspaceSelection({
+        isGitRepo,
+        environmentMode: draft.workspaceSelection?.mode ?? workspaceMode,
+        branch: draft.workspaceSelection?.branch ?? null,
+        worktreePath: draft.workspaceSelection?.worktreePath ?? null,
+      });
+      const mode = workspaceSelection.environmentMode;
       // When the selection is the stand-in built from the queued snapshot,
       // persist the original (possibly absent) snapshot values — the
       // stand-in's placeholder title/workspaceRoot must never be written back
@@ -859,12 +884,12 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
           ...(projectTitle !== undefined ? { projectTitle } : {}),
           ...(projectCwd !== undefined ? { projectCwd } : {}),
           workspaceMode: mode,
-          branch: workspaceSelection?.branch ?? null,
-          worktreePath: mode === "worktree" ? null : (workspaceSelection?.worktreePath ?? null),
+          branch: workspaceSelection.branch,
+          worktreePath: mode === "worktree" ? null : workspaceSelection.worktreePath,
           // The draft only carries the flag when the user touched it; fall
           // back to the resolved default (server settings) so queued tasks
           // drain with the same origin mode the composer displayed.
-          ...((workspaceSelection?.startFromOrigin ?? startFromOrigin)
+          ...((draft.workspaceSelection?.startFromOrigin ?? startFromOrigin)
             ? { startFromOrigin: true }
             : {}),
         },
@@ -874,6 +899,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     [
       editingPendingProject,
       editingPendingTask,
+      isGitRepo,
       selectedEnvironmentServerConfig,
       selectedModel,
       selectedProject,
@@ -981,6 +1007,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       selectedEnvironmentId,
       selectedProjectKey,
       selectedModelKey,
+      isGitRepo,
       workspaceMode,
       selectedBranchName,
       selectedWorktreePath,
@@ -1049,6 +1076,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       filteredBranches,
       finishEditingPendingTask,
       interactionMode,
+      isGitRepo,
       planModeEnabled,
       loadBranches,
       loadMoreBranches,

--- a/apps/mobile/src/features/threads/projectThreadCreationValidation.test.ts
+++ b/apps/mobile/src/features/threads/projectThreadCreationValidation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveProjectThreadWorkspaceSelection } from "./projectThreadCreationValidation";
+
+describe("resolveProjectThreadWorkspaceSelection", () => {
+  it("preserves git project workspace selections", () => {
+    expect(
+      resolveProjectThreadWorkspaceSelection({
+        isGitRepo: true,
+        environmentMode: "worktree",
+        branch: "main",
+        worktreePath: "/repo/.t3/worktrees/feature",
+      }),
+    ).toEqual({
+      environmentMode: "worktree",
+      branch: "main",
+      worktreePath: "/repo/.t3/worktrees/feature",
+    });
+  });
+
+  it("forces non-git projects onto the local checkout without git metadata", () => {
+    expect(
+      resolveProjectThreadWorkspaceSelection({
+        isGitRepo: false,
+        environmentMode: "worktree",
+        branch: "stale-branch",
+        worktreePath: "/stale/worktree",
+      }),
+    ).toEqual({
+      environmentMode: "local",
+      branch: null,
+      worktreePath: null,
+    });
+  });
+});

--- a/apps/mobile/src/features/threads/projectThreadCreationValidation.ts
+++ b/apps/mobile/src/features/threads/projectThreadCreationValidation.ts
@@ -32,6 +32,31 @@ export const ProjectThreadCreationValidationError = Schema.Union([
 ]);
 export type ProjectThreadCreationValidationError = typeof ProjectThreadCreationValidationError.Type;
 
+export function resolveProjectThreadWorkspaceSelection(input: {
+  readonly isGitRepo: boolean;
+  readonly environmentMode: "local" | "worktree";
+  readonly branch: string | null;
+  readonly worktreePath: string | null;
+}): {
+  readonly environmentMode: "local" | "worktree";
+  readonly branch: string | null;
+  readonly worktreePath: string | null;
+} {
+  if (input.isGitRepo) {
+    return {
+      environmentMode: input.environmentMode,
+      branch: input.branch,
+      worktreePath: input.worktreePath,
+    };
+  }
+
+  return {
+    environmentMode: "local",
+    branch: null,
+    worktreePath: null,
+  };
+}
+
 export function validateProjectThreadCreation(input: {
   readonly environmentId: EnvironmentId;
   readonly projectId: ProjectId;


### PR DESCRIPTION
## What Changed

- Hide the New Thread workspace control on mobile when the selected project is not a Git repository.
- Skip branch loading for non-git projects.
- Force non-git thread creation to use the local checkout without branch or worktree metadata.
- Apply the same normalization to immediate sends and queued tasks.

## Why

Mobile did not match web and desktop for non-git projects: it still displayed Git-specific workspace controls and did not explicitly force local checkout when sending.

This change makes the behavior consistent across clients. Git projects preserve their workspace selection, while non-git projects always create threads using the local checkout.

## UI Changes

| Before | After |
| --- | --- |
| The Workspace control was shown for non-git projects. | The Workspace control is hidden for non-git projects. |
| <img width="575" height="246" alt="Workspace control shown for a non-git project" src="https://github.com/user-attachments/assets/773403ae-59d7-4627-a8c0-daa26ec219e3" /> | <img width="420" height="171" alt="Workspace control hidden for a non-git project" src="https://github.com/user-attachments/assets/258afb49-fa7f-4627-b6bb-b791a3c7cd02" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix new thread behavior for non-git projects in mobile
> - Adds `resolveProjectThreadWorkspaceSelection` in [`projectThreadCreationValidation.ts`](https://github.com/pingdotgg/t3code/pull/5907/files#diff-38690cf67687d3b29ae5abcfdd3fd017dc5f60cdde0cc1f420fce74b88c84afb) to force local workspace mode with null branch/worktree when a project is not a git repo, preserving inputs otherwise.
> - [`NewTaskFlowProvider`](https://github.com/pingdotgg/t3code/pull/5907/files#diff-70cedfb5c403f777ceda2ca120dd7f822b033acf06053841f85a63b7d0cd3192) queries git status for the selected project and exposes `isGitRepo` via context, skipping branch listing queries for non-git projects.
> - [`NewTaskDraftScreen`](https://github.com/pingdotgg/t3code/pull/5907/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2) hides branch/worktree controls and uses the resolved workspace selection when `isGitRepo` is false.
> - Behavioral Change: non-git projects now always submit tasks with local workspace mode and no branch/worktree, regardless of any draft state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b42e30c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->