### PR TITLE
feat(swift-ios): mark debug threads with warning chrome

### DIFF
--- a/apps/swift-ios/DesignSystem/T3Theme.swift
+++ b/apps/swift-ios/DesignSystem/T3Theme.swift
@@ -7,6 +7,8 @@ enum T3Colors {
     // system appearance changes as SwiftUI views.
     static let uiBackground = adaptive(light: rgb(0xF2F2F7), dark: rgb(0x0A0A0A))
     static let uiTextPrimary = adaptive(light: rgb(0x262626), dark: rgb(0xF5F5F5))
+    static let uiWarning = adaptive(light: rgb(0xD97706), dark: rgb(0xFF9F0A))
+    static let uiWarningForeground = adaptive(light: rgb(0x000000), dark: rgb(0x000000))
 
     static let background = Color(uiColor: uiBackground)
     static let sheet = color(light: rgb(0xF2F2F7, alpha: 0.98), dark: rgb(0x0E0E0E, alpha: 0.98))
@@ -36,8 +38,16 @@ enum T3Colors {
     static let statusRunning = color(light: rgb(0x0284C7), dark: rgb(0x22D3EE))
     static let statusInput = color(light: rgb(0x4F46E5), dark: rgb(0xA5B4FC))
     static let success = color(light: rgb(0x16A34A), dark: rgb(0x30D158))
-    static let warning = color(light: rgb(0xD97706), dark: rgb(0xFF9F0A))
+    static let warning = Color(uiColor: uiWarning)
+    static let warningForeground = Color(uiColor: uiWarningForeground)
     static let danger = color(light: rgb(0xDC2626), dark: rgb(0xFF453A))
+
+    static func warning(for colorScheme: ColorScheme) -> Color {
+        let traits = UITraitCollection(
+            userInterfaceStyle: colorScheme == .dark ? .dark : .light
+        )
+        return Color(uiColor: uiWarning.resolvedColor(with: traits))
+    }
 
     static let syntaxKeyword = color(light: rgb(0x7C3AED), dark: rgb(0xC78EFF))
     static let syntaxLiteral = color(light: rgb(0x2563EB), dark: rgb(0x8CC7FF))
@@ -61,6 +71,84 @@ enum T3Colors {
             blue: CGFloat(hex & 0xFF) / 255,
             alpha: alpha
         )
+    }
+}
+
+enum T3BuildChrome {
+    enum Surface: String, CaseIterable, Sendable {
+        case home
+        case newTask
+        case thread
+
+        var accessibilityName: String {
+            switch self {
+            case .home: String(localized: "Home")
+            case .newTask: String(localized: "New task")
+            case .thread: String(localized: "Thread")
+            }
+        }
+    }
+
+    enum Presentation: Equatable, Sendable {
+        case standard
+        case warning
+    }
+
+#if DEBUG
+    static let isDebugBuild = true
+#else
+    static let isDebugBuild = false
+#endif
+
+    static func presentation(
+        for _: Surface,
+        isDebugBuild: Bool = isDebugBuild
+    ) -> Presentation {
+        isDebugBuild ? .warning : .standard
+    }
+
+    static func accessibilityValue(
+        for surface: Surface,
+        isDebugBuild: Bool = isDebugBuild
+    ) -> String? {
+        guard presentation(for: surface, isDebugBuild: isDebugBuild) == .warning else {
+            return nil
+        }
+        return "\(surface.accessibilityName), \(String(localized: "Development build"))"
+    }
+
+    static func background(
+        for surface: Surface,
+        standard: Color,
+        warning: Color = T3Colors.warning,
+        isDebugBuild: Bool = isDebugBuild
+    ) -> Color {
+        presentation(for: surface, isDebugBuild: isDebugBuild) == .warning ? warning : standard
+    }
+
+    static func foreground(
+        for surface: Surface,
+        standard: Color,
+        isDebugBuild: Bool = isDebugBuild
+    ) -> Color {
+        presentation(for: surface, isDebugBuild: isDebugBuild) == .warning
+            ? T3Colors.warningForeground
+            : standard
+    }
+
+    static func toolbarColorScheme(
+        for surface: Surface,
+        isDebugBuild: Bool = isDebugBuild
+    ) -> ColorScheme? {
+        presentation(for: surface, isDebugBuild: isDebugBuild) == .warning ? .light : nil
+    }
+
+    static func contentOpacity(
+        for surface: Surface,
+        standard: Double,
+        isDebugBuild: Bool = isDebugBuild
+    ) -> Double {
+        presentation(for: surface, isDebugBuild: isDebugBuild) == .warning ? 1 : standard
     }
 }
 
