### PR TITLE
fix(swift-ios): prevent approved device build downgrades

### DIFF
--- a/apps/swift-ios/README.md
+++ b/apps/swift-ios/README.md
@@ -125,14 +125,16 @@ Developer account for the requested team.
 ```sh
 T3_SWIFT_DEVICE_ID="DEVICE-IDENTIFIER" \
 T3_SWIFT_DEVELOPMENT_TEAM="TEAMID1234" \
+T3_SWIFT_BUILD_NUMBER="123" \
 ./Scripts/install-device.sh
 ```
 
 The script builds, provisions, installs, and launches the Debug identity by
 default. Set `T3_SWIFT_CONFIGURATION=Release` for the TestFlight identity. It
-accepts the T3 Connect build settings above as environment variables. Optional
-overrides are `T3_SWIFT_DERIVED_DATA_PATH`, `T3_SWIFT_VERSION`, and
-`T3_SWIFT_BUILD_NUMBER`. Run with
+accepts the T3 Connect build settings above as environment variables.
+`T3_SWIFT_BUILD_NUMBER` is required and must be greater than the build already
+installed on the phone. Optional overrides are `T3_SWIFT_DERIVED_DATA_PATH` and
+`T3_SWIFT_VERSION`. Run with
 `T3_SWIFT_VERIFY_BUNDLE_IDENTIFIERS_ONLY=1` to verify the configuration's host
 and extension bundle identifiers without a device build.
 

--- a/apps/swift-ios/README.md
+++ b/apps/swift-ios/README.md
@@ -134,7 +134,9 @@ default. Set `T3_SWIFT_CONFIGURATION=Release` for the TestFlight identity. It
 accepts the T3 Connect build settings above as environment variables.
 `T3_SWIFT_BUILD_NUMBER` is required and must be greater than the build already
 installed on the phone. Optional overrides are `T3_SWIFT_DERIVED_DATA_PATH` and
-`T3_SWIFT_VERSION`. Run with
+`T3_SWIFT_VERSION`. If the phone cannot report its installed apps, retry only
+after checking the target device with `T3_SWIFT_SKIP_INSTALLED_BUILD_CHECK=1`.
+Run with
 `T3_SWIFT_VERIFY_BUNDLE_IDENTIFIERS_ONLY=1` to verify the configuration's host
 and extension bundle identifiers without a device build.
 

--- a/apps/swift-ios/Scripts/Fixtures/installed-apps.json
+++ b/apps/swift-ios/Scripts/Fixtures/installed-apps.json
@@ -6,6 +6,13 @@
         "bundleVersion": "4"
       },
       {
+        "bundleIdentifier": "com.example.missing-version"
+      },
+      {
+        "bundleIdentifier": "com.example.empty-version",
+        "bundleVersion": ""
+      },
+      {
         "bundleIdentifier": "com.t3tools.t3code.swiftui.dev",
         "bundleVersion": "21"
       }

--- a/apps/swift-ios/Scripts/Fixtures/installed-apps.json
+++ b/apps/swift-ios/Scripts/Fixtures/installed-apps.json
@@ -1,0 +1,14 @@
+{
+  "result": {
+    "apps": [
+      {
+        "bundleIdentifier": "com.example.other",
+        "bundleVersion": "4"
+      },
+      {
+        "bundleIdentifier": "com.t3tools.t3code.swiftui.dev",
+        "bundleVersion": "21"
+      }
+    ]
+  }
+}

--- a/apps/swift-ios/Scripts/ci-test.sh
+++ b/apps/swift-ios/Scripts/ci-test.sh
@@ -21,6 +21,8 @@ require_cmd awk
 require_cmd xcodebuild
 require_cmd xcrun
 
+"${SCRIPT_DIR}/validate-device-build-number.test.sh"
+
 if [[ -z "${SIMULATOR_ID}" ]]; then
   # simctl groups devices by runtime. Keeping the last available iPhone picks
   # the newest installed iOS runtime without coupling CI to a device model.

