### PR TITLE
feat(web): make the sidebar project filter a searchable combobox

### DIFF
--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -23,7 +23,15 @@ import { resolveEnvModeLabel } from "../BranchToolbar.logic";
 import { createModelSelection } from "@t3tools/shared/model";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import * as Cause from "effect/Cause";
-import { CopyIcon, FolderIcon, PlusIcon, ServerIcon, SettingsIcon, Trash2Icon } from "lucide-react";
+import {
+  CopyIcon,
+  FolderIcon,
+  PlusIcon,
+  SearchIcon,
+  ServerIcon,
+  SettingsIcon,
+  Trash2Icon,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useComposerDraftStore } from "../../composerDraftStore";
@@ -78,6 +86,7 @@ import {
 } from "../projectScriptEditor";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "../ui/input-group";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import {
@@ -131,6 +140,22 @@ export function ProjectSettingsPanel({
   const groups = useSettingsProjectGroups();
   const navigate = useNavigate();
   const currentHash = useLocation({ select: (location) => location.hash });
+  const [searchQuery, setSearchQuery] = useState("");
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  // Match checkout titles and paths too, so a group is findable by any of
+  // the names it goes by, not just the grouped display name.
+  const visibleGroups = useMemo(() => {
+    if (!normalizedQuery) return groups;
+    return groups.filter(
+      (group) =>
+        group.displayName.toLowerCase().includes(normalizedQuery) ||
+        group.memberProjects.some(
+          (member) =>
+            member.title.toLowerCase().includes(normalizedQuery) ||
+            member.workspaceRoot.toLowerCase().includes(normalizedQuery),
+        ),
+    );
+  }, [groups, normalizedQuery]);
 
   // The index route auto-selects the first project so /settings/projects is
   // never a dead end. Hash is preserved for settings-search jumps.
@@ -206,7 +231,37 @@ export function ProjectSettingsPanel({
         aria-label="Projects"
         className="w-60 shrink-0 space-y-0.5 overflow-y-auto border-e border-border/40 p-3 pt-10 max-sm:hidden sm:pt-12"
       >
-        {groups.map((group) => {
+        {groups.length > 0 ? (
+          <InputGroup variant="ghost" className="mb-1 h-8 rounded-md">
+            <InputGroupAddon>
+              <SearchIcon className="size-4 text-muted-foreground" />
+            </InputGroupAddon>
+            <InputGroupInput
+              type="search"
+              size="sm"
+              value={searchQuery}
+              aria-label="Search projects"
+              placeholder="Search projects"
+              spellCheck={false}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              onKeyDown={(event) => {
+                // Only intercept Escape while filtering, so an empty field
+                // still lets the global shortcut close the settings page.
+                if (event.key === "Escape" && searchQuery.length > 0) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setSearchQuery("");
+                  return;
+                }
+                if (event.key === "Enter") {
+                  const first = visibleGroups[0];
+                  if (first) selectProject(first.projectKey);
+                }
+              }}
+            />
+          </InputGroup>
+        ) : null}
+        {visibleGroups.map((group) => {
           const isActive = group.projectKey === selected?.projectKey;
           return (
             <button
@@ -236,6 +291,10 @@ export function ProjectSettingsPanel({
         })}
         {groups.length === 0 ? (
           <p className="px-2 py-4 text-sm text-muted-foreground">No projects yet.</p>
+        ) : visibleGroups.length === 0 ? (
+          <p role="status" className="px-2 py-4 text-sm text-muted-foreground">
+            No matching projects.
+          </p>
         ) : null}
       </nav>
       {selected ? (


### PR DESCRIPTION
> [!NOTE]
> Reworked after #5923 removed the standalone projects settings page. Per the suggestion, the sidebar's "All projects" filter is now a combobox with search — the previous revision of this PR (search on the settings project list) no longer applies.

## What

Converts the sidebar's project filter dropdown from a plain `Menu` into the existing `Combobox` primitive, adding a search field that filters projects by name as you type.

- Same trigger, same rows (favicon, name, per-project settings gear) — the only visual addition is the search input at the top of the popup.
- Typing filters by project display name; **Enter** picks the highlighted match; **Escape** closes; the query resets on close.
- "All projects" behaves like the diff panel's "Automatic" row: it's a scope reset, not a searchable entry, so it only shows while the query is empty.
- "No matching projects." shows for a query with no hits.

Follows the established combobox-with-search composition from `DiffPanel`'s base-ref picker and `FontFamilyPicker`.

## Why

With many projects the scope dropdown is a long scan-and-scroll list. A type-to-filter combobox makes switching scope O(keystrokes), and was the suggested direction after the projects settings page (where this PR originally added search) was replaced by contextual project routes in #5923.

## Before / After

| Before | After |
| --- | --- |
| ![Project filter dropdown without search](https://raw.githubusercontent.com/SunkenInTime/t3code/ac6527e24638325eceaa60e0d9efacc8bfd61946/sidebar-before-open.png) | ![Project filter combobox with search input](https://raw.githubusercontent.com/SunkenInTime/t3code/ac6527e24638325eceaa60e0d9efacc8bfd61946/sidebar-after-open.png) |

Filtering:

![Typing "chess" filters the list to chess-engine](https://raw.githubusercontent.com/SunkenInTime/t3code/ac6527e24638325eceaa60e0d9efacc8bfd61946/sidebar-after-filtered.png)

## Testing

- `pnpm typecheck` and `pnpm lint` pass.
- Verified in a local dev environment seeded with 8 projects (driven via Playwright): typing filters the list, Enter selects the match and scopes the thread list (trigger shows the picked project), Escape closes, the query resets on reopen, "All projects" restores the unscoped view, the no-match empty state renders, and the per-project settings gear still routes to `/projects/$projectKey`.
