### PR TITLE
fix(server): stop the provider title mirror from overwriting real thread titles

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -40,6 +40,10 @@ import {
 } from "../Services/ProviderCommandReactor.ts";
 import { forkParked, ServerActivation } from "../../serverActivation.ts";
 import {
+  canReplaceThreadTitle,
+  DEFAULT_THREAD_TITLE,
+} from "../threadTitles.ts";
+import {
   resolveSourceControlWriterModelSelection,
   ServerSettingsService,
 } from "../../serverSettings.ts";
@@ -91,7 +95,6 @@ const turnStartKeyForEvent = (event: ProviderIntentEvent): string =>
 const HANDLED_TURN_START_KEY_MAX = 10_000;
 const HANDLED_TURN_START_KEY_TTL = Duration.minutes(30);
 const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
-const DEFAULT_THREAD_TITLE = "New thread";
 const MAX_REGENERATION_ATTACHMENTS = 4;
 const MAX_THREAD_TITLE_CONTEXT_CHARS = 8_000;
 const MAX_FIRST_USER_TITLE_CONTEXT_CHARS = 2_000;
@@ -225,18 +228,6 @@ export function providerErrorLabelFromInstanceHint(input: {
   return providerErrorLabel(
     input.instanceId ?? input.modelSelectionInstanceId ?? input.sessionProvider,
   );
-}
-
-function canReplaceThreadTitle(currentTitle: string, titleSeed?: string): boolean {
-  const trimmedCurrentTitle = currentTitle.trim();
-  if (trimmedCurrentTitle === DEFAULT_THREAD_TITLE) {
-    return true;
-  }
-
-  const trimmedTitleSeed = titleSeed?.trim();
-  return trimmedTitleSeed !== undefined && trimmedTitleSeed.length > 0
-    ? trimmedCurrentTitle === trimmedTitleSeed
-    : false;
 }
 
 function findProviderAdapterRequestError(
@@ -626,6 +617,7 @@ const make = Effect.gen(function* () {
         ...(preferredProvider ? { provider: preferredProvider } : {}),
         providerInstanceId: desiredInstanceId,
         ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+        ...(thread.title ? { title: thread.title } : {}),
         modelSelection: desiredModelSelection,
         ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
         runtimeMode: desiredRuntimeMode,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -39,10 +39,7 @@ import {
   type ProviderCommandReactorShape,
 } from "../Services/ProviderCommandReactor.ts";
 import { forkParked, ServerActivation } from "../../serverActivation.ts";
-import {
-  canReplaceThreadTitle,
-  DEFAULT_THREAD_TITLE,
-} from "../threadTitles.ts";
+import { canReplaceThreadTitle, DEFAULT_THREAD_TITLE } from "../threadTitles.ts";
 import {
   resolveSourceControlWriterModelSelection,
   ServerSettingsService,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -221,7 +221,10 @@ describe("ProviderRuntimeIngestion", () => {
     }
   });
 
-  async function createHarness(options?: { serverSettings?: Partial<ServerSettings> }) {
+  async function createHarness(options?: {
+    serverSettings?: Partial<ServerSettings>;
+    threadTitle?: string;
+  }) {
     const workspaceRoot = makeTempDir("t3-provider-project-");
     NodeFS.mkdirSync(NodePath.join(workspaceRoot, ".git"));
     const provider = createProviderServiceHarness();
@@ -277,7 +280,7 @@ describe("ProviderRuntimeIngestion", () => {
       commandId: CommandId.make("cmd-thread-create"),
       threadId: ThreadId.make("thread-1"),
       projectId: asProjectId("project-1"),
-      title: "Thread",
+      title: options?.threadTitle ?? "Thread",
       modelSelection: {
         instanceId: ProviderInstanceId.make("codex"),
         model: "gpt-5-codex",
@@ -2915,7 +2918,7 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(
       harness.readModel,
       (entry) =>
-        entry.title === "Renamed by provider" &&
+        entry.title === "Thread" &&
         entry.activities.some(
           (activity: ProviderRuntimeTestActivity) => activity.kind === "turn.plan.updated",
         ) &&
@@ -2930,7 +2933,7 @@ describe("ProviderRuntimeIngestion", () => {
         ),
     );
 
-    expect(thread.title).toBe("Renamed by provider");
+    expect(thread.title).toBe("Thread");
 
     const planActivity = thread.activities.find(
       (activity: ProviderRuntimeTestActivity) => activity.id === "evt-turn-plan-updated",
@@ -2969,6 +2972,51 @@ describe("ProviderRuntimeIngestion", () => {
     expect(checkpoint?.status).toBe("missing");
     expect(checkpoint?.assistantMessageId).toBe("assistant:item-p1-assistant");
     expect(checkpoint?.checkpointRef).toBe("provider-diff:evt-turn-diff-updated");
+  });
+
+  it("mirrors a provider title only while the thread still has the default title", async () => {
+    const harness = await createHarness({ threadTitle: "New thread" });
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-default"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      payload: {
+        name: "Renamed by provider",
+        metadata: { source: "provider" },
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.title === "Renamed by provider",
+    );
+    expect(thread.title).toBe("Renamed by provider");
+  });
+
+  it("rejects a provider title once the thread has a real title", async () => {
+    const harness = await createHarness({ threadTitle: "User-set title" });
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-real"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      payload: {
+        name: "Renamed by provider",
+        metadata: { source: "provider" },
+      },
+    });
+
+    await harness.drain();
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.title).toBe("User-set title");
   });
 
   it("projects context window updates into normalized thread activities", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -48,6 +48,7 @@ import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQu
 import * as ThreadBackgroundLiveness from "../ThreadBackgroundLiveness.ts";
 import * as ThreadPlanProgress from "../ThreadPlanProgress.ts";
 import { ProviderRuntimeIngestionLive } from "./ProviderRuntimeIngestion.ts";
+import { DEFAULT_THREAD_TITLE } from "../threadTitles.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
@@ -2975,7 +2976,7 @@ describe("ProviderRuntimeIngestion", () => {
   });
 
   it("mirrors a provider title only while the thread still has the default title", async () => {
-    const harness = await createHarness({ threadTitle: "New thread" });
+    const harness = await createHarness({ threadTitle: DEFAULT_THREAD_TITLE });
     const now = "2026-01-01T00:00:00.000Z";
 
     harness.emit({

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -43,6 +43,7 @@ import {
 } from "../Services/ProviderRuntimeIngestion.ts";
 import { forkParked } from "../../serverActivation.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { canReplaceThreadTitle } from "../threadTitles.ts";
 
 const providerTurnKey = (threadId: ThreadId, turnId: TurnId) => `${threadId}:${turnId}`;
 const providerTaskKey = (threadId: ThreadId, taskId: string) => `${threadId}:${taskId}`;
@@ -1892,12 +1893,14 @@ const make = Effect.gen(function* () {
       }
 
       if (event.type === "thread.metadata.updated" && event.payload.name) {
-        yield* orchestrationEngine.dispatch({
-          type: "thread.meta.update",
-          commandId: yield* providerCommandId(event, "thread-meta-update"),
-          threadId: thread.id,
-          title: event.payload.name,
-        });
+        if (canReplaceThreadTitle(thread.title)) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.meta.update",
+            commandId: yield* providerCommandId(event, "thread-meta-update"),
+            threadId: thread.id,
+            title: event.payload.name,
+          });
+        }
       }
 
       if (event.type === "turn.diff.updated") {

--- a/apps/server/src/orchestration/threadTitles.ts
+++ b/apps/server/src/orchestration/threadTitles.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_THREAD_TITLE = "New thread";
+
+export function canReplaceThreadTitle(currentTitle: string, titleSeed?: string): boolean {
+  const trimmedCurrentTitle = currentTitle.trim();
+  if (trimmedCurrentTitle === DEFAULT_THREAD_TITLE) {
+    return true;
+  }
+
+  const trimmedTitleSeed = titleSeed?.trim();
+  return trimmedTitleSeed !== undefined && trimmedTitleSeed.length > 0
+    ? trimmedCurrentTitle === trimmedTitleSeed
+    : false;
+}

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1191,6 +1191,73 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("passes the thread title to session.create when provided", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-title-provided");
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+        title: "Investigate reconnect failures",
+      });
+
+      NodeAssert.equal(runtimeMock.state.sessionCreateInputs.length, 1);
+      NodeAssert.equal(
+        runtimeMock.state.sessionCreateInputs[0]?.title,
+        "Investigate reconnect failures",
+      );
+    }),
+  );
+
+  it.effect("does not mirror OpenCode's default placeholder session titles", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-placeholder-title");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "session.updated",
+          properties: {
+            info: {
+              id: "http://127.0.0.1:9999/session",
+              title: "New session - 2026-08-09T10:20:30.456Z",
+            },
+          },
+        },
+        {
+          type: "session.updated",
+          properties: {
+            info: {
+              id: "http://127.0.0.1:9999/session",
+              title: "Investigate reconnect failures",
+            },
+          },
+        },
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      const metadataUpdated = events.filter((event) => event.type === "thread.metadata.updated");
+      NodeAssert.equal(metadataUpdated.length, 1);
+      if (metadataUpdated[0]?.type === "thread.metadata.updated") {
+        NodeAssert.equal(metadataUpdated[0].payload.name, "Investigate reconnect failures");
+      }
+    }),
+  );
+
   it.effect("writes provider-native observability records using the session thread id", () =>
     Effect.gen(function* () {
       const nativeEvents: Array<{

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -201,7 +201,24 @@ function openCodeEventSessionTitle(event: OpenCodeSubscribedEvent): string | und
     return undefined;
   }
 
-  return trimText(event.properties.info.title);
+  const title = trimText(event.properties.info.title);
+  // OpenCode mints a placeholder title at session.create when no title was
+  // provided, and re-emits it on every `session.updated`. Mirroring it would
+  // overwrite the thread's real title (openCodeEventSessionTitle feeds the
+  // `thread.metadata.updated` mirror). Ignore it: a thread whose title is
+  // still the default is titled by T3 Code instead.
+  if (!title || isOpenCodeDefaultTitle(title)) {
+    return undefined;
+  }
+
+  return title;
+}
+
+const OPENCODE_DEFAULT_TITLE_PATTERN =
+  /^(New session - |Child session - )\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function isOpenCodeDefaultTitle(title: string): boolean {
+  return OPENCODE_DEFAULT_TITLE_PATTERN.test(title);
 }
 
 interface OpenCodeSessionContext {
@@ -1302,6 +1319,7 @@ export function makeOpenCodeAdapter(
                 }
                 const createdSession = yield* runOpenCodeSdk("session.create", () =>
                   client.session.create({
+                    ...(input.title ? { title: input.title } : {}),
                     permission: buildOpenCodePermissionRules(input.runtimeMode),
                   }),
                 );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -205,8 +205,8 @@ function openCodeEventSessionTitle(event: OpenCodeSubscribedEvent): string | und
   // OpenCode mints a placeholder title at session.create when no title was
   // provided, and re-emits it on every `session.updated`. Mirroring it would
   // overwrite the thread's real title (openCodeEventSessionTitle feeds the
-  // `thread.metadata.updated` mirror). Ignore it: a thread whose title is
-  // still the default is titled by T3 Code instead.
+  // `thread.metadata.updated` mirror). Ignore OpenCode's auto-generated
+  // placeholders so the thread isn't locked onto them.
   if (!title || isOpenCodeDefaultTitle(title)) {
     return undefined;
   }

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -56,6 +56,7 @@ export const ProviderSessionStartInput = Schema.Struct({
   // See ProviderSession for the migration story.
   providerInstanceId: Schema.optional(ProviderInstanceId),
   cwd: Schema.optional(TrimmedNonEmptyString),
+  title: Schema.optional(TrimmedNonEmptyString),
   modelSelection: Schema.optional(ModelSelection),
   resumeCursor: Schema.optional(Schema.Unknown),
   approvalPolicy: Schema.optional(ProviderApprovalPolicy),


### PR DESCRIPTION
## Summary

The provider title mirror (`thread.metadata.updated` -> `thread.meta.update`) in `ProviderRuntimeIngestion` dispatched every provider title with **no guard and no `titleSeed`**, bypassing `canReplaceThreadTitle` entirely. When OpenCode (or Codex) emits a session title, the mirror unconditionally overwrote the thread title.

Concretely with OpenCode:
1. OpenCode mints a placeholder title at `session.create` (`New session - <ts>`) and re-emits it on every `session.updated`.
2. The mirror copies it into the thread (`canReplaceThreadTitle` would have allowed it anyway while the thread is titled `New thread`).
3. Once the thread carries the placeholder, the real generated title is **rejected** in `maybeGenerateThreadTitleForFirstTurn` because the current title no longer equals the title seed. The thread is stuck with the placeholder.

## Changes

- **Pass the thread title at `session.create`** (`ProviderSessionStartInput.title` -> `OpenCodeAdapter`). OpenCode backs off titling any non-default title, so it never mints a placeholder in the first place.
- **Guard the shared mirror with `canReplaceThreadTitle`** in `ProviderRuntimeIngestion`: a provider title is only applied while the thread still has its default title. This closes the same hole for Codex and any other provider.
- **Stop mirroring OpenCode's default placeholder titles** in the adapter, covering older OpenCode builds whose `session.create` ignores the provided title.
- Extracted `canReplaceThreadTitle` / `DEFAULT_THREAD_TITLE` into `orchestration/threadTitles.ts`, shared by the reactor and the ingestion layer (no import cycle).

## Tests

- Adapter: title passed to `session.create` when provided; placeholder `New session - <ts>` titles are not mirrored while real ones are.
- Ingestion: provider title mirrored only while thread title is the default; rejected once the thread has a real title.
- Existing title-generation and mirror tests updated/kept green.

Fixes #5245

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread-title behavior across providers and OpenCode session creation; wrong guards could leave default titles or still accept unwanted renames, but scope is limited to metadata mirroring with tests.
> 
> **Overview**
> Fixes provider-emitted session titles **unconditionally overwriting** thread names (notably OpenCode’s `New session - <timestamp>` placeholder), which could block server-side title generation.
> 
> **Provider runtime ingestion** now applies `thread.metadata.updated` → `thread.meta.update` only when `canReplaceThreadTitle` allows it (default **"New thread"** or title matching a seed). **`DEFAULT_THREAD_TITLE`** and **`canReplaceThreadTitle`** move to shared **`threadTitles.ts`** for the reactor and ingestion layer.
> 
> **Session start** passes the current thread **`title`** through **`ProviderSessionStartInput`** into **`providerService.startSession`**; **OpenCode** sends it to **`session.create`** so placeholders are less likely. The adapter still **drops** auto-generated **`New session -`** / **`Child session -`** titles before emitting metadata updates.
> 
> Tests cover mirror gating, OpenCode title forwarding, and placeholder filtering; the broad P1 ingestion test no longer expects provider rename when the harness thread already has a real title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5afe24ea4af529900a16ddb8466700b359499096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop provider title mirroring from overwriting user-set thread titles
> - Adds a `canReplaceThreadTitle` guard in [`ProviderRuntimeIngestion.ts`](https://github.com/pingdotgg/t3code/pull/5941/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) so provider-originated title updates are only applied when the thread still has the default title (`'New thread'`).
> - Filters out OpenCode's auto-generated placeholder titles (matching `New session - <ISO timestamp>` or `Child session - <ISO timestamp>`) in [`OpenCodeAdapter.ts`](https://github.com/pingdotgg/t3code/pull/5941/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) so they are never mirrored as thread metadata updates.
> - Passes the current thread title to `providerService.startSession` and forwards it to `client.session.create` in OpenCode, so new sessions inherit the existing thread title.
> - Extracts shared utilities `DEFAULT_THREAD_TITLE` and `canReplaceThreadTitle` into [`threadTitles.ts`](https://github.com/pingdotgg/t3code/pull/5941/files#diff-c640b24f6e23d548aae27e3674ad646053c184a7492c78d299fd7d2ea5f89d2b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5afe24e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->