--- a/apps/swift-ios/Scripts/install-device.sh
+++ b/apps/swift-ios/Scripts/install-device.sh
@@ -19,8 +19,6 @@ require_cmd() {
 }
 
 require_cmd awk
-require_cmd git
-require_cmd jq
 require_cmd mktemp
 require_cmd plutil
 require_cmd xcodebuild
@@ -88,15 +86,16 @@ DESTINATION_ID="$(
   xcrun swift "${SCRIPT_DIR}/resolve-device-udid.swift" "${DEVICE_JSON}" "${DEVICE_ID}"
 )" || die "could not resolve device '${DEVICE_ID}' to an Xcode destination UDID"
 
-xcrun devicectl device info apps \
+if ! xcrun devicectl device info apps \
   --device "${DESTINATION_ID}" \
   --bundle-id "${BUNDLE_IDENTIFIER}" \
   --json-output "${INSTALLED_APPS_JSON}" \
-  --quiet >/dev/null
+  --quiet >/dev/null; then
+  die "could not query installed apps on device '${DESTINATION_ID}'"
+fi
 INSTALLED_BUILD_NUMBER="$(
-  jq -r --arg bundle "${BUNDLE_IDENTIFIER}" \
-    'first(.result.apps[]? | select(.bundleIdentifier == $bundle) | .bundleVersion) // empty' \
-    "${INSTALLED_APPS_JSON}"
+  xcrun swift "${SCRIPT_DIR}/resolve-installed-build-number.swift" \
+    "${INSTALLED_APPS_JSON}" "${BUNDLE_IDENTIFIER}"
 )"
 "${SCRIPT_DIR}/validate-device-build-number.sh" \
   "${T3_SWIFT_BUILD_NUMBER}" "${INSTALLED_BUILD_NUMBER}"

--- a/apps/swift-ios/Scripts/install-device.sh
+++ b/apps/swift-ios/Scripts/install-device.sh
@@ -78,12 +78,15 @@ build_settings=(
   "DEVELOPMENT_TEAM=${DEVELOPMENT_TEAM}"
 )
 
-DEVICE_JSON="$(mktemp -t t3-swift-devices.XXXXXX)"
-INSTALLED_APPS_JSON="$(mktemp -t t3-swift-installed-apps.XXXXXX)"
+DEVICE_JSON=""
+INSTALLED_APPS_JSON=""
 cleanup() {
-  rm -f -- "${DEVICE_JSON}" "${INSTALLED_APPS_JSON}"
+  [[ -z "${DEVICE_JSON}" ]] || rm -f -- "${DEVICE_JSON}"
+  [[ -z "${INSTALLED_APPS_JSON}" ]] || rm -f -- "${INSTALLED_APPS_JSON}"
 }
 trap cleanup EXIT
+DEVICE_JSON="$(mktemp -t t3-swift-devices.XXXXXX)"
+INSTALLED_APPS_JSON="$(mktemp -t t3-swift-installed-apps.XXXXXX)"
 xcrun devicectl list devices --json-output "${DEVICE_JSON}" --quiet >/dev/null
 DESTINATION_ID="$(
   xcrun swift "${SCRIPT_DIR}/resolve-device-udid.swift" "${DEVICE_JSON}" "${DEVICE_ID}"

--- a/apps/swift-ios/Scripts/install-device.sh
+++ b/apps/swift-ios/Scripts/install-device.sh
@@ -19,6 +19,8 @@ require_cmd() {
 }
 
 require_cmd awk
+require_cmd git
+require_cmd jq
 require_cmd mktemp
 require_cmd plutil
 require_cmd xcodebuild
@@ -71,17 +73,34 @@ fi
   "set T3_SWIFT_DEVICE_ID to a CoreDevice identifier or UDID from 'xcrun devicectl list devices --columns UDID'"
 [[ -n "${DEVELOPMENT_TEAM}" ]] || die \
   "set T3_SWIFT_DEVELOPMENT_TEAM to your Apple Developer team ID"
