### PR TITLE
feat(web): add terminal.focus and chat.focusComposer keybindings

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -26,6 +26,7 @@ import {
   isBranchMismatchDismissedForSession,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
+  resolveTerminalFocusTarget,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
   scheduleEnvironmentReconnectWarning,
@@ -434,6 +435,58 @@ describe("session branch mismatch dismissal", () => {
     expect(isBranchMismatchDismissedForSession("t1:a:b")).toBe(true);
     expect(isBranchMismatchDismissedForSession("t1:a:c")).toBe(false);
     expect(isBranchMismatchDismissedForSession(null)).toBe(false);
+  });
+});
+
+describe("resolveTerminalFocusTarget", () => {
+  it("opens the drawer when no terminal surface is showing", () => {
+    expect(
+      resolveTerminalFocusTarget({
+        terminalOpen: false,
+        panelTerminalActive: false,
+        rightPanelMaximized: false,
+      }),
+    ).toBe("open-drawer");
+  });
+
+  it("targets the panel terminal when the drawer is closed", () => {
+    expect(
+      resolveTerminalFocusTarget({
+        terminalOpen: false,
+        panelTerminalActive: true,
+        rightPanelMaximized: false,
+      }),
+    ).toBe("panel");
+  });
+
+  it("prefers the open drawer over a visible panel terminal", () => {
+    expect(
+      resolveTerminalFocusTarget({
+        terminalOpen: true,
+        panelTerminalActive: true,
+        rightPanelMaximized: false,
+      }),
+    ).toBe("drawer");
+  });
+
+  it("targets the panel terminal when maximizing hides the drawer", () => {
+    expect(
+      resolveTerminalFocusTarget({
+        terminalOpen: true,
+        panelTerminalActive: true,
+        rightPanelMaximized: true,
+      }),
+    ).toBe("panel");
+  });
+
+  it("targets the drawer when the maximized panel shows no terminal", () => {
+    expect(
+      resolveTerminalFocusTarget({
+        terminalOpen: true,
+        panelTerminalActive: false,
+        rightPanelMaximized: true,
+      }),
+    ).toBe("drawer");
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -149,6 +149,24 @@ export function buildThreadTurnInterruptInput(thread: Pick<Thread, "id" | "sessi
   };
 }
 
+export type TerminalFocusTarget = "panel" | "drawer" | "open-drawer";
+
+/**
+ * Picks which terminal surface `terminal.focus` should focus. The drawer wins
+ * while both surfaces are visible; a maximized right panel hides the chat
+ * column (and the drawer with it), so the panel terminal wins there.
+ */
+export function resolveTerminalFocusTarget(input: {
+  terminalOpen: boolean;
+  panelTerminalActive: boolean;
+  rightPanelMaximized: boolean;
+}): TerminalFocusTarget {
+  if (input.panelTerminalActive && (input.rightPanelMaximized || !input.terminalOpen)) {
+    return "panel";
+  }
+  return input.terminalOpen ? "drawer" : "open-drawer";
+}
+
 export function reconcileMountedTerminalThreadIds(input: {
   currentThreadIds: ReadonlyArray<string>;
   openThreadIds: ReadonlyArray<string>;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3252,7 +3252,7 @@ function ChatViewContent(props: ChatViewProps) {
     const cwd = gitCwd ?? activeProject.workspaceRoot;
     const terminalId = nextTerminalId(allocatableActiveTerminalIds);
     useRightPanelStore.getState().openTerminal(activeThreadRef, terminalId);
-    setTerminalFocusRequestId((value) => value + 1);
+    setPanelTerminalFocusRequestId((value) => value + 1);
     void openTerminal({
       environmentId: activeThreadRef.environmentId,
       input: {
@@ -3291,7 +3291,7 @@ function ChatViewContent(props: ChatViewProps) {
       useRightPanelStore
         .getState()
         .splitTerminal(activeThreadRef, activeRightPanelSurface.id, terminalId, direction);
-      setTerminalFocusRequestId((value) => value + 1);
+      setPanelTerminalFocusRequestId((value) => value + 1);
       void openTerminal({
         environmentId: activeThreadRef.environmentId,
         input: {
@@ -3326,7 +3326,7 @@ function ChatViewContent(props: ChatViewProps) {
       useRightPanelStore
         .getState()
         .activateTerminal(activeThreadRef, activeRightPanelSurface.id, terminalId);
-      setTerminalFocusRequestId((value) => value + 1);
+      setPanelTerminalFocusRequestId((value) => value + 1);
     },
     [activeRightPanelSurface, activeThreadRef],
   );
@@ -3341,7 +3341,7 @@ function ChatViewContent(props: ChatViewProps) {
       useRightPanelStore
         .getState()
         .closeTerminal(activeThreadRef, activeRightPanelSurface.id, terminalId);
-      setTerminalFocusRequestId((value) => value + 1);
+      setPanelTerminalFocusRequestId((value) => value + 1);
     },
     [activeRightPanelSurface, activeThreadRef, closeTerminalMutation, storeCloseTerminal],
   );
@@ -3353,7 +3353,7 @@ function ChatViewContent(props: ChatViewProps) {
         setActivePreviewTab(activeThreadRef, surface.resourceId);
       }
       if (surface.kind === "terminal") {
-        setTerminalFocusRequestId((value) => value + 1);
+        setPanelTerminalFocusRequestId((value) => value + 1);
       }
       if (surface.kind === "diff" && !diffOpen) {
         onDiffPanelOpen?.();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4617,6 +4617,25 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
 
+      if (command === "terminal.focus") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (terminalUiState.terminalOpen || activeRightPanelSurface?.kind === "terminal") {
+          setTerminalFocusRequestId((value) => value + 1);
+          return;
+        }
+        // The closed->open transition already requests terminal focus.
+        toggleTerminalVisibility();
+        return;
+      }
+
+      if (command === "chat.focusComposer") {
+        event.preventDefault();
+        event.stopPropagation();
+        focusComposer();
+        return;
+      }
+
       if (command === "rightPanel.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -4712,6 +4731,7 @@ function ChatViewContent(props: ChatViewProps) {
     closeTerminal,
     closePanelTerminal,
     createNewTerminal,
+    focusComposer,
     setTerminalOpen,
     runProjectScript,
     splitTerminal,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -297,6 +297,7 @@ import {
   deriveLockedProvider,
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
+  resolveTerminalFocusTarget,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
   revokeBlobPreviewUrl,
@@ -1342,6 +1343,7 @@ function ChatViewContent(props: ChatViewProps) {
     useState<Record<string, number>>({});
   const shouldUseRightPanelSheet = useMediaQuery(RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY);
   const [terminalFocusRequestId, setTerminalFocusRequestId] = useState(0);
+  const [panelTerminalFocusRequestId, setPanelTerminalFocusRequestId] = useState(0);
   const [pullRequestDialogState, setPullRequestDialogState] =
     useState<PullRequestDialogState | null>(null);
   const [terminalUiLaunchContext, setTerminalUiLaunchContext] =
@@ -4620,18 +4622,38 @@ function ChatViewContent(props: ChatViewProps) {
       if (command === "terminal.focus") {
         event.preventDefault();
         event.stopPropagation();
-        if (terminalUiState.terminalOpen || activeRightPanelSurface?.kind === "terminal") {
-          setTerminalFocusRequestId((value) => value + 1);
+        const target = resolveTerminalFocusTarget({
+          terminalOpen: Boolean(terminalUiState.terminalOpen),
+          panelTerminalActive: activeRightPanelSurface?.kind === "terminal",
+          rightPanelMaximized,
+        });
+        if (target === "panel") {
+          setPanelTerminalFocusRequestId((value) => value + 1);
           return;
         }
-        // The closed->open transition already requests terminal focus.
-        toggleTerminalVisibility();
+        // The drawer lives in the chat column, which a maximized right panel
+        // collapses to zero width.
+        if (rightPanelMaximized) {
+          toggleRightPanelMaximized();
+        }
+        if (target === "open-drawer") {
+          // The closed->open transition already requests terminal focus.
+          toggleTerminalVisibility();
+          return;
+        }
+        setTerminalFocusRequestId((value) => value + 1);
         return;
       }
 
       if (command === "chat.focusComposer") {
         event.preventDefault();
         event.stopPropagation();
+        if (rightPanelMaximized) {
+          toggleRightPanelMaximized();
+          // Focus once the chat column regains its width.
+          scheduleComposerFocus();
+          return;
+        }
         focusComposer();
         return;
       }
@@ -4732,6 +4754,8 @@ function ChatViewContent(props: ChatViewProps) {
     closePanelTerminal,
     createNewTerminal,
     focusComposer,
+    rightPanelMaximized,
+    scheduleComposerFocus,
     setTerminalOpen,
     runProjectScript,
     splitTerminal,
@@ -4739,6 +4763,7 @@ function ChatViewContent(props: ChatViewProps) {
     keybindings,
     onToggleDiff,
     toggleRightPanel,
+    toggleRightPanelMaximized,
     toggleTerminalVisibility,
     composerRef,
   ]);
@@ -5980,7 +6005,7 @@ function ChatViewContent(props: ChatViewProps) {
         threadRef={activeThreadRef}
         surface={activeRightPanelSurface}
         launchContext={activeTerminalLaunchContext ?? null}
-        focusRequestId={terminalFocusRequestId}
+        focusRequestId={panelTerminalFocusRequestId}
         keybindings={keybindings}
         onAddTerminalContext={addTerminalContextToDraft}
         onSplitTerminal={splitPanelTerminal}

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -123,6 +123,8 @@ describe("KeybindingsSettings.logic", () => {
   it("formats static and project script command labels", () => {
     expect(commandLabel("commandPalette.toggle")).toBe("Command Palette: Toggle");
     expect(commandLabel("themeEditor.toggle")).toBe("Theme Editor: Toggle");
+    expect(commandLabel("terminal.focus")).toBe("Terminal: Focus");
+    expect(commandLabel("chat.focusComposer")).toBe("Chat: Focus Composer");
     expect(commandLabel("script.setup-db.run")).toBe("Run Script: Setup Db");
   });
 
@@ -150,7 +152,14 @@ describe("KeybindingsSettings.logic", () => {
       },
     ] satisfies ResolvedKeybindingsConfig);
 
-    expect(options).toEqual(expect.arrayContaining(["chat.new", "script.setup-db.run"]));
+    expect(options).toEqual(
+      expect.arrayContaining([
+        "chat.new",
+        "terminal.focus",
+        "chat.focusComposer",
+        "script.setup-db.run",
+      ]),
+    );
   });
 
   it("reports unknown when variables without rejecting parseable expressions", () => {

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -6,6 +6,7 @@ import {
   type KeybindingWhenNode,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
 import {
   formatShortcutLabel,
   isChatNewShortcut,
@@ -602,6 +603,32 @@ describe("chat/editor shortcuts", () => {
         context: { terminalFocus: true },
       }),
     );
+  });
+});
+
+describe("focus shortcuts", () => {
+  it("defaults Ctrl+` to terminal.focus outside the terminal", () => {
+    for (const platform of ["MacIntel", "Win32"]) {
+      assert.strictEqual(
+        resolveShortcutCommand(event({ key: "`", ctrlKey: true }), DEFAULT_RESOLVED_KEYBINDINGS, {
+          platform,
+          context: { terminalFocus: false },
+        }),
+        "terminal.focus",
+      );
+    }
+  });
+
+  it("defaults Ctrl+` to chat.focusComposer while the terminal is focused", () => {
+    for (const platform of ["MacIntel", "Win32"]) {
+      assert.strictEqual(
+        resolveShortcutCommand(event({ key: "`", ctrlKey: true }), DEFAULT_RESOLVED_KEYBINDINGS, {
+          platform,
+          context: { terminalFocus: true },
+        }),
+        "chat.focusComposer",
+      );
+    }
   });
 });
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -47,6 +47,11 @@ Use **Inspect** to pick an element in the app and reveal its color token. Inspec
 successful pick; its hover glow and badge preview the element and token that click will select.
 **Cancel** or `Escape` exits Inspect and clears its selection and spotlight.
 
+`terminal.focus` moves focus into the terminal, opening the drawer first if it is closed.
+`chat.focusComposer` moves focus back to the message composer and leaves the terminal open. Both
+default to `` ctrl+` ``, so the same key hops focus in either direction without hiding the
+terminal — unlike `terminal.toggle`, which moves focus by showing or hiding the drawer.
+
 The command palette searches active thread titles, projects, branches, user messages, and final
 agent responses across connected environments. Message matches show one labeled excerpt while
 keeping the thread's project, branch, and machine context visible. Message search begins after two

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -50,6 +50,7 @@ export type ModelPickerKeybindingCommand = (typeof MODEL_PICKER_KEYBINDING_COMMA
 const STATIC_KEYBINDING_COMMANDS = [
   "sidebar.toggle",
   "terminal.toggle",
+  "terminal.focus",
   "terminal.split",
   "terminal.splitVertical",
   "terminal.new",
@@ -69,6 +70,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "composer.stash",
   "chat.new",
   "chat.newLocal",
+  "chat.focusComposer",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -21,6 +21,9 @@ type WhenToken =
 export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+b", command: "sidebar.toggle" },
   { key: "mod+j", command: "terminal.toggle" },
+  // One key hops focus both ways without touching drawer visibility.
+  { key: "ctrl+`", command: "terminal.focus", when: "!terminalFocus" },
+  { key: "ctrl+`", command: "chat.focusComposer", when: "terminalFocus" },
   { key: "mod+alt+b", command: "rightPanel.toggle" },
   { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
   { key: "mod+shift+d", command: "terminal.splitVertical", when: "terminalFocus" },


### PR DESCRIPTION
Part of #4641 (items 4 and 5).

## Problem

Focus is coupled to panel visibility. Opening the terminal drawer requests terminal focus and closing it returns focus to the composer, but there is no keyboard route between the two while the drawer stays open: type-to-focus bails when focus sits in any input or textarea, and the terminal renders a textarea, so typing in the terminal can never bring you back. The workaround today is toggling the drawer twice with `mod+j`.

## What changed

- **`packages/contracts`** — `terminal.focus` and `chat.focusComposer` join `STATIC_KEYBINDING_COMMANDS`. Older clients drop unknown commands through the existing `ForwardCompatibleArray` decoding, so no compatibility work was needed.
- **`packages/shared`** — both ship as one default key with mutually exclusive `when` clauses, so a single key hops focus in either direction without touching drawer visibility:

  ```json
  { "key": "ctrl+`", "command": "terminal.focus", "when": "!terminalFocus" },
  { "key": "ctrl+`", "command": "chat.focusComposer", "when": "terminalFocus" }
  ```

  `` ctrl+` `` follows VS Code's focus-terminal binding and is unclaimed by the existing defaults on every platform. Each command is still independently rebindable; the startup default sync backfills both rules into existing configs.
- **`apps/web` (`ChatView`)** — dispatch in the existing global shortcut handler.
  - `terminal.focus` picks one target via a pure `resolveTerminalFocusTarget` decision (unit-tested): the right-panel terminal when it is the only terminal showing (drawer closed, or right panel maximized), otherwise the drawer — opening it when closed, where the closed→open transition already requests focus and creates the first session. The right-panel terminal now consumes its own `panelTerminalFocusRequestId` — bumped by the panel's own lifecycle actions (add, split, activate, close, surface activation) and by `terminal.focus` when the panel is the target — so a focus request lands on exactly one surface instead of broadcasting to both terminal hosts.
  - `chat.focusComposer` calls the existing `focusComposer()` and leaves the terminal open.
  - Both commands first un-maximize the right panel when their target lives in the chat column, which a maximized panel collapses to zero width — without this, focus would land on an invisible element.
- **Settings → Keybindings** — no changes needed: labels derive from the command IDs ("Terminal: Focus", "Chat: Focus Composer") and both commands appear in the add-binding dropdown because they ship as defaults.
- **`docs/user/keybindings.md`** — short note on the pair and how it differs from `terminal.toggle`.

## Verification

- `vp test run` on the touched suites: web keybindings 46 passed (4 new: the `` ctrl+` `` pair resolves per `terminalFocus` context on macOS and Windows, against the real shipped defaults so the rules are proven to parse), ChatView logic 43 passed (5 new covering every `resolveTerminalFocusTarget` branch), keybindings settings logic 9 passed (label + dropdown coverage), server keybindings 22 passed (default backfill is generic over `DEFAULT_KEYBINDINGS`).
- `tsgo --noEmit` clean for `contracts`, `shared`, and `web`; `vp lint` clean on touched files.
- **Demo video (25s):** [ctrl-backtick-focus-demo.webm](https://github.com/achtan/t3code/releases/download/pr-5961-proof/ctrl-backtick-focus-demo.webm) — recorded in a real browser against a dev build of this branch. It shows: typing in the composer → `` ctrl+` `` opens the drawer and focuses the terminal (an `echo` typed immediately after the keypress lands at the shell prompt) → `` ctrl+` `` hops back to the composer with the drawer still open → a third press hops into the already-open terminal (`pwd`) → a final press returns to the composer. No mouse after the first click.

  Final state:

  ![final state: composer text typed across two hops, terminal transcript with echo and pwd](https://github.com/achtan/t3code/releases/download/pr-5961-proof/final-state.png)

Built with Claude Fable 5 (claude-fable-5) via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI focus and keybinding routing only; no auth, data, or API changes. Logic is isolated and covered by new unit tests.
> 
> **Overview**
> Adds **`terminal.focus`** and **`chat.focusComposer`** so users can hop between the message composer and terminal without toggling the drawer (addresses the gap where typing cannot return focus from the terminal textarea).
> 
> **Defaults:** Both bind to `` ctrl+` `` with opposite `when: terminalFocus` clauses in shared keybindings; contracts register the new static commands.
> 
> **Behavior:** `ChatView` handles the commands in the global shortcut handler. `resolveTerminalFocusTarget` (pure, unit-tested) chooses the right-panel terminal vs drawer vs open-drawer, including when the right panel is maximized. Right-panel terminal actions bump a separate **`panelTerminalFocusRequestId`** so focus requests hit one surface instead of drawer + panel together. Either command un-maximizes the right panel when focus must land in the chat column.
> 
> Docs and settings tests cover labels and the new commands in the keybindings UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 488b424b5db82553f78053a0b99d2608ae575c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `terminal.focus` and `chat.focusComposer` keybindings mapped to Ctrl+`
> - Pressing Ctrl+` outside the terminal focuses the terminal: targeting the panel terminal if active, or opening/focusing the drawer otherwise.
> - Pressing Ctrl+` while inside the terminal focuses the message composer and collapses a maximized right panel if needed.
> - Adds `resolveTerminalFocusTarget` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/5961/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) to determine which terminal surface (`panel`, `drawer`, or `open-drawer`) to target.
> - Introduces a dedicated `panelTerminalFocusRequestId` state separate from `terminalFocusRequestId` so panel terminal actions no longer interfere with drawer focus requests.
> - Behavioral Change: panel terminal actions (`addTerminalSurface`, `splitPanelTerminal`, etc.) now increment `panelTerminalFocusRequestId` instead of `terminalFocusRequestId`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 488b424.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->