@@ -101,5 +189,48 @@ extension View {
     func t3NavigationChrome(background: Color = T3Colors.sheet) -> some View {
         toolbarBackground(background, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
+    }
+
+    func t3BuildNavigationChrome(_ surface: T3BuildChrome.Surface) -> some View {
+        modifier(T3BuildNavigationChromeModifier(surface: surface))
+    }
+
+    func t3BuildChromeBackground(
+        _ surface: T3BuildChrome.Surface,
+        standard: Color
+    ) -> some View {
+        background(
+            T3BuildChrome.background(for: surface, standard: standard),
+            ignoresSafeAreaEdges: []
+        )
+    }
+
+    @ViewBuilder
+    func t3BuildChromeMarker(_ surface: T3BuildChrome.Surface) -> some View {
+        if let value = T3BuildChrome.accessibilityValue(for: surface) {
+            accessibilityValue(value)
+        } else {
+            self
+        }
+    }
+}
+
+private struct T3BuildNavigationChromeModifier: ViewModifier {
+    @SwiftUI.Environment(\.colorScheme) private var colorScheme
+    let surface: T3BuildChrome.Surface
+
+    func body(content: Content) -> some View {
+        content
+            .t3NavigationChrome(
+                background: T3BuildChrome.background(
+                    for: surface,
+                    standard: T3Colors.sheet,
+                    warning: T3Colors.warning(for: colorScheme)
+                )
+            )
+            .toolbarColorScheme(
+                T3BuildChrome.toolbarColorScheme(for: surface),
+                for: .navigationBar
+            )
     }
 }

--- a/apps/swift-ios/DesignSystem/T3Theme.swift
+++ b/apps/swift-ios/DesignSystem/T3Theme.swift
@@ -82,9 +82,9 @@ enum T3BuildChrome {
 
         var accessibilityName: String {
             switch self {
-            case .home: String(localized: "Home")
-            case .newTask: String(localized: "New task")
-            case .thread: String(localized: "Thread")
+            case .home: "Home"
+            case .newTask: "New task"
+            case .thread: "Thread"
             }
         }
     }
@@ -114,7 +114,7 @@ enum T3BuildChrome {
         guard presentation(for: surface, isDebugBuild: isDebugBuild) == .warning else {
             return nil
         }
-        return "\(surface.accessibilityName), \(String(localized: "Development build"))"
+        return "\(surface.accessibilityName), Development build"
     }
 
     static func background(
@@ -199,6 +199,8 @@ extension View {
         _ surface: T3BuildChrome.Surface,
         standard: Color
     ) -> some View {
+        // Keep the Home/New Task warning inside their bars; unlike navigation
+        // chrome, those surfaces do not own the status-bar safe area.
         background(
             T3BuildChrome.background(for: surface, standard: standard),
             ignoresSafeAreaEdges: []
@@ -225,6 +227,8 @@ private struct T3BuildNavigationChromeModifier: ViewModifier {
                 background: T3BuildChrome.background(
                     for: surface,
                     standard: T3Colors.sheet,
+                    // Resolve before toolbarColorScheme(.light) changes the
+                    // navigation bar's environment and flattens the warning.
                     warning: T3Colors.warning(for: colorScheme)
                 )
             )

--- a/apps/swift-ios/DesignSystem/T3Theme.swift
+++ b/apps/swift-ios/DesignSystem/T3Theme.swift
@@ -98,8 +98,8 @@ enum T3Metrics {
 }
 
 extension View {
-    func t3NavigationChrome() -> some View {
-        toolbarBackground(T3Colors.sheet, for: .navigationBar)
+    func t3NavigationChrome(background: Color = T3Colors.sheet) -> some View {
+        toolbarBackground(background, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
     }
 }

--- a/apps/swift-ios/DesignSystem/T3Theme.swift
+++ b/apps/swift-ios/DesignSystem/T3Theme.swift
@@ -232,6 +232,12 @@ private struct T3BuildNavigationChromeModifier: ViewModifier {
                     warning: T3Colors.warning(for: colorScheme)
                 )
             )
+            .tint(
+                T3BuildChrome.foreground(
+                    for: surface,
+                    standard: T3Colors.accent
+                )
+            )
             .toolbarColorScheme(
                 T3BuildChrome.toolbarColorScheme(for: surface),
                 for: .navigationBar

--- a/apps/swift-ios/DesignSystem/T3Theme.swift
+++ b/apps/swift-ios/DesignSystem/T3Theme.swift
@@ -232,12 +232,6 @@ private struct T3BuildNavigationChromeModifier: ViewModifier {
                     warning: T3Colors.warning(for: colorScheme)
                 )
             )
-            .tint(
-                T3BuildChrome.foreground(
-                    for: surface,
-                    standard: T3Colors.accent
-                )
-            )
             .toolbarColorScheme(
                 T3BuildChrome.toolbarColorScheme(for: surface),
                 for: .navigationBar

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -54,13 +54,7 @@ public struct ThreadDetailView: View {
         .background(T3Colors.background)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(false)
-#if DEBUG
-        // Dev-build marker inside a thread: the whole title bar goes orange.
-        .t3NavigationChrome(background: T3Colors.warning)
-        .toolbarColorScheme(.light, for: .navigationBar)
-#else
-        .t3NavigationChrome()
-#endif
+        .t3BuildNavigationChrome(.thread)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 threadHeaderTitle
@@ -159,6 +153,7 @@ public struct ThreadDetailView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .layoutPriority(1)
+                .t3BuildChromeMarker(.thread)
 
             HStack(spacing: 5) {
                 HStack(spacing: 5) {
@@ -276,7 +271,9 @@ public struct ThreadDetailView: View {
                 .frame(width: T3Metrics.minimumTapTarget, height: T3Metrics.minimumTapTarget)
         }
         .buttonStyle(.plain)
-        .foregroundStyle(T3Colors.textSecondary)
+        .foregroundStyle(
+            T3BuildChrome.foreground(for: .thread, standard: T3Colors.textSecondary)
+        )
         .accessibilityLabel("Thread actions")
     }
 
@@ -302,12 +299,7 @@ public struct ThreadDetailView: View {
     }
 
     private var headerStatusColor: Color {
-#if DEBUG
-        // The debug navigation bar uses the warning orange for the current
-        // appearance. Keep every semantic status legible on both variants.
-        return .black
-#else
-        switch currentThread.homeStatus {
+        let standard: Color = switch currentThread.homeStatus {
         case .working: T3Colors.statusRunning
         case .monitoring: T3Colors.statusRunning
         case .approval: T3Colors.warning
@@ -316,23 +308,15 @@ public struct ThreadDetailView: View {
         case .done: T3Colors.success
         case .ready: T3Colors.textTertiary
         }
-#endif
+        return T3BuildChrome.foreground(for: .thread, standard: standard)
     }
 
     private var headerTitleColor: Color {
-#if DEBUG
-        .black
-#else
-        T3Colors.textPrimary
-#endif
+        T3BuildChrome.foreground(for: .thread, standard: T3Colors.textPrimary)
     }
 
     private var headerMetadataColor: Color {
-#if DEBUG
-        .black.opacity(0.8)
-#else
-        T3Colors.textTertiary
-#endif
+        T3BuildChrome.foreground(for: .thread, standard: T3Colors.textTertiary)
     }
 
     private func timeline(_ detail: FeatureThreadDetail) -> some View {

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -54,7 +54,13 @@ public struct ThreadDetailView: View {
         .background(T3Colors.background)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(false)
+#if DEBUG
+        // Dev-build marker inside a thread: the whole title bar goes orange.
+        .toolbarBackground(Color.orange, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+#else
         .t3NavigationChrome()
+#endif
         .toolbar {
             ToolbarItem(placement: .principal) {
                 threadHeaderTitle

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -57,7 +57,7 @@ public struct ThreadDetailView: View {
 #if DEBUG
         // Dev-build marker inside a thread: the whole title bar goes orange.
         .t3NavigationChrome(background: T3Colors.warning)
-        .tint(.black)
+        .toolbarColorScheme(.light, for: .navigationBar)
 #else
         .t3NavigationChrome()
 #endif

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -56,7 +56,7 @@ public struct ThreadDetailView: View {
         .navigationBarBackButtonHidden(false)
 #if DEBUG
         // Dev-build marker inside a thread: the whole title bar goes orange.
-        .t3NavigationChrome(background: .orange)
+        .t3NavigationChrome(background: T3Colors.warning)
 #else
         .t3NavigationChrome()
 #endif

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -56,8 +56,7 @@ public struct ThreadDetailView: View {
         .navigationBarBackButtonHidden(false)
 #if DEBUG
         // Dev-build marker inside a thread: the whole title bar goes orange.
-        .toolbarBackground(Color.orange, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
+        .t3NavigationChrome(background: .orange)
 #else
         .t3NavigationChrome()
 #endif

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -153,7 +153,6 @@ public struct ThreadDetailView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .layoutPriority(1)
-                .t3BuildChromeMarker(.thread)
 
             HStack(spacing: 5) {
                 HStack(spacing: 5) {
@@ -192,6 +191,7 @@ public struct ThreadDetailView: View {
         .padding(.trailing, horizontalSizeClass == .compact ? 10 : 0)
         .frame(maxWidth: horizontalSizeClass == .compact ? 260 : 460, alignment: .leading)
         .accessibilityElement(children: .combine)
+        .t3BuildChromeMarker(.thread)
         .accessibilityAddTraits(.isHeader)
     }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -57,6 +57,7 @@ public struct ThreadDetailView: View {
 #if DEBUG
         // Dev-build marker inside a thread: the whole title bar goes orange.
         .t3NavigationChrome(background: T3Colors.warning)
+        .tint(.black)
 #else
         .t3NavigationChrome()
 #endif
@@ -154,7 +155,7 @@ public struct ThreadDetailView: View {
         VStack(alignment: .leading, spacing: 1) {
             Text(currentThread.title)
                 .font(T3Typography.navigationTitle)
-                .foregroundStyle(T3Colors.textPrimary)
+                .foregroundStyle(headerTitleColor)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .layoutPriority(1)
@@ -190,7 +191,7 @@ public struct ThreadDetailView: View {
                 .fixedSize(horizontal: true, vertical: false)
             }
             .font(T3Typography.navigationMetadata)
-            .foregroundStyle(T3Colors.textTertiary)
+            .foregroundStyle(headerMetadataColor)
         }
         // Leave compact-width clearance for the trailing thread menu.
         .padding(.trailing, horizontalSizeClass == .compact ? 10 : 0)
@@ -301,6 +302,11 @@ public struct ThreadDetailView: View {
     }
 
     private var headerStatusColor: Color {
+#if DEBUG
+        // The debug navigation bar uses the warning orange for the current
+        // appearance. Keep every semantic status legible on both variants.
+        return .black
+#else
         switch currentThread.homeStatus {
         case .working: T3Colors.statusRunning
         case .monitoring: T3Colors.statusRunning
@@ -310,6 +316,23 @@ public struct ThreadDetailView: View {
         case .done: T3Colors.success
         case .ready: T3Colors.textTertiary
         }
+#endif
+    }
+
+    private var headerTitleColor: Color {
+#if DEBUG
+        .black
+#else
+        T3Colors.textPrimary
+#endif
+    }
+
+    private var headerMetadataColor: Color {
+#if DEBUG
+        .black.opacity(0.8)
+#else
+        T3Colors.textTertiary
+#endif
     }
 
     private func timeline(_ detail: FeatureThreadDetail) -> some View {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -167,12 +167,16 @@ public struct NewThreadView: View {
         HStack {
             Button("Cancel") { dismiss() }
                 .font(.body)
-                .foregroundStyle(T3Colors.textSecondary)
+                .foregroundStyle(
+                    T3BuildChrome.foreground(for: .newTask, standard: T3Colors.textSecondary)
+                )
                 .disabled(isSubmitting)
+                .t3BuildChromeMarker(.newTask)
             Spacer()
         }
         .padding(.horizontal, 16)
         .frame(height: 48)
+        .t3BuildChromeBackground(.newTask, standard: T3Colors.background)
     }
 
     private var hero: some View {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -171,7 +171,6 @@ public struct NewThreadView: View {
                     T3BuildChrome.foreground(for: .newTask, standard: T3Colors.textSecondary)
                 )
                 .disabled(isSubmitting)
-                .t3BuildChromeMarker(.newTask)
             Spacer()
         }
         .padding(.horizontal, 16)
@@ -182,6 +181,7 @@ public struct NewThreadView: View {
     private var hero: some View {
         VStack(spacing: 10) {
             Text("What should we build")
+                .t3BuildChromeMarker(.newTask)
             HStack(spacing: 0) {
                 Text("in")
                 Button {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -295,6 +295,7 @@ public struct WorkspaceView: View {
         HStack(spacing: 2) {
             connectionBrand
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .t3BuildChromeMarker(.home)
 
             Button {
                 withAnimation(.easeOut(duration: 0.16)) {
@@ -315,7 +316,9 @@ public struct WorkspaceView: View {
                     .frame(width: 40, height: T3Metrics.minimumTapTarget)
             }
             .buttonStyle(.plain)
-            .foregroundStyle(T3Colors.textSecondary)
+            .foregroundStyle(
+                T3BuildChrome.foreground(for: .home, standard: T3Colors.textSecondary)
+            )
             .accessibilityLabel(isSearching ? "Close search" : "Search tasks")
             .accessibilityIdentifier("sidebar-search-button")
 
@@ -325,14 +328,16 @@ public struct WorkspaceView: View {
                     .frame(width: 40, height: T3Metrics.minimumTapTarget)
             }
             .buttonStyle(.plain)
-            .foregroundStyle(T3Colors.textSecondary)
+            .foregroundStyle(
+                T3BuildChrome.foreground(for: .home, standard: T3Colors.textSecondary)
+            )
             .accessibilityLabel("Settings")
             .accessibilityIdentifier("sidebar-settings-button")
         }
         .padding(.leading, 15)
         .padding(.trailing, 8)
         .frame(height: 49)
-        .background(T3Colors.background)
+        .t3BuildChromeBackground(.home, standard: T3Colors.background)
     }
 
     @ViewBuilder
@@ -352,10 +357,16 @@ public struct WorkspaceView: View {
                 .padding(.horizontal, 9)
                 .frame(height: 26)
                 .overlay {
-                    Capsule().stroke(T3Colors.danger.opacity(0.42), lineWidth: 1)
+                    Capsule().stroke(
+                        T3BuildChrome.foreground(for: .home, standard: T3Colors.danger)
+                            .opacity(
+                                T3BuildChrome.contentOpacity(for: .home, standard: 0.42)
+                            ),
+                        lineWidth: 1
+                    )
                 }
             }
-            .foregroundStyle(T3Colors.danger)
+            .foregroundStyle(T3BuildChrome.foreground(for: .home, standard: T3Colors.danger))
             .accessibilityElement(children: .contain)
         } else if let reconnecting = reconnectingEnvironments.first {
             Button { showingSettings = true } label: {
@@ -366,10 +377,12 @@ public struct WorkspaceView: View {
                         .lineLimit(1)
                     Text("reconnecting")
                         .fontWeight(.medium)
-                        .opacity(0.76)
+                        .opacity(
+                            T3BuildChrome.contentOpacity(for: .home, standard: 0.76)
+                        )
                 }
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(T3Colors.warning)
+                .foregroundStyle(T3BuildChrome.foreground(for: .home, standard: T3Colors.warning))
             }
             .buttonStyle(.plain)
             .accessibilityLabel("\(reconnecting.name) reconnecting")
@@ -377,10 +390,14 @@ public struct WorkspaceView: View {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text("T3")
                     .fontWeight(.bold)
-                    .foregroundStyle(T3Colors.textPrimary)
+                    .foregroundStyle(
+                        T3BuildChrome.foreground(for: .home, standard: T3Colors.textPrimary)
+                    )
                 Text("Code")
                     .fontWeight(.medium)
-                    .foregroundStyle(T3Colors.textSecondary)
+                    .foregroundStyle(
+                        T3BuildChrome.foreground(for: .home, standard: T3Colors.textSecondary)
+                    )
             }
             .font(.system(size: 16))
             .accessibilityElement(children: .combine)

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -295,7 +295,6 @@ public struct WorkspaceView: View {
         HStack(spacing: 2) {
             connectionBrand
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .t3BuildChromeMarker(.home)
 
             Button {
                 withAnimation(.easeOut(duration: 0.16)) {
@@ -349,6 +348,7 @@ public struct WorkspaceView: View {
                 Text(unreachableBrandLabel)
                     .lineLimit(2)
                     .font(.system(size: 13, weight: .semibold))
+                    .t3BuildChromeMarker(.home)
                 Button("Reconnect") {
                     Task { await model.reload() }
                 }
@@ -386,6 +386,7 @@ public struct WorkspaceView: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("\(reconnecting.name) reconnecting")
+            .t3BuildChromeMarker(.home)
         } else {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text("T3")
@@ -402,6 +403,7 @@ public struct WorkspaceView: View {
             .font(.system(size: 16))
             .accessibilityElement(children: .combine)
             .accessibilityLabel("T3 Code")
+            .t3BuildChromeMarker(.home)
         }
     }
 

--- a/apps/swift-ios/README.md
+++ b/apps/swift-ios/README.md
@@ -53,6 +53,8 @@ the active selection are stored separately in Application Support.
   and software keyboard controls, and per-thread session switching.
 - Native settings with persisted appearance and behavior preferences, platform
   deep links, shortcuts, background refresh, and notification routing.
+- Adaptive warning chrome identifies Debug builds on Home, New Task, and thread
+  title bars without changing Release builds.
 - A Share extension that imports text, URLs, and images into persistent project
   drafts, plus Home Screen widgets and aggregate Live Activities for active work.
 - DPoP-bound T3 Connect sessions with account-scoped relay credentials, APNs

--- a/apps/swift-ios/Tests/FeatureTests/DebugBuildChromeTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DebugBuildChromeTests.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+import Testing
+import UIKit
+
+@testable import T3Code
+
+@Suite("Debug build chrome")
+struct DebugBuildChromeTests {
+    @Test func debugBuildMarksEveryPrimarySurface() {
+        for surface in T3BuildChrome.Surface.allCases {
+            let presentation = T3BuildChrome.presentation(
+                for: surface,
+                isDebugBuild: true
+            )
+
+            #expect(presentation == .warning)
+            #expect(
+                T3BuildChrome.accessibilityValue(
+                    for: surface,
+                    isDebugBuild: true
+                ) == "\(surface.accessibilityName), Development build"
+            )
+            #expect(
+                T3BuildChrome.toolbarColorScheme(
+                    for: surface,
+                    isDebugBuild: true
+                ) == .light
+            )
+            #expect(
+                resolvedComponents(
+                    T3BuildChrome.background(
+                        for: surface,
+                        standard: .pink,
+                        warning: .orange,
+                        isDebugBuild: true
+                    )
+                ) == resolvedComponents(.orange)
+            )
+            #expect(
+                resolvedComponents(
+                    T3BuildChrome.foreground(
+                        for: surface,
+                        standard: .white,
+                        isDebugBuild: true
+                    )
+                ) == resolvedComponents(T3Colors.warningForeground)
+            )
+            #expect(
+                T3BuildChrome.contentOpacity(
+                    for: surface,
+                    standard: 0.76,
+                    isDebugBuild: true
+                ) == 1
+            )
+        }
+    }
+
+    @Test func releaseBuildLeavesEveryPrimarySurfaceUnmarked() {
+        for surface in T3BuildChrome.Surface.allCases {
+            let presentation = T3BuildChrome.presentation(
+                for: surface,
+                isDebugBuild: false
+            )
+
+            #expect(presentation == .standard)
+            #expect(
+                T3BuildChrome.accessibilityValue(
+                    for: surface,
+                    isDebugBuild: false
+                ) == nil
+            )
+            #expect(
+                T3BuildChrome.toolbarColorScheme(
+                    for: surface,
+                    isDebugBuild: false
+                ) == nil
+            )
+            #expect(
+                resolvedComponents(
+                    T3BuildChrome.background(
+                        for: surface,
+                        standard: .pink,
+                        warning: .orange,
+                        isDebugBuild: false
+                    )
+                ) == resolvedComponents(.pink)
+            )
+            #expect(
+                resolvedComponents(
+                    T3BuildChrome.foreground(
+                        for: surface,
+                        standard: .white,
+                        isDebugBuild: false
+                    )
+                ) == resolvedComponents(.white)
+            )
+            #expect(
+                T3BuildChrome.contentOpacity(
+                    for: surface,
+                    standard: 0.76,
+                    isDebugBuild: false
+                ) == 0.76
+            )
+        }
+    }
+
+    @Test func warningChromeMeetsTextContrastInLightAndDarkAppearances() throws {
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            let traits = UITraitCollection(userInterfaceStyle: style)
+            let background = T3Colors.uiWarning.resolvedColor(with: traits)
+            let foreground = T3Colors.uiWarningForeground.resolvedColor(with: traits)
+            let scheme: ColorScheme = style == .dark ? .dark : .light
+
+            #expect(try contrastRatio(foreground, background) >= 4.5)
+            #expect(
+                resolvedComponents(T3Colors.warning(for: scheme), style: style)
+                    == resolvedComponents(T3Colors.warning, style: style)
+            )
+        }
+    }
+
+    private func resolvedComponents(
+        _ color: Color,
+        style: UIUserInterfaceStyle = .light
+    ) -> [CGFloat] {
+        let resolved = UIColor(color).resolvedColor(
+            with: UITraitCollection(userInterfaceStyle: style)
+        )
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        resolved.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return [red, green, blue, alpha]
+    }
+
+    private func contrastRatio(_ first: UIColor, _ second: UIColor) throws -> Double {
+        let firstLuminance = try relativeLuminance(first)
+        let secondLuminance = try relativeLuminance(second)
+        let lighter = max(firstLuminance, secondLuminance)
+        let darker = min(firstLuminance, secondLuminance)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private func relativeLuminance(_ color: UIColor) throws -> Double {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            throw ContrastTestError.unresolvedColor
+        }
+
+        func linearized(_ component: CGFloat) -> Double {
+            let value = Double(component)
+            return value <= 0.04045
+                ? value / 12.92
+                : pow((value + 0.055) / 1.055, 2.4)
+        }
+
+        return 0.2126 * linearized(red)
+            + 0.7152 * linearized(green)
+            + 0.0722 * linearized(blue)
+    }
+}
+
+private enum ContrastTestError: Error {
+    case unresolvedColor
+}

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 


### PR DESCRIPTION
## Summary

Uses the adaptive warning color for the navigation title bar of thread screens in DEBUG builds only, making development threads visually unmistakable without changing release builds.

## Verification

- apps/swift-ios/Scripts/ci-test.sh — 218 tests passed
- Fresh independent Claude Opus 5 high review completed; all actionable findings were addressed and the final repair review found no blockers.
- Simulator visual evidence will be attached before marking this PR ready for review.

## Scope

Targets the active native SwiftUI owner branch (#5178).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark debug build navigation bars with warning-themed chrome on Home, New Task, and Thread screens
> - Adds a `T3BuildChrome` utility in [T3Theme.swift](https://github.com/pingdotgg/t3code/pull/5972/files#diff-520f9274d004e2ce8cedef46ece9bdc37852a7b3b5a38e155dcbf6891ccff908) that selects warning background/foreground colors, toolbar color scheme, content opacity, and accessibility values based on whether the current build is a debug build.
> - Applies the new chrome to the Home (`WorkspaceView`), New Task (`NewThreadView`), and Thread (`ThreadDetailView`) surfaces via new view modifiers `t3BuildNavigationChrome`, `t3BuildChromeBackground`, and `t3BuildChromeMarker`.
> - Adds a `warning(for:)` helper that resolves the adaptive `UIColor` warning color for a specific `ColorScheme`, backing the toolbar background in dark/light mode.
> - Adds `DebugBuildChromeTests` covering presentation, accessibility values, toolbar color scheme, and foreground/background selection for all three surfaces.
> - Release builds retain their existing appearance with no code-path changes at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a488a3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Debug presentation changes gated by compile-time flags; Release chrome and behavior are unaffected.
> 
> **Overview**
> **Debug builds** now show adaptive **warning chrome** on Home, New Task, and Thread bars so development builds are visually unmistakable. Release builds are unchanged.
> 
> Adds `T3BuildChrome` with per-surface helpers for warning backgrounds, foregrounds, toolbar color scheme, opacity, and accessibility markers. Wires those helpers into `WorkspaceView`, `NewThreadView`, and `ThreadDetailView`.
> 
> Includes contrast-checked warning colors plus unit tests covering debug vs release presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a488a3dfdb3d50de9ad387c515cf0624c988ade2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Green at a488a3dfdb3d50de9ad387c515cf0624c988ade2 against Theo f98cab553546558e28d6e22f3dbe9807ecc3325f: contract fixture generation, 8 focused native tests, exact-head Simulator build/launch, Contract fixtures and native tests, CI Test/Check, Mobile Native Static Analysis, and Release Smoke passed. APPROVED and MERGEABLE. Independent Claude Opus 5 high review launcher exited 1 because session quota was exhausted, so no cross-provider review occurred. Unrelated Vercel marketing authorization remains maintainer-side.
<!-- swiftui-delivery:end -->
