### PR TITLE
feat(web): add configurable compact inbox mode

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -832,6 +832,20 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     }
                   : null;
   const isWokeStatus = topStatus?.icon === "woke";
+  const compactStatusDotClassName =
+    topStatus === null
+      ? "bg-muted-foreground/35"
+      : topStatus.icon === "working" || topStatus.label === "Monitoring"
+        ? "bg-sky-500 dark:bg-sky-400"
+        : topStatus.label === "Approval"
+          ? "bg-amber-500 dark:bg-amber-400"
+          : topStatus.label === "Input"
+            ? "bg-indigo-500 dark:bg-indigo-400"
+            : topStatus.label === "Failed"
+              ? "bg-red-500 dark:bg-red-400"
+              : topStatus.icon === "woke"
+                ? "bg-amber-500 dark:bg-amber-400"
+                : "bg-emerald-500 dark:bg-emerald-400";
 
   const branchMismatch = resolveLocalCheckoutBranchMismatch({
     effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
@@ -1093,7 +1107,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       data-testid={`sidebar-terminal-status-${thread.id}`}
       className={cn("inline-flex shrink-0 items-center justify-center", terminalStatus.colorClass)}
     >
-      <TerminalIcon className={cn("size-3.5", terminalStatus.pulse && "animate-status-pulse")} />
+      <TerminalIcon className={cn("size-3", terminalStatus.pulse && "animate-status-pulse")} />
     </span>
   ) : null;
 
@@ -1101,7 +1115,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     return (
       <li
         data-thread-item
-        className="list-none [content-visibility:auto] [contain-intrinsic-size:auto_34px]"
+        className="list-none [content-visibility:auto] [contain-intrinsic-size:auto_30px]"
       >
         <Tooltip>
           <TooltipTrigger
@@ -1111,7 +1125,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 tabIndex={0}
                 data-testid="sidebar-row-slim"
                 aria-busy={isRegeneratingTitle || undefined}
-                className={cn(rowSurfaceClassName, "flex h-9 items-center gap-2.5 px-2.5")}
+                className={cn(rowSurfaceClassName, "flex h-[1.875rem] items-center gap-0.5 px-1.5")}
                 onClick={handleClick}
                 onDoubleClick={handleDoubleClick}
                 onKeyDown={handleKeyDown}
@@ -1132,11 +1146,50 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 environmentId={thread.environmentId}
                 cwd={props.projectCwd ?? ""}
                 faviconPath={props.projectFaviconPath}
-                className="size-4"
+                className="size-3.5"
                 fallbackIcon={MessageSquareIcon}
               />
             </span>
+            {props.isPinned ? (
+              props.pinningSupported ? (
+                <button
+                  type="button"
+                  aria-label="Unpin thread"
+                  title="Unpin thread"
+                  onClick={handleUnpinClick}
+                  className="inline-flex shrink-0 cursor-pointer items-center rounded-sm text-muted-foreground/65 outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <PinIcon aria-hidden className="size-2.5 shrink-0" />
+                </button>
+              ) : (
+                <PinIcon
+                  aria-label="Pinned"
+                  role="img"
+                  className="size-2.5 shrink-0 text-muted-foreground/65"
+                />
+              )
+            ) : null}
             {title}
+            {compactStatusDotClassName ? (
+              <span
+                aria-label={topStatus?.label ?? "Ready"}
+                className={cn("size-1.5 shrink-0 rounded-full", compactStatusDotClassName)}
+                role="img"
+                title={topStatus?.label ?? "Ready"}
+              />
+            ) : null}
+            {driverKind ? (
+              <span
+                className="inline-flex shrink-0 items-center opacity-65"
+                title={thread.session?.providerName ?? modelInstanceId}
+              >
+                <ProviderInstanceIcon
+                  driverKind={driverKind}
+                  displayName={thread.session?.providerName ?? modelInstanceId}
+                  iconClassName="size-3"
+                />
+              </span>
+            ) : null}
             {terminalStatusIcon}
             {isRegeneratingTitle ? (
               <span role="status" className="sr-only">
@@ -1147,7 +1200,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               remain visible AND clickable while the row is hovered. Only
               the time/jump label yields to the settle affordance. */}
             {prBadge}
-            <span className="relative ml-auto flex h-6 min-w-8 shrink-0 items-center justify-end">
+            <span className="relative flex h-5 shrink-0 items-center">
               <span
                 className={cn(
                   "inline-flex justify-end tabular-nums text-secondary-label transition-opacity",
@@ -1174,7 +1227,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     <span role="status">Woke</span>
                   </button>
                 ) : (
-                  <span className="text-xs">
+                  <span className="text-[10px]">
                     {variantAction === "unsettle"
                       ? settledTimeLabel(thread)
                       : threadTimeLabel(thread)}
@@ -1572,6 +1625,7 @@ export default function Sidebar() {
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const sidebarCompactMode = useClientSettings((s) => s.sidebarCompactMode);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
@@ -3410,26 +3464,23 @@ export default function Sidebar() {
                     const threadKey = scopedThreadKey(
                       scopeThreadRef(thread.environmentId, thread.id),
                     );
-                    // Settled and snoozed are the ONLY things that collapse a
-                    // row: every other thread is a full card. Density comes
-                    // from users (or the auto rules) actually parking work,
-                    // not from the sidebar second-guessing what still matters.
-                    const isCard = section === "active" || section === "pinned";
+                    // Every inbox thread uses the compact one-line treatment.
+                    // Secondary metadata remains available in the tooltip so
+                    // the row can prioritize title, provider and time.
+                    const isCard =
+                      !sidebarCompactMode && (section === "active" || section === "pinned");
                     const rowVariant = isCard ? "card" : "slim";
                     return (
                       <SidebarThreadRow
-                        // Keyed per variant on purpose: when a thread settles,
-                        // the card fades out in place and the slim row fades
-                        // in at its settled position instead of one element
-                        // FLIP-sliding through every row in between (rows here
-                        // are translucent, so a crossing row reads as text
-                        // painted over text).
+                        // Keep the section in the key while lifecycle state
+                        // changes so list transitions do not FLIP-slide a row
+                        // through every neighboring item.
                         key={`${threadKey}:${rowVariant}`}
                         thread={thread}
                         variant={rowVariant}
                         // Snoozed rows wake; settled rows un-settle (explicit
                         // settles clear the override, auto-settled rows get
-                        // pinned active); cards settle.
+                        // pinned active); inbox rows settle.
                         variantAction={
                           section === "snoozed"
                             ? "unsnooze"

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -462,6 +462,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.sidebarThreadPreviewCount !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount
         ? ["Visible threads"]
         : []),
+      ...(settings.sidebarCompactMode !== DEFAULT_UNIFIED_SETTINGS.sidebarCompactMode
+        ? ["Compact sidebar inbox"]
+        : []),
       ...(settings.sidebarProjectGroupingMode !==
       DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode
         ? ["Project Grouping"]
@@ -533,6 +536,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.enableLegacyTokenStreaming,
       settings.enableProviderUpdateChecks,
       settings.sidebarAutoSettleAfterDays,
+      settings.sidebarCompactMode,
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
       settings.timestampFormat,
@@ -610,6 +614,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+      sidebarCompactMode: DEFAULT_UNIFIED_SETTINGS.sidebarCompactMode,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
       enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
@@ -1754,6 +1759,32 @@ export function GeneralSettingsPanel() {
                 });
               }}
               aria-label="Project grouping"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("compact-sidebar-inbox")}
+          description="Use one-line inbox rows with provider icons and timestamps. Turn this off to show active and pinned threads as larger two-line cards."
+          resetAction={
+            settings.sidebarCompactMode !== DEFAULT_UNIFIED_SETTINGS.sidebarCompactMode ? (
+              <SettingResetButton
+                label="compact sidebar inbox"
+                onClick={() =>
+                  updateSettings({
+                    sidebarCompactMode: DEFAULT_UNIFIED_SETTINGS.sidebarCompactMode,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.sidebarCompactMode}
+              onCheckedChange={(checked) =>
+                updateSettings({ sidebarCompactMode: Boolean(checked) })
+              }
+              aria-label="Compact sidebar inbox"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -101,6 +101,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "compact-sidebar-inbox",
+    title: "Compact sidebar inbox",
+    to: "/settings/general",
+  },
+  {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
     to: "/settings/general",

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -71,6 +71,7 @@ describe("ClientSettings sidebar", () => {
   it("defaults to the current sidebar with a three-day auto-settle threshold", () => {
     const settings = decodeClientSettings({});
     expect(settings.legacySidebarEnabled).toBe(false);
+    expect(settings.sidebarCompactMode).toBe(true);
     expect(settings.sidebarAutoSettleAfterDays).toBe(3);
   });
 
@@ -89,6 +90,11 @@ describe("ClientSettings sidebar", () => {
     expect(decodeClientSettingsPatch({ legacySidebarEnabled: true }).legacySidebarEnabled).toBe(
       true,
     );
+  });
+
+  it("supports opting out of compact inbox rows", () => {
+    expect(decodeClientSettings({ sidebarCompactMode: false }).sidebarCompactMode).toBe(false);
+    expect(decodeClientSettingsPatch({ sidebarCompactMode: false }).sidebarCompactMode).toBe(false);
   });
 
   it("allows auto-settle by inactivity to be disabled", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -177,6 +177,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  sidebarCompactMode: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
   ),
@@ -792,6 +793,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
+  sidebarCompactMode: Schema.optionalKey(Schema.Boolean),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(


### PR DESCRIPTION
Adds a configurable compact inbox mode with one-line sidebar rows, provider icons, status indicators, and timestamps. The General settings panel can disable compact mode to restore larger active and pinned cards.

Verification:
- 136 focused tests passed
- Web typecheck passed
- Contracts typecheck passed

Implemented and verified by Codex via the T3 Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side presentation and a persisted boolean preference only; no auth, data, or server behavior changes.
> 
> **Overview**
> Adds a **`sidebarCompactMode`** client setting (default **on**) and wires it through contracts, settings restore/search, and the sidebar thread list.
> 
> With compact mode enabled, **active and pinned** threads render as **one-line slim rows** instead of two-line cards; turning the setting off restores the larger card layout for those sections. Slim rows gain **colored status dots**, **pin** and **provider** icons, and slightly tighter spacing; richer detail stays in the existing row tooltip.
> 
> **General → Compact sidebar inbox** exposes a switch to toggle the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0862df3cdc37b7b879de34f2e10ac191835e9a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable compact inbox mode to sidebar for active and pinned threads
> - Adds a `sidebarCompactMode` client setting (default `true`) that switches active and pinned sidebar threads from full cards to compact one-line rows.
> - Slim rows include a compact status dot, provider instance icon, and a quick unpin action (or passive pin marker) when pinning is supported.
> - Exposes a 'Compact sidebar inbox' toggle in General settings, including reset-to-default support and settings search indexing.
> - Behavioral Change: `sidebarCompactMode` defaults to `true`, so existing users will see compact rows immediately on upgrade.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0862df3. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->