### PR TITLE
fix(web): usage page says when model rates are unavailable

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,4 +1,4 @@
-import type { UsageProviderKind } from "@t3tools/contracts";
+import type { UsagePricingStatus, UsageProviderKind } from "@t3tools/contracts";
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
@@ -137,6 +137,9 @@ export function UsagePage() {
                   environments={environments}
                   duplicateSources={merged.duplicateSources}
                   staleEnvironments={merged.staleEnvironments}
+                  pricingStatus={merged.pricingStatus}
+                  unpricedShare={merged.costQuality.unpricedShare}
+                  records={merged.records}
                 />
 
                 {/* Cost first: the financial answer, then the provider split. */}
@@ -407,25 +410,52 @@ function Metric({
 }
 
 /**
- * Says plainly when the totals are incomplete: an environment that failed, or
- * one whose transcripts another environment already reported. Environments
- * that are still answering never reach this notice; the page shows the
- * loading skeleton until every one is terminal.
+ * Says plainly when the totals are incomplete: an environment that failed, one
+ * whose transcripts another environment already reported, or a rate table that
+ * never loaded. Environments that are still answering never reach this notice;
+ * the page shows the loading skeleton until every one is terminal.
  */
 function UsageCoverageNotice({
   environments,
   duplicateSources,
   staleEnvironments,
+  pricingStatus,
+  unpricedShare,
+  records,
 }: {
   readonly environments: readonly EnvironmentUsageStatus[];
   readonly duplicateSources: readonly string[];
   readonly staleEnvironments: readonly string[];
+  readonly pricingStatus: UsagePricingStatus;
+  readonly unpricedShare: number;
+  readonly records: number;
 }) {
   const failed = environments.filter((environment) => environment.error !== null);
   const stale = environments.filter((environment) =>
     staleEnvironments.includes(environment.environmentId),
   );
-  if (failed.length === 0 && stale.length === 0 && duplicateSources.length === 0) {
+  // Rate provenance only matters once there is something to price, and only
+  // `unavailable` is worth a line: stale rates move cost by rounding, not by
+  // orders of magnitude. `unpricedShare` carries the magnitude either way, so
+  // the message never has to guess how much cost went missing.
+  //
+  // The failure and the share are stated as separate facts rather than cause
+  // and effect. They are aggregated independently, so across several devices
+  // the environment whose rates failed need not be the one that contributed
+  // the unpriced records.
+  const pricingNotice =
+    records === 0 || unpricedShare === 0
+      ? null
+      : pricingStatus === "unavailable"
+        ? `Model rates could not be loaded. ${formatPercent(unpricedShare)} of responses are excluded from cost. Token counts are unaffected.`
+        : `${formatPercent(unpricedShare)} of responses used a model with no published rate and are excluded from cost.`;
+
+  if (
+    failed.length === 0 &&
+    stale.length === 0 &&
+    duplicateSources.length === 0 &&
+    pricingNotice === null
+  ) {
     return null;
   }
 
@@ -445,6 +475,7 @@ function UsageCoverageNotice({
           {duplicateSources.join(", ")}
         </span>
       ) : null}
+      {pricingNotice === null ? null : <span>{pricingNotice}</span>}
     </div>
   );
 }

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -3,6 +3,7 @@ import {
   type EnvironmentId,
   type UsageBucket,
   type UsageDay,
+  type UsagePricingStatus,
   type UsageProviderKind,
   type UsageSummary,
 } from "@t3tools/contracts";
@@ -42,6 +43,7 @@ function summary(
     distinctSessions?: number;
   }[],
   contractVersion: number = USAGE_CONTRACT_VERSION,
+  pricingStatus: UsagePricingStatus = "fresh",
 ): UsageSummary {
   return {
     contractVersion,
@@ -64,7 +66,7 @@ function summary(
       distinctSessions: source.distinctSessions ?? 1,
       message: null,
     })),
-    pricing: { status: "fresh", source: "litellm", fetchedAt: null, knownModels: 10 },
+    pricing: { status: pricingStatus, source: "litellm", fetchedAt: null, knownModels: 10 },
     scanDurationMs: 1,
   };
 }
