### PR TITLE
fix(web): preserve preview annotations across reloads

### DIFF
--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -13,6 +13,7 @@ import {
   ProviderInstanceId,
   ThreadId,
   type ModelSelection,
+  type PreviewAnnotationPayload,
   type ProviderOptionSelection,
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
@@ -613,6 +614,50 @@ describe("composerDraftStore element contexts", () => {
     // Persistence does NOT include htmlPreview / styles oversize-clamping —
     // that happens at normalization time, before the value reaches the store.
     expect(typeof entry?.htmlPreview).toBe("string");
+  });
+});
+
+describe("composerDraftStore preview annotations", () => {
+  const threadId = ThreadId.make("thread-preview-annotation");
+  const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+  const annotation: PreviewAnnotationPayload = {
+    id: "annotation-1",
+    pageUrl: "http://localhost:3000/dashboard",
+    pageTitle: "Dashboard",
+    comment: "Align these cards.",
+    elements: [],
+    regions: [{ id: "region-1", rect: { x: 10, y: 20, width: 100, height: 80 } }],
+    strokes: [],
+    styleChanges: [],
+    screenshot: null,
+    createdAt: "2026-07-31T12:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("restores persisted preview annotations on reload", () => {
+    useComposerDraftStore.getState().addPreviewAnnotation(threadRef, annotation);
+
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const persistedState = persistApi.getOptions().partialize(useComposerDraftStore.getState());
+    const mergedState = persistApi
+      .getOptions()
+      .merge(persistedState, useComposerDraftStore.getInitialState());
+
+    expect(
+      mergedState.draftsByThreadKey[threadKeyFor(threadId, TEST_ENVIRONMENT_ID)]
+        ?.previewAnnotations,
+    ).toEqual([annotation]);
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -54,6 +54,7 @@ import { UnifiedSettings } from "@t3tools/contracts/settings";
 import { ReviewCommentContextSchema, type ReviewCommentContext } from "./reviewCommentContext";
 const isRuntimeMode = Schema.is(RuntimeMode);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
+const isPreviewAnnotationPayload = Schema.is(PreviewAnnotationPayloadSchema);
 const isReviewCommentContext = Schema.is(ReviewCommentContextSchema);
 
 export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
@@ -1695,6 +1696,9 @@ function normalizePersistedDraftsByThreadId(
           return normalized ? [normalized] : [];
         })
       : [];
+    const previewAnnotations = Array.isArray(draftCandidate.previewAnnotations)
+      ? draftCandidate.previewAnnotations.filter(isPreviewAnnotationPayload)
+      : [];
     const reviewComments = Array.isArray(draftCandidate.reviewComments)
       ? draftCandidate.reviewComments.filter(isReviewCommentContext)
       : [];
@@ -1762,6 +1766,7 @@ function normalizePersistedDraftsByThreadId(
       attachments.length === 0 &&
       terminalContexts.length === 0 &&
       elementContexts.length === 0 &&
+      previewAnnotations.length === 0 &&
       reviewComments.length === 0 &&
       !hasModelData &&
       !runtimeMode &&
@@ -1786,6 +1791,7 @@ function normalizePersistedDraftsByThreadId(
       attachments,
       ...(terminalContexts.length > 0 ? { terminalContexts } : {}),
       ...(elementContexts.length > 0 ? { elementContexts } : {}),
+      ...(previewAnnotations.length > 0 ? { previewAnnotations } : {}),
       ...(reviewComments.length > 0 ? { reviewComments } : {}),
       ...(hasModelData
         ? {


### PR DESCRIPTION
## Problem

Preview annotations were written to persisted composer drafts but silently dropped during reload normalization. Annotation-only drafts were also treated as empty, so unsent preview context disappeared after refreshing the app.

## Fix

Preserve schema-valid `previewAnnotations` while normalizing persisted drafts, count them as user content, and carry them into hydration. A focused regression test exercises the real Zustand `partialize()` and `merge()` path.

## Validation

- `node_modules/.bin/vp test run apps/web/src/composerDraftStore.test.ts` — 77 passed
- `node_modules/.bin/vp run --filter @t3tools/web typecheck`
- Focused lint and format checks for both changed files
- `npx react-doctor@latest --verbose --scope changed --base upstream/main --project @t3tools/web` — 92/100, no issues

## Screenshots

Both captures use an isolated dev home and a synthetic project/draft. The page was reloaded before each capture.

**Before (`main`)** — the draft text returns, but the persisted annotation card is missing.

![Before reload normalization drops the annotation](https://raw.githubusercontent.com/Lucenx9/t3code/pr-5937-assets-v2/images/5937/before.png)

**After (this PR)** — the draft text and persisted annotation card both return.

![After reload normalization preserves the annotation](https://raw.githubusercontent.com/Lucenx9/t3code/pr-5937-assets-v2/images/5937/after.png)

---

Implemented with OpenAI GPT-5.6 through the Codex harness in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve preview annotations in composer drafts across page reloads
> - Extends `normalizePersistedDraftsByThreadId` in [composerDraftStore.ts](https://github.com/pingdotgg/t3code/pull/5937/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a) to parse and restore `previewAnnotations` from persisted state, filtering out any entries that fail schema validation via a new `isPreviewAnnotationPayload` guard.
> - Drafts that contain only `previewAnnotations` (with no other fields) are now retained instead of being discarded as empty.
> - Adds a test suite in [composerDraftStore.test.ts](https://github.com/pingdotgg/t3code/pull/5937/files#diff-61714da43700c6105d471eadf7c6f4e80aee8189d14bed8e4362b66dded855e1) covering the full serialize/merge round-trip for preview annotations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b473fe7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to composer draft persistence normalization with schema filtering; no auth, security, or server-side impact.
> 
> **Overview**
> **Preview annotations now survive a full page reload** in the composer draft store. Persisted `previewAnnotations` were written to local storage but **dropped during reload normalization** in `normalizePersistedDraftsByThreadId`, so annotation cards disappeared after refresh even when draft text returned.
> 
> The fix **parses and keeps schema-valid** `previewAnnotations` (via `PreviewAnnotationPayloadSchema`), **treats annotation-only drafts as non-empty** so they are not discarded as blank, and **writes them back** into the normalized persisted draft shape on merge/hydration.
> 
> A regression test exercises the real Zustand **`partialize()` → `merge()`** path so reload behavior stays covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b473fe718ffc1bfafe9033415943298a1df78aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->