### PR TITLE
feat(swift-ios): open thread links directly in the app

### DIFF
--- a/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
+++ b/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
@@ -143,29 +143,43 @@ enum PlatformDeepLinkParser {
     /// chat can contain a thread URL copied from the web or Electron client.
     /// A loopback URL points back at the machine that rendered the message, not
     /// at the phone, so translate its route locally instead of opening Safari.
-    static func parseInAppLink(_ url: URL) throws -> PlatformRoute {
+    static func parseInAppLink(
+        _ url: URL,
+        knownEnvironmentIDs: Set<String>
+    ) throws -> PlatformRoute {
+        let route: PlatformRoute
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
            let scheme = components.scheme?.lowercased() {
             if ["t3code", "t3code-dev"].contains(scheme),
                components.host?.lowercased() == "app" {
-                return try webThreadRoute(components)
+                route = try webThreadRoute(components)
+                return try validatedInAppThreadRoute(route, knownEnvironmentIDs: knownEnvironmentIDs)
             }
 
             if ["http", "https"].contains(scheme),
                let host = components.host?.lowercased(),
                isLoopbackHost(host) {
-                return try webThreadRoute(components)
+                route = try webThreadRoute(components)
+                return try validatedInAppThreadRoute(route, knownEnvironmentIDs: knownEnvironmentIDs)
+            }
+
+            if ["http", "https"].contains(scheme) {
+                route = try parse(url)
+                return try validatedInAppThreadRoute(route, knownEnvironmentIDs: knownEnvironmentIDs)
             }
         }
 
-        return try parse(url)
+        throw PlatformDeepLinkError.unsupportedURL
     }
 
-    static func parseInAppLink(_ value: String) throws -> PlatformRoute {
+    static func parseInAppLink(
+        _ value: String,
+        knownEnvironmentIDs: Set<String>
+    ) throws -> PlatformRoute {
         guard let url = URL(string: value.trimmingCharacters(in: .whitespacesAndNewlines)) else {
             throw PlatformDeepLinkError.unsupportedURL
         }
-        return try parseInAppLink(url)
+        return try parseInAppLink(url, knownEnvironmentIDs: knownEnvironmentIDs)
     }
 
     private static func navigationRoute(
@@ -252,6 +266,17 @@ enum PlatformDeepLinkParser {
             environmentID: try validatedIdentifier(segments[0]),
             threadID: try validatedIdentifier(segments[1])
         )
+    }
+
+    private static func validatedInAppThreadRoute(
+        _ route: PlatformRoute,
+        knownEnvironmentIDs: Set<String>
+    ) throws -> PlatformRoute {
+        guard case let .thread(environmentID?, _) = route,
+              knownEnvironmentIDs.contains(environmentID) else {
+            throw PlatformDeepLinkError.unsupportedURL
+        }
+        return route
     }
 
     private static func isLoopbackHost(_ host: String) -> Bool {

--- a/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
+++ b/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
@@ -287,11 +287,21 @@ enum PlatformDeepLinkParser {
         _ route: PlatformRoute,
         knownEnvironmentIDs: Set<String>
     ) throws -> PlatformRoute {
-        guard case let .thread(environmentID?, _) = route,
-              knownEnvironmentIDs.contains(environmentID) else {
+        switch route {
+        case let .thread(environmentID?, _):
+            guard knownEnvironmentIDs.contains(environmentID) else {
+                throw PlatformDeepLinkError.unsupportedURL
+            }
+            return route
+        case let .thread(nil, threadID):
+            guard knownEnvironmentIDs.count == 1,
+                  let environmentID = knownEnvironmentIDs.first else {
+                throw PlatformDeepLinkError.unsupportedURL
+            }
+            return .thread(environmentID: environmentID, threadID: threadID)
+        default:
             throw PlatformDeepLinkError.unsupportedURL
         }
-        return route
     }
 
     private static func isLoopbackHost(_ host: String) -> Bool {

--- a/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
+++ b/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
@@ -86,11 +86,9 @@ enum PlatformDeepLinkParser {
     private static let t3Schemes: Set<String> = [
         "t3", "t3code", "t3code-dev", "t3code-swiftui", "t3code-swiftui-dev",
     ]
-    private static let trustedWebHosts: Set<String> = [
-        "app.t3.codes",
-        "t3.codes",
-        "www.t3.codes",
-    ]
+    private static let appWebHost = "app.t3.codes"
+    private static let marketingWebHosts: Set<String> = ["t3.codes", "www.t3.codes"]
+    private static let trustedWebHosts = marketingWebHosts.union([appWebHost])
 
     static func parse(_ url: URL) throws -> PlatformRoute {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -178,13 +176,16 @@ enum PlatformDeepLinkParser {
         throw PlatformDeepLinkError.unsupportedURL
     }
 
-    static func claimsInAppURL(_ url: URL) -> Bool {
+    /// Whether a failed in-app parse belongs exclusively to T3 Code and must
+    /// not fall through to the system. Marketing-host failures remain normal
+    /// web links; valid thread routes have already succeeded before this runs.
+    static func shouldDiscardFailedInAppURL(_ url: URL) -> Bool {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let scheme = components.scheme?.lowercased() else { return false }
         if t3Schemes.contains(scheme) { return true }
         guard ["http", "https"].contains(scheme),
               let host = components.host?.lowercased() else { return false }
-        return trustedWebHosts.contains(host) || isLoopbackHost(host)
+        return isLoopbackHost(host) || host == appWebHost
     }
 
     static func parseInAppLink(

--- a/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
+++ b/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
@@ -83,6 +83,9 @@ enum PlatformDeepLinkError: LocalizedError, Equatable {
 }
 
 enum PlatformDeepLinkParser {
+    private static let t3Schemes: Set<String> = [
+        "t3", "t3code", "t3code-dev", "t3code-swiftui", "t3code-swiftui-dev",
+    ]
     private static let trustedWebHosts: Set<String> = [
         "app.t3.codes",
         "t3.codes",
@@ -97,7 +100,7 @@ enum PlatformDeepLinkParser {
         }
 
         let query = queryValues(components.queryItems ?? [])
-        if ["t3", "t3code", "t3code-swiftui", "t3code-swiftui-dev"].contains(scheme) {
+        if t3Schemes.contains(scheme) {
             let segments = customSchemeSegments(components)
             if isConnectionRoute(segments: segments, query: query) {
                 return try connectionRoute(url)
@@ -150,9 +153,12 @@ enum PlatformDeepLinkParser {
         let route: PlatformRoute
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
            let scheme = components.scheme?.lowercased() {
-            if ["t3code", "t3code-dev"].contains(scheme),
-               components.host?.lowercased() == "app" {
-                route = try webThreadRoute(components)
+            if t3Schemes.contains(scheme) {
+                route = if components.host?.lowercased() == "app" {
+                    try webThreadRoute(components)
+                } else {
+                    try parse(url)
+                }
                 return try validatedInAppThreadRoute(route, knownEnvironmentIDs: knownEnvironmentIDs)
             }
 
@@ -170,6 +176,15 @@ enum PlatformDeepLinkParser {
         }
 
         throw PlatformDeepLinkError.unsupportedURL
+    }
+
+    static func claimsInAppURL(_ url: URL) -> Bool {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme?.lowercased() else { return false }
+        if t3Schemes.contains(scheme) { return true }
+        guard ["http", "https"].contains(scheme),
+              let host = components.host?.lowercased() else { return false }
+        return trustedWebHosts.contains(host) || isLoopbackHost(host)
     }
 
     static func parseInAppLink(

--- a/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
+++ b/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
@@ -139,6 +139,35 @@ enum PlatformDeepLinkParser {
         return try parse(url)
     }
 
+    /// Resolves links tapped inside the app. In addition to normal deep links,
+    /// chat can contain a thread URL copied from the web or Electron client.
+    /// A loopback URL points back at the machine that rendered the message, not
+    /// at the phone, so translate its route locally instead of opening Safari.
+    static func parseInAppLink(_ url: URL) throws -> PlatformRoute {
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+           let scheme = components.scheme?.lowercased() {
+            if ["t3code", "t3code-dev"].contains(scheme),
+               components.host?.lowercased() == "app" {
+                return try webThreadRoute(components)
+            }
+
+            if ["http", "https"].contains(scheme),
+               let host = components.host?.lowercased(),
+               isLoopbackHost(host) {
+                return try webThreadRoute(components)
+            }
+        }
+
+        return try parse(url)
+    }
+
+    static func parseInAppLink(_ value: String) throws -> PlatformRoute {
+        guard let url = URL(string: value.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            throw PlatformDeepLinkError.unsupportedURL
+        }
+        return try parseInAppLink(url)
+    }
+
     private static func navigationRoute(
         segments: [String],
         query: [String: String]
@@ -212,6 +241,27 @@ enum PlatformDeepLinkParser {
             throw PlatformDeepLinkError.missingIdentifier
         }
         return (try queryEnvironment.map(validatedIdentifier), try validatedIdentifier(destination))
+    }
+
+    private static func webThreadRoute(_ components: URLComponents) throws -> PlatformRoute {
+        let segments = pathSegments(components.percentEncodedPath)
+        guard segments.count >= 2 else {
+            throw PlatformDeepLinkError.unsupportedURL
+        }
+        return .thread(
+            environmentID: try validatedIdentifier(segments[0]),
+            threadID: try validatedIdentifier(segments[1])
+        )
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        if host == "localhost" || host == "::1" || host == "[::1]" {
+            return true
+        }
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        return octets.count == 4
+            && octets.first == "127"
+            && octets.allSatisfy { UInt8($0) != nil }
     }
 
     private static func connectionRoute(_ url: URL) throws -> PlatformRoute {

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -31,7 +31,10 @@ struct PlatformRootView: View {
         }
         .environment(\.openURL, OpenURLAction { url in
             do {
-                let route = try PlatformDeepLinkParser.parseInAppLink(url)
+                let route = try PlatformDeepLinkParser.parseInAppLink(
+                    url,
+                    knownEnvironmentIDs: Set(model.snapshot.environments.map(\.id))
+                )
                 handle(route)
                 return .handled
             } catch {

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -38,7 +38,9 @@ struct PlatformRootView: View {
                 handle(route)
                 return .handled
             } catch {
-                return .systemAction(url)
+                return PlatformDeepLinkParser.claimsInAppURL(url)
+                    ? .discarded
+                    : .systemAction(url)
             }
         })
         .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -29,6 +29,15 @@ struct PlatformRootView: View {
         .onOpenURL { url in
             handle(url: url, letOnboardingConfirmConnection: true)
         }
+        .environment(\.openURL, OpenURLAction { url in
+            do {
+                let route = try PlatformDeepLinkParser.parseInAppLink(url)
+                handle(route)
+                return .handled
+            } catch {
+                return .systemAction(url)
+            }
+        })
         .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
             guard let url = activity.webpageURL else { return }
             handle(url: url, letOnboardingConfirmConnection: false)

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -38,7 +38,7 @@ struct PlatformRootView: View {
                 handle(route)
                 return .handled
             } catch {
-                return PlatformDeepLinkParser.claimsInAppURL(url)
+                return PlatformDeepLinkParser.shouldDiscardFailedInAppURL(url)
                     ? .discarded
                     : .systemAction(url)
             }

--- a/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
@@ -56,7 +56,10 @@ struct PlatformDeepLinkTests {
             "http://[::1]:3773/environment-1/thread-7",
         ] {
             #expect(
-                try PlatformDeepLinkParser.parseInAppLink(try #require(URL(string: value)))
+                try PlatformDeepLinkParser.parseInAppLink(
+                    try #require(URL(string: value)),
+                    knownEnvironmentIDs: ["environment-1"]
+                )
                     == .thread(environmentID: "environment-1", threadID: "thread-7")
             )
         }
@@ -66,12 +69,14 @@ struct PlatformDeepLinkTests {
     func resolvesElectronThreadLinksTappedInApp() throws {
         #expect(
             try PlatformDeepLinkParser.parseInAppLink(
-                try #require(URL(string: "t3code://app/environment-1/thread-7"))
+                try #require(URL(string: "t3code://app/environment-1/thread-7")),
+                knownEnvironmentIDs: ["environment-1"]
             ) == .thread(environmentID: "environment-1", threadID: "thread-7")
         )
         #expect(
             try PlatformDeepLinkParser.parseInAppLink(
-                try #require(URL(string: "t3code-dev://app/environment-1/thread-7"))
+                try #require(URL(string: "t3code-dev://app/environment-1/thread-7")),
+                knownEnvironmentIDs: ["environment-1"]
             ) == .thread(environmentID: "environment-1", threadID: "thread-7")
         )
     }
@@ -83,7 +88,26 @@ struct PlatformDeepLinkTests {
             "http://127.example.com/environment/thread",
         ] {
             #expect(throws: PlatformDeepLinkError.unsupportedURL) {
-                try PlatformDeepLinkParser.parseInAppLink(value)
+                try PlatformDeepLinkParser.parseInAppLink(
+                    value,
+                    knownEnvironmentIDs: ["environment"]
+                )
+            }
+        }
+    }
+
+    @Test
+    func rejectsInAppLinksOutsideKnownThreadRoutes() {
+        for value in [
+            "t3code://connect?url=ws%3A%2F%2Fhost.example&token=secret",
+            "http://localhost:3773/settings/general",
+            "t3code://app/unknown/thread-7",
+        ] {
+            #expect(throws: PlatformDeepLinkError.unsupportedURL) {
+                try PlatformDeepLinkParser.parseInAppLink(
+                    value,
+                    knownEnvironmentIDs: ["environment-1"]
+                )
             }
         }
     }

--- a/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
@@ -104,6 +104,21 @@ struct PlatformDeepLinkTests {
                 )
             }
         }
+        #expect(!PlatformDeepLinkParser.shouldDiscardFailedInAppURL(
+            URL(string: "https://t3.codes/privacy")!
+        ))
+        #expect(!PlatformDeepLinkParser.shouldDiscardFailedInAppURL(
+            URL(string: "https://www.t3.codes/docs")!
+        ))
+        #expect(!PlatformDeepLinkParser.shouldDiscardFailedInAppURL(
+            URL(string: "https://t3.codes/docs/getting-started")!
+        ))
+        #expect(!PlatformDeepLinkParser.shouldDiscardFailedInAppURL(
+            URL(string: "https://www.t3.codes/connect?endpoint=https://example.com")!
+        ))
+        #expect(PlatformDeepLinkParser.shouldDiscardFailedInAppURL(
+            URL(string: "https://app.t3.codes/environment/thread")!
+        ))
     }
 
     @Test
@@ -120,13 +135,13 @@ struct PlatformDeepLinkTests {
                 )
             }
         }
-        #expect(PlatformDeepLinkParser.claimsInAppURL(
+        #expect(PlatformDeepLinkParser.shouldDiscardFailedInAppURL(
             URL(string: "t3code-swiftui://connect?endpoint=https://attacker.example")!
         ))