+[[ -n "${T3_SWIFT_BUILD_NUMBER:-}" ]] || die \
+  "set T3_SWIFT_BUILD_NUMBER to a number newer than the installed phone build"
 
 build_settings=(
   "DEVELOPMENT_TEAM=${DEVELOPMENT_TEAM}"
 )
 
 DEVICE_JSON="$(mktemp -t t3-swift-devices.XXXXXX)"
-trap 'unlink "${DEVICE_JSON}" 2>/dev/null || true' EXIT
+INSTALLED_APPS_JSON="$(mktemp -t t3-swift-installed-apps.XXXXXX)"
+trap 'unlink "${DEVICE_JSON}" "${INSTALLED_APPS_JSON}" 2>/dev/null || true' EXIT
 xcrun devicectl list devices --json-output "${DEVICE_JSON}" --quiet >/dev/null
 DESTINATION_ID="$(
   xcrun swift "${SCRIPT_DIR}/resolve-device-udid.swift" "${DEVICE_JSON}" "${DEVICE_ID}"
 )" || die "could not resolve device '${DEVICE_ID}' to an Xcode destination UDID"
+
+xcrun devicectl device info apps \
+  --device "${DESTINATION_ID}" \
+  --bundle-id "${BUNDLE_IDENTIFIER}" \
+  --json-output "${INSTALLED_APPS_JSON}" \
+  --quiet >/dev/null
+INSTALLED_BUILD_NUMBER="$(
+  jq -r --arg bundle "${BUNDLE_IDENTIFIER}" \
+    'first(.result.apps[]? | select(.bundleIdentifier == $bundle) | .bundleVersion) // empty' \
+    "${INSTALLED_APPS_JSON}"
+)"
+"${SCRIPT_DIR}/validate-device-build-number.sh" \
+  "${T3_SWIFT_BUILD_NUMBER}" "${INSTALLED_BUILD_NUMBER}"
+build_settings+=("CURRENT_PROJECT_VERSION=${T3_SWIFT_BUILD_NUMBER}")
 
 for key in \
   T3CODE_CLERK_PUBLISHABLE_KEY \
@@ -96,10 +115,6 @@ done
 if [[ -n "${T3_SWIFT_VERSION:-}" ]]; then
   build_settings+=("MARKETING_VERSION=${T3_SWIFT_VERSION}")
 fi
-if [[ -n "${T3_SWIFT_BUILD_NUMBER:-}" ]]; then
-  build_settings+=("CURRENT_PROJECT_VERSION=${T3_SWIFT_BUILD_NUMBER}")
-fi
-
 printf '[swift-ios-device] building %s for %s\n' "${BUNDLE_IDENTIFIER}" "${DESTINATION_ID}"
 xcodebuild build \
   -project "${APP_DIR}/T3Code.xcodeproj" \

--- a/apps/swift-ios/Scripts/install-device.sh
+++ b/apps/swift-ios/Scripts/install-device.sh
@@ -80,23 +80,29 @@ build_settings=(
 
 DEVICE_JSON="$(mktemp -t t3-swift-devices.XXXXXX)"
 INSTALLED_APPS_JSON="$(mktemp -t t3-swift-installed-apps.XXXXXX)"
-trap 'unlink "${DEVICE_JSON}" "${INSTALLED_APPS_JSON}" 2>/dev/null || true' EXIT
+cleanup() {
+  rm -f -- "${DEVICE_JSON}" "${INSTALLED_APPS_JSON}"
+}
+trap cleanup EXIT
 xcrun devicectl list devices --json-output "${DEVICE_JSON}" --quiet >/dev/null
 DESTINATION_ID="$(
   xcrun swift "${SCRIPT_DIR}/resolve-device-udid.swift" "${DEVICE_JSON}" "${DEVICE_ID}"
 )" || die "could not resolve device '${DEVICE_ID}' to an Xcode destination UDID"
 
