### PR TITLE
feat(composer): show provider account usage in the input area

### DIFF
--- a/apps/mobile/src/components/AppSymbol.tsx
+++ b/apps/mobile/src/components/AppSymbol.tsx
@@ -36,6 +36,7 @@ import {
   IconFolder,
   IconFolderOpen,
   IconFolderPlus,
+  IconGauge,
   IconGitBranch,
   IconHammer,
   IconGitMerge,
@@ -80,6 +81,7 @@ import { SymbolView as ExpoSymbolView, type SFSymbol, type SymbolViewProps } fro
 
 const ANDROID_ICON_BY_SF_SYMBOL: Partial<Record<SFSymbol, Icon>> = {
   "arrow.branch": IconGitBranch,
+  "gauge.with.dots.needle.bottom.50percent": IconGauge,
   "arrow.clockwise": IconRefresh,
   "arrow.down.circle": IconArrowDownCircle,
   "arrow.right.circle": IconArrowRightCircle,

--- a/apps/mobile/src/components/ControlPill.tsx
+++ b/apps/mobile/src/components/ControlPill.tsx
@@ -86,9 +86,18 @@ export function ControlPill(props: {
 // Android renders the token-styled AndroidAnchoredMenu, since the native
 // AppCompat popup can't be themed past its stock animation, metrics, and
 // submenu chrome.
+/**
+ * A render-function child keeps the trigger interactive on Android.
+ *
+ * The plain-node form there is wrapped in a `pointerEvents="none"` view so
+ * the anchor Pressable owns the tap, which silently swallows any `onPress`
+ * the child declared. Callers that need their own press side effects take
+ * `open` and call it themselves. On iOS the native menu opens on tap and the
+ * child's handlers already run, so `open` is a no-op there.
+ */
 export function ControlPillMenu(
   props: Omit<ComponentProps<typeof MenuView>, "children" | "themeVariant"> & {
-    readonly children: ReactNode;
+    readonly children: ReactNode | ((open: () => void) => ReactNode);
     readonly className?: string;
   },
 ) {
@@ -133,7 +142,12 @@ export function ControlPillMenu(
   }
 
   const { className: _className, ...menuProps } = props;
-  let children = menuProps.children;
+  // iOS opens the native menu from the tap itself, so the render-function
+  // form has nothing to trigger.
+  let children: ReactNode =
+    typeof menuProps.children === "function"
+      ? menuProps.children(() => undefined)
+      : menuProps.children;
   // In long-press mode the wrapped pressable still receives the touch (the
   // patched MenuView button is touch-transparent) and RN's Fabric touch
   // handler is never cancelled by the in-tree UIContextMenuInteraction, so a

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -1,6 +1,7 @@
 import { isLiquidGlassSupported, LiquidGlassView } from "@callstack/liquid-glass";
 import type {
   EnvironmentId,
+  ProviderUsageWindow,
   MessageId,
   ModelSelection,
   OrchestrationThreadShell,
@@ -18,6 +19,7 @@ import type { ReactNode } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import {
   ActivityIndicator,
+  AppState,
   Image,
   Platform,
   Pressable,
@@ -51,7 +53,15 @@ import {
   ComposerToolbarScroller,
   ComposerToolbarTrigger,
 } from "../../components/ComposerToolbarTrigger";
-import { ControlPill } from "../../components/ControlPill";
+import { ControlPill, ControlPillMenu } from "../../components/ControlPill";
+import {
+  formatUsagePercent,
+  formatUsageResetLabel,
+  formatUsageUpdatedAtLabel,
+  pickWorstUsageWindow,
+} from "@t3tools/client-runtime/state/provider-usage";
+import { serverEnvironment } from "../../state/server";
+import { useAtomCommand } from "../../state/use-atom-command";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import { buildModelOptions, groupByProvider } from "../../lib/modelOptions";
@@ -73,6 +83,10 @@ import { useThreadSettingsSheetPresentation } from "./use-thread-settings-sheet-
  * Exported so the parent can compute feed overlap / content insets.
  */
 export const COMPOSER_COLLAPSED_CHROME = 60;
+
+// Stable empty reference — a fresh `[]` per render would defeat the memos
+// that keep the toolbar from rebuilding on every provider-status push.
+const EMPTY_USAGE_WINDOWS: ReadonlyArray<ProviderUsageWindow> = [];
 
 /**
  * Height of the expanded composer (card + toolbar + vertical padding, excluding safe-area inset).
@@ -623,6 +637,69 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     interactionMode: currentInteractionMode,
   });
 
+  // ── Account usage ────────────────────────────────────────
+  // Mobile gets one chevron button rather than a row of rings: three 44pt
+  // touch targets would crowd the toolbar, and hover tooltips do not exist
+  // on touch. Each window becomes a menu row whose subtitle carries the
+  // percentage and reset time, so nothing needs a second tap to read.
+  const usageWindows = selectedProviderStatus?.usageLimits?.windows ?? EMPTY_USAGE_WINDOWS;
+  const usageUpdatedAt = selectedProviderStatus?.usageLimits?.updatedAt ?? null;
+  const worstUsageWindow = useMemo(() => pickWorstUsageWindow(usageWindows), [usageWindows]);
+  const usageInstanceId = currentModelSelection.instanceId;
+  const refreshProviderUsage = useAtomCommand(serverEnvironment.refreshProviderUsage, {
+    reportFailure: false,
+  });
+  // Claude only ever reports usage in response to a pull, so without this
+  // the meters stay empty forever in a phone-only session — the web client's
+  // triggers are no substitute when no web client is connected.
+  const requestUsageRefresh = useCallback(() => {
+    void refreshProviderUsage({
+      environmentId: props.environmentId,
+      input: { instanceId: usageInstanceId },
+    });
+  }, [props.environmentId, refreshProviderUsage, usageInstanceId]);
+  useEffect(() => {
+    requestUsageRefresh();
+  }, [requestUsageRefresh]);
+  useEffect(() => {
+    // The touch analogue of the web client's window `focus` trigger.
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        requestUsageRefresh();
+      }
+    });
+    return () => {
+      subscription.remove();
+    };
+  }, [requestUsageRefresh]);
+
+  // Rebuilt when the menu opens, not only when the numbers change. The rows
+  // carry relative times ("resets in 2h 15m", "as of 12m ago"); keying the
+  // memo on the data alone freezes those at whatever the clock read when the
+  // reading last landed, which can be hours before anyone looks at them.
+  const [usageMenuNonce, setUsageMenuNonce] = useState(0);
+  const usageMenuActions = useMemo(() => {
+    void usageMenuNonce;
+    const nowMs = Date.now();
+    const staleLabel = formatUsageUpdatedAtLabel(usageUpdatedAt, nowMs);
+    const windowRows = usageWindows.map((window) => {
+      const resetLabel = formatUsageResetLabel(window.resetsAt, nowMs);
+      const percentLabel = formatUsagePercent(window.usedPercent);
+      return {
+        id: `usage:${window.id}`,
+        title: window.label,
+        subtitle: resetLabel ? `${percentLabel} · ${resetLabel}` : percentLabel,
+        attributes: { disabled: true },
+      };
+    });
+    return staleLabel
+      ? [
+          ...windowRows,
+          { id: "usage:updated-at", title: staleLabel, attributes: { disabled: true } },
+        ]
+      : windowRows;
+  }, [usageWindows, usageUpdatedAt, usageMenuNonce]);
+
   return (
     <Animated.View
       className="px-4"
@@ -801,6 +878,23 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                   maxWidth={320}
                   onPress={settingsSheetPresentation.open}
                 />
+                {worstUsageWindow ? (
+                  <ControlPillMenu actions={usageMenuActions} title="Usage">
+                    <ComposerToolbarTrigger
+                      accessibilityLabel={`Usage, ${worstUsageWindow.label} ${formatUsagePercent(
+                        worstUsageWindow.usedPercent,
+                      )} used`}
+                      icon="gauge.with.dots.needle.bottom.50percent"
+                      label={formatUsagePercent(worstUsageWindow.usedPercent)}
+                      onPress={() => {
+                        // Restamp the relative labels and ask for a fresh
+                        // reading; the server debounces the pull.
+                        setUsageMenuNonce((nonce) => nonce + 1);
+                        requestUsageRefresh();
+                      }}
+                    />
+                  </ControlPillMenu>
+                ) : null}
                 {showStopAction ? (
                   <ComposerToolbarButton
                     accessibilityLabel="Stop"

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -880,19 +880,28 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                 />
                 {worstUsageWindow ? (
                   <ControlPillMenu actions={usageMenuActions} title="Usage">
-                    <ComposerToolbarTrigger
-                      accessibilityLabel={`Usage, ${worstUsageWindow.label} ${formatUsagePercent(
-                        worstUsageWindow.usedPercent,
-                      )} used`}
-                      icon="gauge.with.dots.needle.bottom.50percent"
-                      label={formatUsagePercent(worstUsageWindow.usedPercent)}
-                      onPress={() => {
-                        // Restamp the relative labels and ask for a fresh
-                        // reading; the server debounces the pull.
-                        setUsageMenuNonce((nonce) => nonce + 1);
-                        requestUsageRefresh();
-                      }}
-                    />
+                    {/*
+                      Render-function form so the trigger stays interactive on
+                      Android, where a plain child sits under a
+                      `pointerEvents="none"` view and never sees the tap.
+                      `open` is a no-op on iOS, which opens natively.
+                    */}
+                    {(open) => (
+                      <ComposerToolbarTrigger
+                        accessibilityLabel={`Usage, ${worstUsageWindow.label} ${formatUsagePercent(
+                          worstUsageWindow.usedPercent,
+                        )} used`}
+                        icon="gauge.with.dots.needle.bottom.50percent"
+                        label={formatUsagePercent(worstUsageWindow.usedPercent)}
+                        onPress={() => {
+                          // Restamp the relative labels and ask for a fresh
+                          // reading; the server debounces the pull.
+                          setUsageMenuNonce((nonce) => nonce + 1);
+                          requestUsageRefresh();
+                          open();
+                        }}
+                      />
+                    )}
                   </ControlPillMenu>
                 ) : null}
                 {showStopAction ? (

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -32,6 +32,9 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverProbe]: AuthOrchestrationReadScope,
   [WS_METHODS.serverGetConfig]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRefreshProviders]: AuthOrchestrationOperateScope,
+  // Read-only: pulls a usage number the account already owes the user and
+  // spends no quota doing it.
+  [WS_METHODS.serverRefreshProviderUsage]: AuthOrchestrationReadScope,
   [WS_METHODS.serverUpdateProvider]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServer]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServerWithProgress]: AuthOrchestrationOperateScope,

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -61,7 +61,7 @@ function parseSkillFrontmatter(contents: string): SkillFrontmatter {
  * `CLAUDE_CONFIG_DIR` by `makeClaudeEnvironment`), then a `CLAUDE_CONFIG_DIR`
  * already present in the process environment, then `~/.claude`.
  */
-const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(function* (
+export const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(function* (
   config: Pick<ClaudeSettings, "homePath">,
   environment: NodeJS.ProcessEnv,
   cwd?: string,

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -21,6 +21,7 @@ import type {
   ProviderOptionDescriptor,
   ServerProviderModel,
   ServerProviderSkill,
+  ProviderUsageLimits,
 } from "@t3tools/contracts";
 import { PREFERRED_DEFAULT_CODEX_MODELS, ServerSettingsError } from "@t3tools/contracts";
 
@@ -32,11 +33,17 @@ import {
   buildServerProvider,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
+import { normalizeCodexUsage } from "../usageLimits.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
 
 const CODEX_APP_SERVER_PROBE_FORCE_KILL_AFTER = "2 seconds" as const;
+
+// Deadline for the ambient usage read inside the status probe. Deliberately
+// well under the probe's own budget: usage is a nice-to-have and must never
+// be able to consume the time the probe needs for models and skills.
+const CODEX_RATE_LIMITS_READ_TIMEOUT_MS = 2_000;
 
 const CODEX_PRESENTATION = {
   displayName: "Codex",
@@ -48,6 +55,12 @@ export interface CodexAppServerProviderSnapshot {
   readonly version: string | undefined;
   readonly models: ReadonlyArray<ServerProviderModel>;
   readonly skills: ReadonlyArray<ServerProviderSkill>;
+  // Account quota usage, read on the app-server connection this probe
+  // already opened. Absent when the read failed or the account reports no
+  // windows. Live updates arrive separately via
+  // `account/rateLimits/updated`; this read exists so the meters are
+  // populated before the first turn of a session.
+  readonly usageLimits?: ProviderUsageLimits | undefined;
 }
 
 const REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
@@ -395,15 +408,27 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     } satisfies CodexAppServerProviderSnapshot;
   }
 
-  const [skillsResponse, models] = yield* Effect.all(
+  const [skillsResponse, models, rateLimits] = yield* Effect.all(
     [
       client.request("skills/list", {
         cwds: [input.cwd],
       }),
       requestAllCodexModels(client),
+      // Ambient extra on a connection we already paid for. An app-server
+      // that predates the method may never answer at all rather than
+      // failing, so this needs its own deadline: sharing only the probe's
+      // budget would let a silent request consume it and drop Codex to
+      // "no models, no skills" over a usage read nobody asked for.
+      client.request("account/rateLimits/read", undefined).pipe(
+        Effect.timeoutOption(Duration.millis(CODEX_RATE_LIMITS_READ_TIMEOUT_MS)),
+        Effect.map(Option.getOrNull),
+        Effect.orElseSucceed(() => null),
+      ),
     ],
     { concurrency: "unbounded" },
   );
+
+  const usageLimits = normalizeCodexUsage(rateLimits, DateTime.formatIso(yield* DateTime.now));
 
   return {
     account: accountResponse,
@@ -412,6 +437,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
       appendCustomCodexModels(models, input.customModels ?? []),
     ),
     skills: parseCodexSkillsListResponse(skillsResponse, input.cwd),
+    ...(usageLimits ? { usageLimits } : {}),
   } satisfies CodexAppServerProviderSnapshot;
 });
 
@@ -595,20 +621,23 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   const snapshot = probeResult.success.value;
   const accountStatus = accountProbeStatus(snapshot.account);
 
-  return buildServerProvider({
-    presentation: CODEX_PRESENTATION,
-    enabled: codexSettings.enabled,
-    checkedAt,
-    models: snapshot.models,
-    skills: snapshot.skills,
-    probe: {
-      installed: true,
-      version: snapshot.version ?? null,
-      status: accountStatus.status,
-      auth: accountStatus.auth,
-      ...(accountStatus.message ? { message: accountStatus.message } : {}),
-    },
-  });
+  return {
+    ...buildServerProvider({
+      presentation: CODEX_PRESENTATION,
+      enabled: codexSettings.enabled,
+      checkedAt,
+      models: snapshot.models,
+      skills: snapshot.skills,
+      probe: {
+        installed: true,
+        version: snapshot.version ?? null,
+        status: accountStatus.status,
+        auth: accountStatus.auth,
+        ...(accountStatus.message ? { message: accountStatus.message } : {}),
+      },
+    }),
+    ...(snapshot.usageLimits ? { usageLimits: snapshot.usageLimits } : {}),
+  };
 });
 
 // NOTE: the singleton `CodexProviderLive` Layer has been removed as part of

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -45,6 +45,7 @@ import {
   selectProvidersByKind,
 } from "./ProviderRegistry.ts";
 import { ProviderUsageLimitsStoreLive } from "./ProviderUsageLimits.ts";
+import { ProviderUsageLimitsStore } from "../Services/ProviderUsageLimits.ts";
 import * as ServerConfig from "../../config.ts";
 import * as ServerSettingsModule from "../../serverSettings.ts";
 import { readProviderStatusCache, resolveProviderStatusCachePath } from "../providerStatusCache.ts";
@@ -1662,6 +1663,128 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             assert.deepStrictEqual(spawnedCommands, [firstMissing, secondMissing]);
             assert.strictEqual(reprobedCodex?.status, "error");
             assert.strictEqual(reprobedCodex?.installed, false);
+          }).pipe(Effect.provide(runtimeServices));
+        }),
+      );
+
+      // A rebuilt instance may point at a different account. Its snapshots
+      // arrive without `usageLimits` (usage is decorated from the store),
+      // so without an explicit clear the registry would keep decorating the
+      // new configuration with the previous account's numbers.
+      it.effect("drops stored usage when settings rebuild the instance", () =>
+        Effect.gen(function* () {
+          const firstMissing = `t3code_codex_usage_first_`;
+          const secondMissing = `t3code_codex_usage_second_`;
+          const spawnedCommands: Array<string> = [];
+          const serverSettings = yield* makeMutableServerSettingsService(
+            decodeServerSettings(
+              deepMerge(encodedDefaultServerSettings, {
+                providers: {
+                  codex: { enabled: true, binaryPath: firstMissing },
+                  claudeAgent: { enabled: false },
+                  cursor: { enabled: false },
+                  grok: { enabled: false },
+                  opencode: { enabled: false },
+                },
+              }),
+            ),
+          );
+          const scope = yield* Scope.make();
+          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+          const providerRegistryLayer = ProviderRegistryLive.pipe(
+            Layer.provideMerge(ProviderUsageLimitsStoreLive),
+            Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
+            Layer.provideMerge(
+              Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
+            ),
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), {
+                prefix: "t3-provider-registry-",
+              }),
+            ),
+            Layer.provideMerge(TestHttpClientLive),
+            Layer.provideMerge(
+              Layer.succeed(
+                ProviderEventLoggers.ProviderEventLoggers,
+                ProviderEventLoggers.NoOpProviderEventLoggers,
+              ),
+            ),
+            Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
+            Layer.updateService(ChildProcessSpawner.ChildProcessSpawner, (spawner) =>
+              ChildProcessSpawner.make((command) => {
+                spawnedCommands.push((command as { readonly command: string }).command);
+                return spawner.spawn(command);
+              }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+            Layer.provideMerge(BackgroundPolicyAlwaysRunLayer),
+          );
+          const runtimeServices = yield* Layer.build(providerRegistryLayer).pipe(
+            Scope.provide(scope),
+          );
+
+          yield* Effect.gen(function* () {
+            const registry = yield* ProviderRegistry.ProviderRegistry;
+            const usageStore = yield* ProviderUsageLimitsStore;
+            const codexId = ProviderInstanceId.make("codex");
+
+            // Wait for the boot-time probe so the instance exists.
+            let initialProviders = yield* registry.getProviders;
+            for (
+              let attempts = 0;
+              attempts < 50 &&
+              initialProviders.find((provider) => provider.instanceId === "codex")?.status !==
+                "error";
+              attempts += 1
+            ) {
+              yield* TestClock.adjust("10 millis");
+              yield* Effect.yieldNow;
+              initialProviders = yield* registry.getProviders;
+            }
+
+            // A reading lands for the current configuration.
+            yield* usageStore.set(
+              codexId,
+              {
+                windows: [
+                  { id: "codex-primary", label: "Session", usedPercent: 55, resetsAt: null },
+                ],
+                updatedAt: "2026-08-09T12:00:00.000Z",
+              },
+              "full",
+            );
+
+            // Rebuild the instance by changing its configuration.
+            yield* serverSettings.updateSettings({
+              providers: {
+                codex: { enabled: true, binaryPath: secondMissing },
+              },
+            });
+
+            // Poll until the rebuilt instance's probe ran and the stored
+            // reading is gone.
+            let storedAfterRebuild = yield* usageStore.get(codexId);
+            for (
+              let attempts = 0;
+              attempts < 60 &&
+              !(storedAfterRebuild === undefined && spawnedCommands.includes(secondMissing));
+              attempts += 1
+            ) {
+              yield* TestClock.adjust("50 millis");
+              yield* Effect.yieldNow;
+              storedAfterRebuild = yield* usageStore.get(codexId);
+            }
+            assert.isUndefined(
+              storedAfterRebuild,
+              "a rebuilt instance must not inherit the previous configuration's reading",
+            );
+
+            const providers = yield* registry.getProviders;
+            const rebuiltCodex = providers.find((provider) => provider.instanceId === "codex");
+            assert.isUndefined(
+              rebuiltCodex?.usageLimits,
+              "the rebuilt snapshot must not be decorated with stale usage",
+            );
           }).pipe(Effect.provide(runtimeServices));
         }),
       );

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -44,6 +44,7 @@ import {
   ProviderRegistryLive,
   selectProvidersByKind,
 } from "./ProviderRegistry.ts";
