### PR TITLE
feat(web): folder picker can sort by last modified

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -13,6 +13,7 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopClientSettings from "./DesktopClientSettings.ts";
 
 const clientSettings: ClientSettings = {
+  addProjectFolderSortOrder: "modified",
   confirmThreadArchive: true,
   confirmThreadDelete: false,
   dismissedProviderUpdateNotificationKeys: [],

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -18,7 +18,7 @@ import * as WorkspacePaths from "./WorkspacePaths.ts";
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
-  return { ...actual, readdir: vi.fn(actual.readdir) };
+  return { ...actual, readdir: vi.fn(actual.readdir), stat: vi.fn(actual.stat) };
 });
 
 const TestLayer = Layer.empty.pipe(
@@ -655,6 +655,48 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
             { name: "alpine", fullPath: path.join(cwd, "alpine") },
           ],
         });
+      }),
+    );
+
+    it.effect("sorts directories by their own modified time when requested", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-modified-" });
+        yield* writeTextFile(cwd, "alpha/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "beta/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "zulu/index.ts", "export {};\n");
+        const older = new Date("2025-01-01T00:00:00.000Z");
+        const newer = new Date("2025-02-01T00:00:00.000Z");
+        yield* fileSystem.utimes(path.join(cwd, "alpha"), older, older);
+        yield* fileSystem.utimes(path.join(cwd, "beta"), newer, newer);
+        yield* fileSystem.utimes(path.join(cwd, "zulu"), newer, newer);
+
+        const result = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+          sortOrder: "modified",
+        });
+
+        expect(result.entries.map((entry) => entry.name)).toEqual(["beta", "zulu", "alpha"]);
+      }),
+    );
+
+    it.effect("does not stat directories for the default name order", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-name-" });
+        yield* writeTextFile(cwd, "zulu/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "alpha/index.ts", "export {};\n");
+        const stat = vi.mocked(NodeFSP.stat);
+        stat.mockClear();
+
+        const result = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+        });
+
+        expect(result.entries.map((entry) => entry.name)).toEqual(["alpha", "zulu"]);
+        expect(stat).not.toHaveBeenCalled();
       }),
     );
 

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -230,9 +230,30 @@ export const make = Effect.gen(function* () {
         }
       }
 
+      const entriesByName = () =>
+        entries.toSorted((left, right) => left.name.localeCompare(right.name));
+      if (input.sortOrder !== "modified") {
+        return { parentPath, entries: entriesByName() };
+      }
+
+      const entriesWithModifiedTime = yield* Effect.forEach(
+        entries,
+        (entry) =>
+          Effect.tryPromise(() => NodeFSP.stat(entry.fullPath)).pipe(
+            Effect.map((stats) => ({ entry, modifiedAt: stats.mtimeMs })),
+            Effect.orElseSucceed(() => ({ entry, modifiedAt: Number.NEGATIVE_INFINITY })),
+          ),
+        { concurrency: 16 },
+      );
+
       return {
         parentPath,
-        entries: entries.toSorted((left, right) => left.name.localeCompare(right.name)),
+        entries: entriesWithModifiedTime
+          .toSorted(
+            (left, right) =>
+              right.modifiedAt - left.modifiedAt || left.entry.name.localeCompare(right.entry.name),
+          )
+          .map(({ entry }) => entry),
       };
     },
   );

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -848,6 +848,7 @@ function OpenCommandPaletteDialog(props: {
           environmentId: browseEnvironmentId,
           input: {
             partialPath: browsePath.directoryPath,
+            sortOrder: clientSettings.addProjectFolderSortOrder,
             ...(currentProjectCwdForBrowse ? { cwd: currentProjectCwdForBrowse } : {}),
           },
         })
@@ -881,11 +882,18 @@ function OpenCommandPaletteDialog(props: {
         environmentId,
         input: {
           partialPath,
+          sortOrder: clientSettings.addProjectFolderSortOrder,
           ...(cwd ? { cwd } : {}),
         },
       });
     },
-    [browseEnvironmentId, currentProjectCwdForBrowse, environments, loadBrowsePath],
+    [
+      browseEnvironmentId,
+      clientSettings.addProjectFolderSortOrder,
+      currentProjectCwdForBrowse,
+      environments,
+      loadBrowsePath,
+    ],
   );
 
   useEffect(

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -525,6 +525,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
+      ...(settings.addProjectFolderSortOrder !== DEFAULT_UNIFIED_SETTINGS.addProjectFolderSortOrder
+        ? ["Folder sort order"]
+        : []),
       ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
         ? ["Archive confirmation"]
         : []),
@@ -539,6 +542,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
+      settings.addProjectFolderSortOrder,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
@@ -645,6 +649,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+      addProjectFolderSortOrder: DEFAULT_UNIFIED_SETTINGS.addProjectFolderSortOrder,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
       textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
