### PR TITLE
fix(usage): unreachable environments no longer block the usage tab

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -92,8 +92,8 @@ export function UsageRouteScreen() {
   );
 
   // The pull spinner tracks re-scans of environments that have answered
-  // before. The initial scan renders its own placeholder, and an unreachable
-  // environment stays pending forever — neither may pin the spinner on.
+  // before. The initial scan renders its own placeholder, and the query
+  // deadline prevents an unreachable environment from pinning the spinner on.
   const refreshingUsage = environments.some((entry) => entry.isPending && entry.summary !== null);
   const showingLimits = tab === "limits";
   // One ScrollView serves both tabs, so the offset would otherwise carry over

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -185,7 +185,7 @@ export function UsageRouteScreen() {
               </Text>
             ) : isUnreachable ? (
               <Text className="py-16 text-center text-base text-foreground-muted">
-                No device reported usage. Reconnect a device or pull to scan again.
+                No device reported usage.
               </Text>
             ) : (
               <>

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -64,7 +64,7 @@ export function UsageRouteScreen() {
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
   const { days: windowDays, window } = windowSelection;
   const isPast24Hours = windowDays === 1;
-  const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
+  const { merged, environments, isPending, isPartial, isUnreachable, refresh } = useUsage(window);
   const limits = useRefreshLimits();
 
   const days = useMemo(
@@ -182,6 +182,10 @@ export function UsageRouteScreen() {
             ) : environments.length === 0 ? (
               <Text className="py-16 text-center text-base text-foreground-muted">
                 Connect an environment to see usage.
+              </Text>
+            ) : isUnreachable ? (
+              <Text className="py-16 text-center text-base text-foreground-muted">
+                No device reported usage. Reconnect a device or pull to scan again.
               </Text>
             ) : (
               <>

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -65,6 +65,11 @@ export interface UsageView {
    * improve by waiting on them, so they must not read as "still reporting".
    */
   readonly isPartial: boolean;
+  /**
+   * True when environments exist but none answered: every one failed or timed
+   * out. Pages show a no-report state instead of zero totals.
+   */
+  readonly isUnreachable: boolean;
   readonly refresh: () => void;
 }
 
@@ -119,6 +124,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
     environments,
     isPending: usage.isPending,
     isPartial: usage.isPartial,
+    isUnreachable: usage.isUnreachable,
     refresh,
   };
 }

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -10,29 +10,22 @@
  * @module state/usage
  */
 import { useAtomValue } from "@effect/atom-react";
+import { type UsageSummaryInput } from "@t3tools/contracts";
 import {
-  USAGE_CONTRACT_VERSION,
-  type EnvironmentId,
-  type UsageSummary,
-  type UsageSummaryInput,
-} from "@t3tools/contracts";
+  deriveUsageState,
+  environmentUsageStatus,
+  type EnvironmentUsageStatus,
+} from "@t3tools/client-runtime/state/usage";
 import { runAtomCommand } from "@t3tools/client-runtime/state/runtime";
-import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
-import * as Option from "effect/Option";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
+import { type MergedUsage } from "@t3tools/shared/usageMerge";
+import { Atom } from "effect/unstable/reactivity";
 import { useCallback, useMemo } from "react";
 
 import { appAtomRegistry } from "./atom-registry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
 
-export interface EnvironmentUsageStatus {
-  readonly environmentId: EnvironmentId;
-  readonly label: string;
-  readonly isPending: boolean;
-  readonly error: string | null;
-  readonly summary: UsageSummary | null;
-}
+export type { EnvironmentUsageStatus } from "@t3tools/client-runtime/state/usage";
 
 /**
  * Reads every environment's summary for one window.
@@ -49,13 +42,13 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
     const statuses: EnvironmentUsageStatus[] = [];
     for (const [environmentId, presentation] of presentations) {
       const result = get(serverEnvironment.usageSummary({ environmentId, input }));
-      statuses.push({
-        environmentId,
-        label: presentation.entry.target.label,
-        isPending: result.waiting,
-        error: result._tag === "Failure" ? "This environment could not report usage." : null,
-        summary: Option.getOrNull(AsyncResult.value(result)),
-      });
+      statuses.push(
+        environmentUsageStatus({
+          environmentId,
+          label: presentation.entry.target.label,
+          result,
+        }),
+      );
     }
     return statuses;
   }).pipe(Atom.withLabel(`mobile-usage:window:${windowKey}`)),
@@ -119,31 +112,13 @@ export function useUsage(input: UsageSummaryInput): UsageView {
     }
   }, [environments, windowKey]);
 
-  const merged = useMemo(() => {
-    const answered: EnvironmentUsage[] = environments.flatMap((environment) =>
-      environment.summary === null
-        ? []
-        : [
-            {
-              environmentId: environment.environmentId,
-              label: environment.label,
-              summary: environment.summary,
-            },
-          ],
-    );
-    return mergeUsage(answered, USAGE_CONTRACT_VERSION);
-  }, [environments]);
-
-  const answeredCount = environments.filter((environment) => environment.summary !== null).length;
-  const stillReporting = environments.filter(
-    (environment) => environment.summary === null && environment.error === null,
-  ).length;
+  const usage = useMemo(() => deriveUsageState(environments), [environments]);
 
   return {
-    merged,
+    merged: usage.merged,
     environments,
-    isPending: answeredCount === 0 && stillReporting > 0,
-    isPartial: answeredCount > 0 && stillReporting > 0,
+    isPending: usage.isPending,
+    isPartial: usage.isPartial,
     refresh,
   };
 }

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -129,6 +129,7 @@ function usageView() {
     environments: [],
     isPending: false,
     isPartial: false,
+    isUnreachable: false,
     refresh: vi.fn(),
   };
 }
@@ -174,6 +175,29 @@ describe("UsagePage loading coverage", () => {
     expect(markup).toContain("Laptop");
     expect(markup).toContain("Remote…");
     expect(markup).toContain("1 device still scanning");
+  });
+
+  it("shows the no-report notice instead of zero totals when nothing answered", () => {
+    testState.useUsage.mockReturnValue({
+      ...usageView(),
+      merged: mergeUsage([], USAGE_CONTRACT_VERSION),
+      environments: [
+        {
+          environmentId: EnvironmentId.make("away-environment"),
+          label: "Away Laptop",
+          isPending: false,
+          error: "This environment could not report usage.",
+          summary: null,
+        },
+      ],
+      isUnreachable: true,
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).toContain("No device reported usage.");
+    expect(markup).toContain("Away Laptop could not report usage.");
+    expect(markup).not.toContain("$0.00");
   });
 });
 

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -1,4 +1,4 @@
-import { EnvironmentId, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
+import { USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
 import { mergeUsage } from "@t3tools/shared/usageMerge";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
@@ -104,8 +104,10 @@ const modelTotals = Object.freeze([
   },
 ]);
 
-function usageView() {
-  return {
+beforeEach(() => {
+  testState.metric = "cost";
+  testState.breakdown = "time";
+  testState.useUsage.mockReturnValue({
     merged: {
       ...mergeUsage([], USAGE_CONTRACT_VERSION),
       models: modelTotals,
@@ -131,73 +133,6 @@ function usageView() {
     isPartial: false,
     isUnreachable: false,
     refresh: vi.fn(),
-  };
-}
-
-beforeEach(() => {
-  testState.metric = "cost";
-  testState.breakdown = "time";
-  testState.useUsage.mockReturnValue(usageView());
-});
-
-describe("UsagePage loading coverage", () => {
-  it("renders available totals while another environment is still reporting", () => {
-    const loaded = usageView();
-    testState.useUsage.mockReturnValue({
-      ...loaded,
-      merged: {
-        ...loaded.merged,
-        costUsd: 42.37,
-      },
-      environments: [
-        {
-          environmentId: EnvironmentId.make("loaded-environment"),
-          label: "Laptop",
-          isPending: false,
-          error: null,
-          summary: {},
-        },
-        {
-          environmentId: EnvironmentId.make("pending-environment"),
-          label: "Remote",
-          isPending: true,
-          error: null,
-          summary: null,
-        },
-      ],
-      isPartial: true,
-    });
-
-    const markup = renderToStaticMarkup(<UsagePage />);
-
-    expect(markup).toContain("$42.37");
-    expect(markup).toContain("$11.00");
-    expect(markup).toContain("Laptop");
-    expect(markup).toContain("Remote…");
-    expect(markup).toContain("1 device still scanning");
-  });
-
-  it("shows the no-report notice instead of zero totals when nothing answered", () => {
-    testState.useUsage.mockReturnValue({
-      ...usageView(),
-      merged: mergeUsage([], USAGE_CONTRACT_VERSION),
-      environments: [
-        {
-          environmentId: EnvironmentId.make("away-environment"),
-          label: "Away Laptop",
-          isPending: false,
-          error: "This environment could not report usage.",
-          summary: null,
-        },
-      ],
-      isUnreachable: true,
-    });
-
-    const markup = renderToStaticMarkup(<UsagePage />);
-
-    expect(markup).toContain("No device reported usage.");
-    expect(markup).toContain("Away Laptop could not report usage.");
-    expect(markup).not.toContain("$0.00");
   });
 });
 

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -1,4 +1,4 @@
-import { USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
+import { EnvironmentId, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
 import { mergeUsage } from "@t3tools/shared/usageMerge";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
@@ -104,10 +104,8 @@ const modelTotals = Object.freeze([
   },
 ]);
 
-beforeEach(() => {
-  testState.metric = "cost";
-  testState.breakdown = "time";
-  testState.useUsage.mockReturnValue({
+function usageView() {
+  return {
     merged: {
       ...mergeUsage([], USAGE_CONTRACT_VERSION),
       models: modelTotals,
@@ -132,6 +130,50 @@ beforeEach(() => {
     isPending: false,
     isPartial: false,
     refresh: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  testState.metric = "cost";
+  testState.breakdown = "time";
+  testState.useUsage.mockReturnValue(usageView());
+});
+
+describe("UsagePage loading coverage", () => {
+  it("renders available totals while another environment is still reporting", () => {
+    const loaded = usageView();
+    testState.useUsage.mockReturnValue({
+      ...loaded,
+      merged: {
+        ...loaded.merged,
+        costUsd: 42.37,
+      },
+      environments: [
+        {
+          environmentId: EnvironmentId.make("loaded-environment"),
+          label: "Laptop",
+          isPending: false,
+          error: null,
+          summary: {},
+        },
+        {
+          environmentId: EnvironmentId.make("pending-environment"),
+          label: "Remote",
+          isPending: true,
+          error: null,
+          summary: null,
+        },
+      ],
+      isPartial: true,
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).toContain("$42.37");
+    expect(markup).toContain("$11.00");
+    expect(markup).toContain("Laptop");
+    expect(markup).toContain("Remote…");
+    expect(markup).toContain("1 device still scanning");
   });
 });
 

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -69,7 +69,7 @@ export function UsagePage() {
   const [breakdown, setBreakdown] = useState<"model" | "time">("model");
   const { days: windowDays, window } = windowSelection;
   const isPast24Hours = windowDays === 1;
-  const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
+  const { merged, environments, isPending, isPartial, isUnreachable, refresh } = useUsage(window);
   const presentations = useAtomValue(environmentPresentations.presentationsAtom);
   const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
     reportFailure: false,
@@ -271,6 +271,17 @@ export function UsagePage() {
               <>
                 {environments.length > 1 ? <UsageDeviceStrip environments={environments} /> : null}
                 <UsageSkeleton />
+              </>
+            ) : isUnreachable ? (
+              <>
+                <UsageCoverageNotice
+                  environments={environments}
+                  duplicateSources={merged.duplicateSources}
+                  staleEnvironments={merged.staleEnvironments}
+                />
+                <p className="py-16 text-center text-sm text-muted-foreground">
+                  No device reported usage. Reconnect a device or refresh to scan again.
+                </p>
               </>
             ) : (
               <>

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -280,7 +280,7 @@ export function UsagePage() {
                   staleEnvironments={merged.staleEnvironments}
                 />
                 <p className="py-16 text-center text-sm text-muted-foreground">
-                  No device reported usage. Reconnect a device or refresh to scan again.
+                  No device reported usage.
                 </p>
               </>
             ) : (

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -75,11 +75,6 @@ export function UsagePage() {
     reportFailure: false,
   });
 
-  // Hold the content until every environment is terminal. Rendering merged
-  // totals while devices are still answering makes every number on the page
-  // jump as each one lands.
-  const settling = isPending || isPartial;
-
   const days = useMemo(
     () => enumerateDays(window.sinceDay, window.untilDay),
     [window.sinceDay, window.untilDay],
@@ -272,13 +267,16 @@ export function UsagePage() {
             ) : null}
             {showingLimits ? (
               <UsageLimitsSection />
-            ) : settling ? (
+            ) : isPending ? (
               <>
                 {environments.length > 1 ? <UsageDeviceStrip environments={environments} /> : null}
                 <UsageSkeleton />
               </>
             ) : (
               <>
+                {isPartial && environments.length > 1 ? (
+                  <UsageDeviceStrip environments={environments} />
+                ) : null}
                 <UsageCoverageNotice
                   environments={environments}
                   duplicateSources={merged.duplicateSources}
@@ -552,8 +550,7 @@ function Metric({ label, value }: { readonly label: string; readonly value: stri
 /**
  * Says plainly when the totals are incomplete: an environment that failed, or
  * one whose transcripts another environment already reported. Environments
- * that are still answering never reach this notice; the page shows the
- * loading skeleton until every one is terminal.
+ * that are still answering are reflected in the device strip above it.
  */
 function UsageCoverageNotice({
   environments,
@@ -575,10 +572,10 @@ function UsageCoverageNotice({
   return (
     <div className="flex flex-col gap-1 border border-border px-3 py-2 text-xs text-muted-foreground">
       {failed.map((environment) => (
-        <span key={environment.label}>{environment.label} could not report usage.</span>
+        <span key={environment.environmentId}>{environment.label} could not report usage.</span>
       ))}
       {stale.map((environment) => (
-        <span key={environment.label}>
+        <span key={environment.environmentId}>
           {environment.label} runs an older server version and is excluded from totals.
         </span>
       ))}
@@ -593,9 +590,8 @@ function UsageCoverageNotice({
 }
 
 /**
- * Per-device progress while the page waits for every environment to answer.
- * Only rendered with two or more devices; a lone device has nothing to
- * enumerate.
+ * Per-device progress while at least one environment is still answering. Only
+ * rendered with two or more devices; a lone device has nothing to enumerate.
  */
 function UsageDeviceStrip({
   environments,
@@ -651,7 +647,7 @@ function UsageDeviceStrip({
 /**
  * Stand-in with the loaded page's shape, using the shared `Skeleton` bars so it
  * breathes with the same `animate-skeleton` pulse as every other loading state.
- * Blocks fill in exactly once when the last device answers.
+ * Content appears when the first device answers.
  */
 function UsageSkeleton() {
   return (

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -7,29 +7,22 @@
  * @module state/usage
  */
 import { useAtomValue } from "@effect/atom-react";
+import { type UsageSummaryInput } from "@t3tools/contracts";
 import {
-  USAGE_CONTRACT_VERSION,
-  type EnvironmentId,
-  type UsageSummary,
-  type UsageSummaryInput,
-} from "@t3tools/contracts";
+  deriveUsageState,
+  environmentUsageStatus,
+  type EnvironmentUsageStatus,
+} from "@t3tools/client-runtime/state/usage";
 import { runAtomCommand } from "@t3tools/client-runtime/state/runtime";
-import * as Option from "effect/Option";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
+import { type MergedUsage } from "@t3tools/shared/usageMerge";
+import { Atom } from "effect/unstable/reactivity";
 import { useCallback, useMemo } from "react";
 
-import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
 
-export interface EnvironmentUsageStatus {
-  readonly environmentId: EnvironmentId;
-  readonly label: string;
-  readonly isPending: boolean;
-  readonly error: string | null;
-  readonly summary: UsageSummary | null;
-}
+export type { EnvironmentUsageStatus } from "@t3tools/client-runtime/state/usage";
 
 /**
  * Reads every environment's summary for one window.
@@ -46,13 +39,13 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
     const statuses: EnvironmentUsageStatus[] = [];
     for (const [environmentId, presentation] of presentations) {
       const result = get(serverEnvironment.usageSummary({ environmentId, input }));
-      statuses.push({
-        environmentId,
-        label: presentation.entry.target.label,
-        isPending: result.waiting,
-        error: result._tag === "Failure" ? "This environment could not report usage." : null,
-        summary: Option.getOrNull(AsyncResult.value(result)),
-      });
+      statuses.push(
+        environmentUsageStatus({
+          environmentId,
+          label: presentation.entry.target.label,
+          result,
+        }),
+      );
     }
     return statuses;
   }).pipe(Atom.withLabel(`web-usage:window:${windowKey}`)),
@@ -116,31 +109,13 @@ export function useUsage(input: UsageSummaryInput): UsageView {
     }
   }, [environments, windowKey]);
 
-  const merged = useMemo(() => {
-    const answered: EnvironmentUsage[] = environments.flatMap((environment) =>
-      environment.summary === null
-        ? []
-        : [
-            {
-              environmentId: environment.environmentId,
-              label: environment.label,
-              summary: environment.summary,
-            },
-          ],
-    );
-    return mergeUsage(answered, USAGE_CONTRACT_VERSION);
-  }, [environments]);
-
-  const answeredCount = environments.filter((environment) => environment.summary !== null).length;
-  const stillReporting = environments.filter(
-    (environment) => environment.summary === null && environment.error === null,
-  ).length;
+  const usage = useMemo(() => deriveUsageState(environments), [environments]);
 
   return {
-    merged,
+    merged: usage.merged,
     environments,
-    isPending: answeredCount === 0 && stillReporting > 0,
-    isPartial: answeredCount > 0 && stillReporting > 0,
+    isPending: usage.isPending,
+    isPartial: usage.isPartial,
     refresh,
   };
 }

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -62,6 +62,11 @@ export interface UsageView {
    * improve by waiting on them, so they must not read as "still reporting".
    */
   readonly isPartial: boolean;
+  /**
+   * True when environments exist but none answered: every one failed or timed
+   * out. Pages show a no-report state instead of zero totals.
+   */
+  readonly isUnreachable: boolean;
   readonly refresh: () => void;
 }
 
@@ -116,6 +121,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
     environments,
     isPending: usage.isPending,
     isPartial: usage.isPartial,
+    isUnreachable: usage.isUnreachable,
     refresh,
   };
 }

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -12,6 +12,9 @@ record are missing from the totals.
 If recent work is missing or a new model shows no cost, refresh to rescan session history and
 update model pricing.
 
+Results appear as each environment responds. An environment that cannot report within 30 seconds
+is marked unavailable without hiding results from other environments. Refresh to retry it.
+
 ## Set custom model prices
 
 On web or desktop, open **Usage → Model prices** to add, edit, or remove a model's estimated

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -13,7 +13,8 @@ If recent work is missing or a new model shows no cost, refresh to rescan sessio
 update model pricing.
 
 Results appear as each environment responds. An environment that cannot report within 30 seconds
-is marked unavailable without hiding results from other environments. Refresh to retry it.
+is marked unavailable without hiding results from other environments. If no environment reports,
+the page shows a no-report notice instead of zero totals. Refresh to retry.
 
 ## Set custom model prices
 

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -175,6 +175,10 @@
       "types": "./src/state/threads.ts",
       "default": "./src/state/threads.ts"
     },
+    "./state/usage": {
+      "types": "./src/state/usage.ts",
+      "default": "./src/state/usage.ts"
+    },
     "./state/subagentRuntime": {
       "types": "./src/state/subagentRuntime.ts",
       "default": "./src/state/subagentRuntime.ts"

--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -425,7 +425,7 @@ describe("environment query lifecycle", () => {
     ),
   );
 
-  it.effect("keeps the timeout deadline while the connection state changes", () =>
+  it.effect("keeps the timeout deadline through retries and restarts after refresh", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const harness = yield* makeEnvironmentQueryHarness(
@@ -467,6 +467,18 @@ describe("environment query lifecycle", () => {
         if (AsyncResult.isFailure(result)) {
           expect(Cause.squash(result.cause)).toMatchObject({ _tag: "TimeoutError" });
         }
+
+        registry.refresh(harness.atom);
+        yield* SubscriptionRef.set(harness.supervisorSession, Option.some(QUERY_RPC_SESSION));
+        yield* SubscriptionRef.set(
+          harness.supervisorState,
+          queryConnectionState({ generation: 2 }),
+        );
+        expect(
+          yield* AtomRegistry.getResult(registry, harness.atom, {
+            suspendOnWaiting: true,
+          }),
+        ).toBe("connected");
       }),
     ),
   );

--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -425,7 +425,7 @@ describe("environment query lifecycle", () => {
     ),
   );
 
-  it.effect("keeps the timeout deadline through retries and restarts after refresh", () =>
+  it.effect("keeps one 30-second timeout deadline through connection retries", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const harness = yield* makeEnvironmentQueryHarness(
@@ -444,7 +444,7 @@ describe("environment query lifecycle", () => {
             reportDefect: false,
             reportFailure: false,
           }),
-        ).pipe(Effect.timeout("31 seconds"), Effect.forkChild({ startImmediately: true }));
+        ).pipe(Effect.forkChild({ startImmediately: true }));
         yield* Effect.yieldNow;
         yield* TestClock.adjust("20 seconds");
         yield* SubscriptionRef.set(
@@ -460,25 +460,93 @@ describe("environment query lifecycle", () => {
           }),
         );
         yield* Effect.yieldNow;
-        yield* TestClock.adjust("11 seconds");
+        yield* TestClock.adjust("9 seconds");
+        expect(resultFiber.pollUnsafe()).toBeUndefined();
+
+        yield* TestClock.adjust("1 second");
+        expect(resultFiber.pollUnsafe()).toBeDefined();
         const result = yield* Fiber.join(resultFiber);
 
         expect(AsyncResult.isFailure(result)).toBe(true);
         if (AsyncResult.isFailure(result)) {
           expect(Cause.squash(result.cause)).toMatchObject({ _tag: "TimeoutError" });
         }
+      }),
+    ),
+  );
+
+  it.effect("restarts a timed-out query after an explicit refresh", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let executions = 0;
+        const harness = yield* makeEnvironmentQueryHarness(
+          Effect.suspend(() => {
+            executions += 1;
+            return executions === 1 ? Effect.never : Effect.succeed("refreshed");
+          }),
+          "30 seconds",
+        );
+        const registry = yield* mountEnvironmentQuery(harness.atom);
+        const firstResultFiber = yield* AtomRegistry.getResult(registry, harness.atom, {
+          suspendOnWaiting: true,
+        }).pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+
+        yield* Effect.yieldNow;
+        expect(executions).toBe(1);
+        yield* TestClock.adjust("30 seconds");
+        const firstResult = yield* Fiber.join(firstResultFiber);
+        expect(Exit.isFailure(firstResult)).toBe(true);
+        if (Exit.isFailure(firstResult)) {
+          expect(Cause.squash(firstResult.cause)).toMatchObject({ _tag: "TimeoutError" });
+        }
 
         registry.refresh(harness.atom);
+        expect(
+          yield* AtomRegistry.getResult(registry, harness.atom, {
+            suspendOnWaiting: true,
+          }),
+        ).toBe("refreshed");
+        expect(executions).toBe(2);
+      }),
+    ),
+  );
+
+  it.effect("recovers automatically when an environment reconnects after timing out", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeEnvironmentQueryHarness(
+          Effect.succeed("reconnected"),
+          "30 seconds",
+        );
+        yield* SubscriptionRef.set(
+          harness.supervisorState,
+          queryConnectionState({ phase: "connecting", stage: "opening" }),
+        );
+        yield* SubscriptionRef.set(harness.supervisorSession, Option.none());
+        const registry = yield* mountEnvironmentQuery(harness.atom);
+        const timedOutFiber = yield* AtomRegistry.getResult(registry, harness.atom, {
+          suspendOnWaiting: true,
+        }).pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust("30 seconds");
+        const timedOut = yield* Fiber.join(timedOutFiber);
+        expect(Exit.isFailure(timedOut)).toBe(true);
+        if (Exit.isFailure(timedOut)) {
+          expect(Cause.squash(timedOut.cause)).toMatchObject({ _tag: "TimeoutError" });
+        }
+
         yield* SubscriptionRef.set(harness.supervisorSession, Option.some(QUERY_RPC_SESSION));
         yield* SubscriptionRef.set(
           harness.supervisorState,
           queryConnectionState({ generation: 2 }),
         );
+        yield* Effect.yieldNow;
         expect(
           yield* AtomRegistry.getResult(registry, harness.atom, {
             suspendOnWaiting: true,
           }),
-        ).toBe("connected");
+        ).toBe("reconnected");
       }),
     ),
   );

