### PR TITLE
fix(server): sandbox user-provided SVGs

### DIFF
--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from "@effect/vitest";
 import { describe } from "vite-plus/test";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import { assetResponseHeaders, isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -24,5 +24,24 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("assetResponseHeaders", () => {
+  it("sandboxes SVG assets", () => {
+    expect(assetResponseHeaders("/attachments/user-image.svg")).toMatchObject({
+      "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+      "X-Content-Type-Options": "nosniff",
+    });
+    expect(assetResponseHeaders("/attachments/user-image.SVG")).toHaveProperty(
+      "Content-Security-Policy",
+    );
+  });
+
+  it("does not apply document policy to raster images", () => {
+    expect(assetResponseHeaders("/attachments/user-image.png")).toEqual({
+      "Cache-Control": "private, max-age=3600",
+      "X-Content-Type-Options": "nosniff",
+    });
   });
 });

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -43,6 +43,18 @@ import { browserApiCorsAllowedHeaders, browserApiCorsAllowedMethods } from "./ht
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 const DESKTOP_RENDERER_ORIGINS = ["t3code://app", "t3code-dev://app"];
+const SVG_CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+export function assetResponseHeaders(filePath: string): Record<string, string> {
+  return {
+    "Cache-Control": "private, max-age=3600",
+    "X-Content-Type-Options": "nosniff",
+    ...(filePath.toLowerCase().endsWith(".svg")
+      ? { "Content-Security-Policy": SVG_CONTENT_SECURITY_POLICY }
+      : {}),
+  };
+}
+
 export const httpCompressionLayer = HttpRouter.middleware(HttpMiddleware.compression(), {
   global: true,
 });
@@ -207,10 +219,7 @@ export const assetRouteLayer = HttpRouter.add(
     }
     return yield* HttpServerResponse.file(asset.path, {
       status: 200,
-      headers: {
-        "Cache-Control": "private, max-age=3600",
-        "X-Content-Type-Options": "nosniff",
-      },
+      headers: assetResponseHeaders(asset.path),
     }).pipe(
       Effect.orElseSucceed(() => HttpServerResponse.text("Internal Server Error", { status: 500 })),
     );


### PR DESCRIPTION
User-provided SVGs are served from signed URLs on the app origin. Opening one directly could run active SVG content with access to that origin.

This adds a restrictive Content Security Policy to SVG asset responses. Inline SVG styles still render, while scripts, external loads, and same-origin access are blocked. Raster asset responses are unchanged.

Tests: `vp test run apps/server/src/http.test.ts`

Made with GPT-5.6 using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets a real XSS/origin-abuse vector on user content, but the change is limited to response headers on the asset route and is covered by unit tests.
> 
> **Overview**
> **User-uploaded SVGs** served from signed asset URLs now get a restrictive **Content-Security-Policy** so opening them directly cannot run scripts or access the app origin.
> 
> A shared `assetResponseHeaders` helper centralizes asset response headers: **`.svg`** paths (case-insensitive) add `default-src 'none'; style-src 'unsafe-inline'; sandbox` on top of existing private cache and `nosniff`. **Raster and other assets** keep the same headers as before, with no CSP.
> 
> The signed asset `GET` route uses this helper instead of inline header objects. **Tests** cover SVG vs PNG behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457efa6704182042ce7206a597a5e06d26942dd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CSP sandbox header to SVG assets served by the asset route
> Adds a `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox` header to responses for `.svg` files (case-insensitive) to prevent script execution in user-provided SVGs. Header logic is centralized in a new exported `assetResponseHeaders` function in [http.ts](https://github.com/pingdotgg/t3code/pull/5916/files#diff-55fb49cf72ecef123d8f2fa7061526dadb37cf93f8e9dd9e7f0d4f8cd4ff9f6d). Non-SVG assets continue to receive only `Cache-Control` and `X-Content-Type-Options` headers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 457efa6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->