### PR TITLE
fix(web): show worktree icon in sidebar v2

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -137,6 +137,7 @@ import {
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
+  ThreadWorktreeIndicator,
   prStatusIndicator,
   resolveThreadPr,
   settledPrHoverColorClass,
@@ -1412,7 +1413,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                   working, but it truncated to a half-sentence and dropped the
                   branch, so the row lost its most stable identifier. */}
               {thread.branch ? (
-                <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
+                <>
+                  <ThreadWorktreeIndicator thread={thread} />
+                  <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
+                </>
               ) : (
                 <span className="flex-1" />
               )}


### PR DESCRIPTION
## Problem

Sidebar v2 shows the branch name without Sidebar v1’s worktree indicator, so users cannot tell whether a thread targets a worktree or a plain ref.

## Fix

Reuse the existing worktree indicator beside the Sidebar v2 branch label. Worktree threads now show the folder/git icon and its existing accessible tooltip; ref-only threads remain text-only.

## Before / after

<table>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/a9b5f310-611d-4af0-8c8b-842f0750e154" alt="Sidebar v2 before — no worktree indicator" width="600"></td>
    <td><img src="https://github.com/user-attachments/assets/51469796-5da5-42b2-a35f-8993544b60d6" alt="Sidebar v2 after — worktree indicator beside branch" width="600"></td>
  </tr>
</table>.

## Verification

- Web typecheck
- Web unit tests (1,995 tests)
- Formatter and diff checks
- Integrated web pass with ref-only and worktree fixtures

Implemented with GPT-5.6-sol via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI parity change reusing an existing component with no auth, data, or API impact.
> 
> **Overview**
> **Sidebar v2** now matches **v1** for worktree threads: the shared `ThreadWorktreeIndicator` is rendered next to the branch label on **card** rows when a branch is present.
> 
> Worktree threads get the existing folder/git icon and tooltip; ref-only threads stay unchanged (the indicator renders nothing without `worktreePath`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97c128f46d0fe9bc65bd04fee2efb42b405b2237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show worktree indicator before branch label in sidebar thread rows
> Adds `ThreadWorktreeIndicator` before the branch name in each sidebar thread row when a branch exists. The branch display changes from a single `<span>` to a fragment containing the indicator and the branch span.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97c128f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->