### PR TITLE
feat(web): add configurable compact inbox mode

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1617,23 +1617,26 @@ function ChatViewContent(props: ChatViewProps) {
     return openTerminalThreadKeys.filter((nextThreadKey) => existingThreadKeys.has(nextThreadKey));
   }, [draftThreadKeys, openTerminalThreadKeys, serverThreadKeys]);
   const activeLatestTurn = activeThread?.latestTurn ?? null;
-  // Reading a finished thread clears the sidebar's Done badge. The visit is
-  // stamped at the turn's completion time — not now/updatedAt — so it clears
-  // exactly the completion the user is looking at: a wake or completion that
-  // lands later still gets its signal (markThreadVisited never moves the
-  // timestamp backwards).
+  // Keep the open thread read as assistant messages arrive. Finished turns use
+  // their completion timestamp; an in-flight message uses the shell update that
+  // delivered it. The message ID, rather than generic shell activity, controls
+  // title brightness, so later tool-only updates do not create unread text.
   useEffect(() => {
-    const completedAt = serverThread?.latestTurn?.completedAt;
-    if (!serverThread?.id || !completedAt) return;
+    const latestTurn = serverThread?.latestTurn;
+    const visitedAt = latestTurn?.completedAt ?? serverThread?.updatedAt;
+    if (!serverThread?.id || !visitedAt) return;
     markThreadVisited(
       scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
-      completedAt,
+      visitedAt,
+      latestTurn?.assistantMessageId,
     );
   }, [
     markThreadVisited,
     serverThread?.environmentId,
     serverThread?.id,
+    serverThread?.latestTurn?.assistantMessageId,
     serverThread?.latestTurn?.completedAt,
+    serverThread?.updatedAt,
   ]);
   useEffect(() => {
     setMountedTerminalThreadKeys((currentThreadIds) => {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -11,13 +11,16 @@ import {
   getVisibleThreadsForProject,
   getProjectSortTimestamp,
   hasUnseenCompletion,
+  hasUnreadAssistantMessage,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
+  resolveSidebarSortableRowBag,
   resolveThreadRowClassName,
   resolveSidebarThreadStatus,
+  resolveSidebarV2UnreadState,
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
   searchSidebarThreadsByTitle,
@@ -32,6 +35,7 @@ import {
   sortThreadsForSidebar,
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
+  sidebarThreadRowRenderKey,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
 } from "./Sidebar.logic";
 import {
@@ -50,6 +54,23 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("compact sidebar row identity and sorting", () => {
+  it("keeps lifecycle sections distinct when every section uses slim rows", () => {
+    expect(sidebarThreadRowRenderKey("environment:thread", "active", "slim")).toBe(
+      "environment:thread:active:slim",
+    );
+    expect(sidebarThreadRowRenderKey("environment:thread", "settled", "slim")).toBe(
+      "environment:thread:settled:slim",
+    );
+  });
+
+  it("keeps pinned drag-and-drop wiring on slim rows", () => {
+    const sortable = { id: "sortable-row" };
+
+    expect(resolveSidebarSortableRowBag("slim", sortable)).toBe(sortable);
+  });
+});
 
 describe("shouldNavigateAfterProjectRemoval", () => {
   const projectThreads = [{ environmentId: "environment-local", id: "thread-1" }];
@@ -285,6 +306,61 @@ describe("hasUnseenCompletion", () => {
         session: null,
       }),
     ).toBe(false);
+  });
+});
+
+describe("hasUnreadAssistantMessage", () => {
+  it("lights only a newly observed assistant message", () => {
+    expect(
+      hasUnreadAssistantMessage({
+        latestAssistantMessageId: "assistant-2",
+        lastReadAssistantMessageId: "assistant-1",
+      }),
+    ).toBe(true);
+    expect(
+      hasUnreadAssistantMessage({
+        latestAssistantMessageId: "assistant-1",
+        lastReadAssistantMessageId: "assistant-1",
+      }),
+    ).toBe(false);
+    expect(
+      hasUnreadAssistantMessage({
+        latestAssistantMessageId: "assistant-1",
+        lastReadAssistantMessageId: undefined,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveSidebarV2UnreadState", () => {
+  const completedThread = {
+    hasActionableProposedPlan: false,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    interactionMode: "default" as const,
+    latestTurn: makeLatestTurn({ completedAt: "2026-03-09T10:30:00.000Z" }),
+    lastVisitedAt: "2026-03-09T10:20:00.000Z",
+    session: null,
+  };
+
+  it("keeps an acknowledged message title read when its turn later completes", () => {
+    expect(
+      resolveSidebarV2UnreadState({
+        thread: completedThread,
+        latestAssistantMessageId: "assistant-1",
+        lastReadAssistantMessageId: "assistant-1",
+      }),
+    ).toEqual({ hasUnreadCompletion: true, hasUnreadAssistantMessage: false });
+  });
+
+  it("does not treat a tool-only completion as unread assistant text", () => {
+    expect(
+      resolveSidebarV2UnreadState({
+        thread: completedThread,
+        latestAssistantMessageId: null,
+        lastReadAssistantMessageId: undefined,
+      }),
+    ).toEqual({ hasUnreadCompletion: true, hasUnreadAssistantMessage: false });
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -23,6 +23,28 @@ export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
 // it small; cold opens still render instantly from the cached snapshot.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 3;
 
+export type SidebarThreadRowVariant = "card" | "slim";
+export type SidebarThreadSection = "pinned" | "active" | "snoozed" | "settled";
+
+export function sidebarThreadRowRenderKey(
+  threadKey: string,
+  section: SidebarThreadSection,
+  rowVariant: SidebarThreadRowVariant,
+): string {
+  return `${threadKey}:${section}:${rowVariant}`;
+}
+
+export function resolveSidebarSortableRowBag<T>(
+  rowVariant: SidebarThreadRowVariant,
+  sortable: T | undefined,
+): T | undefined {
+  switch (rowVariant) {
+    case "card":
+    case "slim":
+      return sortable;
+  }
+}
+
 type SidebarProject = {
   id: string;
   title: string;
@@ -258,6 +280,28 @@ export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
   const lastVisitedAt = Date.parse(thread.lastVisitedAt);
   if (Number.isNaN(lastVisitedAt)) return true;
   return completedAt > lastVisitedAt;
+}
+
+export function hasUnreadAssistantMessage(input: {
+  latestAssistantMessageId: string | null | undefined;
+  lastReadAssistantMessageId: string | undefined;
+}): boolean {
+  return (
+    input.latestAssistantMessageId != null &&
+    input.lastReadAssistantMessageId !== undefined &&
+    input.latestAssistantMessageId !== input.lastReadAssistantMessageId
+  );
+}
+
+export function resolveSidebarV2UnreadState(input: {
+  thread: ThreadStatusInput;
+  latestAssistantMessageId: string | null | undefined;
+  lastReadAssistantMessageId: string | undefined;
+}): { hasUnreadCompletion: boolean; hasUnreadAssistantMessage: boolean } {
+  return {
+    hasUnreadCompletion: hasUnseenCompletion(input.thread),
+    hasUnreadAssistantMessage: hasUnreadAssistantMessage(input),
+  };
 }
 
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -121,14 +121,16 @@ import {
   buildBulkTitleRegenerationContextMenuItem,
   formatWorkingDurationLabel,
   firstValidTimestampMs,
-  hasUnseenCompletion,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   planPinnedReorder,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
+  resolveSidebarV2UnreadState,
+  resolveSidebarSortableRowBag,
   searchSidebarThreadsByTitle,
+  sidebarThreadRowRenderKey,
   resolveWorkingStartedAt,
   sortLogicalProjectsForSidebar,
   sortPinnedThreadsForSidebar,
@@ -723,6 +725,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   const threadKey = scopedThreadKey(threadRef);
   const isRegeneratingTitle = thread.titleRegeneration != null;
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const lastReadAssistantMessageId = useUiStateStore(
+    (state) => state.threadLastReadAssistantMessageIdById[threadKey],
+  );
+  const observeAssistantMessage = useUiStateStore((state) => state.observeThreadAssistantMessage);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const openPrLink = useOpenPrLink();
   const runningTerminalIds = useThreadRunningTerminalIds({
@@ -749,7 +755,16 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
 
   // Same semantics as the legacy sidebar (never-visited counts as read):
   // switching sidebars must not light up every historical thread as unread.
-  const isUnread = hasUnseenCompletion({ ...thread, lastVisitedAt });
+  const latestAssistantMessageId = thread.latestTurn?.assistantMessageId ?? null;
+  useEffect(() => {
+    observeAssistantMessage(threadKey, latestAssistantMessageId);
+  }, [latestAssistantMessageId, observeAssistantMessage, threadKey]);
+  const unreadState = resolveSidebarV2UnreadState({
+    thread: { ...thread, lastVisitedAt },
+    latestAssistantMessageId,
+    lastReadAssistantMessageId,
+  });
+  const isUnread = unreadState.hasUnreadAssistantMessage;
   const status = resolveSidebarThreadStatus(thread);
   // A woken thread reappears at its original position (the sort is
   // deliberately static), so the pill has to carry the weight. Snoozing is
@@ -824,7 +839,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     icon: "woke" as const,
                     className: "text-amber-700 dark:text-amber-300",
                   }
-                : isUnread
+                : unreadState.hasUnreadCompletion
                   ? {
                       label: "Done",
                       icon: "done" as const,
@@ -832,6 +847,20 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     }
                   : null;
   const isWokeStatus = topStatus?.icon === "woke";
+  const compactStatusDotClassName =
+    topStatus === null
+      ? "bg-muted-foreground/35"
+      : topStatus.icon === "working" || topStatus.label === "Monitoring"
+        ? "bg-sky-500 dark:bg-sky-400"
+        : topStatus.label === "Approval"
+          ? "bg-amber-500 dark:bg-amber-400"
+          : topStatus.label === "Input"
+            ? "bg-indigo-500 dark:bg-indigo-400"
+            : topStatus.label === "Failed"
+              ? "bg-red-500 dark:bg-red-400"
+              : topStatus.icon === "woke"
+                ? "bg-amber-500 dark:bg-amber-400"
+                : "bg-emerald-500 dark:bg-emerald-400";
 
   const branchMismatch = resolveLocalCheckoutBranchMismatch({
     effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
@@ -1093,15 +1122,29 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       data-testid={`sidebar-terminal-status-${thread.id}`}
       className={cn("inline-flex shrink-0 items-center justify-center", terminalStatus.colorClass)}
     >
-      <TerminalIcon className={cn("size-3.5", terminalStatus.pulse && "animate-status-pulse")} />
+      <TerminalIcon className={cn("size-3", terminalStatus.pulse && "animate-status-pulse")} />
     </span>
   ) : null;
+  const sortable = resolveSidebarSortableRowBag(variant, props.sortable);
 
   if (variant === "slim") {
     return (
       <li
         data-thread-item
-        className="list-none [content-visibility:auto] [contain-intrinsic-size:auto_34px]"
+        ref={sortable?.setNodeRef}
+        style={
+          sortable
+            ? {
+                transform: CSS.Translate.toString(sortable.transform),
+                transition: sortable.transition,
+              }
+            : undefined
+        }
+        {...(sortable?.listeners ?? {})}
+        className={cn(
+          "list-none [content-visibility:auto] [contain-intrinsic-size:auto_30px]",
+          sortable?.isDragging && "z-20 opacity-80",
+        )}
       >
         <Tooltip>
           <TooltipTrigger
@@ -1111,7 +1154,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 tabIndex={0}
                 data-testid="sidebar-row-slim"
                 aria-busy={isRegeneratingTitle || undefined}
-                className={cn(rowSurfaceClassName, "flex h-9 items-center gap-2.5 px-2.5")}
+                className={cn(rowSurfaceClassName, "flex h-[1.875rem] items-center gap-0.5 px-1.5")}
                 onClick={handleClick}
                 onDoubleClick={handleDoubleClick}
                 onKeyDown={handleKeyDown}
@@ -1132,10 +1175,37 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 environmentId={thread.environmentId}
                 cwd={props.projectCwd ?? ""}
                 faviconPath={props.projectFaviconPath}
-                className="size-4"
+                className="size-3.5"
                 fallbackIcon={MessageSquareIcon}
               />
             </span>
+            {props.isPinned ? (
+              props.pinningSupported ? (
+                <button
+                  type="button"
+                  aria-label="Unpin thread"
+                  title="Unpin thread"
+                  onClick={handleUnpinClick}
+                  className="inline-flex shrink-0 cursor-pointer items-center rounded-sm text-muted-foreground/65 outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <PinIcon aria-hidden className="size-2.5 shrink-0" />
+                </button>
+              ) : (
+                <PinIcon
+                  aria-label="Pinned"
+                  role="img"
+                  className="size-2.5 shrink-0 text-muted-foreground/65"
+                />
+              )
+            ) : null}
+            {compactStatusDotClassName ? (
+              <span
+                aria-label={topStatus?.label ?? "Ready"}
+                className={cn("size-1.5 shrink-0 rounded-full", compactStatusDotClassName)}
+                role="img"
+                title={topStatus?.label ?? "Ready"}
+              />
+            ) : null}
             {title}
             {terminalStatusIcon}
             {isRegeneratingTitle ? (
@@ -1147,7 +1217,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               remain visible AND clickable while the row is hovered. Only
               the time/jump label yields to the settle affordance. */}
             {prBadge}
-            <span className="relative ml-auto flex h-6 min-w-8 shrink-0 items-center justify-end">
+            <span className="relative flex h-5 shrink-0 items-center">
               <span
                 className={cn(
                   "inline-flex justify-end tabular-nums text-secondary-label transition-opacity",
@@ -1174,7 +1244,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     <span role="status">Woke</span>
                   </button>
                 ) : (
-                  <span className="text-xs">
+                  <span className="text-[10px]">
                     {variantAction === "unsettle"
                       ? settledTimeLabel(thread)
                       : threadTimeLabel(thread)}
@@ -1221,6 +1291,18 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 </button>
               )}
             </span>
+            {driverKind ? (
+              <span
+                className="inline-flex shrink-0 items-center opacity-65"
+                title={thread.session?.providerName ?? modelInstanceId}
+              >
+                <ProviderInstanceIcon
+                  driverKind={driverKind}
+                  displayName={thread.session?.providerName ?? modelInstanceId}
+                  iconClassName="size-3"
+                />
+              </span>
+            ) : null}
             {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
           </TooltipTrigger>
           {detailsTooltip}
@@ -1231,7 +1313,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
 
   const diff = latestTurnDiff(thread);
 
-  const sortable = props.sortable;
   return (
     <li
       data-thread-item
@@ -1572,6 +1653,7 @@ export default function Sidebar() {
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const sidebarCompactMode = useClientSettings((s) => s.sidebarCompactMode);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
@@ -3410,26 +3492,23 @@ export default function Sidebar() {
                     const threadKey = scopedThreadKey(
                       scopeThreadRef(thread.environmentId, thread.id),
                     );
-                    // Settled and snoozed are the ONLY things that collapse a
-                    // row: every other thread is a full card. Density comes
-                    // from users (or the auto rules) actually parking work,
-                    // not from the sidebar second-guessing what still matters.
-                    const isCard = section === "active" || section === "pinned";
+                    // Every inbox thread uses the compact one-line treatment.
+                    // Secondary metadata remains available in the tooltip so
+                    // the row can prioritize title, provider and time.
+                    const isCard =
+                      !sidebarCompactMode && (section === "active" || section === "pinned");
                     const rowVariant = isCard ? "card" : "slim";
                     return (
                       <SidebarThreadRow
-                        // Keyed per variant on purpose: when a thread settles,
-                        // the card fades out in place and the slim row fades
-                        // in at its settled position instead of one element
-                        // FLIP-sliding through every row in between (rows here
-                        // are translucent, so a crossing row reads as text
-                        // painted over text).
-                        key={`${threadKey}:${rowVariant}`}
+                        // Keep the section in the key while lifecycle state
+                        // changes so list transitions do not FLIP-slide a row
+                        // through every neighboring item.
+                        key={sidebarThreadRowRenderKey(threadKey, section, rowVariant)}
                         thread={thread}
                         variant={rowVariant}
                         // Snoozed rows wake; settled rows un-settle (explicit
                         // settles clear the override, auto-settled rows get
-                        // pinned active); cards settle.
+                        // pinned active); inbox rows settle.
                         variantAction={
                           section === "snoozed"
                             ? "unsnooze"

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -462,6 +462,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.sidebarThreadPreviewCount !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount
         ? ["Visible threads"]
         : []),
+      ...(settings.sidebarCompactMode !== DEFAULT_UNIFIED_SETTINGS.sidebarCompactMode
+        ? ["Compact sidebar inbox"]
+        : []),
       ...(settings.sidebarProjectGroupingMode !==
       DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode
         ? ["Project Grouping"]
@@ -533,6 +536,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.enableLegacyTokenStreaming,
       settings.enableProviderUpdateChecks,
       settings.sidebarAutoSettleAfterDays,
+      settings.sidebarCompactMode,
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
       settings.timestampFormat,
@@ -610,6 +614,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+      sidebarCompactMode: DEFAULT_UNIFIED_SETTINGS.sidebarCompactMode,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
       enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
@@ -1754,6 +1759,32 @@ export function GeneralSettingsPanel() {
                 });
               }}
               aria-label="Project grouping"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("compact-sidebar-inbox")}
+          description="Use one-line inbox rows with provider icons and timestamps. Turn this off to show active and pinned threads as larger two-line cards."
+          resetAction={
+            settings.sidebarCompactMode !== DEFAULT_UNIFIED_SETTINGS.sidebarCompactMode ? (
+              <SettingResetButton
+                label="compact sidebar inbox"
+                onClick={() =>
+                  updateSettings({
+                    sidebarCompactMode: DEFAULT_UNIFIED_SETTINGS.sidebarCompactMode,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.sidebarCompactMode}
+              onCheckedChange={(checked) =>
+                updateSettings({ sidebarCompactMode: Boolean(checked) })
+              }
+              aria-label="Compact sidebar inbox"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -99,6 +99,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "compact-sidebar-inbox",
+    title: "Compact sidebar inbox",
+    to: "/settings/general",
+  },
+  {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
     to: "/settings/general",

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -5,6 +5,7 @@ import {
   legacyProjectCwdPreferenceKey,
   markThreadUnread,
   markThreadVisited,
+  observeThreadAssistantMessage,
   parsePersistedState,
   PERSISTED_STATE_KEY,
   type PersistedUiState,
@@ -22,6 +23,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectExpandedById: {},
     projectOrder: [],
     threadLastVisitedAtById: {},
+    threadLastReadAssistantMessageIdById: {},
     threadChangedFilesExpandedById: {},
     defaultAdvertisedEndpointKey: null,
     ...overrides,
@@ -29,6 +31,25 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
 }
 
 describe("uiStateStore pure functions", () => {
+  it("acknowledges the visible assistant message on visit", () => {
+    const threadId = ThreadId.make("thread-1");
+    const read = markThreadVisited(
+      makeUiState(),
+      threadId,
+      "2026-02-25T12:30:00.000Z",
+      "assistant-2",
+    );
+    expect(read.threadLastReadAssistantMessageIdById[threadId]).toBe("assistant-2");
+  });
+
+  it("baselines only the first observed assistant message", () => {
+    const threadId = ThreadId.make("thread-1");
+    const observed = observeThreadAssistantMessage(makeUiState(), threadId, "assistant-1");
+
+    expect(observed.threadLastReadAssistantMessageIdById[threadId]).toBe("assistant-1");
+    expect(observeThreadAssistantMessage(observed, threadId, "assistant-2")).toBe(observed);
+  });
+
   it("stores server timestamps without moving visit state backwards", () => {
     const threadId = ThreadId.make("thread-1");
     const initialState = makeUiState();
@@ -158,6 +179,10 @@ describe("parsePersistedState", () => {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
         invalid: "not-a-date",
       },
+      threadLastReadAssistantMessageIdById: {
+        "environment:thread-1": "assistant-1",
+        invalid: "",
+      },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpansionVersion: 1,
       threadChangedFilesExpandedById: {
@@ -175,6 +200,9 @@ describe("parsePersistedState", () => {
       projectOrder: ["physical-b", "physical-a"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
+      },
+      threadLastReadAssistantMessageIdById: {
+        "environment:thread-1": "assistant-1",
       },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpandedById: {
@@ -273,6 +301,9 @@ describe("uiStateStore persistence", () => {
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
+      threadLastReadAssistantMessageIdById: {
+        "environment:thread-1": "assistant-1",
+      },
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
           "turn-1": false,
@@ -294,6 +325,9 @@ describe("uiStateStore persistence", () => {
       projectOrder: ["physical-b", "physical-a"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
+      },
+      threadLastReadAssistantMessageIdById: {
+        "environment:thread-1": "assistant-1",
       },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpansionVersion: 1,

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -21,6 +21,7 @@ export interface PersistedUiState {
   projectExpandedById?: Record<string, boolean>;
   projectOrder?: string[];
   threadLastVisitedAtById?: Record<string, string>;
+  threadLastReadAssistantMessageIdById?: Record<string, string>;
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
@@ -36,6 +37,7 @@ export interface UiProjectState {
 
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
+  threadLastReadAssistantMessageIdById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
 }
 
@@ -49,6 +51,7 @@ const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
   threadLastVisitedAtById: {},
+  threadLastReadAssistantMessageIdById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
 };
@@ -98,6 +101,16 @@ function sanitizeTimestampRecord(value: unknown): Record<string, string> {
   );
 }
 
+function sanitizeStringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object") return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] =>
+        entry[0].length > 0 && typeof entry[1] === "string" && entry[1].length > 0,
+    ),
+  );
+}
+
 export function parsePersistedState(parsed: PersistedUiState): UiState {
   const projectExpandedById =
     parsed.projectExpandedById === undefined
@@ -126,6 +139,9 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
     projectExpandedById,
     projectOrder,
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
+    threadLastReadAssistantMessageIdById: sanitizeStringRecord(
+      parsed.threadLastReadAssistantMessageIdById,
+    ),
     threadChangedFilesExpandedById:
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
         ? sanitizePersistedThreadChangedFilesExpanded(parsed.threadChangedFilesExpandedById)
@@ -204,6 +220,7 @@ export function persistState(state: UiState): void {
         projectExpandedById,
         projectOrder: state.projectOrder,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
+        threadLastReadAssistantMessageIdById: state.threadLastReadAssistantMessageIdById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
         threadChangedFilesExpandedById: state.threadChangedFilesExpandedById,
@@ -222,25 +239,56 @@ export function persistState(state: UiState): void {
 
 const debouncedPersistState = new Debouncer(persistState, { wait: 500 });
 
-export function markThreadVisited(state: UiState, threadId: string, visitedAt: string): UiState {
+export function markThreadVisited(
+  state: UiState,
+  threadId: string,
+  visitedAt: string,
+  assistantMessageId?: string | null,
+): UiState {
   const visitedAtMs = Date.parse(visitedAt);
   if (!Number.isFinite(visitedAtMs)) {
     return state;
   }
   const previousVisitedAt = state.threadLastVisitedAtById[threadId];
   const previousVisitedAtMs = previousVisitedAt ? Date.parse(previousVisitedAt) : NaN;
-  if (
+  const advancesVisit = !(
     Number.isFinite(previousVisitedAtMs) &&
     Number.isFinite(visitedAtMs) &&
     previousVisitedAtMs >= visitedAtMs
+  );
+  const acknowledgesAssistantMessage =
+    assistantMessageId != null &&
+    state.threadLastReadAssistantMessageIdById[threadId] !== assistantMessageId;
+  if (!advancesVisit && !acknowledgesAssistantMessage) {
+    return state;
+  }
+  return {
+    ...state,
+    threadLastVisitedAtById: advancesVisit
+      ? { ...state.threadLastVisitedAtById, [threadId]: visitedAt }
+      : state.threadLastVisitedAtById,
+    threadLastReadAssistantMessageIdById: acknowledgesAssistantMessage
+      ? { ...state.threadLastReadAssistantMessageIdById, [threadId]: assistantMessageId }
+      : state.threadLastReadAssistantMessageIdById,
+  };
+}
+
+export function observeThreadAssistantMessage(
+  state: UiState,
+  threadId: string,
+  assistantMessageId: string | null | undefined,
+): UiState {
+  if (
+    assistantMessageId == null ||
+    state.threadLastReadAssistantMessageIdById[threadId] !== undefined
   ) {
     return state;
   }
   return {
     ...state,
-    threadLastVisitedAtById: {
-      ...state.threadLastVisitedAtById,
-      [threadId]: visitedAt,
+    threadLastReadAssistantMessageIdById: {
+      ...state.threadLastReadAssistantMessageIdById,
+      [threadId]: assistantMessageId,
     },
   };
 }
@@ -382,7 +430,15 @@ export function reorderProjects(
 }
 
 interface UiStateStore extends UiState {
-  markThreadVisited: (threadId: string, visitedAt: string) => void;
+  markThreadVisited: (
+    threadId: string,
+    visitedAt: string,
+    assistantMessageId?: string | null,
+  ) => void;
+  observeThreadAssistantMessage: (
+    threadId: string,
+    assistantMessageId: string | null | undefined,
+  ) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
@@ -396,8 +452,10 @@ interface UiStateStore extends UiState {
 
 export const useUiStateStore = create<UiStateStore>((set) => ({
   ...readPersistedState(),
-  markThreadVisited: (threadId, visitedAt) =>
-    set((state) => markThreadVisited(state, threadId, visitedAt)),
+  markThreadVisited: (threadId, visitedAt, assistantMessageId) =>
+    set((state) => markThreadVisited(state, threadId, visitedAt, assistantMessageId)),
+  observeThreadAssistantMessage: (threadId, assistantMessageId) =>
+    set((state) => observeThreadAssistantMessage(state, threadId, assistantMessageId)),
   markThreadUnread: (threadId, latestTurnCompletedAt) =>
     set((state) => markThreadUnread(state, threadId, latestTurnCompletedAt)),
   setThreadChangedFilesExpanded: (threadId, turnId, expanded) =>

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -11,3 +11,7 @@ other connected devices.
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.
+
+Thread titles are bright when a new assistant message has arrived since you last opened the thread,
+including messages sent while the agent is still working. Opening the thread marks that message as
+read. Tool activity does not make a title bright.

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -71,6 +71,7 @@ describe("ClientSettings sidebar", () => {
   it("defaults to the current sidebar with a three-day auto-settle threshold", () => {
     const settings = decodeClientSettings({});
     expect(settings.legacySidebarEnabled).toBe(false);
+    expect(settings.sidebarCompactMode).toBe(true);
     expect(settings.sidebarAutoSettleAfterDays).toBe(3);
   });
 
@@ -89,6 +90,11 @@ describe("ClientSettings sidebar", () => {
     expect(decodeClientSettingsPatch({ legacySidebarEnabled: true }).legacySidebarEnabled).toBe(
       true,
     );
+  });
+
+  it("supports opting out of compact inbox rows", () => {
+    expect(decodeClientSettings({ sidebarCompactMode: false }).sidebarCompactMode).toBe(false);
+    expect(decodeClientSettingsPatch({ sidebarCompactMode: false }).sidebarCompactMode).toBe(false);
   });
 
   it("allows auto-settle by inactivity to be disabled", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -177,6 +177,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  sidebarCompactMode: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
   ),
@@ -792,6 +793,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
+  sidebarCompactMode: Schema.optionalKey(Schema.Boolean),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(


### PR DESCRIPTION
Adds a configurable compact inbox mode with one-line sidebar rows, provider icons, status indicators, and timestamps. The General settings panel can disable compact mode to restore larger active and pinned cards.

The feature history is preserved on `feature/compact-inbox-mode`; this release branch is its single-commit squash projection.

Verification:
- 136 focused tests passed
- Web typecheck passed
- Contracts typecheck passed

Implemented and verified by Codex via the T3 Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on layout change and new persisted read-state logic affect sidebar behavior for all users; changes are UX-focused with broad test coverage but no auth/data-path risk.
> 
> **Overview**
> Introduces **`sidebarCompactMode`** (defaults **on**) so inbox threads use one-line **slim** rows with a status dot, provider icon, pin control, and pinned drag-and-drop; turning the setting off restores two-line **cards** for active and pinned sections only.
> 
> **Unread UI is split:** title emphasis tracks **new assistant messages** via persisted `threadLastReadAssistantMessageIdById` (`observeThreadAssistantMessage` baselines the first seen ID; opening a thread acks via `markThreadVisited` with `assistantMessageId`), while the **Done** pill still reflects unseen **turn completion**. Tool-only shell updates no longer brighten titles.
> 
> **ChatView** marks the open thread read as messages arrive (completion time or in-flight `updatedAt` + message id). Row list keys include section/variant to avoid bad FLIP transitions when lifecycle changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf403968e15c63a17c7f007a46327f09435a41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable compact inbox mode to the thread sidebar
> - Introduces a `sidebarCompactMode` setting (default `true`) that renders active and pinned threads as single-line slim rows instead of cards, togglable from General Settings and searchable in the settings catalog.
> - Refines unread state tracking so thread titles brighten only for new assistant messages (not tool-only activity); `markThreadVisited` now records the visible `assistantMessageId` to baseline future reads.
> - Adds `observeThreadAssistantMessage` to establish a per-thread baseline on first observation, persisted across sessions in `threadLastReadAssistantMessageIdById`.
> - Slim rows support drag-and-drop wiring, provider instance icons, compact status dots, and section-aware render keys to prevent cross-section animations.
> - Behavioral Change: compact mode is on by default; existing users will see slim rows until they opt out via settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdf4039.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->