### PR TITLE
feat(web): move thread search into the command palette with Discord-style operators

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -184,9 +184,14 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
   getContentMatch?: (thread: TThread) => CommandPaletteThreadContentMatch | undefined;
   runThread: (thread: Pick<SidebarThreadSummary, "environmentId" | "id">) => Promise<void>;
   limit?: number;
+  /** Keep archived threads (search corpora); the default drops them so the
+      recents list never surfaces archived rows. */
+  includeArchived?: boolean;
 }): CommandPaletteActionItem[] {
   const sortedThreads = sortThreads(
-    input.threads.filter((thread) => thread.archivedAt === null),
+    input.includeArchived === true
+      ? [...input.threads]
+      : input.threads.filter((thread) => thread.archivedAt === null),
     input.sortOrder,
   );
   const visibleThreads =
@@ -204,6 +209,9 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
     }
     if (thread.id === input.activeThreadId) {
       descriptionParts.push("Current thread");
+    }
+    if (thread.archivedAt !== null) {
+      descriptionParts.push("Archived");
     }
 
     const leadingContent = input.renderLeadingContent?.(thread);

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import {
+  scopeThreadShell,
+  type EnvironmentThreadShell,
+} from "@t3tools/client-runtime/state/models";
 import { canCreateProjectInEnvironment } from "@t3tools/client-runtime/operations/projects";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
@@ -83,6 +87,17 @@ import {
   resolveProjectPathForDispatch,
 } from "../lib/projectPaths";
 import { onOpenCommandPalette } from "../commandPaletteBus";
