### PR TITLE
feat: add three-hour snooze option

### DIFF
--- a/apps/web/src/components/Sidebar.snooze.test.ts
+++ b/apps/web/src/components/Sidebar.snooze.test.ts
@@ -8,15 +8,18 @@ function localDate(year: number, month: number, day: number, hour: number, minut
 }
 
 describe("resolveSnoozePresets", () => {
-  it("offers hour, evening, tomorrow, next week in the morning", () => {
+  it("offers one hour, three hours, evening, tomorrow, and next week in the morning", () => {
     // Wednesday 2026-04-08 10:00 local.
     const presets = resolveSnoozePresets(localDate(2026, 4, 8, 10), "locale");
     expect(presets.map((preset) => preset.id)).toEqual([
       "hour",
+      "three-hours",
       "evening",
       "tomorrow",
       "next-week",
     ]);
+    const threeHours = presets.find((preset) => preset.id === "three-hours");
+    expect(new Date(threeHours!.snoozedUntil).getHours()).toBe(13);
     const evening = presets.find((preset) => preset.id === "evening");
     expect(new Date(evening!.snoozedUntil).getHours()).toBe(18);
     const tomorrow = presets.find((preset) => preset.id === "tomorrow");
@@ -45,10 +48,10 @@ describe("resolveSnoozePresets", () => {
   it("drops the evening preset once evening is near or past", () => {
     expect(
       resolveSnoozePresets(localDate(2026, 4, 8, 17, 30), "locale").map((preset) => preset.id),
-    ).toEqual(["hour", "tomorrow", "next-week"]);
+    ).toEqual(["hour", "three-hours", "tomorrow", "next-week"]);
     expect(
       resolveSnoozePresets(localDate(2026, 4, 8, 21), "locale").map((preset) => preset.id),
-    ).toEqual(["hour", "tomorrow", "next-week"]);
+    ).toEqual(["hour", "three-hours", "tomorrow", "next-week"]);
   });
 
   it("puts next week a full week out when today is Monday", () => {

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -284,7 +284,7 @@ const HOUR_MS = 60 * 60 * 1_000;
 const EVENING_HOUR = 18;
 const MORNING_HOUR = 9;
 
-export type SnoozePresetId = "hour" | "evening" | "tomorrow" | "next-week";
+export type SnoozePresetId = "hour" | "three-hours" | "evening" | "tomorrow" | "next-week";
 
 export interface SnoozePreset {
   readonly id: SnoozePresetId;
@@ -317,17 +317,24 @@ function addSnoozeDays(base: Date, days: number): Date {
 
 /**
  * Shared "snooze until" choices for every client. "This evening" only
- * appears while it is meaningfully before evening; after that the list
- * starts at "Tomorrow".
+ * appears while it is meaningfully before evening; after that the calendar
+ * choices start at "Tomorrow".
  */
 export function resolveSnoozePresets(now: Date): ReadonlyArray<SnoozePreset> {
   const inAnHour = new Date(now.getTime() + HOUR_MS);
+  const inThreeHours = new Date(now.getTime() + 3 * HOUR_MS);
   const presets: SnoozePreset[] = [
     {
       id: "hour",
       label: "In 1 hour",
       whenLabel: snoozeTimeOfDayLabel(inAnHour),
       snoozedUntil: inAnHour.toISOString(),
+    },
+    {
+      id: "three-hours",
+      label: "In 3 hours",
+      whenLabel: snoozeTimeOfDayLabel(inThreeHours),
+      snoozedUntil: inThreeHours.toISOString(),
     },
   ];
 

--- a/packages/client-runtime/src/state/threadSnoozed.test.ts
+++ b/packages/client-runtime/src/state/threadSnoozed.test.ts
@@ -265,10 +265,15 @@ describe("resolveSnoozePresets", () => {
     const presets = resolveSnoozePresets(localDate(2026, 4, 8, 10));
     expect(presets.map((preset) => preset.id)).toEqual([
       "hour",
+      "three-hours",
       "evening",
       "tomorrow",
       "next-week",
     ]);
+    expect(presets.find((preset) => preset.id === "three-hours")?.snoozedUntil).toBe(
+      localDate(2026, 4, 8, 13).toISOString(),
+    );
+    expect(presets.find((preset) => preset.id === "three-hours")?.label).toBe("In 3 hours");
     expect(presets.find((preset) => preset.id === "evening")?.label).toBe("This evening");
     expect(
       new Date(presets.find((preset) => preset.id === "tomorrow")!.snoozedUntil).getHours(),
@@ -278,6 +283,7 @@ describe("resolveSnoozePresets", () => {
   it("drops the evening choice once evening is near or past", () => {
     expect(resolveSnoozePresets(localDate(2026, 4, 8, 17, 30)).map((preset) => preset.id)).toEqual([
       "hour",
+      "three-hours",
       "tomorrow",
       "next-week",
     ]);


### PR DESCRIPTION
Users currently have to choose between snoozing for one hour and longer calendar-based presets.

This adds an **In 3 hours** preset to the shared snooze model, making it available consistently in web, desktop, and mobile menus. It also extends the shared and web preset tests to cover the new duration and menu ordering.

## Testing
- `vp test run packages/client-runtime/src/state/threadSnoozed.test.ts apps/web/src/components/Sidebar.snooze.test.ts apps/mobile/src/features/threads/threadListV2.test.ts apps/web/src/components/threadActionMenu.logic.test.ts`
- Targeted typechecks for `@t3tools/client-runtime`, `@t3tools/web`, and `@t3tools/mobile`
- React Doctor: 100/100

Created with GPT-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, data-driven addition to shared snooze presets with test coverage only; no auth, persistence, or snooze eligibility logic changes.
> 
> **Overview**
> Adds an **In 3 hours** snooze choice between the existing one-hour and calendar presets so users can defer threads without jumping straight to “this evening” or longer.
> 
> The shared `resolveSnoozePresets` in `client-runtime` now exposes a `three-hours` preset (`SnoozePresetId`, label, `whenLabel`, and ISO `snoozedUntil` at `now + 3h`). Web, desktop, and mobile pick it up through the existing shared preset list; only tests and the shared resolver change in this diff.
> 
> Preset ordering and “drop evening when too late” behavior are updated in tests so `three-hours` stays after `hour` even when evening is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de01e5a5b15aaa9b61bfcc4eb5aa1176c209da61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add three-hour snooze preset to snooze options
> Adds a new `three-hours` preset to `resolveSnoozePresets` in [threadSettled.ts](https://github.com/pingdotgg/t3code/pull/5914/files#diff-89ad1700cfc6c0784f0813b572a6b6110e04b480f108c404b4c755705748083c), setting `snoozedUntil` to now +3 hours with the label "In 3 hours". The `SnoozePresetId` union type is extended to include `'three-hours'`. The preset is always included, unlike `evening` which is omitted when within one hour of evening time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de01e5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

