### PR TITLE
feat(web): add configurable settle shortcut

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -135,7 +135,7 @@ describe("KeybindingsSettings.logic", () => {
     expect(options).not.toContain("customModeActive");
   });
 
-  it("builds command options from defaults and resolved project bindings", () => {
+  it("builds command options from supported commands and resolved project bindings", () => {
     const options = buildKeybindingCommandOptions([
       {
         command: "script.setup-db.run",
@@ -150,7 +150,9 @@ describe("KeybindingsSettings.logic", () => {
       },
     ] satisfies ResolvedKeybindingsConfig);
 
-    expect(options).toEqual(expect.arrayContaining(["chat.new", "script.setup-db.run"]));
+    expect(options).toEqual(
+      expect.arrayContaining(["chat.new", "thread.settle", "script.setup-db.run"]),
+    );
   });
 
   it("reports unknown when variables without rejecting parseable expressions", () => {

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -1,4 +1,5 @@
 import {
+  STATIC_KEYBINDING_COMMANDS,
   type KeybindingCommand,
   type KeybindingShortcut,
   type KeybindingWhenNode,
@@ -255,7 +256,7 @@ export function buildWhenVariableOptions(): ReadonlyArray<WhenVariableOption> {
 export function buildKeybindingCommandOptions(
   keybindings: ResolvedKeybindingsConfig,
 ): ReadonlyArray<KeybindingCommandOption> {
-  const commands = new Set<KeybindingCommand>();
+  const commands = new Set<KeybindingCommand>(STATIC_KEYBINDING_COMMANDS);
   for (const binding of DEFAULT_RESOLVED_KEYBINDINGS) {
     commands.add(binding.command);
   }

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -480,6 +480,31 @@ describe("model picker navigation helpers", () => {
 });
 
 describe("chat/editor shortcuts", () => {
+  it("matches a configured thread settle shortcut", () => {
+    const bindings = compile([
+      {
+        shortcut: modShortcut("s", { shiftKey: true }),
+        command: "thread.settle",
+        whenAst: whenNot(whenIdentifier("terminalFocus")),
+      },
+    ]);
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "s", metaKey: true, shiftKey: true }), bindings, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "thread.settle",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "s", metaKey: true, shiftKey: true }), bindings, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+      null,
+    );
+  });
+
   it("matches chat.new shortcut", () => {
     assert.isTrue(
       isChatNewShortcut(event({ key: "o", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,5 +1,9 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
 import { useEffect, useMemo } from "react";
 
 import { isCommandPaletteOpen } from "../commandPaletteBus";
@@ -11,6 +15,7 @@ import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useThreadActions } from "../hooks/useThreadActions";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -27,6 +32,7 @@ function ChatRouteGlobalShortcuts() {
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
     useHandleNewThread();
+  const { settleThread } = useThreadActions();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const legacySidebarEnabled = useLegacySidebarEnabled();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
@@ -108,6 +114,26 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
+      if (command === "thread.settle") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!routeThreadRef || event.repeat) return;
+        void (async () => {
+          const result = await settleThread(routeThreadRef);
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Failed to settle thread",
+                description: error instanceof Error ? error.message : "An error occurred.",
+              }),
+            );
+          }
+        })();
+        return;
+      }
+
       if (command === "preview.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -167,6 +193,7 @@ function ChatRouteGlobalShortcuts() {
     projectGroupCount,
     routeThreadRef,
     selectedThreadKeysSize,
+    settleThread,
     legacySidebarEnabled,
     terminalOpen,
   ]);

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -37,6 +37,9 @@ Examples: `mod+j`, `mod+shift+d`, `ctrl+l`, `cmd+k`.
 Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refresh`, and
 `chat.new`. Project scripts are addressable as `script.{id}.run`, for example `script.test.run`.
 
+`thread.settle` settles the open thread when it no longer needs attention. It has no default
+shortcut; add one from **Settings** → **Keybindings** if you want a keyboard-first settle action.
+
 `filePicker.toggle` opens file search for the active project and defaults to `mod+p`.
 `projectSearch.toggle` searches inside the active project's files and defaults to `mod+shift+f`.
 Repeating either shortcut closes that search, and switching shortcuts replaces the open search.

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -126,6 +126,17 @@ it.effect("accepts dynamic script run commands", () =>
   }),
 );
 
+it.effect("accepts the configurable thread settle command", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decode(KeybindingRule, {
+      key: "mod+shift+s",
+      command: "thread.settle",
+      when: "!terminalFocus",
+    });
+    assert.strictEqual(parsed.command, "thread.settle");
+  }),
+);
+
 it.effect("parses keybindings array payload", () =>
   Effect.gen(function* () {
     const parsed = yield* decode(KeybindingsConfig, [

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -37,6 +37,7 @@ export type ModelPickerJumpKeybindingCommand =
 export const THREAD_KEYBINDING_COMMANDS = [
   "thread.previous",
   "thread.next",
+  "thread.settle",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,
 ] as const;
 export type ThreadKeybindingCommand = (typeof THREAD_KEYBINDING_COMMANDS)[number];
@@ -47,7 +48,7 @@ export const MODEL_PICKER_KEYBINDING_COMMANDS = [
 ] as const;
 export type ModelPickerKeybindingCommand = (typeof MODEL_PICKER_KEYBINDING_COMMANDS)[number];
 
-const STATIC_KEYBINDING_COMMANDS = [
+export const STATIC_KEYBINDING_COMMANDS = [
   "sidebar.toggle",
   "terminal.toggle",
   "terminal.split",


### PR DESCRIPTION
## Problem

Settling the open thread is only available through pointer-driven thread actions. The keybinding schema does not recognize a settle command, so users cannot add their own shortcut in Settings or `keybindings.json`.

## Change

- register `thread.settle` as a supported keybinding command
- include every supported static command in the Settings command picker, even when it has no default binding
- dispatch the shortcut through the existing settlement checks and failure handling
- document the command and cover schema, picker, and shortcut resolution behavior with focused tests

This intentionally adds no default chord, so existing keymaps do not change and users can choose a conflict-free shortcut.

Related: #4277 and #4876. Both currently conflict with `main`; this draft is a smaller, freshly rebased configurable-only alternative.

## Impact

Users can select **Thread: Settle** from Settings → Keybindings or add `thread.settle` to `keybindings.json`. The existing lifecycle rules still prevent settling threads that need attention, and failures use the existing toast path.

## Validation

- `vp test run packages/contracts/src/keybindings.test.ts apps/web/src/keybindings.test.ts apps/web/src/components/settings/KeybindingsSettings.logic.test.ts` — 66 tests passed
- scoped contracts and web typechecks passed
- targeted lint and format checks passed
- production web build passed

Created with Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `thread.settle` keyboard shortcut to global chat shortcuts
> - Adds `'thread.settle'` to `THREAD_KEYBINDING_COMMANDS` and exports `STATIC_KEYBINDING_COMMANDS` from [keybindings.ts](https://github.com/pingdotgg/t3code/pull/5940/files#diff-4eff8b6cf08dc64a9d8f37ff97b369a5719340e4c6203ab7070cc8cfffd28db6) so consumers can reference static commands.
> - Handles the `thread.settle` command in [_chat.tsx](https://github.com/pingdotgg/t3code/pull/5940/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691), calling `settleThread` on the active thread and showing an error toast on failure (unless interrupted).
> - Updates `buildKeybindingCommandOptions` in [KeybindingsSettings.logic.ts](https://github.com/pingdotgg/t3code/pull/5940/files#diff-3e063dd9ee56de309e7e9618f62b33b69ff212f57241c19cc7114065efb919dd) to seed the command list with `STATIC_KEYBINDING_COMMANDS`, so `thread.settle` appears in the keybindings settings UI with no default shortcut assigned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cb3344.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reuses existing thread settlement APIs and UI toasts; no default binding means no behavior change until users configure a shortcut.
> 
> **Overview**
> Adds **`thread.settle`** as a first-class keybinding command so users can settle the open thread from the keyboard without changing anyone’s default keymap.
> 
> The contracts layer registers the command and **exports `STATIC_KEYBINDING_COMMANDS`**, and the Settings command picker is seeded from that list so commands like settle show up even when they have no built-in chord. On the chat route, a resolved `thread.settle` shortcut calls the same **`settleThread`** path as the thread menu, with existing failure toasts; repeats and missing route thread are ignored.
> 
> User docs note that settle has **no default shortcut**—users add one in Settings or `keybindings.json`. Tests cover schema acceptance, picker options, and shortcut resolution with `when` context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb33441f7f5f2c03d9b3d198e14db70b70756ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->