### PR TITLE
fix(server): respect OpenCode's configured default agent

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -207,6 +207,80 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
     }),
   );
 
+  it.effect("prefers OpenCode's configured default agent over the built-in fallback", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.inventory = {
+        providerList: {
+          connected: ["openai"],
+          all: [
+            {
+              id: "openai",
+              name: "OpenAI",
+              models: { "gpt-5.4": { id: "gpt-5.4", name: "GPT-5.4" } },
+            },
+          ],
+          default: {},
+        },
+        agents: [
+          { name: "build", hidden: false, mode: "primary" },
+          { name: "plan", hidden: false, mode: "primary" },
+        ],
+        defaultAgent: "plan",
+      };
+
+      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const model = snapshot.models.find((entry) => entry.slug === "openai/gpt-5.4");
+
+      NodeAssert.ok(model);
+      const agentDescriptor = model.capabilities?.optionDescriptors?.find(
+        (descriptor) => descriptor.id === "agent" && descriptor.type === "select",
+      );
+      NodeAssert.ok(agentDescriptor && agentDescriptor.type === "select");
+      NodeAssert.equal(
+        agentDescriptor.options.find((option) => option.isDefault === true)?.id,
+        "plan",
+      );
+      NodeAssert.equal(agentDescriptor.currentValue, "plan");
+    }),
+  );
+
+  it.effect("ignores a configured default agent that is not selectable", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.inventory = {
+        providerList: {
+          connected: ["openai"],
+          all: [
+            {
+              id: "openai",
+              name: "OpenAI",
+              models: { "gpt-5.4": { id: "gpt-5.4", name: "GPT-5.4" } },
+            },
+          ],
+          default: {},
+        },
+        agents: [
+          { name: "build", hidden: false, mode: "primary" },
+          { name: "plan", hidden: false, mode: "primary" },
+          { name: "reviewer", hidden: false, mode: "subagent" },
+        ],
+        defaultAgent: "reviewer",
+      };
+
+      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const model = snapshot.models.find((entry) => entry.slug === "openai/gpt-5.4");
+
+      NodeAssert.ok(model);
+      const agentDescriptor = model.capabilities?.optionDescriptors?.find(
+        (descriptor) => descriptor.id === "agent" && descriptor.type === "select",
+      );
+      NodeAssert.ok(agentDescriptor && agentDescriptor.type === "select");
+      NodeAssert.equal(
+        agentDescriptor.options.find((option) => option.isDefault === true)?.id,
+        "build",
+      );
+    }),
+  );
+
   it.effect("does not spawn a local server for health check (uses CLI instead)", () =>
     Effect.gen(function* () {
       yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -160,7 +160,19 @@ function inferDefaultVariant(
   return undefined;
 }
 
-function inferDefaultAgent(agents: ReadonlyArray<Agent>): string | undefined {
+function inferDefaultAgent(
+  agents: ReadonlyArray<Agent>,
+  configuredDefault: string | undefined,
+): string | undefined {
+  const configured = configuredDefault?.trim();
+  if (configured !== undefined && configured.length > 0) {
+    // Only honour a configured default that is actually selectable here, so a
+    // hidden or subagent-only value still falls back to the built-in ordering.
+    const configuredAgent = agents.find((agent) => agent.name === configured);
+    if (configuredAgent !== undefined) {
+      return configuredAgent.name;
+    }
+  }
   return agents.find((agent) => agent.name === "build")?.name ?? agents[0]?.name ?? undefined;
 }
 
@@ -172,6 +184,7 @@ function openCodeCapabilitiesForModel(input: {
   readonly providerID: string;
   readonly model: ProviderListResponse["all"][number]["models"][string];
   readonly agents: ReadonlyArray<Agent>;
+  readonly defaultAgent: string | undefined;
 }): ModelCapabilities {
   const variantValues = Object.keys(input.model.variants ?? {});
   const defaultVariant = inferDefaultVariant(input.providerID, variantValues);
@@ -183,7 +196,7 @@ function openCodeCapabilitiesForModel(input: {
   const primaryAgents = input.agents.filter(
     (agent) => !agent.hidden && (agent.mode === "primary" || agent.mode === "all"),
   );
-  const defaultAgent = inferDefaultAgent(primaryAgents);
+  const defaultAgent = inferDefaultAgent(primaryAgents, input.defaultAgent);
   const agentOptions = primaryAgents.map((agent) =>
     defaultAgent === agent.name
       ? { id: agent.name, label: titleCaseSlug(agent.name), isDefault: true as const }
@@ -242,6 +255,7 @@ function flattenOpenCodeModels(input: OpenCodeInventory): ReadonlyArray<ServerPr
           providerID: provider.id,
           model,
           agents: input.agents,
+          defaultAgent: input.defaultAgent,
         }),
       });
     }

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -101,6 +101,11 @@ export interface OpenCodeCommandResult {
 export interface OpenCodeInventory {
   readonly providerList: ProviderListResponse;
   readonly agents: ReadonlyArray<Agent>;
+  /**
+   * OpenCode's configured `default_agent`, when the server reports one. Absent
+   * for servers that do not expose it and for CLI-sourced inventories.
+   */
+  readonly defaultAgent?: string;
 }
 
 export interface ParsedOpenCodeModelSlug {
@@ -649,9 +654,23 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       Effect.map((result) => result.data ?? []),
     );
 
+  // The configured default agent only refines capability defaults, so a server
+  // that cannot report it must not fail the whole inventory load.
+  const loadDefaultAgent = (client: OpencodeClient) =>
+    runOpenCodeSdk("config.get", () => client.config.get()).pipe(
+      Effect.map((result) => result.data?.default_agent),
+      Effect.orElseSucceed(() => undefined),
+    );
+
   const loadOpenCodeInventory: OpenCodeRuntimeShape["loadOpenCodeInventory"] = (client) =>
-    Effect.all([loadProviders(client), loadAgents(client)], { concurrency: "unbounded" }).pipe(
-      Effect.map(([providerList, agents]) => ({ providerList, agents })),
+    Effect.all([loadProviders(client), loadAgents(client), loadDefaultAgent(client)], {
+      concurrency: "unbounded",
+    }).pipe(
+      Effect.map(([providerList, agents, defaultAgent]) => ({
+        providerList,
+        agents,
+        ...(defaultAgent === undefined ? {} : { defaultAgent }),
+      })),
     );
 
   const loadInventoryFromCli: OpenCodeRuntimeShape["loadInventoryFromCli"] = (input) =>


### PR DESCRIPTION
## What changed

The OpenCode provider now honours OpenCode's configured `default_agent` when deciding which agent option to mark as the default, instead of always preferring `build`.

- `opencodeRuntime.ts`: `OpenCodeInventory` gains an optional `defaultAgent`, loaded from `client.config.get()` in parallel with the existing provider and agent lookups.
- `OpenCodeProvider.ts`: `inferDefaultAgent` takes the configured value and prefers it when it names a selectable agent, otherwise keeps the existing `build` → first-agent fallback.

## Why

OpenCode already exposes the user's configured default through `GET /config`:

```console
$ curl -s -u opencode:… http://opencode-server:4096/config | jq .default_agent
"DIT-Auto"
```

t3 fetched everything else from that same client but dropped this field, so a user who had set `default_agent` still got `build` preselected on every model. The agent picker disagreed with the server's own configuration, and there was no way to change it from the t3 side.

## Behaviour and safety

- No configured `default_agent` → unchanged. Existing behaviour is the fallback path.
- Configured value that is hidden, subagent-only, or unknown → unchanged. The lookup runs against the already-filtered primary agent list, so only a genuinely selectable agent can win.
- `config.get()` failing (older or restricted server) → `Effect.orElseSucceed(() => undefined)` degrades to the old behaviour rather than failing the whole inventory load.
- CLI-sourced inventories are untouched; `defaultAgent` is simply absent there.

## Tests

Two cases added to `OpenCodeProvider.test.ts`: a configured default that is selectable becomes the default option, and one that is not selectable falls back to `build`. The existing test asserting the `build` default with no configuration still passes.

```
Tests  9 passed (9)
```

Verified the new tests fail without the production change (`1 failed | 8 passed`), and `vp fmt --check` plus `vp lint` are clean on the touched paths.

No UI change, so no screenshots apply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized provider capability defaults with graceful degradation on config fetch failure; no auth, data, or API contract changes.
> 
> **Overview**
> The OpenCode provider now aligns model **agent** picker defaults with OpenCode’s server `default_agent` instead of always preselecting `build`.
> 
> Inventory loading fetches `default_agent` via `config.get()` alongside providers and agents; failures degrade to the previous behavior so inventory still loads. **`inferDefaultAgent`** uses that value only when it names a **primary/selectable** agent; hidden or subagent-only names still fall back to `build` then the first agent. CLI-based inventories are unchanged (`defaultAgent` stays absent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4beb9367c8533a6f6a41801a55eefc5e7f2986ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent capability default to respect OpenCode's configured `defaultAgent`
> - `loadOpenCodeInventory` in [`opencodeRuntime.ts`](https://github.com/pingdotgg/t3code/pull/5950/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) now fetches the server's `default_agent` via `client.config.get()` concurrently with providers and agents, storing it as `defaultAgent` on the inventory (absent on failure or when not reported).
> - `inferDefaultAgent` in [`OpenCodeProvider.ts`](https://github.com/pingdotgg/t3code/pull/5950/files#diff-4477b51690b8bf5db4f32c13ac9bb4ed2be7798d366111f84b38be236cc034bd) accepts the configured default and uses it when it matches a selectable (primary, non-hidden) agent, falling back to `'build'` or the first available agent otherwise.
> - Behavioral Change: the `agent` option descriptor's `default` and `currentValue` may now differ from `'build'` when the server reports a valid configured default agent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4beb936.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->