+import { ProviderUsageLimitsStoreLive } from "./ProviderUsageLimits.ts";
 import * as ServerConfig from "../../config.ts";
 import * as ServerSettingsModule from "../../serverSettings.ts";
 import { readProviderStatusCache, resolveProviderStatusCachePath } from "../providerStatusCache.ts";
@@ -876,6 +877,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const runtimeServices = yield* Layer.build(
             ProviderRegistryLive.pipe(
+              Layer.provideMerge(ProviderUsageLimitsStoreLive),
               Layer.provideMerge(instanceRegistryLayer),
               Layer.provideMerge(
                 ServerConfig.layerTest(process.cwd(), {
@@ -1031,6 +1033,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const runtimeServices = yield* Layer.build(
             ProviderRegistryLive.pipe(
+              Layer.provideMerge(ProviderUsageLimitsStoreLive),
               Layer.provideMerge(instanceRegistryLayer),
               Layer.provideMerge(
                 ServerConfig.layerTest(process.cwd(), {
@@ -1160,6 +1163,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
             const runtimeServices = yield* Layer.build(
               ProviderRegistryLive.pipe(
+                Layer.provideMerge(ProviderUsageLimitsStoreLive),
                 Layer.provideMerge(instanceRegistryLayer),
                 Layer.provideMerge(
                   ServerConfig.layerTest(process.cwd(), {
@@ -1267,6 +1271,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const runtimeServices = yield* Layer.build(
             ProviderRegistryLive.pipe(
+              Layer.provideMerge(ProviderUsageLimitsStoreLive),
               Layer.provideMerge(instanceRegistryLayer),
               Layer.provideMerge(
                 ServerConfig.layerTest(process.cwd(), {
@@ -1375,6 +1380,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const runtimeServices = yield* Layer.build(
             ProviderRegistryLive.pipe(
+              Layer.provideMerge(ProviderUsageLimitsStoreLive),
               Layer.provideMerge(instanceRegistryLayer),
               Layer.provideMerge(
                 ServerConfig.layerTest(process.cwd(), {
@@ -1469,6 +1475,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           const scope = yield* Scope.make();
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const providerRegistryLayer = ProviderRegistryLive.pipe(
+            Layer.provideMerge(ProviderUsageLimitsStoreLive),
             Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
             Layer.provideMerge(
               Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
@@ -1562,6 +1569,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           const scope = yield* Scope.make();
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const providerRegistryLayer = ProviderRegistryLive.pipe(
+            Layer.provideMerge(ProviderUsageLimitsStoreLive),
             Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
             Layer.provideMerge(
               Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
@@ -1684,6 +1692,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           const scope = yield* Scope.make();
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const providerRegistryLayer = ProviderRegistryLive.pipe(
+            Layer.provideMerge(ProviderUsageLimitsStoreLive),
             Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
             Layer.provideMerge(
               Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
@@ -1746,6 +1755,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             const scope = yield* Scope.make();
             yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
             const providerRegistryLayer = ProviderRegistryLive.pipe(
+              Layer.provideMerge(ProviderUsageLimitsStoreLive),
               Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
               Layer.provideMerge(
                 Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -599,6 +599,20 @@ export const ProviderRegistryLive = Layer.effect(
           newlyAdded.push([instanceId, instance] as const);
         }
 
+        // Forget stored usage for every instance that was not carried over
+        // unchanged: a rebuilt instance may point at a different account,
+        // and `applyProviderUsageLimits` would otherwise decorate its fresh
+        // snapshots with the previous configuration's numbers until a new
+        // reading happened to arrive. Removed instances get the same
+        // treatment so a later instance reusing the id starts clean. Done
+        // before the rebuilt instance's snapshot is read, so its own probe
+        // seeds the store first.
+        for (const instanceId of previousSubs.keys()) {
+          if (!carriedOver.has(instanceId)) {
+            yield* usageStore.clear(instanceId);
+          }
+        }
+
         // Fork long-lived subscriptions to each new/rebuilt instance's
         // change stream before reading its current snapshot. If the
         // driver's own initial probe finishes during this sync, either
@@ -700,9 +714,17 @@ export const ProviderRegistryLive = Layer.effect(
           const provider = providers.find(
             (candidate) => snapshotInstanceKey(candidate) === instanceId,
           );
-          return provider === undefined
-            ? Effect.void
-            : upsertProviders([provider], { persist: false });
+          if (provider === undefined) {
+            return Effect.void;
+          }
+          // Strip the previous decoration before re-upserting: the snapshot
+          // in `providersRef` carries whatever `usageLimits` the store held
+          // last time, and `applyProviderUsageLimits` seeds snapshot values
+          // back into the store. Left on, a cleared reading would boomerang —
+          // the clear announces, this subscriber re-upserts the stale
+          // decoration, and the seed resurrects exactly what was cleared.
+          const { usageLimits: _usageLimits, ...undecorated } = provider;
+          return upsertProviders([undecorated], { persist: false });
         }),
       ),
     ).pipe(Effect.forkScoped);

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -43,6 +43,8 @@ import * as Semaphore from "effect/Semaphore";
 import { ServerConfig } from "../../config.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { ProviderRegistry, type ProviderRegistryShape } from "../Services/ProviderRegistry.ts";
+import { ProviderUsageLimitsStore } from "../Services/ProviderUsageLimits.ts";
+
 import {
   hydrateCachedProvider,
   isCachedProviderCorrelated,
@@ -210,6 +212,7 @@ export const ProviderRegistryLive = Layer.effect(
   ProviderRegistry,
   Effect.gen(function* () {
     const instanceRegistry = yield* ProviderInstanceRegistry;
+    const usageStore = yield* ProviderUsageLimitsStore;
     const config = yield* ServerConfig;
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -321,7 +324,12 @@ export const ProviderRegistryLive = Layer.effect(
           cacheDir: config.providerStatusCacheDir,
           instanceId: key,
         }).pipe(Effect.provideService(Path.Path, path));
-        yield* writeProviderStatusCache({ filePath, provider }).pipe(
+        // Usage readings are deliberately not cached. They go stale in
+        // minutes, and rehydrating a days-old reading on boot would draw
+        // confident-looking meters that are simply wrong; the first probe
+        // or turn repopulates them within seconds.
+        const { usageLimits: _usageLimits, ...providerToPersist } = provider;
+        yield* writeProviderStatusCache({ filePath, provider: providerToPersist }).pipe(
           Effect.provideService(FileSystem.FileSystem, fileSystem),
           Effect.provideService(Path.Path, path),
           Effect.tapError(Effect.logError),
@@ -344,6 +352,38 @@ export const ProviderRegistryLive = Layer.effect(
       };
     });
 
+    /**
+     * Project account usage onto a snapshot.
+     *
+     * The store is the single source of truth, because only it can fold the
+     * sparse per-bucket readings that arrive on turn events into a complete
+     * picture. A driver probe that read usage on a connection it already had
+     * open (Codex does this) carries a full reading on its snapshot; seed
+     * that into the store rather than reading it directly, so a later sparse
+     * event merges onto it instead of replacing it.
+     *
+     * Seeding is idempotent: the value written back onto the snapshot is the
+     * store's own, so re-decorating an unchanged snapshot is a no-op and
+     * cannot loop.
+     */
+    const applyProviderUsageLimits = Effect.fn("applyProviderUsageLimits")(function* (
+      provider: ServerProvider,
+    ) {
+      if (provider.usageLimits !== undefined) {
+        yield* usageStore.set(provider.instanceId, provider.usageLimits, "full");
+      }
+      const usageLimits = yield* usageStore.get(provider.instanceId);
+      if (!usageLimits) {
+        const { usageLimits: _usageLimits, ...providerWithoutUsage } = provider;
+        return providerWithoutUsage;
+      }
+      return { ...provider, usageLimits };
+    });
+
+    const decorateProvider = Effect.fn("decorateProvider")(function* (provider: ServerProvider) {
+      return yield* applyProviderUsageLimits(yield* applyProviderUpdateState(provider));
+    });
+
     const upsertProviders = Effect.fn("upsertProviders")(function* (
       nextProviders: ReadonlyArray<ServerProvider>,
       options?: {
@@ -352,13 +392,9 @@ export const ProviderRegistryLive = Layer.effect(
         readonly replace?: boolean;
       },
     ) {
-      const nextProvidersWithUpdateState = yield* Effect.forEach(
-        nextProviders,
-        applyProviderUpdateState,
-        {
-          concurrency: "unbounded",
-        },
-      );
+      const nextProvidersWithUpdateState = yield* Effect.forEach(nextProviders, decorateProvider, {
+        concurrency: "unbounded",
+      });
       const [previousProviders, providers, providersToPersist] = yield* Ref.modify(
         providersRef,
         (previousProviders) => {
@@ -642,6 +678,34 @@ export const ProviderRegistryLive = Layer.effect(
         );
       }),
     );
+
+    // Usage readings arrive out of band (turn events, on-demand pulls) and
+    // must reach clients without waiting for the next status probe. Re-run
+    // the affected instance through `upsertProviders` so it picks up the
+    // fresh reading and publishes — without persisting, since a usage
+    // change is not a status change and every turn would otherwise cost a
+    // disk write.
+    //
+    // Subscribed and forked here, ahead of `syncLiveSources`, for two
+    // reasons. `Stream.fromPubSub` defers `PubSub.subscribe` to stream
+    // start, so the subscription is acquired eagerly (same reasoning as
+    // `instanceChanges` below). And forking after `syncLiveSources` would
+    // put this fiber behind the single `Effect.yieldNow` that its
+    // per-instance subscribers rely on to attach, delaying theirs by a
+    // tick and dropping the first snapshot published to them.
+    const usageChanges = yield* usageStore.subscribeChanges;
+    yield* Stream.runForEach(Stream.fromSubscription(usageChanges), (instanceId) =>
+      Ref.get(providersRef).pipe(
+        Effect.flatMap((providers) => {
+          const provider = providers.find(
+            (candidate) => snapshotInstanceKey(candidate) === instanceId,
+          );
+          return provider === undefined
+            ? Effect.void
+            : upsertProviders([provider], { persist: false });
+        }),
+      ),
+    ).pipe(Effect.forkScoped);
 
     // Seed `providersRef` with the boot-time fallback snapshots so
     // consumers calling `getProviders` immediately after layer build see

--- a/apps/server/src/provider/Layers/ProviderUsageIngestion.test.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageIngestion.test.ts
@@ -1,0 +1,91 @@
+import {
+  EventId,
+  ProviderDriverKind,
+  ThreadId,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { normalizeRuntimeUsageEvent } from "./ProviderUsageIngestion.ts";
+
+const UPDATED_AT = "2026-08-09T12:00:00.000Z";
+
+/**
+ * Build the event exactly as an adapter emits it. This is the seam the
+ * normalizers are actually called across, and it is where a mismatch between
+ * "what the SDK sends" and "what the normalizer reads" hides — testing the
+ * normalizers alone with hand-written payloads cannot catch it.
+ */
+const usageEvent = (
+  provider: string,
+  rateLimits: unknown,
+): Extract<ProviderRuntimeEvent, { type: "account.rate-limits.updated" }> =>
+  ({
+    type: "account.rate-limits.updated",
+    eventId: EventId.make("11111111-1111-4111-8111-111111111111"),
+    provider: ProviderDriverKind.make(provider),
+    threadId: ThreadId.make("11111111-1111-4111-8111-111111111112"),
+    createdAt: UPDATED_AT,
+    payload: { rateLimits },
+  }) as Extract<ProviderRuntimeEvent, { type: "account.rate-limits.updated" }>;
+
+describe("normalizeRuntimeUsageEvent", () => {
+  it("reads the Claude adapter's verbatim SDK rate_limit_event", () => {
+    // ClaudeAdapter forwards the whole SDKRateLimitEvent as `rateLimits`.
+    const usage = normalizeRuntimeUsageEvent(
+      usageEvent("claudeAgent", {
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "allowed_warning",
+          rateLimitType: "five_hour",
+          utilization: 76,
+          resetsAt: 1_786_000_000,
+        },
+        uuid: "11111111-1111-4111-8111-111111111113",
+        session_id: "session-1",
+      }),
+      UPDATED_AT,
+    );
+
+    expect(usage).not.toBeNull();
+    expect(usage?.windows).toEqual([
+      {
+        id: "session",
+        label: "Session",
+        usedPercent: 76,
+        resetsAt: "2026-08-06T07:06:40.000Z",
+      },
+    ]);
+  });
+
+  it("reads the Codex adapter's verbatim rateLimits notification", () => {
+    const usage = normalizeRuntimeUsageEvent(
+      usageEvent("codex", {
+        rateLimits: {
+          primary: { usedPercent: 20, windowDurationMins: 300, resetsAt: 1_786_000_000 },
+          secondary: { usedPercent: 70, windowDurationMins: 10_080 },
+        },
+      }),
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows.map((window) => window.id)).toEqual(["codex-primary", "codex-secondary"]);
+  });
+
+  it("drops events from drivers that report no usage", () => {
+    expect(
+      normalizeRuntimeUsageEvent(usageEvent("cursor", { anything: true }), UPDATED_AT),
+    ).toBeNull();
+  });
+
+  it("drops a Claude event whose bucket type has no meter", () => {
+    expect(
+      normalizeRuntimeUsageEvent(
+        usageEvent("claudeAgent", {
+          rate_limit_info: { status: "allowed", rateLimitType: "overage", utilization: 12 },
+        }),
+        UPDATED_AT,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/server/src/provider/Layers/ProviderUsageIngestion.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageIngestion.ts
@@ -1,0 +1,86 @@
+/**
+ * ProviderUsageIngestionLive — the free usage feed.
+ *
+ * Both the Claude and Codex adapters already emit
+ * `account.rate-limits.updated` whenever the upstream harness volunteers a
+ * fresh quota reading, which in practice is at the end of every turn. Until
+ * now nothing consumed those events. This layer routes them into
+ * `ProviderUsageLimitsStore`, which costs zero additional network calls and
+ * keeps the meters current for anyone actively working.
+ *
+ * @module ProviderUsageIngestionLive
+ */
+import { ProviderDriverKind, type ProviderRuntimeEvent } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+
+import { ProviderService } from "../Services/ProviderService.ts";
+import { ProviderUsageLimitsStore } from "../Services/ProviderUsageLimits.ts";
+import { normalizeClaudeRateLimitEvent, normalizeCodexUsage } from "../usageLimits.ts";
+
+// Driver kind slugs, not display names: Claude's driver is `claudeAgent`.
+const CLAUDE_AGENT = ProviderDriverKind.make("claudeAgent");
+const CODEX = ProviderDriverKind.make("codex");
+
+/**
+ * Which normalizer applies is a function of the driver that produced the
+ * event, not of the payload's shape — the two vocabularies overlap enough
+ * that sniffing would be guesswork. Drivers with no usage reporting yield
+ * `null` and the event is dropped, same as before this layer existed.
+ *
+ * Both feeds are `partial`. Claude's SDK event describes exactly one bucket,
+ * and Codex documents `account/rateLimits/updated` as a sparse rolling
+ * update that clients must merge. Treating either as a full reading would
+ * blank whichever meters the event happened not to mention.
+ */
+export const normalizeRuntimeUsageEvent = (
+  event: Extract<ProviderRuntimeEvent, { type: "account.rate-limits.updated" }>,
+  updatedAt: string,
+) => {
+  if (event.provider === CLAUDE_AGENT) {
+    return normalizeClaudeRateLimitEvent(event.payload.rateLimits, updatedAt);
+  }
+  if (event.provider === CODEX) {
+    return normalizeCodexUsage(event.payload.rateLimits, updatedAt);
+  }
+  return null;
+};
+
+export const ProviderUsageIngestionLive = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const providerService = yield* ProviderService;
+    const usageStore = yield* ProviderUsageLimitsStore;
+
+    yield* Stream.runForEach(providerService.streamEvents, (event) =>
+      Effect.gen(function* () {
+        if (event.type !== "account.rate-limits.updated") {
+          return;
+        }
+        // Pre-instance-migration emitters may omit the routing key. Usage is
+        // account-level state hung off one configured instance, so without
+        // an instance id there is nowhere correct to put it.
+        const instanceId = event.providerInstanceId;
+        if (instanceId === undefined) {
+          return;
+        }
+        const updatedAt = DateTime.formatIso(yield* DateTime.now);
+        const usage = normalizeRuntimeUsageEvent(event, updatedAt);
+        if (usage === null) {
+          return;
+        }
+        yield* usageStore.set(instanceId, usage, "partial");
+      }).pipe(
+        // Per event, not per subscription. `streamEvents` cannot fail and only
+        // ends when the service scope closes, so the fiber's real risk is a
+        // defect thrown while handling one event — which would otherwise take
+        // the whole feed down for the life of the process and leave every
+        // meter frozen with nothing logged at the point of failure. Same
+        // stance as the on-demand pull: a reading we cannot take is ambient,
+        // so drop it and keep listening.
+        Effect.ignoreCause({ log: true }),
+      ),
+    ).pipe(Effect.forkScoped);
+  }),
+);

--- a/apps/server/src/provider/Layers/ProviderUsageLimits.test.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageLimits.test.ts
@@ -1,0 +1,144 @@
+import { assert, describe, it } from "@effect/vitest";
+import { ProviderInstanceId, type ProviderUsageLimits } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as PubSub from "effect/PubSub";
+import * as TestClock from "effect/testing/TestClock";
+
+import { ProviderUsageLimitsStore } from "../Services/ProviderUsageLimits.ts";
+import { ProviderUsageLimitsStoreLive, USAGE_REFRESH_DEBOUNCE_MS } from "./ProviderUsageLimits.ts";
+
+const CLAUDE = ProviderInstanceId.make("claudeAgent");
+const CODEX = ProviderInstanceId.make("codex");
+
+const usageAt = (updatedAt: string, usedPercent: number): ProviderUsageLimits => ({
+  windows: [{ id: "session", label: "Session", usedPercent, resetsAt: null }],
+  updatedAt,
+});
+
+describe("ProviderUsageLimitsStoreLive", () => {
+  it.effect("collapses concurrent refresh claims into one", () =>
+    Effect.gen(function* () {
+      const store = yield* ProviderUsageLimitsStore;
+
+      const claims = yield* Effect.all(
+        [
+          store.claimRefreshSlot(CLAUDE),
+          store.claimRefreshSlot(CLAUDE),
+          store.claimRefreshSlot(CLAUDE),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      assert.deepStrictEqual(
+        claims.filter(Boolean).length,
+        1,
+        "three simultaneous callers should produce exactly one upstream call",
+      );
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
+  );
+
+  it.effect("debounces per instance, not globally", () =>
+    Effect.gen(function* () {
+      const store = yield* ProviderUsageLimitsStore;
+
+      assert.isTrue(yield* store.claimRefreshSlot(CLAUDE));
+      assert.isTrue(
+        yield* store.claimRefreshSlot(CODEX),
+        "a different instance must not be blocked by another instance's claim",
+      );
+      assert.isFalse(yield* store.claimRefreshSlot(CLAUDE));
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
+  );
+
+  it.effect("allows a new claim once the debounce window elapses", () =>
+    Effect.gen(function* () {
+      const store = yield* ProviderUsageLimitsStore;
+
+      assert.isTrue(yield* store.claimRefreshSlot(CLAUDE));
+      yield* TestClock.adjust(USAGE_REFRESH_DEBOUNCE_MS - 1);
+      assert.isFalse(yield* store.claimRefreshSlot(CLAUDE));
+      yield* TestClock.adjust(1);
+      assert.isTrue(yield* store.claimRefreshSlot(CLAUDE));
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
+  );
+
+  it.effect("keeps the newest reading when writes arrive out of order", () =>
+    Effect.gen(function* () {
+      const store = yield* ProviderUsageLimitsStore;
+
+      yield* store.set(CLAUDE, usageAt("2026-08-09T12:00:00.000Z", 50), "full");
+      yield* store.set(CLAUDE, usageAt("2026-08-09T11:00:00.000Z", 10), "full");
+
+      const stored = yield* store.get(CLAUDE);
+      assert.strictEqual(stored?.updatedAt, "2026-08-09T12:00:00.000Z");
+      assert.strictEqual(stored?.windows[0]?.usedPercent, 50);
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
+  );
+
+  it.effect("merges a partial reading instead of blanking the other windows", () =>
+    Effect.gen(function* () {
+      const store = yield* ProviderUsageLimitsStore;
+
+      yield* store.set(
+        CODEX,
+        {
+          windows: [
+            { id: "codex-primary", label: "Session", usedPercent: 20, resetsAt: null },
+            { id: "codex-secondary", label: "Weekly", usedPercent: 70, resetsAt: null },
+          ],
+          updatedAt: "2026-08-09T11:00:00.000Z",
+        },
+        "full",
+      );
+      // A sparse rolling update carrying only the primary window.
+      yield* store.set(
+        CODEX,
+        {
+          windows: [{ id: "codex-primary", label: "Session", usedPercent: 25, resetsAt: null }],
+          updatedAt: "2026-08-09T12:00:00.000Z",
+        },
+        "partial",
+      );
+
+      const stored = yield* store.get(CODEX);
+      assert.deepStrictEqual(
+        stored?.windows.map((window) => [window.id, window.usedPercent]),
+        [
+          ["codex-primary", 25],
+          ["codex-secondary", 70],
+        ],
+      );
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
+  );
+
+  it.effect("does not announce a change when only the timestamp moved", () =>
+    Effect.gen(function* () {
+      // `updatedAt` is stamped server-side on every reading, so a provider
+      // re-reporting identical numbers would otherwise wake the registry and
+      // push the whole provider array to every client, once per turn.
+      const store = yield* ProviderUsageLimitsStore;
+      const changes = yield* store.subscribeChanges;
+
+      yield* store.set(CLAUDE, usageAt("2026-08-09T11:00:00.000Z", 40), "full");
+      yield* store.set(CLAUDE, usageAt("2026-08-09T12:00:00.000Z", 40), "full");
+      yield* store.set(CLAUDE, usageAt("2026-08-09T13:00:00.000Z", 41), "full");
+
+      // Returns everything buffered so far; the middle write must not appear.
+      const announced = yield* PubSub.takeAll(changes);
+      assert.strictEqual(
+        announced.length,
+        2,
+        "only the two readings that moved a number should be announced",
+      );
+      // The fresher stamp is still stored even though it was not announced.
+      assert.strictEqual((yield* store.get(CLAUDE))?.updatedAt, "2026-08-09T13:00:00.000Z");
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive), Effect.scoped),
+  );
+
+  it.effect("reports no reading for an instance that never reported one", () =>
+    Effect.gen(function* () {
+      const store = yield* ProviderUsageLimitsStore;
+      assert.isUndefined(yield* store.get(CODEX));
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
+  );
+});

--- a/apps/server/src/provider/Layers/ProviderUsageLimits.test.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageLimits.test.ts
@@ -62,6 +62,24 @@ describe("ProviderUsageLimitsStoreLive", () => {
     }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
   );
 
+  it.effect("does not wedge the debounce when the wall clock jumps backwards", () =>
+    Effect.gen(function* () {
+      // An NTP correction or a wake in another timezone can move
+      // `currentTimeMillis` backwards. A plain `now - lastRefreshAt` reads
+      // negative, which would look like "still inside the window" and block
+      // refreshes until the clock caught up.
+      const store = yield* ProviderUsageLimitsStore;
+
+      yield* TestClock.adjust(USAGE_REFRESH_DEBOUNCE_MS * 10);
+      assert.isTrue(yield* store.claimRefreshSlot(CLAUDE));
+      yield* TestClock.setTime(0);
+      assert.isTrue(
+        yield* store.claimRefreshSlot(CLAUDE),
+        "a backwards clock should expire the slot, not extend it",
+      );
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
+  );
+
   it.effect("keeps the newest reading when writes arrive out of order", () =>
     Effect.gen(function* () {
       const store = yield* ProviderUsageLimitsStore;

--- a/apps/server/src/provider/Layers/ProviderUsageLimits.test.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageLimits.test.ts
@@ -159,4 +159,42 @@ describe("ProviderUsageLimitsStoreLive", () => {
       assert.isUndefined(yield* store.get(CODEX));
     }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
   );
+
+  it.effect("clear drops the reading and frees the debounce slot", () =>
+    Effect.gen(function* () {
+      // A rebuilt instance may point at a different account; its old
+      // reading must not survive, and it must be allowed to pull
+      // immediately rather than inherit the old instance's debounce.
+      const store = yield* ProviderUsageLimitsStore;
+
+      yield* store.set(CLAUDE, usageAt("2026-08-09T12:00:00.000Z", 50), "full");
+      assert.isTrue(yield* store.claimRefreshSlot(CLAUDE));
+      yield* store.clear(CLAUDE);
+
+      assert.isUndefined(yield* store.get(CLAUDE));
+      assert.isTrue(
+        yield* store.claimRefreshSlot(CLAUDE),
+        "a cleared instance should be allowed to pull immediately",
+      );
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive)),
+  );
+
+  it.effect("clear announces only when a reading was actually dropped", () =>
+    Effect.gen(function* () {
+      const store = yield* ProviderUsageLimitsStore;
+      const changes = yield* store.subscribeChanges;
+
+      // First clear finds nothing and must stay silent; the set and the
+      // second clear should each announce once. A wrongly-announcing first
+      // clear would surface as a third buffered element here.
+      yield* store.clear(CLAUDE);
+      yield* store.set(CLAUDE, usageAt("2026-08-09T12:00:00.000Z", 50), "full");
+      yield* store.clear(CLAUDE);
+      assert.strictEqual(
+        (yield* PubSub.takeAll(changes)).length,
+        2,
+        "only the reading and its removal should announce",
+      );
+    }).pipe(Effect.provide(ProviderUsageLimitsStoreLive), Effect.scoped),
+  );
 });

--- a/apps/server/src/provider/Layers/ProviderUsageLimits.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageLimits.ts
@@ -93,9 +93,33 @@ export const ProviderUsageLimitsStoreLive = Layer.effect(
         ),
       );
 
+    const clear = (instanceId: ProviderInstanceId) =>
+      Effect.gen(function* () {
+        yield* Ref.update(lastRefreshAtRef, (previous) => {
+          if (!previous.has(instanceId)) {
+            return previous;
+          }
+          const next = new Map(previous);
+          next.delete(instanceId);
+          return next;
+        });
+        const hadReading = yield* Ref.modify(usageRef, (previous) => {
+          if (!previous.has(instanceId)) {
+            return [false, previous] as const;
+          }
+          const next = new Map(previous);
+          next.delete(instanceId);
+          return [true, next] as const;
+        });
+        if (hadReading) {
+          yield* PubSub.publish(changes, instanceId);
+        }
+      });
+
     return {
       get: (instanceId) => Ref.get(usageRef).pipe(Effect.map((usage) => usage.get(instanceId))),
       set,
+      clear,
       claimRefreshSlot,
       get streamChanges() {
         return Stream.fromPubSub(changes);

--- a/apps/server/src/provider/Layers/ProviderUsageLimits.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageLimits.ts
@@ -1,0 +1,101 @@
+/**
+ * ProviderUsageLimitsStoreLive — in-memory store for account quota usage.
+ *
+ * Readings are volatile by design. They are never persisted: a usage number
+ * is only interesting while it is roughly current, and the two feeds that
+ * write here repopulate it within one turn or one refresh of a restart.
+ *
+ * @module ProviderUsageLimitsStoreLive
+ */
+import type { ProviderInstanceId, ProviderUsageLimits } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Equal from "effect/Equal";
+import * as Layer from "effect/Layer";
+import * as PubSub from "effect/PubSub";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+
+import {
+  ProviderUsageLimitsStore,
+  type ProviderUsageLimitsStoreShape,
+} from "../Services/ProviderUsageLimits.ts";
+import { applyUsageReading, type UsageReadingMode } from "../usageLimits.ts";
+
+/**
+ * How long a pull is suppressed after the previous one for the same
+ * instance. Ambient triggers (window focus, thread switch, meter hover) fire
+ * far more often than the numbers move, and the free turn-event feed covers
+ * the gaps.
+ */
+export const USAGE_REFRESH_DEBOUNCE_MS = 60_000;
+
+export const ProviderUsageLimitsStoreLive = Layer.effect(
+  ProviderUsageLimitsStore,
+  Effect.gen(function* () {
+    const usageRef = yield* Ref.make<ReadonlyMap<ProviderInstanceId, ProviderUsageLimits>>(
+      new Map(),
+    );
+    const lastRefreshAtRef = yield* Ref.make<ReadonlyMap<ProviderInstanceId, number>>(new Map());
+    const changes = yield* Effect.acquireRelease(
+      PubSub.unbounded<ProviderInstanceId>(),
+      PubSub.shutdown,
+    );
+
+    const set = (
+      instanceId: ProviderInstanceId,
+      usage: ProviderUsageLimits,
+      mode: UsageReadingMode,
+    ) =>
+      Effect.gen(function* () {
+        const didWindowsChange = yield* Ref.modify(usageRef, (previous) => {
+          const existing = previous.get(instanceId);
+          const merged = applyUsageReading(existing, usage, mode);
+          if (existing !== undefined && Equal.equals(existing, merged)) {
+            return [false, previous] as const;
+          }
+          const next = new Map(previous);
+          next.set(instanceId, merged);
+          // Announce only when the numbers moved, not when the stamp did.
+          // `updatedAt` is generated server-side on every reading, so a
+          // provider re-reporting identical usage would otherwise wake the
+          // registry and push the entire provider array — every model,
+          // capability, and skill — to every connected client, once per
+          // turn, for no visible change.
+          return [
+            existing === undefined || !Equal.equals(existing.windows, merged.windows),
+            next,
+          ] as const;
+        });
+        if (didWindowsChange) {
+          yield* PubSub.publish(changes, instanceId);
+        }
+      });
+
+    const claimRefreshSlot = (instanceId: ProviderInstanceId) =>
+      Effect.clockWith((clock) =>
+        clock.currentTimeMillis.pipe(
+          Effect.flatMap((now) =>
+            Ref.modify(lastRefreshAtRef, (previous) => {
+              const lastRefreshAt = previous.get(instanceId);
+              if (lastRefreshAt !== undefined && now - lastRefreshAt < USAGE_REFRESH_DEBOUNCE_MS) {
+                return [false, previous] as const;
+              }
+              const next = new Map(previous);
+              next.set(instanceId, now);
+              return [true, next] as const;
+            }),
+          ),
+        ),
+      );
+
+    return {
+      get: (instanceId) => Ref.get(usageRef).pipe(Effect.map((usage) => usage.get(instanceId))),
+      set,
+      claimRefreshSlot,
+      get streamChanges() {
+        return Stream.fromPubSub(changes);
+      },
+      subscribeChanges: PubSub.subscribe(changes),
+    } satisfies ProviderUsageLimitsStoreShape;
+  }),
+);

--- a/apps/server/src/provider/Layers/ProviderUsageLimits.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageLimits.ts
@@ -77,7 +77,12 @@ export const ProviderUsageLimitsStoreLive = Layer.effect(
           Effect.flatMap((now) =>
             Ref.modify(lastRefreshAtRef, (previous) => {
               const lastRefreshAt = previous.get(instanceId);
-              if (lastRefreshAt !== undefined && now - lastRefreshAt < USAGE_REFRESH_DEBOUNCE_MS) {
+              const elapsed = lastRefreshAt === undefined ? undefined : now - lastRefreshAt;
+              // A negative elapsed means the wall clock moved backwards — an
+              // NTP correction, a laptop waking in another timezone. Treating
+              // that as "still inside the window" would wedge the meters until
+              // the clock caught back up, which can be hours.
+              if (elapsed !== undefined && elapsed >= 0 && elapsed < USAGE_REFRESH_DEBOUNCE_MS) {
                 return [false, previous] as const;
               }
               const next = new Map(previous);

--- a/apps/server/src/provider/Layers/ProviderUsageRefresher.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageRefresher.ts
@@ -1,0 +1,152 @@
+/**
+ * ProviderUsageRefresherLive — the on-demand usage feed.
+ *
+ * Clients call this from ambient triggers (window focus, thread opened,
+ * meter hovered). Debouncing lives here rather than in each client so three
+ * clients hovering the same meter at once produce one upstream call.
+ *
+ * Only Claude needs a pull. Codex volunteers its numbers over the
+ * app-server connection — on every turn while a session is live, and once
+ * per status probe otherwise — so a separate pull would spawn a process to
+ * learn something already on its way.
+ *
+ * @module ProviderUsageRefresherLive
+ */
+import {
+  ClaudeSettings,
+  defaultInstanceIdForDriver,
+  ProviderDriverKind,
+  type ProviderInstanceId,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import { HttpClient } from "effect/unstable/http";
+
+import { ChildProcessSpawner } from "effect/unstable/process";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
+
+import { resolveClaudeConfigDirPath } from "../Drivers/ClaudeSkills.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { fetchClaudeUsage, readClaudeAccessToken } from "../claudeUsageFetch.ts";
+import {
+  ProviderUsageLimitsStore,
+  ProviderUsageRefresher,
+  type ProviderUsageRefresherShape,
+} from "../Services/ProviderUsageLimits.ts";
+import { normalizeClaudeUsage } from "../usageLimits.ts";
+
+const CLAUDE_AGENT = ProviderDriverKind.make("claudeAgent");
+const CLAUDE_DEFAULT_INSTANCE_ID = defaultInstanceIdForDriver(CLAUDE_AGENT);
+
+const decodeClaudeSettings = Schema.decodeUnknownEffect(ClaudeSettings);
+
+export const ProviderUsageRefresherLive = Layer.effect(
+  ProviderUsageRefresher,
+  Effect.gen(function* () {
+    const layerScope = yield* Scope.Scope;
+    const settingsService = yield* ServerSettingsService;
+    const usageStore = yield* ProviderUsageLimitsStore;
+    const httpClient = yield* HttpClient.HttpClient;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+    /**
+     * Resolve the Claude config for one configured instance, or `null` when
+     * the instance is not a Claude instance at all. Explicit
+     * `providerInstances` envelopes win; the legacy default instance falls
+     * back to the single-instance-per-driver settings block.
+     */
+    const resolveClaudeSettings = Effect.fn("resolveClaudeSettings")(function* (
+      instanceId: ProviderInstanceId,
+    ) {
+      const settings = yield* settingsService.getSettings.pipe(Effect.orElseSucceed(() => null));
+      if (settings === null) {
+        return null;
+      }
+      const envelope = settings.providerInstances[instanceId];
+      if (envelope !== undefined) {
+        if (envelope.driver !== CLAUDE_AGENT) {
+          return null;
+        }
+        return yield* decodeClaudeSettings(envelope.config ?? {}).pipe(
+          Effect.orElseSucceed(() => null),
+        );
+      }
+      return instanceId === CLAUDE_DEFAULT_INSTANCE_ID ? settings.providers.claudeAgent : null;
+    });
+
+    const refreshClaude = Effect.fn("refreshClaudeUsage")(function* (
+      instanceId: ProviderInstanceId,
+      claudeSettings: ClaudeSettings,
+    ) {
+      // Resolve exactly the directory the spawned CLI would use — including
+      // an ambient `CLAUDE_CONFIG_DIR` that `makeClaudeEnvironment` leaves
+      // in place when the instance sets no `homePath`. Reading a different
+      // directory than the CLI writes means authenticating as one account
+      // and drawing meters for another.
+      const environment = yield* HostProcessEnvironment;
+      const credentialsDir = yield* resolveClaudeConfigDirPath(claudeSettings, environment);
+      const accessToken = yield* readClaudeAccessToken(credentialsDir, {
+        // The macOS keychain item is global and carries no instance
+        // identity, so it may only stand in for the instance that has no
+        // config-dir override of its own. Borrowing it for an explicitly
+        // scoped instance would read another account's token.
+        allowKeychain:
+          claudeSettings.homePath.trim().length === 0 &&
+          (environment.CLAUDE_CONFIG_DIR?.trim() ?? "").length === 0,
+      });
+      if (accessToken === null) {
+        return;
+      }
+      const payload = yield* fetchClaudeUsage(accessToken);
+      const usage = normalizeClaudeUsage(payload, DateTime.formatIso(yield* DateTime.now));
+      if (usage === null) {
+        return;
+      }
+      // The OAuth endpoint reports every bucket, so this is authoritative:
+      // a window it omits really is gone.
+      yield* usageStore.set(instanceId, usage, "full");
+    });
+
+    const runRefresh = (instanceId: ProviderInstanceId) =>
+      Effect.gen(function* () {
+        const claudeSettings = yield* resolveClaudeSettings(instanceId);
+        if (claudeSettings === null || !claudeSettings.enabled) {
+          return;
+        }
+        // Claim before doing any work so concurrent callers collapse into
+        // one upstream call rather than one call each.
+        const claimed = yield* usageStore.claimRefreshSlot(instanceId);
+        if (!claimed) {
+          return;
+        }
+        yield* refreshClaude(instanceId, claudeSettings);
+      }).pipe(
+        Effect.provideService(HttpClient.HttpClient, httpClient),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        // Ambient telemetry: a failed reading keeps the last-known numbers
+        // and never surfaces to the user.
+        Effect.ignoreCause({ log: true }),
+      );
+
+    // Fork onto this layer's scope, not the caller's. A refresh can take up
+    // to 15 seconds on the slow path (locked keychain, then a stalled HTTP
+    // request), and callers are ambient UI triggers — a hover must not hold
+    // an RPC open that long. Forking also decouples the work from the
+    // client: a disconnect mid-refresh would otherwise interrupt the fiber
+    // after `claimRefreshSlot` had already burned the 60s slot, leaving the
+    // meters stale for a full minute with nothing in flight.
+    const refresh = (instanceId: ProviderInstanceId) =>
+      Effect.forkIn(runRefresh(instanceId), layerScope).pipe(Effect.asVoid);
+
+    return { refresh } satisfies ProviderUsageRefresherShape;
+  }),
+);

--- a/apps/server/src/provider/Services/ProviderUsageLimits.ts
+++ b/apps/server/src/provider/Services/ProviderUsageLimits.ts
@@ -45,6 +45,15 @@ export interface ProviderUsageLimitsStoreShape {
   ) => Effect.Effect<void>;
 
   /**
+   * Forget everything about an instance: its reading and its refresh
+   * debounce. For instances that were removed or rebuilt with a changed
+   * configuration — a rebuilt instance may point at a different account,
+   * and its old numbers must not decorate the new one's snapshots.
+   * Emits on `streamChanges` only when a reading was actually dropped.
+   */
+  readonly clear: (instanceId: ProviderInstanceId) => Effect.Effect<void>;
+
+  /**
    * Whether an upstream pull for this instance is due, and claim the slot if
    * so. Debouncing lives here rather than in each client so three clients
    * hovering a meter at once produce one upstream call.

--- a/apps/server/src/provider/Services/ProviderUsageLimits.ts
+++ b/apps/server/src/provider/Services/ProviderUsageLimits.ts
@@ -1,0 +1,88 @@
+/**
+ * ProviderUsageLimits — the single store for account-level quota usage,
+ * keyed by configured provider instance.
+ *
+ * Two feeds write here and neither owns the value:
+ *   - turn events (`account.rate-limits.updated`), which both the Claude and
+ *     Codex adapters already emit and which cost nothing;
+ *   - on-demand pulls, which the refresher schedules from ambient client
+ *     triggers.
+ *
+ * `ProviderRegistry` reads from here to decorate its snapshots, which is why
+ * this service is deliberately dependency-free — it sits below the registry
+ * in the layer graph and must not reach back up.
+ *
+ * @module ProviderUsageLimits
+ */
+import type { ProviderInstanceId, ProviderUsageLimits } from "@t3tools/contracts";
+
+import type { UsageReadingMode } from "../usageLimits.ts";
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+import type * as PubSub from "effect/PubSub";
+import type * as Scope from "effect/Scope";
+import type * as Stream from "effect/Stream";
+
+export interface ProviderUsageLimitsStoreShape {
+  /** Latest known reading for one instance, or `undefined` if never read. */
+  readonly get: (instanceId: ProviderInstanceId) => Effect.Effect<ProviderUsageLimits | undefined>;
+
+  /**
+   * Record a reading. Older readings are dropped rather than applied, so a
+   * slow pull that resolves after a turn event cannot rewind the meters.
+   *
+   * `mode` says how much of the picture the reading covers: `partial`
+   * readings (per-bucket turn events, sparse rolling updates) update only
+   * the windows they name, while `full` ones replace the set. Getting this
+   * wrong blanks meters the reading simply did not mention.
+   *
+   * Emits on `streamChanges` only when the stored value actually changed.
+   */
+  readonly set: (
+    instanceId: ProviderInstanceId,
+    usage: ProviderUsageLimits,
+    mode: UsageReadingMode,
+  ) => Effect.Effect<void>;
+
+  /**
+   * Whether an upstream pull for this instance is due, and claim the slot if
+   * so. Debouncing lives here rather than in each client so three clients
+   * hovering a meter at once produce one upstream call.
+   */
+  readonly claimRefreshSlot: (instanceId: ProviderInstanceId) => Effect.Effect<boolean>;
+
+  /** Instance ids whose stored reading just changed. */
+  readonly streamChanges: Stream.Stream<ProviderInstanceId>;
+
+  /**
+   * Acquire the change subscription eagerly, for consumers that must not
+   * miss a publish between "fiber scheduled" and "fiber starts running".
+   * `streamChanges` defers `PubSub.subscribe` to stream start, which is a
+   * dropped-event race when the consumer is forked. See the same
+   * distinction on `ProviderInstanceRegistry`.
+   */
+  readonly subscribeChanges: Effect.Effect<
+    PubSub.Subscription<ProviderInstanceId>,
+    never,
+    Scope.Scope
+  >;
+}
+
+export class ProviderUsageLimitsStore extends Context.Service<
+  ProviderUsageLimitsStore,
+  ProviderUsageLimitsStoreShape
+>()("t3/provider/Services/ProviderUsageLimits/ProviderUsageLimitsStore") {}
+
+export interface ProviderUsageRefresherShape {
+  /**
+   * Pull a fresh reading for one instance. Debounced per instance and
+   * silently a no-op when the provider does not support pulls or the pull
+   * fails — callers never need to handle an error.
+   */
+  readonly refresh: (instanceId: ProviderInstanceId) => Effect.Effect<void>;
+}
+
+export class ProviderUsageRefresher extends Context.Service<
+  ProviderUsageRefresher,
+  ProviderUsageRefresherShape
+>()("t3/provider/Services/ProviderUsageLimits/ProviderUsageRefresher") {}

--- a/apps/server/src/provider/claudeUsageFetch.test.ts
+++ b/apps/server/src/provider/claudeUsageFetch.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { readAccessToken } from "./claudeUsageFetch.ts";
+
+const NOW_MILLIS = Date.UTC(2026, 7, 9, 12, 0, 0);
+
+const credentials = (claudeAiOauth: Record<string, unknown>): string =>
+  JSON.stringify({ claudeAiOauth });
+
+describe("readAccessToken", () => {
+  it("reads the token out of the CLI's envelope", () => {
+    expect(
+      readAccessToken(
+        credentials({ accessToken: "sk-live", expiresAt: NOW_MILLIS + 60_000 }),
+        NOW_MILLIS,
+      ),
+    ).toBe("sk-live");
+  });
+
+  it("accepts an epoch-second expiry that is still in the future", () => {
+    // Some CLI versions write seconds. Comparing those against a millisecond
+    // clock dates every token to 1970, which reads as "logged out" forever.
+    expect(
+      readAccessToken(
+        credentials({ accessToken: "sk-live", expiresAt: Math.floor(NOW_MILLIS / 1000) + 3600 }),
+        NOW_MILLIS,
+      ),
+    ).toBe("sk-live");
+  });
+
+  it("rejects an expired token in either epoch flavour", () => {
+    expect(
+      readAccessToken(
+        credentials({ accessToken: "sk-dead", expiresAt: NOW_MILLIS - 1 }),
+        NOW_MILLIS,
+      ),
+    ).toBeNull();
+    expect(
+      readAccessToken(
+        credentials({ accessToken: "sk-dead", expiresAt: Math.floor(NOW_MILLIS / 1000) - 3600 }),
+        NOW_MILLIS,
+      ),
+    ).toBeNull();
+  });
+
+  it("assumes an absent or unreadable expiry is usable", () => {
+    // The endpoint is the real authority; a 401 already degrades to blank
+    // meters, so guessing "expired" here would hide a working token.
+    expect(readAccessToken(credentials({ accessToken: "sk-live" }), NOW_MILLIS)).toBe("sk-live");
+    expect(
+      readAccessToken(credentials({ accessToken: "sk-live", expiresAt: "soon" }), NOW_MILLIS),
+    ).toBe("sk-live");
+  });
+
+  it("returns null for a truncated or tokenless credentials file", () => {
+    expect(readAccessToken("{ not json", NOW_MILLIS)).toBeNull();
+    expect(readAccessToken("null", NOW_MILLIS)).toBeNull();
+    expect(readAccessToken(credentials({ accessToken: "   " }), NOW_MILLIS)).toBeNull();
+  });
+});

--- a/apps/server/src/provider/claudeUsageFetch.ts
+++ b/apps/server/src/provider/claudeUsageFetch.ts
@@ -162,16 +162,17 @@ export const fetchClaudeUsage = Effect.fn("fetchClaudeUsage")(function* (
     HttpClientRequest.setHeader("anthropic-beta", OAUTH_USAGE_BETA),
     HttpClientRequest.setHeader("accept", "application/json"),
   );
-  const response = yield* client.execute(request).pipe(
+  // The timeout has to cover the body too. A server that sends 2xx headers
+  // and then trickles the body would satisfy a timeout scoped to `execute`
+  // alone and leave this fiber parked on `json` forever.
+  const payload = yield* client.execute(request).pipe(
+    Effect.flatMap((httpResponse) =>
+      httpResponse.status < 200 || httpResponse.status >= 300
+        ? Effect.succeed(null)
+        : httpResponse.json,
+    ),
     Effect.timeoutOption(USAGE_REQUEST_TIMEOUT_MS),
-    Effect.orElseSucceed(() => Option.none()),
+    Effect.orElseSucceed(() => Option.none<unknown>()),
   );
-  if (Option.isNone(response)) {
-    return null;
-  }
-  const httpResponse = response.value;
-  if (httpResponse.status < 200 || httpResponse.status >= 300) {
-    return null;
-  }
-  return yield* httpResponse.json.pipe(Effect.orElseSucceed(() => null));
+  return Option.getOrNull(payload);
 });

--- a/apps/server/src/provider/claudeUsageFetch.ts
+++ b/apps/server/src/provider/claudeUsageFetch.ts
@@ -1,0 +1,177 @@
+/**
+ * Reads Claude's OAuth access token and pulls account quota usage.
+ *
+ * This is the one place the server touches Claude's credentials. Everywhere
+ * else we shell out to the `claude` CLI and let it own its auth, but the CLI
+ * has no `usage` subcommand, so a usage reading means calling the endpoint
+ * ourselves with the token the CLI already stored.
+ *
+ * The endpoint reports quota utilization *without* spending message quota,
+ * which is what makes it safe to call on ambient triggers.
+ *
+ * Every failure mode here — no credentials file, a locked keychain, an
+ * expired token, a network blip — resolves to `null`. Usage meters are
+ * ambient: the correct response to "we could not read your usage" is to draw
+ * nothing, never to surface an error the user cannot act on.
+ *
+ * @module claudeUsageFetch
+ */
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+import { spawnAndCollect } from "./providerSnapshot.ts";
+
+const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+// The usage endpoint is gated behind this beta opt-in.
+const OAUTH_USAGE_BETA = "oauth-2025-04-20";
+const USAGE_REQUEST_TIMEOUT_MS = 10_000;
+const KEYCHAIN_TIMEOUT_MS = 5_000;
+
+// The keychain entry Claude Code writes on macOS.
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+
+/**
+ * Total by construction: a truncated or non-JSON credentials file is a "no
+ * token available" answer, not a crash.
+ *
+ * An expired token is also "no token": we only ever read credentials, never
+ * refresh them, so re-sending a known-dead bearer every minute would just
+ * generate 401s until the CLI happens to renew it.
+ */
+export const readAccessToken = (raw: string, nowMillis: number): string | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+  const envelope = parsed as { readonly claudeAiOauth?: unknown };
+  const credentials =
+    typeof envelope.claudeAiOauth === "object" && envelope.claudeAiOauth !== null
+      ? (envelope.claudeAiOauth as {
+          readonly accessToken?: unknown;
+          readonly expiresAt?: unknown;
+        })
+      : (parsed as { readonly accessToken?: unknown; readonly expiresAt?: unknown });
+  const accessToken = credentials.accessToken;
+  if (typeof accessToken !== "string" || accessToken.trim().length === 0) {
+    return null;
+  }
+  // Absent or unparseable `expiresAt` means "assume usable" — the endpoint
+  // is the real authority and a 401 already degrades to blank meters.
+  //
+  // The stamp arrives in either epoch flavour depending on which CLI version
+  // wrote the file, and the 1e12 split is the same one `readIsoTimestamp`
+  // uses. Reading seconds as milliseconds would date every token to 1970 and
+  // permanently report "no token", which looks identical to being logged out.
+  const expiresAt = credentials.expiresAt;
+  if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
+    const expiresAtMillis = expiresAt < 1e12 ? expiresAt * 1000 : expiresAt;
+    if (expiresAtMillis <= nowMillis) {
+      return null;
+    }
+  }
+  return accessToken;
+};
+
+/**
+ * On macOS the credentials live in the login keychain rather than on disk.
+ * `security` prompts interactively when the keychain is locked, so this call
+ * is bounded — a hung prompt must not wedge a refresh.
+ */
+const readTokenFromKeychain = Effect.fn("readClaudeTokenFromKeychain")(function* (
+  nowMillis: number,
+) {
+  const result = yield* spawnAndCollect(
+    "security",
+    ChildProcess.make("security", ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"]),
+  );
+  if (result.code !== 0) {
+    return null;
+  }
+  return readAccessToken(result.stdout.trim(), nowMillis);
+});
+
+/**
+ * Resolve the OAuth access token for one Claude config directory.
+ *
+ * `configDir` is the directory the CLI itself would use for this instance —
+ * multi-instance setups point at different directories and must not read
+ * each other's tokens.
+ *
+ * `allowKeychain` gates the macOS fallback. That keychain item is a single
+ * global entry with no instance identity, so it may only stand in for an
+ * instance that has no config-dir override of its own; using it for a
+ * scoped instance would silently authenticate as a different account.
+ */
+export const readClaudeAccessToken = Effect.fn("readClaudeAccessToken")(function* (
+  configDir: string,
+  options: { readonly allowKeychain: boolean },
+): Effect.fn.Return<
+  string | null,
+  never,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const nowMillis = yield* Effect.clockWith((clock) => clock.currentTimeMillis);
+
+  const credentialsPath = path.join(configDir, ".credentials.json");
+  const fromFile = yield* fileSystem.readFileString(credentialsPath).pipe(
+    Effect.map((raw) => readAccessToken(raw, nowMillis)),
+    Effect.orElseSucceed(() => null),
+  );
+  if (fromFile !== null) {
+    return fromFile;
+  }
+
+  if (!options.allowKeychain) {
+    return null;
+  }
+  const platform = yield* HostProcessPlatform;
+  if (platform !== "darwin") {
+    return null;
+  }
+  return yield* readTokenFromKeychain(nowMillis).pipe(
+    Effect.timeoutOption(KEYCHAIN_TIMEOUT_MS),
+    Effect.map(Option.getOrNull),
+    Effect.orElseSucceed(() => null),
+  );
+});
+
+/**
+ * Fetch the raw usage payload. Returns `null` on any non-2xx, timeout, or
+ * transport failure; callers keep their last-known reading rather than
+ * blanking the meters.
+ */
+export const fetchClaudeUsage = Effect.fn("fetchClaudeUsage")(function* (
+  accessToken: string,
+): Effect.fn.Return<unknown, never, HttpClient.HttpClient> {
+  const client = yield* HttpClient.HttpClient;
+  const request = HttpClientRequest.get(USAGE_URL).pipe(
+    HttpClientRequest.bearerToken(accessToken),
+    HttpClientRequest.setHeader("anthropic-beta", OAUTH_USAGE_BETA),
+    HttpClientRequest.setHeader("accept", "application/json"),
+  );
+  const response = yield* client.execute(request).pipe(
+    Effect.timeoutOption(USAGE_REQUEST_TIMEOUT_MS),
+    Effect.orElseSucceed(() => Option.none()),
+  );
+  if (Option.isNone(response)) {
+    return null;
+  }
+  const httpResponse = response.value;
+  if (httpResponse.status < 200 || httpResponse.status >= 300) {
+    return null;
+  }
+  return yield* httpResponse.json.pipe(Effect.orElseSucceed(() => null));
+});

--- a/apps/server/src/provider/usageLimits.test.ts
+++ b/apps/server/src/provider/usageLimits.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  applyUsageReading,
+  normalizeClaudeRateLimitEvent,
+  normalizeClaudeUsage,
+  normalizeCodexUsage,
+} from "./usageLimits.ts";
+
+const UPDATED_AT = "2026-08-09T12:00:00.000Z";
+
+describe("normalizeClaudeUsage", () => {
+  it("reads session, weekly, and the model-scoped Fable bucket", () => {
+    const usage = normalizeClaudeUsage(
+      {
+        five_hour: { utilization: 42, resets_at: "2026-08-09T14:15:00.000Z" },
+        seven_day: { utilization: 61, resets_at: "2026-08-14T00:00:00.000Z" },
+        limits: [
+          {
+            group: "weekly",
+            percent: 12,
+            resets_at: "2026-08-14T00:00:00.000Z",
+            scope: { model: { display_name: "Claude Fable 5" } },
+          },
+        ],
+      },
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows).toEqual([
+      {
+        id: "session",
+        label: "Session",
+        usedPercent: 42,
+        resetsAt: "2026-08-09T14:15:00.000Z",
+      },
+      { id: "weekly", label: "Weekly", usedPercent: 61, resetsAt: "2026-08-14T00:00:00.000Z" },
+      {
+        id: "weekly-fable",
+        label: "Fable",
+        usedPercent: 12,
+        resetsAt: "2026-08-14T00:00:00.000Z",
+      },
+    ]);
+    expect(usage?.updatedAt).toBe(UPDATED_AT);
+  });
+
+  it("omits Fable when no weekly limit is scoped to it", () => {
+    const usage = normalizeClaudeUsage(
+      {
+        five_hour: { utilization: 5 },
+        limits: [{ group: "weekly", percent: 30, scope: { model: { display_name: "Opus 5" } } }],
+      },
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows.map((window) => window.id)).toEqual(["session"]);
+  });
+
+  it("accepts epoch-second reset stamps", () => {
+    const usage = normalizeClaudeUsage(
+      { five_hour: { utilization: 1, resets_at: 1_786_000_000 } },
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows[0]?.resetsAt).toBe("2026-08-06T07:06:40.000Z");
+  });
+
+  it("returns null for malformed input", () => {
+    expect(normalizeClaudeUsage(null, UPDATED_AT)).toBeNull();
+    expect(normalizeClaudeUsage("nope", UPDATED_AT)).toBeNull();
+    expect(normalizeClaudeUsage({}, UPDATED_AT)).toBeNull();
+    expect(normalizeClaudeUsage({ five_hour: { utilization: "abc" } }, UPDATED_AT)).toBeNull();
+  });
+
+  it("treats a blank percentage as absent rather than zero", () => {
+    // `Number("")` is 0, which would draw a confident empty meter for a
+    // bucket the provider declined to report.
+    expect(normalizeClaudeUsage({ five_hour: { utilization: "" } }, UPDATED_AT)).toBeNull();
+    expect(normalizeClaudeUsage({ five_hour: { utilization: "  " } }, UPDATED_AT)).toBeNull();
+  });
+});
+
+/**
+ * The shape here is the real `SDKRateLimitEvent` the Claude Agent SDK emits
+ * and `ClaudeAdapter` forwards verbatim — flat, with a single bucket under
+ * `rate_limit_info`. An earlier version of this test invented a bucketed
+ * envelope, which let a normalizer that could never read a real event pass.
+ */
+describe("normalizeClaudeRateLimitEvent", () => {
+  it("maps a five_hour event onto the session window", () => {
+    const usage = normalizeClaudeRateLimitEvent(
+      {
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "allowed",
+          rateLimitType: "five_hour",
+          utilization: 88,
+          resetsAt: 1_786_000_000,
+        },
+        uuid: "1a5d5f5c-0000-4000-8000-000000000000",
+        session_id: "session-1",
+      },
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows).toEqual([
+      {
+        id: "session",
+        label: "Session",
+        usedPercent: 88,
+        resetsAt: "2026-08-06T07:06:40.000Z",
+      },
+    ]);
+  });
+
+  it("maps seven_day onto the weekly window", () => {
+    const usage = normalizeClaudeRateLimitEvent(
+      { rate_limit_info: { status: "allowed", rateLimitType: "seven_day", utilization: 30 } },
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows[0]?.id).toBe("weekly");
+    expect(usage?.windows[0]?.resetsAt).toBeNull();
+  });
+
+  it("keeps model-scoped weekly buckets on their own windows", () => {
+    for (const [rateLimitType, id] of [
+      ["seven_day_opus", "weekly-opus"],
+      ["seven_day_sonnet", "weekly-sonnet"],
+    ] as const) {
+      const usage = normalizeClaudeRateLimitEvent(
+        { rate_limit_info: { status: "allowed", rateLimitType, utilization: 4 } },
+        UPDATED_AT,
+      );
+      expect(usage?.windows[0]?.id).toBe(id);
+    }
+  });
+
+  it("ignores overage, which is a spend state rather than a quota window", () => {
+    expect(
+      normalizeClaudeRateLimitEvent(
+        { rate_limit_info: { status: "allowed", rateLimitType: "overage", utilization: 50 } },
+        UPDATED_AT,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the event carries no usable bucket", () => {
+    expect(normalizeClaudeRateLimitEvent(null, UPDATED_AT)).toBeNull();
+    expect(normalizeClaudeRateLimitEvent({ type: "rate_limit_event" }, UPDATED_AT)).toBeNull();
+    expect(
+      normalizeClaudeRateLimitEvent({ rate_limit_info: { status: "allowed" } }, UPDATED_AT),
+    ).toBeNull();
+    expect(
+      normalizeClaudeRateLimitEvent(
+        { rate_limit_info: { status: "allowed", rateLimitType: "five_hour" } },
+        UPDATED_AT,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("normalizeCodexUsage", () => {
+  it("labels windows by duration, not by slot", () => {
+    const usage = normalizeCodexUsage(
+      {
+        rateLimits: {
+          primary: { usedPercent: 20, windowDurationMins: 300, resetsAt: 1_786_000_000 },
+          secondary: { usedPercent: 70, windowDurationMins: 10_080, resetsAt: 1_786_500_000 },
+        },
+      },
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows.map((window) => [window.id, window.label])).toEqual([
+      ["codex-primary", "Session"],
+      ["codex-secondary", "Weekly"],
+    ]);
+  });
+
+  it("keeps slot identity when the duration flips the label", () => {
+    const usage = normalizeCodexUsage(
+      { rateLimits: { primary: { usedPercent: 20, windowDurationMins: 10_080 } } },
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows[0]).toEqual({
+      id: "codex-primary",
+      label: "Weekly",
+      usedPercent: 20,
+      resetsAt: null,
+    });
+  });
+
+  it("falls back to slot order when the duration is missing", () => {
+    const usage = normalizeCodexUsage(
+      { rateLimits: { primary: { usedPercent: 1 }, secondary: { usedPercent: 2 } } },
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows.map((window) => window.label)).toEqual(["Session", "Weekly"]);
+  });
+
+  it("returns null for malformed input", () => {
+    expect(normalizeCodexUsage(null, UPDATED_AT)).toBeNull();
+    expect(normalizeCodexUsage({ rateLimits: {} }, UPDATED_AT)).toBeNull();
+    expect(normalizeCodexUsage({ rateLimits: { primary: {} } }, UPDATED_AT)).toBeNull();
+  });
+});
+
+describe("applyUsageReading", () => {
+  const window = (id: string, usedPercent: number) => ({
+    id,
+    label: id,
+    usedPercent,
+    resetsAt: null,
+  });
+  const stored = {
+    windows: [window("session", 40), window("weekly", 60), window("weekly-fable", 10)],
+    updatedAt: "2026-08-09T11:00:00.000Z",
+  };
+
+  it("keeps unmentioned windows when a partial reading lands", () => {
+    // The regression this guards: a Claude turn event describes one bucket,
+    // and Codex's rolling update is explicitly sparse. Treating either as a
+    // full reading blanks every other meter.
+    const merged = applyUsageReading(
+      stored,
+      { windows: [window("session", 55)], updatedAt: "2026-08-09T12:00:00.000Z" },
+      "partial",
+    );
+
+    expect(merged.windows).toEqual([
+      window("session", 55),
+      window("weekly", 60),
+      window("weekly-fable", 10),
+    ]);
+    expect(merged.updatedAt).toBe("2026-08-09T12:00:00.000Z");
+  });
+
+  it("appends a genuinely new window without reordering the existing ones", () => {
+    const merged = applyUsageReading(
+      stored,
+      { windows: [window("weekly-opus", 3)], updatedAt: "2026-08-09T12:00:00.000Z" },
+      "partial",
+    );
+
+    expect(merged.windows.map((entry) => entry.id)).toEqual([
+      "session",
+      "weekly",
+      "weekly-fable",
+      "weekly-opus",
+    ]);
+  });
+
+  it("lets a full reading retire a window the account no longer has", () => {
+    const merged = applyUsageReading(
+      stored,
+      { windows: [window("session", 55)], updatedAt: "2026-08-09T12:00:00.000Z" },
+      "full",
+    );
+
+    expect(merged.windows.map((entry) => entry.id)).toEqual(["session"]);
+  });
+
+  it("adopts any reading when nothing is stored yet", () => {
+    const incoming = { windows: [window("session", 1)], updatedAt: "2026-08-09T12:00:00.000Z" };
+    expect(applyUsageReading(undefined, incoming, "partial")).toBe(incoming);
+  });
+
+  it("never lets a stale reading rewind the meters", () => {
+    const stale = { windows: [window("session", 5)], updatedAt: "2026-08-09T10:00:00.000Z" };
+    expect(applyUsageReading(stored, stale, "partial")).toBe(stored);
+    expect(applyUsageReading(stored, stale, "full")).toBe(stored);
+  });
+
+  it("treats an unparseable stamp as the oldest possible reading", () => {
+    const malformed = { windows: [window("session", 5)], updatedAt: "not-a-date" };
+    expect(applyUsageReading(stored, malformed, "full")).toBe(stored);
+  });
+});

--- a/apps/server/src/provider/usageLimits.test.ts
+++ b/apps/server/src/provider/usageLimits.test.ts
@@ -79,6 +79,17 @@ describe("normalizeClaudeUsage", () => {
     expect(normalizeClaudeUsage({ five_hour: { utilization: "" } }, UPDATED_AT)).toBeNull();
     expect(normalizeClaudeUsage({ five_hour: { utilization: "  " } }, UPDATED_AT)).toBeNull();
   });
+
+  it("falls through to the next percent alias when the first is unreadable", () => {
+    // A present-but-malformed `used_percentage` must not mask a readable
+    // `utilization` on the same bucket.
+    const usage = normalizeClaudeUsage(
+      { five_hour: { used_percentage: "abc", utilization: 42 } },
+      UPDATED_AT,
+    );
+
+    expect(usage?.windows[0]?.usedPercent).toBe(42);
+  });
 });
 
 /**

--- a/apps/server/src/provider/usageLimits.ts
+++ b/apps/server/src/provider/usageLimits.ts
@@ -87,9 +87,15 @@ const readClaudeBucket = (
   if (!isRecord(value)) {
     return null;
   }
-  const usedPercent = readPercent(
-    value.used_percentage ?? value.utilization ?? value.usedPercentage ?? value.percent,
-  );
+  // Try each alias through the parser rather than `??`-chaining the raw
+  // values: a present-but-malformed first alias must not mask a readable
+  // later one.
+  const usedPercent = [
+    value.used_percentage,
+    value.utilization,
+    value.usedPercentage,
+    value.percent,
+  ].reduce<number | null>((found, candidate) => found ?? readPercent(candidate), null);
   if (usedPercent === null) {
     return null;
   }

--- a/apps/server/src/provider/usageLimits.ts
+++ b/apps/server/src/provider/usageLimits.ts
@@ -1,0 +1,373 @@
+/**
+ * Normalizers that turn provider-shaped rate-limit payloads into the
+ * provider-agnostic `ProviderUsageLimits` contract.
+ *
+ * Every provider reports quota differently — Claude's OAuth usage endpoint
+ * nests per-model weekly limits inside a `limits[]` array, Codex hands back
+ * `primary`/`secondary` windows with a duration in minutes. All of that mess
+ * stops here so the registry, the wire, and the UI only ever see
+ * `{ id, label, usedPercent, resetsAt }`.
+ *
+ * These functions are total: any input they cannot make sense of yields an
+ * empty window list rather than an error. Usage meters are ambient, so a
+ * malformed payload must degrade to "no circles", never to a failed turn.
+ *
+ * @module usageLimits
+ */
+import type { ProviderUsageLimits, ProviderUsageWindow } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Option from "effect/Option";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/**
+ * Coerce the many shapes a percentage arrives in, clamped to 0-100.
+ *
+ * Blank strings are rejected rather than coerced: `Number("")` is `0`, which
+ * would draw a confident "0% used" meter for a field the provider left empty.
+ */
+const readPercent = (value: unknown): number | null => {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : NaN;
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return Math.max(0, Math.min(100, parsed));
+};
+
+/**
+ * Reset times arrive as ISO strings, second-precision epochs, or
+ * millisecond-precision epochs depending on provider and transport. The 1e12
+ * threshold separates the two epoch flavours (1e12 ms is 2001; no plausible
+ * reset time is that far in the past, and no plausible epoch-seconds value is
+ * that large).
+ */
+const readIsoTimestamp = (value: unknown): string | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const milliseconds = value < 1e12 ? value * 1000 : value;
+    return Option.match(DateTime.make(milliseconds), {
+      onNone: () => null,
+      onSome: DateTime.formatIso,
+    });
+  }
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+  const asNumber = Number(value);
+  if (Number.isFinite(asNumber)) {
+    return readIsoTimestamp(asNumber);
+  }
+  return Option.match(DateTime.make(value), {
+    onNone: () => null,
+    onSome: DateTime.formatIso,
+  });
+};
+
+const makeWindow = (input: {
+  readonly id: string;
+  readonly label: string;
+  readonly usedPercent: number;
+  readonly resetsAt: string | null;
+}): ProviderUsageWindow => input;
+
+/**
+ * Read one bucket out of the Claude usage payload. Claude names the same
+ * concept `utilization` on some buckets and `used_percentage` on others, and
+ * the reset key varies the same way.
+ */
+const readClaudeBucket = (
+  value: unknown,
+  window: { readonly id: string; readonly label: string },
+): ProviderUsageWindow | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const usedPercent = readPercent(
+    value.used_percentage ?? value.utilization ?? value.usedPercentage ?? value.percent,
+  );
+  if (usedPercent === null) {
+    return null;
+  }
+  return makeWindow({
+    id: window.id,
+    label: window.label,
+    usedPercent,
+    resetsAt: readIsoTimestamp(
+      value.resets_at ?? value.resetsAt ?? value.reset_at ?? value.resetAt,
+    ),
+  });
+};
+
+/**
+ * Fable is not a top-level bucket. It is reported as a model-scoped weekly
+ * entry inside `limits[]`, matched on the model's display name. The legacy
+ * top-level `seven_day_<model>` keys read null on current plans, so this is
+ * the only place the number exists.
+ */
+const findScopedWeeklyLimit = (payload: Record<string, unknown>, pattern: RegExp): unknown => {
+  const limits = Array.isArray(payload.limits) ? payload.limits : [];
+  return (
+    limits.find((limit) => {
+      if (!isRecord(limit) || limit.group !== "weekly") {
+        return false;
+      }
+      const scope = isRecord(limit.scope) ? limit.scope : undefined;
+      const model = scope && isRecord(scope.model) ? scope.model : undefined;
+      const displayName = model?.display_name;
+      return typeof displayName === "string" && pattern.test(displayName);
+    }) ?? null
+  );
+};
+
+/**
+ * Normalize the OAuth usage endpoint's response. This is the only Claude
+ * source that reports every bucket at once, and therefore the only one that
+ * can populate Fable — the Agent SDK's turn events carry a single bucket and
+ * have no Fable bucket type at all (see `normalizeClaudeRateLimitEvent`).
+ *
+ * The response has no envelope, so read the top level directly. Unwrapping a
+ * speculative one risks descending past the buckets if the payload ever
+ * grows an unrelated `usage` key.
+ */
+export const normalizeClaudeUsage = (
+  raw: unknown,
+  updatedAt: string,
+): ProviderUsageLimits | null => {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const payload = raw;
+
+  const windows: Array<ProviderUsageWindow> = [];
+  const session = readClaudeBucket(payload.five_hour ?? payload.fiveHour ?? payload.session, {
+    id: "session",
+    label: "Session",
+  });
+  if (session) {
+    windows.push(session);
+  }
+  const weekly = readClaudeBucket(payload.seven_day ?? payload.sevenDay ?? payload.weekly, {
+    id: "weekly",
+    label: "Weekly",
+  });
+  if (weekly) {
+    windows.push(weekly);
+  }
+  const fable = readClaudeBucket(findScopedWeeklyLimit(payload, /fable/i), {
+    id: "weekly-fable",
+    label: "Fable",
+  });
+  if (fable) {
+    windows.push(fable);
+  }
+
+  if (windows.length === 0) {
+    return null;
+  }
+  return { windows, updatedAt };
+};
+
+/**
+ * Which window each `SDKRateLimitInfo.rateLimitType` describes.
+ *
+ * `overage` is deliberately absent: it is a spend state, not a quota window,
+ * and has no meter. Note there is no Fable bucket type — the SDK cannot
+ * report it, so the Fable circle only ever populates from the OAuth pull.
+ */
+const CLAUDE_SDK_WINDOW_BY_RATE_LIMIT_TYPE: Readonly<
+  Record<string, { readonly id: string; readonly label: string }>
+> = {
+  five_hour: { id: "session", label: "Session" },
+  seven_day: { id: "weekly", label: "Weekly" },
+  seven_day_opus: { id: "weekly-opus", label: "Opus" },
+  seven_day_sonnet: { id: "weekly-sonnet", label: "Sonnet" },
+};
+
+/**
+ * Normalize the Agent SDK's `rate_limit_event`, which the Claude adapter
+ * forwards verbatim as `payload.rateLimits`.
+ *
+ * The shape is flat and describes exactly one bucket:
+ * `{ rate_limit_info: { rateLimitType, utilization, resetsAt } }`. That is
+ * why readings from this feed must be merged into the stored set rather than
+ * replacing it — a `five_hour` event says nothing about the weekly window,
+ * and treating it as a full reading would blank the other meters.
+ */
+export const normalizeClaudeRateLimitEvent = (
+  raw: unknown,
+  updatedAt: string,
+): ProviderUsageLimits | null => {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const info = isRecord(raw.rate_limit_info) ? raw.rate_limit_info : null;
+  if (info === null) {
+    return null;
+  }
+  const rateLimitType = info.rateLimitType;
+  if (typeof rateLimitType !== "string") {
+    return null;
+  }
+  const window = CLAUDE_SDK_WINDOW_BY_RATE_LIMIT_TYPE[rateLimitType];
+  if (window === undefined) {
+    return null;
+  }
+  // `utilization` is a 0-100 percentage, matching the OAuth endpoint's
+  // `used_percentage` for the same buckets.
+  const usedPercent = readPercent(info.utilization);
+  if (usedPercent === null) {
+    return null;
+  }
+  return {
+    windows: [
+      makeWindow({
+        id: window.id,
+        label: window.label,
+        usedPercent,
+        resetsAt: readIsoTimestamp(info.resetsAt),
+      }),
+    ],
+    updatedAt,
+  };
+};
+
+/**
+ * Codex labels come from the window's own duration rather than from which
+ * slot it arrived in, because the slots are not guaranteed to mean
+ * session/weekly across plan types. A missing duration falls back to slot
+ * order. The `id` stays slot-derived so identity survives a label change.
+ */
+const codexWindowLabel = (
+  durationMinutes: unknown,
+  fallback: "Session" | "Weekly",
+): "Session" | "Weekly" => {
+  const minutes = typeof durationMinutes === "number" ? durationMinutes : Number(durationMinutes);
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return fallback;
+  }
+  return minutes < 24 * 60 ? "Session" : "Weekly";
+};
+
+const readCodexWindow = (
+  value: unknown,
+  slot: { readonly id: string; readonly fallbackLabel: "Session" | "Weekly" },
+): ProviderUsageWindow | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const usedPercent = readPercent(value.usedPercent ?? value.used_percent);
+  if (usedPercent === null) {
+    return null;
+  }
+  return makeWindow({
+    id: slot.id,
+    label: codexWindowLabel(
+      value.windowDurationMins ?? value.window_duration_mins,
+      slot.fallbackLabel,
+    ),
+    usedPercent,
+    resetsAt: readIsoTimestamp(value.resetsAt ?? value.resets_at),
+  });
+};
+
+/**
+ * Normalize `account/rateLimits/read` responses and
+ * `account/rateLimits/updated` notifications — both wrap the snapshot in a
+ * `rateLimits` key.
+ */
+export const normalizeCodexUsage = (
+  raw: unknown,
+  updatedAt: string,
+): ProviderUsageLimits | null => {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const snapshot = isRecord(raw.rateLimits) ? raw.rateLimits : raw;
+
+  const windows: Array<ProviderUsageWindow> = [];
+  const primary = readCodexWindow(snapshot.primary, {
+    id: "codex-primary",
+    fallbackLabel: "Session",
+  });
+  if (primary) {
+    windows.push(primary);
+  }
+  const secondary = readCodexWindow(snapshot.secondary, {
+    id: "codex-secondary",
+    fallbackLabel: "Weekly",
+  });
+  if (secondary) {
+    windows.push(secondary);
+  }
+
+  if (windows.length === 0) {
+    return null;
+  }
+  return { windows, updatedAt };
+};
+
+/**
+ * How much of the picture a reading claims to describe.
+ *
+ * `full` — every window the account has, so windows the reading omits are
+ * genuinely gone (a plan change, a bucket retired). Produced by Claude's
+ * OAuth pull and Codex's `account/rateLimits/read`.
+ *
+ * `partial` — one or more windows, saying nothing about the rest. Produced
+ * by Claude's per-bucket `rate_limit_event` and by Codex's explicitly sparse
+ * `account/rateLimits/updated`. Applying one of these as if it were full
+ * would blank every meter it happens not to mention.
+ */
+export type UsageReadingMode = "full" | "partial";
+
+// An unparseable `updatedAt` sorts as the oldest possible reading, so a
+// malformed stamp can never displace a good one.
+const usageEpochMillis = (isoTimestamp: string): number =>
+  Option.match(DateTime.make(isoTimestamp), {
+    onNone: () => Number.NEGATIVE_INFINITY,
+    onSome: DateTime.toEpochMillis,
+  });
+
+/**
+ * Fold a new reading into the stored one.
+ *
+ * Several feeds write usage for the same instance and they land out of
+ * order, so a stale reading never overwrites a fresher one. A `partial`
+ * reading updates only the windows it names and leaves the rest standing;
+ * a `full` one replaces the set outright.
+ *
+ * Window order follows the stored reading, with genuinely new windows
+ * appended — the circles must not reshuffle in the composer when one bucket
+ * happens to update on its own.
+ */
+export const applyUsageReading = (
+  previous: ProviderUsageLimits | undefined,
+  incoming: ProviderUsageLimits,
+  mode: UsageReadingMode,
+): ProviderUsageLimits => {
+  if (previous === undefined) {
+    return incoming;
+  }
+  const isStale = usageEpochMillis(incoming.updatedAt) < usageEpochMillis(previous.updatedAt);
+  if (isStale) {
+    return previous;
+  }
+  if (mode === "full") {
+    return incoming;
+  }
+
+  const incomingById = new Map(incoming.windows.map((window) => [window.id, window] as const));
+  const merged = previous.windows.map((window) => incomingById.get(window.id) ?? window);
+  const known = new Set(previous.windows.map((window) => window.id));
+  for (const window of incoming.windows) {
+    if (!known.has(window.id)) {
+      merged.push(window);
+    }
+  }
+  return { windows: merged, updatedAt: incoming.updatedAt };
+};

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -113,6 +113,7 @@ import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSna
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
 import { PersistenceSqlError } from "./persistence/Errors.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
+import * as ProviderUsageLimits from "./provider/Services/ProviderUsageLimits.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "./provider/providerMaintenance.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
@@ -385,6 +386,7 @@ const buildAppUnderTest = (options?: {
   layers?: {
     keybindings?: Partial<Keybindings.Keybindings["Service"]>;
     providerRegistry?: Partial<ProviderRegistry.ProviderRegistry["Service"]>;
+    providerUsageRefresher?: Partial<ProviderUsageLimits.ProviderUsageRefresher["Service"]>;
     serverSettings?: Partial<ServerSettings.ServerSettingsService["Service"]>;
     externalLauncher?: Partial<ExternalLauncher.ExternalLauncher["Service"]>;
     vcsDriver?: Partial<VcsDriver.VcsDriver["Service"]>;
@@ -626,18 +628,24 @@ const buildAppUnderTest = (options?: {
         }),
       ),
       Layer.provide(
-        Layer.mock(ProviderRegistry.ProviderRegistry)({
-          getProviders: Effect.succeed([]),
-          refresh: () => Effect.succeed([]),
-          refreshInstance: () => Effect.succeed([]),
-          getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
-            Effect.succeed(
-              makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null }),
-            ),
-          setProviderMaintenanceActionState: () => Effect.succeed([]),
-          streamChanges: Stream.empty,
-          ...options?.layers?.providerRegistry,
-        }),
+        Layer.mergeAll(
+          Layer.mock(ProviderUsageLimits.ProviderUsageRefresher)({
+            refresh: () => Effect.void,
+            ...options?.layers?.providerUsageRefresher,
+          }),
+          Layer.mock(ProviderRegistry.ProviderRegistry)({
+            getProviders: Effect.succeed([]),
+            refresh: () => Effect.succeed([]),
+            refreshInstance: () => Effect.succeed([]),
+            getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
+              Effect.succeed(
+                makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null }),
+              ),
+            setProviderMaintenanceActionState: () => Effect.succeed([]),
+            streamChanges: Stream.empty,
+            ...options?.layers?.providerRegistry,
+          }),
+        ),
       ),
       Layer.provide(
         Layer.mock(ServerSettings.ServerSettingsService)({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -58,6 +58,9 @@ import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletion
 import * as AgentAwarenessRelay from "./relay/AgentAwarenessRelay.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
+import { ProviderUsageLimitsStoreLive } from "./provider/Layers/ProviderUsageLimits.ts";
+import { ProviderUsageIngestionLive } from "./provider/Layers/ProviderUsageIngestion.ts";
+import { ProviderUsageRefresherLive } from "./provider/Layers/ProviderUsageRefresher.ts";
 import * as ServerSettings from "./serverSettings.ts";
 import * as ProjectFaviconResolver from "./project/ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "./project/T3ProjectFileLoader.ts";
@@ -357,12 +360,20 @@ const CloudManagedEndpointRuntimeLive = Layer.mergeAll(
   ),
 );
 
-const ProviderRuntimeLayerLive = ProviderSessionReaperLive.pipe(
-  Layer.provideMerge(ProviderLayerLive),
-  Layer.provideMerge(OrchestrationLayerLive),
-);
+const ProviderRuntimeLayerLive = Layer.mergeAll(
+  ProviderSessionReaperLive,
+  // Turn-event usage feed. Sits here because it needs `ProviderService`'s
+  // runtime event stream; the store it writes into is provided further down.
+  ProviderUsageIngestionLive,
+).pipe(Layer.provideMerge(ProviderLayerLive), Layer.provideMerge(OrchestrationLayerLive));
 
-const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
+const RuntimeCoreDependenciesLive = Layer.mergeAll(
+  ReactorLayerLive,
+  // On-demand usage pulls. Shallowest position in this graph because it
+  // reads `ServerSettingsService` to resolve each Claude instance's config
+  // directory.
+  ProviderUsageRefresherLive,
+).pipe(
   // Core Services
   Layer.provideMerge(ServerSettingsLayerLive),
   Layer.provideMerge(CheckpointingLayerLive),
@@ -379,7 +390,15 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   // through this layer. Built-in drivers come from `BUILT_IN_DRIVERS`;
   // `providerInstances` hydration merges `settings.providers.<kind>`
   // with explicit `providerInstances` entries on boot.
-  Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
+  Layer.provideMerge(
+    Layer.mergeAll(
+      ProviderInstanceRegistryHydrationLive,
+      // Volatile usage store. Deliberately dependency-free, and provided
+      // below `ProviderRegistryLive` because the registry reads it to
+      // decorate every provider snapshot it publishes.
+      ProviderUsageLimitsStoreLive,
+    ),
+  ),
   // Shared native/canonical NDJSON writers used by both the per-instance
   // drivers (native stream, written from inside each `<X>Adapter`) and
   // `ProviderService` (canonical stream, written after event normalization).

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -79,6 +79,7 @@ import {
   observeRpcStreamEffect as instrumentRpcStreamEffect,
 } from "./observability/RpcInstrumentation.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
+import * as ProviderUsageLimits from "./provider/Services/ProviderUsageLimits.ts";
 import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner.ts";
 import * as ServerSelfUpdate from "./cloud/selfUpdate.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
@@ -368,6 +369,7 @@ const makeWsRpcLayer = (
       const previewManager = yield* PreviewManager.PreviewManager;
       const portDiscovery = yield* PortScanner.PortDiscovery;
       const providerRegistry = yield* ProviderRegistry.ProviderRegistry;
+      const providerUsageRefresher = yield* ProviderUsageLimits.ProviderUsageRefresher;
       const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.ProviderMaintenanceRunner;
       const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
       const config = yield* ServerConfig.ServerConfig;
@@ -1443,6 +1445,15 @@ const makeWsRpcLayer = (
               ? providerRegistry.refreshInstance(input.instanceId)
               : providerRegistry.refresh()
             ).pipe(Effect.map((providers) => ({ providers }))),
+            { "rpc.aggregate": "server" },
+          ),
+        [WS_METHODS.serverRefreshProviderUsage]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverRefreshProviderUsage,
+            // Resolves as soon as the refresh is scheduled. The reading
+            // itself lands on the provider snapshot stream, so clients never
+            // block a hover or a focus event on a network round trip.
+            providerUsageRefresher.refresh(input.instanceId).pipe(Effect.as({})),
             { "rpc.aggregate": "server" },
           ),
         [WS_METHODS.serverUpdateProvider]: (input) =>

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -398,6 +398,10 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
   compact: boolean;
   activeContextWindow: ReturnType<typeof deriveLatestContextWindowSnapshot>;
   activeThreadProviderDisplayName: string | null;
+  // Scoped to the instance the meters read from, which is the selection for
+  // the *next* turn — not the thread's persisted provider. Picking a new
+  // provider swaps the numbers, so the title has to move with them.
+  usageProviderDisplayName: string | null;
   usageWindows: ReadonlyArray<ProviderUsageWindow>;
   usageUpdatedAt: string | null;
   onRequestUsageRefresh: () => void;
@@ -434,7 +438,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
         windows={props.usageWindows}
         updatedAt={props.usageUpdatedAt}
         compact={props.compact}
-        providerDisplayName={props.activeThreadProviderDisplayName}
+        providerDisplayName={props.usageProviderDisplayName}
         onRequestRefresh={props.onRequestUsageRefresh}
       />
       {props.isPreparingWorktree ? (
@@ -985,6 +989,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       globalThis.removeEventListener("focus", onFocus);
     };
   }, [requestUsageRefresh]);
+  // The meters read `selectedInstanceId`, so their label must too. Using the
+  // thread's persisted provider here would attribute the new provider's
+  // quota to the old provider's name for the whole gap between picking a
+  // model and sending the next turn.
+  const usageProviderDisplayName = useMemo(() => {
+    const entry = providerStatuses.find((status) => status.instanceId === selectedInstanceId);
+    return entry
+      ? getProviderDisplayName(providerStatuses, entry.driver)
+      : formatProviderDisplayName(selectedInstanceId);
+  }, [providerStatuses, selectedInstanceId]);
   const activeThreadProviderDisplayName = useMemo(() => {
     if (!activeThreadModelSelection) return null;
     const entry = providerStatuses.find(
@@ -3253,6 +3267,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   compact={isComposerPrimaryActionsCompact}
                   activeContextWindow={activeContextWindow}
                   activeThreadProviderDisplayName={activeThreadProviderDisplayName}
+                  usageProviderDisplayName={usageProviderDisplayName}
                   usageWindows={usageWindows}
                   usageUpdatedAt={usageUpdatedAt}
                   onRequestUsageRefresh={requestUsageRefresh}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -5,6 +5,7 @@ import type {
   PreviewAnnotationPayload,
   ProviderApprovalDecision,
   ProviderInteractionMode,
+  ProviderUsageWindow,
   ResolvedKeybindingsConfig,
   RuntimeMode,
   ScopedThreadRef,
@@ -18,6 +19,10 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
+import {
+  selectProviderUsageUpdatedAt,
+  selectProviderUsageWindows,
+} from "@t3tools/client-runtime/state/provider-usage";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import {
@@ -42,6 +47,8 @@ import {
   shouldSubmitComposerOnEnter,
 } from "../../composer-logic";
 import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
+import { serverEnvironment } from "../../state/server";
+import { useAtomCommand } from "../../state/use-atom-command";
 import {
   dataTransferHasComposerMention,
   makeComposerMentionDragHandlers,
@@ -102,6 +109,7 @@ import {
   renderProviderTraitsPicker,
 } from "./composerProviderState";
 import { ContextWindowMeter } from "./ContextWindowMeter";
+import { UsageLimitsMeters } from "./UsageLimitsMeters";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
@@ -390,6 +398,9 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
   compact: boolean;
   activeContextWindow: ReturnType<typeof deriveLatestContextWindowSnapshot>;
   activeThreadProviderDisplayName: string | null;
+  usageWindows: ReadonlyArray<ProviderUsageWindow>;
+  usageUpdatedAt: string | null;
+  onRequestUsageRefresh: () => void;
   isPreparingWorktree: boolean;
   pendingAction: {
     questionIndex: number;
@@ -419,6 +430,13 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
           providerDisplayName={props.activeThreadProviderDisplayName}
         />
       ) : null}
+      <UsageLimitsMeters
+        windows={props.usageWindows}
+        updatedAt={props.usageUpdatedAt}
+        compact={props.compact}
+        providerDisplayName={props.activeThreadProviderDisplayName}
+        onRequestRefresh={props.onRequestUsageRefresh}
+      />
       {props.isPreparingWorktree ? (
         <span className="text-secondary-label text-xs">Preparing worktree...</span>
       ) : null}
@@ -918,6 +936,55 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () => deriveLatestContextWindowSnapshot(activeThreadActivities ?? []),
     [activeThreadActivities],
   );
+
+  // ------------------------------------------------------------------
+  // Account usage limits
+  // ------------------------------------------------------------------
+  // Scoped to the instance the *next* turn will use, not the thread's
+  // historical one — the meters answer "how much have I got left for this",
+  // and switching providers in the picker should switch the numbers.
+  const usageWindows = useMemo(
+    () => selectProviderUsageWindows(providerStatuses, selectedInstanceId),
+    [providerStatuses, selectedInstanceId],
+  );
+  const usageUpdatedAt = useMemo(
+    () => selectProviderUsageUpdatedAt(providerStatuses, selectedInstanceId),
+    [providerStatuses, selectedInstanceId],
+  );
+  const refreshProviderUsage = useAtomCommand(serverEnvironment.refreshProviderUsage, {
+    reportFailure: false,
+  });
+  // Ambient and best-effort: the server debounces, and a failed pull leaves
+  // the last-known numbers on screen. Nothing here is worth a toast.
+  const requestUsageRefresh = useCallback(() => {
+    // The placeholder selection is never a real instance — dispatching it
+    // would spend a round trip per composer per load, since the first render
+    // always precedes provider hydration.
+    if (selectedInstanceId === NO_PROVIDER_MODEL_SELECTION.instanceId) {
+      return;
+    }
+    void refreshProviderUsage({
+      environmentId,
+      input: { instanceId: selectedInstanceId },
+    });
+  }, [environmentId, refreshProviderUsage, selectedInstanceId]);
+
+  // Refresh on the two moments the number is most likely to have moved
+  // without us hearing about it: coming back to the app, and switching to a
+  // different provider instance. Hovering a meter is the third trigger and
+  // lives on the meter itself.
+  useEffect(() => {
+    requestUsageRefresh();
+  }, [requestUsageRefresh]);
+  useEffect(() => {
+    const onFocus = () => {
+      requestUsageRefresh();
+    };
+    globalThis.addEventListener("focus", onFocus);
+    return () => {
+      globalThis.removeEventListener("focus", onFocus);
+    };
+  }, [requestUsageRefresh]);
   const activeThreadProviderDisplayName = useMemo(() => {
     if (!activeThreadModelSelection) return null;
     const entry = providerStatuses.find(
@@ -3186,6 +3253,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   compact={isComposerPrimaryActionsCompact}
                   activeContextWindow={activeContextWindow}
                   activeThreadProviderDisplayName={activeThreadProviderDisplayName}
+                  usageWindows={usageWindows}
+                  usageUpdatedAt={usageUpdatedAt}
+                  onRequestUsageRefresh={requestUsageRefresh}
                   pendingAction={pendingPrimaryAction}
                   isRunning={phase === "running"}
                   showPlanFollowUpPrompt={pendingUserInputs.length === 0 && showPlanFollowUpPrompt}

--- a/apps/web/src/components/chat/UsageLimitsMeters.test.tsx
+++ b/apps/web/src/components/chat/UsageLimitsMeters.test.tsx
@@ -1,0 +1,68 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ProviderUsageWindow } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { UsageLimitsMeters } from "./UsageLimitsMeters";
+
+const window = (id: string, label: string, usedPercent: number): ProviderUsageWindow => ({
+  id,
+  label,
+  usedPercent,
+  resetsAt: null,
+});
+
+const CLAUDE_WINDOWS = [
+  window("session", "Session", 42),
+  window("weekly", "Weekly", 61),
+  window("weekly-fable", "Fable", 12),
+];
+
+const render = (props: Partial<Parameters<typeof UsageLimitsMeters>[0]> = {}) =>
+  renderToStaticMarkup(
+    <UsageLimitsMeters
+      windows={CLAUDE_WINDOWS}
+      updatedAt={null}
+      compact={false}
+      providerDisplayName="Claude"
+      onRequestRefresh={() => {}}
+      {...props}
+    />,
+  );
+
+const countMeterButtons = (markup: string) =>
+  markup.match(/aria-label="[^"]* usage /g)?.length ?? 0;
+
+describe("UsageLimitsMeters", () => {
+  it("renders nothing at all when the provider reports no windows", () => {
+    // Not a placeholder: switching to a provider without usage must not
+    // shift the composer's action row.
+    expect(render({ windows: [] })).toBe("");
+  });
+
+  it("renders one circle per window in full mode", () => {
+    expect(countMeterButtons(render())).toBe(3);
+  });
+
+  it("collapses to a single circle in compact mode", () => {
+    expect(countMeterButtons(render({ compact: true }))).toBe(1);
+  });
+
+  it("shows the bucket closest to running out when collapsed", () => {
+    const markup = render({ compact: true });
+    expect(markup).toContain('aria-label="Weekly usage 61% used"');
+  });
+
+  it("puts the percentage inside the ring as bare digits", () => {
+    // The ring leaves ~13px of clear space; a `%` sign would not fit.
+    const markup = render({ windows: [window("session", "Session", 42)] });
+    expect(markup).toContain(">42</span>");
+    expect(markup).not.toContain(">42%</span>");
+  });
+
+  it("tightens tracking only when the digits reach three characters", () => {
+    expect(render({ windows: [window("session", "Session", 99)] })).not.toContain(
+      "tracking-tighter",
+    );
+    expect(render({ windows: [window("session", "Session", 100)] })).toContain("tracking-tighter");
+  });
+});

--- a/apps/web/src/components/chat/UsageLimitsMeters.tsx
+++ b/apps/web/src/components/chat/UsageLimitsMeters.tsx
@@ -1,0 +1,222 @@
+import { useMemo, useState } from "react";
+import type { ProviderUsageWindow } from "@t3tools/contracts";
+import {
+  clampUsagePercent,
+  formatUsagePercent,
+  formatUsageResetLabel,
+  formatUsageRingLabel,
+  formatUsageUpdatedAtLabel,
+  isUsageWindowCritical,
+  pickWorstUsageWindow,
+} from "@t3tools/client-runtime/state/provider-usage";
+import { cn } from "~/lib/utils";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+
+const RADIUS = 9.75;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+function UsageRing(props: { usedPercent: number }) {
+  const normalized = clampUsagePercent(props.usedPercent);
+  const isCritical = normalized > 90;
+  const usageColor = isCritical
+    ? "var(--color-error)"
+    : "color-mix(in oklab, var(--color-muted-foreground) 72%, transparent)";
+  const digits = formatUsageRingLabel(props.usedPercent);
+
+  return (
+    <span className="relative flex size-5 items-center justify-center">
+      <svg
+        viewBox="0 0 24 24"
+        className="-rotate-90 absolute inset-0 size-full transform-gpu"
+        aria-hidden="true"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r={RADIUS}
+          fill="none"
+          stroke="color-mix(in oklab, var(--color-muted-foreground) 24%, transparent)"
+          strokeWidth="3"
+        />
+        <circle
+          cx="12"
+          cy="12"
+          r={RADIUS}
+          fill="none"
+          stroke={usageColor}
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={CIRCUMFERENCE * (1 - normalized / 100)}
+          className="transition-[stroke-dashoffset,stroke] duration-500 ease-out motion-reduce:transition-none"
+        />
+      </svg>
+      {/*
+        The ring leaves roughly 13px of clear space, which fits two digits
+        comfortably. A literal 100 needs the tighter tracking to stay inside;
+        by then the colour already says "nearly out" on its own, so slightly
+        cramped digits are a cosmetic problem, not a legibility one.
+      */}
+      <span
+        className={cn(
+          "relative font-medium text-[9px] leading-none tabular-nums",
+          isCritical ? "text-error" : "text-muted-foreground",
+          digits.length > 2 ? "tracking-tighter" : null,
+        )}
+        aria-hidden="true"
+      >
+        {digits}
+      </span>
+    </span>
+  );
+}
+
+function UsageWindowSummary(props: { window: ProviderUsageWindow; nowMs: number | null }) {
+  // `nowMs` stays null until the popover opens. Measuring the countdown
+  // against epoch zero instead would render every reset as decades past.
+  const resetLabel =
+    props.nowMs === null ? null : formatUsageResetLabel(props.window.resetsAt, props.nowMs);
+  return (
+    <div className="flex items-center justify-between gap-3 text-[11px] leading-4">
+      <span className="text-secondary-label">{props.window.label}</span>
+      <span className="flex items-center gap-1.5">
+        <span
+          className={cn(
+            "font-medium tabular-nums",
+            isUsageWindowCritical(props.window) ? "text-error" : "text-secondary-label",
+          )}
+        >
+          {formatUsagePercent(props.window.usedPercent)}
+        </span>
+        {resetLabel ? <span className="text-muted-foreground">· {resetLabel}</span> : null}
+      </span>
+    </div>
+  );
+}
+
+function UsageMeterButton(props: {
+  windows: ReadonlyArray<ProviderUsageWindow>;
+  ringWindow: ProviderUsageWindow;
+  title: string;
+  updatedAt: string | null;
+  onOpen: (() => void) | undefined;
+}) {
+  // Stamped when the popover opens, not at render, and not on a ticker.
+  //
+  // The composer footer is memoised and these props barely change, so a
+  // render-time `Date.now()` would be captured once and then reused for the
+  // life of the mount — a countdown frozen at whatever it read hours ago. A
+  // ticking timer would fix that but repaint the composer forever for labels
+  // this coarse ("in 2h 15m", "as of 12m ago"). Reading the clock on open is
+  // the only moment the numbers are actually looked at.
+  const [openedAtMs, setOpenedAtMs] = useState<number | null>(null);
+  const staleLabel =
+    openedAtMs === null ? null : formatUsageUpdatedAtLabel(props.updatedAt, openedAtMs);
+
+  return (
+    <Popover
+      onOpenChange={(open) => {
+        if (open) {
+          setOpenedAtMs(Date.now());
+          props.onOpen?.();
+        }
+      }}
+    >
+      <PopoverTrigger
+        openOnHover
+        delay={150}
+        closeDelay={0}
+        render={
+          <button
+            type="button"
+            className={cn(
+              "inline-flex size-7 cursor-pointer items-center justify-center rounded-full border border-transparent text-muted-foreground outline-none transition-colors",
+              "hover:bg-accent data-[pressed]:bg-accent",
+              "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+            )}
+            aria-label={`${props.ringWindow.label} usage ${formatUsagePercent(
+              props.ringWindow.usedPercent,
+            )} used`}
+          >
+            <UsageRing usedPercent={props.ringWindow.usedPercent} />
+          </button>
+        }
+      />
+      <PopoverPopup
+        tooltipStyle
+        side="top"
+        align="end"
+        viewportClassName="p-0"
+        className="w-56 max-w-none text-left whitespace-normal"
+      >
+        <div className="flex flex-col gap-2 p-[var(--floating-content-inset)]">
+          <div className="font-medium text-muted-foreground text-xs">{props.title}</div>
+          <div className="flex flex-col gap-1">
+            {props.windows.map((window) => (
+              <UsageWindowSummary key={window.id} window={window} nowMs={openedAtMs} />
+            ))}
+          </div>
+          {staleLabel ? (
+            <div className="text-[11px] text-muted-foreground leading-4">{staleLabel}</div>
+          ) : null}
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}
+
+/**
+ * Account quota meters for the composer footer, sized to sit beside
+ * `ContextWindowMeter` without looking like a different control.
+ *
+ * Renders nothing at all when the provider reports no windows — Cursor,
+ * Grok, and OpenCode never will — so switching threads between providers
+ * costs no layout shift.
+ *
+ * In compact mode the row collapses to a single circle showing the bucket
+ * closest to running out, with the full breakdown still one hover away. The
+ * container it lives in is `flex-nowrap shrink-0`, so three 28px buttons is
+ * ~100px that cannot yield to the send button when the composer narrows.
+ */
+export function UsageLimitsMeters(props: {
+  windows: ReadonlyArray<ProviderUsageWindow>;
+  updatedAt: string | null;
+  compact: boolean;
+  providerDisplayName: string | null;
+  onRequestRefresh: () => void;
+}) {
+  const { windows, compact } = props;
+  const worstWindow = useMemo(() => pickWorstUsageWindow(windows), [windows]);
+  const title = props.providerDisplayName ? `${props.providerDisplayName} usage` : "Usage";
+
+  if (windows.length === 0 || worstWindow === null) {
+    return null;
+  }
+
+  if (compact) {
+    return (
+      <UsageMeterButton
+        windows={windows}
+        ringWindow={worstWindow}
+        title={title}
+        updatedAt={props.updatedAt}
+        onOpen={props.onRequestRefresh}
+      />
+    );
+  }
+
+  return (
+    <>
+      {windows.map((window) => (
+        <UsageMeterButton
+          key={window.id}
+          windows={windows}
+          ringWindow={window}
+          title={title}
+          updatedAt={props.updatedAt}
+          onOpen={props.onRequestRefresh}
+        />
+      ))}
+    </>
+  );
+}

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -116,6 +116,10 @@ Controls how assistant text reaches the thread timeline. In [the contracts][1], 
 
 A point-in-time view of state. The word is used in multiple layers, including orchestration, provider, and checkpointing. See [ProjectionSnapshotQuery.ts][10], [ProviderAdapter.ts][15], and [CheckpointStore.ts][19].
 
+#### Usage window
+
+One quota bucket a provider account is metered against — Claude's 5-hour session window, its weekly window, its weekly Fable window, Codex's primary and secondary windows. Modelled provider-agnostically in [the server contracts][26] as `{ id, label, usedPercent, resetsAt }`, so clients map over the list rather than branching per provider. Provider-shaped payloads are flattened into it by `normalizeClaudeUsage` / `normalizeCodexUsage` in [usageLimits.ts][25]. Readings are volatile and never persisted: two feeds write them, the free `account.rate-limits.updated` turn events and a debounced on-demand pull, and the newer reading always wins. Cursor, Grok, and OpenCode report none.
+
 ### Checkpointing
 
 Checkpointing captures workspace state over time so the app can diff turns and restore earlier points. The main pieces are [CheckpointStore.ts][19], [CheckpointDiffQuery.ts][20], and [CheckpointReactor.ts][6].
@@ -179,3 +183,5 @@ The file patch and changed-file summary for one turn. It is usually computed in 
 [22]: ../../apps/server/src/checkpointing/Utils.ts
 [23]: ../../apps/server/src/checkpointing/Diffs.ts
 [24]: ./overview.md
+[25]: ../../apps/server/src/provider/usageLimits.ts
+[26]: ../../packages/contracts/src/server.ts

--- a/docs/user/usage-meters.md
+++ b/docs/user/usage-meters.md
@@ -25,7 +25,7 @@ stops you at any number.
 
 ## Seeing more detail
 
-Hover a circle for the exact percentage and when that limit resets. Resets
+Hover a circle for the displayed percentage and when that limit resets. Resets
 less than a day away count down ("resets in 2h 15m"); further out they show
 the day and time ("resets Mon 9:00 AM"), and beyond a couple of days the date
 comes along too.

--- a/docs/user/usage-meters.md
+++ b/docs/user/usage-meters.md
@@ -1,0 +1,64 @@
+# Usage meters
+
+The small circles next to the send button show how much of your provider
+subscription you have used up. They are there so you find out you are running
+low before a turn stops halfway through, not after.
+
+## What the circles mean
+
+Each circle is one limit your account is measured against. The ring fills up as
+you use it, and the number in the middle is the percentage used.
+
+**Claude** shows three:
+
+- **Session** — your 5-hour window
+- **Weekly** — your weekly window
+- **Fable** — your weekly window for Fable models specifically
+
+**Codex** shows two, usually a shorter window and a weekly one.
+
+**Cursor, Grok, and OpenCode** show nothing. They do not report usage, so
+rather than show you an empty or guessed circle, T3 Code shows none at all.
+
+A circle turns red past 90%. That is a nudge, not a block — nothing in T3 Code
+stops you at any number.
+
+## Seeing more detail
+
+Hover a circle for the exact percentage and when that limit resets. Resets
+less than a day away count down ("resets in 2h 15m"); further out they show
+the day and time ("resets Mon 9:00 AM"), and beyond a couple of days the date
+comes along too.
+
+If a limit does not report a reset time, the line is simply left out.
+
+On mobile there is one button in the composer toolbar instead of a row of
+circles — it shows whichever limit is closest to running out, and tapping it
+lists them all.
+
+## When the composer is narrow
+
+In a narrow window the circles collapse into one, showing whichever limit is
+closest to running out. Hover it and you still get the full breakdown.
+
+## How fresh the numbers are
+
+They refresh when you come back to the app, when you switch providers, and
+when you hover or tap a meter. Codex also volunteers new numbers at the end of
+every turn. If a reading is more than a minute old, the popover tells you how
+old ("as of 12m ago").
+
+Checking your usage never costs you any of it.
+
+## If no circles appear
+
+That is normal in several cases and never an error you need to fix:
+
+- your provider does not report usage
+- no usage has been read yet — switching away from the app and back asks for
+  a fresh reading
+- T3 Code could not read your provider credentials, or they have expired.
+  Signing in again with the provider's own CLI fixes it
+
+Usage meters are informational. When they cannot be shown, everything else
+keeps working exactly as before.

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -79,6 +79,10 @@
       "types": "./src/state/preview.ts",
       "default": "./src/state/preview.ts"
     },
+    "./state/provider-usage": {
+      "types": "./src/state/providerUsage.ts",
+      "default": "./src/state/providerUsage.ts"
+    },
     "./state/projects": {
       "types": "./src/state/projects.ts",
       "default": "./src/state/projects.ts"

--- a/packages/client-runtime/src/state/providerUsage.test.ts
+++ b/packages/client-runtime/src/state/providerUsage.test.ts
@@ -1,0 +1,154 @@
+import type { ProviderUsageWindow, ServerProvider } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Option from "effect/Option";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  formatUsagePercent,
+  formatUsageResetLabel,
+  formatUsageRingLabel,
+  formatUsageUpdatedAtLabel,
+  pickWorstUsageWindow,
+  selectProviderUsageWindows,
+} from "./providerUsage.ts";
+
+const NOW_MS = Date.parse("2026-08-09T12:00:00.000Z");
+
+// Epoch millis -> ISO, without reaching for the global `Date` constructor.
+const isoAt = (millis: number): string =>
+  Option.match(DateTime.make(millis), {
+    onNone: () => "",
+    onSome: DateTime.formatIso,
+  });
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const usageWindow = (id: string, usedPercent: number): ProviderUsageWindow => ({
+  id,
+  label: id,
+  usedPercent,
+  resetsAt: null,
+});
+
+describe("selectProviderUsageWindows", () => {
+  const providers = [
+    {
+      instanceId: "claudeAgent",
+      usageLimits: { windows: [usageWindow("session", 42)], updatedAt: "2026-08-09T12:00:00.000Z" },
+    },
+    { instanceId: "opencode" },
+  ] as unknown as ReadonlyArray<ServerProvider>;
+
+  it("reads the selected instance's windows", () => {
+    expect(selectProviderUsageWindows(providers, "claudeAgent")).toHaveLength(1);
+  });
+
+  it("returns empty for a provider that reports no usage", () => {
+    expect(selectProviderUsageWindows(providers, "opencode")).toEqual([]);
+  });
+
+  it("returns empty for an unknown or absent instance", () => {
+    expect(selectProviderUsageWindows(providers, "cursor")).toEqual([]);
+    expect(selectProviderUsageWindows(providers, null)).toEqual([]);
+  });
+});
+
+describe("pickWorstUsageWindow", () => {
+  it("picks the bucket closest to running out", () => {
+    const worst = pickWorstUsageWindow([
+      usageWindow("session", 42),
+      usageWindow("weekly", 61),
+      usageWindow("weekly-fable", 12),
+    ]);
+    expect(worst?.id).toBe("weekly");
+  });
+
+  it("breaks ties by array order so the circle does not flicker", () => {
+    const worst = pickWorstUsageWindow([usageWindow("session", 50), usageWindow("weekly", 50)]);
+    expect(worst?.id).toBe("session");
+  });
+
+  it("returns null when there is nothing to show", () => {
+    expect(pickWorstUsageWindow([])).toBeNull();
+  });
+});
+
+describe("formatUsageRingLabel", () => {
+  it("renders bare integers so two digits fit inside the ring", () => {
+    expect(formatUsageRingLabel(0)).toBe("0");
+    expect(formatUsageRingLabel(42.6)).toBe("43");
+    expect(formatUsageRingLabel(100)).toBe("100");
+  });
+
+  it("clamps out-of-range readings rather than drawing them", () => {
+    expect(formatUsageRingLabel(140)).toBe("100");
+    expect(formatUsageRingLabel(Number.NaN)).toBe("0");
+  });
+});
+
+describe("formatUsagePercent", () => {
+  it("keeps one decimal below 10% where rounding would read as zero", () => {
+    expect(formatUsagePercent(0.4)).toBe("0.4%");
+    expect(formatUsagePercent(5)).toBe("5%");
+    expect(formatUsagePercent(61.4)).toBe("61%");
+  });
+});
+
+describe("formatUsageResetLabel", () => {
+  const at = (offsetMs: number) => isoAt(NOW_MS + offsetMs);
+
+  it("counts down within a day", () => {
+    expect(formatUsageResetLabel(at(2 * HOUR + 15 * MINUTE), NOW_MS)).toBe("resets in 2h 15m");
+    expect(formatUsageResetLabel(at(3 * HOUR), NOW_MS)).toBe("resets in 3h");
+    expect(formatUsageResetLabel(at(45 * MINUTE), NOW_MS)).toBe("resets in 45m");
+  });
+
+  it("never counts down to zero minutes", () => {
+    expect(formatUsageResetLabel(at(20_000), NOW_MS)).toBe("resets in 1m");
+  });
+
+  it("switches to an absolute time past a day, where a countdown stops helping", () => {
+    // Punctuation between the parts is ICU-version dependent, so assert on
+    // the parts rather than the exact rendering.
+    const label = formatUsageResetLabel(at(30 * HOUR), NOW_MS, "en-US");
+    expect(label).toMatch(/^resets \w{3}\b/);
+    expect(label).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("includes the date once a weekday alone would be ambiguous", () => {
+    // A weekly window resetting in 6 days reads identically to one
+    // resetting tomorrow if all you print is "Sat".
+    const label = formatUsageResetLabel(at(6 * DAY), NOW_MS, "en-US");
+    expect(label).toMatch(/Aug/);
+    expect(label).toMatch(/\b15\b/);
+  });
+
+  it("omits the line rather than guessing when there is no reset time", () => {
+    expect(formatUsageResetLabel(null, NOW_MS)).toBeNull();
+    expect(formatUsageResetLabel("not-a-date", NOW_MS)).toBeNull();
+  });
+
+  it("degrades gracefully once the reset is in the past", () => {
+    expect(formatUsageResetLabel(at(-HOUR), NOW_MS)).toBe("resets shortly");
+  });
+});
+
+describe("formatUsageUpdatedAtLabel", () => {
+  const at = (ageMs: number) => isoAt(NOW_MS - ageMs);
+
+  it("stays quiet while the reading is essentially current", () => {
+    expect(formatUsageUpdatedAtLabel(at(30_000), NOW_MS)).toBeNull();
+  });
+
+  it("reports age at the coarsest useful unit", () => {
+    expect(formatUsageUpdatedAtLabel(at(12 * MINUTE), NOW_MS)).toBe("as of 12m ago");
+    expect(formatUsageUpdatedAtLabel(at(5 * HOUR), NOW_MS)).toBe("as of 5h ago");
+    expect(formatUsageUpdatedAtLabel(at(3 * DAY), NOW_MS)).toBe("as of 3d ago");
+  });
+
+  it("says nothing when there is no reading", () => {
+    expect(formatUsageUpdatedAtLabel(null, NOW_MS)).toBeNull();
+    expect(formatUsageUpdatedAtLabel("not-a-date", NOW_MS)).toBeNull();
+  });
+});

--- a/packages/client-runtime/src/state/providerUsage.ts
+++ b/packages/client-runtime/src/state/providerUsage.ts
@@ -1,0 +1,170 @@
+/**
+ * Derivation and formatting for provider usage meters, shared by the web and
+ * mobile composers.
+ *
+ * The two clients draw very different things — three SVG rings on web, a
+ * popover list on mobile — but they answer the same questions about the same
+ * numbers, so the answers live here rather than being written twice.
+ *
+ * @module state/providerUsage
+ */
+import type { ProviderUsageWindow, ServerProvider } from "@t3tools/contracts";
+
+/** Past this the ring turns red: the user is close enough to care. */
+export const USAGE_CRITICAL_PERCENT = 90;
+
+export const isUsageWindowCritical = (window: ProviderUsageWindow): boolean =>
+  window.usedPercent > USAGE_CRITICAL_PERCENT;
+
+/** Clamp for drawing — a provider reporting 103% still draws a full ring. */
+export const clampUsagePercent = (usedPercent: number): number =>
+  Number.isFinite(usedPercent) ? Math.max(0, Math.min(100, usedPercent)) : 0;
+
+// Shared empty result. Returning a fresh `[]` would hand a new reference to
+// every consumer on every provider-status push — which happens mid-turn —
+// breaking the composer footer's memo and re-rendering the send button and
+// context meter for providers that will never show a usage meter at all.
+const NO_USAGE_WINDOWS: ReadonlyArray<ProviderUsageWindow> = [];
+
+/**
+ * The usage windows to draw for one provider instance, or an empty array
+ * when the instance reports none. Callers render nothing at all for an empty
+ * array — no placeholder, so switching to a provider without usage costs no
+ * layout shift.
+ */
+export const selectProviderUsageWindows = (
+  providers: ReadonlyArray<ServerProvider>,
+  instanceId: string | null | undefined,
+): ReadonlyArray<ProviderUsageWindow> => {
+  if (!instanceId) {
+    return NO_USAGE_WINDOWS;
+  }
+  const provider = providers.find((candidate) => candidate.instanceId === instanceId);
+  return provider?.usageLimits?.windows ?? NO_USAGE_WINDOWS;
+};
+
+export const selectProviderUsageUpdatedAt = (
+  providers: ReadonlyArray<ServerProvider>,
+  instanceId: string | null | undefined,
+): string | null => {
+  if (!instanceId) {
+    return null;
+  }
+  const provider = providers.find((candidate) => candidate.instanceId === instanceId);
+  return provider?.usageLimits?.updatedAt ?? null;
+};
+
+/**
+ * The window a single collapsed circle should show: the one closest to
+ * running out. Ties keep array order, so the server's ordering decides and
+ * the circle does not flicker between two equal buckets.
+ */
+export const pickWorstUsageWindow = (
+  windows: ReadonlyArray<ProviderUsageWindow>,
+): ProviderUsageWindow | null => {
+  let worst: ProviderUsageWindow | null = null;
+  for (const window of windows) {
+    if (worst === null || window.usedPercent > worst.usedPercent) {
+      worst = window;
+    }
+  }
+  return worst;
+};
+
+/**
+ * The digits inside the ring. Integer only and no `%` sign — the ring leaves
+ * roughly 13px of clear space, which fits two digits and nothing more.
+ */
+export const formatUsageRingLabel = (usedPercent: number): string =>
+  `${Math.round(clampUsagePercent(usedPercent))}`;
+
+/** The exact figure, for popovers where there is room to be precise. */
+export const formatUsagePercent = (usedPercent: number): string => {
+  const clamped = clampUsagePercent(usedPercent);
+  return clamped < 10 ? `${clamped.toFixed(1).replace(/\.0$/, "")}%` : `${Math.round(clamped)}%`;
+};
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Reset times inside a day read better as a countdown ("resets in 2h 15m");
+ * beyond that a countdown in hours stops being meaningful and an absolute
+ * time ("resets Mon 9 AM") is what someone actually plans around.
+ *
+ * Returns `null` for a missing or unparseable reset — callers omit the line
+ * rather than inventing one.
+ */
+export const formatUsageResetLabel = (
+  resetsAt: string | null,
+  nowMs: number,
+  locale?: string,
+): string | null => {
+  if (!resetsAt) {
+    return null;
+  }
+  const resetMs = Date.parse(resetsAt);
+  if (!Number.isFinite(resetMs)) {
+    return null;
+  }
+  const remainingMs = resetMs - nowMs;
+  if (remainingMs <= 0) {
+    return "resets shortly";
+  }
+  // Past a couple of days a weekday alone is ambiguous — a weekly window
+  // resetting in 6 days reads identically to one resetting tomorrow — so the
+  // date comes along once "next Saturday" stops meaning "this Saturday".
+  if (remainingMs >= 2 * DAY_MS) {
+    const formatted = new Intl.DateTimeFormat(locale, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(resetMs);
+    return `resets ${formatted}`;
+  }
+  if (remainingMs >= DAY_MS) {
+    const formatted = new Intl.DateTimeFormat(locale, {
+      weekday: "short",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(resetMs);
+    return `resets ${formatted}`;
+  }
+  const hours = Math.floor(remainingMs / HOUR_MS);
+  const minutes = Math.floor((remainingMs % HOUR_MS) / MINUTE_MS);
+  if (hours === 0) {
+    return `resets in ${Math.max(1, minutes)}m`;
+  }
+  return minutes === 0 ? `resets in ${hours}h` : `resets in ${hours}h ${minutes}m`;
+};
+
+/**
+ * How stale the reading is. Only surfaced once it is old enough to matter —
+ * a reading from the last minute is just "now" and saying so is noise.
+ */
+export const formatUsageUpdatedAtLabel = (
+  updatedAt: string | null,
+  nowMs: number,
+): string | null => {
+  if (!updatedAt) {
+    return null;
+  }
+  const updatedMs = Date.parse(updatedAt);
+  if (!Number.isFinite(updatedMs)) {
+    return null;
+  }
+  const ageMs = nowMs - updatedMs;
+  if (ageMs < MINUTE_MS) {
+    return null;
+  }
+  if (ageMs < HOUR_MS) {
+    return `as of ${Math.floor(ageMs / MINUTE_MS)}m ago`;
+  }
+  if (ageMs < DAY_MS) {
+    return `as of ${Math.floor(ageMs / HOUR_MS)}h ago`;
+  }
+  return `as of ${Math.floor(ageMs / DAY_MS)}d ago`;
+};

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -731,6 +731,17 @@ export function createServerEnvironmentAtoms<R, E>(
         key: ({ environmentId }) => environmentId,
       },
     }),
+    // Ambient trigger from the usage meters. Single-flighted per instance so
+    // a burst of focus/hover events collapses client-side too, on top of the
+    // server's own debounce.
+    refreshProviderUsage: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:server:refresh-provider-usage",
+      tag: WS_METHODS.serverRefreshProviderUsage,
+      concurrency: {
+        mode: "singleFlight",
+        key: ({ environmentId, input }) => JSON.stringify([environmentId, input.instanceId]),
+      },
+    }),
     updateProvider: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:server:update-provider",
       tag: WS_METHODS.serverUpdateProvider,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -228,6 +228,7 @@ export const WS_METHODS = {
   serverProbe: "server.probe",
   serverGetConfig: "server.getConfig",
   serverRefreshProviders: "server.refreshProviders",
+  serverRefreshProviderUsage: "server.refreshProviderUsage",
   serverUpdateProvider: "server.updateProvider",
   serverUpdateServer: "server.updateServer",
   serverUpdateServerWithProgress: "server.updateServerWithProgress",
@@ -304,6 +305,22 @@ export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProv
     instanceId: Schema.optional(ProviderInstanceId),
   }),
   success: ServerProviderUpdatedPayload,
+  error: EnvironmentAuthorizationError,
+});
+
+/**
+ * Ask the server to pull fresh account usage for one provider instance.
+ * Clients fire this on ambient triggers (window focus, thread opened,
+ * meter hovered) and the server debounces upstream calls, so callers never
+ * have to rate-limit themselves. The reading arrives out of band on the
+ * provider snapshot stream — this call resolves as soon as the refresh is
+ * scheduled.
+ */
+export const WsServerRefreshProviderUsageRpc = Rpc.make(WS_METHODS.serverRefreshProviderUsage, {
+  payload: Schema.Struct({
+    instanceId: ProviderInstanceId,
+  }),
+  success: Schema.Struct({}),
   error: EnvironmentAuthorizationError,
 });
 
@@ -814,6 +831,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerProbeRpc,
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,
+  WsServerRefreshProviderUsageRpc,
   WsServerUpdateProviderRpc,
   WsServerUpdateServerRpc,
   WsServerUpdateServerWithProgressRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -158,6 +158,35 @@ export const ServerProviderUpdateState = Schema.Struct({
 });
 export type ServerProviderUpdateState = typeof ServerProviderUpdateState.Type;
 
+/**
+ * One quota bucket a provider account is metered against — Claude's 5-hour
+ * session window, its weekly window, Codex's primary/secondary windows, and
+ * so on. Deliberately provider-agnostic: the UI maps over `windows` and never
+ * branches on which provider produced them, so adding a bucket later is a
+ * server-only change.
+ */
+export const ProviderUsageWindow = Schema.Struct({
+  // Stable identity for the bucket (`session`, `weekly`, `weekly-fable`,
+  // `codex-primary`, ...). Stays stable even when `label` changes.
+  id: TrimmedNonEmptyString,
+  label: TrimmedNonEmptyString,
+  usedPercent: Schema.Number,
+  // Absent when the provider does not report a reset time. Consumers omit
+  // the reset line rather than guessing one.
+  resetsAt: Schema.NullOr(IsoDateTime),
+});
+export type ProviderUsageWindow = typeof ProviderUsageWindow.Type;
+
+/**
+ * Account-level quota usage for one configured provider instance.
+ * `updatedAt` answers the only staleness question the UI asks ("as of when?").
+ */
+export const ProviderUsageLimits = Schema.Struct({
+  windows: Schema.Array(ProviderUsageWindow),
+  updatedAt: IsoDateTime,
+});
+export type ProviderUsageLimits = typeof ProviderUsageLimits.Type;
+
 export const ServerProvider = Schema.Struct({
   // Routing key for the configured instance this snapshot represents. This
   // is the only stable identity consumers may use for provider routing.
@@ -194,6 +223,10 @@ export const ServerProvider = Schema.Struct({
   skills: Schema.Array(ServerProviderSkill).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
   versionAdvisory: Schema.optionalKey(ServerProviderVersionAdvisory),
   updateState: Schema.optionalKey(ServerProviderUpdateState),
+  // Account-level quota usage for this instance. Absent for providers that
+  // do not report usage (Cursor, Grok, OpenCode) and before the first
+  // reading lands; consumers render nothing rather than a placeholder.
+  usageLimits: Schema.optionalKey(ProviderUsageLimits),
 });
 export type ServerProvider = typeof ServerProvider.Type;
 


### PR DESCRIPTION
> **Up front: this is a very large feature PR (~2,650 lines), which your contributing guide says not to open.** I am opening it anyway because the feature is finished, tested, and stable rather than a sketch, and it seemed more useful to you as working code than as an issue describing it. It is a UX addition, not a bug fix. **Please close it without ceremony if it is not a direction you want** — no reply needed, and I will not re-open or follow up.

## What Changed

Adds account usage meters to the composer.

**Contract** — a provider-agnostic `ProviderUsageLimits` in `packages/contracts`, shaped `{ id, label, usedPercent, resetsAt }`, so clients map over a list instead of branching per provider.

**Server** — an in-memory `ProviderUsageLimitsStore` fed by two sources:

- `ProviderUsageIngestion` consumes the `account.rate-limits.updated` runtime events the Claude and Codex adapters **already emit** and nothing currently reads. Zero extra network calls.
- `ProviderUsageRefresher` does a debounced (60s/instance) pull for Claude only, since Claude reports usage only on request. It reads the token the `claude` CLI already stored and calls the OAuth usage endpoint, which reports utilization **without spending message quota**. Codex needs no pull — it volunteers numbers over the app-server connection.

Provider-shaped payloads are flattened in `usageLimits.ts`. Every normalizer is total: anything unparseable yields no windows rather than an error.

**Web** — a ring per window beside the send button, collapsing to the worst window when the composer is narrow. Hover gives exact percentages and reset times.

**Mobile** — one toolbar button instead of three 44pt touch targets, listing the windows on tap.

Providers that do not report usage (Cursor, Grok, OpenCode) render nothing at all, so switching threads between providers costs no layout shift.

## Why

Right now you find out you are out of quota when a turn stops halfway through. The data to prevent that is already flowing — both adapters emit rate-limit events at the end of every turn and nothing consumes them.

Design decisions worth flagging, since they are the ones you would push back on:

- **Nothing is persisted.** A usage number is only interesting while it is roughly current, and both feeds repopulate within one turn of a restart.
- **The store only announces when a number actually moves.** `updatedAt` is stamped server-side on every reading, so publishing on the stamp would wake the registry and push the entire provider array — every model, capability, and skill — to every connected client once per turn, for no visible change.
- **No tickers.** Relative labels ("resets in 2h 15m") are stamped when the popover opens, not on an interval. A continuously repainting composer pegs the GPU on high-refresh displays.
- **Every failure path draws nothing.** No credentials, locked keychain, expired token, network blip — all resolve to blank meters. There is no error a user could act on here.

## UI Changes

Hovering a meter in the web composer:

![Claude usage popover in the composer, showing Session at 0%, Weekly at 17%, and Fable at 16% with reset times, beside the send button](https://raw.githubusercontent.com/gfsaaser24/t3code/7a10bc96ecee4e97063080a82926f1f2c46e405a/usage-meters.png)

Before is the same composer with no circles and no popover — the meters are purely additive, and providers that report no usage still render exactly that.

No motion or transitions were added, so there is no video.

## Testing

Branched off `main` at `3d74474f`. Focused tests for the normalizers, the store's merge/debounce/announce behavior, the ingestion seam, the token reader, and the web components. Typecheck and lint clean across server, web, mobile, contracts, and client-runtime.

Two pre-existing failures in `ProviderRegistry.test.ts` and `server.test.ts` reproduce identically on unmodified `main` on my machine — they look like Windows-only arg-quoting artifacts in the spawn mocks (`Unexpected args: ^"--version^"`), unrelated to this change.

## Checklist

- [ ] This PR is small and focused — **it is not; stated plainly above**
- [x] I explained what changed and why
- [x] I included a screenshot for the UI change
- [ ] I included a video for animation/interaction changes — no motion added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-cutting feature touching provider registry, OAuth credential reads, and macOS keychain subprocesses; failures are designed to degrade to empty meters rather than block turns.
> 
> **Overview**
> Adds **account quota usage** to the composer on web and mobile, driven by a new optional `usageLimits` field on `ServerProvider` and a `serverRefreshProviderUsage` RPC that schedules a background pull and returns immediately.
> 
> On the server, a **volatile in-memory store** merges full vs partial readings from turn-time `account.rate-limits.updated` events (Claude/Codex) and from **Claude-only on-demand pulls** (OAuth token from the CLI credentials path or macOS keychain, debounced per instance). **Codex** also seeds usage during status probe via `account/rateLimits/read` with a tight timeout. The **provider registry** decorates snapshots from the store, republishes on usage-only changes without disk writes, strips usage from status cache persistence, and **clears stored usage** when an instance is rebuilt or removed.
> 
> **Web** shows ring meters beside send (compact = worst window); **mobile** uses one gauge menu in the toolbar. `ControlPillMenu` gains a render-prop child so Android triggers stay tappable. Shared formatting/selection lives in `@t3tools/client-runtime/state/provider-usage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a8a88532fbaca232ca548af9a747fd5d9d68b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider account usage meters to the composer input area
> - Adds per-provider usage windows (percent used, reset time) to the web and mobile composer toolbars, shown as circular ring meters that turn critical above 90%.
> - Introduces a server-side in-memory `ProviderUsageLimitsStore` that tracks usage per provider instance, populated via runtime turn events (`ProviderUsageIngestionLive`) and on-demand HTTP fetches (`ProviderUsageRefresher`) for Claude and Codex.
> - Adds a new `serverRefreshProviderUsage` WebSocket RPC that schedules a background usage refresh without blocking the caller; client-side calls are deduplicated with single-flight keying.
> - Usage is refreshed on composer mount, on window/app focus, and when the usage popover is opened; server-side refreshes are debounced to once per 60 seconds per instance.
> - Usage data is decorated onto `ServerProvider` snapshots in the registry and propagated to clients without disk persistence or waiting for full status probes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75a8a88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->