@@ -187,6 +189,49 @@ describe("mergeUsage", () => {
     expect(merged.providers[0]?.costShare).toBeCloseTo(0.75, 5);
     expect(merged.costQuality.unpricedShare).toBeCloseTo(0.5, 5);
     expect(merged.costQuality.cacheSavingsUsd).toBe(4);
+  });
+
+  it("reports the weakest rate table among contributing environments", () => {
+    // #given one device priced against a live rate table and one that never
+    // loaded it
+    const environments = [
+      environment(
+        "env-a",
+        summary([bucket()], [{ provider: "claude", hostId: "mac-a", homePath: "/a/.claude" }]),
+      ),
+      environment(
+        "env-b",
+        summary(
+          [bucket({ costUsd: 0, costSource: "unpriced", unpricedRecords: 5 })],
+          [{ provider: "claude", hostId: "mac-b", homePath: "/b/.claude" }],
+          USAGE_CONTRACT_VERSION,
+          "unavailable",
+        ),
+      ),
+    ];
+
+    // #when the summaries are merged
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+
+    // #then the merged cost is an undercount and says so
+    expect(merged.pricingStatus).toBe("unavailable");
+  });
+
+  it("ignores the rate table of an environment that contributed no buckets", () => {
+    // #given an idle second device whose rate table failed to load
+    const environments = [
+      environment(
+        "env-a",
+        summary([bucket()], [{ provider: "claude", hostId: "mac-a", homePath: "/a/.claude" }]),
+      ),
+      environment("env-b", summary([], [], USAGE_CONTRACT_VERSION, "unavailable")),
+    ];
+
+    // #when the summaries are merged
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+
+    // #then it cannot have skewed a cost it did not contribute to
+    expect(merged.pricingStatus).toBe("fresh");
   });
 
   it("keeps two machines apart when hostname and home path collide", () => {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -9,6 +9,7 @@
 import type {
   EnvironmentId,
   UsageBucket,
+  UsagePricingStatus,
   UsageProviderKind,
   UsageSourceFingerprint,
   UsageSummary,
@@ -54,6 +55,12 @@ export interface CostQuality {
 
 export interface MergedUsage {
   readonly costUsd: number;
+  /**
+   * Weakest rate-table provenance among the environments that contributed. A
+   * single environment without rates makes the merged cost an undercount, so
+   * the pessimistic status is the honest one to report.
+   */
+  readonly pricingStatus: UsagePricingStatus;
   readonly uncachedInputTokens: number;
   readonly cachedInputTokens: number;
   readonly cacheCreationTokens: number;
@@ -155,8 +162,15 @@ function bucketTokens(bucket: UsageBucket): number {
   );
 }
 
+const PRICING_STATUS_RANK: Record<UsagePricingStatus, number> = {
+  unavailable: 0,
+  cached: 1,
+  fresh: 2,
+};
+
 const EMPTY_MERGED: MergedUsage = {
   costUsd: 0,
+  pricingStatus: "unavailable",
   uncachedInputTokens: 0,
   cachedInputTokens: 0,
   cacheCreationTokens: 0,
@@ -233,13 +247,17 @@ export function mergeUsage(
     }
   >();
   const contributingEnvironments: EnvironmentId[] = [];
+  const contributingPricingStatuses: UsagePricingStatus[] = [];
 
   for (const environment of current) {
     const { buckets, sessions: environmentSessions } = ownedContribution(
       environment,
       ownerByFingerprint,
     );
-    if (buckets.length > 0) contributingEnvironments.push(environment.environmentId);
+    if (buckets.length > 0) {
+      contributingEnvironments.push(environment.environmentId);
+      contributingPricingStatuses.push(environment.summary.pricing.status);
+    }
     sessions += environmentSessions;
 
     for (const bucket of buckets) {
@@ -326,8 +344,20 @@ export function mergeUsage(
     }))
     .sort((a, b) => a.day.localeCompare(b.day));
 
+  // An environment that contributed nothing cannot have skewed cost, so its rate
+  // table is not evidence about the numbers on screen.
+  const pricingStatuses =
+    contributingPricingStatuses.length > 0
+      ? contributingPricingStatuses
+      : current.map((environment) => environment.summary.pricing.status);
+
   return {
     costUsd,
+    pricingStatus: pricingStatuses.reduce<UsagePricingStatus>(
+      (weakest, status) =>
+        PRICING_STATUS_RANK[status] < PRICING_STATUS_RANK[weakest] ? status : weakest,
+      "fresh",
+    ),
     uncachedInputTokens,
     cachedInputTokens,
     cacheCreationTokens,


### PR DESCRIPTION
Closes #5948

## What Changed

`mergeUsage` now derives a `pricingStatus` from the environments that actually contributed buckets, and `UsageCoverageNotice` renders one line when the model rate table could not be loaded:

> Model rates could not be loaded, so 100.0% of responses are excluded from cost. Token counts are unaffected.

No contract change, no new UI surface, no change to any cost calculation. Two tests added in `usageMerge.test.ts`.

## Why

When the LiteLLM rate table fails to fetch, `UsageService.ensureRates` swallows the failure and every bucket falls through `lookupRate` to `{ costUsd: 0, costSource: "unpriced" }`. The usage page then renders a confident `$0.00` for every model, `0.0% of cost` for every provider, and `$0.00` cache savings — beside perfectly correct token counts. It is indistinguishable from having spent nothing.

Degrading instead of failing the page is the right call, and this PR does not change it. The bug is that it degrades invisibly.

The server already ships the diagnosis: `UsageSummary.pricing.status` carries `fresh | cached | unavailable`, with a doc comment saying it exists "so the UI can be honest about how good the cost figures are", and every bucket carries `unpricedRecords`. Both cross the wire on every request and no client reads either — `grep -rn "pricing" apps/web/src apps/mobile/src` returns nothing. This plumbs the existing signal to the existing notice strip.

Two deliberate details:

- The magnitude comes from `unpricedShare`, not an assumption. Codex buckets can carry `providerReported` cost even with no rate table, so "everything reads $0.00" would be an overclaim. This also makes the message correct for the partial case: a genuinely new model missing from LiteLLM's table silently undercounts cost today, and gets the same message with a real percentage.
- `cached` gets no line. Stale rates move cost by rounding, not orders of magnitude; warning about it would be noise.

Reproduced on a machine behind TLS inspection, where the fetch to `raw.githubusercontent.com` fails. Diagnosing it required reading `server.trace.ndjson` and noticing `usage-model-rates.json` was absent from the state dir. That should not be the discovery path.

## UI Changes

Before and after, same data, same viewport, same commit base — the only difference is the notice line.

| before | after |
| :---: | :---: |
| <img width="1244" height="775" alt="Screenshot 2026-08-10 at 16 31 32" src="https://github.com/user-attachments/assets/fb43ae32-16c4-4eae-879f-49c65861af1c" /> | <img width="1244" height="775" alt="Screenshot 2026-08-10 at 16 40 59" src="https://github.com/user-attachments/assets/3453220e-58cc-4bc9-9e01-5c5f4cf9daed" /> |

Follow-up: #5949 tracks the underlying fragility — the rate table has no bundled fallback, so a fresh offline install has no prices at all. Deliberately not addressed here.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (n/a — static text, no motion)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show pricing unavailability notice on the usage page when model rates cannot be loaded
> - Adds a `pricingStatus` field to `MergedUsage` in [usageMerge.ts](https://github.com/pingdotgg/t3code/pull/5947/files#diff-143d7ed21cccd3774754bd4f261d302d61b7997008db82ed56a3920e176a57b3), computed as the weakest rate-table status (`unavailable` < `cached` < `fresh`) across environments that contributed usage buckets; idle environments are excluded.
> - Updates `UsageCoverageNotice` in [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/5947/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) to display an explanatory message when some responses are unpriced, distinguishing between rates being unavailable (failed to load) and models having no published rate.
> - No notice is shown when there are no records or the unpriced share is zero.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38d1f68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only messaging plus merge metadata derived from existing pricing fields; cost math and contracts are unchanged.
> 
> **Overview**
> When model rates fail to load or some responses have no published price, the usage page can show **$0 cost** while token counts look correct. This PR surfaces that gap in the existing coverage notice strip—no new API fields and no change to how cost is calculated.
> 
> **`mergeUsage`** now exposes **`pricingStatus`** on merged totals: the **weakest** `UsageSummary.pricing.status` among environments that actually contributed buckets (`unavailable` &lt; `cached` &lt; `fresh`). Idle environments with failed rate tables do not drag down the merged status.
> 
> **`UsageCoverageNotice`** shows a line when there are records and **`unpricedShare` &gt; 0**: either that rates could not be loaded, or that a percentage of responses lack a published rate (with token counts called out as unaffected where relevant). **`cached`** pricing does not get its own warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d1f685a4cdc94e27af122786e48f50133ace3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->