### PR TITLE
fix(web): enable restore defaults after theme mix changes

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -539,6 +539,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.wordWrap,
       followSystem,
       theme,
+      themeHalves,
     ],
   );
 


### PR DESCRIPTION
## Problem

Changing only the light or dark theme mix could leave the restore dirty-state memo stale because themeHalves was read but omitted from its dependency list. Restore defaults could therefore remain disabled and the restore action could return early.

## Fix

Include themeHalves in the changedSettingLabels memo dependencies so theme-mix-only changes immediately update the restore state.

## Verification

- Reproduced the missing dependency with a targeted react-hooks/exhaustive-deps check; the themeHalves diagnostic disappears after the fix
- node_modules/.bin/vp fmt --check apps/web/src/components/settings/SettingsPanels.tsx
- node_modules/.bin/vp lint --report-unused-disable-directives apps/web/src/components/settings/SettingsPanels.tsx
- node_modules/.bin/vp run --filter @t3tools/web typecheck
- git diff --check upstream/main...HEAD

Screenshots are not included because this changes state invalidation only, with no layout or styling changes.

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 'Restore Defaults' detection to update when theme mix changes
> Adds `themeHalves` to the `useMemo` dependency array in the `useSettingsRestore` hook in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/5928/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18), so `changedSettingLabels` recomputes immediately when the theme mix is modified. Previously, theme mix changes were not reflected in the restore defaults check or confirmation dialog.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8dab78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single React hook dependency fix in settings restore state; no auth, data, or API behavior changes.
> 
> **Overview**
> **Restore defaults** now reacts when only the light/dark **theme mix** changes.
> 
> `useSettingsRestore` already treated a non-null `themeHalves` as dirty and listed **Theme mix** in `changedSettingLabels`, but the `useMemo` for that list omitted `themeHalves` from its dependency array. After a mix-only edit, the memo could stay stale so restore stayed disabled and `restoreDefaults` could no-op on an empty label list.
> 
> The fix adds `themeHalves` to that dependency array so mix-only changes immediately refresh restore UI and confirmation copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8dab78a7bd5c0d08160b60b4970c0004da64a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->