-        #expect(PlatformDeepLinkParser.claimsInAppURL(
+        #expect(PlatformDeepLinkParser.shouldDiscardFailedInAppURL(
             URL(string: "https://app.t3.codes/connect?endpoint=https://attacker.example")!
         ))
-        #expect(!PlatformDeepLinkParser.claimsInAppURL(
+        #expect(!PlatformDeepLinkParser.shouldDiscardFailedInAppURL(
             URL(string: "https://example.com/connect")!
         ))
     }

--- a/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
@@ -48,6 +48,47 @@ struct PlatformDeepLinkTests {
     }
 
     @Test
+    func resolvesLoopbackWebThreadLinksTappedInApp() throws {
+        for value in [
+            "http://127.0.0.1:3773/environment-1/thread-7",
+            "http://127.12.34.56:3773/environment-1/thread-7",
+            "http://localhost:3773/environment-1/thread-7",
+            "http://[::1]:3773/environment-1/thread-7",
+        ] {
+            #expect(
+                try PlatformDeepLinkParser.parseInAppLink(try #require(URL(string: value)))
+                    == .thread(environmentID: "environment-1", threadID: "thread-7")
+            )
+        }
+    }
+
+    @Test
+    func resolvesElectronThreadLinksTappedInApp() throws {
+        #expect(
+            try PlatformDeepLinkParser.parseInAppLink(
+                try #require(URL(string: "t3code://app/environment-1/thread-7"))
+            ) == .thread(environmentID: "environment-1", threadID: "thread-7")
+        )
+        #expect(
+            try PlatformDeepLinkParser.parseInAppLink(
+                try #require(URL(string: "t3code-dev://app/environment-1/thread-7"))
+            ) == .thread(environmentID: "environment-1", threadID: "thread-7")
+        )
+    }
+
+    @Test
+    func leavesOrdinaryWebLinksForTheSystem() {
+        for value in [
+            "https://example.com/environment/thread",
+            "http://127.example.com/environment/thread",
+        ] {
+            #expect(throws: PlatformDeepLinkError.unsupportedURL) {
+                try PlatformDeepLinkParser.parseInAppLink(value)
+            }
+        }
+    }
+
+    @Test
     func rejectsUntrustedWebNavigationRoute() {
         #expect(throws: PlatformDeepLinkError.unsupportedURL) {
             try PlatformDeepLinkParser.parse("https://malicious.example/threads/env/thread")

--- a/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
@@ -110,6 +110,15 @@ struct PlatformDeepLinkTests {
                 )
             }
         }