-if ! xcrun devicectl device info apps \
-  --device "${DESTINATION_ID}" \
-  --bundle-id "${BUNDLE_IDENTIFIER}" \
-  --json-output "${INSTALLED_APPS_JSON}" \
-  --quiet >/dev/null; then
-  die "could not query installed apps on device '${DESTINATION_ID}'"
+INSTALLED_BUILD_NUMBER=""
+if [[ "${T3_SWIFT_SKIP_INSTALLED_BUILD_CHECK:-0}" != "1" ]]; then
+  if ! xcrun devicectl device info apps \
+    --device "${DESTINATION_ID}" \
+    --bundle-id "${BUNDLE_IDENTIFIER}" \
+    --json-output "${INSTALLED_APPS_JSON}" \
+    --quiet >/dev/null; then
+    die "could not query installed apps; set T3_SWIFT_SKIP_INSTALLED_BUILD_CHECK=1 to bypass this check"
+  fi
+  INSTALLED_BUILD_NUMBER="$(
+    xcrun swift "${SCRIPT_DIR}/resolve-installed-build-number.swift" \
+      "${INSTALLED_APPS_JSON}" "${BUNDLE_IDENTIFIER}"
+  )" || die "could not read the installed build number"
 fi
-INSTALLED_BUILD_NUMBER="$(
-  xcrun swift "${SCRIPT_DIR}/resolve-installed-build-number.swift" \
-    "${INSTALLED_APPS_JSON}" "${BUNDLE_IDENTIFIER}"
-)"
 "${SCRIPT_DIR}/validate-device-build-number.sh" \
   "${T3_SWIFT_BUILD_NUMBER}" "${INSTALLED_BUILD_NUMBER}"
 build_settings+=("CURRENT_PROJECT_VERSION=${T3_SWIFT_BUILD_NUMBER}")

--- a/apps/swift-ios/Scripts/resolve-installed-build-number.swift
+++ b/apps/swift-ios/Scripts/resolve-installed-build-number.swift
@@ -26,9 +26,15 @@ do {
         from: Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))
     )
     let bundleIdentifier = CommandLine.arguments[2]
-    if let version = payload.result.apps.first(where: {
+    if let app = payload.result.apps.first(where: {
         $0.bundleIdentifier == bundleIdentifier
-    })?.bundleVersion {
+    }) {
+        guard let version = app.bundleVersion, !version.isEmpty else {
+            FileHandle.standardError.write(
+                Data("Installed app \(bundleIdentifier) has no build number.\n".utf8)
+            )
+            exit(1)
+        }
         print(version)
     }
 } catch {

--- a/apps/swift-ios/Scripts/resolve-installed-build-number.swift
+++ b/apps/swift-ios/Scripts/resolve-installed-build-number.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+private struct InstalledApps: Decodable {
+    struct Result: Decodable {
+        struct App: Decodable {
+            let bundleIdentifier: String
+            let bundleVersion: String?
+        }
+
+        let apps: [App]
+    }
+
+    let result: Result
+}
+
+guard CommandLine.arguments.count == 3 else {
+    FileHandle.standardError.write(
+        Data("usage: resolve-installed-build-number <apps.json> <bundle-identifier>\n".utf8)
+    )
+    exit(64)
+}
+
+do {
+    let payload = try JSONDecoder().decode(
+        InstalledApps.self,
+        from: Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))
+    )
+    let bundleIdentifier = CommandLine.arguments[2]
+    if let version = payload.result.apps.first(where: {
+        $0.bundleIdentifier == bundleIdentifier
+    })?.bundleVersion {
+        print(version)
+    }
+} catch {
+    FileHandle.standardError.write(
+        Data("Could not read installed app build number: \(error.localizedDescription)\n".utf8)
+    )
+    exit(1)
+}

--- a/apps/swift-ios/Scripts/validate-device-build-number.sh
+++ b/apps/swift-ios/Scripts/validate-device-build-number.sh
@@ -20,8 +20,9 @@ esac
 
 case "$installed" in
   *[!0-9]*)
-    printf '[swift-ios-device] error: installed app has nonnumeric build number %s\n' "$installed" >&2
-    exit 1
+    printf '[swift-ios-device] warning: installed app has nonnumeric build number %s; skipping comparison\n' \
+      "$installed" >&2
+    exit 0
     ;;
 esac
 