+import { useArchivedThreadSnapshots } from "../lib/archivedThreadsState";
+import {
+  applyProjectSuggestionToQuery,
+  filterProjectSuggestions,
+  getTrailingProjectOperatorToken,
+  hasThreadSearchOperators,
+  matchesParsedThreadSearch,
+  parseThreadSearchQuery,
+  resolveProjectFilterKeys,
+  segmentThreadSearchQuery,
+} from "./threadSearchQuery.logic";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
@@ -104,6 +119,7 @@ import {
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   type CommandPaletteActionItem,
+  type CommandPaletteGroup,
   type CommandPaletteOpenIntent,
   type CommandPaletteSubmenuItem,
   type CommandPaletteView,
@@ -610,8 +626,31 @@ function OpenCommandPaletteDialog(props: {
         .map((environment) => environment.environmentId),
     [environments],
   );
-  const threadSearchQuery = currentView === null && !isActionsOnly ? deferredQuery : "";
+  // Discord-style operators (in:, agent:, before:/after:/on:) apply only to
+  // the root search — submenus and > queries keep their own semantics.
+  // Non-null only when the query actually carries operator criteria.
+  const parsedOperatorQuery = useMemo(() => {
+    if (currentView !== null || isActionsOnly) return null;
+    const parsed = parseThreadSearchQuery(deferredQuery, new Date());
+    return hasThreadSearchOperators(parsed) ? parsed : null;
+  }, [currentView, deferredQuery, isActionsOnly]);
+  // The server content search must see only the residual text — operator
+  // tokens would pollute the message LIKE query.
+  const threadSearchQuery =
+    currentView === null && !isActionsOnly ? (parsedOperatorQuery?.text ?? deferredQuery) : "";
   const threadSearch = useThreadSearch(environmentIds, threadSearchQuery);
+  // Archived threads live in a separate query-style snapshot, not the live
+  // shell stream; search subscribes only while a root query is active so the
+  // palette otherwise never pays for archive data. Archive/unarchive actions
+  // refresh these atoms (useThreadActions), so hits stay current in-session.
+  const archivedSearchEnvironmentIds = useMemo(
+    () =>
+      currentView === null && !isActionsOnly && deferredQuery.trim().length > 0
+        ? environmentIds
+        : [],
+    [currentView, deferredQuery, environmentIds, isActionsOnly],
+  );
+  const archivedThreadSnapshots = useArchivedThreadSnapshots(archivedSearchEnvironmentIds);
   const threadContentMatchByKey = useMemo(
     () =>
       new Map(
@@ -1011,16 +1050,30 @@ function OpenCommandPaletteDialog(props: {
     [contextualProjectRef, handleNewThread, pickerProjects, projectGroupByTargetKey],
   );
 
-  const allThreadItems = useMemo(
-    () =>
+  const buildPaletteThreadItems = useCallback(
+    (
+      threadList: ReadonlyArray<EnvironmentThreadShell>,
+      options?: { readonly includeArchived?: boolean },
+    ) =>
       buildThreadActionItems({
-        threads,
+        threads: threadList,
         ...(activeThreadId ? { activeThreadId } : {}),
+        ...(options?.includeArchived === true ? { includeArchived: true } : {}),
         projectTitleById,
         sortOrder: clientSettings.sidebarThreadSortOrder,
         icon: <MessageSquareIcon className={ITEM_ICON_CLASS} />,
         renderLeadingContent: (thread) => <ThreadRowLeadingStatus thread={thread} />,
-        renderTrailingContent: (thread) => <ThreadRowTrailingStatus thread={thread} />,
+        renderTrailingContent: (thread) =>
+          // An archived row's marker replaces the live status decorations —
+          // whatever session state the shell froze with is history, not
+          // status.
+          thread.archivedAt !== null ? (
+            <span className="ms-1 shrink-0 rounded border border-border/70 px-1 text-[10px] font-medium text-muted-foreground/80">
+              Archived
+            </span>
+          ) : (
+            <ThreadRowTrailingStatus thread={thread} />
+          ),
         renderDescription: (thread, { projectTitle }) => {
           const modelInstanceId =
             thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
@@ -1076,9 +1129,63 @@ function OpenCommandPaletteDialog(props: {
       providerEntryByEnvironmentAndInstanceId,
       threadContentMatchByKey,
       threadSearchQuery,
-      threads,
     ],
   );
+  const allThreadItems = useMemo(
+    () => buildPaletteThreadItems(threads),
+    [buildPaletteThreadItems, threads],
+  );
+  const archivedSearchThreads = useMemo(() => {
+    if (archivedThreadSnapshots.snapshots.length === 0) return [];
+    // A shell can linger in the live stream with archivedAt freshly set (or
+    // appear in both after an unarchive races the snapshot refresh); the
+    // live stream wins so a thread never renders twice.
+    const liveThreadKeys = new Set(threads.map((thread) => `${thread.environmentId}:${thread.id}`));
+    return archivedThreadSnapshots.snapshots.flatMap((entry) =>
+      entry.snapshot.threads
+        .filter((thread) => !liveThreadKeys.has(`${entry.environmentId}:${thread.id}`))
+        .map((thread) => scopeThreadShell(entry.environmentId, thread)),
+    );
+  }, [archivedThreadSnapshots.snapshots, threads]);
+  const archivedThreadItems = useMemo(
+    () => buildPaletteThreadItems(archivedSearchThreads, { includeArchived: true }),
+    [archivedSearchThreads, buildPaletteThreadItems],
+  );
+  // The search corpus: live threads first, archived history after. With
+  // operator criteria the corpus is narrowed thread-by-thread (project keys
+  // for in:, agent/date via the matcher) BEFORE items are built; residual
+  // text then ranks against titles, project names, and content snippets in
+  // filterCommandPaletteGroups like any other query.
+  const threadSearchItems = useMemo(() => {
+    if (parsedOperatorQuery === null) {
+      return [...allThreadItems, ...archivedThreadItems];
+    }
+    const projectFilterKeys = resolveProjectFilterKeys(
+      projectGroups,
+      parsedOperatorQuery.projectQueries,
+    );
+    const operatorOnlyQuery = { ...parsedOperatorQuery, text: "" };
+    const passesOperators = (thread: EnvironmentThreadShell) =>
+      (projectFilterKeys === null ||
+        projectFilterKeys.has(`${thread.environmentId}:${thread.projectId}`)) &&
+      matchesParsedThreadSearch(thread, operatorOnlyQuery);
+    return [
+      ...buildPaletteThreadItems(
+        threads.filter((thread) => thread.archivedAt === null && passesOperators(thread)),
+      ),
+      ...buildPaletteThreadItems(archivedSearchThreads.filter(passesOperators), {
+        includeArchived: true,
+      }),
+    ];
+  }, [
+    allThreadItems,
+    archivedSearchThreads,
+    archivedThreadItems,
+    buildPaletteThreadItems,
+    parsedOperatorQuery,
+    projectGroups,
+    threads,
+  ]);
   const recentThreadItems = allThreadItems.slice(0, RECENT_THREAD_LIMIT);
 
   const pushPaletteView = useCallback(
@@ -1593,13 +1700,78 @@ function OpenCommandPaletteDialog(props: {
         )
       : (currentView?.groups ?? rootGroups);
 
-  const filteredGroups = filterCommandPaletteGroups({
-    activeGroups,
-    query: deferredQuery,
-    isInSubmenu: currentView !== null,
-    projectSearchItems: projectSearchItems,
-    threadSearchItems: allThreadItems,
-  });
+  // With operator criteria the palette becomes a pure thread search: actions
+  // and project rows would degenerate to matching the residual text (or, with
+  // no text, matching everything), so only the operator-narrowed Threads
+  // group renders. Residual text still ranks within it.
+  const operatorFilteredGroups: CommandPaletteGroup[] | null =
+    parsedOperatorQuery === null
+      ? null
+      : parsedOperatorQuery.text.trim().length === 0
+        ? threadSearchItems.length > 0
+          ? [{ value: "threads-search", label: "Threads", items: threadSearchItems }]
+          : []
+        : filterCommandPaletteGroups({
+            activeGroups: [],
+            query: parsedOperatorQuery.text,
+            isInSubmenu: false,
+            projectSearchItems: [],
+            threadSearchItems,
+          });
+
+  const baseFilteredGroups =
+    operatorFilteredGroups ??
+    filterCommandPaletteGroups({
+      activeGroups,
+      query: deferredQuery,
+      isInSubmenu: currentView !== null,
+      projectSearchItems: projectSearchItems,
+      threadSearchItems,
+    });
+
+  // While the caret sits inside an in: token, project completions lead the
+  // list: Enter commits the filter into the query (palette stays open)
+  // instead of navigating.
+  const trailingProjectOperatorToken =
+    currentView === null && !isActionsOnly ? getTrailingProjectOperatorToken(query) : null;
+  const projectFilterSuggestionItems = useMemo((): CommandPaletteActionItem[] => {
+    if (trailingProjectOperatorToken === null) return [];
+    return filterProjectSuggestions(projectGroups, trailingProjectOperatorToken.partialValue)
+      .slice(0, 8)
+      .map((group) => ({
+        kind: "action" as const,
+        value: `filter-project:${group.projectKey}`,
+        searchTerms: [],
+        title: group.displayName,
+        description: group.workspaceRoot,
+        icon: projectFavicon(group),
+        keepOpen: true,
+        run: async () => {
+          handleQueryChange(
+            applyProjectSuggestionToQuery(
+              query,
+              getTrailingProjectOperatorToken(query),
+              group.displayName,
+            ),
+          );
+        },
+      }));
+    // handleQueryChange (a plain function declaration) is intentionally not
+    // a dependency: listing it would churn this memo every render for no
+    // observable difference.
+  }, [projectGroups, query, trailingProjectOperatorToken]);
+
+  const filteredGroups =
+    projectFilterSuggestionItems.length > 0
+      ? [
+          {
+            value: "project-filter-suggestions",
+            label: "Filter by project",
+            items: projectFilterSuggestionItems,
+          },
+          ...baseFilteredGroups,
+        ]
+      : baseFilteredGroups;
 
   const handleAddProjectForEnvironment = useCallback(
     async (input: {
@@ -1986,6 +2158,65 @@ function OpenCommandPaletteDialog(props: {
     remoteProjectInputPlaceholder(addProjectCloneFlow) ??
     getCommandPaletteInputPlaceholder(paletteMode);
   const isSubmenu = paletteMode === "submenu" || paletteMode === "submenu-browse";
+
+  // Discord-style operator pills: the input's own text goes transparent (the
+  // caret stays visible) and a metric-identical backdrop renders the same
+  // string with a pill behind each recognized operator token, translating
+  // with the input's scrollLeft. Root command mode only — browse and
+  // submenu queries have no operators.
+  const showOperatorPills = !isSubmenu && !isBrowsing && addProjectCloneFlow === null;
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const operatorPillHighlightRef = useRef<HTMLDivElement>(null);
+  const syncOperatorPillScroll = useCallback(() => {
+    const highlight = operatorPillHighlightRef.current;
+    const input = searchInputRef.current;
+    if (highlight === null || input === null) return;
+    highlight.style.transform = `translateX(${-input.scrollLeft}px)`;
+  }, []);
+  useLayoutEffect(() => {
+    // Typing at the end of an overflowing query scrolls the input after the
+    // change event; re-sync once the new value has laid out.
+    syncOperatorPillScroll();
+  }, [query, syncOperatorPillScroll]);
+  const operatorQuerySegments = useMemo(
+    () => (showOperatorPills ? segmentThreadSearchQuery(query, new Date()) : []),
+    [query, showOperatorPills],
+  );
+  const operatorPillBackdrop =
+    showOperatorPills && operatorQuerySegments.length > 0 ? (
+      // Mirrors CommandInput's metrics exactly: the outer div reproduces the
+      // shell inset, the row reproduces the lg input's height and start
+      // padding, and the text run carries no padding of its own — the pill
+      // look comes from a layout-neutral shadow halo.
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 px-[var(--command-shell-inset)] py-1.5"
+      >
+        <div className="flex h-9.5 items-center overflow-hidden pe-[calc(--spacing(3)-1px)] ps-9 text-base sm:h-8.5 sm:ps-[calc(var(--command-shell-inset)+1.5rem)] sm:text-sm">
+          <div ref={operatorPillHighlightRef} className="shrink-0 whitespace-pre text-foreground">
+            {(() => {
+              // Segments tile the query, so each one's character offset is a
+              // stable, data-derived key even when texts repeat.
+              let offset = 0;
+              return operatorQuerySegments.map((segment) => {
+                const key = `${offset}:${segment.text}`;
+                offset += segment.text.length;
+                return segment.isOperator ? (
+                  <span
+                    key={key}
+                    className="rounded-xs bg-message-action text-message-action-foreground shadow-[0_0_0_2px] shadow-message-action"
+                  >
+                    {segment.text}
+                  </span>
+                ) : (
+                  <span key={key}>{segment.text}</span>
+                );
+              });
+            })()}
+          </div>
+        </div>
+      </div>
+    ) : null;
   const hasHighlightedBrowseItem = highlightedItemValue?.startsWith("browse:") ?? false;
   const canSubmitBrowsePath =
     isBrowsing &&
@@ -2344,8 +2575,11 @@ function OpenCommandPaletteDialog(props: {
       footerActionLabel={footerActionLabel}
       footerTrailing={footerTrailing}
       inputAccessory={inputAccessory}
+      inputBackdrop={operatorPillBackdrop}
       inputProps={{
-        className:
+        ref: searchInputRef,
+        onScroll: syncOperatorPillScroll,
+        className: cn(
           addProjectCloneFlow?.step === "repository"
             ? "pe-32"
             : isBrowsing
@@ -2353,6 +2587,11 @@ function OpenCommandPaletteDialog(props: {
                 ? "pe-36"
                 : "pe-16"
               : undefined,
+          // Glyphs render in the pill backdrop; the input keeps the caret
+          // and selection. Only while the backdrop is actually mounted.
+          operatorPillBackdrop !== null &&
+            "*:data-[slot=autocomplete-input]:text-transparent! *:data-[slot=autocomplete-input]:caret-foreground",
+        ),
         placeholder: inputPlaceholder,
         wrapperClassName: isSubmenu
           ? "[&_[data-slot=autocomplete-start-addon]]:pointer-events-auto"

--- a/apps/web/src/components/CommandPaletteContent.tsx
+++ b/apps/web/src/components/CommandPaletteContent.tsx
@@ -10,6 +10,8 @@ type CommandPaletteContentProps = Omit<ComponentProps<typeof Command>, "children
   readonly footerActionLabel?: ReactNode;
   readonly footerTrailing?: ReactNode;
   readonly inputAccessory?: ReactNode;
+  /** Layer rendered behind the input's text (operator pills). */
+  readonly inputBackdrop?: ReactNode;
   readonly inputProps: ComponentProps<typeof CommandInput>;
   readonly panelClassName?: string;
   readonly showBackHint?: boolean;
@@ -27,6 +29,7 @@ export function CommandPaletteContent({
   footerActionLabel,
   footerTrailing,
   inputAccessory,
+  inputBackdrop,
   inputProps,
   panelClassName,
   showBackHint,
@@ -37,6 +40,7 @@ export function CommandPaletteContent({
     <div className="contents" data-testid={testId}>
       <Command {...commandProps}>
         <div className="relative">
+          {inputBackdrop}
           <CommandInput {...inputProps} />
           {inputAccessory}
         </div>

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -21,7 +21,6 @@ import {
   resolveSidebarThreadStatus,
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
-  searchSidebarThreadsByTitle,
   formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
@@ -732,26 +731,6 @@ describe("resolveSidebarThreadStatus", () => {
 
   it("defaults to ready with no session", () => {
     expect(resolveSidebarThreadStatus({ ...idle, session: null })).toBe("ready");
-  });
-});
-
-describe("searchSidebarThreadsByTitle", () => {
-  const threads = [
-    { id: "thread-1", title: "Fix workspace search", project: "Alpha" },
-    { id: "thread-2", title: "Review providers", project: "Workspace" },
-    { id: "thread-3", title: "WORKTREE cleanup", project: "Beta" },
-  ];
-
-  it("matches thread titles case-insensitively and preserves their order", () => {
-    expect(searchSidebarThreadsByTitle(threads, "work")).toEqual([threads[0], threads[2]]);
-  });
-
-  it("does not match project metadata", () => {
-    expect(searchSidebarThreadsByTitle(threads, "workspace")).toEqual([threads[0]]);
-  });
-
-  it("returns no results for an empty query", () => {
-    expect(searchSidebarThreadsByTitle(threads, "   ")).toEqual([]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -20,7 +20,13 @@ import {
   resolveSidebarThreadStatus,
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
-  searchSidebarThreadsByTitle,
+  applyProjectSuggestionToQuery,
+  filterProjectSuggestions,
+  getTrailingProjectOperatorToken,
+  hasSidebarSearchCriteria,
+  parseSidebarSearchQuery,
+  resolveProjectFilterKeys,
+  searchSidebarThreads,
   formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
@@ -697,23 +703,258 @@ describe("resolveSidebarThreadStatus", () => {
   });
 });
 
-describe("searchSidebarThreadsByTitle", () => {
-  const threads = [
-    { id: "thread-1", title: "Fix workspace search", project: "Alpha" },
-    { id: "thread-2", title: "Review providers", project: "Workspace" },
-    { id: "thread-3", title: "WORKTREE cleanup", project: "Beta" },
-  ];
+describe("parseSidebarSearchQuery", () => {
+  // Local-time construction on purpose: the day operators resolve against
+  // the user's calendar, not UTC.
+  const now = new Date(2026, 7, 9, 12, 30, 0);
+  const DAY_MS = 86_400_000;
 
-  it("matches thread titles case-insensitively and preserves their order", () => {
-    expect(searchSidebarThreadsByTitle(threads, "work")).toEqual([threads[0], threads[2]]);
+  it("treats a plain query as lowercased title text with no filters", () => {
+    const parsed = parseSidebarSearchQuery("  Fix Bug ", now);
+    expect(parsed).toEqual({
+      text: "fix bug",
+      projectQueries: [],
+      agentQueries: [],
+      updatedStartMs: null,
+      updatedEndMs: null,
+    });
   });
 
-  it("does not match project metadata", () => {
-    expect(searchSidebarThreadsByTitle(threads, "workspace")).toEqual([threads[0]]);
+  it("extracts in: values, including quoted multi-word names", () => {
+    const parsed = parseSidebarSearchQuery('in:Icarus in:"My Project" fix', now);
+    expect(parsed.projectQueries).toEqual(["icarus", "my project"]);
+    expect(parsed.text).toBe("fix");
+  });
+
+  it("extracts agent: values", () => {
+    const parsed = parseSidebarSearchQuery("agent:Claude retry", now);
+    expect(parsed.agentQueries).toEqual(["claude"]);
+    expect(parsed.text).toBe("retry");
+  });
+
+  it("resolves relative before:/after: values against now", () => {
+    const parsed = parseSidebarSearchQuery("after:7d before:2d", now);
+    expect(parsed.updatedStartMs).toBe(now.getTime() - 7 * DAY_MS);
+    expect(parsed.updatedEndMs).toBe(now.getTime() - 2 * DAY_MS);
+  });
+
+  it("resolves week-relative values", () => {
+    const parsed = parseSidebarSearchQuery("after:2w", now);
+    expect(parsed.updatedStartMs).toBe(now.getTime() - 14 * DAY_MS);
+  });
+
+  it("resolves on: to a local calendar day", () => {
+    const parsed = parseSidebarSearchQuery("on:2026-08-01", now);
+    expect(parsed.updatedStartMs).toBe(new Date(2026, 7, 1).getTime());
+    expect(parsed.updatedEndMs).toBe(new Date(2026, 7, 2).getTime());
+  });
+
+  it("resolves on:today and on:yesterday", () => {
+    const today = parseSidebarSearchQuery("on:today", now);
+    expect(today.updatedStartMs).toBe(new Date(2026, 7, 9).getTime());
+    expect(today.updatedEndMs).toBe(new Date(2026, 7, 10).getTime());
+    const yesterday = parseSidebarSearchQuery("on:yesterday", now);
+    expect(yesterday.updatedStartMs).toBe(new Date(2026, 7, 8).getTime());
+    expect(yesterday.updatedEndMs).toBe(new Date(2026, 7, 9).getTime());
+  });
+
+  it("excludes the named day from before: and after: bounds", () => {
+    const parsed = parseSidebarSearchQuery("after:2026-08-01 before:2026-08-05", now);
+    expect(parsed.updatedStartMs).toBe(new Date(2026, 7, 2).getTime());
+    expect(parsed.updatedEndMs).toBe(new Date(2026, 7, 5).getTime());
+  });
+
+  it("degrades unparseable and rolled-over dates to plain text", () => {
+    expect(parseSidebarSearchQuery("before:banana", now).text).toBe("before:banana");
+    expect(parseSidebarSearchQuery("on:2026-02-31", now).text).toBe("on:2026-02-31");
+    expect(parseSidebarSearchQuery("on:7d", now).text).toBe("on:7d");
+  });
+
+  it("ignores a half-typed operator with no value", () => {
+    const parsed = parseSidebarSearchQuery("in:", now);
+    expect(hasSidebarSearchCriteria(parsed)).toBe(false);
+  });
+
+  it("leaves unknown operator-shaped tokens as text", () => {
+    expect(parseSidebarSearchQuery("re: meeting notes", now).text).toBe("re: meeting notes");
+  });
+});
+
+describe("searchSidebarThreads", () => {
+  const now = new Date(2026, 7, 9, 12, 30, 0);
+  const makeThread = (input: {
+    id: string;
+    title: string;
+    updatedAt?: string;
+    providerName?: string | null;
+    instanceId?: string;
+  }) => ({
+    id: input.id,
+    title: input.title,
+    updatedAt: input.updatedAt ?? "2026-08-09T10:00:00.000Z",
+    modelSelection: { instanceId: input.instanceId ?? "claude-code" },
+    session: input.providerName === undefined ? null : { providerName: input.providerName },
+  });
+
+  it("matches thread titles case-insensitively and preserves their order", () => {
+    const threads = [
+      makeThread({ id: "thread-1", title: "Fix workspace search" }),
+      makeThread({ id: "thread-2", title: "Review providers" }),
+      makeThread({ id: "thread-3", title: "WORKTREE cleanup" }),
+    ];
+    const results = searchSidebarThreads(threads, parseSidebarSearchQuery("work", now));
+    expect(results).toEqual([threads[0], threads[2]]);
   });
 
   it("returns no results for an empty query", () => {
-    expect(searchSidebarThreadsByTitle(threads, "   ")).toEqual([]);
+    const threads = [makeThread({ id: "thread-1", title: "Anything" })];
+    expect(searchSidebarThreads(threads, parseSidebarSearchQuery("   ", now))).toEqual([]);
+  });
+
+  it("filters by agent against provider name and instance id", () => {
+    const threads = [
+      makeThread({ id: "thread-1", title: "One", providerName: "claude", instanceId: "cc" }),
+      makeThread({ id: "thread-2", title: "Two", providerName: "codex", instanceId: "codex-cli" }),
+      makeThread({ id: "thread-3", title: "Three", instanceId: "claude-code" }),
+    ];
+    const results = searchSidebarThreads(threads, parseSidebarSearchQuery("agent:claude", now));
+    expect(results).toEqual([threads[0], threads[2]]);
+  });
+
+  it("filters by the updatedAt window", () => {
+    const threads = [
+      makeThread({ id: "old", title: "Old", updatedAt: "2026-07-01T00:00:00.000Z" }),
+      makeThread({ id: "recent", title: "Recent", updatedAt: "2026-08-08T00:00:00.000Z" }),
+    ];
+    const results = searchSidebarThreads(threads, parseSidebarSearchQuery("after:7d", now));
+    expect(results).toEqual([threads[1]]);
+    const older = searchSidebarThreads(threads, parseSidebarSearchQuery("before:7d", now));
+    expect(older).toEqual([threads[0]]);
+  });
+
+  it("excludes threads with malformed timestamps from date-filtered results", () => {
+    const threads = [makeThread({ id: "bad", title: "Bad", updatedAt: "not-a-date" })];
+    expect(searchSidebarThreads(threads, parseSidebarSearchQuery("after:7d", now))).toEqual([]);
+  });
+
+  it("ANDs operators together", () => {
+    const threads = [
+      makeThread({ id: "thread-1", title: "Fix search", providerName: "claude", instanceId: "cc" }),
+      makeThread({
+        id: "thread-2",
+        title: "Fix search",
+        providerName: "codex",
+        instanceId: "codex-cli",
+      }),
+    ];
+    const results = searchSidebarThreads(threads, parseSidebarSearchQuery("agent:claude fix", now));
+    expect(results).toEqual([threads[0]]);
+  });
+});
+
+describe("resolveProjectFilterKeys", () => {
+  const groups = [
+    {
+      projectKey: "group-icarus",
+      displayName: "Icarus",
+      workspaceRoot: "/Users/dev/icarus",
+      memberProjectRefs: [
+        { environmentId: "env-1", projectId: "proj-1" },
+        { environmentId: "env-2", projectId: "proj-9" },
+      ],
+    },
+    {
+      projectKey: "group-daedalus",
+      displayName: "Daedalus",
+      workspaceRoot: "/Users/dev/daedalus",
+      memberProjectRefs: [{ environmentId: "env-1", projectId: "proj-2" }],
+    },
+  ];
+
+  it("returns null when there is no in: filter", () => {
+    expect(resolveProjectFilterKeys(groups, [])).toBeNull();
+  });
+
+  it("expands matching groups into every member project key", () => {
+    expect(resolveProjectFilterKeys(groups, ["icarus"])).toEqual(
+      new Set(["env-1:proj-1", "env-2:proj-9"]),
+    );
+  });
+
+  it("matches by workspace path and ORs multiple values", () => {
+    expect(resolveProjectFilterKeys(groups, ["dev/daedalus", "icarus"])).toEqual(
+      new Set(["env-1:proj-1", "env-2:proj-9", "env-1:proj-2"]),
+    );
+  });
+
+  it("returns an empty set (zero results, not all) when nothing matches", () => {
+    expect(resolveProjectFilterKeys(groups, ["zeus"])).toEqual(new Set());
+  });
+});
+
+describe("sidebar search project autocomplete", () => {
+  it("detects a trailing partial in: token", () => {
+    expect(getTrailingProjectOperatorToken("fix in:ica")).toEqual({
+      start: 4,
+      partialValue: "ica",
+    });
+    expect(getTrailingProjectOperatorToken("in:")).toEqual({ start: 0, partialValue: "" });
+  });
+
+  it("detects an unterminated quoted value", () => {
+    expect(getTrailingProjectOperatorToken('in:"my pro')).toEqual({
+      start: 0,
+      partialValue: "my pro",
+    });
+  });
+
+  it("returns null once the operator is committed or absent", () => {
+    expect(getTrailingProjectOperatorToken("in:icarus ")).toBeNull();
+    expect(getTrailingProjectOperatorToken("fix in:alpha beta")).toBeNull();
+    expect(getTrailingProjectOperatorToken("fix")).toBeNull();
+  });
+
+  it("replaces the trailing token with a quoted committed filter", () => {
+    const token = getTrailingProjectOperatorToken("fix in:ica");
+    expect(applyProjectSuggestionToQuery("fix in:ica", token, "Icarus")).toBe('fix in:"Icarus" ');
+  });
+
+  it("replaces the whole query for a bare-text project match", () => {
+    expect(applyProjectSuggestionToQuery("icarus", null, "Icarus")).toBe('in:"Icarus" ');
+  });
+
+  it("ranks suggestions: name prefix, then name substring, then path", () => {
+    const groups = [
+      { displayName: "Tools", workspaceRoot: "/dev/icarus-tools" },
+      { displayName: "My Icarus Fork", workspaceRoot: "/dev/fork" },
+      { displayName: "Icarus", workspaceRoot: "/dev/icarus" },
+      { displayName: "Unrelated", workspaceRoot: "/dev/other" },
+    ];
+    expect(filterProjectSuggestions(groups, "ica").map((group) => group.displayName)).toEqual([
+      "Icarus",
+      "My Icarus Fork",
+      "Tools",
+    ]);
+  });
+
+  it("skips workspace-path matches when matchWorkspaceRoot is false", () => {
+    const groups = [
+      { displayName: "Icarus", workspaceRoot: "/dev/icarus" },
+      { displayName: "Tools", workspaceRoot: "/dev/icarus-tools" },
+    ];
+    expect(
+      filterProjectSuggestions(groups, "ica", { matchWorkspaceRoot: false }).map(
+        (group) => group.displayName,
+      ),
+    ).toEqual(["Icarus"]);
+  });
+
+  it("lists every project for an empty partial value", () => {
+    const groups = [
+      { displayName: "Alpha", workspaceRoot: "/a" },
+      { displayName: "Beta", workspaceRoot: "/b" },
+    ];
+    expect(filterProjectSuggestions(groups, "")).toEqual(groups);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -525,18 +525,333 @@ export {
 } from "@t3tools/client-runtime/state/thread-sort";
 export { sortPinnedThreadsByOrderKey as sortPinnedThreadsForSidebar } from "@t3tools/client-runtime/state/thread-sort";
 
+// ── Sidebar search query language ───────────────────────────────────
+// Discord-style operators over the already-synced shell data:
+//   in:<project>      scope to projects whose name or path contains the value
+//   agent:<provider>  provider name / instance id substring
+//   before: after:    updatedAt bounds — ISO day, or relative like 7d / 2w
+//   on:               one calendar day — ISO day, today, yesterday
+// Everything else remains a title substring match. Operators AND together;
+// repeated values of the same operator OR within it. Values with spaces are
+// quoted: in:"My Project". An operator token whose value doesn't parse (bad
+// date) degrades to plain text instead of silently filtering everything out.
+
+export interface ParsedSidebarSearchQuery {
+  /** Lowercased free text left after operator extraction; matches titles. */
+  readonly text: string;
+  /** Lowercased in: values. Project-key resolution happens in the caller
+      (via resolveProjectFilterKeys) because group names live outside the
+      thread shells. */
+  readonly projectQueries: readonly string[];
+  /** Lowercased agent: values. */
+  readonly agentQueries: readonly string[];
+  /** Half-open [start, end) bounds on updatedAt, merged across all date
+      operators; null side = unbounded. */
+  readonly updatedStartMs: number | null;
+  readonly updatedEndMs: number | null;
+}
+
+const SEARCH_OPERATOR_PATTERN = /^(in|agent|before|after|on):(.*)$/i;
+const DAY_MS = 86_400_000;
+
+/** Splits on whitespace, except inside double quotes (an unterminated quote
+    runs to the end — that's just a user mid-typing). */
+function tokenizeSearchQuery(query: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (const char of query) {
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      current += char;
+      continue;
+    }
+    if (!inQuotes && /\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+function unquoteSearchValue(value: string): string {
+  return value.replace(/^"/, "").replace(/"$/, "");
+}
+
+type SearchDateToken =
+  | { readonly kind: "instant"; readonly ms: number }
+  | { readonly kind: "day"; readonly startMs: number; readonly endMs: number };
+
+/** Local-calendar day math goes through the Date constructor (day ± 1) so
+    month rollover and DST transitions resolve correctly. */
+function localDayRange(year: number, monthIndex: number, day: number): SearchDateToken {
+  return {
+    kind: "day",
+    startMs: new Date(year, monthIndex, day).getTime(),
+    endMs: new Date(year, monthIndex, day + 1).getTime(),
+  };
+}
+
+export function resolveSearchDateToken(rawValue: string, now: Date): SearchDateToken | null {
+  const value = rawValue.toLowerCase();
+  const relative = /^(\d{1,4})([dw])$/.exec(value);
+  if (relative) {
+    const amount = Number(relative[1]);
+    const unitMs = relative[2] === "w" ? 7 * DAY_MS : DAY_MS;
+    return { kind: "instant", ms: now.getTime() - amount * unitMs };
+  }
+  if (value === "today" || value === "yesterday") {
+    const offset = value === "yesterday" ? 1 : 0;
+    return localDayRange(now.getFullYear(), now.getMonth(), now.getDate() - offset);
+  }
+  const isoDay = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (isoDay) {
+    const year = Number(isoDay[1]);
+    const monthIndex = Number(isoDay[2]) - 1;
+    const day = Number(isoDay[3]);
+    const start = new Date(year, monthIndex, day);
+    // The Date constructor rolls invalid components over (2026-02-31 →
+    // March 3rd); a rolled-over date is a typo, not a filter.
+    if (
+      start.getFullYear() !== year ||
+      start.getMonth() !== monthIndex ||
+      start.getDate() !== day
+    ) {
+      return null;
+    }
+    return localDayRange(year, monthIndex, day);
+  }
+  return null;
+}
+
+export function parseSidebarSearchQuery(query: string, now: Date): ParsedSidebarSearchQuery {
+  const textTokens: string[] = [];
+  const projectQueries: string[] = [];
+  const agentQueries: string[] = [];
+  let updatedStartMs: number | null = null;
+  let updatedEndMs: number | null = null;
+  const tightenStart = (ms: number) => {
+    updatedStartMs = updatedStartMs === null ? ms : Math.max(updatedStartMs, ms);
+  };
+  const tightenEnd = (ms: number) => {
+    updatedEndMs = updatedEndMs === null ? ms : Math.min(updatedEndMs, ms);
+  };
+
+  for (const token of tokenizeSearchQuery(query)) {
+    const operator = SEARCH_OPERATOR_PATTERN.exec(token);
+    if (!operator) {
+      textTokens.push(token);
+      continue;
+    }
+    const keyword = operator[1]!.toLowerCase();
+    const value = unquoteSearchValue(operator[2]!).trim().toLowerCase();
+    // A bare `in:` is someone mid-typing (the autocomplete is open); an
+    // empty value must not filter anything.
+    if (value.length === 0) continue;
+    if (keyword === "in") {
+      projectQueries.push(value);
+      continue;
+    }
+    if (keyword === "agent") {
+      agentQueries.push(value);
+      continue;
+    }
+    const dateToken = resolveSearchDateToken(value, now);
+    if (dateToken === null) {
+      textTokens.push(token);
+      continue;
+    }
+    // before: excludes the named day/instant; after: starts past it; on:
+    // pins both bounds to the day. All merge by intersection.
+    if (keyword === "before") {
+      tightenEnd(dateToken.kind === "instant" ? dateToken.ms : dateToken.startMs);
+    } else if (keyword === "after") {
+      tightenStart(dateToken.kind === "instant" ? dateToken.ms : dateToken.endMs);
+    } else if (dateToken.kind === "day") {
+      tightenStart(dateToken.startMs);
+      tightenEnd(dateToken.endMs);
+    } else {
+      // on:7d is a point, not a day — degrade to text like other bad dates.
+      textTokens.push(token);
+    }
+  }
+
+  return {
+    text: textTokens.join(" ").toLowerCase(),
+    projectQueries,
+    agentQueries,
+    updatedStartMs,
+    updatedEndMs,
+  };
+}
+
+/** Whether the parsed query filters anything at all. False for whitespace or
+    a lone half-typed operator — the result list should stay empty then. */
+export function hasSidebarSearchCriteria(parsed: ParsedSidebarSearchQuery): boolean {
+  return (
+    parsed.text.length > 0 ||
+    parsed.projectQueries.length > 0 ||
+    parsed.agentQueries.length > 0 ||
+    parsed.updatedStartMs !== null ||
+    parsed.updatedEndMs !== null
+  );
+}
+
+export interface SidebarSearchableThread {
+  readonly title: string;
+  readonly updatedAt: string;
+  readonly modelSelection: { readonly instanceId: string };
+  readonly session: {
+    readonly providerName: string | null;
+    readonly providerInstanceId?: string | undefined;
+  } | null;
+}
+
+export function matchesParsedSidebarSearch(
+  thread: SidebarSearchableThread,
+  parsed: ParsedSidebarSearchQuery,
+): boolean {
+  if (parsed.text.length > 0 && !thread.title.toLowerCase().includes(parsed.text)) {
+    return false;
+  }
+  if (parsed.agentQueries.length > 0) {
+    const agentHaystack = [
+      thread.session?.providerName,
+      thread.session?.providerInstanceId,
+      thread.modelSelection.instanceId,
+    ]
+      .filter((candidate): candidate is string => typeof candidate === "string")
+      .join(" ")
+      .toLowerCase();
+    if (!parsed.agentQueries.some((query) => agentHaystack.includes(query))) {
+      return false;
+    }
+  }
+  if (parsed.updatedStartMs !== null || parsed.updatedEndMs !== null) {
+    const updatedMs = Date.parse(thread.updatedAt);
+    if (Number.isNaN(updatedMs)) return false;
+    if (parsed.updatedStartMs !== null && updatedMs < parsed.updatedStartMs) return false;
+    if (parsed.updatedEndMs !== null && updatedMs >= parsed.updatedEndMs) return false;
+  }
+  return true;
+}
+
 /**
- * Search the already-ordered sidebar thread collection by title only.
- * Keeping the input order means lifecycle ordering (active, snoozed, settled)
- * remains stable while the user narrows the list.
+ * Filter the already-ordered sidebar thread collection by a parsed query.
+ * Keeping the input order means lifecycle ordering (active, snoozed,
+ * settled, archived tail) remains stable while the user narrows the list.
+ * The in: operator is applied by the caller as a project-key filter before
+ * this runs — thread shells don't carry project names.
  */
-export function searchSidebarThreadsByTitle<T extends { readonly title: string }>(
+export function searchSidebarThreads<T extends SidebarSearchableThread>(
   threads: readonly T[],
-  query: string,
+  parsed: ParsedSidebarSearchQuery,
 ): T[] {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (normalizedQuery.length === 0) return [];
-  return threads.filter((thread) => thread.title.toLowerCase().includes(normalizedQuery));
+  if (!hasSidebarSearchCriteria(parsed)) return [];
+  return threads.filter((thread) => matchesParsedSidebarSearch(thread, parsed));
+}
+
+export interface SidebarSearchProjectGroup {
+  readonly projectKey: string;
+  readonly displayName: string;
+  readonly workspaceRoot: string;
+  readonly memberProjectRefs: readonly {
+    readonly environmentId: string;
+    readonly projectId: string;
+  }[];
+}
+
+/** Expands in: values into the `${environmentId}:${projectId}` key set the
+    sidebar already filters by. null = no in: filter; an empty set means the
+    values matched no project (zero results, not all results). */
+export function resolveProjectFilterKeys(
+  groups: readonly SidebarSearchProjectGroup[],
+  projectQueries: readonly string[],
+): ReadonlySet<string> | null {
+  if (projectQueries.length === 0) return null;
+  const keys = new Set<string>();
+  for (const group of groups) {
+    const name = group.displayName.toLowerCase();
+    const root = group.workspaceRoot.toLowerCase();
+    if (projectQueries.some((query) => name.includes(query) || root.includes(query))) {
+      for (const ref of group.memberProjectRefs) {
+        keys.add(`${ref.environmentId}:${ref.projectId}`);
+      }
+    }
+  }
+  return keys;
+}
+
+export interface TrailingProjectOperatorToken {
+  /** Index in the query where the trailing in: token starts. */
+  readonly start: number;
+  /** The unquoted partial value typed so far (may be empty). */
+  readonly partialValue: string;
+}
+
+/** Detects an in-progress trailing `in:` token — the caret is still inside
+    it, so the project autocomplete should be open. Trailing whitespace (or a
+    different trailing token) means the operator is committed and this
+    returns null. */
+export function getTrailingProjectOperatorToken(
+  query: string,
+): TrailingProjectOperatorToken | null {
+  const match = /(^|\s)(in:("[^"]*"?|[^\s"]*))$/i.exec(query);
+  if (!match) return null;
+  return {
+    start: match.index + match[1]!.length,
+    partialValue: unquoteSearchValue(match[2]!.slice("in:".length)),
+  };
+}
+
+/** Ranks project groups for the in: autocomplete: name prefix, then name
+    substring, then workspace-path substring. An empty partial lists all.
+    Path matching is opt-out: a bare text query offering "Filter by project"
+    must only match project NAMES — a folder path coincidentally containing
+    the words someone typed is noise there, while inside an explicit in:
+    token the path is a deliberate handle. */
+export function filterProjectSuggestions<
+  T extends { readonly displayName: string; readonly workspaceRoot: string },
+>(
+  groups: readonly T[],
+  partialValue: string,
+  options?: { readonly matchWorkspaceRoot?: boolean },
+): T[] {
+  const matchWorkspaceRoot = options?.matchWorkspaceRoot ?? true;
+  const query = partialValue.trim().toLowerCase();
+  if (query.length === 0) return [...groups];
+  const ranked: { group: T; rank: number }[] = [];
+  for (const group of groups) {
+    const name = group.displayName.toLowerCase();
+    const rank = name.startsWith(query)
+      ? 0
+      : name.includes(query)
+        ? 1
+        : matchWorkspaceRoot && group.workspaceRoot.toLowerCase().includes(query)
+          ? 2
+          : null;
+    if (rank !== null) ranked.push({ group, rank });
+  }
+  // toSorted is stable: groups keep their sidebar order within each rank.
+  return ranked.toSorted((left, right) => left.rank - right.rank).map((entry) => entry.group);
+}
+
+/** Applies a picked project suggestion: replaces the in-progress trailing
+    in: token — or, for a bare-text match, the whole query — with a quoted,
+    committed filter plus a trailing space so typing continues naturally. */
+export function applyProjectSuggestionToQuery(
+  query: string,
+  token: TrailingProjectOperatorToken | null,
+  projectName: string,
+): string {
+  const filter = `in:"${projectName.replaceAll('"', "")}" `;
+  if (token === null) return filter;
+  return `${query.slice(0, token.start)}${filter}`;
 }
 
 type SettledTimestampInput = Pick<

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -554,20 +554,6 @@ export {
 } from "@t3tools/client-runtime/state/thread-sort";
 export { sortPinnedThreadsByOrderKey as sortPinnedThreadsForSidebar } from "@t3tools/client-runtime/state/thread-sort";
 
-/**
- * Search the already-ordered sidebar thread collection by title only.
- * Keeping the input order means lifecycle ordering (active, snoozed, settled)
- * remains stable while the user narrows the list.
- */
-export function searchSidebarThreadsByTitle<T extends { readonly title: string }>(
-  threads: readonly T[],
-  query: string,
-): T[] {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (normalizedQuery.length === 0) return [];
-  return threads.filter((thread) => thread.title.toLowerCase().includes(normalizedQuery));
-}
-
 type SettledTimestampInput = Pick<
   SidebarThreadSummary,
   "settledAt" | "latestUserMessageAt" | "latestTurn" | "updatedAt"

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -132,7 +132,6 @@ import {
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
-  searchSidebarThreadsByTitle,
   shouldCreateNewThreadInCurrentProject,
   resolveWorkingStartedAt,
   sortLogicalProjectsForSidebar,
@@ -162,8 +161,8 @@ import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../pr
 import { primaryServerProvidersAtom } from "../state/server";
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { stackedThreadToast, toastManager } from "./ui/toast";
-import { Button } from "./ui/button";
-import { Input } from "./ui/input";
+import { CommandDialogTrigger } from "./ui/command";
+import { Kbd } from "./ui/kbd";
 import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
@@ -1489,109 +1488,6 @@ function latestTurnDiff(
   return null;
 }
 
-const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
-  thread: SidebarThreadSummary;
-  projectCwd: string | null;
-  projectFaviconPath: string | null;
-  projectTitle: string | null;
-  environmentLabel: string | null;
-  providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
-  isHighlighted: boolean;
-  isRouteActive: boolean;
-  resultId: string;
-  onHighlight: () => void;
-  onSelect: () => void;
-}) {
-  const { thread } = props;
-  // Same details tooltip as the regular rows: a search hit is still a thread,
-  // and the hover card is how you disambiguate identically-titled results.
-  const gitCwd = thread.worktreePath ?? props.projectCwd;
-  const gitStatus = useEnvironmentQuery(
-    (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
-      ? vcsEnvironment.status({
-          environmentId: thread.environmentId,
-          input: { cwd: gitCwd },
-        })
-      : null,
-  );
-  const branchMismatch = resolveLocalCheckoutBranchMismatch({
-    effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
-    activeWorktreePath: thread.worktreePath,
-    activeThreadBranch: thread.branch,
-    currentGitBranch: gitStatus.data?.refName ?? null,
-  });
-  const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
-  const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
-  const driverKind = providerEntry?.driverKind ?? null;
-  const selectedModel = providerEntry?.models.find(
-    (model) => model.slug === thread.modelSelection.model,
-  );
-  const modelLabel = selectedModel
-    ? getTriggerDisplayModelLabel(selectedModel)
-    : thread.modelSelection.model;
-  const runningTerminalIds = useThreadRunningTerminalIds({
-    environmentId: thread.environmentId,
-    threadId: thread.id,
-  });
-  const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
-  return (
-    <li role="presentation" className="list-none">
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <button
-              id={props.resultId}
-              type="button"
-              role="option"
-              // aria-activedescendant options: focus stays on the search input,
-              // which owns all keyboard interaction for the listbox.
-              tabIndex={-1}
-              aria-selected={props.isHighlighted}
-              aria-current={props.isRouteActive ? "page" : undefined}
-              aria-label={
-                props.projectTitle ? `${thread.title}, ${props.projectTitle}` : thread.title
-              }
-              onMouseMove={props.onHighlight}
-              onClick={props.onSelect}
-              className={cn(
-                "flex h-9 w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 text-left text-sm outline-none",
-                props.isHighlighted || props.isRouteActive
-                  ? "bg-sidebar-row-active text-sidebar-foreground"
-                  : "text-sidebar-muted-foreground/75 hover:bg-sidebar-row-hover hover:text-sidebar-foreground",
-              )}
-            />
-          }
-        >
-          <ProjectFavicon
-            environmentId={thread.environmentId}
-            cwd={props.projectCwd ?? ""}
-            faviconPath={props.projectFaviconPath}
-            className="size-4 shrink-0"
-            fallbackIcon={MessageSquareIcon}
-          />
-          <span className="min-w-0 flex-1 truncate">{thread.title}</span>
-          <span className="shrink-0 text-xs text-muted-foreground/55 tabular-nums">
-            {threadTimeLabel(thread)}
-          </span>
-        </TooltipTrigger>
-        <SidebarThreadTooltip
-          thread={thread}
-          projectTitle={props.projectTitle}
-          projectCwd={props.projectCwd}
-          projectFaviconPath={props.projectFaviconPath}
-          environmentLabel={props.environmentLabel}
-          driverKind={driverKind}
-          modelInstanceId={modelInstanceId}
-          modelLabel={modelLabel}
-          branchMismatch={branchMismatch}
-          terminalStatus={terminalStatus}
-          terminalProcessCount={runningTerminalIds.length}
-        />
-      </Tooltip>
-    </li>
-  );
-});
-
 export default function Sidebar() {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
@@ -2004,33 +1900,6 @@ export default function Sidebar() {
     threads,
   ]);
 
-  const threadSearchInputRef = useRef<HTMLInputElement>(null);
-  const [threadSearchQuery, setThreadSearchQuery] = useState("");
-  const [activeSearchResultIndex, setActiveSearchResultIndex] = useState(0);
-  const isSearchingThreads = threadSearchQuery.trim().length > 0;
-  const searchableThreads = useMemo(
-    () => [...pinnedThreads, ...activeThreads, ...snoozedThreads, ...settledThreads],
-    [activeThreads, pinnedThreads, settledThreads, snoozedThreads],
-  );
-  const threadSearchResults = useMemo(
-    () => searchSidebarThreadsByTitle(searchableThreads, threadSearchQuery),
-    [searchableThreads, threadSearchQuery],
-  );
-  const threadSearchResultOrderKey = threadSearchResults
-    .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)))
-    .join("\0");
-
-  useEffect(() => {
-    setActiveSearchResultIndex(0);
-  }, [threadSearchResultOrderKey]);
-
-  useEffect(() => {
-    if (!isSearchingThreads) return;
-    document
-      .getElementById(`sidebar-thread-search-result-${activeSearchResultIndex}`)
-      ?.scrollIntoView({ block: "nearest" });
-  }, [activeSearchResultIndex, isSearchingThreads, threadSearchResultOrderKey]);
-
   // Arm a timeout for the earliest upcoming wake so the shelf empties the
   // moment a snooze expires instead of on the next minute tick. Sorted
   // soonest-first, so entry 0 is the boundary.
@@ -2231,56 +2100,6 @@ export default function Sidebar() {
       void router.navigate({ to: "/draft/$draftId", params: { draftId } });
     },
     [clearSelection, isMobile, router, setOpenMobile],
-  );
-
-  const clearThreadSearch = useCallback(() => {
-    setThreadSearchQuery("");
-    setActiveSearchResultIndex(0);
-  }, []);
-  const selectThreadSearchResult = useCallback(
-    (thread: EnvironmentThreadShell) => {
-      clearThreadSearch();
-      navigateToThread(scopeThreadRef(thread.environmentId, thread.id));
-    },
-    [clearThreadSearch, navigateToThread],
-  );
-  const handleThreadSearchKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLInputElement>) => {
-      // IME composition (Japanese/Chinese input) uses the same keys; committing
-      // a candidate must not move the highlight or navigate away mid-compose.
-      if (event.nativeEvent.isComposing || event.keyCode === 229) return;
-      if (event.key === "Escape" && isSearchingThreads) {
-        event.preventDefault();
-        event.stopPropagation();
-        clearThreadSearch();
-        return;
-      }
-      if (threadSearchResults.length === 0) return;
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setActiveSearchResultIndex((index) => (index + 1) % threadSearchResults.length);
-        return;
-      }
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setActiveSearchResultIndex(
-          (index) => (index - 1 + threadSearchResults.length) % threadSearchResults.length,
-        );
-        return;
-      }
-      if (event.key === "Enter") {
-        event.preventDefault();
-        const result = threadSearchResults[activeSearchResultIndex];
-        if (result) selectThreadSearchResult(result);
-      }
-    },
-    [
-      activeSearchResultIndex,
-      clearThreadSearch,
-      isSearchingThreads,
-      selectThreadSearchResult,
-      threadSearchResults,
-    ],
   );
 
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
@@ -3235,6 +3054,7 @@ export default function Sidebar() {
     shortcutLabelForCommand(keybindings, "chat.new") ??
     (projectGroups.length <= 1 ? shortcutLabelForCommand(keybindings, "chat.newLocal") : undefined);
   const newThreadInProjectShortcutLabel = shortcutLabelForCommand(keybindings, "chat.newLocal");
+  const commandPaletteShortcutLabel = shortcutLabelForCommand(keybindings, "commandPalette.toggle");
   return (
     <>
       <SidebarChromeHeader isElectron={isElectron} />
@@ -3245,52 +3065,27 @@ export default function Sidebar() {
           // header and would otherwise paint across the search row's outline.
           <SidebarGroup className="relative z-[1] gap-1 p-[var(--sidebar-content-inset)]">
             <div className="flex items-center gap-1">
-              <div className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground">
-                <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
-                <Input
-                  ref={threadSearchInputRef}
-                  nativeInput
-                  unstyled
-                  type="search"
-                  value={threadSearchQuery}
-                  onChange={(event) => {
-                    setThreadSearchQuery(event.currentTarget.value);
-                    setActiveSearchResultIndex(0);
-                  }}
-                  onKeyDown={handleThreadSearchKeyDown}
-                  placeholder="Search"
-                  aria-label="Search threads"
-                  role="combobox"
-                  aria-autocomplete="list"
-                  aria-expanded={isSearchingThreads && threadSearchResults.length > 0}
-                  aria-controls={
-                    isSearchingThreads && threadSearchResults.length > 0
-                      ? "sidebar-thread-search-results"
-                      : undefined
-                  }
-                  aria-activedescendant={
-                    isSearchingThreads && threadSearchResults[activeSearchResultIndex]
-                      ? `sidebar-thread-search-result-${activeSearchResultIndex}`
-                      : undefined
-                  }
-                  className="min-w-0 flex-1 [&_[data-slot=input]]:h-auto [&_[data-slot=input]]:p-0 [&_[data-slot=input]]:leading-normal [&_[data-slot=input]]:text-sm [&_[data-slot=input]]:font-medium [&_[data-slot=input]]:text-sidebar-foreground [&_[data-slot=input]]:placeholder:text-sidebar-muted-foreground"
-                />
-                {isSearchingThreads ? (
-                  <Button
+              {/* Search lives in the command palette (operators, content
+                  search, project autocomplete); the sidebar only offers the
+                  doorway, mirroring the legacy sidebar's trigger. */}
+              <CommandDialogTrigger
+                render={
+                  <button
                     type="button"
-                    size="icon-xs"
-                    variant="ghost"
-                    className="size-5 shrink-0 rounded-sm text-sidebar-muted-foreground hover:bg-sidebar-control-surface hover:text-sidebar-foreground"
-                    aria-label="Clear thread search"
-                    onClick={() => {
-                      clearThreadSearch();
-                      threadSearchInputRef.current?.focus();
-                    }}
-                  >
-                    <XIcon className="size-3" />
-                  </Button>
+                    data-testid="command-palette-trigger"
+                    aria-label="Search threads"
+                    className="flex h-8 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-sidebar-muted-foreground outline-none hover:bg-sidebar-row-hover hover:text-sidebar-foreground focus-visible:ring-1 focus-visible:ring-ring"
+                  />
+                }
+              >
+                <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
+                <span className="min-w-0 flex-1 truncate text-left">Search</span>
+                {commandPaletteShortcutLabel ? (
+                  <Kbd className="h-4 min-w-0 rounded-sm px-1.5 text-[10px]">
+                    {commandPaletteShortcutLabel}
+                  </Kbd>
                 ) : null}
-              </div>
+              </CommandDialogTrigger>
               <div className="shrink-0">
                 <Tooltip>
                   <TooltipTrigger
@@ -3436,63 +3231,7 @@ export default function Sidebar() {
         }
       >
         <SidebarGroup className="ps-[calc(var(--sidebar-content-inset)+1px)] pe-[var(--sidebar-content-inset)] pb-1 pt-0">
-          {isSearchingThreads ? (
-            threadSearchResults.length > 0 ? (
-              <TooltipProvider
-                key="sidebar-thread-search-tooltips-150"
-                delay={150}
-                closeDelay={0}
-                timeout={400}
-              >
-                <ul
-                  id="sidebar-thread-search-results"
-                  role="listbox"
-                  aria-label="Thread search results"
-                  className="flex flex-col gap-px"
-                >
-                  {threadSearchResults.map((thread, index) => {
-                    const threadKey = scopedThreadKey(
-                      scopeThreadRef(thread.environmentId, thread.id),
-                    );
-                    return (
-                      <SidebarSearchResultRow
-                        key={threadKey}
-                        thread={thread}
-                        projectCwd={
-                          projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null
-                        }
-                        projectFaviconPath={
-                          projectFaviconPathByKey.get(
-                            `${thread.environmentId}:${thread.projectId}`,
-                          ) ?? null
-                        }
-                        projectTitle={
-                          projectDisplayNameByKey.get(
-                            `${thread.environmentId}:${thread.projectId}`,
-                          ) ?? null
-                        }
-                        environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
-                        providerEntryByInstanceId={providerEntryByInstanceId}
-                        isHighlighted={activeSearchResultIndex === index}
-                        isRouteActive={routeThreadKey === threadKey}
-                        resultId={`sidebar-thread-search-result-${index}`}
-                        onHighlight={() => setActiveSearchResultIndex(index)}
-                        onSelect={() => selectThreadSearchResult(thread)}
-                      />
-                    );
-                  })}
-                </ul>
-              </TooltipProvider>
-            ) : (
-              <p
-                role="status"
-                className="px-2 py-6 text-center text-xs text-sidebar-muted-foreground"
-              >
-                No threads found
-              </p>
-            )
-          ) : null}
-          {!isSearchingThreads ? (
+          {
             <TooltipProvider
               key="sidebar-thread-tooltips-150"
               delay={150}
@@ -3752,9 +3491,8 @@ export default function Sidebar() {
                 ) : null}
               </ul>
             </TooltipProvider>
-          ) : null}
-          {!isSearchingThreads &&
-          visibleDraftSessionCount === 0 &&
+          }
+          {visibleDraftSessionCount === 0 &&
           pinnedThreads.length +
             activeThreads.length +
             snoozedThreads.length +

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -22,7 +22,10 @@ import {
   effectiveSnoozed,
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
-import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+import {
+  scopeThreadShell,
+  type EnvironmentThreadShell,
+} from "@t3tools/client-runtime/state/models";
 import {
   scopeProjectRef,
   scopeThreadRef,
@@ -98,6 +101,7 @@ import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
+import { useArchivedThreadSnapshots } from "../lib/archivedThreadsState";
 import { useClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
@@ -128,7 +132,12 @@ import {
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
-  searchSidebarThreadsByTitle,
+  applyProjectSuggestionToQuery,
+  filterProjectSuggestions,
+  getTrailingProjectOperatorToken,
+  parseSidebarSearchQuery,
+  resolveProjectFilterKeys,
+  searchSidebarThreads,
   resolveWorkingStartedAt,
   sortLogicalProjectsForSidebar,
   sortPinnedThreadsForSidebar,
@@ -1521,9 +1530,13 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
               tabIndex={-1}
               aria-selected={props.isHighlighted}
               aria-current={props.isRouteActive ? "page" : undefined}
-              aria-label={
-                props.projectTitle ? `${thread.title}, ${props.projectTitle}` : thread.title
-              }
+              aria-label={[
+                thread.title,
+                props.projectTitle,
+                thread.archivedAt !== null ? "archived" : null,
+              ]
+                .filter(Boolean)
+                .join(", ")}
               onMouseMove={props.onHighlight}
               onClick={props.onSelect}
               className={cn(
@@ -1543,6 +1556,11 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
             fallbackIcon={MessageSquareIcon}
           />
           <span className="min-w-0 flex-1 truncate">{thread.title}</span>
+          {thread.archivedAt !== null ? (
+            <span className="shrink-0 rounded border border-sidebar-border px-1 text-[10px] font-medium text-sidebar-muted-foreground/80">
+              Archived
+            </span>
+          ) : null}
           <span className="shrink-0 text-xs text-muted-foreground/55 tabular-nums">
             {threadTimeLabel(thread)}
           </span>
@@ -1561,6 +1579,47 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
           terminalProcessCount={runningTerminalIds.length}
         />
       </Tooltip>
+    </li>
+  );
+});
+
+const SidebarProjectSuggestionRow = memo(function SidebarProjectSuggestionRow(props: {
+  group: SidebarProjectSnapshot;
+  isHighlighted: boolean;
+  resultId: string;
+  onHighlight: () => void;
+  onSelect: () => void;
+}) {
+  return (
+    <li role="presentation" className="list-none">
+      <button
+        id={props.resultId}
+        type="button"
+        role="option"
+        // aria-activedescendant option, same as the thread rows: focus stays
+        // on the search input, which owns all keyboard interaction.
+        tabIndex={-1}
+        aria-selected={props.isHighlighted}
+        aria-label={`Filter by project ${props.group.displayName}`}
+        onMouseMove={props.onHighlight}
+        onClick={props.onSelect}
+        className={cn(
+          "flex h-9 w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 text-left text-sm outline-none",
+          props.isHighlighted
+            ? "bg-sidebar-row-active text-sidebar-foreground"
+            : "text-sidebar-muted-foreground/75 hover:bg-sidebar-row-hover hover:text-sidebar-foreground",
+        )}
+      >
+        <ProjectFavicon
+          environmentId={props.group.environmentId}
+          cwd={props.group.workspaceRoot}
+          faviconPath={props.group.faviconPath}
+          className="size-4 shrink-0"
+          fallbackIcon={FolderIcon}
+        />
+        <span className="min-w-0 flex-1 truncate">{props.group.displayName}</span>
+        <span className="shrink-0 text-xs text-muted-foreground/55">Filter by project</span>
+      </button>
     </li>
   );
 });
@@ -1857,14 +1916,11 @@ export default function Sidebar() {
   // merging, no optimistic holds. Archived threads remain hidden here —
   // archive keeps its original "remove from sidebar" meaning.
   const serverConfigs = useAtomValue(environmentServerConfigsAtom);
-  const {
-    pinnedThreads,
-    reorderablePinnedKeys,
-    activeThreads,
-    snoozedThreads,
-    settledThreads,
-    snoozeNow,
-  } = useMemo(() => {
+  // The partition is UNSCOPED: search with an explicit in: filter must see
+  // every project, so the project-scope menu applies afterwards (filtering a
+  // sorted list and sorting a filtered list agree — the comparators are
+  // per-thread). The scope-independent work then never reruns on scope flips.
+  const threadPartition = useMemo(() => {
     const now = `${nowMinute}:00.000Z`;
     // Snooze classification uses a REAL clock, not the quantized minute:
     // wake times are second-precise and a woken thread must not linger on
@@ -1872,12 +1928,7 @@ export default function Sidebar() {
     // memo exactly at the next wake boundary.
     void snoozeWakeTick;
     const preciseNow = new Date().toISOString();
-    const visible = threads.filter(
-      (thread) =>
-        thread.archivedAt === null &&
-        (scopedProjectKeys === null ||
-          scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
-    );
+    const visible = threads.filter((thread) => thread.archivedAt === null);
     const pinned: EnvironmentThreadShell[] = [];
     const active: EnvironmentThreadShell[] = [];
     const snoozed: EnvironmentThreadShell[] = [];
@@ -1922,7 +1973,7 @@ export default function Sidebar() {
     // sort, or mixed-version fleets would render different pinned orders on
     // web and mobile from the same data.
     return {
-      pinnedThreads: sortPinnedThreadsForSidebar(pinned),
+      pinned: sortPinnedThreadsForSidebar(pinned),
       reorderablePinnedKeys: new Set(
         pinned
           .filter(
@@ -1932,41 +1983,150 @@ export default function Sidebar() {
           )
           .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
       ),
-      activeThreads: sortThreadsForSidebar(active),
+      active: sortThreadsForSidebar(active),
       // Soonest wake first: "what comes back next" is the shelf's question.
-      snoozedThreads: snoozed.toSorted(
+      snoozed: snoozed.toSorted(
         (left, right) =>
           firstValidTimestampMs(left.snoozedUntil ?? null) -
           firstValidTimestampMs(right.snoozedUntil ?? null),
       ),
-      settledThreads: sortSettledThreadsForSidebar(settled),
+      settled: sortSettledThreadsForSidebar(settled),
       snoozeNow: preciseNow,
     };
   }, [
     autoSettleAfterDays,
     changeRequestStateByKey,
     nowMinute,
-    scopedProjectKeys,
     serverConfigs,
     snoozeWakeTick,
     threads,
   ]);
+  const { reorderablePinnedKeys, snoozeNow } = threadPartition;
+  const { pinnedThreads, activeThreads, snoozedThreads, settledThreads } = useMemo(() => {
+    const inProjectScope = (thread: EnvironmentThreadShell) =>
+      scopedProjectKeys === null ||
+      scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`);
+    return {
+      pinnedThreads: threadPartition.pinned.filter(inProjectScope),
+      activeThreads: threadPartition.active.filter(inProjectScope),
+      snoozedThreads: threadPartition.snoozed.filter(inProjectScope),
+      settledThreads: threadPartition.settled.filter(inProjectScope),
+    };
+  }, [scopedProjectKeys, threadPartition]);
 
   const threadSearchInputRef = useRef<HTMLInputElement>(null);
   const [threadSearchQuery, setThreadSearchQuery] = useState("");
   const [activeSearchResultIndex, setActiveSearchResultIndex] = useState(0);
   const isSearchingThreads = threadSearchQuery.trim().length > 0;
-  const searchableThreads = useMemo(
-    () => [...pinnedThreads, ...activeThreads, ...snoozedThreads, ...settledThreads],
-    [activeThreads, pinnedThreads, settledThreads, snoozedThreads],
+  const parsedThreadSearchQuery = useMemo(() => {
+    // nowMinute keeps relative date operators (after:7d) honest while a
+    // query sits open across minute boundaries.
+    void nowMinute;
+    return parseSidebarSearchQuery(threadSearchQuery, new Date());
+  }, [nowMinute, threadSearchQuery]);
+  // Archived threads live in a separate query-style snapshot, not the live
+  // shell stream, so search subscribes only while a query is active — the
+  // sidebar otherwise never pays for archive data. Archive/unarchive actions
+  // refresh these atoms (useThreadActions), so hits stay current in-session.
+  const archivedSearchEnvironmentIds = useMemo(
+    () => (isSearchingThreads ? environments.map((environment) => environment.environmentId) : []),
+    [environments, isSearchingThreads],
   );
-  const threadSearchResults = useMemo(
-    () => searchSidebarThreadsByTitle(searchableThreads, threadSearchQuery),
-    [searchableThreads, threadSearchQuery],
+  const archivedThreadSnapshots = useArchivedThreadSnapshots(archivedSearchEnvironmentIds);
+  const archivedSearchableThreads = useMemo(() => {
+    if (archivedThreadSnapshots.snapshots.length === 0) return [];
+    // A shell can linger in the live stream with archivedAt freshly set (or
+    // appear in both after an unarchive races the snapshot refresh); the
+    // live stream wins so a thread never renders twice.
+    const liveThreadKeys = new Set(
+      threads.map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
+    );
+    return archivedThreadSnapshots.snapshots
+      .flatMap((entry) =>
+        entry.snapshot.threads
+          .filter(
+            (thread) =>
+              !liveThreadKeys.has(scopedThreadKey(scopeThreadRef(entry.environmentId, thread.id))),
+          )
+          .map((thread) => scopeThreadShell(entry.environmentId, thread)),
+      )
+      .toSorted(
+        (left, right) =>
+          firstValidTimestampMs(right.archivedAt, right.updatedAt) -
+          firstValidTimestampMs(left.archivedAt, left.updatedAt),
+      );
+  }, [archivedThreadSnapshots.snapshots, threads]);
+  const threadSearchProjectFilterKeys = useMemo(
+    () => resolveProjectFilterKeys(projectGroups, parsedThreadSearchQuery.projectQueries),
+    [parsedThreadSearchQuery.projectQueries, projectGroups],
   );
-  const threadSearchResultOrderKey = threadSearchResults
-    .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)))
-    .join("\0");
+  const threadSearchResults = useMemo(() => {
+    if (!isSearchingThreads) return [];
+    // Lifecycle order stays the spine of the result list; archived history
+    // trails it, most recently archived first.
+    const orderedThreads = [
+      ...threadPartition.pinned,
+      ...threadPartition.active,
+      ...threadPartition.snoozed,
+      ...threadPartition.settled,
+      ...archivedSearchableThreads,
+    ];
+    // An explicit in: filter overrides the ambient project-scope menu;
+    // without one, search respects the scope exactly like the list does.
+    const scoped = orderedThreads.filter((thread) => {
+      const projectKey = `${thread.environmentId}:${thread.projectId}`;
+      return threadSearchProjectFilterKeys === null
+        ? scopedProjectKeys === null || scopedProjectKeys.has(projectKey)
+        : threadSearchProjectFilterKeys.has(projectKey);
+    });
+    return searchSidebarThreads(scoped, parsedThreadSearchQuery);
+  }, [
+    archivedSearchableThreads,
+    isSearchingThreads,
+    parsedThreadSearchQuery,
+    scopedProjectKeys,
+    threadPartition,
+    threadSearchProjectFilterKeys,
+  ]);
+  const trailingProjectOperatorToken = useMemo(
+    () => getTrailingProjectOperatorToken(threadSearchQuery),
+    [threadSearchQuery],
+  );
+  const projectSearchSuggestions = useMemo(() => {
+    if (!isSearchingThreads || projectGroups.length === 0) return [];
+    // While the caret is inside an in: token the autocomplete lists projects
+    // matching the partial value (all of them for a bare `in:`).
+    if (trailingProjectOperatorToken !== null) {
+      return filterProjectSuggestions(
+        projectGroups,
+        trailingProjectOperatorToken.partialValue,
+      ).slice(0, 8);
+    }
+    // Bare text that happens to match a project name offers "Filter by
+    // project" above the thread results — how the operator gets discovered.
+    const parsed = parsedThreadSearchQuery;
+    const isPlainTextQuery =
+      parsed.projectQueries.length === 0 &&
+      parsed.agentQueries.length === 0 &&
+      parsed.updatedStartMs === null &&
+      parsed.updatedEndMs === null &&
+      parsed.text.length > 0;
+    if (!isPlainTextQuery) return [];
+    // Name-only: a folder path that happens to contain the typed words must
+    // not push project suggestions into a regular text search.
+    return filterProjectSuggestions(projectGroups, parsed.text, {
+      matchWorkspaceRoot: false,
+    }).slice(0, 2);
+  }, [isSearchingThreads, parsedThreadSearchQuery, projectGroups, trailingProjectOperatorToken]);
+  // Suggestions and thread results share one listbox and one active index:
+  // suggestions occupy [0, suggestionCount), results follow.
+  const searchListItemCount = projectSearchSuggestions.length + threadSearchResults.length;
+  const threadSearchResultOrderKey = [
+    ...projectSearchSuggestions.map((group) => `project:${group.projectKey}`),
+    ...threadSearchResults.map((thread) =>
+      scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+    ),
+  ].join("\0");
 
   useEffect(() => {
     setActiveSearchResultIndex(0);
@@ -1983,9 +2143,11 @@ export default function Sidebar() {
   // moment a snooze expires instead of on the next minute tick. Sorted
   // soonest-first, so entry 0 is the boundary.
   useEffect(() => {
+    // Unscoped on purpose: a thread hidden by the project-scope menu still
+    // wakes on time, so flipping the scope later never shows a stale shelf.
     const nextWakeAtMs =
-      snoozedThreads.length > 0 && snoozedThreads[0]?.snoozedUntil != null
-        ? Date.parse(snoozedThreads[0].snoozedUntil)
+      threadPartition.snoozed.length > 0 && threadPartition.snoozed[0]?.snoozedUntil != null
+        ? Date.parse(threadPartition.snoozed[0].snoozedUntil)
         : Number.NaN;
     if (Number.isNaN(nextWakeAtMs)) return;
     // setTimeout delays are signed 32-bit: anything larger overflows and
@@ -1995,7 +2157,7 @@ export default function Sidebar() {
     const delayMs = Math.min(Math.max(0, nextWakeAtMs - Date.now()) + 50, 2_147_483_647);
     const id = window.setTimeout(() => bumpSnoozeWakeTick((tick) => tick + 1), delayMs);
     return () => window.clearTimeout(id);
-  }, [snoozedThreads]);
+  }, [threadPartition.snoozed]);
 
   // The settled tail renders in pages: history shouldn't dominate the
   // sidebar, and the common lookups are recent. Expansion resets when the
@@ -2178,6 +2340,15 @@ export default function Sidebar() {
     },
     [clearThreadSearch, navigateToThread],
   );
+  // Picking a suggestion rewrites the query (committing the in: filter) and
+  // keeps typing flowing — focus never leaves the input.
+  const applyProjectSearchSuggestion = useCallback((projectName: string) => {
+    setThreadSearchQuery((query) =>
+      applyProjectSuggestionToQuery(query, getTrailingProjectOperatorToken(query), projectName),
+    );
+    setActiveSearchResultIndex(0);
+    threadSearchInputRef.current?.focus();
+  }, []);
   const handleThreadSearchKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLInputElement>) => {
       // IME composition (Japanese/Chinese input) uses the same keys; committing
@@ -2189,29 +2360,38 @@ export default function Sidebar() {
         clearThreadSearch();
         return;
       }
-      if (threadSearchResults.length === 0) return;
+      if (searchListItemCount === 0) return;
       if (event.key === "ArrowDown") {
         event.preventDefault();
-        setActiveSearchResultIndex((index) => (index + 1) % threadSearchResults.length);
+        setActiveSearchResultIndex((index) => (index + 1) % searchListItemCount);
         return;
       }
       if (event.key === "ArrowUp") {
         event.preventDefault();
         setActiveSearchResultIndex(
-          (index) => (index - 1 + threadSearchResults.length) % threadSearchResults.length,
+          (index) => (index - 1 + searchListItemCount) % searchListItemCount,
         );
         return;
       }
       if (event.key === "Enter") {
         event.preventDefault();
-        const result = threadSearchResults[activeSearchResultIndex];
+        const suggestion = projectSearchSuggestions[activeSearchResultIndex];
+        if (suggestion) {
+          applyProjectSearchSuggestion(suggestion.displayName);
+          return;
+        }
+        const result =
+          threadSearchResults[activeSearchResultIndex - projectSearchSuggestions.length];
         if (result) selectThreadSearchResult(result);
       }
     },
     [
       activeSearchResultIndex,
+      applyProjectSearchSuggestion,
       clearThreadSearch,
       isSearchingThreads,
+      projectSearchSuggestions,
+      searchListItemCount,
       selectThreadSearchResult,
       threadSearchResults,
     ],
@@ -3179,14 +3359,14 @@ export default function Sidebar() {
                   aria-label="Search threads"
                   role="combobox"
                   aria-autocomplete="list"
-                  aria-expanded={isSearchingThreads && threadSearchResults.length > 0}
+                  aria-expanded={isSearchingThreads && searchListItemCount > 0}
                   aria-controls={
-                    isSearchingThreads && threadSearchResults.length > 0
+                    isSearchingThreads && searchListItemCount > 0
                       ? "sidebar-thread-search-results"
                       : undefined
                   }
                   aria-activedescendant={
-                    isSearchingThreads && threadSearchResults[activeSearchResultIndex]
+                    isSearchingThreads && activeSearchResultIndex < searchListItemCount
                       ? `sidebar-thread-search-result-${activeSearchResultIndex}`
                       : undefined
                   }
@@ -3338,7 +3518,7 @@ export default function Sidebar() {
       >
         <SidebarGroup className="ps-[calc(var(--sidebar-content-inset)+1px)] pe-[var(--sidebar-content-inset)] pb-1 pt-0">
           {isSearchingThreads ? (
-            threadSearchResults.length > 0 ? (
+            searchListItemCount > 0 ? (
               <TooltipProvider
                 key="sidebar-thread-search-tooltips-150"
                 delay={150}
@@ -3351,7 +3531,18 @@ export default function Sidebar() {
                   aria-label="Thread search results"
                   className="flex flex-col gap-px"
                 >
-                  {threadSearchResults.map((thread, index) => {
+                  {projectSearchSuggestions.map((group, index) => (
+                    <SidebarProjectSuggestionRow
+                      key={`project-suggestion-${group.projectKey}`}
+                      group={group}
+                      isHighlighted={activeSearchResultIndex === index}
+                      resultId={`sidebar-thread-search-result-${index}`}
+                      onHighlight={() => setActiveSearchResultIndex(index)}
+                      onSelect={() => applyProjectSearchSuggestion(group.displayName)}
+                    />
+                  ))}
+                  {threadSearchResults.map((thread, threadIndex) => {
+                    const index = projectSearchSuggestions.length + threadIndex;
                     const threadKey = scopedThreadKey(
                       scopeThreadRef(thread.environmentId, thread.id),
                     );

--- a/apps/web/src/components/threadSearchQuery.logic.test.ts
+++ b/apps/web/src/components/threadSearchQuery.logic.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  applyProjectSuggestionToQuery,
+  filterProjectSuggestions,
+  getTrailingProjectOperatorToken,
+  hasThreadSearchOperators,
+  matchesParsedThreadSearch,
+  parseThreadSearchQuery,
+  resolveProjectFilterKeys,
+  segmentThreadSearchQuery,
+} from "./threadSearchQuery.logic";
+
+// Local-time construction on purpose: the day operators resolve against the
+// user's calendar, not UTC.
+const now = new Date(2026, 7, 9, 12, 30, 0);
+const DAY_MS = 86_400_000;
+
+describe("parseThreadSearchQuery", () => {
+  it("treats a plain query as lowercased text with no filters", () => {
+    const parsed = parseThreadSearchQuery("  Fix Bug ", now);
+    expect(parsed).toEqual({
+      text: "fix bug",
+      projectQueries: [],
+      agentQueries: [],
+      updatedStartMs: null,
+      updatedEndMs: null,
+    });
+    expect(hasThreadSearchOperators(parsed)).toBe(false);
+  });
+
+  it("extracts in: values, including quoted multi-word names", () => {
+    const parsed = parseThreadSearchQuery('in:Icarus in:"My Project" fix', now);
+    expect(parsed.projectQueries).toEqual(["icarus", "my project"]);
+    expect(parsed.text).toBe("fix");
+    expect(hasThreadSearchOperators(parsed)).toBe(true);
+  });
+
+  it("extracts agent: values", () => {
+    const parsed = parseThreadSearchQuery("agent:Claude retry", now);
+    expect(parsed.agentQueries).toEqual(["claude"]);
+    expect(parsed.text).toBe("retry");
+  });
+
+  it("resolves relative before:/after: values against now", () => {
+    const parsed = parseThreadSearchQuery("after:7d before:2d", now);
+    expect(parsed.updatedStartMs).toBe(now.getTime() - 7 * DAY_MS);
+    expect(parsed.updatedEndMs).toBe(now.getTime() - 2 * DAY_MS);
+  });
+
+  it("resolves week-relative values", () => {
+    const parsed = parseThreadSearchQuery("after:2w", now);
+    expect(parsed.updatedStartMs).toBe(now.getTime() - 14 * DAY_MS);
+  });
+
+  it("resolves on: to a local calendar day", () => {
+    const parsed = parseThreadSearchQuery("on:2026-08-01", now);
+    expect(parsed.updatedStartMs).toBe(new Date(2026, 7, 1).getTime());
+    expect(parsed.updatedEndMs).toBe(new Date(2026, 7, 2).getTime());
+  });
+
+  it("resolves on:today and on:yesterday", () => {
+    const today = parseThreadSearchQuery("on:today", now);
+    expect(today.updatedStartMs).toBe(new Date(2026, 7, 9).getTime());
+    expect(today.updatedEndMs).toBe(new Date(2026, 7, 10).getTime());
+    const yesterday = parseThreadSearchQuery("on:yesterday", now);
+    expect(yesterday.updatedStartMs).toBe(new Date(2026, 7, 8).getTime());
+    expect(yesterday.updatedEndMs).toBe(new Date(2026, 7, 9).getTime());
+  });
+
+  it("excludes the named day from before: and after: bounds", () => {
+    const parsed = parseThreadSearchQuery("after:2026-08-01 before:2026-08-05", now);
+    expect(parsed.updatedStartMs).toBe(new Date(2026, 7, 2).getTime());
+    expect(parsed.updatedEndMs).toBe(new Date(2026, 7, 5).getTime());
+  });
+
+  it("degrades unparseable and rolled-over dates to plain text", () => {
+    expect(parseThreadSearchQuery("before:banana", now).text).toBe("before:banana");
+    expect(parseThreadSearchQuery("on:2026-02-31", now).text).toBe("on:2026-02-31");
+    expect(parseThreadSearchQuery("on:7d", now).text).toBe("on:7d");
+  });
+
+  it("ignores a half-typed operator with no value", () => {
+    const parsed = parseThreadSearchQuery("in:", now);
+    expect(parsed.text).toBe("");
+    expect(hasThreadSearchOperators(parsed)).toBe(false);
+  });
+
+  it("leaves unknown operator-shaped tokens as text", () => {
+    expect(parseThreadSearchQuery("re: meeting notes", now).text).toBe("re: meeting notes");
+  });
+});
+
+describe("matchesParsedThreadSearch", () => {
+  const makeThread = (input: {
+    title?: string;
+    updatedAt?: string;
+    providerName?: string | null;
+    instanceId?: string;
+  }) => ({
+    title: input.title ?? "Anything",
+    updatedAt: input.updatedAt ?? "2026-08-09T10:00:00.000Z",
+    modelSelection: { instanceId: input.instanceId ?? "claude-code" },
+    session: input.providerName === undefined ? null : { providerName: input.providerName },
+  });
+
+  it("matches titles case-insensitively", () => {
+    const parsed = parseThreadSearchQuery("work", now);
+    expect(matchesParsedThreadSearch(makeThread({ title: "WORKTREE cleanup" }), parsed)).toBe(true);
+    expect(matchesParsedThreadSearch(makeThread({ title: "Review providers" }), parsed)).toBe(
+      false,
+    );
+  });
+
+  it("filters by agent against provider name and instance id", () => {
+    const parsed = parseThreadSearchQuery("agent:claude", now);
+    expect(
+      matchesParsedThreadSearch(makeThread({ providerName: "claude", instanceId: "cc" }), parsed),
+    ).toBe(true);
+    expect(
+      matchesParsedThreadSearch(
+        makeThread({ providerName: "codex", instanceId: "codex-cli" }),
+        parsed,
+      ),
+    ).toBe(false);
+    expect(matchesParsedThreadSearch(makeThread({ instanceId: "claude-code" }), parsed)).toBe(true);
+  });
+
+  it("filters by the updatedAt window and rejects malformed timestamps", () => {
+    const recent = makeThread({ updatedAt: "2026-08-08T00:00:00.000Z" });
+    const old = makeThread({ updatedAt: "2026-07-01T00:00:00.000Z" });
+    const after = parseThreadSearchQuery("after:7d", now);
+    expect(matchesParsedThreadSearch(recent, after)).toBe(true);
+    expect(matchesParsedThreadSearch(old, after)).toBe(false);
+    const before = parseThreadSearchQuery("before:7d", now);
+    expect(matchesParsedThreadSearch(recent, before)).toBe(false);
+    expect(matchesParsedThreadSearch(old, before)).toBe(true);
+    expect(matchesParsedThreadSearch(makeThread({ updatedAt: "not-a-date" }), after)).toBe(false);
+  });
+
+  it("ANDs operators together", () => {
+    const parsed = parseThreadSearchQuery("agent:claude fix", now);
+    expect(
+      matchesParsedThreadSearch(
+        makeThread({ title: "Fix search", providerName: "claude", instanceId: "cc" }),
+        parsed,
+      ),
+    ).toBe(true);
+    expect(
+      matchesParsedThreadSearch(
+        makeThread({ title: "Fix search", providerName: "codex", instanceId: "codex-cli" }),
+        parsed,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("resolveProjectFilterKeys", () => {
+  const groups = [
+    {
+      projectKey: "group-icarus",
+      displayName: "Icarus",
+      workspaceRoot: "/Users/dev/icarus",
+      memberProjectRefs: [
+        { environmentId: "env-1", projectId: "proj-1" },
+        { environmentId: "env-2", projectId: "proj-9" },
+      ],
+    },
+    {
+      projectKey: "group-daedalus",
+      displayName: "Daedalus",
+      workspaceRoot: "/Users/dev/daedalus",
+      memberProjectRefs: [{ environmentId: "env-1", projectId: "proj-2" }],
+    },
+  ];
+
+  it("returns null when there is no in: filter", () => {
+    expect(resolveProjectFilterKeys(groups, [])).toBeNull();
+  });
+
+  it("expands matching groups into every member project key", () => {
+    expect(resolveProjectFilterKeys(groups, ["icarus"])).toEqual(
+      new Set(["env-1:proj-1", "env-2:proj-9"]),
+    );
+  });
+
+  it("matches by workspace path and ORs multiple values", () => {
+    expect(resolveProjectFilterKeys(groups, ["dev/daedalus", "icarus"])).toEqual(
+      new Set(["env-1:proj-1", "env-2:proj-9", "env-1:proj-2"]),
+    );
+  });
+
+  it("returns an empty set (zero results, not all) when nothing matches", () => {
+    expect(resolveProjectFilterKeys(groups, ["zeus"])).toEqual(new Set());
+  });
+});
+
+describe("thread search project autocomplete", () => {
+  it("detects a trailing partial in: token", () => {
+    expect(getTrailingProjectOperatorToken("fix in:ica")).toEqual({
+      start: 4,
+      partialValue: "ica",
+    });
+    expect(getTrailingProjectOperatorToken("in:")).toEqual({ start: 0, partialValue: "" });
+  });
+
+  it("detects an unterminated quoted value", () => {
+    expect(getTrailingProjectOperatorToken('in:"my pro')).toEqual({
+      start: 0,
+      partialValue: "my pro",
+    });
+  });
+
+  it("returns null once the operator is committed or absent", () => {
+    expect(getTrailingProjectOperatorToken("in:icarus ")).toBeNull();
+    expect(getTrailingProjectOperatorToken("fix in:alpha beta")).toBeNull();
+    expect(getTrailingProjectOperatorToken("fix")).toBeNull();
+  });
+
+  it("replaces the trailing token with a quoted committed filter", () => {
+    const token = getTrailingProjectOperatorToken("fix in:ica");
+    expect(applyProjectSuggestionToQuery("fix in:ica", token, "Icarus")).toBe('fix in:"Icarus" ');
+  });
+
+  it("replaces the whole query when no trailing token exists", () => {
+    expect(applyProjectSuggestionToQuery("icarus", null, "Icarus")).toBe('in:"Icarus" ');
+  });
+
+  it("ranks suggestions: name prefix, then name substring, then path", () => {
+    const groups = [
+      { displayName: "Tools", workspaceRoot: "/dev/icarus-tools" },
+      { displayName: "My Icarus Fork", workspaceRoot: "/dev/fork" },
+      { displayName: "Icarus", workspaceRoot: "/dev/icarus" },
+      { displayName: "Unrelated", workspaceRoot: "/dev/other" },
+    ];
+    expect(filterProjectSuggestions(groups, "ica").map((group) => group.displayName)).toEqual([
+      "Icarus",
+      "My Icarus Fork",
+      "Tools",
+    ]);
+  });
+
+  it("skips workspace-path matches when matchWorkspaceRoot is false", () => {
+    const groups = [
+      { displayName: "Icarus", workspaceRoot: "/dev/icarus" },
+      { displayName: "Tools", workspaceRoot: "/dev/icarus-tools" },
+    ];
+    expect(
+      filterProjectSuggestions(groups, "ica", { matchWorkspaceRoot: false }).map(
+        (group) => group.displayName,
+      ),
+    ).toEqual(["Icarus"]);
+  });
+
+  it("lists every project for an empty partial value", () => {
+    const groups = [
+      { displayName: "Alpha", workspaceRoot: "/a" },
+      { displayName: "Beta", workspaceRoot: "/b" },
+    ];
+    expect(filterProjectSuggestions(groups, "")).toEqual(groups);
+  });
+});
+
+describe("segmentThreadSearchQuery", () => {
+  it("returns the whole query as one plain segment when there are no operators", () => {
+    expect(segmentThreadSearchQuery("fix wing telemetry", now)).toEqual([
+      { text: "fix wing telemetry", isOperator: false },
+    ]);
+  });
+
+  it("highlights operator tokens and reproduces the input verbatim", () => {
+    const query = 'fix in:"My Project" after:7d tail';
+    const segments = segmentThreadSearchQuery(query, now);
+    expect(segments).toEqual([
+      { text: "fix ", isOperator: false },
+      { text: 'in:"My Project"', isOperator: true },
+      { text: " ", isOperator: false },
+      { text: "after:7d", isOperator: true },
+      { text: " tail", isOperator: false },
+    ]);
+    expect(segments.map((segment) => segment.text).join("")).toBe(query);
+  });
+
+  it("highlights a bare operator keyword while its value is being typed", () => {
+    expect(segmentThreadSearchQuery("in:", now)).toEqual([{ text: "in:", isOperator: true }]);
+  });
+
+  it("does not highlight tokens the parser degrades to plain text", () => {
+    expect(segmentThreadSearchQuery("before:banana", now)).toEqual([
+      { text: "before:banana", isOperator: false },
+    ]);
+    expect(segmentThreadSearchQuery("on:7d", now)).toEqual([{ text: "on:7d", isOperator: false }]);
+    expect(segmentThreadSearchQuery("re: meeting", now)).toEqual([
+      { text: "re: meeting", isOperator: false },
+    ]);
+  });
+});

--- a/apps/web/src/components/threadSearchQuery.logic.ts
+++ b/apps/web/src/components/threadSearchQuery.logic.ts
@@ -1,0 +1,385 @@
+// ── Thread search query language ─────────────────────────────────────
+// Discord-style operators over the already-synced shell data, used by the
+// command palette's thread search:
+//   in:<project>      scope to projects whose name or path contains the value
+//   agent:<provider>  provider name / instance id substring
+//   before: after:    updatedAt bounds — ISO day, or relative like 7d / 2w
+//   on:               one calendar day — ISO day, today, yesterday
+// Everything else remains free text. Operators AND together; repeated values
+// of the same operator OR within it. Values with spaces are quoted:
+// in:"My Project". An operator token whose value doesn't parse (bad date)
+// degrades to plain text instead of silently filtering everything out.
+
+export interface ParsedThreadSearchQuery {
+  /** Lowercased free text left after operator extraction. */
+  readonly text: string;
+  /** Lowercased in: values. Project-key resolution happens in the caller
+      (via resolveProjectFilterKeys) because group names live outside the
+      thread shells. */
+  readonly projectQueries: readonly string[];
+  /** Lowercased agent: values. */
+  readonly agentQueries: readonly string[];
+  /** Half-open [start, end) bounds on updatedAt, merged across all date
+      operators; null side = unbounded. */
+  readonly updatedStartMs: number | null;
+  readonly updatedEndMs: number | null;
+}
+
+const SEARCH_OPERATOR_PATTERN = /^(in|agent|before|after|on):(.*)$/i;
+const DAY_MS = 86_400_000;
+
+/** Splits on whitespace, except inside double quotes (an unterminated quote
+    runs to the end — that's just a user mid-typing). */
+function tokenizeSearchQuery(query: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (const char of query) {
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      current += char;
+      continue;
+    }
+    if (!inQuotes && /\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+function unquoteSearchValue(value: string): string {
+  return value.replace(/^"/, "").replace(/"$/, "");
+}
+
+type SearchDateToken =
+  | { readonly kind: "instant"; readonly ms: number }
+  | { readonly kind: "day"; readonly startMs: number; readonly endMs: number };
+
+/** Local-calendar day math goes through the Date constructor (day ± 1) so
+    month rollover and DST transitions resolve correctly. */
+function localDayRange(year: number, monthIndex: number, day: number): SearchDateToken {
+  return {
+    kind: "day",
+    startMs: new Date(year, monthIndex, day).getTime(),
+    endMs: new Date(year, monthIndex, day + 1).getTime(),
+  };
+}
+
+export function resolveSearchDateToken(rawValue: string, now: Date): SearchDateToken | null {
+  const value = rawValue.toLowerCase();
+  const relative = /^(\d{1,4})([dw])$/.exec(value);
+  if (relative) {
+    const amount = Number(relative[1]);
+    const unitMs = relative[2] === "w" ? 7 * DAY_MS : DAY_MS;
+    return { kind: "instant", ms: now.getTime() - amount * unitMs };
+  }
+  if (value === "today" || value === "yesterday") {
+    const offset = value === "yesterday" ? 1 : 0;
+    return localDayRange(now.getFullYear(), now.getMonth(), now.getDate() - offset);
+  }
+  const isoDay = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (isoDay) {
+    const year = Number(isoDay[1]);
+    const monthIndex = Number(isoDay[2]) - 1;
+    const day = Number(isoDay[3]);
+    const start = new Date(year, monthIndex, day);
+    // The Date constructor rolls invalid components over (2026-02-31 →
+    // March 3rd); a rolled-over date is a typo, not a filter.
+    if (
+      start.getFullYear() !== year ||
+      start.getMonth() !== monthIndex ||
+      start.getDate() !== day
+    ) {
+      return null;
+    }
+    return localDayRange(year, monthIndex, day);
+  }
+  return null;
+}
+
+export function parseThreadSearchQuery(query: string, now: Date): ParsedThreadSearchQuery {
+  const textTokens: string[] = [];
+  const projectQueries: string[] = [];
+  const agentQueries: string[] = [];
+  let updatedStartMs: number | null = null;
+  let updatedEndMs: number | null = null;
+  const tightenStart = (ms: number) => {
+    updatedStartMs = updatedStartMs === null ? ms : Math.max(updatedStartMs, ms);
+  };
+  const tightenEnd = (ms: number) => {
+    updatedEndMs = updatedEndMs === null ? ms : Math.min(updatedEndMs, ms);
+  };
+
+  for (const token of tokenizeSearchQuery(query)) {
+    const operator = SEARCH_OPERATOR_PATTERN.exec(token);
+    if (!operator) {
+      textTokens.push(token);
+      continue;
+    }
+    const keyword = operator[1]!.toLowerCase();
+    const value = unquoteSearchValue(operator[2]!).trim().toLowerCase();
+    // A bare `in:` is someone mid-typing (the autocomplete is open); an
+    // empty value must not filter anything.
+    if (value.length === 0) continue;
+    if (keyword === "in") {
+      projectQueries.push(value);
+      continue;
+    }
+    if (keyword === "agent") {
+      agentQueries.push(value);
+      continue;
+    }
+    const dateToken = resolveSearchDateToken(value, now);
+    if (dateToken === null) {
+      textTokens.push(token);
+      continue;
+    }
+    // before: excludes the named day/instant; after: starts past it; on:
+    // pins both bounds to the day. All merge by intersection.
+    if (keyword === "before") {
+      tightenEnd(dateToken.kind === "instant" ? dateToken.ms : dateToken.startMs);
+    } else if (keyword === "after") {
+      tightenStart(dateToken.kind === "instant" ? dateToken.ms : dateToken.endMs);
+    } else if (dateToken.kind === "day") {
+      tightenStart(dateToken.startMs);
+      tightenEnd(dateToken.endMs);
+    } else {
+      // on:7d is a point, not a day — degrade to text like other bad dates.
+      textTokens.push(token);
+    }
+  }
+
+  return {
+    text: textTokens.join(" ").toLowerCase(),
+    projectQueries,
+    agentQueries,
+    updatedStartMs,
+    updatedEndMs,
+  };
+}
+
+/** Whether the parsed query carries any OPERATOR criteria (project, agent,
+    or date bounds) — free text alone doesn't count. */
+export function hasThreadSearchOperators(parsed: ParsedThreadSearchQuery): boolean {
+  return (
+    parsed.projectQueries.length > 0 ||
+    parsed.agentQueries.length > 0 ||
+    parsed.updatedStartMs !== null ||
+    parsed.updatedEndMs !== null
+  );
+}
+
+export interface OperatorSearchableThread {
+  readonly title: string;
+  readonly updatedAt: string;
+  readonly modelSelection: { readonly instanceId: string };
+  readonly session: {
+    readonly providerName: string | null;
+    readonly providerInstanceId?: string | undefined;
+  } | null;
+}
+
+/**
+ * Applies the parsed query's OPERATOR criteria (agent, date bounds) plus the
+ * free text against the thread title. Callers that rank text against richer
+ * haystacks (project title, content snippets) pass `{ ...parsed, text: "" }`
+ * and match the text themselves. The in: operator is applied separately as a
+ * project-key filter — thread shells don't carry project names.
+ */
+export function matchesParsedThreadSearch(
+  thread: OperatorSearchableThread,
+  parsed: ParsedThreadSearchQuery,
+): boolean {
+  if (parsed.text.length > 0 && !thread.title.toLowerCase().includes(parsed.text)) {
+    return false;
+  }
+  if (parsed.agentQueries.length > 0) {
+    const agentHaystack = [
+      thread.session?.providerName,
+      thread.session?.providerInstanceId,
+      thread.modelSelection.instanceId,
+    ]
+      .filter((candidate): candidate is string => typeof candidate === "string")
+      .join(" ")
+      .toLowerCase();
+    if (!parsed.agentQueries.some((query) => agentHaystack.includes(query))) {
+      return false;
+    }
+  }
+  if (parsed.updatedStartMs !== null || parsed.updatedEndMs !== null) {
+    const updatedMs = Date.parse(thread.updatedAt);
+    if (Number.isNaN(updatedMs)) return false;
+    if (parsed.updatedStartMs !== null && updatedMs < parsed.updatedStartMs) return false;
+    if (parsed.updatedEndMs !== null && updatedMs >= parsed.updatedEndMs) return false;
+  }
+  return true;
+}
+
+export interface ThreadSearchProjectGroup {
+  readonly projectKey: string;
+  readonly displayName: string;
+  readonly workspaceRoot: string;
+  readonly memberProjectRefs: readonly {
+    readonly environmentId: string;
+    readonly projectId: string;
+  }[];
+}
+
+/** Expands in: values into the `${environmentId}:${projectId}` key set the
+    clients already filter by. null = no in: filter; an empty set means the
+    values matched no project (zero results, not all results). */
+export function resolveProjectFilterKeys(
+  groups: readonly ThreadSearchProjectGroup[],
+  projectQueries: readonly string[],
+): ReadonlySet<string> | null {
+  if (projectQueries.length === 0) return null;
+  const keys = new Set<string>();
+  for (const group of groups) {
+    const name = group.displayName.toLowerCase();
+    const root = group.workspaceRoot.toLowerCase();
+    if (projectQueries.some((query) => name.includes(query) || root.includes(query))) {
+      for (const ref of group.memberProjectRefs) {
+        keys.add(`${ref.environmentId}:${ref.projectId}`);
+      }
+    }
+  }
+  return keys;
+}
+
+export interface TrailingProjectOperatorToken {
+  /** Index in the query where the trailing in: token starts. */
+  readonly start: number;
+  /** The unquoted partial value typed so far (may be empty). */
+  readonly partialValue: string;
+}
+
+/** Detects an in-progress trailing `in:` token — the caret is still inside
+    it, so the project autocomplete should be open. Trailing whitespace (or a
+    different trailing token) means the operator is committed and this
+    returns null. */
+export function getTrailingProjectOperatorToken(
+  query: string,
+): TrailingProjectOperatorToken | null {
+  const match = /(^|\s)(in:("[^"]*"?|[^\s"]*))$/i.exec(query);
+  if (!match) return null;
+  return {
+    start: match.index + match[1]!.length,
+    partialValue: unquoteSearchValue(match[2]!.slice("in:".length)),
+  };
+}
+
+/** Ranks project groups for the in: autocomplete: name prefix, then name
+    substring, then workspace-path substring. An empty partial lists all.
+    Path matching is opt-out for surfaces where a folder path coincidentally
+    containing the typed words would be noise. */
+export function filterProjectSuggestions<
+  T extends { readonly displayName: string; readonly workspaceRoot: string },
+>(
+  groups: readonly T[],
+  partialValue: string,
+  options?: { readonly matchWorkspaceRoot?: boolean },
+): T[] {
+  const matchWorkspaceRoot = options?.matchWorkspaceRoot ?? true;
+  const query = partialValue.trim().toLowerCase();
+  if (query.length === 0) return [...groups];
+  const ranked: { group: T; rank: number }[] = [];
+  for (const group of groups) {
+    const name = group.displayName.toLowerCase();
+    const rank = name.startsWith(query)
+      ? 0
+      : name.includes(query)
+        ? 1
+        : matchWorkspaceRoot && group.workspaceRoot.toLowerCase().includes(query)
+          ? 2
+          : null;
+    if (rank !== null) ranked.push({ group, rank });
+  }
+  // toSorted is stable: groups keep their input order within each rank.
+  return ranked.toSorted((left, right) => left.rank - right.rank).map((entry) => entry.group);
+}
+
+/** Applies a picked project suggestion: replaces the in-progress trailing
+    in: token — or, absent one, the whole query — with a quoted, committed
+    filter plus a trailing space so typing continues naturally. */
+export function applyProjectSuggestionToQuery(
+  query: string,
+  token: TrailingProjectOperatorToken | null,
+  projectName: string,
+): string {
+  const filter = `in:"${projectName.replaceAll('"', "")}" `;
+  if (token === null) return filter;
+  return `${query.slice(0, token.start)}${filter}`;
+}
+
+export interface ThreadSearchQuerySegment {
+  readonly text: string;
+  readonly isOperator: boolean;
+}
+
+/**
+ * Splits the raw query into alternating plain/operator segments covering the
+ * exact input string (including whitespace), for the Discord-style operator
+ * pills rendered behind the search input. A segment is highlighted only when
+ * the parser would honor it: in:/agent: tokens always (an empty value means
+ * the autocomplete is open), date tokens only while empty or parseable — a
+ * token the parser degrades to plain text must not wear a pill.
+ */
+export function segmentThreadSearchQuery(query: string, now: Date): ThreadSearchQuerySegment[] {
+  const operatorRanges: [number, number][] = [];
+  const classifyToken = (start: number, end: number) => {
+    const operator = SEARCH_OPERATOR_PATTERN.exec(query.slice(start, end));
+    if (!operator) return;
+    const keyword = operator[1]!.toLowerCase();
+    const value = unquoteSearchValue(operator[2]!).trim();
+    if (keyword === "in" || keyword === "agent") {
+      operatorRanges.push([start, end]);
+      return;
+    }
+    if (value.length === 0) {
+      operatorRanges.push([start, end]);
+      return;
+    }
+    const dateToken = resolveSearchDateToken(value, now);
+    if (dateToken !== null && (keyword !== "on" || dateToken.kind === "day")) {
+      operatorRanges.push([start, end]);
+    }
+  };
+
+  // Same walk as tokenizeSearchQuery, but tracking positions so segments
+  // reproduce the input verbatim.
+  let tokenStart = -1;
+  let inQuotes = false;
+  for (let index = 0; index < query.length; index += 1) {
+    const char = query[index]!;
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      if (tokenStart === -1) tokenStart = index;
+      continue;
+    }
+    if (!inQuotes && /\s/.test(char)) {
+      if (tokenStart !== -1) {
+        classifyToken(tokenStart, index);
+        tokenStart = -1;
+      }
+      continue;
+    }
+    if (tokenStart === -1) tokenStart = index;
+  }
+  if (tokenStart !== -1) classifyToken(tokenStart, query.length);
+
+  const segments: ThreadSearchQuerySegment[] = [];
+  let cursor = 0;
+  for (const [start, end] of operatorRanges) {
+    if (start > cursor) segments.push({ text: query.slice(cursor, start), isOperator: false });
+    segments.push({ text: query.slice(start, end), isOperator: true });
+    cursor = end;
+  }
+  if (cursor < query.length) segments.push({ text: query.slice(cursor), isOperator: false });
+  return segments;
+}


### PR DESCRIPTION
## What Changed

Thread search is consolidated into the command palette (⌘K), and it understands Discord-style operators. The sidebar's inline search input becomes a "Search" trigger button (mirroring the legacy sidebar) that opens the palette.

In the palette's root search:

- `in:<project>` — scope results to projects whose name or workspace path contains the value, with quoted multi-word values (`in:"My Project"`). Typing `in:` surfaces a **Filter by project** completion group at the top of the list; Enter commits the filter into the query (palette stays open) instead of navigating.
- `agent:<provider>` — match the session provider name or model instance id (`agent:claude`, `agent:codex`).
- `before:` / `after:` / `on:` — bounds on `updatedAt`: ISO days (`2026-08-01`), relative values (`7d`, `2w`), and `today` / `yesterday` for `on:`. Local-calendar day math, DST-safe; unparseable dates degrade to plain text instead of silently filtering everything out.
- **Operator pill highlighting** — recognized operator tokens render with a pill (send-button `message-action` tokens) inside the palette input, via a metric-identical backdrop layer; the input's text goes transparent while the caret stays visible, and the backdrop translates with `scrollLeft`. Pills follow the parser's honesty rule: `in:`/`agent:` highlight immediately, date operators only once their value parses.

Operators AND together; repeated `in:` values OR. With operator criteria present the palette becomes a pure thread search (actions/projects groups don't degenerate to matching the residual text). Residual text keeps ranking against titles, project names, and the existing server-side content-search snippets — operator tokens are stripped from the content-search query so they never pollute the message `LIKE`.

Archived threads join the search corpus (their snapshot is fetched only while a root query is active, and archive/unarchive actions already refresh it) and render with an "Archived" badge in place of the live status decorations.

All parsing/matching/segmentation/suggestion logic is pure and lives in `threadSearchQuery.logic.ts` with unit tests. Plain queries, `>` actions mode, submenus, path-browse, and the recents list are unchanged.

## Why

Search previously lived in two places with two behavior sets: the sidebar matched thread titles only (typing a project's name found nothing, archived threads were unreachable), while the palette had richer matching and server content search. Consolidating into the palette gives one search surface with operators for exactly what's hard to find — project scoping, old-by-date lookups, archived history — following the search idiom Discord established.

## UI Changes

Sidebar: the search input row is replaced by a "Search" button with the ⌘K shortcut hint. Palette: operator pills in the input, a "Filter by project" completion group while typing `in:`, and "Archived" badges on archived thread rows. Happy to attach screenshots/video on request.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move thread search from sidebar into the command palette with Discord-style operators
> - Replaces the sidebar's inline thread title search with a button that opens the command palette, removing the local combobox, keyboard nav, and `searchSidebarThreadsByTitle` util.
> - Adds a query language in [`threadSearchQuery.logic.ts`](https://github.com/pingdotgg/t3code/pull/5927/files#diff-1e592fbc6f94cefa7d8c22c4e5caf79dd2bbdd7f49980895f96f4c8a8291a2ca) supporting `in:`, `agent:`, `before:`, `after:`, and `on:` operators parsed from the command palette input.
> - When operators are present, the palette narrows results client-side by project, agent, and date, showing only a Threads group; without operators, existing group behavior is preserved.
> - Archived threads are fetched and merged into the search corpus when a query is active, with an 'Archived' label and chip in results.
> - Renders operator tokens as highlighted pills behind the input via an `inputBackdrop` layer in [`CommandPaletteContent.tsx`](https://github.com/pingdotgg/t3code/pull/5927/files#diff-f790d22169c924d9e038d60d843cbe89e166da5b93d1f884c2a10b536b1e2337), with project autocomplete for trailing `in:` tokens.
> - Behavioral Change: keyboard-driven in-place sidebar search is removed; all thread search now goes through the command palette.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6001a9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->