### PR TITLE
feat(web): add "Clear inactive" to the Agents panel

### DIFF
--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -18,15 +18,18 @@ import type {
   RuntimeSubagent,
 } from "@t3tools/client-runtime/state/subagentRuntime";
 import {
+  applyAgentPanelClearedAt,
   formatSubagentModelLabel,
   formatSubagentTokenCount,
+  hasClearableAgents,
 } from "@t3tools/client-runtime/state/subagentRuntime";
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { Bot, Braces, Check, ChevronDown, ChevronRight, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { cn } from "~/lib/utils";
 import { orchestrationEnvironment } from "~/state/orchestration";
+import { Button } from "~/components/ui/button";
 import { ScrollArea } from "~/components/ui/scroll-area";
 
 /**
@@ -522,20 +525,45 @@ export function AgentsPanel({
   model,
   environmentId = null,
   threadId = null,
+  clearedAt = null,
+  onClearInactive,
+  onShowAll,
 }: {
   model: AgentPanelModel;
   environmentId?: EnvironmentId | null;
   threadId?: ThreadId | null;
+  clearedAt?: string | null;
+  onClearInactive?: () => void;
+  onShowAll?: () => void;
 }) {
-  if (!model.hasAgents) {
+  const { model: visibleModel, hiddenCount } = useMemo(
+    () => applyAgentPanelClearedAt(model, clearedAt),
+    [clearedAt, model],
+  );
+  const canClearInactive = hasClearableAgents(visibleModel);
+
+  if (!visibleModel.hasAgents) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
         <Bot aria-hidden className="size-6 text-muted-foreground/60" />
-        <p className="text-sm font-medium">No agents yet</p>
-        <p className="max-w-56 text-xs text-muted-foreground">
-          When this thread spawns subagents or runs a workflow, they show up here with live status,
-          activity, and token usage.
+        <p className="text-sm font-medium">
+          {hiddenCount > 0 ? "No active agents" : "No agents yet"}
         </p>
+        <p className="max-w-56 text-xs text-muted-foreground">
+          {hiddenCount > 0
+            ? `${hiddenCount} cleared ${hiddenCount === 1 ? "agent is" : "agents are"} hidden. New spawns still show up here.`
+            : "When this thread spawns subagents or runs a workflow, they show up here with live status, activity, and token usage."}
+        </p>
+        {hiddenCount > 0 && onShowAll ? (
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={onShowAll}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            Show all
+          </Button>
+        ) : null}
       </div>
     );
   }
@@ -544,7 +572,7 @@ export function AgentsPanel({
     <div className="flex h-full min-h-0 flex-col">
       <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-2 p-2">
-          {model.workflows.map((group) => (
+          {visibleModel.workflows.map((group) => (
             <WorkflowSection
               key={group.workflow.id}
               group={group}
@@ -552,29 +580,54 @@ export function AgentsPanel({
               threadId={threadId}
             />
           ))}
-          {model.directAgents.length > 0 ? (
+          {visibleModel.directAgents.length > 0 ? (
             <section>
               <div className="px-1.5 pt-1 text-[.65rem] font-medium uppercase tracking-wider text-muted-foreground">
                 Direct spawns
               </div>
-              {model.directAgents.map((agent) => (
+              {visibleModel.directAgents.map((agent) => (
                 <AgentRow key={agent.id} agent={agent} />
               ))}
             </section>
           ) : null}
         </div>
       </ScrollArea>
-      <footer className="flex items-center justify-between border-t border-border/60 px-3 py-1.5 font-mono text-[.7rem] text-muted-foreground">
-        <span className="flex items-center gap-2">
-          {model.runningCount + model.waitingCount > 0 ? (
+      <footer className="flex items-center justify-between gap-2 border-t border-border/60 px-3 py-1.5 font-mono text-[.7rem] text-muted-foreground">
+        <span className="flex min-w-0 items-center gap-2">
+          {visibleModel.runningCount + visibleModel.waitingCount > 0 ? (
             <span className="text-info-foreground">
-              ● {model.runningCount + model.waitingCount} working
+              ● {visibleModel.runningCount + visibleModel.waitingCount} working
             </span>
           ) : null}
-          {model.idleCount > 0 ? <span>{model.idleCount} idle</span> : null}
-          {model.settledCount > 0 ? <span>{model.settledCount} settled</span> : null}
+          {visibleModel.idleCount > 0 ? <span>{visibleModel.idleCount} idle</span> : null}
+          {visibleModel.settledCount > 0 ? <span>{visibleModel.settledCount} settled</span> : null}
+          {hiddenCount > 0 && onShowAll ? (
+            <button
+              type="button"
+              onClick={onShowAll}
+              className="shrink-0 underline-offset-2 hover:text-foreground hover:underline"
+            >
+              {hiddenCount} hidden · Show all
+            </button>
+          ) : null}
         </span>
-        <span className="tabular-nums">Σ {formatSubagentTokenCount(model.totalTokens)} tok</span>
+        <span className="flex shrink-0 items-center gap-1.5">
+          {onClearInactive ? (
+            <Button
+              variant="ghost"
+              size="xs"
+              disabled={!canClearInactive}
+              onClick={onClearInactive}
+              title="Hide agents that are no longer working"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              Clear inactive
+            </Button>
+          ) : null}
+          <span className="tabular-nums">
+            Σ {formatSubagentTokenCount(visibleModel.totalTokens)} tok
+          </span>
+        </span>
       </footer>
     </div>
   );

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -6,12 +6,16 @@ import {
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { Thread, ThreadShell } from "../types";
 import {
+  AgentsClearedAtByThreadSchema,
+  MAX_AGENTS_CLEARED_AT_ENTRIES,
   MAX_HIDDEN_MOUNTED_PREVIEW_THREADS,
   MAX_HIDDEN_MOUNTED_TERMINAL_THREADS,
+  boundAgentsClearedAtByThread,
   branchMismatchKey,
   buildExpiredTerminalContextToastCopy,
   buildLoadingThreadFromShell,
@@ -715,5 +719,42 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     expect(hasServerAcknowledgedLocalDispatch({ ...common, hasPendingApproval: true })).toBe(true);
     expect(hasServerAcknowledgedLocalDispatch({ ...common, hasPendingUserInput: true })).toBe(true);
     expect(hasServerAcknowledgedLocalDispatch({ ...common, threadError: "failed" })).toBe(true);
+  });
+});
+
+const AgentsClearedAtByThreadJson = Schema.fromJsonString(AgentsClearedAtByThreadSchema);
+const encodeAgentsClearedAtByThread = Schema.encodeSync(AgentsClearedAtByThreadJson);
+const decodeAgentsClearedAtByThread = Schema.decodeSync(AgentsClearedAtByThreadJson);
+
+describe("boundAgentsClearedAtByThread", () => {
+  const entries = (count: number, startMinute = 0): Record<string, string> =>
+    Object.fromEntries(
+      Array.from({ length: count }, (_, index) => [
+        `thread-${index}`,
+        `2026-08-01T00:${String(startMinute + index).padStart(2, "0")}:00.000Z`,
+      ]),
+    );
+
+  it("passes an under-cap map through by reference", () => {
+    const under = entries(MAX_AGENTS_CLEARED_AT_ENTRIES);
+    expect(boundAgentsClearedAtByThread(under)).toBe(under);
+  });
+
+  it("keeps the newest cutoffs and drops the oldest past the cap", () => {
+    const over = entries(MAX_AGENTS_CLEARED_AT_ENTRIES + 3);
+    const bounded = boundAgentsClearedAtByThread(over);
+
+    expect(Object.keys(bounded)).toHaveLength(MAX_AGENTS_CLEARED_AT_ENTRIES);
+    expect(bounded["thread-0"]).toBeUndefined();
+    expect(bounded["thread-1"]).toBeUndefined();
+    expect(bounded["thread-2"]).toBeUndefined();
+    expect(bounded[`thread-${MAX_AGENTS_CLEARED_AT_ENTRIES + 2}`]).toBeDefined();
+  });
+
+  it("round-trips through the persisted schema", () => {
+    const value = { "env:thread": "2026-08-01T00:00:00.000Z" };
+    const encoded = encodeAgentsClearedAtByThread(value);
+
+    expect(decodeAgentsClearedAtByThread(encoded)).toEqual(value);
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -23,11 +23,37 @@ import {
 import type { DraftThreadEnvMode } from "../composerDraftStore";
 
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
+export const AGENTS_CLEARED_AT_BY_THREAD_KEY = "t3code:agents-cleared-at-by-thread";
 export const MAX_HIDDEN_MOUNTED_TERMINAL_THREADS = 10;
 export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 export const ENVIRONMENT_RECONNECT_WARNING_GRACE_MS = 2_000;
+export const MAX_AGENTS_CLEARED_AT_ENTRIES = 200;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
+
+/** thread key -> ISO cutoff for the Agents panel's hidden history. */
+export const AgentsClearedAtByThreadSchema = Schema.Record(Schema.String, Schema.String);
+
+export const EMPTY_AGENTS_CLEARED_AT_BY_THREAD: Record<string, string> = {};
+
+/**
+ * Bounds the persisted cutoff map so a long-lived install cannot grow it
+ * without limit; the oldest cutoffs fall off first (ISO sorts lexically).
+ */
+export function boundAgentsClearedAtByThread(
+  entries: Record<string, string>,
+): Record<string, string> {
+  const pairs = Object.entries(entries);
+  if (pairs.length <= MAX_AGENTS_CLEARED_AT_ENTRIES) {
+    return entries;
+  }
+  return Object.fromEntries(
+    pairs
+      .slice()
+      .sort((a, b) => b[1].localeCompare(a[1]))
+      .slice(0, MAX_AGENTS_CLEARED_AT_ENTRIES),
+  );
+}
 
 export function scheduleEnvironmentReconnectWarning(showWarning: () => void): () => void {
   const timeoutId = globalThis.setTimeout(showWarning, ENVIRONMENT_RECONNECT_WARNING_GRACE_MS);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -291,6 +291,10 @@ import {
   getStartedThreadModelChangeBlockReason,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
   LastInvokedScriptByProjectSchema,
+  AGENTS_CLEARED_AT_BY_THREAD_KEY,
+  AgentsClearedAtByThreadSchema,
+  boundAgentsClearedAtByThread,
+  EMPTY_AGENTS_CLEARED_AT_BY_THREAD,
   type LocalDispatchSnapshot,
   PullRequestDialogState,
   cloneComposerImageForRetry,
@@ -1361,6 +1365,11 @@ function ChatViewContent(props: ChatViewProps) {
     {},
     LastInvokedScriptByProjectSchema,
   );
+  const [agentsClearedAtByThreadKey, setAgentsClearedAtByThreadKey] = useLocalStorage(
+    AGENTS_CLEARED_AT_BY_THREAD_KEY,
+    EMPTY_AGENTS_CLEARED_AT_BY_THREAD,
+    AgentsClearedAtByThreadSchema,
+  );
   const legendListRef = useRef<LegendListRef | null>(null);
   const [composerOverlayElement, setComposerOverlayElement] = useState<HTMLDivElement | null>(null);
   const [composerOverlayHeight, setComposerOverlayHeight] = useState(0);
@@ -1543,6 +1552,30 @@ function ChatViewContent(props: ChatViewProps) {
     [activeThreadEnvironmentId, activeThreadId],
   );
   const activeThreadKey = activeThreadRef ? scopedThreadKey(activeThreadRef) : null;
+  const activeAgentsClearedAt =
+    activeThreadKey === null ? null : (agentsClearedAtByThreadKey[activeThreadKey] ?? null);
+  const handleClearInactiveAgents = useCallback(() => {
+    if (activeThreadKey === null) {
+      return;
+    }
+    const clearedAt = new Date().toISOString();
+    setAgentsClearedAtByThreadKey((current) =>
+      boundAgentsClearedAtByThread({ ...current, [activeThreadKey]: clearedAt }),
+    );
+  }, [activeThreadKey, setAgentsClearedAtByThreadKey]);
+  const handleShowAllAgents = useCallback(() => {
+    if (activeThreadKey === null) {
+      return;
+    }
+    setAgentsClearedAtByThreadKey((current) => {
+      if (current[activeThreadKey] === undefined) {
+        return current;
+      }
+      const next = { ...current };
+      delete next[activeThreadKey];
+      return next;
+    });
+  }, [activeThreadKey, setAgentsClearedAtByThreadKey]);
   const [timelineAnchor, setTimelineAnchor] = useState<{
     readonly threadKey: string | null;
     readonly messageId: MessageId | null;
@@ -5986,6 +6019,9 @@ function ChatViewContent(props: ChatViewProps) {
         model={agentPanelModel}
         environmentId={activeThreadRef?.environmentId ?? null}
         threadId={activeThreadRef?.threadId ?? null}
+        clearedAt={activeAgentsClearedAt}
+        onClearInactive={handleClearInactiveAgents}
+        onShowAll={handleShowAllAgents}
       />
     ) : (activeRightPanelSurface?.kind === "files" || activeRightPanelSurface?.kind === "file") &&
       activeProject &&

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -148,6 +148,7 @@ import { AgentsPanel } from "./AgentsPanel";
 import {
   deriveAgentPanelModel,
   foldSubagentActivities,
+  latestAgentActivityAt,
 } from "@t3tools/client-runtime/state/subagentRuntime";
 import { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
 import { BranchToolbar } from "./BranchToolbar";
@@ -1554,15 +1555,6 @@ function ChatViewContent(props: ChatViewProps) {
   const activeThreadKey = activeThreadRef ? scopedThreadKey(activeThreadRef) : null;
   const activeAgentsClearedAt =
     activeThreadKey === null ? null : (agentsClearedAtByThreadKey[activeThreadKey] ?? null);
-  const handleClearInactiveAgents = useCallback(() => {
-    if (activeThreadKey === null) {
-      return;
-    }
-    const clearedAt = new Date().toISOString();
-    setAgentsClearedAtByThreadKey((current) =>
-      boundAgentsClearedAtByThread({ ...current, [activeThreadKey]: clearedAt }),
-    );
-  }, [activeThreadKey, setAgentsClearedAtByThreadKey]);
   const handleShowAllAgents = useCallback(() => {
     if (activeThreadKey === null) {
       return;
@@ -2173,15 +2165,31 @@ function ChatViewContent(props: ChatViewProps) {
   // Native subagent fold: memoized by activity-list identity, shared by the
   // Agents surface, live strip, and workflow cards. v2Projection is null
   // until orchestration-v2 lands (source precedence lives in the derive).
-  // sessionLive derives interruption for agents orphaned by session death.
+  // sessionLive derives interruption for agents orphaned by session death;
+  // the session's updatedAt dates that derived transition.
   const agentSessionLive = phase !== "disconnected";
+  const agentSessionUpdatedAt = activeThread?.session?.updatedAt;
   const agentPanelModel = useMemo(
     () =>
       deriveAgentPanelModel({
-        agents: foldSubagentActivities(threadActivities, { sessionLive: agentSessionLive }),
+        agents: foldSubagentActivities(threadActivities, {
+          sessionLive: agentSessionLive,
+          sessionUpdatedAt: agentSessionUpdatedAt,
+        }),
       }),
-    [agentSessionLive, threadActivities],
+    [agentSessionLive, agentSessionUpdatedAt, threadActivities],
   );
+  const handleClearInactiveAgents = useCallback(() => {
+    if (activeThreadKey === null) {
+      return;
+    }
+    // Cutoff comes from the rows themselves: updatedAt is server-stamped, and
+    // a client clock ahead of the server would hide rows that settle later.
+    const clearedAt = latestAgentActivityAt(agentPanelModel) ?? new Date().toISOString();
+    setAgentsClearedAtByThreadKey((current) =>
+      boundAgentsClearedAtByThread({ ...current, [activeThreadKey]: clearedAt }),
+    );
+  }, [activeThreadKey, agentPanelModel, setAgentsClearedAtByThreadKey]);
   const pendingApprovals = useMemo(
     () => derivePendingApprovals(threadActivities),
     [threadActivities],

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -3,10 +3,12 @@ import { classifyTaskAgentKind, type OrchestrationThreadActivity } from "@t3tool
 import {
   applyAgentPanelClearedAt,
   deriveAgentPanelModel,
+  emptyAgentPanelModel,
   foldSubagentActivities,
   formatSubagentModelLabel,
   formatSubagentTokenCount,
   hasClearableAgents,
+  latestAgentActivityAt,
   isAgentAttributedToolActivity,
   isSubagentActivityKind,
   isTimelineBypassActivity,
@@ -797,6 +799,175 @@ describe("cleared agent panel models", () => {
     expect(hiddenCount).toBe(2);
     expect(hasClearableAgents(model)).toBe(true);
     expect(hasClearableAgents(visible)).toBe(false);
+  });
+
+  it("advances updatedAt when a late completion enriches an already-terminal row", () => {
+    const [agent] = fold([
+      activity(
+        "task.started",
+        { taskId: "late", taskType: "local_agent" },
+        "2026-08-01T09:00:00.000Z",
+      ),
+      activity("task.updated", { taskId: "late", status: "completed" }, "2026-08-01T09:01:00.000Z"),
+      activity(
+        "task.completed",
+        { taskId: "late", status: "completed", summary: "done", typedUsage: { totalTokens: 4 } },
+        "2026-08-03T09:02:00.000Z",
+      ),
+    ]);
+
+    expect(agent!.result).toBe("done");
+    // Frozen: the enrichment is not a transition.
+    expect(agent!.completedAt).toBe("2026-08-01T09:01:00.000Z");
+    // Advanced: a row cleared before its result landed must come back with it.
+    expect(agent!.updatedAt).toBe("2026-08-03T09:02:00.000Z");
+    expect(
+      applyAgentPanelClearedAt(deriveAgentPanelModel({ agents: [agent!] }), cutoff).hiddenCount,
+    ).toBe(0);
+  });
+
+  it("stamps session-derived interruption at the session timestamp so a cleared-while-working row returns", () => {
+    const rows = [
+      activity(
+        "task.started",
+        { taskId: "working", taskType: "local_agent" },
+        "2026-08-01T09:00:00.000Z",
+      ),
+      activity(
+        "task.progress",
+        { taskId: "working", status: "running" },
+        "2026-08-01T09:01:00.000Z",
+      ),
+    ];
+
+    const agents = foldSubagentActivities(rows, {
+      sessionLive: false,
+      sessionUpdatedAt: "2026-08-03T09:05:00.000Z",
+    });
+
+    expect(agents[0]!.status).toBe("interrupted");
+    expect(agents[0]!.updatedAt).toBe("2026-08-03T09:05:00.000Z");
+    expect(agents[0]!.completedAt).toBe("2026-08-01T09:01:00.000Z");
+    // Cleared while it was working (active rows survive a clear), then killed
+    // by session death after the cutoff: it must stay visible.
+    expect(applyAgentPanelClearedAt(deriveAgentPanelModel({ agents }), cutoff).hiddenCount).toBe(0);
+  });
+
+  it("falls back to the newest activity for session death and never stamps backwards", () => {
+    const rows = [
+      activity(
+        "task.started",
+        { taskId: "working", taskType: "local_agent" },
+        "2026-08-01T09:00:00.000Z",
+      ),
+      activity(
+        "task.progress",
+        { taskId: "working", status: "running" },
+        "2026-08-01T09:01:00.000Z",
+      ),
+      activity(
+        "task.started",
+        { taskId: "other", taskType: "local_agent" },
+        "2026-08-01T09:03:00.000Z",
+      ),
+    ];
+
+    expect(foldSubagentActivities(rows, { sessionLive: false })[0]!.updatedAt).toBe(
+      "2026-08-01T09:03:00.000Z",
+    );
+    // A session record older than the row cannot drag the stamp back.
+    expect(
+      foldSubagentActivities(rows, {
+        sessionLive: false,
+        sessionUpdatedAt: "2026-07-01T00:00:00.000Z",
+      })[0]!.updatedAt,
+    ).toBe("2026-08-01T09:01:00.000Z");
+  });
+
+  it("keeps a coordinator cascade from stamping a member in the past", () => {
+    const agents = fold([
+      activity(
+        "task.started",
+        { taskId: "wf", taskType: "local_workflow" },
+        "2026-08-01T10:00:00.000Z",
+      ),
+      activity(
+        "task.completed",
+        { taskId: "wf", taskType: "local_workflow", status: "failed" },
+        "2026-08-01T10:02:00.000Z",
+      ),
+      activity(
+        "task.progress",
+        { taskId: "wf:member", parentAgentId: "wf", status: "running" },
+        "2026-08-01T10:05:00.000Z",
+      ),
+    ]);
+    const member = agents.find((agent) => agent.id === "wf:member")!;
+
+    expect(member.status).toBe("interrupted");
+    expect(member.updatedAt).toBe("2026-08-01T10:05:00.000Z");
+  });
+});
+
+describe("latestAgentActivityAt", () => {
+  const model = (agents: ReadonlyArray<OrchestrationThreadActivity>) =>
+    deriveAgentPanelModel({ agents: fold(agents) });
+
+  it("returns the newest updatedAt across workflows and direct agents", () => {
+    expect(
+      latestAgentActivityAt(
+        model([
+          activity(
+            "task.started",
+            { taskId: "wf", taskType: "local_workflow" },
+            "2026-08-01T11:00:00.000Z",
+          ),
+          activity(
+            "task.progress",
+            { taskId: "wf:member", parentAgentId: "wf", status: "completed" },
+            "2026-08-01T11:04:00.000Z",
+          ),
+          activity(
+            "task.completed",
+            { taskId: "wf", taskType: "local_workflow", status: "completed" },
+            "2026-08-01T11:02:00.000Z",
+          ),
+          activity(
+            "task.started",
+            { taskId: "direct", taskType: "local_agent" },
+            "2026-08-01T11:01:00.000Z",
+          ),
+          activity(
+            "task.progress",
+            { taskId: "direct", status: "running" },
+            "2026-08-01T11:03:00.000Z",
+          ),
+        ]),
+      ),
+    ).toBe("2026-08-01T11:04:00.000Z");
+  });
+
+  it("returns null for an empty panel and skips undateable rows", () => {
+    expect(latestAgentActivityAt(emptyAgentPanelModel())).toBe(null);
+    const dated = model([
+      activity(
+        "task.started",
+        { taskId: "dated", taskType: "local_agent" },
+        "2026-08-01T12:00:00.000Z",
+      ),
+    ]).directAgents[0]!;
+    expect(
+      latestAgentActivityAt(
+        deriveAgentPanelModel({
+          agents: [dated, { ...dated, id: "undateable", updatedAt: "not-a-timestamp" }],
+        }),
+      ),
+    ).toBe("2026-08-01T12:00:00.000Z");
+    expect(
+      latestAgentActivityAt(
+        deriveAgentPanelModel({ agents: [{ ...dated, updatedAt: "not-a-timestamp" }] }),
+      ),
+    ).toBe(null);
   });
 });
 

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vite-plus/test";
 import { classifyTaskAgentKind, type OrchestrationThreadActivity } from "@t3tools/contracts";
 import {
+  applyAgentPanelClearedAt,
   deriveAgentPanelModel,
   foldSubagentActivities,
   formatSubagentModelLabel,
   formatSubagentTokenCount,
+  hasClearableAgents,
   isAgentAttributedToolActivity,
   isSubagentActivityKind,
   isTimelineBypassActivity,
@@ -479,6 +481,322 @@ describe("deriveAgentPanelModel", () => {
     const model = deriveAgentPanelModel({ agents: orphans });
     expect(model.workflows).toHaveLength(0);
     expect(model.directAgents.map((agent) => agent.id)).toEqual(["gone:wf:0"]);
+  });
+});
+
+describe("cleared agent panel models", () => {
+  const cutoff = "2026-08-02T00:00:00.000Z";
+
+  it("hides old inactive direct agents — idle included — while retaining working and newer rows with recalculated totals", () => {
+    const model = deriveAgentPanelModel({
+      agents: fold([
+        activity(
+          "task.started",
+          { taskId: "old-completed", taskType: "local_agent" },
+          "2026-08-01T08:00:00.000Z",
+        ),
+        activity(
+          "task.completed",
+          { taskId: "old-completed", status: "completed", typedUsage: { totalTokens: 1 } },
+          "2026-08-01T08:01:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "old-failed", taskType: "local_agent" },
+          "2026-08-01T08:02:00.000Z",
+        ),
+        activity(
+          "task.updated",
+          { taskId: "old-failed", status: "failed" },
+          "2026-08-01T08:03:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "old-cancelled", taskType: "local_agent" },
+          "2026-08-01T08:04:00.000Z",
+        ),
+        activity(
+          "task.updated",
+          { taskId: "old-cancelled", status: "cancelled" },
+          "2026-08-01T08:05:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "old-interrupted", taskType: "local_agent" },
+          "2026-08-01T08:06:00.000Z",
+        ),
+        activity(
+          "task.updated",
+          { taskId: "old-interrupted", status: "interrupted" },
+          "2026-08-01T08:07:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "running", taskType: "local_agent", typedUsage: { totalTokens: 5 } },
+          "2026-08-01T08:08:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          { taskId: "running", status: "running", typedUsage: { totalTokens: 5 } },
+          "2026-08-01T08:09:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "pending", taskType: "local_agent", typedUsage: { totalTokens: 6 } },
+          "2026-08-01T08:10:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          { taskId: "pending", status: "pending", typedUsage: { totalTokens: 6 } },
+          "2026-08-01T08:11:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "waiting", taskType: "local_agent", typedUsage: { totalTokens: 7 } },
+          "2026-08-01T08:12:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          { taskId: "waiting", status: "waiting", typedUsage: { totalTokens: 7 } },
+          "2026-08-01T08:13:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "idle", taskType: "local_agent", typedUsage: { totalTokens: 8 } },
+          "2026-08-01T08:14:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          { taskId: "idle", status: "idle", typedUsage: { totalTokens: 8 } },
+          "2026-08-01T08:15:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "reactivated", taskType: "local_agent", typedUsage: { totalTokens: 9 } },
+          "2026-08-01T08:16:00.000Z",
+        ),
+        activity(
+          "task.completed",
+          { taskId: "reactivated", status: "completed" },
+          "2026-08-01T08:17:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          { taskId: "reactivated", status: "running", typedUsage: { totalTokens: 9 } },
+          "2026-08-03T08:18:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "newly-completed", taskType: "local_agent", typedUsage: { totalTokens: 10 } },
+          "2026-08-01T08:19:00.000Z",
+        ),
+        activity(
+          "task.completed",
+          { taskId: "newly-completed", status: "completed", typedUsage: { totalTokens: 10 } },
+          "2026-08-03T08:20:00.000Z",
+        ),
+      ]),
+    });
+
+    const { model: visible, hiddenCount } = applyAgentPanelClearedAt(model, cutoff);
+
+    expect(visible.directAgents.map((agent) => agent.id)).toEqual([
+      "running",
+      "pending",
+      "waiting",
+      "reactivated",
+      "newly-completed",
+    ]);
+    expect(hiddenCount).toBe(5);
+    expect(visible.runningCount).toBe(3);
+    expect(visible.waitingCount).toBe(1);
+    expect(visible.idleCount).toBe(0);
+    expect(visible.settledCount).toBe(1);
+    expect(visible.totalTokens).toBe(37);
+    // newly-completed postdates the cutoff, so a second clear still has work.
+    expect(hasClearableAgents(visible)).toBe(true);
+  });
+
+  it("fails open for an invalid cutoff and clears rows with an undateable timestamp", () => {
+    const model = deriveAgentPanelModel({
+      agents: fold([
+        activity(
+          "task.started",
+          { taskId: "old", taskType: "local_agent" },
+          "2026-08-01T09:00:00.000Z",
+        ),
+        activity(
+          "task.completed",
+          { taskId: "old", status: "completed" },
+          "2026-08-01T09:01:00.000Z",
+        ),
+      ]),
+    });
+    const undateableModel = deriveAgentPanelModel({
+      agents: [{ ...model.directAgents[0]!, updatedAt: "not-a-timestamp" }],
+    });
+
+    // A bad cutoff leaves the model untouched, by reference.
+    expect(applyAgentPanelClearedAt(model, "not-a-timestamp").model).toBe(model);
+    expect(applyAgentPanelClearedAt(model, "not-a-timestamp").hiddenCount).toBe(0);
+    expect(applyAgentPanelClearedAt(model, null).model).toBe(model);
+    // A row we cannot date is still inactive: clear it rather than latch the
+    // affordance on forever.
+    expect(applyAgentPanelClearedAt(undateableModel, cutoff).model.hasAgents).toBe(false);
+    expect(applyAgentPanelClearedAt(undateableModel, cutoff).hiddenCount).toBe(1);
+  });
+
+  it("returns the same model reference when the cutoff hides nothing", () => {
+    const model = deriveAgentPanelModel({
+      agents: fold([
+        activity(
+          "task.started",
+          { taskId: "live", taskType: "local_agent" },
+          "2026-08-01T09:00:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          { taskId: "live", status: "running" },
+          "2026-08-01T09:01:00.000Z",
+        ),
+      ]),
+    });
+
+    const cleared = applyAgentPanelClearedAt(model, cutoff);
+
+    expect(cleared.model).toBe(model);
+    expect(cleared.hiddenCount).toBe(0);
+  });
+
+  it("treats every non-working status as clearable and keeps workflows atomic", () => {
+    const directModel = deriveAgentPanelModel({
+      agents: fold([
+        activity(
+          "task.started",
+          { taskId: "old-direct", taskType: "local_agent" },
+          "2026-08-01T09:10:00.000Z",
+        ),
+        activity(
+          "task.completed",
+          { taskId: "old-direct", status: "completed" },
+          "2026-08-01T09:11:00.000Z",
+        ),
+      ]),
+    });
+    const idleDirectModel = deriveAgentPanelModel({
+      agents: [{ ...directModel.directAgents[0]!, status: "idle" }],
+    });
+    const runningDirectModel = deriveAgentPanelModel({
+      agents: [{ ...directModel.directAgents[0]!, status: "running" }],
+    });
+    const waitingDirectModel = deriveAgentPanelModel({
+      agents: [{ ...directModel.directAgents[0]!, status: "waiting" }],
+    });
+    const workflowModel = deriveAgentPanelModel({
+      agents: fold([
+        activity(
+          "task.started",
+          { taskId: "old-workflow", taskType: "local_workflow" },
+          "2026-08-01T09:20:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          { taskId: "old-workflow:member", parentAgentId: "old-workflow", status: "completed" },
+          "2026-08-01T09:21:00.000Z",
+        ),
+        activity(
+          "task.completed",
+          { taskId: "old-workflow", taskType: "local_workflow", status: "completed" },
+          "2026-08-01T09:22:00.000Z",
+        ),
+      ]),
+    });
+    const workflow = workflowModel.workflows[0]!;
+    const idleMemberWorkflowModel = deriveAgentPanelModel({
+      agents: [workflow.workflow, { ...workflow.unphasedMembers[0]!, status: "idle" }],
+    });
+    const runningMemberWorkflowModel = deriveAgentPanelModel({
+      agents: [workflow.workflow, { ...workflow.unphasedMembers[0]!, status: "running" }],
+    });
+
+    expect(hasClearableAgents(directModel)).toBe(true);
+    // The regression this fixes: a resting Codex child used to be unclearable.
+    expect(hasClearableAgents(idleDirectModel)).toBe(true);
+    expect(hasClearableAgents(runningDirectModel)).toBe(false);
+    expect(hasClearableAgents(waitingDirectModel)).toBe(false);
+    expect(hasClearableAgents(workflowModel)).toBe(true);
+    expect(hasClearableAgents(idleMemberWorkflowModel)).toBe(true);
+    // One working member pins the whole group.
+    expect(hasClearableAgents(runningMemberWorkflowModel)).toBe(false);
+    // Offset-form cutoffs parse the same as Z-form.
+    expect(applyAgentPanelClearedAt(directModel, "2026-08-02T00:00:00+00:00").hiddenCount).toBe(1);
+  });
+
+  it("preserves a working workflow atomically and hides a fully inactive old workflow", () => {
+    const model = deriveAgentPanelModel({
+      agents: fold([
+        activity(
+          "task.started",
+          { taskId: "active-workflow", taskType: "local_workflow" },
+          "2026-08-01T10:00:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          {
+            taskId: "active-workflow:old-member",
+            parentAgentId: "active-workflow",
+            status: "completed",
+            typedUsage: { totalTokens: 11 },
+          },
+          "2026-08-01T10:01:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          {
+            taskId: "active-workflow:running-member",
+            parentAgentId: "active-workflow",
+            status: "running",
+            typedUsage: { totalTokens: 12 },
+          },
+          "2026-08-03T10:02:00.000Z",
+        ),
+        activity(
+          "task.started",
+          { taskId: "settled-workflow", taskType: "local_workflow" },
+          "2026-08-01T10:03:00.000Z",
+        ),
+        activity(
+          "task.progress",
+          {
+            taskId: "settled-workflow:member",
+            parentAgentId: "settled-workflow",
+            status: "completed",
+            typedUsage: { totalTokens: 13 },
+          },
+          "2026-08-01T10:04:00.000Z",
+        ),
+        activity(
+          "task.completed",
+          { taskId: "settled-workflow", taskType: "local_workflow", status: "completed" },
+          "2026-08-01T10:05:00.000Z",
+        ),
+      ]),
+    });
+
+    const { model: visible, hiddenCount } = applyAgentPanelClearedAt(model, cutoff);
+    const active = visible.workflows[0]!;
+
+    expect(visible.workflows.map((group) => group.workflow.id)).toEqual(["active-workflow"]);
+    expect(active.workflow.id).toBe("active-workflow");
+    // The settled member rides along: its group still has work in flight.
+    expect(
+      [...active.phases.flatMap((phase) => phase.members), ...active.unphasedMembers].map(
+        (member) => member.id,
+      ),
+    ).toEqual(["active-workflow:old-member", "active-workflow:running-member"]);
+    expect(hiddenCount).toBe(2);
+    expect(hasClearableAgents(model)).toBe(true);
+    expect(hasClearableAgents(visible)).toBe(false);
   });
 });
 

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -854,6 +854,82 @@ export function deriveAgentPanelModel({
   };
 }
 
+function workflowGroupEntries(group: AgentPanelWorkflowGroup): ReadonlyArray<RuntimeSubagent> {
+  return [
+    group.workflow,
+    ...group.phases.flatMap((phase) => phase.members),
+    ...group.unphasedMembers,
+  ];
+}
+
+/**
+ * Clearable = not actively working. Terminal rows are plainly done, and an
+ * idle row is resting-but-resumable — it piles up in the panel exactly like
+ * terminal history, which is the thing the user wants gone. Only
+ * pending/running/waiting survive a clear.
+ */
+function isClearableSubagent(agent: RuntimeSubagent): boolean {
+  return !isActiveSubagentStatus(agent.status);
+}
+
+function clearedByCutoff(agent: RuntimeSubagent, cutoff: number): boolean {
+  if (!isClearableSubagent(agent)) {
+    return false;
+  }
+  const updatedAt = Date.parse(agent.updatedAt);
+  // An undateable row cannot be shown to postdate the cutoff, and keeping it
+  // would latch the clear affordance on with nothing left to clear.
+  return Number.isNaN(updatedAt) || updatedAt <= cutoff;
+}
+
+export interface ClearedAgentPanelModel {
+  readonly model: AgentPanelModel;
+  /** Rows the cutoff hid, for the "N hidden · Show all" affordance. */
+  readonly hiddenCount: number;
+}
+
+/**
+ * Presentation-only history cutoff. Workflows stay atomic: any still-working
+ * or newer row preserves its entire coordinator/member group.
+ */
+export function applyAgentPanelClearedAt(
+  model: AgentPanelModel,
+  clearedAt: string | null,
+): ClearedAgentPanelModel {
+  if (clearedAt === null) {
+    return { model, hiddenCount: 0 };
+  }
+  const cutoff = Date.parse(clearedAt);
+  if (Number.isNaN(cutoff)) {
+    return { model, hiddenCount: 0 };
+  }
+
+  const groupEntries = model.workflows.map(workflowGroupEntries);
+  const totalCount =
+    groupEntries.reduce((sum, entries) => sum + entries.length, 0) + model.directAgents.length;
+  const visibleAgents = [
+    ...groupEntries.flatMap((entries) =>
+      entries.every((agent) => clearedByCutoff(agent, cutoff)) ? [] : entries,
+    ),
+    ...model.directAgents.filter((agent) => !clearedByCutoff(agent, cutoff)),
+  ];
+  const hiddenCount = totalCount - visibleAgents.length;
+
+  // Nothing hidden: hand back the same reference so the panel skips a re-derive.
+  return {
+    model: hiddenCount === 0 ? model : deriveAgentPanelModel({ agents: visibleAgents }),
+    hiddenCount,
+  };
+}
+
+/** Whether clearing now would hide anything. */
+export function hasClearableAgents(model: AgentPanelModel): boolean {
+  return (
+    model.directAgents.some(isClearableSubagent) ||
+    model.workflows.some((group) => workflowGroupEntries(group).every(isClearableSubagent))
+  );
+}
+
 /**
  * Members ordered by urgency for the capped inline workflow card: running and
  * failed first, then waiting, then most recently updated.

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -104,6 +104,20 @@ export function isActiveSubagentStatus(status: RuntimeSubagentStatus): boolean {
   return status === "pending" || status === "running" || status === "waiting";
 }
 
+/**
+ * Later of two ISO timestamps, unparseable-tolerant. Status transitions must
+ * never stamp updatedAt in the past: the Agents panel's clear cutoff hides
+ * rows by updatedAt, so a backwards stamp retroactively hides a row that just
+ * changed.
+ */
+function laterTimestamp(current: string, candidate: string): string {
+  const currentAt = Date.parse(current);
+  const candidateAt = Date.parse(candidate);
+  if (Number.isNaN(candidateAt)) return current;
+  if (Number.isNaN(currentAt)) return candidate;
+  return candidateAt > currentAt ? candidate : current;
+}
+
 const RECENT_ACTIVITY_LIMIT = 6;
 const SUMMARY_CHAR_LIMIT = 180;
 const ROSTER_LIMIT = 100;
@@ -455,12 +469,18 @@ function asRuntimeStatus(value: unknown): RuntimeSubagentStatus | undefined {
  * restart, crash) must not read as running forever (review finding: a dead
  * session left a panel full of "Working" agents while the sidebar showed
  * nothing). Idle is preserved — a resumable Codex child stays resumable.
+ * sessionUpdatedAt stamps that derived transition: it is when the session
+ * record entered its dead state, the only timestamp the interruption has.
  */
 export function foldSubagentActivities(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
-  options?: { readonly sessionLive?: boolean },
+  options?: {
+    readonly sessionLive?: boolean | undefined;
+    readonly sessionUpdatedAt?: string | undefined;
+  },
 ): ReadonlyArray<RuntimeSubagent> {
   const agents = new Map<string, MutableAgent>();
+  let latestActivityAt = "";
 
   for (const activity of activities) {
     if (typeof activity.payload !== "object" || activity.payload === null) {
@@ -468,6 +488,7 @@ export function foldSubagentActivities(
     }
     const payload = activity.payload as Record<string, unknown>;
     const at = activity.createdAt;
+    latestActivityAt = laterTimestamp(latestActivityAt, at);
 
     switch (activity.kind) {
       case "task.started": {
@@ -592,6 +613,10 @@ export function foldSubagentActivities(
             }
           }
           agent.usage = mergeUsageMax(agent.usage, asUsage(payload.typedUsage));
+          // Status and completedAt stay frozen, but the row did change: the
+          // Agents panel clear cutoff hides by updatedAt, and a row cleared
+          // before its result arrived would otherwise stay hidden forever.
+          agent.updatedAt = laterTimestamp(agent.updatedAt, at);
           break;
         }
         const status = TASK_COMPLETED_STATUS.get(asString(payload.status) ?? "") ?? "completed";
@@ -644,7 +669,9 @@ export function foldSubagentActivities(
       }
       member.status = agent.status === "completed" ? "completed" : "interrupted";
       member.completedAt = member.completedAt ?? agent.completedAt ?? agent.updatedAt;
-      member.updatedAt = agent.updatedAt;
+      // The cascade is a status transition: it may only move the member's
+      // stamp forward, never back to an older coordinator timestamp.
+      member.updatedAt = laterTimestamp(member.updatedAt, agent.updatedAt);
     }
   }
 
@@ -652,10 +679,16 @@ export function foldSubagentActivities(
   // them. Mirrors the server-side liveness registry clearing on
   // session.exited, so panel and sidebar can never disagree.
   if (options?.sessionLive === false) {
+    // The session's own timestamp dates the death; the newest activity is the
+    // fallback when the caller has no session record. Either way the stamp
+    // advances, so a clear issued while the agent was still working cannot
+    // retroactively hide the interruption (review finding).
+    const interruptedAt = options.sessionUpdatedAt ?? latestActivityAt;
     for (const agent of agents.values()) {
       if (isActiveSubagentStatus(agent.status)) {
         agent.status = "interrupted";
         agent.completedAt = agent.completedAt ?? agent.updatedAt;
+        agent.updatedAt = laterTimestamp(agent.updatedAt, interruptedAt);
       }
     }
   }
@@ -920,6 +953,23 @@ export function applyAgentPanelClearedAt(
     model: hiddenCount === 0 ? model : deriveAgentPanelModel({ agents: visibleAgents }),
     hiddenCount,
   };
+}
+
+/**
+ * Newest updatedAt on screen, or null when the panel holds no dateable row.
+ * The clear cutoff comes from here rather than the client clock: updatedAt is
+ * server-stamped, and a client running ahead of the server would hide rows
+ * that settle after the clear. Because the cutoff test is `<=`, this hides
+ * exactly the rows visible now and nothing stamped later.
+ */
+export function latestAgentActivityAt(model: AgentPanelModel): string | null {
+  let latest: string | null = null;
+  const agents = [...model.workflows.flatMap(workflowGroupEntries), ...model.directAgents];
+  for (const agent of agents) {
+    if (Number.isNaN(Date.parse(agent.updatedAt))) continue;
+    latest = latest === null ? agent.updatedAt : laterTimestamp(latest, agent.updatedAt);
+  }
+  return latest;
 }
 
 /** Whether clearing now would hide anything. */


### PR DESCRIPTION
Closes #5918

## What Changed

Adds a **Clear inactive** button to the Agents panel footer. It hides every
agent in the current thread that is not actively working — both settled
(completed / failed / cancelled / interrupted) and idle. Only `pending`,
`running`, and `waiting` agents stay.

Cleared rows are not gone: the footer shows **N hidden · Show all**, and the
empty state offers the same escape hatch. The cutoff is a timestamp stored in
`localStorage`, scoped per thread and capped at 200 entries.

Workflow groups stay atomic — if any member of a workflow is still working or
newer than the cutoff, the whole coordinator/member group remains visible.

## Why

On a long-lived thread the Agents panel accumulates finished and idle
subagents indefinitely, and there was no way to hide them. The working agent
you actually care about ends up buried in history.

Idle is deliberately treated as clearable. An idle agent is
resting-but-resumable, and in the panel it piles up exactly like a terminal
row — it is precisely the clutter being cleared. Gating only on terminal
statuses leaves the button dead in the common case.

## UI Changes

- Footer gains a **Clear inactive** button, disabled when there is nothing to
  clear.
- Footer gains a **N hidden · Show all** link once a cutoff is active.
- Empty state reads "No active agents" with a hidden count and a **Show all**
  button, instead of the generic "No agents yet".

*Before/after screenshots attached below.*
<img width="435" height="1386" alt="image" src="https://github.com/user-attachments/assets/5bc6a67e-d9cc-48dd-938a-d3964cae673b" />

<img width="486" height="1272" alt="image" src="https://github.com/user-attachments/assets/e692ff9b-3887-46d7-b495-5621d6a9dae2" />

## Verification

Run under Node 24.19.0 (the repo requires `^24.13.1`), re-run after rebasing
onto `upstream/main`.

```
packages/client-runtime $ npx vp test run src/state/subagentRuntime.test.ts
  Test Files  1 passed (1)
       Tests  51 passed (51)

apps/web $ npx vp test run src/components/ChatView.logic.test.ts
  Test Files  1 passed (1)
       Tests  41 passed (41)

packages/client-runtime $ npx tsgo --noEmit      # exit 0
apps/web              $ npx tsgo --noEmit        # exit 0
$ npx vp lint <changed files>                    # clean
$ npx vp fmt --check <changed files>             # clean
$ git diff --check                               # clean
```

New coverage: idle rows are clearable; invalid and undateable timestamps fail
safe; the model reference is preserved when nothing is hidden; workflow groups
clear atomically; the persisted map respects its 200-entry cap and round-trips
through its schema.

Manually verified in a dev build against a real thread: a panel holding two
idle agents and one working agent cleared to just the working agent, and
**Show all** restored the other two.

## Scope / Safety

This is a **presentation-level change only**. Clearing agents does **not**:

- cancel or interrupt any agent,
- delete provider history or transcripts,
- mutate orchestration state or emit any event.

Nothing server-side is touched — no commands, deciders, projectors, or provider
adapters. The cutoff lives entirely in client `localStorage`, is per thread, and
is reversible via **Show all**.

An agent that resumes after being cleared reappears on its own, because its
`updatedAt` advances past the cutoff. This is covered by unit test; it was not
exercised manually in the UI.

## Checklist

- [x] Focused tests pass for every changed file
- [x] Typecheck clean in both affected packages
- [x] Lint and format clean on the diff
- [x] `git diff --check` clean
- [x] Manually verified in a dev build
- [x] No server, event, or orchestration changes
- [ ] Before/after screenshots attached

---

Implemented with GPT-5.6 Sol through the Codex harness in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering and local persistence; no auth, server, or agent lifecycle changes beyond presentation-layer timestamp rules.
> 
> **Overview**
> Adds **Clear inactive** to the Agents panel so users can hide non-working agents (settled and idle) per thread without touching orchestration or server state. A per-thread ISO cutoff is stored in `localStorage` (capped at 200 threads), with **Show all** and footer/empty-state copy when rows are hidden.
> 
> `applyAgentPanelClearedAt`, `hasClearableAgents`, and `latestAgentActivityAt` in client-runtime filter the panel model by cutoff, treat workflow groups atomically, and derive the clear timestamp from visible agent `updatedAt` (not the client clock). `foldSubagentActivities` now accepts `sessionUpdatedAt` and only advances `updatedAt` forward so late completions, session death, and coordinator cascades do not leave cleared rows permanently hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2128e0ad3b9e33e86cf5e32e8b1fde711d304d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Clear inactive" button to the Agents panel with per-thread persistence
> - Adds a "Clear inactive" button to [AgentsPanel](https://github.com/pingdotgg/t3code/pull/5919/files#diff-10464442e3a11a770b2b1a5718e7a452453347c492f6aa0533f267063e2c6494) that hides agents whose last activity is at or before a cutoff timestamp; workflows are kept or hidden atomically.
> - The cutoff is stored per-thread in localStorage via `agentsClearedAtByThread`, bounded to the newest entries by `boundAgentsClearedAtByThread` to cap storage growth.
> - A "Show all" affordance appears when rows are hidden, and the hidden count is shown in the footer; status counts and total tokens reflect only visible agents.
> - `foldSubagentActivities` in [subagentRuntime.ts](https://github.com/pingdotgg/t3code/pull/5919/files#diff-b28278fe62e259afab164f07d2e56800ca49f60942f6b12da5f748e9415c8259) now tracks `updatedAt` more accurately: terminal rows enriched post-completion advance `updatedAt`, and session-death interruptions are stamped at `sessionUpdatedAt` to remain visible relative to a prior clear.
> - Behavioral Change: agents interrupted by session death now carry a server-derived timestamp that affects their visibility when a cleared-at cutoff is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2128e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->