### PR TITLE
feat(web): stop the running turn from the keyboard via chat.interrupt

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4607,7 +4607,18 @@ function ChatViewContent(props: ChatViewProps) {
         modelPickerOpen: composerRef.current?.isModelPickerOpen() ?? false,
       };
 
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: shortcutContext,
+      });
+
+      // chat.interrupt outranks type-to-focus while a turn is running: a
+      // printable-key binding would otherwise be typed into the composer
+      // instead of stopping the turn. When idle, the key keeps its usual
+      // meaning, so bindings like plain Escape stay safe.
+      const interruptClaimsKey = command === "chat.interrupt" && phase === "running";
+
       if (
+        !interruptClaimsKey &&
         !shortcutContext.terminalFocus &&
         !shortcutContext.modelPickerOpen &&
         shouldTypeToFocusComposer(event)
@@ -4619,9 +4630,6 @@ function ChatViewContent(props: ChatViewProps) {
         }
       }
 
-      const command = resolveShortcutCommand(event, keybindings, {
-        context: shortcutContext,
-      });
       if (!command) return;
 
       if (command === "terminal.toggle") {
@@ -4707,9 +4715,7 @@ function ChatViewContent(props: ChatViewProps) {
       }
 
       if (command === "chat.interrupt") {
-        // Claims the key only while a turn is running, so a binding like
-        // plain Escape keeps its usual meaning the rest of the time.
-        if (phase !== "running") return;
+        if (!interruptClaimsKey) return;
         event.preventDefault();
         event.stopPropagation();
         void onInterrupt();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4310,6 +4310,20 @@ function ChatViewContent(props: ChatViewProps) {
       }
     }
   }, [activeThread, environmentId, interruptThreadTurn, setThreadError]);
+  const onInterrupt = useCallback(async () => {
+    if (!activeThread) return;
+    const result = await interruptThreadTurn({
+      environmentId,
+      input: buildThreadTurnInterruptInput(activeThread),
+    });
+    if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+      const error = squashAtomCommandFailure(result);
+      setThreadError(
+        activeThread.id,
+        error instanceof Error ? error.message : "Failed to interrupt the current turn.",
+      );
+    }
+  }, [activeThread, environmentId, interruptThreadTurn, setThreadError]);
   const backgroundLivenessBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
     if (activeBackgroundLiveness === null || !activeThread) {
       return null;
@@ -4692,6 +4706,16 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
 
+      if (command === "chat.interrupt") {
+        // Claims the key only while a turn is running, so a binding like
+        // plain Escape keeps its usual meaning the rest of the time.
+        if (phase !== "running") return;
+        event.preventDefault();
+        event.stopPropagation();
+        void onInterrupt();
+        return;
+      }
+
       const scriptId = projectScriptIdFromCommand(command);
       if (!scriptId || !activeProject) return;
       const script = activeProject.scripts.find((entry) => entry.id === scriptId);
@@ -4717,7 +4741,9 @@ function ChatViewContent(props: ChatViewProps) {
     splitTerminal,
     splitPanelTerminal,
     keybindings,
+    onInterrupt,
     onToggleDiff,
+    phase,
     toggleRightPanel,
     toggleTerminalVisibility,
     composerRef,
@@ -5233,21 +5259,6 @@ function ChatViewContent(props: ChatViewProps) {
         currentThreadKey === activeThreadKey ? null : currentThreadKey,
       );
       resetLocalDispatch();
-    }
-  };
-
-  const onInterrupt = async () => {
-    if (!activeThread) return;
-    const result = await interruptThreadTurn({
-      environmentId,
-      input: buildThreadTurnInterruptInput(activeThread),
-    });
-    if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-      const error = squashAtomCommandFailure(result);
-      setThreadError(
-        activeThread.id,
-        error instanceof Error ? error.message : "Failed to interrupt the current turn.",
-      );
     }
   };
 

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -150,7 +150,9 @@ describe("KeybindingsSettings.logic", () => {
       },
     ] satisfies ResolvedKeybindingsConfig);
 