--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "@effect/vitest";
 import { EnvironmentId } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
 import * as Deferred from "effect/Deferred";
+import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -12,6 +14,7 @@ import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
+import * as TestClock from "effect/testing/TestClock";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
 import {
@@ -81,6 +84,7 @@ function queryConnectionState(
 
 const makeEnvironmentQueryHarness = Effect.fn("TestEnvironmentQuery.makeHarness")(function* <A, E>(
   execute: Effect.Effect<A, E>,
+  timeout?: Duration.Input,
 ) {
   const supervisorState = yield* SubscriptionRef.make(queryConnectionState());
   const supervisorSession = yield* SubscriptionRef.make(Option.some(QUERY_RPC_SESSION));
@@ -104,12 +108,17 @@ const makeEnvironmentQueryHarness = Effect.fn("TestEnvironmentQuery.makeHarness"
     followStream,
     stateChanges: () => SubscriptionRef.changes(supervisorState),
   } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
+  const clock = yield* Clock.Clock;
   const runtime = Atom.runtime(
-    Layer.succeed(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+    Layer.merge(
+      Layer.succeed(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+      Layer.succeed(Clock.Clock, clock),
+    ),
   );
   const family = createEnvironmentQueryAtomFamily(runtime, {
     label: "test.environment-query",
     staleTimeMs: 60_000,
+    ...(timeout === undefined ? {} : { timeout }),
     execute: () => execute,
   });
 
@@ -411,6 +420,52 @@ describe("environment query lifecycle", () => {
         expect(result.waiting).toBe(false);
         if (AsyncResult.isFailure(result) && expectedFailure !== null) {
           expect(Cause.squash(result.cause)).toBe(expectedFailure);
+        }
+      }),
+    ),
+  );
+
+  it.effect("keeps the timeout deadline while the connection state changes", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeEnvironmentQueryHarness(
+          Effect.succeed("connected"),
+          "30 seconds",
+        );
+        yield* SubscriptionRef.set(
+          harness.supervisorState,
+          queryConnectionState({ phase: "connecting", stage: "opening" }),
+        );
+        yield* SubscriptionRef.set(harness.supervisorSession, Option.none());
+        const registry = yield* mountEnvironmentQuery(harness.atom);
+
+        const resultFiber = yield* Effect.promise(() =>
+          executeAtomQuery(registry, harness.atom, {
+            reportDefect: false,
+            reportFailure: false,
+          }),
+        ).pipe(Effect.timeout("31 seconds"), Effect.forkChild({ startImmediately: true }));
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust("20 seconds");
+        yield* SubscriptionRef.set(
+          harness.supervisorState,
+          queryConnectionState({
+            phase: "backoff",
+            stage: null,
+            lastFailure: new ConnectionTransientError({
+              reason: "transport",
+              detail: "Retrying.",
+            }),
+            retryAt: 21_000,
+          }),
+        );
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust("11 seconds");
+        const result = yield* Fiber.join(resultFiber);
+
+        expect(AsyncResult.isFailure(result)).toBe(true);
+        if (AsyncResult.isFailure(result)) {
+          expect(Cause.squash(result.cause)).toMatchObject({ _tag: "TimeoutError" });
         }
       }),
     ),

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -8,10 +8,7 @@ import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
-import type {
-  ConnectionAttemptError,
-  SupervisorConnectionState,
-} from "../connection/model.ts";
+import type { ConnectionAttemptError, SupervisorConnectionState } from "../connection/model.ts";
 import { EnvironmentNotRegisteredError, EnvironmentRegistry } from "../connection/registry.ts";
 import {
   type EnvironmentRpcInput,
@@ -68,10 +65,7 @@ interface EnvironmentSubscriptionAtomOptions<Input, A, E, R> {
   readonly idleTtlMs?: number;
 }
 
-type EnvironmentQueryConnection = readonly [
-  SupervisorConnectionState,
-  Option.Option<unknown>,
-];
+type EnvironmentQueryConnection = readonly [SupervisorConnectionState, Option.Option<unknown>];
 
 function environmentQueryConnectionEquals(
   left: EnvironmentQueryConnection,
@@ -93,9 +87,7 @@ function environmentQueryConnectionEquals(
   const leftFailed =
     left[0].phase === "available" || left[0].phase === "offline" || left[0].phase === "blocked";
   const rightFailed =
-    right[0].phase === "available" ||
-    right[0].phase === "offline" ||
-    right[0].phase === "blocked";
+    right[0].phase === "available" || right[0].phase === "offline" || right[0].phase === "blocked";
   if (leftFailed || rightFailed) {
     return (
       leftFailed &&
@@ -627,7 +619,10 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
         ? boundedQueryAtom
         : Atom.readable(
             (get) => get(boundedQueryAtom),
-            (refresh) => refresh(queryAtom),
+            (refresh) => {
+              refresh(queryAtom);
+              refresh(boundedQueryAtom);
+            },
           );
     const intervalQuery =
       options.refreshIntervalMs === undefined

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -1,5 +1,6 @@
 import { EnvironmentId, type EnvironmentId as EnvironmentIdType } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
@@ -7,7 +8,10 @@ import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
-import type { ConnectionAttemptError } from "../connection/model.ts";
+import type {
+  ConnectionAttemptError,
+  SupervisorConnectionState,
+} from "../connection/model.ts";
 import { EnvironmentNotRegisteredError, EnvironmentRegistry } from "../connection/registry.ts";
 import {
   type EnvironmentRpcInput,
@@ -55,12 +59,53 @@ interface EnvironmentQueryAtomOptions<Input, A, E, R> extends EnvironmentAtomOpt
     readonly environmentId: EnvironmentIdType;
     readonly input: Input;
   }) => Atom.Atom<unknown> | undefined;
+  readonly timeout?: Duration.Input;
 }
 
 interface EnvironmentSubscriptionAtomOptions<Input, A, E, R> {
   readonly label: string;
   readonly subscribe: (input: Input) => Stream.Stream<A, E, R>;
   readonly idleTtlMs?: number;
+}
+
+type EnvironmentQueryConnection = readonly [
+  SupervisorConnectionState,
+  Option.Option<unknown>,
+];
+
+function environmentQueryConnectionEquals(
+  left: EnvironmentQueryConnection,
+  right: EnvironmentQueryConnection,
+): boolean {
+  const leftSession = Option.getOrNull(left[1]);
+  const rightSession = Option.getOrNull(right[1]);
+  const leftConnected = left[0].phase === "connected" && leftSession !== null;
+  const rightConnected = right[0].phase === "connected" && rightSession !== null;
+  if (leftConnected || rightConnected) {
+    return (
+      leftConnected &&
+      rightConnected &&
+      left[0].generation === right[0].generation &&
+      leftSession === rightSession
+    );
+  }
+
+  const leftFailed =
+    left[0].phase === "available" || left[0].phase === "offline" || left[0].phase === "blocked";
+  const rightFailed =
+    right[0].phase === "available" ||
+    right[0].phase === "offline" ||
+    right[0].phase === "blocked";
+  if (leftFailed || rightFailed) {
+    return (
+      leftFailed &&
+      rightFailed &&
+      left[0].lastFailure === right[0].lastFailure &&
+      (left[0].lastFailure !== null || left[0].phase === right[0].phase)
+    );
+  }
+
+  return true;
 }
 
 export type SettledAsyncResult<A, E> = AsyncResult.Success<A, E> | AsyncResult.Failure<A, E>;
@@ -515,6 +560,7 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
             Effect.map((supervisor) =>
               SubscriptionRef.changes(supervisor.state).pipe(
                 Stream.zipLatest(SubscriptionRef.changes(supervisor.session)),
+                Stream.changesWith(environmentQueryConnectionEquals),
               ),
             ),
           ),
@@ -569,10 +615,24 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
         }),
         Atom.setIdleTTL(idleTtlMs),
       );
+    const timeout = options.timeout;
+    const boundedQueryAtom =
+      timeout === undefined
+        ? queryAtom
+        : runtime.atom((get) =>
+            get.result(queryAtom, { suspendOnWaiting: true }).pipe(Effect.timeout(timeout)),
+          );
+    const refreshableQueryAtom =
+      timeout === undefined
+        ? boundedQueryAtom
+        : Atom.readable(
+            (get) => get(boundedQueryAtom),
+            (refresh) => refresh(queryAtom),
+          );
     const intervalQuery =
       options.refreshIntervalMs === undefined
-        ? queryAtom
-        : queryAtom.pipe(Atom.withRefresh(options.refreshIntervalMs));
+        ? refreshableQueryAtom
+        : refreshableQueryAtom.pipe(Atom.withRefresh(options.refreshIntervalMs));
     const refreshTrigger = options.refreshTrigger?.(target);
     return (
       refreshTrigger === undefined
@@ -628,6 +688,7 @@ export function createEnvironmentRpcQueryAtomFamily<R, ER, TTag extends Environm
       readonly environmentId: EnvironmentIdType;
       readonly input: EnvironmentRpcInput<TTag>;
     }) => Atom.Atom<unknown> | undefined;
