### PR TITLE
Add Cmd-R shortcut to rename threads

### DIFF
--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -180,4 +180,25 @@ describe("DesktopApplicationMenu", () => {
       assert.equal(yield* Deferred.await(selectedAction), "zoom-in");
     }),
   );
+
+  it.effect("leaves the primary reload shortcut available to renderer keybindings", () =>
+    Effect.gen(function* () {
+      const selectedAction = yield* Deferred.make<string>();
+      const applicationMenuTemplate =
+        yield* Deferred.make<readonly Electron.MenuItemConstructorOptions[]>();
+
+      yield* configureMenu(selectedAction, applicationMenuTemplate);
+
+      const template = yield* Deferred.await(applicationMenuTemplate);
+      const viewMenu = template.find((item) => item.label === "View");
+      assert.isDefined(viewMenu);
+      if (!Array.isArray(viewMenu.submenu)) {
+        throw new Error("Expected View menu submenu to be an array.");
+      }
+
+      const reload = viewMenu.submenu.find((item) => item.role === "reload");
+      assert.isDefined(reload);
+      assert.equal(reload.accelerator, "CmdOrCtrl+Alt+R");
+    }),
+  );
 });

--- a/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -187,7 +187,7 @@ export const make = Effect.gen(function* () {
       {
         label: "View",
         submenu: [
-          { role: "reload" },
+          { role: "reload", accelerator: "CmdOrCtrl+Alt+R" },
           { role: "forceReload" },
           { role: "toggleDevTools" },
           { type: "separator" },

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -194,6 +194,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       );
 
       assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
+      assert.equal(defaultsByCommand.get("thread.rename"), "mod+r");
       assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("thread.jump.9"), "mod+9");

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -74,6 +74,7 @@ import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
+import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isMacPlatform } from "../lib/utils";
 import {
@@ -176,6 +177,7 @@ import {
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   resolveProjectStatusIndicator,
+  resolveThreadRenameTargetKey,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
@@ -225,6 +227,11 @@ const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> =
 };
 const SIDEBAR_ICON_ACTION_BUTTON_CLASS =
   "inline-flex h-6 min-w-6 cursor-pointer items-center justify-center rounded-md px-[calc(--spacing(1)-1px)] text-icon-muted hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring";
+
+interface ThreadRenameRequest {
+  id: number;
+  threadKey: string;
+}
 
 function SidebarThreadDetailPrewarmer({ threadRef }: { readonly threadRef: ScopedThreadRef }) {
   useEnvironmentThread(threadRef.environmentId, threadRef.threadId);
@@ -1051,6 +1058,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
 
 interface SidebarProjectItemProps {
   project: SidebarProjectSnapshot;
+  threadRenameRequest: ThreadRenameRequest | null;
   isThreadListExpanded: boolean;
   activeRouteThreadKey: string | null;
   newThreadShortcutLabel: string | null;
@@ -1071,6 +1079,7 @@ interface SidebarProjectItemProps {
 const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjectItemProps) {
   const {
     project,
+    threadRenameRequest,
     isThreadListExpanded,
     activeRouteThreadKey,
     newThreadShortcutLabel,
@@ -1205,6 +1214,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   >("inherit");
   const renamingCommittedRef = useRef(false);
   const renamingInputRef = useRef<HTMLInputElement | null>(null);
+  const handledThreadRenameRequestIdRef = useRef<number | null>(null);
   const confirmArchiveButtonRefs = useRef(new Map<string, HTMLButtonElement>());
   const memberProjectByScopedKey = useMemo(
     () =>
@@ -1973,6 +1983,21 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     setRenamingTitle(title);
     renamingCommittedRef.current = false;
   }, []);
+
+  useEffect(() => {
+    if (
+      !threadRenameRequest ||
+      handledThreadRenameRequestIdRef.current === threadRenameRequest.id
+    ) {
+      return;
+    }
+    const thread = sidebarThreadByKeyRef.current.get(threadRenameRequest.threadKey);
+    if (!thread) {
+      return;
+    }
+    handledThreadRenameRequestIdRef.current = threadRenameRequest.id;
+    startThreadRename(threadRenameRequest.threadKey, thread.title);
+  }, [startThreadRename, threadRenameRequest]);
 
   const commitRename = useCallback(
     async (threadRef: ScopedThreadRef, newTitle: string, originalTitle: string) => {
@@ -2746,6 +2771,7 @@ interface SidebarProjectsContentProps {
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   sortedProjects: readonly SidebarProjectSnapshot[];
+  threadRenameRequest: ThreadRenameRequest | null;
   expandedThreadListsByProject: ReadonlySet<string>;
   activeRouteProjectKey: string | null;
   routeThreadKey: string | null;
@@ -2786,6 +2812,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     archiveThread,
     deleteThread,
     sortedProjects,
+    threadRenameRequest,
     expandedThreadListsByProject,
     activeRouteProjectKey,
     routeThreadKey,
@@ -2925,6 +2952,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                     {(dragHandleProps) => (
                       <SidebarProjectItem
                         project={project}
+                        threadRenameRequest={threadRenameRequest}
                         isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                         activeRouteThreadKey={
                           activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -2957,6 +2985,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
               <SidebarProjectListRow
                 key={project.projectKey}
                 project={project}
+                threadRenameRequest={threadRenameRequest}
                 isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                 activeRouteThreadKey={
                   activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -3027,6 +3056,8 @@ export default function LegacySidebar() {
   const [expandedThreadListsByProject, setExpandedThreadListsByProject] = useState<
     ReadonlySet<string>
   >(() => new Set());
+  const [threadRenameRequest, setThreadRenameRequest] = useState<ThreadRenameRequest | null>(null);
+  const threadRenameRequestIdRef = useRef(0);
   const { showThreadJumpHints, updateThreadJumpHintsVisibility } = useThreadJumpHintVisibility();
   const dragInProgressRef = useRef(false);
   const suppressProjectClickAfterDragRef = useRef(false);
@@ -3155,6 +3186,7 @@ export default function LegacySidebar() {
     () => ({
       terminalFocus: isTerminalFocused(),
       terminalOpen: routeTerminalOpen,
+      previewFocus: isPreviewFocused(),
       modelPickerOpen: isModelPickerOpen(),
     }),
     [routeTerminalOpen],
@@ -3413,6 +3445,23 @@ export default function LegacySidebar() {
         platform,
         context: shortcutContext,
       });
+      if (command === "thread.rename") {
+        event.preventDefault();
+        event.stopPropagation();
+        const targetThreadKey = resolveThreadRenameTargetKey({
+          selectedThreadKeys: useThreadSelectionStore.getState().selectedThreadKeys,
+          activeThreadKey: routeThreadKey,
+        });
+        if (!targetThreadKey) return;
+        const targetThread = sidebarThreadByKey.get(targetThreadKey);
+        if (!targetThread) return;
+        threadRenameRequestIdRef.current += 1;
+        setThreadRenameRequest({
+          id: threadRenameRequestIdRef.current,
+          threadKey: targetThreadKey,
+        });
+        return;
+      }
       const traversalDirection = threadTraversalDirectionFromCommand(command);
       if (traversalDirection !== null) {
         const targetThreadKey = resolveAdjacentThreadId({
@@ -3610,6 +3659,7 @@ export default function LegacySidebar() {
         archiveThread={archiveThread}
         deleteThread={deleteThread}
         sortedProjects={sortedProjects}
+        threadRenameRequest={threadRenameRequest}
         expandedThreadListsByProject={expandedThreadListsByProject}
         activeRouteProjectKey={activeRouteProjectKey}
         routeThreadKey={routeThreadKey}

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -7,6 +7,7 @@ import {
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
   resolveAdjacentThreadId,
+  resolveThreadRenameTargetKey,
   getFallbackThreadIdAfterDelete,
   getVisibleThreadsForProject,
   getProjectSortTimestamp,
@@ -50,6 +51,35 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("resolveThreadRenameTargetKey", () => {
+  it("prefers the one selected thread over the active thread", () => {
+    expect(
+      resolveThreadRenameTargetKey({
+        selectedThreadKeys: new Set(["selected"]),
+        activeThreadKey: "active",
+      }),
+    ).toBe("selected");
+  });
+
+  it("uses the active thread when there is no sidebar selection", () => {
+    expect(
+      resolveThreadRenameTargetKey({
+        selectedThreadKeys: new Set(),
+        activeThreadKey: "active",
+      }),
+    ).toBe("active");
+  });
+
+  it("does not choose arbitrarily from a multi-selection", () => {
+    expect(
+      resolveThreadRenameTargetKey({
+        selectedThreadKeys: new Set(["one", "two"]),
+        activeThreadKey: "active",
+      }),
+    ).toBeNull();
+  });
+});
 
 describe("shouldNavigateAfterProjectRemoval", () => {
   const projectThreads = [{ environmentId: "environment-local", id: "thread-1" }];

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -50,6 +50,14 @@ type LogicalSidebarProject = SidebarProject & {
 
 export type ThreadTraversalDirection = "previous" | "next";
 
+export function resolveThreadRenameTargetKey(input: {
+  selectedThreadKeys: ReadonlySet<string>;
+  activeThreadKey: string | null;
+}): string | null {
+  if (input.selectedThreadKeys.size > 1) return null;
+  return input.selectedThreadKeys.values().next().value ?? input.activeThreadKey;
+}
+
 export async function archiveSelectedThreadEntries<
   TEntry extends { readonly threadKey: string },
   TResult extends { readonly _tag: "Success" | "Failure" },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -81,6 +81,7 @@ import {
   threadTraversalDirectionFromCommand,
 } from "../keybindings";
 import { useShortcutModifierState } from "../shortcutModifierState";
+import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isModelPickerOpen } from "../modelPickerVisibility";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
@@ -126,6 +127,7 @@ import {
   orderItemsByPreferredIds,
   planPinnedReorder,
   resolveAdjacentThreadId,
+  resolveThreadRenameTargetKey,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
   searchSidebarThreadsByTitle,
@@ -3069,6 +3071,7 @@ export default function Sidebar() {
         context: {
           terminalFocus: isTerminalFocused(),
           terminalOpen: routeTerminalOpen,
+          previewFocus: isPreviewFocused(),
           modelPickerOpen: isModelPickerOpen(),
         },
       });
@@ -3081,6 +3084,22 @@ export default function Sidebar() {
         navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
         return true;
       };
+      if (command === "thread.rename") {
+        event.preventDefault();
+        event.stopPropagation();
+        const targetThreadKey = resolveThreadRenameTargetKey({
+          selectedThreadKeys: useThreadSelectionStore.getState().selectedThreadKeys,
+          activeThreadKey: routeThreadKey,
+        });
+        if (!targetThreadKey) return;
+        const targetThread = threadByKey.get(targetThreadKey);
+        if (!targetThread) return;
+        startThreadRename(
+          scopeThreadRef(targetThread.environmentId, targetThread.id),
+          targetThread.title,
+        );
+        return;
+      }
       const traversalDirection = threadTraversalDirectionFromCommand(command);
       if (traversalDirection !== null) {
         navigateToThreadKey(
@@ -3104,6 +3123,7 @@ export default function Sidebar() {
     orderedThreadKeys,
     routeTerminalOpen,
     routeThreadKey,
+    startThreadRename,
     threadByKey,
   ]);
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -40,6 +40,8 @@ Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refre
 `filePicker.toggle` opens file search for the active project and defaults to `mod+p`.
 `projectSearch.toggle` searches inside the active project's files and defaults to `mod+shift+f`.
 Repeating either shortcut closes that search, and switching shortcuts replaces the open search.
+`thread.rename` starts inline rename for the one selected thread, or the active thread when there
+is no sidebar selection. It defaults to `mod+r` outside the terminal, preview, and model picker.
 `themeEditor.toggle` opens or closes the floating theme editor and defaults to
 `mod+alt+shift+t`. Select a color label to spotlight the elements that use it; select the label
 again to clear the spotlight. The swatch and hex field keep that color selected while you edit it.

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -101,6 +101,12 @@ it.effect("parses keybinding rules", () =>
       command: "thread.previous",
     });
     assert.strictEqual(parsedThreadPrevious.command, "thread.previous");
+
+    const parsedThreadRename = yield* decode(KeybindingRule, {
+      key: "mod+r",
+      command: "thread.rename",
+    });
+    assert.strictEqual(parsedThreadRename.command, "thread.rename");
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -35,6 +35,7 @@ export type ModelPickerJumpKeybindingCommand =
   (typeof MODEL_PICKER_JUMP_KEYBINDING_COMMANDS)[number];
 
 export const THREAD_KEYBINDING_COMMANDS = [
+  "thread.rename",
   "thread.previous",
   "thread.next",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -46,6 +46,11 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  {
+    key: "mod+r",
+    command: "thread.rename",
+    when: "!terminalFocus && !previewFocus && !modelPickerOpen",
+  },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,


### PR DESCRIPTION
## What changed

- add a `thread.rename` keybinding command with `mod+r` as its default
- start inline rename for the single selected sidebar thread, falling back to the active thread when there is no selection
- support both current and legacy sidebar implementations
- preserve `mod+r` for preview refresh while moving the Electron reload accelerator to `CmdOrCtrl+Alt+R`
- document and test the new behavior

## Why

Renaming currently requires pointer interaction even when a thread is already selected. This adds a direct keyboard path while preserving the existing context-sensitive preview refresh shortcut.

The Electron application menu previously claimed the primary reload accelerator before renderer keybindings could handle it, so reload now uses `CmdOrCtrl+Alt+R`.

## User impact

Users can select a thread and press Cmd-R on macOS (Ctrl-R on Windows/Linux) to rename it inline. With no sidebar selection, the active thread is renamed. Multi-selection remains unchanged because renaming multiple threads is ambiguous.

## Validation

- focused Vitest suite: 4 files, 136 tests passed
- contracts, shared, web, and desktop type checks passed
- targeted lint passed
- production desktop build passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cmd-R shortcut to rename threads in the sidebar
> - Adds a `thread.rename` keybinding defaulting to `mod+r` with a `when` clause (`!terminalFocus && !previewFocus && !modelPickerOpen`) so it does not conflict with the existing `mod+r` preview refresh shortcut.
> - Both [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/5924/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/5924/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86) handle the new command, resolving the target thread via `resolveThreadRenameTargetKey` (selected thread preferred; falls back to active thread; no-op on multi-select).
> - The View → Reload menu item accelerator is changed to `CmdOrCtrl+Alt+R` in [DesktopApplicationMenu.ts](https://github.com/pingdotgg/t3code/pull/5924/files#diff-1d27d62f2db6ae3d67221b54135a0260783acf7594fd4ad9f60035f0819a96eb) to free up `CmdOrCtrl+R` for the rename shortcut.
> - Behavioral Change: `Cmd/Ctrl+R` no longer triggers a page reload from the desktop app menu; reload is now `Cmd/Ctrl+Alt+R`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 20e880f. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->