-    expect(options).toEqual(expect.arrayContaining(["chat.new", "script.setup-db.run"]));
+    expect(options).toEqual(
+      expect.arrayContaining(["chat.new", "chat.interrupt", "script.setup-db.run"]),
+    );
   });
 
   it("reports unknown when variables without rejecting parseable expressions", () => {

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -4,6 +4,7 @@ import {
   type KeybindingWhenNode,
   type ResolvedKeybindingRule,
   type ResolvedKeybindingsConfig,
+  STATIC_KEYBINDING_COMMANDS,
 } from "@t3tools/contracts";
 import {
   DEFAULT_RESOLVED_KEYBINDINGS,
@@ -255,7 +256,9 @@ export function buildWhenVariableOptions(): ReadonlyArray<WhenVariableOption> {
 export function buildKeybindingCommandOptions(
   keybindings: ResolvedKeybindingsConfig,
 ): ReadonlyArray<KeybindingCommandOption> {
-  const commands = new Set<KeybindingCommand>();
+  // Static commands are listed directly so commands that ship without a
+  // default binding (like chat.interrupt) stay bindable from the UI.
+  const commands = new Set<KeybindingCommand>(STATIC_KEYBINDING_COMMANDS);
   for (const binding of DEFAULT_RESOLVED_KEYBINDINGS) {
     commands.add(binding.command);
   }

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -47,6 +47,11 @@ Use **Inspect** to pick an element in the app and reveal its color token. Inspec
 successful pick; its hover glow and badge preview the element and token that click will select.
 **Cancel** or `Escape` exits Inspect and clears its selection and spotlight.
 
+`chat.interrupt` stops the active thread's running turn, same as the composer's stop button. It
+ships without a default shortcut; bind one in **Settings** → **Keybindings**. The shortcut only
+takes effect while a turn is running, so a key you bind keeps its normal behavior the rest of the
+time.
+
 The command palette searches active thread titles, projects, branches, user messages, and final
 agent responses across connected environments. Message matches show one labeled excerpt while
 keeping the thread's project, branch, and machine context visible. Message search begins after two

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -84,6 +84,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedLocal.command, "chat.newLocal");
 
+    const parsedInterrupt = yield* decode(KeybindingRule, {
+      key: "mod+shift+c",
+      command: "chat.interrupt",
+    });
+    assert.strictEqual(parsedInterrupt.command, "chat.interrupt");
+
     const parsedModelPickerToggle = yield* decode(KeybindingRule, {
       key: "mod+shift+m",
       command: "modelPicker.toggle",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -47,7 +47,7 @@ export const MODEL_PICKER_KEYBINDING_COMMANDS = [
 ] as const;
 export type ModelPickerKeybindingCommand = (typeof MODEL_PICKER_KEYBINDING_COMMANDS)[number];
 
-const STATIC_KEYBINDING_COMMANDS = [
+export const STATIC_KEYBINDING_COMMANDS = [
   "sidebar.toggle",
   "terminal.toggle",
   "terminal.split",
@@ -69,6 +69,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "composer.stash",
   "chat.new",
   "chat.newLocal",
+  "chat.interrupt",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,


### PR DESCRIPTION
## Summary

There is currently no keyboard path to stop a running turn — `interruptThreadTurn` is reachable only through the composer's stop button, so interrupting an agent that's heading the wrong way requires the mouse. This is item 1 ("smallest useful scope") of #4641.

This PR adds `chat.interrupt` as a bindable keybinding command that does exactly what the stop button does.

## Changes

- **Contracts**: `chat.interrupt` added to `STATIC_KEYBINDING_COMMANDS` (`packages/contracts/src/keybindings.ts`). The list is now exported so the settings UI can enumerate bindable commands. Old clients drop the unknown command via the existing `ForwardCompatibleArray` decode, so nothing breaks across versions.
- **Dispatch** (`ChatView.tsx`): a `chat.interrupt` branch in the existing keydown handler that calls the same `onInterrupt` the stop button uses (`onInterrupt` is now a `useCallback` so the effect can depend on it). The command claims the key **only while a turn is running** (`phase === "running"`, mirroring the stop button); otherwise the event falls through untouched. While a turn is running, the command is resolved ahead of the type-to-focus fallback so a printable-key binding interrupts instead of being typed into the composer; type-to-focus precedence for every other command is unchanged.
- **Settings UI**: the command dropdown now includes all static commands, not just ones derived from default bindings — otherwise a command shipped without a default would be unbindable from the UI.
- **Docs**: `docs/user/keybindings.md` documents the command.

## No default shortcut, deliberately

The issue proposes `escape` with `when: "!terminalFocus"` but also offers shipping unbound if Escape feels too overloaded — and it is: the dispatch handler runs in window capture phase, ahead of every dialog, picker, and composer menu that closes on Escape, so a default Escape binding would swallow those during a running turn. Shipping the command unbound lets users opt in (`{ "key": "esc", "command": "chat.interrupt" }` works fine for those who want it), and the running-turn gate means even a bare-Escape binding keeps its normal meaning while idle. A default can be added later as a one-line change if the maintainers want one.

## Relationship to other open PRs

#5669 (`thread.interrupt`, default Escape, stacked on #5668) and #4308 (`thread.stop`, unbound) address the same gap. This PR implements item 1 of the tracking issue #4641 under the command name specced there (`chat.interrupt`, matching the existing `chat.new` / `chat.newLocal` namespace for composer-scoped actions). Beyond naming, it differs in resolving the command ahead of the type-to-focus fallback while a turn runs, and in the no-default rationale above being grounded in the capture-phase handler analysis. No objection from my side if the maintainers prefer to land one of the others instead — the gap getting closed matters more than whose diff does it.

## Testing

- `vp test run` on `packages/contracts/src/keybindings.test.ts`, `apps/web/src/components/settings/KeybindingsSettings.logic.test.ts`, `apps/web/src/keybindings.test.ts`, `apps/server/src/keybindings.test.ts` — 86 passed. New assertions: `chat.interrupt` decodes as a valid `KeybindingRule` command; the settings command options include it without any binding present.
- `tsgo --noEmit` clean for `@t3tools/contracts` and `@t3tools/web`; `vp lint` clean on touched files.
- Verified in a live client (isolated dev environment, real Claude provider turn): bound `esc` via `keybindings.json`, hot reload picked it up, pressing Escape during a running turn dispatched `chat.interrupt` and the turn stopped. Interrupt-to-stop latency matched the mouse stop button (both route through the same `interruptThreadTurn`).

## Proof of work

Settings → Keybindings listing the `esc` → Chat: Interrupt binding sourced from `keybindings.json` (Custom):

![keybindings rows](https://github.com/achtan/t3code/releases/download/pr-5959-proof/keybindings-rows-with-chat-interrupt.png)

The add-keybinding command dropdown offering Chat: Interrupt (before this PR the dropdown only listed commands that have a default binding, so an unbound command could not be selected; `chat.interrupt` does not exist on main at all):

![keybindings dropdown](https://github.com/achtan/t3code/releases/download/pr-5959-proof/keybindings-dropdown-chat-interrupt.png)

Video of Escape stopping a live running turn (badge overlay marks the key press; the stop takes a few seconds — that is provider interrupt latency, identical for the mouse stop button): [esc-interrupts-running-turn.webm](https://github.com/achtan/t3code/releases/download/pr-5959-proof/esc-interrupts-running-turn.webm)

Related to #4641 (item 1 of the tracking list — does not close it).

Work done by Claude Fable 5 via Claude Agent SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-triggered interrupt reuses the existing stop-button path and only overrides keys during an active turn; no auth or data-layer changes.
> 
> **Overview**
> Adds a bindable **`chat.interrupt`** command so users can stop an in-flight agent turn from the keyboard, matching the composer stop button. There is **no default shortcut**; users assign one in **Settings → **Keybindings**.
> 
> In **`ChatView`**, shortcut resolution runs before type-to-focus so a bound printable key stops the turn instead of typing into the composer. The binding **only claims the key while `phase === "running"`**; when idle, the key behaves normally (e.g. Escape still closes dialogs). **`onInterrupt`** is a **`useCallback`** wired into the existing keydown effect.
> 
> **Contracts** export **`STATIC_KEYBINDING_COMMANDS`** and include **`chat.interrupt`**. The settings command picker seeds from that list so commands without default bindings stay bindable. User docs describe the command and running-turn behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1535189be6be47f117730be3e15869930b08f4b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `chat.interrupt` keybinding to stop a running thread turn from the keyboard
> - Adds a `chat.interrupt` command that interrupts the active thread turn when pressed while a turn is running; when idle, the key is not claimed and falls through to other handlers (including type-to-focus).
> - The command has no default binding but appears in the Keybindings settings UI so users can assign a shortcut.
> - `STATIC_KEYBINDING_COMMANDS` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/5959/files#diff-4eff8b6cf08dc64a9d8f37ff97b369a5719340e4c6203ab7070cc8cfffd28db6) now exports `chat.interrupt`, and [KeybindingsSettings.logic.ts](https://github.com/pingdotgg/t3code/pull/5959/files#diff-3e063dd9ee56de309e7e9618f62b33b69ff212f57241c19cc7114065efb919dd) seeds the options list from this constant so commands without default bindings are still shown.
> - Documents the new command in [keybindings.md](https://github.com/pingdotgg/t3code/pull/5959/files#diff-2858dfbce3443e10e5180f361437183badc111f8cac64cfe3094bae56b568e43).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1535189.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