+    readonly timeout?: Duration.Input;
   },
 ) {
   return createEnvironmentQueryAtomFamily(runtime, {
@@ -638,6 +699,7 @@ export function createEnvironmentRpcQueryAtomFamily<R, ER, TTag extends Environm
       ? {}
       : { refreshIntervalMs: options.refreshIntervalMs }),
     ...(options.refreshTrigger === undefined ? {} : { refreshTrigger: options.refreshTrigger }),
+    ...(options.timeout === undefined ? {} : { timeout: options.timeout }),
     execute: (input: EnvironmentRpcInput<TTag>) => request(options.tag, input),
   });
 }

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -3,21 +3,25 @@ import {
   type ServerConfig,
   type ServerConfigStreamEvent,
   type ServerLifecycleWelcomePayload,
+  type UsageDay,
   WS_METHODS,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
 import * as Duration from "effect/Duration";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import * as TestClock from "effect/testing/TestClock";
+import { Atom, AtomRegistry } from "effect/unstable/reactivity";
 import { RpcClientError } from "effect/unstable/rpc";
 import * as Socket from "effect/unstable/socket/Socket";
 
@@ -25,12 +29,15 @@ import {
   AVAILABLE_CONNECTION_STATE,
   PrimaryConnectionTarget,
   type PreparedConnection,
+  type SupervisorConnectionState,
 } from "../connection/model.ts";
+import * as EnvironmentRegistry from "../connection/registry.ts";
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import * as Persistence from "../platform/persistence.ts";
 import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
 import type { RpcSession } from "../rpc/session.ts";
 import {
+  createServerEnvironmentAtoms,
   makeEnvironmentServerConfigState,
   isLegacyUpdateHandoffLoss,
   matchesServerUpdateReadyEvent,
@@ -84,6 +91,95 @@ function session(client: WsRpcProtocolClient): RpcSession {
     closed: Effect.never,
   };
 }
+
+describe("usage summary query", () => {
+  it.effect("settles an unreachable environment after 30 seconds", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const supervisorState = yield* SubscriptionRef.make<SupervisorConnectionState>({
+          ...AVAILABLE_CONNECTION_STATE,
+          desired: true,
+          network: "online",
+          phase: "connecting",
+          stage: "opening",
+          attempt: 1,
+        });
+        const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
+          target: TARGET,
+          state: supervisorState,
+          session: yield* SubscriptionRef.make<Option.Option<RpcSession>>(Option.none()),
+          prepared: yield* SubscriptionRef.make<Option.Option<PreparedConnection>>(Option.none()),
+          connect: Effect.void,
+          disconnect: Effect.void,
+          retryNow: Effect.void,
+        } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+        const followStream: EnvironmentRegistry.EnvironmentRegistry["Service"]["followStream"] = (
+          _environmentId,
+          stream,
+        ) => Stream.provideService(stream, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+        const environmentRegistry = EnvironmentRegistry.EnvironmentRegistry.of({
+          followStream,
+        } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
+        const cache = Persistence.EnvironmentCacheStore.of({
+          loadShell: () => Effect.succeed(Option.none()),
+          saveShell: () => Effect.void,
+          loadThread: () => Effect.succeed(Option.none()),
+          saveThread: () => Effect.void,
+          removeThread: () => Effect.void,
+          loadServerConfig: () => Effect.succeed(Option.none()),
+          saveServerConfig: () => Effect.void,
+          loadVcsRefs: () => Effect.succeed(Option.none()),
+          saveVcsRefs: () => Effect.void,
+          removeVcsRefs: () => Effect.void,
+          clearVcsRefs: () => Effect.void,
+          clear: () => Effect.void,
+        });
+        const clock = yield* Clock.Clock;
+        const runtime = Atom.runtime(
+          Layer.mergeAll(
+            Layer.succeed(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+            Layer.succeed(Persistence.EnvironmentCacheStore, cache),
+            Layer.succeed(Clock.Clock, clock),
+          ),
+        );
+        const atoms = createServerEnvironmentAtoms(runtime, {
+          initialConfigValueAtom: () => Atom.make(null),
+        });
+        const atom = atoms.usageSummary({
+          environmentId: TARGET.environmentId,
+          input: {
+            sinceDay: "2026-08-01" as UsageDay,
+            untilDay: "2026-08-29" as UsageDay,
+            timeZone: "UTC",
+          },
+        });
+        const registry = AtomRegistry.make();
+        const unmount = registry.mount(atom);
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            unmount();
+            registry.dispose();
+          }),
+        );
+        const resultFiber = yield* AtomRegistry.getResult(registry, atom, {
+          suspendOnWaiting: true,
+        }).pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust("29 seconds");
+        expect(resultFiber.pollUnsafe()).toBeUndefined();
+
+        yield* TestClock.adjust("1 second");
+        expect(resultFiber.pollUnsafe()).toBeDefined();
+        const result = yield* Fiber.join(resultFiber);
+        expect(Exit.isFailure(result)).toBe(true);
+        if (Exit.isFailure(result)) {
+          expect(Cause.squash(result.cause)).toMatchObject({ _tag: "TimeoutError" });
+        }
+      }),
+    ),
+  );
+});
 
 describe("update restart reconnect nudges", () => {
   it.effect("retries a desktop commit that was lost before delivery", () =>

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -907,13 +907,14 @@ export function createServerEnvironmentAtoms<R, E>(
       tag: WS_METHODS.serverGetResourceTelemetryHistory,
       staleTimeMs: 5_000,
     }),
-    // A cold transcript scan is measured in seconds, so keep the result around
-    // long enough that switching windows or re-rendering does not rescan.
+    // A cold transcript scan is measured in seconds, so cache the result while
+    // bounding each device so a disconnected registration cannot pin the view.
     usageSummary: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:server:usage-summary",
       tag: WS_METHODS.serverGetUsageSummary,
       staleTimeMs: 60_000,
       refreshTrigger: ({ environmentId }) => usagePricesAtom(environmentId),
+      timeout: "30 seconds",
     }),
     configProjection,
     welcome: createEnvironmentRpcSubscriptionAtomFamily(runtime, {

--- a/packages/client-runtime/src/state/usage.test.ts
+++ b/packages/client-runtime/src/state/usage.test.ts
@@ -70,6 +70,28 @@ function status(
 }
 
 describe("usage state", () => {
+  it("treats a waiting failure as reporting during retry", () => {
+    const failed = AsyncResult.failure<UsageSummary, string>(Cause.fail("offline"));
+    const retrying = status(ENVIRONMENT_B, AsyncResult.waitingFrom(Option.some(failed)));
+
+    expect(retrying).toMatchObject({
+      isPending: true,
+      error: null,
+      summary: null,
+    });
+    expect(deriveUsageState([retrying])).toMatchObject({
+      isPending: true,
+      isPartial: false,
+    });
+
+    const partial = deriveUsageState([
+      status(ENVIRONMENT_A, AsyncResult.success(summary(10))),
+      retrying,
+    ]);
+    expect(partial).toMatchObject({ isPending: false, isPartial: true });
+    expect(partial.merged.costUsd).toBe(10);
+  });
+
   it("renders partial totals, then excludes a failed environment's previous success", () => {
     const pendingA = status(ENVIRONMENT_A, AsyncResult.initial(true));
     const pendingB = status(ENVIRONMENT_B, AsyncResult.initial(true));

--- a/packages/client-runtime/src/state/usage.test.ts
+++ b/packages/client-runtime/src/state/usage.test.ts
@@ -83,6 +83,7 @@ describe("usage state", () => {
     expect(deriveUsageState([retrying])).toMatchObject({
       isPending: true,
       isPartial: false,
+      isUnreachable: false,
     });
 
     const partial = deriveUsageState([
@@ -120,9 +121,45 @@ describe("usage state", () => {
       error: "This environment could not report usage.",
       summary: null,
     });
-    expect(settled).toMatchObject({ isPending: false, isPartial: false });
+    expect(settled).toMatchObject({ isPending: false, isPartial: false, isUnreachable: false });
     expect(settled.merged.costUsd).toBe(10);
     expect(settled.merged.contributingEnvironments).toEqual([ENVIRONMENT_A]);
+  });
+
+  it("reports unreachable instead of zero totals once every environment has settled without an answer", () => {
+    const timedOut = (environmentId: typeof ENVIRONMENT_A) =>
+      status(environmentId, AsyncResult.failure(Cause.fail("timeout")));
+    const unreachable = deriveUsageState([timedOut(ENVIRONMENT_A), timedOut(ENVIRONMENT_B)]);
+    expect(unreachable).toMatchObject({ isPending: false, isPartial: false, isUnreachable: true });
+    expect(unreachable.merged.costUsd).toBe(0);
+
+    // A late answer restores totals.
+    const lateAnswer = deriveUsageState([
+      timedOut(ENVIRONMENT_A),
+      status(ENVIRONMENT_B, AsyncResult.success(summary(10))),
+    ]);
+    expect(lateAnswer).toMatchObject({ isPending: false, isPartial: false, isUnreachable: false });
+    expect(lateAnswer.merged.costUsd).toBe(10);
+
+    // Refresh puts the timed-out queries back to waiting, which reads as a new scan.
+    const retrying = deriveUsageState([
+      status(
+        ENVIRONMENT_A,
+        AsyncResult.waitingFrom(Option.some(AsyncResult.failure(Cause.fail("timeout")))),
+      ),
+      timedOut(ENVIRONMENT_B),
+    ]);
+    expect(retrying).toMatchObject({ isPending: true, isPartial: false, isUnreachable: false });
+
+    // An environment added after the others settled gets its own attempt.
+    const added = deriveUsageState([
+      timedOut(ENVIRONMENT_A),
+      timedOut(ENVIRONMENT_B),
+      status(EnvironmentId.make("environment-c"), AsyncResult.initial(true)),
+    ]);
+    expect(added).toMatchObject({ isPending: true, isPartial: false, isUnreachable: false });
+
+    expect(deriveUsageState([])).toMatchObject({ isUnreachable: false });
   });
 
   it("keeps the initial placeholder when only an incompatible environment has answered", () => {

--- a/packages/client-runtime/src/state/usage.test.ts
+++ b/packages/client-runtime/src/state/usage.test.ts
@@ -1,0 +1,119 @@
+import {
+  EnvironmentId,
+  USAGE_CONTRACT_VERSION,
+  type UsageDay,
+  type UsageSummary,
+} from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as Option from "effect/Option";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { describe, expect, it } from "vite-plus/test";
+
+import { deriveUsageState, environmentUsageStatus, type EnvironmentUsageStatus } from "./usage.ts";
+
+const ENVIRONMENT_A = EnvironmentId.make("environment-a");
+const ENVIRONMENT_B = EnvironmentId.make("environment-b");
+
+function summary(costUsd: number, contractVersion: number = USAGE_CONTRACT_VERSION): UsageSummary {
+  return {
+    contractVersion,
+    readAt: "2026-08-09T00:00:00.000Z",
+    timeZone: "UTC",
+    sinceDay: "2026-08-01" as UsageDay,
+    untilDay: "2026-08-09" as UsageDay,
+    buckets: [
+      {
+        day: "2026-08-09" as UsageDay,
+        provider: "claude",
+        model: "claude-fable-5",
+        totals: {
+          uncachedInputTokens: 100,
+          cachedInputTokens: 0,
+          cacheCreationTokens: 0,
+          outputTokens: 50,
+          reasoningTokens: 0,
+        },
+        costUsd,
+        cacheSavingsUsd: 0,
+        costSource: "modelPriced",
+        records: 1,
+        unpricedRecords: 0,
+        sessions: 1,
+      },
+    ],
+    sources: [
+      {
+        fingerprint: {
+          hostId: `host-${costUsd}`,
+          provider: "claude",
+          resolvedHomePath: `/home/${costUsd}/.claude`,
+          volumeId: `volume-${costUsd}`,
+        },
+        status: "ok",
+        scannedFiles: 1,
+        skippedFiles: 0,
+        malformedRecords: 0,
+        distinctSessions: 1,
+        message: null,
+      },
+    ],
+    pricing: { status: "fresh", source: "litellm", fetchedAt: null, knownModels: 1 },
+    scanDurationMs: 1,
+  };
+}
+
+function status(
+  environmentId: typeof ENVIRONMENT_A,
+  result: AsyncResult.AsyncResult<UsageSummary, string>,
+): EnvironmentUsageStatus {
+  return environmentUsageStatus({ environmentId, label: environmentId, result });
+}
+
+describe("usage state", () => {
+  it("renders partial totals, then excludes a failed environment's previous success", () => {
+    const pendingA = status(ENVIRONMENT_A, AsyncResult.initial(true));
+    const pendingB = status(ENVIRONMENT_B, AsyncResult.initial(true));
+    expect(deriveUsageState([pendingA, pendingB])).toMatchObject({
+      isPending: true,
+      isPartial: false,
+    });
+
+    const loadedA = status(ENVIRONMENT_A, AsyncResult.success(summary(10)));
+    const partial = deriveUsageState([loadedA, pendingB]);
+    expect(partial).toMatchObject({ isPending: false, isPartial: true });
+    expect(partial.merged.costUsd).toBe(10);
+
+    const previousB = AsyncResult.success<UsageSummary, string>(summary(20));
+    const failedB = status(
+      ENVIRONMENT_B,
+      AsyncResult.failure(Cause.fail("offline"), {
+        previousSuccess: Option.some(previousB),
+      }),
+    );
+    const settled = deriveUsageState([loadedA, failedB]);
+
+    expect(failedB).toMatchObject({
+      isPending: false,
+      error: "This environment could not report usage.",
+      summary: null,
+    });
+    expect(settled).toMatchObject({ isPending: false, isPartial: false });
+    expect(settled.merged.costUsd).toBe(10);
+    expect(settled.merged.contributingEnvironments).toEqual([ENVIRONMENT_A]);
+  });
+
+  it("keeps the initial placeholder when only an incompatible environment has answered", () => {
+    const incompatible = status(
+      ENVIRONMENT_A,
+      AsyncResult.success(summary(10, USAGE_CONTRACT_VERSION - 1)),
+    );
+    const state = deriveUsageState([
+      incompatible,
+      status(ENVIRONMENT_B, AsyncResult.initial(true)),
+    ]);
+
+    expect(state).toMatchObject({ isPending: true, isPartial: false });
+    expect(state.merged.costUsd).toBe(0);
+    expect(state.merged.staleEnvironments).toEqual([ENVIRONMENT_A]);
+  });
+});

--- a/packages/client-runtime/src/state/usage.test.ts
+++ b/packages/client-runtime/src/state/usage.test.ts
@@ -1,6 +1,7 @@
 import {
   EnvironmentId,
   USAGE_CONTRACT_VERSION,
+  USAGE_MERGE_COMPATIBLE_SINCE,
   type UsageDay,
   type UsageSummary,
 } from "@t3tools/contracts";
@@ -127,7 +128,7 @@ describe("usage state", () => {
   it("keeps the initial placeholder when only an incompatible environment has answered", () => {
     const incompatible = status(
       ENVIRONMENT_A,
-      AsyncResult.success(summary(10, USAGE_CONTRACT_VERSION - 1)),
+      AsyncResult.success(summary(10, USAGE_MERGE_COMPATIBLE_SINCE - 1)),
     );
     const state = deriveUsageState([
       incompatible,
@@ -137,5 +138,16 @@ describe("usage state", () => {
     expect(state).toMatchObject({ isPending: true, isPartial: false });
     expect(state.merged.costUsd).toBe(0);
     expect(state.merged.staleEnvironments).toEqual([ENVIRONMENT_A]);
+  });
+
+  it("renders a compatible older answer while another environment is reporting", () => {
+    const state = deriveUsageState([
+      status(ENVIRONMENT_A, AsyncResult.success(summary(10, USAGE_MERGE_COMPATIBLE_SINCE))),
+      status(ENVIRONMENT_B, AsyncResult.initial(true)),
+    ]);
+
+    expect(state).toMatchObject({ isPending: false, isPartial: true });
+    expect(state.merged.costUsd).toBe(10);
+    expect(state.merged.staleEnvironments).toEqual([]);
   });
 });

--- a/packages/client-runtime/src/state/usage.ts
+++ b/packages/client-runtime/src/state/usage.ts
@@ -21,6 +21,12 @@ export interface DerivedUsageState {
   readonly isPending: boolean;
   /** True after a compatible answer lands while another environment is still answering. */
   readonly isPartial: boolean;
+  /**
+   * True when environments exist but none gave a usable answer and none is
+   * still trying: every one failed, timed out, or runs an incompatible server.
+   * The merged zeros are not data, so pages must not show them as totals.
+   */
+  readonly isUnreachable: boolean;
 }
 
 /** A waiting failure is retrying; only a settled failure should surface as an error. */
@@ -67,5 +73,6 @@ export function deriveUsageState(
     merged,
     isPending: compatibleAnswers === 0 && stillReporting > 0,
     isPartial: compatibleAnswers > 0 && stillReporting > 0,
+    isUnreachable: environments.length > 0 && compatibleAnswers === 0 && stillReporting === 0,
   };
 }

--- a/packages/client-runtime/src/state/usage.ts
+++ b/packages/client-runtime/src/state/usage.ts
@@ -18,13 +18,13 @@ export interface DerivedUsageState {
   readonly isPartial: boolean;
 }
 
-/** Maps only the current result; a failure's cached previous success is not current usage. */
+/** A waiting failure is retrying; only a settled failure should surface as an error. */
 export function environmentUsageStatus<E>(input: {
   readonly environmentId: EnvironmentId;
   readonly label: string;
   readonly result: AsyncResult.AsyncResult<UsageSummary, E>;
 }): EnvironmentUsageStatus {
-  const failed = AsyncResult.isFailure(input.result);
+  const failed = AsyncResult.isFailure(input.result) && !input.result.waiting;
   return {
     environmentId: input.environmentId,
     label: input.label,

--- a/packages/client-runtime/src/state/usage.ts
+++ b/packages/client-runtime/src/state/usage.ts
@@ -1,0 +1,64 @@
+import { USAGE_CONTRACT_VERSION, type EnvironmentId, type UsageSummary } from "@t3tools/contracts";
+import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
+import { AsyncResult } from "effect/unstable/reactivity";
+
+export interface EnvironmentUsageStatus {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly isPending: boolean;
+  readonly error: string | null;
+  readonly summary: UsageSummary | null;
+}
+
+export interface DerivedUsageState {
+  readonly merged: MergedUsage;
+  /** True until at least one compatible environment has answered. */
+  readonly isPending: boolean;
+  /** True after a compatible answer lands while another environment is still answering. */
+  readonly isPartial: boolean;
+}
+
+/** Maps only the current result; a failure's cached previous success is not current usage. */
+export function environmentUsageStatus<E>(input: {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly result: AsyncResult.AsyncResult<UsageSummary, E>;
+}): EnvironmentUsageStatus {
+  const failed = AsyncResult.isFailure(input.result);
+  return {
+    environmentId: input.environmentId,
+    label: input.label,
+    isPending: input.result.waiting,
+    error: failed ? "This environment could not report usage." : null,
+    summary: AsyncResult.isSuccess(input.result) ? input.result.value : null,
+  };
+}
+
+export function deriveUsageState(
+  environments: readonly EnvironmentUsageStatus[],
+): DerivedUsageState {
+  const answered: EnvironmentUsage[] = environments.flatMap((environment) =>
+    environment.error !== null || environment.summary === null
+      ? []
+      : [
+          {
+            environmentId: environment.environmentId,
+            label: environment.label,
+            summary: environment.summary,
+          },
+        ],
+  );
+  const merged = mergeUsage(answered, USAGE_CONTRACT_VERSION);
+  const compatibleAnswers = answered.filter(
+    (environment) => environment.summary.contractVersion === USAGE_CONTRACT_VERSION,
+  ).length;
+  const stillReporting = environments.filter(
+    (environment) => environment.summary === null && environment.error === null,
+  ).length;
+
+  return {
+    merged,
+    isPending: compatibleAnswers === 0 && stillReporting > 0,
+    isPartial: compatibleAnswers > 0 && stillReporting > 0,
+  };
+}

--- a/packages/client-runtime/src/state/usage.ts
+++ b/packages/client-runtime/src/state/usage.ts
@@ -1,4 +1,9 @@
-import { USAGE_CONTRACT_VERSION, type EnvironmentId, type UsageSummary } from "@t3tools/contracts";
+import {
+  USAGE_CONTRACT_VERSION,
+  USAGE_MERGE_COMPATIBLE_SINCE,
+  type EnvironmentId,
+  type UsageSummary,
+} from "@t3tools/contracts";
 import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
 import { AsyncResult } from "effect/unstable/reactivity";
 
@@ -50,7 +55,9 @@ export function deriveUsageState(
   );
   const merged = mergeUsage(answered, USAGE_CONTRACT_VERSION);
   const compatibleAnswers = answered.filter(
-    (environment) => environment.summary.contractVersion === USAGE_CONTRACT_VERSION,
+    (environment) =>
+      environment.summary.contractVersion >= USAGE_MERGE_COMPATIBLE_SINCE &&
+      environment.summary.contractVersion <= USAGE_CONTRACT_VERSION,
   ).length;
   const stillReporting = environments.filter(
     (environment) => environment.summary === null && environment.error === null,


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-6 on behalf of Oliver**

Resolves #6363, #6045

## What Changed

- Usage fetching now times out per environment after 30 seconds, and the usage tab renders as soon as the first environment answers instead of waiting for all of them. 

- The device strip and coverage notice show a timed-out or failed environment as unavailable while reachable environments still contribute their numbers.
- **Refresh** retries the unavailable ones.
- When every environment fails or times out, web and mobile show a "No device reported usage" notice instead of a zero-totals dashboard. Refresh scans again, and a late answer restores the totals on its own.

## Why

- An environment that never connects, like a Tailscale box while Tailscale is off, used to pin the whole tab on the loading skeleton forever. A timeout plus an optional retry lets you see your usage without first fixing every environment you have configured.

- This does reverse an earlier decision.
    - The page used to hold all content until every environment settled so totals never jumped as devices landed. That tradeoff assumed every environment settles. 
    - When one never does, holding the page means showing nothing indefinitely, which is worse than numbers that tick up. 

- The device strip stays up while environments are still reporting, so you can tell a partial total from a final one.

## UI Changes

<img width="3600" height="2338" alt="SCR-20260809-nwgr" src="https://github.com/user-attachments/assets/686e9c54-28ed-49a6-b25f-fef7fb30083e" />
<img width="3600" height="2338" alt="SCR-20260809-omrs" src="https://github.com/user-attachments/assets/f5d14414-effa-4193-8a23-f2d96de8c2fa" />
<img width="3600" height="2338" alt="SCR-20260809-ongd" src="https://github.com/user-attachments/assets/6d435637-9942-4879-aee7-1e4638077807" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

---

Implemented by GPT-5.6 Sol and Fable 5.1 via Codex and T3 Code. Rebased by GPT-5.6 Sol; test trimming by GPT-6 through Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unreachable environments blocking usage tab by adding 30s query timeout and shared unreachable state
> - Environment usage queries now fail with a timeout after 30 seconds instead of staying pending indefinitely; a timed-out query can be retried via explicit refresh or automatic reconnect
> - Usage state derivation (merge, pending, partial, unreachable) moves into the shared `client-runtime` package so web and mobile use the same logic via `deriveUsageState` and `environmentUsageStatus`
> - Web and mobile Usage pages now render the first compatible environment's totals while others still scan, and show a no-report message when all environments settle without a usable answer
> - Connection-state comparator in `environmentQueryConnectionEquals` dedupes equivalent transient, connected, and failed states so query subscribers no longer receive no-op connection changes
> - Behavioral Change: `UsageView` gains a required `isUnreachable` boolean field on both platforms; any caller of `useUsage` that mocks or destructures the return must include it. `UsageCoverageNotice` row keys change from labels to environment IDs, which may affect snapshots or tests relying on label-based keys.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 028f6ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->