### PR TITLE
fix(web): correct model picker trigger padding

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3129,7 +3129,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     instanceEntries={providerInstanceEntries}
                     keybindings={keybindings}
                     modelOptionsByInstance={modelOptionsByInstance}
-                    triggerClassName="-ms-px ps-0"
+                    triggerClassName="-ms-px"
                     terminalOpen={terminalOpen}
                     open={isComposerModelPickerOpen}
                     {...(composerProviderState.modelPickerIconClassName


### PR DESCRIPTION
The model picker trigger removed only its inline-start padding, which left the provider logo nearly touching the pressed-state edge while the chevron retained its end spacing.

This removes the ps-0 override while preserving the existing one-pixel optical offset. The trigger now inherits the shared ComposerControl padding on both sides.

### Before / after verification

| State | Start padding | End padding |
| --- | ---: | ---: |
| Before | 0px | 10px |
| After | 10px | 10px |

Measured in T3 Code Dev at a 1280x800 viewport.

### Tests

- vp lint apps/web/src/components/chat/ChatComposer.tsx --report-unused-disable-directives
- vp run --filter @t3tools/web typecheck
- vp test run src/components/chat/modelPickerSearch.test.ts src/components/chat/modelPickerKeys.test.ts --project unit (9 tests)

pre fix:
<img width="296" height="122" alt="image" src="https://github.com/user-attachments/assets/8a80d645-838a-442b-8a6f-307b60424334" />

post fix:
<img width="210" height="64" alt="image" src="https://github.com/user-attachments/assets/5a0fd940-e7a3-432f-9ba6-5b535f41b208" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c5cd136264b3752369fdfc67dfd653b848783ae0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `ps-0` padding from `ProviderModelPicker` trigger in `ChatComposer`
> Removes the `ps-0` class from the `triggerClassName` prop passed to `ProviderModelPicker` in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/5935/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a), correcting the start-padding on the model picker trigger element.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5cd136.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->