@@ -2101,6 +2106,48 @@ export function GeneralSettingsPanel() {
               spellCheck={false}
               aria-label="Add project base directory"
             />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("folder-sort-order")}
+          description="Choose how folders are ordered in the Add Project browser."
+          resetAction={
+            settings.addProjectFolderSortOrder !==
+            DEFAULT_UNIFIED_SETTINGS.addProjectFolderSortOrder ? (
+              <SettingResetButton
+                label="folder sort order"
+                onClick={() =>
+                  updateSettings({
+                    addProjectFolderSortOrder: DEFAULT_UNIFIED_SETTINGS.addProjectFolderSortOrder,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.addProjectFolderSortOrder}
+              onValueChange={(value) => {
+                if (value === "name" || value === "modified") {
+                  updateSettings({ addProjectFolderSortOrder: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-44" aria-label="Folder sort order">
+                <SelectValue>
+                  {settings.addProjectFolderSortOrder === "modified" ? "Last modified" : "Name"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="name">
+                  Name
+                </SelectItem>
+                <SelectItem hideIndicator value="modified">
+                  Last modified
+                </SelectItem>
+              </SelectPopup>
+            </Select>
           }
         />
 

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -135,6 +135,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "folder-sort-order",
+    title: "Folder sort order",
+    to: "/settings/general",
+  },
+  {
     id: "archive-confirmation",
     title: "Archive confirmation",
     to: "/settings/general",

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -21,6 +21,9 @@ T3 Code works with the platforms your team already uses:
 - Choose **GitHub repository**, **GitLab repository**, **Bitbucket repository**, **Azure DevOps repository**, or paste any **Git URL**
 - Enter the repository path (`owner/repo`, `group/project`, `workspace/repository`, or `project/repository`) or a full Git URL, pick a destination, and start coding
 
+When browsing local folders, use **Settings → General → Folder sort order** to list folders by
+name or with the most recently modified folders first.
+
 **Publish local projects to the cloud**
 
 - Have a local Git repository without a remote?

--- a/packages/contracts/src/filesystem.test.ts
+++ b/packages/contracts/src/filesystem.test.ts
@@ -1,7 +1,25 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { FilesystemBrowseError } from "./filesystem.ts";
+import { FilesystemBrowseError, FilesystemBrowseInput } from "./filesystem.ts";
+
+describe("FilesystemBrowseInput", () => {
+  const decodeInput = Schema.decodeUnknownSync(FilesystemBrowseInput);
+
+  it("keeps name ordering compatible with clients that omit a sort order", () => {
+    expect(decodeInput({ partialPath: "~/projects/" })).toEqual({
+      partialPath: "~/projects/",
+    });
+  });
+
+  it.each(["name", "modified"] as const)("accepts the %s sort order", (sortOrder) => {
+    expect(decodeInput({ partialPath: "~/projects/", sortOrder }).sortOrder).toBe(sortOrder);
+  });
+
+  it("rejects unsupported sort orders", () => {
+    expect(() => decodeInput({ partialPath: "~/projects/", sortOrder: "size" })).toThrow();
+  });
+});
 
 describe("FilesystemBrowseError", () => {
   it("derives a stable message from browse context while retaining the cause", () => {

--- a/packages/contracts/src/filesystem.ts
+++ b/packages/contracts/src/filesystem.ts
@@ -3,9 +3,13 @@ import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 const FILESYSTEM_PATH_MAX_LENGTH = 512;
 
+export const FilesystemBrowseSortOrder = Schema.Literals(["name", "modified"]);
+export type FilesystemBrowseSortOrder = typeof FilesystemBrowseSortOrder.Type;
+
 export const FilesystemBrowseInput = Schema.Struct({
   partialPath: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
   cwd: Schema.optional(TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH))),
+  sortOrder: Schema.optionalKey(FilesystemBrowseSortOrder),
 });
 export type FilesystemBrowseInput = typeof FilesystemBrowseInput.Type;
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -16,6 +16,27 @@ const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
 const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 
+describe("ClientSettings add project folder order", () => {
+  it("defaults to name order", () => {
+    expect(decodeClientSettings({}).addProjectFolderSortOrder).toBe("name");
+  });
+
+  it("accepts last-modified order in settings and patches", () => {
+    expect(
+      decodeClientSettings({ addProjectFolderSortOrder: "modified" }).addProjectFolderSortOrder,
+    ).toBe("modified");
+    expect(
+      decodeClientSettingsPatch({ addProjectFolderSortOrder: "modified" })
+        .addProjectFolderSortOrder,
+    ).toBe("modified");
+  });
+
+  it("rejects unsupported folder orders", () => {
+    expect(() => decodeClientSettings({ addProjectFolderSortOrder: "size" })).toThrow();
+    expect(() => decodeClientSettingsPatch({ addProjectFolderSortOrder: "size" })).toThrow();
+  });
+});
+
 describe("ClientSettings word wrap", () => {
   it("defaults word wrap on", () => {
     expect(decodeClientSettings({}).wordWrap).toBe(true);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -4,6 +4,7 @@ import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
 import { TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
 import { ThreadEnvMode } from "./environment.ts";
+import { FilesystemBrowseSortOrder } from "./filesystem.ts";
 import {
   DEFAULT_TEXT_GENERATION_MODEL,
   DEFAULT_TEXT_GENERATION_REASONING_EFFORT,
@@ -25,6 +26,8 @@ export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "upda
 export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
+
+export const DEFAULT_ADD_PROJECT_FOLDER_SORT_ORDER: FilesystemBrowseSortOrder = "name";
 
 export const SidebarProjectGroupingMode = Schema.Literals([
   "repository",
@@ -112,6 +115,9 @@ export const FontFamilyPreference = Schema.String.check(Schema.isMaxLength(200))
 export type FontFamilyPreference = typeof FontFamilyPreference.Type;
 
 export const ClientSettingsSchema = Schema.Struct({
+  addProjectFolderSortOrder: FilesystemBrowseSortOrder.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_ADD_PROJECT_FOLDER_SORT_ORDER)),
+  ),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   dismissedProviderUpdateNotificationKeys: Schema.Array(TrimmedNonEmptyString).pipe(
@@ -755,6 +761,7 @@ export const ServerSettingsPatch = Schema.Struct({
 export type ServerSettingsPatch = typeof ServerSettingsPatch.Type;
 
 export const ClientSettingsPatch = Schema.Struct({
+  addProjectFolderSortOrder: Schema.optionalKey(FilesystemBrowseSortOrder),
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
Fixes #2122.

The Add Project browser always ordered folders by name. That leaves recently touched project directories buried in long alphabetical lists, with no way to put current work first.

This adds **Settings → General → Folder sort order**. Name stays the default, so existing behavior and its single-`readdir` fast path are unchanged. Last modified follows `ls -lt` semantics: it reads each visible directory's own `mtime`, puts the newest first, and uses the name as a stable tie-breaker. Those stats run with bounded concurrency and only when that mode is selected.

The preference is client-local and travels as an optional `filesystem.browse` input, which keeps older clients and the mobile browser on name order. Settings search, reset-to-default, desktop persistence coverage, and user docs follow the new field.

## Screenshots

| Before | After |
| --- | --- |
| ![General settings before the folder sort order setting](https://raw.githubusercontent.com/RodriMora/t3code/pr-assets-2122/pr-assets/issue-2122/before-folder-sort-order.png) | ![General settings with the new folder sort order setting](https://raw.githubusercontent.com/RodriMora/t3code/pr-assets-2122/pr-assets/issue-2122/after-folder-sort-order.png) |

## Verification

- 94 focused contract, server, desktop persistence, client runtime, and web tests pass.
- Targeted lint passes for every changed TypeScript file.
- Format check passes for all 11 changed files.
- An isolated paired web app confirms the General settings row renders correctly; the before/after images use the same app state and viewport.

Built by GPT-5.6-sol in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sort-by-last-modified option to the folder picker when adding a project
> - Adds a new `addProjectFolderSortOrder` client setting ("name" or "modified", default "name") configurable in General Settings.
> - The folder browser in the Command Palette passes this setting as `sortOrder` to the `filesystem.browse` API, which now performs concurrent `fs.stat` calls (concurrency 16) to sort directories by descending `mtimeMs` when `sortOrder="modified"`.
> - Default name ordering no longer calls `fs.stat`, avoiding unnecessary I/O.
> - Adds "Folder sort order" as a searchable entry in settings search and documents the option in [source-control.md](https://github.com/pingdotgg/t3code/pull/5963/files#diff-a171985f6d647c7bc51efc65cf1a0b7261bb1313fe7c275c74f3836f919d1c05).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2a68aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized browse UX and optional API input; default behavior and I/O path are unchanged, with tests covering sort logic and the no-stat fast path.
> 
> **Overview**
> Adds **Settings → General → Folder sort order** so the Add Project folder browser can list directories by **name** (default) or **last modified** (newest first, name as tie-breaker).
> 
> The choice is stored in the client setting `addProjectFolderSortOrder` and sent as optional `sortOrder` on `filesystem.browse`. When `modified` is selected, the server stats each visible directory (`mtimeMs`, concurrency 16); the default name path still sorts after `readdir` only and does not call `stat`. Contracts, settings search/reset, desktop persistence tests, and user docs are updated for the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a68aa13f69ee669cef02f252e6079fb51107aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->