### PR TITLE
fix(web): unify composer control rounding

### DIFF
--- a/apps/web/src/components/chat/ComposerControl.tsx
+++ b/apps/web/src/components/chat/ComposerControl.tsx
@@ -6,7 +6,7 @@ import { Button } from "../ui/button";
 import { SelectTrigger } from "../ui/select";
 
 const composerControlClassName =
-  "h-7 min-h-7 gap-1.5 px-2.5 text-secondary-label transition-none hover:text-foreground [&_svg[data-composer-control-icon]]:mx-0 [&_svg[data-composer-control-chevron]]:-mx-0.5";
+  "h-7 min-h-7 gap-1.5 rounded-[var(--control-radius)] px-2.5 text-secondary-label transition-none hover:text-foreground [&_svg[data-composer-control-icon]]:mx-0 [&_svg[data-composer-control-chevron]]:-mx-0.5";
 
 export function ComposerControl({
   className,


### PR DESCRIPTION
## What Changed

Added `rounded-[var(--control-radius)]` to shared composer control class (`composerControlClassName`) to unify rounding on button-backed and select-backed composer controls.

## Why

The button-backed Model and Traits pickers inherited the shared 8px control radius (from `rounded-[var(--control-radius)]` in `Button`), but the select-backed Runtime mode picker inherited the generic 10px radius (from `rounded-lg` in `Select`). This causes Runtime mode control look inconsistent with the rest of the UI.

Defining the explicit radius in the shared class unifies it for all composer controls.

## UI Changes

### Before

<img width="800" alt="before screenshot" src="https://github.com/user-attachments/assets/b6cad939-2fea-4ad3-9453-fb27a5f5ef4c" />

### After

<img width="800" alt="after screenshot" src="https://github.com/user-attachments/assets/ba5ebf41-0639-4fad-b71f-16ddaab672e6" />

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change on chat composer controls only; no logic or data impact.
> 
> **Overview**
> Adds **`rounded-[var(--control-radius)]`** to the shared **`composerControlClassName`** used by **`ComposerControl`** and **`ComposerSelectControl`**, so button-backed and select-backed composer controls (e.g. Runtime mode vs Model/Traits) share the same corner radius instead of mixing **`Button`**’s control token with **`SelectTrigger`**’s **`rounded-lg`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 425c5ab3e12ac96d5d37543adf21ef2ab972c3c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply `--control-radius` border radius to composer controls
> Adds `rounded-[var(--control-radius)]` to `composerControlClassName` in [ComposerControl.tsx](https://github.com/pingdotgg/t3code/pull/5957/files#diff-c8a8af2bdd16b1820dfb1d78fba93f90763459a607cf9057e06b1646427c4601) so all composer controls use a consistent, theme-driven border radius.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 425c5ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->