### PR TITLE
fix(swift-ios): keep skills popup clear of the keyboard

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -83,7 +83,9 @@ struct FeatureComposerView: View {
                         onSelect: selectCommandItem
                     )
                     .alignmentGuide(.top) { dimensions in
-                        dimensions[.bottom] + 8
+                        // Keep the menu clear of the text entry surface so the
+                        // active `$`/`@`/`/` token remains readable while typing.
+                        dimensions[.bottom] + 24
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Raises the composer command popup clearance so skills, model, command, and path suggestions remain comfortably above the keyboard on small devices.

## Verification

- apps/swift-ios/Scripts/ci-test.sh — 218 tests passed
- Fresh independent Claude Opus 5 high review completed; all actionable findings were addressed and the final repair review found no blockers.
- Simulator visual evidence will be attached before marking this PR ready for review.

## Scope

Targets the active native SwiftUI owner branch (#5178).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move skills popup farther from the keyboard in iOS chat
> Increases the vertical offset of the `FeatureComposerCommandPopover` from +8 to +24 points in [FeatureComposerView.swift](https://github.com/pingdotgg/t3code/pull/5971/files#diff-879cf39f390728cbcdd543b9ea67d63d0509d21cf1c958b1c0a8b8f78948fee8), keeping the skills popup clear of the keyboard when typing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c99616a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only SwiftUI spacing change in the chat composer; no logic, networking, or data handling impact.
> 
> **Overview**
> **Raises the vertical gap** between the chat composer and the `FeatureComposerCommandPopover` so `$` / `@` / `/` suggestion menus sit farther above the text field.
> 
> The popover’s top alignment offset changes from **8pt to 24pt**, with a short comment that the extra space keeps the active token readable while typing and avoids overlap with the keyboard on smaller screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c99616a0d5efa112f1cfaeb1d8c0c8408e629993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable; native/repository checks and current review are green. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