--- a/apps/swift-ios/Scripts/validate-device-build-number.sh
+++ b/apps/swift-ios/Scripts/validate-device-build-number.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+requested=${1:-}
+installed=${2:-}
+
+case "$requested" in
+  ''|*[!0-9]*)
+    printf '[swift-ios-device] error: T3_SWIFT_BUILD_NUMBER must be a positive integer\n' >&2
+    exit 1
+    ;;
+esac
+
+[ "$requested" -gt 0 ] || {
+  printf '[swift-ios-device] error: T3_SWIFT_BUILD_NUMBER must be greater than zero\n' >&2
+  exit 1
+}
+
+[ -n "$installed" ] || exit 0
+
+case "$installed" in
+  *[!0-9]*)
+    printf '[swift-ios-device] error: installed app has nonnumeric build number %s\n' "$installed" >&2
+    exit 1
+    ;;
+esac
+
+[ "$requested" -gt "$installed" ] || {
+  printf '[swift-ios-device] error: requested build %s must be newer than installed build %s\n' \
+    "$requested" "$installed" >&2
+  exit 1
+}

--- a/apps/swift-ios/Scripts/validate-device-build-number.test.sh
+++ b/apps/swift-ios/Scripts/validate-device-build-number.test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+VALIDATE="$SCRIPT_DIR/validate-device-build-number.sh"
+
+expect_acceptance() {
+  label=$1
+  shift
+  if ! /bin/sh "$VALIDATE" "$@" >/dev/null 2>&1; then
+    printf 'expected acceptance: %s\n' "$label" >&2
+    exit 1
+  fi
+}
+
+expect_rejection() {
+  label=$1
+  shift
+  if /bin/sh "$VALIDATE" "$@" >/dev/null 2>&1; then
+    printf 'expected rejection: %s\n' "$label" >&2
+    exit 1
+  fi
+}
+
+expect_acceptance "first install" 1 ""
+expect_acceptance "monotonic upgrade" 22 21
+expect_rejection "missing requested build" "" 21
+expect_rejection "nonnumeric requested build" next 21
+expect_rejection "equal installed build" 21 21
+expect_rejection "older installed build" 20 21
+expect_rejection "nonnumeric installed build" 22 old
+
+printf 'device build-number validation tests passed\n'

--- a/apps/swift-ios/Scripts/validate-device-build-number.test.sh
+++ b/apps/swift-ios/Scripts/validate-device-build-number.test.sh
@@ -44,4 +44,14 @@ missing="$(xcrun swift "$RESOLVE" "$FIXTURE" com.example.missing)"
   exit 1
 }
 
+if xcrun swift "$RESOLVE" "$FIXTURE" com.example.missing-version >/dev/null 2>&1; then
+  printf 'expected an installed app without a build number to fail resolution\n' >&2
+  exit 1
+fi
+
+if xcrun swift "$RESOLVE" "$FIXTURE" com.example.empty-version >/dev/null 2>&1; then
+  printf 'expected an installed app with an empty build number to fail resolution\n' >&2
+  exit 1
+fi
+
 printf 'device build-number validation tests passed\n'

--- a/apps/swift-ios/Scripts/validate-device-build-number.test.sh
+++ b/apps/swift-ios/Scripts/validate-device-build-number.test.sh
@@ -30,7 +30,7 @@ expect_rejection "missing requested build" "" 21
 expect_rejection "nonnumeric requested build" next 21
 expect_rejection "equal installed build" 21 21
 expect_rejection "older installed build" 20 21
