### PR TITLE
fix(web): use import/export-appropriate icons for theme buttons

### DIFF
--- a/apps/web/src/components/settings/ThemeImportDialog.tsx
+++ b/apps/web/src/components/settings/ThemeImportDialog.tsx
@@ -1,4 +1,4 @@
-import { PlusIcon, UploadIcon } from "lucide-react";
+import { DownloadIcon, PlusIcon } from "lucide-react";
 import type { ChangeEvent, DragEvent, UIEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "../../lib/utils";
@@ -456,7 +456,7 @@ export function ThemeImportDialog({
             );
             const chooseButton = (label = "Choose files") => (
               <Button disabled={isReading} size="sm" variant="outline" onClick={openFilePicker}>
-                <UploadIcon />
+                <DownloadIcon />
                 {isReading ? "Reading…" : label}
               </Button>
             );

--- a/apps/web/src/components/settings/ThemeSettings.tsx
+++ b/apps/web/src/components/settings/ThemeSettings.tsx
@@ -183,7 +183,7 @@ function ThemeLibraryCard({
                               onDownload();
                             }}
                           >
-                            <DownloadIcon />
+                            <UploadIcon />
                           </Button>
                         }
                       />
@@ -570,7 +570,7 @@ export function ThemeLibrary({
             Create theme
           </Button>
           <Button size="xs" variant="outline" onClick={() => onImportOpenChange(true)}>
-            <UploadIcon />
+            <DownloadIcon />
             Import theme
           </Button>
         </div>


### PR DESCRIPTION
## What Changed

Swapped the theme icons to match their actual actions (import = down arrow, export = out arrow):

- Import theme button: Upload icon to download icon [up arrow → down arrow (brings a file in)]
- Export theme file button: Download icon to upload icon [down arrow → up arrow (sends a file out)]
- Choose files button in the import dialog: Upload icon to download icon [up arrow → down arrow]

## Why

The two icons were backwards: the import button showed an up arrow (reads as export) and the export button showed a down arrow (reads as import). Now each button's icon matches its action, and the pair is visually distinct.

## UI Changes

Before:
<img width="154" height="36" alt="image" src="https://github.com/user-attachments/assets/983358bf-e6a5-4a54-85a4-5e12883f5c08" />
<img width="216" height="120" alt="image" src="https://github.com/user-attachments/assets/263db755-4090-4d5f-8849-4c2bfd9c14d0" />
<img width="168" height="42" alt="image" src="https://github.com/user-attachments/assets/68e17442-84dd-4840-a455-cedc4174b44f" />

After:
<img width="153" height="36" alt="image" src="https://github.com/user-attachments/assets/6b1c59eb-d97d-4d8e-a996-6c3bfda31017" />
<img width="178" height="115" alt="image" src="https://github.com/user-attachments/assets/750d8466-169a-497d-b2d5-cdc0e5c64b89" />
<img width="168" height="42" alt="image" src="https://github.com/user-attachments/assets/ef580309-0799-43c2-821f-2ad6fd094359" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic icon-only changes in theme settings UI with no logic or data impact.
> 
> **Overview**
> Swaps Lucide icons on theme **import** and **export** controls so the glyphs match the action instead of appearing reversed.
> 
> **Import theme** (settings toolbar) and **Choose files** (import dialog) now use `DownloadIcon`; per-theme **Export theme file** uses `UploadIcon`. Button labels, tooltips, and behavior are unchanged—only the icons and their imports were updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b3ca550e1dcc69c65022725fb0cfacb620cac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix import/export icons on theme buttons in settings
> Corrects mismatched icons on theme import/export controls in [ThemeSettings.tsx](https://github.com/pingdotgg/t3code/pull/5964/files#diff-4cc84a2ea71f7b5fef270e04a72f0110c8530ee83377e432642907950560b408) and [ThemeImportDialog.tsx](https://github.com/pingdotgg/t3code/pull/5964/files#diff-724bc463d6fc18b8d6a9e64d35374c9e06bea66dc38ba6e4c72f39353323b9e5). The export button now shows an upload icon, the import button and file-choose button now show a download icon.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99b3ca5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->