+        #expect(PlatformDeepLinkParser.claimsInAppURL(
+            URL(string: "t3code-swiftui://connect?endpoint=https://attacker.example")!
+        ))
+        #expect(PlatformDeepLinkParser.claimsInAppURL(
+            URL(string: "https://app.t3.codes/connect?endpoint=https://attacker.example")!
+        ))
+        #expect(!PlatformDeepLinkParser.claimsInAppURL(
+            URL(string: "https://example.com/connect")!
+        ))
     }
 
     @Test

--- a/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
@@ -82,6 +82,16 @@ struct PlatformDeepLinkTests {
     }
 
     @Test
+    func resolvesEnvironmentlessNativeThreadLinkWhenOnlyOneEnvironmentIsKnown() throws {
+        #expect(
+            try PlatformDeepLinkParser.parseInAppLink(
+                "t3code-swiftui://threads?thread=thread-7",
+                knownEnvironmentIDs: ["environment-1"]
+            ) == .thread(environmentID: "environment-1", threadID: "thread-7")
+        )
+    }
+
+    @Test
     func leavesOrdinaryWebLinksForTheSystem() {
         for value in [
             "https://example.com/environment/thread",


### PR DESCRIPTION
## Summary

Routes trusted web, Electron, native, and loopback thread links to known local environments. App-owned non-thread links tapped in agent content are discarded, preventing connection/pairing redispatch.

## Verification

- apps/swift-ios/Scripts/ci-test.sh — 223 tests passed
- Fresh independent Claude Opus 5 high review completed; all actionable findings were addressed and the final repair review found no blockers.
- Simulator visual evidence will be attached before marking this PR ready for review.

## Scope

Targets the active native SwiftUI owner branch (#5178).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open thread links directly in the iOS app without launching Safari
> - Adds `PlatformDeepLinkParser.parseInAppLink` to intercept URLs tapped inside the app, handling custom `t3code`/`t3code-dev` scheme links and loopback HTTP/HTTPS hosts by translating web-style thread paths to in-app thread routes.
> - Adds `shouldDiscardFailedInAppURL` to distinguish app-owned failed URLs (discarded) from ordinary web links (passed to the system).
> - Wires interception into `PlatformRootView` via an `openURL` environment handler: valid thread links navigate in-app, app-owned invalid links are discarded, and all other links fall back to the system.
> - Environment IDs are validated against known environments; if only one environment is known, it is auto-filled when none is specified in the link.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31da23e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deep-link handling and URL open behavior in chat; security-sensitive discard rules for `t3*` and app hosts are new but covered by tests.
> 
> **Overview**
> **In-app link taps** (e.g. thread URLs pasted in chat from web, Electron, or localhost) now navigate to the matching thread inside the app instead of opening Safari or doing nothing.
> 
> `PlatformDeepLinkParser` gains **`parseInAppLink`**, which maps loopback hosts (`127.*`, `localhost`, `::1`), `t3*` schemes (including `t3code-dev` and Electron-style `t3code://app/{env}/{thread}`), and trusted `https` thread URLs to a **thread route only**, with environment IDs checked against locally known environments (and inferred when exactly one environment exists). **`shouldDiscardFailedInAppURL`** ensures failed parses on T3-owned URLs (`t3*`, loopback, `app.t3.codes`) are **discarded** so connect/pairing links in agent content cannot fall through to the OS; marketing `t3.codes` links still open externally.
> 
> **`PlatformRootView`** overrides SwiftUI **`openURL`** to run this path: successful parses call existing `handle(route)`; unclaimed failures use **`.systemAction`**.
> 
> Tests cover loopback, Electron, environmentless native links, discard vs system fallback, and rejection of connect/unknown routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31da23ebb66d98edcf42fcb1875e2f6d0da9d077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable; native/repository checks and current review are green. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