-expect_rejection "nonnumeric installed build" 22 old
+expect_acceptance "legacy nonnumeric installed build" 22 old
 
 resolved="$(xcrun swift "$RESOLVE" "$FIXTURE" com.t3tools.t3code.swiftui.dev)"
 [ "$resolved" = 21 ] || {

--- a/apps/swift-ios/Scripts/validate-device-build-number.test.sh
+++ b/apps/swift-ios/Scripts/validate-device-build-number.test.sh
@@ -3,6 +3,8 @@ set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 VALIDATE="$SCRIPT_DIR/validate-device-build-number.sh"
+RESOLVE="$SCRIPT_DIR/resolve-installed-build-number.swift"
+FIXTURE="$SCRIPT_DIR/Fixtures/installed-apps.json"
 
 expect_acceptance() {
   label=$1
@@ -29,5 +31,17 @@ expect_rejection "nonnumeric requested build" next 21
 expect_rejection "equal installed build" 21 21
 expect_rejection "older installed build" 20 21
 expect_rejection "nonnumeric installed build" 22 old
+
+resolved="$(xcrun swift "$RESOLVE" "$FIXTURE" com.t3tools.t3code.swiftui.dev)"
+[ "$resolved" = 21 ] || {
+  printf 'expected installed build 21, got %s\n' "$resolved" >&2
+  exit 1
+}
+
+missing="$(xcrun swift "$RESOLVE" "$FIXTURE" com.example.missing)"
+[ -z "$missing" ] || {
+  printf 'expected no build for a missing app, got %s\n' "$missing" >&2
+  exit 1
+}
 
 printf 'device build-number validation tests passed\n'


### PR DESCRIPTION
## Summary

Makes physical-device installs require a positive build number newer than the installed build. Uses a Swift JSON resolver instead of jq, has an explicit recovery override for device-query failures, and wires validation into native CI.

## Verification

- apps/swift-ios/Scripts/ci-test.sh — 218 tests passed; validate-device-build-number.test.sh passed
- Fresh independent Claude Opus 5 high review completed; all actionable findings were addressed and the final repair review found no blockers.
- Simulator visual evidence will be attached before marking this PR ready for review.

## Scope

Targets the active native SwiftUI owner branch (#5178).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent approved device build downgrades in iOS device install script
> - `install-device.sh` now requires `T3_SWIFT_BUILD_NUMBER` to be set and validates it is a positive integer greater than the build already installed on the target device.
> - Queries the device for installed apps via `xcrun devicectl device info apps`, then resolves the installed build number using the new [`resolve-installed-build-number.swift`](https://github.com/pingdotgg/t3code/pull/5970/files#diff-28a11a36ec561ff5167da2b14c8eb342928afc2259af1419cd28fe3241eca97e) utility.
> - Build comparison logic lives in [`validate-device-build-number.sh`](https://github.com/pingdotgg/t3code/pull/5970/files#diff-57ead9a82ab45492be46e33be5132fb55f965ce73ec6cd1a85a22dd86aad4f17), which warns (but accepts) when the installed build is non-numeric and errors when the requested build is not newer.
> - Set `T3_SWIFT_SKIP_INSTALLED_BUILD_CHECK=1` to bypass the installed-app query when the device cannot report installed apps.
> - Risk: `T3_SWIFT_BUILD_NUMBER` is now mandatory; any existing call to `install-device.sh` that omits it will fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20a57f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to developer install scripts and docs; existing automation that omitted `T3_SWIFT_BUILD_NUMBER` will fail until updated.
> 
> **Overview**
> Physical device installs now **require** `T3_SWIFT_BUILD_NUMBER` and refuse to build when that value is not strictly greater than the build already on the device for the target bundle ID.
> 
> `install-device.sh` queries installed apps with `devicectl`, parses `bundleVersion` via new `resolve-installed-build-number.swift`, and runs `validate-device-build-number.sh` before setting `CURRENT_PROJECT_VERSION`. First install (no app on device) is allowed; equal or lower builds fail. `T3_SWIFT_SKIP_INSTALLED_BUILD_CHECK=1` bypasses the device query when `devicectl` cannot list apps. README documents the required env var and escape hatch.
> 
> `ci-test.sh` runs `validate-device-build-number.test.sh` (shell tests plus Swift resolver against a JSON fixture) ahead of simulator tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a57f4272ebceaa88437b71a55ab43ae881c387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable; native/repository checks and current review are green. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
