### PR TITLE
feat(files): add ignored-file visibility toggle

### DIFF
--- a/apps/mobile/src/components/AndroidScreenHeader.tsx
+++ b/apps/mobile/src/components/AndroidScreenHeader.tsx
@@ -12,6 +12,7 @@ export interface AndroidHeaderAction {
   readonly icon: AppSymbolName;
   readonly onPress: () => void;
   readonly disabled?: boolean;
+  readonly selected?: boolean;
 }
 
 export function AndroidHeaderIconButton(props: {
@@ -19,6 +20,7 @@ export function AndroidHeaderIconButton(props: {
   readonly icon: AppSymbolName;
   readonly onPress?: () => void;
   readonly disabled?: boolean;
+  readonly selected?: boolean;
 }) {
   const foregroundColor = useThemeColor("--color-foreground");
   const disabledColor = useThemeColor("--color-icon-subtle");
@@ -27,11 +29,13 @@ export function AndroidHeaderIconButton(props: {
     <Pressable
       accessibilityLabel={props.accessibilityLabel}
       accessibilityRole="button"
+      accessibilityState={{ selected: props.selected }}
       disabled={props.disabled}
       hitSlop={8}
       onPress={props.onPress}
       className={cn(
-        "size-11 items-center justify-center rounded-full bg-subtle",
+        "size-11 items-center justify-center rounded-full",
+        props.selected ? "bg-subtle-strong" : "bg-subtle",
         props.disabled && "opacity-55",
       )}
     >
@@ -102,6 +106,7 @@ export function AndroidScreenHeader(props: {
             disabled={action.disabled}
             icon={action.icon}
             onPress={action.onPress}
+            selected={action.selected}
           />
         ))}
         {props.trailing}

--- a/apps/mobile/src/features/files/FileTreeBrowser.tsx
+++ b/apps/mobile/src/features/files/FileTreeBrowser.tsx
@@ -55,7 +55,7 @@ const FileTreeRow = memo(function FileTreeRow(props: {
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={node.path}
+      accessibilityLabel={node.ignored ? `${node.path}, ignored` : node.path}
       onPressIn={() => {
         if (node.kind === "file") {
           props.onPreviewFile?.(node.path);
@@ -84,13 +84,18 @@ const FileTreeRow = memo(function FileTreeRow(props: {
       ) : (
         <View className="w-3" />
       )}
-      <PierreEntryIcon path={node.path} kind={node.kind} size={17} />
+      <View className={cn(node.ignored && "opacity-50")}>
+        <PierreEntryIcon path={node.path} kind={node.kind} size={17} />
+      </View>
       <Text
         className={cn(
           "min-w-0 flex-1 text-sm leading-normal",
-          props.selected
-            ? "font-t3-bold text-foreground"
-            : "font-t3-medium text-foreground-secondary",
+          props.selected ? "font-t3-bold" : "font-t3-medium",
+          node.ignored
+            ? "text-foreground-tertiary"
+            : props.selected
+              ? "text-foreground"
+              : "text-foreground-secondary",
         )}
         numberOfLines={1}
       >

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -242,6 +242,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
   const { fileInspector, layout, panes, showAuxiliaryPane, togglePrimarySidebar } =
     useAdaptiveWorkspaceLayout();
   const [searchQuery, setSearchQuery] = useState("");
+  const [includeIgnored, setIncludeIgnored] = useState(false);
   const colorScheme = useColorScheme();
   const isAndroid = Platform.OS === "android";
   const highlightTheme = colorScheme === "dark" ? "dark" : "light";
@@ -254,7 +255,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
     environmentId !== null && cwd !== null && !fileInspector.supported
       ? projectEnvironment.listEntries({
           environmentId,
-          input: { cwd },
+          input: { cwd, includeIgnored },
         })
       : null,
   );
@@ -403,6 +404,12 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
             onBack={handleReturnToThread}
             actions={[
               {
+                accessibilityLabel: "Show ignored files",
+                icon: includeIgnored ? "eye" : "eye.slash",
+                onPress: () => setIncludeIgnored((current) => !current),
+                selected: includeIgnored,
+              },
+              {
                 accessibilityLabel: "Refresh files",
                 icon: "arrow.clockwise",
                 onPress: entriesQuery.refresh,
@@ -424,6 +431,14 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
         </>
       ) : (
         <>
+          <NativeHeaderToolbar placement="right">
+            <NativeHeaderToolbar.Button
+              accessibilityLabel="Show ignored files"
+              icon={includeIgnored ? "eye" : "eye.slash"}
+              onPress={() => setIncludeIgnored((current) => !current)}
+              selected={includeIgnored}
+            />
+          </NativeHeaderToolbar>
           {layout.usesSplitView ? (
             <NativeHeaderToolbar placement="left">
               <NativeHeaderToolbar.Button

--- a/apps/mobile/src/features/files/fileTree.test.ts
+++ b/apps/mobile/src/features/files/fileTree.test.ts
@@ -106,4 +106,17 @@ describe("mobile file tree helpers", () => {
 
     expect([...defaultExpandedTreePaths(tree)]).toEqual(["src"]);
   });
+
+  it("marks explicit ignored entries without muting their inferred ancestors", () => {
+    const tree = buildFileTree([
+      { kind: "directory", path: "cache", ignored: true },
+      { kind: "file", path: "cache/data.json", ignored: true },
+      { kind: "file", path: "src/index.ts" },
+    ]);
+
+    const cache = tree.find((node) => node.path === "cache");
+    expect(cache?.ignored).toBe(true);
+    expect(cache?.children[0]).toMatchObject({ path: "cache/data.json", ignored: true });
+    expect(tree.find((node) => node.path === "src")?.ignored).toBe(false);
+  });
 });

--- a/apps/mobile/src/features/files/fileTree.ts
+++ b/apps/mobile/src/features/files/fileTree.ts
@@ -5,6 +5,7 @@ export interface FileTreeNode {
   readonly path: string;
   readonly name: string;
   readonly kind: ProjectEntry["kind"];
+  readonly ignored: boolean;
   readonly children: ReadonlyArray<FileTreeNode>;
   readonly searchSegments: ReadonlyArray<string>;
   readonly searchWords: ReadonlyArray<string>;
@@ -19,6 +20,7 @@ interface MutableFileTreeNode {
   path: string;
   name: string;
   kind: ProjectEntry["kind"];
+  ignored: boolean;
   children: Map<string, MutableFileTreeNode>;
 }
 
@@ -26,11 +28,13 @@ function createMutableNode(
   path: string,
   name: string,
   kind: ProjectEntry["kind"],
+  ignored = false,
 ): MutableFileTreeNode {
   return {
     path,
     name,
     kind,
+    ignored,
     children: new Map(),
   };
 }
@@ -68,6 +72,7 @@ function freezeNode(node: MutableFileTreeNode): FileTreeNode {
     path: node.path,
     name: node.name,
     kind: node.kind,
+    ignored: node.ignored,
     children: [...node.children.values()].sort(compareNodes).map(freezeNode),
     searchSegments: searchTerms.segments,
     searchWords: searchTerms.words,
@@ -105,10 +110,11 @@ export function buildFileTree(entries: ReadonlyArray<ProjectEntry>): ReadonlyArr
       const kind = isLeaf ? entry.kind : "directory";
       let child = current.children.get(part);
       if (!child) {
-        child = createMutableNode(path, part, kind);
+        child = createMutableNode(path, part, kind, isLeaf && (entry.ignored ?? false));
         current.children.set(part, child);
       } else if (isLeaf) {
         child.kind = entry.kind;
+        child.ignored = entry.ignored ?? false;
       }
       current = child;
     }

--- a/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
+++ b/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native-screens";
 
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
+import { cn } from "../../lib/cn";
 import { nativeHeaderScrollEdgeEffects } from "../../native/StackHeader";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { projectEnvironment } from "../../state/projects";
@@ -27,6 +28,7 @@ export function ThreadFileNavigatorPane(props: {
   readonly onSelectFile: (path: string) => void;
 }) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [includeIgnored, setIncludeIgnored] = useState(false);
   const colorScheme = useColorScheme();
   const highlightTheme = colorScheme === "dark" ? "dark" : "light";
   const iconColor = String(useThemeColor("--color-icon-muted"));
@@ -36,7 +38,7 @@ export function ThreadFileNavigatorPane(props: {
   const entriesQuery = useEnvironmentQuery(
     projectEnvironment.listEntries({
       environmentId: props.environmentId,
-      input: { cwd: props.cwd },
+      input: { cwd: props.cwd, includeIgnored },
     }),
   );
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
@@ -55,6 +57,17 @@ export function ThreadFileNavigatorPane(props: {
     () =>
       [
         {
+          accessibilityLabel: "Show ignored files",
+          icon: { name: includeIgnored ? "eye" : "eye.slash", type: "sfSymbol" as const },
+          identifier: "thread-file-navigator-ignored-files",
+          onPress: () => setIncludeIgnored((current) => !current),
+          selected: includeIgnored,
+          sharesBackground: false,
+          tintColor: foregroundColor,
+          type: "button" as const,
+          width: 44,
+        },
+        {
           accessibilityLabel: "Refresh files",
           icon: { name: "arrow.clockwise", type: "sfSymbol" as const },
           identifier: "thread-file-navigator-refresh",
@@ -65,7 +78,7 @@ export function ThreadFileNavigatorPane(props: {
           width: 44,
         },
       ] as ComponentProps<typeof ScreenStackHeaderConfig>["headerRightBarButtonItems"],
-    [entriesQuery.refresh, foregroundColor],
+    [entriesQuery.refresh, foregroundColor, includeIgnored],
   );
 
   const fileTree = (
@@ -145,6 +158,24 @@ export function ThreadFileNavigatorPane(props: {
               {props.projectName}
             </Text>
           </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Show ignored files"
+            accessibilityState={{ selected: includeIgnored }}
+            hitSlop={8}
+            className={cn(
+              "h-8 w-8 items-center justify-center rounded-full active:bg-subtle",
+              includeIgnored && "bg-subtle-strong",
+            )}
+            onPress={() => setIncludeIgnored((current) => !current)}
+          >
+            <SymbolView
+              name={includeIgnored ? "eye" : "eye.slash"}
+              size={14}
+              tintColor={iconColor}
+              type="monochrome"
+            />
+          </Pressable>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Refresh files"

--- a/apps/mobile/src/native/StackHeader.tsx
+++ b/apps/mobile/src/native/StackHeader.tsx
@@ -310,6 +310,7 @@ function convertToolbarChild(child: ReactNode): NativeStackHeaderItem | null {
         typeof child.props.onPress === "function"
           ? (child.props.onPress as () => void)
           : () => undefined,
+      selected: typeof child.props.selected === "boolean" ? child.props.selected : undefined,
       sharesBackground: !child.props.separateBackground,
       tintColor: child.props.tintColor as ColorValue | undefined,
       variant: "plain",
@@ -406,6 +407,7 @@ function NativeHeaderToolbarButton(_props: {
   readonly icon?: string;
   readonly label?: string;
   readonly onPress?: () => void;
+  readonly selected?: boolean;
   readonly separateBackground?: boolean;
   readonly tintColor?: ColorValue;
 }) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -326,7 +326,10 @@ const PreviewLayerLive = Layer.empty.pipe(
   Layer.provideMerge(PortScannerLayerLive),
 );
 
-const WorkspaceEntriesLayerLive = WorkspaceEntries.layer.pipe(Layer.provide(WorkspacePaths.layer));
+const WorkspaceEntriesLayerLive = WorkspaceEntries.layer.pipe(
+  Layer.provide(WorkspacePaths.layer),
+  Layer.provide(VcsDriverRegistryLayerLive),
+);
 
 const WorkspaceFileSystemLayerLive = WorkspaceFileSystem.layer.pipe(
   Layer.provide(WorkspacePaths.layer),

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -12,6 +12,7 @@ import { vi } from "vite-plus/test";
 
 import * as ServerConfig from "../config.ts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as WorkspaceEntries from "./WorkspaceEntries.ts";
 import * as WorkspacePaths from "./WorkspacePaths.ts";
@@ -24,6 +25,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 const TestLayer = Layer.empty.pipe(
   Layer.provideMerge(WorkspaceEntries.layer.pipe(Layer.provide(WorkspacePaths.layer))),
   Layer.provideMerge(WorkspacePaths.layer),
+  Layer.provideMerge(VcsDriverRegistry.layer),
   Layer.provideMerge(VcsProcess.layer),
   Layer.provide(
     ServerConfig.ServerConfig.layerTest(process.cwd(), {
@@ -120,6 +122,82 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         expect(result.entries.some((entry) => entry.path.startsWith("node_modules"))).toBe(false);
         expect(result.truncated).toBe(false);
       }),
+    );
+
+    it.effect("includes ignored files on request without exposing repository metadata", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ git: true });
+        yield* writeTextFile(cwd, ".gitignore", "ignored/\nignored.txt\n");
+        yield* writeTextFile(cwd, "src/index.ts", "export {};");
+        yield* writeTextFile(cwd, "ignored/cache.json", "{}");
+        yield* writeTextFile(cwd, "ignored.txt", "ignored");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const hidden = yield* workspaceEntries.list({ cwd });
+        const visible = yield* workspaceEntries.list({ cwd, includeIgnored: true });
+
+        expect(hidden.entries.some((entry) => entry.path === "ignored.txt")).toBe(false);
+        expect(visible.entries).toEqual(
+          expect.arrayContaining([
+            { path: "ignored", kind: "directory", ignored: true },
+            { path: "ignored/cache.json", kind: "file", ignored: true },
+            { path: "ignored.txt", kind: "file", ignored: true },
+            { path: "src/index.ts", kind: "file" },
+          ]),
+        );
+        expect(visible.entries.some((entry) => entry.path === ".git")).toBe(false);
+        expect(visible.entries.some((entry) => entry.path.startsWith(".git/"))).toBe(false);
+        expect(visible.truncated).toBe(false);
+      }),
+    );
+
+    it.effect(
+      "does not label ordinary paths as ignored when the workspace index is truncated",
+      () =>
+        Effect.gen(function* () {
+          const cwd = yield* makeTempDir({ git: true });
+          yield* writeTextFile(cwd, ".gitignore", "ignored.txt\n");
+          yield* writeTextFile(cwd, "indexed.ts");
+          yield* writeTextFile(cwd, "ordinary.ts");
+          yield* writeTextFile(cwd, "ignored.txt");
+
+          vi.spyOn(FileFinder.prototype, "mixedSearch").mockReturnValueOnce({
+            ok: true,
+            value: {
+              items: [
+                {
+                  type: "file",
+                  item: {
+                    relativePath: "indexed.ts",
+                    fileName: "indexed.ts",
+                    size: 0,
+                    modified: 0,
+                    accessFrecencyScore: 0,
+                    modificationFrecencyScore: 0,
+                    totalFrecencyScore: 0,
+                    gitStatus: "unmodified",
+                  },
+                },
+              ],
+              scores: [],
+              totalMatched: Number.MAX_SAFE_INTEGER,
+              totalFiles: Number.MAX_SAFE_INTEGER,
+              totalDirs: 0,
+            },
+          });
+
+          const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+          const result = yield* workspaceEntries.list({ cwd, includeIgnored: true });
+
+          expect(result.entries).toContainEqual({ path: "indexed.ts", kind: "file" });
+          expect(result.entries).toContainEqual({
+            path: "ignored.txt",
+            kind: "file",
+            ignored: true,
+          });
+          expect(result.entries.some((entry) => entry.path === "ordinary.ts")).toBe(false);
+          expect(result.truncated).toBe(true);
+        }),
     );
   });
 

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -199,6 +199,24 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
           expect(result.truncated).toBe(true);
         }),
     );
+
+    it.effect("reports the directory that failed during ignored-entry discovery", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ git: true });
+        const cause = new Error("read failed");
+        vi.mocked(NodeFSP.readdir).mockRejectedValueOnce(cause);
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const error = yield* workspaceEntries.list({ cwd, includeIgnored: true }).pipe(Effect.flip);
+
+        expect(error).toMatchObject({
+          _tag: "WorkspaceEntriesIgnoredDirectoryReadError",
+          cwd,
+          directoryPath: cwd,
+          cause,
+        });
+      }),
+    );
   });
 
   describe("search", () => {

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -12,6 +12,7 @@ import * as Schema from "effect/Schema";
 import type {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
+  ProjectEntry,
   ProjectListEntriesInput,
   ProjectListEntriesResult,
   ProjectSearchContentsInput,
@@ -23,6 +24,7 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { isExplicitRelativePath, isWindowsAbsolutePath } from "@t3tools/shared/path";
 import { normalizeSearchQuery } from "@t3tools/shared/searchRanking";
 
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 import * as WorkspacePaths from "./WorkspacePaths.ts";
 import * as WorkspaceSearchIndex from "./WorkspaceSearchIndex.ts";
 
@@ -140,6 +142,7 @@ const resolveBrowseTarget = Effect.fn("WorkspaceEntries.resolveBrowseTarget")(fu
 
 export const make = Effect.gen(function* () {
   const path = yield* Path.Path;
+  const vcsDriverRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
   const workspaceSearchIndexes = yield* WorkspaceSearchIndex.WorkspaceSearchIndexMap;
 
@@ -272,10 +275,106 @@ export const make = Effect.gen(function* () {
     );
   });
 
+  const listIncludingIgnored = Effect.fn("WorkspaceEntries.listIncludingIgnored")(function* (
+    cwd: string,
+    indexed: ProjectListEntriesResult,
+  ): Effect.fn.Return<ProjectListEntriesResult, WorkspaceEntriesError> {
+    const existingPaths = new Set(indexed.entries.map((entry) => entry.path));
+    const candidates: ProjectEntry[] = [];
+    const listFailure = (reason: string, cause: unknown) =>
+      new WorkspaceSearchIndex.WorkspaceSearchIndexSearchFailed({
+        cwd,
+        queryLength: 0,
+        pageSize: indexed.entries.length,
+        reason,
+        cause,
+      });
+    const vcs = yield* vcsDriverRegistry
+      .detect({ cwd })
+      .pipe(
+        Effect.mapError((cause) =>
+          listFailure("Failed to classify ignored workspace entries.", cause),
+        ),
+      );
+
+    // Without a VCS ignore classifier, entries omitted by a truncated index
+    // cannot be distinguished from ordinary entries beyond the index limit.
+    if (indexed.truncated && vcs === null) return indexed;
+
+    const directories = [""];
+    let directoryIndex = 0;
+    let scanIncomplete = false;
+
+    while (directoryIndex < directories.length) {
+      const relativeDirectory = directories[directoryIndex++]!;
+      const absoluteDirectory = relativeDirectory ? path.join(cwd, relativeDirectory) : cwd;
+      const readDirectory = Effect.tryPromise({
+        try: () => NodeFSP.readdir(absoluteDirectory, { withFileTypes: true }),
+        catch: (cause) =>
+          listFailure(
+            `Failed to read '${absoluteDirectory}' while listing ignored workspace entries.`,
+            cause,
+          ),
+      });
+      const dirents = yield* relativeDirectory
+        ? readDirectory.pipe(Effect.orElseSucceed(() => null))
+        : readDirectory;
+      if (dirents === null) {
+        scanIncomplete = true;
+        continue;
+      }
+
+      for (const dirent of dirents.toSorted((left, right) => left.name.localeCompare(right.name))) {
+        // Repository metadata is never a workspace file, even when ignored files are visible.
+        if (dirent.name === ".git") continue;
+
+        const relativePath = relativeDirectory
+          ? `${relativeDirectory}/${dirent.name}`
+          : dirent.name;
+        const kind = dirent.isDirectory()
+          ? "directory"
+          : dirent.isFile() || dirent.isSymbolicLink()
+            ? "file"
+            : null;
+        if (kind === null) continue;
+        if (kind === "directory") directories.push(relativePath);
+        if (existingPaths.has(relativePath)) continue;
+
+        candidates.push({ path: relativePath, kind });
+      }
+    }
+
+    let ignoredCandidates = candidates;
+    if (vcs) {
+      const nonIgnoredPaths = new Set(
+        yield* vcs.driver
+          .filterIgnoredPaths(
+            cwd,
+            candidates.map((entry) => entry.path),
+          )
+          .pipe(
+            Effect.mapError((cause) =>
+              listFailure("Failed to classify ignored workspace entries.", cause),
+            ),
+          ),
+      );
+      ignoredCandidates = candidates.filter((entry) => !nonIgnoredPaths.has(entry.path));
+    }
+    const ignoredEntries: ProjectEntry[] = ignoredCandidates.map((entry) => ({
+      ...entry,
+      ignored: true,
+    }));
+
+    return {
+      entries: [...indexed.entries, ...ignoredEntries],
+      truncated: indexed.truncated || scanIncomplete,
+    };
+  });
+
   const list: WorkspaceEntries["Service"]["list"] = Effect.fn("WorkspaceEntries.list")(
     function* (input) {
       const normalizedCwd = yield* normalizeWorkspaceRoot(input.cwd);
-      return yield* Effect.gen(function* () {
+      const indexed = yield* Effect.gen(function* () {
         const searchIndex = yield* WorkspaceSearchIndex.WorkspaceSearchIndex;
         return yield* searchIndex.list();
       }).pipe(
@@ -285,6 +384,8 @@ export const make = Effect.gen(function* () {
           ),
         ),
       );
+      if (!input.includeIgnored) return indexed;
+      return yield* listIncludingIgnored(normalizedCwd, indexed);
     },
   );
 

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -68,6 +68,32 @@ export class WorkspaceEntriesReadDirectoryError extends Schema.TaggedErrorClass<
   }
 }
 
+export class WorkspaceEntriesIgnoredDirectoryReadError extends Schema.TaggedErrorClass<WorkspaceEntriesIgnoredDirectoryReadError>()(
+  "WorkspaceEntriesIgnoredDirectoryReadError",
+  {
+    cwd: Schema.String,
+    directoryPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read '${this.directoryPath}' while listing ignored entries in '${this.cwd}'.`;
+  }
+}
+
+export class WorkspaceEntriesIgnoreClassificationError extends Schema.TaggedErrorClass<WorkspaceEntriesIgnoreClassificationError>()(
+  "WorkspaceEntriesIgnoreClassificationError",
+  {
+    cwd: Schema.String,
+    pathCount: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to classify ${this.pathCount} paths while listing ignored entries in '${this.cwd}'.`;
+  }
+}
+
 export const WorkspaceEntriesBrowseError = Schema.Union([
   WorkspaceEntriesWindowsPathUnsupportedError,
   WorkspaceEntriesCurrentProjectRequiredError,
@@ -83,6 +109,8 @@ export const WorkspaceEntriesError = Schema.Union([
   WorkspaceSearchIndex.WorkspaceSearchIndexCreateFailed,
   WorkspaceSearchIndex.WorkspaceSearchIndexScanTimedOut,
   WorkspaceSearchIndex.WorkspaceSearchIndexSearchFailed,
+  WorkspaceEntriesIgnoredDirectoryReadError,
+  WorkspaceEntriesIgnoreClassificationError,
 ]);
 export type WorkspaceEntriesError = typeof WorkspaceEntriesError.Type;
 
@@ -281,19 +309,11 @@ export const make = Effect.gen(function* () {
   ): Effect.fn.Return<ProjectListEntriesResult, WorkspaceEntriesError> {
     const existingPaths = new Set(indexed.entries.map((entry) => entry.path));
     const candidates: ProjectEntry[] = [];
-    const listFailure = (reason: string, cause: unknown) =>
-      new WorkspaceSearchIndex.WorkspaceSearchIndexSearchFailed({
-        cwd,
-        queryLength: 0,
-        pageSize: indexed.entries.length,
-        reason,
-        cause,
-      });
     const vcs = yield* vcsDriverRegistry
       .detect({ cwd })
       .pipe(
-        Effect.mapError((cause) =>
-          listFailure("Failed to classify ignored workspace entries.", cause),
+        Effect.mapError(
+          (cause) => new WorkspaceEntriesIgnoreClassificationError({ cwd, pathCount: 0, cause }),
         ),
       );
 
@@ -311,10 +331,11 @@ export const make = Effect.gen(function* () {
       const readDirectory = Effect.tryPromise({
         try: () => NodeFSP.readdir(absoluteDirectory, { withFileTypes: true }),
         catch: (cause) =>
-          listFailure(
-            `Failed to read '${absoluteDirectory}' while listing ignored workspace entries.`,
+          new WorkspaceEntriesIgnoredDirectoryReadError({
+            cwd,
+            directoryPath: absoluteDirectory,
             cause,
-          ),
+          }),
       });
       const dirents = yield* relativeDirectory
         ? readDirectory.pipe(Effect.orElseSucceed(() => null))
@@ -353,8 +374,13 @@ export const make = Effect.gen(function* () {
             candidates.map((entry) => entry.path),
           )
           .pipe(
-            Effect.mapError((cause) =>
-              listFailure("Failed to classify ignored workspace entries.", cause),
+            Effect.mapError(
+              (cause) =>
+                new WorkspaceEntriesIgnoreClassificationError({
+                  cwd,
+                  pathCount: candidates.length,
+                  cause,
+                }),
             ),
           ),
       );

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -94,6 +94,18 @@ export class WorkspaceEntriesIgnoreClassificationError extends Schema.TaggedErro
   }
 }
 
+export class WorkspaceEntriesVcsDetectionError extends Schema.TaggedErrorClass<WorkspaceEntriesVcsDetectionError>()(
+  "WorkspaceEntriesVcsDetectionError",
+  {
+    cwd: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to detect version control while listing ignored entries in '${this.cwd}'.`;
+  }
+}
+
 export const WorkspaceEntriesBrowseError = Schema.Union([
   WorkspaceEntriesWindowsPathUnsupportedError,
   WorkspaceEntriesCurrentProjectRequiredError,
@@ -111,6 +123,7 @@ export const WorkspaceEntriesError = Schema.Union([
   WorkspaceSearchIndex.WorkspaceSearchIndexSearchFailed,
   WorkspaceEntriesIgnoredDirectoryReadError,
   WorkspaceEntriesIgnoreClassificationError,
+  WorkspaceEntriesVcsDetectionError,
 ]);
 export type WorkspaceEntriesError = typeof WorkspaceEntriesError.Type;
 
@@ -311,11 +324,7 @@ export const make = Effect.gen(function* () {
     const candidates: ProjectEntry[] = [];
     const vcs = yield* vcsDriverRegistry
       .detect({ cwd })
-      .pipe(
-        Effect.mapError(
-          (cause) => new WorkspaceEntriesIgnoreClassificationError({ cwd, pathCount: 0, cause }),
-        ),
-      );
+      .pipe(Effect.mapError((cause) => new WorkspaceEntriesVcsDetectionError({ cwd, cause })));
 
     // Without a VCS ignore classifier, entries omitted by a truncated index
     // cannot be distinguished from ordinary entries beyond the index limit.

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -210,6 +210,11 @@ function projectEntriesFailureContext(error: WorkspaceEntries.WorkspaceEntriesEr
         normalizedCwd: error.cwd,
         detail: String(error.pathCount),
       };
+    case "WorkspaceEntriesVcsDetectionError":
+      return {
+        failure: "vcs_detection_failed",
+        normalizedCwd: error.cwd,
+      };
     default:
       return unexpectedCompatibilityError(error);
   }

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -198,6 +198,18 @@ function projectEntriesFailureContext(error: WorkspaceEntries.WorkspaceEntriesEr
         normalizedCwd: error.cwd,
         detail: error.reason,
       };
+    case "WorkspaceEntriesIgnoredDirectoryReadError":
+      return {
+        failure: "ignored_entries_read_failed",
+        normalizedCwd: error.cwd,
+        detail: error.directoryPath,
+      };
+    case "WorkspaceEntriesIgnoreClassificationError":
+      return {
+        failure: "ignored_entries_classification_failed",
+        normalizedCwd: error.cwd,
+        detail: String(error.pathCount),
+      };
     default:
       return unexpectedCompatibilityError(error);
   }

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -1,17 +1,19 @@
 import type {
   ContextMenuItem as TreeContextMenuItem,
   ContextMenuOpenContext as TreeContextMenuOpenContext,
+  GitStatusEntry,
 } from "@pierre/trees";
 import type { EnvironmentId, ProjectEntry } from "@t3tools/contracts";
 import { FileTree, useFileTree, useFileTreeSearch } from "@pierre/trees/react";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
-import { RotateCw } from "lucide-react";
-import { useEffect, useMemo, useRef } from "react";
+import { Eye, EyeOff, RotateCw } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "~/components/ui/button";
 import { InputGroup, InputGroupInput } from "~/components/ui/input-group";
 import { toastManager } from "~/components/ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import { Toggle } from "~/components/ui/toggle";
 import { useComposerHandleContext } from "~/composerHandleContext";
 import { writeTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { useTheme } from "~/hooks/useTheme";
@@ -39,6 +41,7 @@ const TREE_UNSAFE_CSS = `
     --trees-selected-bg-override: color-mix(in srgb, currentColor 12%, transparent);
     --trees-hover-bg-override: color-mix(in srgb, currentColor 7%, transparent);
     --trees-border-color-override: color-mix(in srgb, currentColor 14%, transparent);
+    --trees-git-ignored-color-override: var(--muted-foreground);
     --trees-font-family-override: var(--font-sans);
     --trees-font-size-override: 12px;
   }
@@ -108,7 +111,8 @@ export default function FileBrowserPanel({
 }: FileBrowserPanelProps) {
   const { resolvedTheme } = useTheme();
   const composerRef = useComposerHandleContext();
-  const entriesQuery = useProjectEntriesQuery(environmentId, cwd);
+  const [includeIgnored, setIncludeIgnored] = useState(false);
+  const entriesQuery = useProjectEntriesQuery(environmentId, cwd, includeIgnored);
   const entries = entriesQuery.data?.entries ?? [];
   const entryKinds = useMemo(
     () => new Map(entries.map((entry) => [entry.path, entry.kind] as const)),
@@ -263,6 +267,14 @@ export default function FileBrowserPanel({
   }, [entryKinds, model, treePaths]);
 
   useEffect(() => {
+    const statuses: GitStatusEntry[] = [];
+    for (const entry of entries) {
+      if (entry.ignored) statuses.push({ path: treePath(entry), status: "ignored" });
+    }
+    model.setGitStatus(statuses);
+  }, [entries, model]);
+
+  useEffect(() => {
     if (!selectedPath) {
       handledRevealRef.current = null;
       return;
@@ -359,6 +371,23 @@ export default function FileBrowserPanel({
           onValueChange={handleSearchValueChange}
           onClose={search.close}
         />
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Toggle
+                className="shrink-0"
+                pressed={includeIgnored}
+                onPressedChange={setIncludeIgnored}
+                aria-label="Show ignored files"
+                variant="ghost"
+                size="xs"
+              >
+                {includeIgnored ? <Eye /> : <EyeOff />}
+              </Toggle>
+            }
+          />
+          <TooltipPopup side="bottom">Show ignored files</TooltipPopup>
+        </Tooltip>
       </div>
       {entriesQuery.error && entriesQuery.data === null ? (
         <div className="p-4 text-xs leading-relaxed text-destructive">{entriesQuery.error}</div>

--- a/apps/web/src/components/files/projectFilesQueryState.test.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.test.ts
@@ -60,8 +60,14 @@ describe("project files queries", () => {
       truncated: false,
     };
 
-    expect(retainProjectEntriesWhilePending(null, settled, true)).toBe(settled);
-    expect(retainProjectEntriesWhilePending(replacement, settled, true)).toBe(replacement);
-    expect(retainProjectEntriesWhilePending(null, settled, false)).toBeNull();
+    const normalSnapshot = { data: settled, includeIgnored: false };
+    const ignoredSnapshot = { data: replacement, includeIgnored: true };
+
+    expect(retainProjectEntriesWhilePending(null, normalSnapshot, true, true)).toBe(settled);
+    expect(retainProjectEntriesWhilePending(replacement, normalSnapshot, true, true)).toBe(
+      replacement,
+    );
+    expect(retainProjectEntriesWhilePending(null, ignoredSnapshot, true, false)).toBeNull();
+    expect(retainProjectEntriesWhilePending(null, normalSnapshot, false, true)).toBeNull();
   });
 });

--- a/apps/web/src/components/files/projectFilesQueryState.test.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.test.ts
@@ -6,6 +6,7 @@ import {
   clearProjectFileQueryData,
   confirmProjectFileQueryData,
   getOptimisticProjectFileQueryData,
+  retainProjectEntriesWhilePending,
   resolveProjectFileQueryData,
   setProjectFileQueryData,
 } from "./projectFilesQueryState";
@@ -47,5 +48,20 @@ describe("project files queries", () => {
     expect(
       confirmProjectFileQueryData(environmentId, "/repo", "convex.json", '{"nodeVersion":"22"}'),
     ).toBe(true);
+  });
+
+  it("keeps the settled file tree visible only while a replacement query is pending", () => {
+    const settled = {
+      entries: [{ path: "src/index.ts", kind: "file" as const }],
+      truncated: false,
+    };
+    const replacement = {
+      entries: [...settled.entries, { path: "cache/data.json", kind: "file" as const }],
+      truncated: false,
+    };
+
+    expect(retainProjectEntriesWhilePending(null, settled, true)).toBe(settled);
+    expect(retainProjectEntriesWhilePending(replacement, settled, true)).toBe(replacement);
+    expect(retainProjectEntriesWhilePending(null, settled, false)).toBeNull();
   });
 });

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -130,10 +130,16 @@ function errorMessage<A>(result: AsyncResult.AsyncResult<A, unknown>): string | 
 
 export function retainProjectEntriesWhilePending(
   current: ProjectListEntriesResult | null,
-  settled: ProjectListEntriesResult | null,
+  settled: {
+    readonly includeIgnored: boolean;
+    readonly data: ProjectListEntriesResult;
+  } | null,
   isPending: boolean,
+  includeIgnored: boolean,
 ): ProjectListEntriesResult | null {
-  return current ?? (isPending ? settled : null);
+  const canRetainSettled =
+    settled !== null && (includeIgnored || settled.includeIgnored === includeIgnored);
+  return current ?? (isPending && canRetainSettled ? settled.data : null);
 }
 
 export function useProjectEntriesQuery(
@@ -149,16 +155,24 @@ export function useProjectEntriesQuery(
   const settledRef = useRef<{
     readonly environmentId: EnvironmentId;
     readonly cwd: string;
+    readonly includeIgnored: boolean;
     readonly data: ProjectListEntriesResult;
   } | null>(null);
   useEffect(() => {
-    if (currentData !== null) settledRef.current = { environmentId, cwd, data: currentData };
-  }, [currentData, cwd, environmentId]);
+    if (currentData !== null) {
+      settledRef.current = { environmentId, cwd, includeIgnored, data: currentData };
+    }
+  }, [currentData, cwd, environmentId, includeIgnored]);
   const settled = settledRef.current;
   const settledData =
-    settled?.environmentId === environmentId && settled.cwd === cwd ? settled.data : null;
+    settled?.environmentId === environmentId && settled.cwd === cwd ? settled : null;
   return {
-    data: retainProjectEntriesWhilePending(currentData, settledData, result.waiting),
+    data: retainProjectEntriesWhilePending(
+      currentData,
+      settledData,
+      result.waiting,
+      includeIgnored,
+    ),
     error: errorMessage(result),
     isPending: result.waiting,
     refresh,

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -7,7 +7,7 @@ import type {
 import * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { appAtomRegistry } from "~/rpc/atomRegistry";
 import { projectEnvironment } from "~/state/projects";
@@ -128,6 +128,14 @@ function errorMessage<A>(result: AsyncResult.AsyncResult<A, unknown>): string | 
   return cause instanceof Error ? cause.message : "Workspace query failed.";
 }
 
+export function retainProjectEntriesWhilePending(
+  current: ProjectListEntriesResult | null,
+  settled: ProjectListEntriesResult | null,
+  isPending: boolean,
+): ProjectListEntriesResult | null {
+  return current ?? (isPending ? settled : null);
+}
+
 export function useProjectEntriesQuery(
   environmentId: EnvironmentId,
   cwd: string,
@@ -137,8 +145,20 @@ export function useProjectEntriesQuery(
   const result = useAtomValue(atom);
   const refreshAtom = useAtomRefresh(atom);
   const refresh = useCallback(() => refreshAtom(), [refreshAtom]);
+  const currentData = Option.getOrNull(AsyncResult.value(result));
+  const settledRef = useRef<{
+    readonly environmentId: EnvironmentId;
+    readonly cwd: string;
+    readonly data: ProjectListEntriesResult;
+  } | null>(null);
+  useEffect(() => {
+    if (currentData !== null) settledRef.current = { environmentId, cwd, data: currentData };
+  }, [currentData, cwd, environmentId]);
+  const settled = settledRef.current;
+  const settledData =
+    settled?.environmentId === environmentId && settled.cwd === cwd ? settled.data : null;
   return {
-    data: Option.getOrNull(AsyncResult.value(result)),
+    data: retainProjectEntriesWhilePending(currentData, settledData, result.waiting),
     error: errorMessage(result),
     isPending: result.waiting,
     refresh,

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -29,8 +29,15 @@ interface ProjectQueryState<A> {
   readonly refresh: () => void;
 }
 
-export function getProjectEntriesQueryAtom(environmentId: EnvironmentId, cwd: string) {
-  return projectEnvironment.listEntries({ environmentId, input: { cwd } });
+export function getProjectEntriesQueryAtom(
+  environmentId: EnvironmentId,
+  cwd: string,
+  includeIgnored = false,
+) {
+  return projectEnvironment.listEntries({
+    environmentId,
+    input: { cwd, includeIgnored },
+  });
 }
 
 export function getProjectFileQueryAtom(
@@ -124,8 +131,9 @@ function errorMessage<A>(result: AsyncResult.AsyncResult<A, unknown>): string | 
 export function useProjectEntriesQuery(
   environmentId: EnvironmentId,
   cwd: string,
+  includeIgnored = false,
 ): ProjectQueryState<ProjectListEntriesResult> {
-  const atom = getProjectEntriesQueryAtom(environmentId, cwd);
+  const atom = getProjectEntriesQueryAtom(environmentId, cwd, includeIgnored);
   const result = useAtomValue(atom);
   const refreshAtom = useAtomRefresh(atom);
   const refresh = useCallback(() => refreshAtom(), [refreshAtom]);

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)
+- [Browsing project files](./user/files.md)
 - [Background service (Linux)](./user/background-service.md)
 - Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md)
 

--- a/docs/user/files.md
+++ b/docs/user/files.md
@@ -1,0 +1,5 @@
+# Browsing project files
+
+The Files panel lists files in the current project and hides ignored paths by default.
+
+Use **Show ignored files** in the Files toolbar to include paths excluded by `.gitignore` and other workspace ignore rules. Ignored rows use muted text and icons so they remain distinguishable from regular project files. Turn the toggle off again to return to the focused project view. Repository metadata in `.git` is always hidden.

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -93,6 +93,7 @@ export const ProjectEntriesFailure = Schema.Literals([
   "search_index_search_failed",
   "ignored_entries_read_failed",
   "ignored_entries_classification_failed",
+  "vcs_detection_failed",
 ]);
 export type ProjectEntriesFailure = typeof ProjectEntriesFailure.Type;
 

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -91,6 +91,8 @@ export const ProjectEntriesFailure = Schema.Literals([
   "search_index_create_failed",
   "search_index_scan_timed_out",
   "search_index_search_failed",
+  "ignored_entries_read_failed",
+  "ignored_entries_classification_failed",
 ]);
 export type ProjectEntriesFailure = typeof ProjectEntriesFailure.Type;
 

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -28,6 +28,7 @@ export type ProjectSearchEntriesInput = typeof ProjectSearchEntriesInput.Type;
 export const ProjectEntry = Schema.Struct({
   path: TrimmedNonEmptyString,
   kind: ProjectEntryKind,
+  ignored: Schema.optional(Schema.Literal(true)),
 });
 export type ProjectEntry = typeof ProjectEntry.Type;
 
@@ -72,6 +73,7 @@ export type ProjectSearchContentsResult = typeof ProjectSearchContentsResult.Typ
 
 export const ProjectListEntriesInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
+  includeIgnored: Schema.optional(Schema.Boolean),
 });
 export type ProjectListEntriesInput = typeof ProjectListEntriesInput.Type;
 


### PR DESCRIPTION
## What Changed

- Add a **Show ignored files** toggle to the Files panel on web and mobile.
- Include ignored paths in project listings only when explicitly requested, while keeping `.git` metadata hidden.
- Style ignored file and folder icons and text with muted theme tokens, without adding labels.
- Follow the existing toolbar conventions for tooltips, accessible labels, and pressed or selected state.
- Add focused tests for real `.gitignore` classification, truncated-index correctness, and inferred mobile tree ancestors.
- Document ignored-file browsing behavior.

## Why

The Files panel currently omits gitignored paths entirely. This makes generated artifacts, caches, local configuration, and other intentionally untracked files impossible to inspect without leaving T3 Code.

This keeps the existing focused view as the default and makes ignored-file visibility an explicit opt-in. The typed contract is shared across the server, web, desktop-hosted web, and mobile clients.

### Performance follow-up

The first opt-in can be noticeably slower in large workspaces because ignored paths currently require a recursive filesystem scan followed by VCS classification. Once loaded, subsequent toggles are nearly instant through the existing query cache.

A possible follow-up would move ignored-entry enumeration closer to the VCS or workspace-index boundary. For Git, the VCS driver could enumerate ignored entries directly instead of classifying the result of a recursive filesystem walk. Another option would be caching ignored-entry discovery per workspace and invalidating it incrementally from filesystem events.

Those changes affect indexing, VCS abstractions, caching, and watcher behavior. This PR intentionally does not change that architecture or introduce new entry caps, keeping it focused on the visibility toggle. The existing workspace-list cap work remains in #5107.

## UI Changes

Ignored paths use muted icon and text styling so they remain distinguishable without adding visual noise. The styling uses semantic theme tokens and was checked across light, dark, and custom themes.

### Default and enabled states

| Ignored files hidden by default | Ignored files shown |
| --- | --- |
| ![Ignored files hidden by default](https://raw.githubusercontent.com/diegoarff/t3code/refs/heads/pr-assets/ignored-files-toggle/pr-assets/ignored-files-toggle/ignored-files-hidden.png) | ![Ignored files shown in T3 Code Dark](https://raw.githubusercontent.com/diegoarff/t3code/refs/heads/pr-assets/ignored-files-toggle/pr-assets/ignored-files-toggle/ignored-files-t3-dark.png) |

### Light theme and tooltip

![Show ignored files tooltip and ignored styling in a light theme](https://raw.githubusercontent.com/diegoarff/t3code/refs/heads/pr-assets/ignored-files-toggle/pr-assets/ignored-files-toggle/ignored-files-light-theme.png)

### Dark custom theme

![Ignored-file styling in a dark custom theme](https://raw.githubusercontent.com/diegoarff/t3code/refs/heads/pr-assets/ignored-files-toggle/pr-assets/ignored-files-toggle/ignored-files-dark-theme.png)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] ~~I included a video for animation/interaction changes~~ — Not applicable; no motion or timing behavior changed.

Built with GPT-5.6 in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in listing triggers a full workspace directory scan plus VCS classification (performance and new error paths on large repos); default listings are unchanged and `.git` stays hidden.
> 
> **Overview**
> Adds an opt-in **Show ignored files** control on web and mobile file browsers. Listings still hide ignored paths by default; toggling on passes `includeIgnored` through `projectsListEntries` / `listEntries`.
> 
> **Server:** `WorkspaceEntries.list` merges the search index with a recursive filesystem walk for paths missing from the index, classifies candidates via the VCS driver (`filterIgnoredPaths`), and returns them with `ignored: true`. `.git` is always excluded. New typed failures cover directory read, ignore classification, and VCS detection; WS maps them to `ignored_entries_*` / `vcs_detection_failed`.
> 
> **Clients:** Web drives Pierre tree “ignored” git styling and keeps the previous tree visible while the toggled query is pending. Mobile marks ignored rows (muted icon/text, accessibility) and threads `selected` through Android/native header toolbar buttons. `fileTree` only sets `ignored` on explicit leaf entries, not inferred parent folders.
> 
> Contracts gain optional `ignored` on `ProjectEntry` and `includeIgnored` on list input. User docs added under `docs/user/files.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7105b53725d8f18382a96a97cbc086c6a2c18856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ignored-file visibility toggle to file browser on web and mobile
> - Adds an `includeIgnored` toggle (eye/eye-slash icon) to the web `FileBrowserPanel`, mobile `ThreadFilesTreeScreen`, and `ThreadFileNavigatorPane`; state is sent to the server via the updated `ProjectListEntriesInput` schema.
> - Extends `WorkspaceEntries.list` on the server to scan the filesystem for unindexed ignored files, classify them via VCS detection, and merge them into results marked with `ignored: true`.
> - Ignored entries are visually distinct: muted/dimmed on mobile (`FileTreeRow`) and mapped to a git-ignored color style on web.
> - Adds three new `ProjectEntriesFailure` error codes (`ignored_entries_read_failed`, `ignored_entries_classification_failed`, `vcs_detection_failed`) with corresponding WebSocket error payloads.
> - Risk: server-side ignored-entry discovery adds filesystem traversal cost when `includeIgnored` is requested; failures surface as new structured error types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7105b53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->