### PR TITLE
feat(swift-ios): make settle the primary thread swipe action

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -2229,7 +2229,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func removeCachedApproval(id: String, threadID: String) {
         guard var detail = latestDetails[threadID] else { return }
-        detail.approvals.removeAll { $0.id == id }
+        if let cache = detailRenderCaches[threadID] {
+            cache.approvals.removeAll { $0.id == id }
+            detail.approvals = cache.approvals
+        } else {
+            detail.approvals.removeAll { $0.id == id }
+        }
         if detail.approvals.isEmpty, detail.thread.state == .waitingForApproval {
             detail.thread.state = detail.userInputs.isEmpty ? .idle : .waitingForInput
         }
@@ -2242,7 +2247,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func removeCachedInput(id: String, threadID: String) {
         guard var detail = latestDetails[threadID] else { return }
-        detail.userInputs.removeAll { $0.id == id }
+        if let cache = detailRenderCaches[threadID] {
+            cache.userInputs.removeAll { $0.id == id }
+            detail.userInputs = cache.userInputs
+        } else {
+            detail.userInputs.removeAll { $0.id == id }
+        }
         if detail.userInputs.isEmpty, detail.thread.state == .waitingForInput {
             detail.thread.state = detail.approvals.isEmpty ? .idle : .waitingForApproval
         }
@@ -3390,16 +3400,18 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let backgroundWorkIsActive = backgroundLiveness == .working
         let sessionIsLive = shellThread.session?.status == "starting"
             || shellThread.session?.status == "running"
+        let hasApprovals = shellThread.hasPendingApprovals || !detail.approvals.isEmpty
+        let hasUserInput = shellThread.hasPendingUserInput || !detail.userInputs.isEmpty
         detail.thread.state = Self.resolveThreadState(
             latestTurn: shellThread.latestTurn,
             session: shellThread.session,
-            hasApprovals: !detail.approvals.isEmpty,
-            hasUserInput: !detail.userInputs.isEmpty,
+            hasApprovals: hasApprovals,
+            hasUserInput: hasUserInput,
             backgroundLiveness: backgroundLiveness
         )
         detail.thread.settlementInput = FeatureSettlementProjectionInput(
-            hasPendingApprovals: !detail.approvals.isEmpty,
-            hasPendingUserInput: !detail.userInputs.isEmpty,
+            hasPendingApprovals: hasApprovals,
+            hasPendingUserInput: hasUserInput,
             sessionStatus: shellThread.session?.status,
             latestUserMessageAt: shellThread.latestUserMessageAt,
             latestTurnRequestedAt: shellThread.latestTurn?.requestedAt,
@@ -3965,16 +3977,20 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let backgroundWorkIsActive = backgroundLiveness == .working
         let sessionIsLive = thread.session?.status == "starting"
             || thread.session?.status == "running"
+        let shellThread = shellsByEnvironmentID[environment.id]?.threads
+            .first(where: { $0.id == thread.id })
+        let hasApprovals = shellThread?.hasPendingApprovals == true || !cache.approvals.isEmpty
+        let hasUserInput = shellThread?.hasPendingUserInput == true || !cache.userInputs.isEmpty
         mappedThread.state = Self.resolveThreadState(
             latestTurn: thread.latestTurn,
             session: thread.session,
-            hasApprovals: !cache.approvals.isEmpty,
-            hasUserInput: !cache.userInputs.isEmpty,
+            hasApprovals: hasApprovals,
+            hasUserInput: hasUserInput,
             backgroundLiveness: backgroundLiveness
         )
         mappedThread.settlementInput = mappedThread.settlementInput?.withPendingRequests(
-            approvals: !cache.approvals.isEmpty,
-            userInput: !cache.userInputs.isEmpty
+            approvals: hasApprovals,
+            userInput: hasUserInput
         )
         return FeatureThreadDetail(
             thread: mappedThread,

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -2235,13 +2235,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         } else {
             detail.approvals.removeAll { $0.id == id }
         }
-        if detail.approvals.isEmpty, detail.thread.state == .waitingForApproval {
-            detail.thread.state = detail.userInputs.isEmpty ? .idle : .waitingForInput
-        }
-        detail.thread.settlementInput = detail.thread.settlementInput?.withPendingRequests(
-            approvals: !detail.approvals.isEmpty,
-            userInput: !detail.userInputs.isEmpty
-        )
+        reconcilePendingRequestState(&detail, threadID: threadID)
         publish(detail, threadID: threadID)
     }
 
@@ -2253,14 +2247,41 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         } else {
             detail.userInputs.removeAll { $0.id == id }
         }
-        if detail.userInputs.isEmpty, detail.thread.state == .waitingForInput {
-            detail.thread.state = detail.approvals.isEmpty ? .idle : .waitingForApproval
+        reconcilePendingRequestState(&detail, threadID: threadID)
+        publish(detail, threadID: threadID)
+    }
+
+    private func reconcilePendingRequestState(
+        _ detail: inout FeatureThreadDetail,
+        threadID: String
+    ) {
+        let shellThread = threadEnvironmentIDs[threadID].flatMap { environmentID in
+            threadWireIDs[threadID].flatMap { wireID in
+                shellsByEnvironmentID[environmentID]?.threads.first { $0.id == wireID }
+            }
+        }
+        let hasApprovals = shellThread?.hasPendingApprovals == true || !detail.approvals.isEmpty
+        let hasUserInput = shellThread?.hasPendingUserInput == true || !detail.userInputs.isEmpty
+        if let shellThread {
+            detail.thread.state = Self.resolveThreadState(
+                latestTurn: shellThread.latestTurn,
+                session: shellThread.session,
+                hasApprovals: hasApprovals,
+                hasUserInput: hasUserInput,
+                backgroundLiveness: shellThread.backgroundLiveness
+            )
+        } else if hasApprovals {
+            detail.thread.state = .waitingForApproval
+        } else if hasUserInput {
+            detail.thread.state = .waitingForInput
+        } else if detail.thread.state == .waitingForApproval
+                    || detail.thread.state == .waitingForInput {
+            detail.thread.state = .idle
         }
         detail.thread.settlementInput = detail.thread.settlementInput?.withPendingRequests(
-            approvals: !detail.approvals.isEmpty,
-            userInput: !detail.userInputs.isEmpty
+            approvals: hasApprovals,
+            userInput: hasUserInput
         )
-        publish(detail, threadID: threadID)
     }
 
     private func workspaceContext(route: NativeThreadRoute) throws -> (

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -3788,6 +3788,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             supportsSnooze: environment.descriptor?.capabilities.threadSnooze,
             supportsPinning: environment.descriptor?.capabilities.threadPinning,
             supportsTitleRegeneration: environment.descriptor?.capabilities.threadTitleRegeneration,
+            settlementInput: FeatureSettlementProjectionInput(
+                hasPendingApprovals: thread.hasPendingApprovals,
+                hasPendingUserInput: thread.hasPendingUserInput,
+                sessionStatus: thread.session?.status,
+                latestUserMessageAt: thread.latestUserMessageAt,
+                latestTurnRequestedAt: thread.latestTurn?.requestedAt,
+                latestTurnStartedAt: thread.latestTurn?.startedAt,
+                latestTurnCompletedAt: thread.latestTurn?.completedAt
+            ),
             attentionAt: failureDate(
                 latestTurn: thread.latestTurn,
                 session: thread.session
@@ -3857,6 +3866,16 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             supportsSnooze: environment.descriptor?.capabilities.threadSnooze,
             supportsPinning: environment.descriptor?.capabilities.threadPinning,
             supportsTitleRegeneration: environment.descriptor?.capabilities.threadTitleRegeneration,
+            settlementInput: FeatureSettlementProjectionInput(
+                hasPendingApprovals: false,
+                hasPendingUserInput: false,
+                sessionStatus: thread.session?.status,
+                latestUserMessageAt: thread.messages
+                    .last(where: { $0.role == "user" })?.createdAt,
+                latestTurnRequestedAt: thread.latestTurn?.requestedAt,
+                latestTurnStartedAt: thread.latestTurn?.startedAt,
+                latestTurnCompletedAt: thread.latestTurn?.completedAt
+            ),
             attentionAt: failureDate(
                 latestTurn: thread.latestTurn,
                 session: thread.session

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -2233,6 +2233,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if detail.approvals.isEmpty, detail.thread.state == .waitingForApproval {
             detail.thread.state = detail.userInputs.isEmpty ? .idle : .waitingForInput
         }
+        detail.thread.settlementInput = detail.thread.settlementInput?.withPendingRequests(
+            approvals: !detail.approvals.isEmpty,
+            userInput: !detail.userInputs.isEmpty
+        )
         publish(detail, threadID: threadID)
     }
 
@@ -2242,6 +2246,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if detail.userInputs.isEmpty, detail.thread.state == .waitingForInput {
             detail.thread.state = detail.approvals.isEmpty ? .idle : .waitingForApproval
         }
+        detail.thread.settlementInput = detail.thread.settlementInput?.withPendingRequests(
+            approvals: !detail.approvals.isEmpty,
+            userInput: !detail.userInputs.isEmpty
+        )
         publish(detail, threadID: threadID)
     }
 
@@ -3389,6 +3397,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             hasUserInput: !detail.userInputs.isEmpty,
             backgroundLiveness: backgroundLiveness
         )
+        detail.thread.settlementInput = FeatureSettlementProjectionInput(
+            hasPendingApprovals: !detail.approvals.isEmpty,
+            hasPendingUserInput: !detail.userInputs.isEmpty,
+            sessionStatus: shellThread.session?.status,
+            latestUserMessageAt: shellThread.latestUserMessageAt,
+            latestTurnRequestedAt: shellThread.latestTurn?.requestedAt,
+            latestTurnStartedAt: shellThread.latestTurn?.startedAt,
+            latestTurnCompletedAt: shellThread.latestTurn?.completedAt
+        )
         detail.thread.workingStartedAt = workingStartedAt(
             latestTurn: shellThread.latestTurn,
             session: shellThread.session,
@@ -3954,6 +3971,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             hasApprovals: !cache.approvals.isEmpty,
             hasUserInput: !cache.userInputs.isEmpty,
             backgroundLiveness: backgroundLiveness
+        )
+        mappedThread.settlementInput = mappedThread.settlementInput?.withPendingRequests(
+            approvals: !cache.approvals.isEmpty,
+            userInput: !cache.userInputs.isEmpty
         )
         return FeatureThreadDetail(
             thread: mappedThread,

--- a/apps/swift-ios/Features/Shared/FeatureModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureModels.swift
@@ -298,6 +298,13 @@ public struct FeatureSettlementProjectionInput: Sendable, Equatable, Hashable, C
         self.latestTurnStartedAt = latestTurnStartedAt
         self.latestTurnCompletedAt = latestTurnCompletedAt
     }
+
+    func withPendingRequests(approvals: Bool, userInput: Bool) -> Self {
+        var copy = self
+        copy.hasPendingApprovals = approvals
+        copy.hasPendingUserInput = userInput
+        return copy
+    }
 }
 
 enum FeatureSettlementProjection {

--- a/apps/swift-ios/Features/Shared/FeatureModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureModels.swift
@@ -336,8 +336,16 @@ enum FeatureSettlementProjection {
     }
 
     private static func parseDate(_ value: String) -> Date? {
-        try? Date(value, strategy: .iso8601)
+        fractionalDateFormatter.date(from: value) ?? dateFormatter.date(from: value)
     }
+
+    private static let fractionalDateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let dateFormatter = ISO8601DateFormatter()
 }
 
 public enum FeatureMessageRole: String, Sendable, Codable {

--- a/apps/swift-ios/Features/Shared/FeatureModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureModels.swift
@@ -178,6 +178,7 @@ public struct FeatureThread: Identifiable, Sendable, Equatable, Hashable, Codabl
     public var supportsSnooze: Bool?
     public var supportsPinning: Bool?
     public var supportsTitleRegeneration: Bool?
+    public var settlementInput: FeatureSettlementProjectionInput?
     public var attentionAt: Date?
     public var workingStartedAt: Date?
     public var latestTurnCompletedAt: Date?
@@ -213,6 +214,7 @@ public struct FeatureThread: Identifiable, Sendable, Equatable, Hashable, Codabl
         supportsSnooze: Bool? = nil,
         supportsPinning: Bool? = nil,
         supportsTitleRegeneration: Bool? = nil,
+        settlementInput: FeatureSettlementProjectionInput? = nil,
         attentionAt: Date? = nil,
         workingStartedAt: Date? = nil,
         latestTurnCompletedAt: Date? = nil,
@@ -247,6 +249,7 @@ public struct FeatureThread: Identifiable, Sendable, Equatable, Hashable, Codabl
         self.supportsSnooze = supportsSnooze
         self.supportsPinning = supportsPinning
         self.supportsTitleRegeneration = supportsTitleRegeneration
+        self.settlementInput = settlementInput
         self.attentionAt = attentionAt
         self.workingStartedAt = workingStartedAt
         self.latestTurnCompletedAt = latestTurnCompletedAt
@@ -266,6 +269,67 @@ public struct FeatureThread: Identifiable, Sendable, Equatable, Hashable, Codabl
 
     public var canToggleSnooze: Bool {
         snoozedUntil != nil || supportsSnooze != false
+    }
+}
+
+public struct FeatureSettlementProjectionInput: Sendable, Equatable, Hashable, Codable {
+    public var hasPendingApprovals: Bool
+    public var hasPendingUserInput: Bool
+    public var sessionStatus: String?
+    public var latestUserMessageAt: String?
+    public var latestTurnRequestedAt: String?
+    public var latestTurnStartedAt: String?
+    public var latestTurnCompletedAt: String?
+
+    public init(
+        hasPendingApprovals: Bool,
+        hasPendingUserInput: Bool,
+        sessionStatus: String?,
+        latestUserMessageAt: String?,
+        latestTurnRequestedAt: String?,
+        latestTurnStartedAt: String?,
+        latestTurnCompletedAt: String?
+    ) {
+        self.hasPendingApprovals = hasPendingApprovals
+        self.hasPendingUserInput = hasPendingUserInput
+        self.sessionStatus = sessionStatus
+        self.latestUserMessageAt = latestUserMessageAt
+        self.latestTurnRequestedAt = latestTurnRequestedAt
+        self.latestTurnStartedAt = latestTurnStartedAt
+        self.latestTurnCompletedAt = latestTurnCompletedAt
+    }
+}
+
+enum FeatureSettlementProjection {
+    static let queuedTurnStartGrace: TimeInterval = 2 * 60
+
+    static func canSettle(
+        _ input: FeatureSettlementProjectionInput,
+        now: Date
+    ) -> Bool {
+        if input.hasPendingApprovals || input.hasPendingUserInput { return false }
+        if input.sessionStatus == "starting" || input.sessionStatus == "running" { return false }
+        if input.sessionStatus == "error" { return true }
+        guard let rawMessageAt = input.latestUserMessageAt,
+              let messageAt = parseDate(rawMessageAt),
+              abs(now.timeIntervalSince(messageAt)) <= queuedTurnStartGrace else {
+            return true
+        }
+        let latestTurnDates = [
+            input.latestTurnRequestedAt,
+            input.latestTurnStartedAt,
+            input.latestTurnCompletedAt,
+        ]
+        let queued = latestTurnDates.allSatisfy { candidate in
+            guard let candidate else { return true }
+            guard let date = parseDate(candidate) else { return false }
+            return date < messageAt
+        }
+        return !queued
+    }
+
+    private static func parseDate(_ value: String) -> Date? {
+        try? Date(value, strategy: .iso8601)
     }
 }
 

--- a/apps/swift-ios/Features/Shared/FeatureModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureModels.swift
@@ -357,21 +357,17 @@ enum FeatureSettlementProjection {
         if input.sessionStatus == "starting" || input.sessionStatus == "running" { return false }
         if input.sessionStatus == "error" { return true }
         guard let rawMessageAt = input.latestUserMessageAt,
-              let messageAt = parseDate(rawMessageAt),
-              abs(now.timeIntervalSince(messageAt)) <= queuedTurnStartGrace else {
+              let messageAt = parseDate(rawMessageAt) else {
             return true
         }
-        let latestTurnDates = [
-            input.latestTurnRequestedAt,
-            input.latestTurnStartedAt,
-            input.latestTurnCompletedAt,
-        ]
-        let queued = latestTurnDates.allSatisfy { candidate in
-            guard let candidate else { return true }
-            guard let date = parseDate(candidate) else { return false }
-            return date < messageAt
+        let messageAge = now.timeIntervalSince(messageAt)
+        if messageAge < 0 { return false }
+        if messageAge > queuedTurnStartGrace { return true }
+        if let completedAt = input.latestTurnCompletedAt.flatMap(parseDate),
+           completedAt >= messageAt {
+            return true
         }
-        return !queued
+        return false
     }
 
     private static func parseDate(_ value: String) -> Date? {

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -653,13 +653,17 @@ extension FeatureThread {
         state == .waitingForApproval || state == .waitingForInput || state == .failed
     }
 
-    func isEffectivelySettled(at now: Date) -> Bool {
+    var canSettle: Bool {
         switch state {
-        case .queued, .working, .monitoring, .waitingForApproval, .waitingForInput:
-            return false
         case .idle, .failed, .completed:
-            break
+            true
+        case .queued, .working, .monitoring, .waitingForApproval, .waitingForInput:
+            false
         }
+    }
+
+    func isEffectivelySettled(at now: Date) -> Bool {
+        guard canSettle else { return false }
         if isSettled {
             return true
         }

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -646,7 +646,14 @@ extension FeatureThread {
             return providerName
         }
         guard let providerID else { return nil }
-        return snapshot.providers.first(where: { $0.id == providerID })?.name ?? providerID
+        let projectEnvironmentID = snapshot.projects
+            .first(where: { $0.id == projectID })?
+            .environmentID
+        let resolvedEnvironmentID = environmentID ?? projectEnvironmentID
+        let providers = resolvedEnvironmentID.flatMap {
+            snapshot.providersByEnvironment?[$0]
+        } ?? snapshot.providers
+        return providers.first(where: { $0.id == providerID })?.name ?? providerID
     }
 
     var needsAttention: Bool {

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -654,12 +654,9 @@ extension FeatureThread {
     }
 
     var canSettle: Bool {
-        switch state {
-        case .idle, .failed, .completed:
-            true
-        case .queued, .working, .monitoring, .waitingForApproval, .waitingForInput:
-            false
-        }
+        isSettled || settlementInput.map {
+            FeatureSettlementProjection.canSettle($0, now: .now)
+        } == true
     }
 
     func isEffectivelySettled(at now: Date) -> Bool {

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -660,6 +660,12 @@ extension FeatureThread {
     }
 
     func isEffectivelySettled(at now: Date) -> Bool {
+        switch state {
+        case .queued, .working, .monitoring, .waitingForApproval, .waitingForInput:
+            return false
+        case .idle, .failed, .completed:
+            break
+        }
         guard canSettle else { return false }
         if isSettled {
             return true

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -22,7 +22,11 @@ enum HomeThreadSwipeActions {
 
         var kinds: [HomeThreadSwipeActionKind] = []
         if thread.canToggleSettlement {
-            kinds.append(thread.isEffectivelySettled(at: now) ? .reopen : .settle)
+            if thread.isEffectivelySettled(at: now) {
+                kinds.append(.reopen)
+            } else if thread.canSettle {
+                kinds.append(.settle)
+            }
         }
         if thread.pinnedAt != nil, thread.canTogglePin {
             kinds.append(.unpin)
@@ -457,16 +461,18 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 if thread.canToggleSettlement {
                     let isSettled = thread.isEffectivelySettled(at: .now)
-                    actions.append(
-                        UIAction(
-                            title: isSettled ? "Reopen" : "Settle",
-                            image: UIImage(
-                                systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
-                            )
-                        ) { [weak self] _ in
-                            self?.parent.onSettle(thread, !isSettled)
-                        }
-                    )
+                    if isSettled || thread.canSettle {
+                        actions.append(
+                            UIAction(
+                                title: isSettled ? "Reopen" : "Settle",
+                                image: UIImage(
+                                    systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
+                                )
+                            ) { [weak self] _ in
+                                self?.parent.onSettle(thread, !isSettled)
+                            }
+                        )
+                    }
                 }
 
                 if thread.canToggleSnooze {

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -11,6 +11,15 @@ enum HomeThreadSwipeActionKind: Equatable {
 }
 
 enum HomeThreadSwipeActions {
+    static func allowsFullSwipe(
+        for thread: FeatureThread,
+        isArchived: Bool,
+        now: Date
+    ) -> Bool {
+        if isArchived || !thread.canToggleSettlement { return true }
+        return thread.isEffectivelySettled(at: now) || thread.canSettle
+    }
+
     static func kinds(
         for thread: FeatureThread,
         isArchived: Bool,
@@ -239,7 +248,11 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             let configuration = UISwipeActionsConfiguration(actions: actions)
             // UIKit performs actions[0] on a full swipe. The model keeps the
             // reversible lifecycle action first and destructive Delete last.
-            configuration.performsFirstActionWithFullSwipe = true
+            configuration.performsFirstActionWithFullSwipe = HomeThreadSwipeActions.allowsFullSwipe(
+                for: thread,
+                isArchived: isArchived,
+                now: .now
+            )
             return configuration
         }
 

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -16,8 +16,10 @@ enum HomeThreadSwipeActions {
         isArchived: Bool,
         now: Date
     ) -> Bool {
-        if isArchived || !thread.canToggleSettlement { return true }
-        return thread.isEffectivelySettled(at: now) || thread.canSettle
+        switch kinds(for: thread, isArchived: isArchived, now: now).first {
+        case .restore, .unpin, .settle, .reopen: true
+        case .archive, .delete, nil: false
+        }
     }
 
     static func kinds(

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -1,6 +1,39 @@
 import SwiftUI
 import UIKit
 
+enum HomeThreadSwipeActionKind: Equatable {
+    case delete
+    case restore
+    case unpin
+    case settle
+    case reopen
+    case archive
+}
+
+enum HomeThreadSwipeActions {
+    static func kinds(
+        for thread: FeatureThread,
+        isArchived: Bool,
+        now: Date
+    ) -> [HomeThreadSwipeActionKind] {
+        if isArchived {
+            return [.delete, .restore]
+        }
+
+        var kinds: [HomeThreadSwipeActionKind] = [.delete]
+        if thread.pinnedAt != nil, thread.canTogglePin {
+            kinds.append(.unpin)
+        }
+        if thread.canToggleSettlement {
+            kinds.append(thread.isEffectivelySettled(at: now) ? .reopen : .settle)
+        }
+        if kinds.count == 1 {
+            kinds.append(.archive)
+        }
+        return kinds
+    }
+}
+
 /// A recycled, diffable Home surface. SwiftUI still owns the surrounding shell,
 /// while UIKit keeps row creation and updates proportional to visible threads.
 struct HomeThreadCollectionView: UIViewRepresentable {
@@ -193,55 +226,71 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 return nil
             }
 
-            let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
-                self?.parent.onDelete(thread)
-                finish(true)
-            }
-            delete.image = UIImage(systemName: "trash")
+            let actions = HomeThreadSwipeActions.kinds(
+                for: thread,
+                isArchived: isArchived,
+                now: .now
+            ).map { swipeAction($0, for: thread) }
+            let configuration = UISwipeActionsConfiguration(actions: actions)
+            configuration.performsFirstActionWithFullSwipe = false
+            return configuration
+        }
 
-            let primaryAction: UIContextualAction
-            if isArchived {
-                primaryAction = UIContextualAction(style: .normal, title: "Restore") {
+        private func swipeAction(
+            _ kind: HomeThreadSwipeActionKind,
+            for thread: FeatureThread
+        ) -> UIContextualAction {
+            switch kind {
+            case .delete:
+                let action = UIContextualAction(style: .destructive, title: "Delete") {
+                    [weak self] _, _, finish in
+                    self?.parent.onDelete(thread)
+                    finish(true)
+                }
+                action.image = UIImage(systemName: "trash")
+                return action
+            case .restore:
+                let action = UIContextualAction(style: .normal, title: "Restore") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, false)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "arrow.uturn.backward")
-                primaryAction.backgroundColor = .systemBlue
-            } else if thread.pinnedAt != nil, thread.canTogglePin {
-                primaryAction = UIContextualAction(style: .normal, title: "Unpin") {
+                action.image = UIImage(systemName: "arrow.uturn.backward")
+                action.backgroundColor = .systemBlue
+                return action
+            case .unpin:
+                let action = UIContextualAction(style: .normal, title: "Unpin") {
                     [weak self] _, _, finish in
                     self?.parent.onPin(thread, false)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "pin.slash")
-                primaryAction.backgroundColor = .systemBlue
-            } else if thread.canToggleSettlement {
-                let isSettled = thread.isEffectivelySettled(at: .now)
-                primaryAction = UIContextualAction(
+                action.image = UIImage(systemName: "pin.slash")
+                action.backgroundColor = .systemBlue
+                return action
+            case .settle, .reopen:
+                let isSettled = kind == .reopen
+                let action = UIContextualAction(
                     style: .normal,
                     title: isSettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
                     self?.parent.onSettle(thread, !isSettled)
                     finish(true)
                 }
-                primaryAction.image = UIImage(
+                action.image = UIImage(
                     systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
                 )
-                primaryAction.backgroundColor = isSettled ? .systemBlue : .systemGreen
-            } else {
-                primaryAction = UIContextualAction(style: .normal, title: "Archive") {
+                action.backgroundColor = isSettled ? .systemBlue : .systemGreen
+                return action
+            case .archive:
+                let action = UIContextualAction(style: .normal, title: "Archive") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, true)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "archivebox")
-                primaryAction.backgroundColor = .systemGray
+                action.image = UIImage(systemName: "archivebox")
+                action.backgroundColor = .systemGray
+                return action
             }
-
-            let configuration = UISwipeActionsConfiguration(actions: [delete, primaryAction])
-            configuration.performsFirstActionWithFullSwipe = false
-            return configuration
         }
 
         private func configure(

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -232,7 +232,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 now: .now
             ).map { swipeAction($0, for: thread) }
             let configuration = UISwipeActionsConfiguration(actions: actions)
-            configuration.performsFirstActionWithFullSwipe = false
+            configuration.performsFirstActionWithFullSwipe = true
             return configuration
         }
 

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -17,19 +17,20 @@ enum HomeThreadSwipeActions {
         now: Date
     ) -> [HomeThreadSwipeActionKind] {
         if isArchived {
-            return [.delete, .restore]
+            return [.restore, .delete]
         }
 
-        var kinds: [HomeThreadSwipeActionKind] = [.delete]
-        if thread.pinnedAt != nil, thread.canTogglePin {
-            kinds.append(.unpin)
-        }
+        var kinds: [HomeThreadSwipeActionKind] = []
         if thread.canToggleSettlement {
             kinds.append(thread.isEffectivelySettled(at: now) ? .reopen : .settle)
         }
-        if kinds.count == 1 {
+        if thread.pinnedAt != nil, thread.canTogglePin {
+            kinds.append(.unpin)
+        }
+        if kinds.isEmpty {
             kinds.append(.archive)
         }
+        kinds.append(.delete)
         return kinds
     }
 }
@@ -232,6 +233,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 now: .now
             ).map { swipeAction($0, for: thread) }
             let configuration = UISwipeActionsConfiguration(actions: actions)
+            // UIKit performs actions[0] on a full swipe. The model keeps the
+            // reversible lifecycle action first and destructive Delete last.
             configuration.performsFirstActionWithFullSwipe = true
             return configuration
         }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -812,9 +812,6 @@ struct HomeThreadRowContext: Equatable {
         let environmentByID = snapshot.environments.reduce(into: [String: FeatureEnvironment]()) {
             $0[$1.id] = $1
         }
-        let providerByID = snapshot.providers.reduce(into: [String: FeatureProvider]()) {
-            $0[$1.id] = $1
-        }
         let activeEnvironmentID = snapshot.environments.first(where: \.isActive)?.id
 
         return snapshot.threads.reduce(into: [String: HomeThreadRowContext]()) { result, thread in
@@ -825,7 +822,11 @@ struct HomeThreadRowContext: Equatable {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let explicitProvider = thread.providerName?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            let configuredProvider = thread.providerID.flatMap { providerByID[$0] }
+            let configuredProvider = thread.providerID.flatMap { providerID in
+                environmentID.flatMap {
+                    snapshot.providersByEnvironment?[$0]?.first(where: { $0.id == providerID })
+                } ?? snapshot.providers.first(where: { $0.id == providerID })
+            }
             let providerName = (explicitProvider?.isEmpty == false ? explicitProvider : nil)
                 ?? configuredProvider?.name
                 ?? thread.providerID

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -138,6 +138,31 @@ struct DailyUXSidebarTests {
         #expect(actions.last == .delete)
     }
 
+    @Test(arguments: [
+        FeatureThreadState.queued,
+        .working,
+        .monitoring,
+        .waitingForApproval,
+        .waitingForInput,
+    ])
+    func blockedThreadsDoNotOfferSettleAsAFullSwipe(state: FeatureThreadState) {
+        let blocked = thread(
+            id: state.rawValue,
+            created: -100,
+            updated: -50,
+            state: state
+        )
+
+        #expect(blocked.canSettle == false)
+        #expect(
+            HomeThreadSwipeActions.kinds(
+                for: blocked,
+                isArchived: false,
+                now: now
+            ) == [.archive, .delete]
+        )
+    }
+
     @Test
     func fullSwipeAlwaysChoosesAReversibleAction() {
         let settled = thread(

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -220,6 +220,50 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func detailPendingRequestsKeepHomeSettlementAndFullSwipeBlocked() {
+        let base = FeatureSettlementProjectionInput(
+            hasPendingApprovals: false,
+            hasPendingUserInput: false,
+            sessionStatus: nil,
+            latestUserMessageAt: now.addingTimeInterval(-300).ISO8601Format(),
+            latestTurnRequestedAt: nil,
+            latestTurnStartedAt: nil,
+            latestTurnCompletedAt: nil
+        )
+        var pendingApproval = thread(
+            id: "approval",
+            created: -300,
+            updated: -300,
+            settlementEligible: true
+        )
+        pendingApproval.settlementInput = base.withPendingRequests(
+            approvals: true,
+            userInput: false
+        )
+        var pendingInput = thread(
+            id: "input",
+            created: -300,
+            updated: -300,
+            settlementEligible: true
+        )
+        pendingInput.settlementInput = base.withPendingRequests(
+            approvals: false,
+            userInput: true
+        )
+
+        for thread in [pendingApproval, pendingInput] {
+            #expect(!thread.canSettle)
+            #expect(
+                HomeThreadSwipeActions.kinds(for: thread, isArchived: false, now: now)
+                    == [.archive, .delete]
+            )
+            #expect(
+                !HomeThreadSwipeActions.allowsFullSwipe(for: thread, isArchived: false, now: now)
+            )
+        }
+    }
+
+    @Test
     func fullSwipeAlwaysChoosesAReversibleAction() {
         let settled = thread(
             id: "settled",

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -207,6 +207,31 @@ struct DailyUXSidebarTests {
         #expect(!eligible)
     }
 
+    @Test
+    func queuedTurnAndFutureMessageBlockSettlementProjection() {
+        let queued = FeatureSettlementProjectionInput(
+            hasPendingApprovals: false,
+            hasPendingUserInput: false,
+            sessionStatus: nil,
+            latestUserMessageAt: now.addingTimeInterval(-30).ISO8601Format(),
+            latestTurnRequestedAt: now.addingTimeInterval(-20).ISO8601Format(),
+            latestTurnStartedAt: nil,
+            latestTurnCompletedAt: nil
+        )
+        let future = FeatureSettlementProjectionInput(
+            hasPendingApprovals: false,
+            hasPendingUserInput: false,
+            sessionStatus: nil,
+            latestUserMessageAt: now.addingTimeInterval(300).ISO8601Format(),
+            latestTurnRequestedAt: nil,
+            latestTurnStartedAt: nil,
+            latestTurnCompletedAt: nil
+        )
+
+        #expect(!FeatureSettlementProjection.canSettle(queued, now: now))
+        #expect(!FeatureSettlementProjection.canSettle(future, now: now))
+    }
+
     @Test(arguments: [FeatureThreadState.working, .monitoring])
     func backgroundOnlyShellsRemainSettlementEligible(state: FeatureThreadState) {
         let eligible = FeatureSettlementProjection.canSettle(

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -150,7 +150,8 @@ struct DailyUXSidebarTests {
             id: state.rawValue,
             created: -100,
             updated: -50,
-            state: state
+            state: state,
+            settlementEligible: false
         )
 
         #expect(blocked.canSettle == false)
@@ -160,6 +161,61 @@ struct DailyUXSidebarTests {
                 isArchived: false,
                 now: now
             ) == [.archive, .delete]
+        )
+        #expect(
+            !HomeThreadSwipeActions.allowsFullSwipe(
+                for: blocked,
+                isArchived: false,
+                now: now
+            )
+        )
+    }
+
+    @Test
+    func freshUnadoptedUserMessageBlocksSettlementProjection() {
+        let eligible = FeatureSettlementProjection.canSettle(
+            FeatureSettlementProjectionInput(
+                hasPendingApprovals: false,
+                hasPendingUserInput: false,
+                sessionStatus: nil,
+                latestUserMessageAt: now.addingTimeInterval(-30).ISO8601Format(),
+                latestTurnRequestedAt: nil,
+                latestTurnStartedAt: nil,
+                latestTurnCompletedAt: nil
+            ),
+            now: now
+        )
+
+        #expect(!eligible)
+    }
+
+    @Test(arguments: [FeatureThreadState.working, .monitoring])
+    func backgroundOnlyShellsRemainSettlementEligible(state: FeatureThreadState) {
+        let eligible = FeatureSettlementProjection.canSettle(
+            FeatureSettlementProjectionInput(
+                hasPendingApprovals: false,
+                hasPendingUserInput: false,
+                sessionStatus: nil,
+                latestUserMessageAt: now.addingTimeInterval(-300).ISO8601Format(),
+                latestTurnRequestedAt: nil,
+                latestTurnStartedAt: nil,
+                latestTurnCompletedAt: nil
+            ),
+            now: now
+        )
+        let projected = thread(
+            id: state.rawValue,
+            created: -300,
+            updated: -300,
+            state: state,
+            settlementEligible: eligible
+        )
+
+        #expect(eligible)
+        #expect(projected.canSettle)
+        #expect(
+            HomeThreadSwipeActions.kinds(for: projected, isArchived: false, now: now).first
+                == .settle
         )
     }
 
@@ -529,7 +585,8 @@ struct DailyUXSidebarTests {
         created: TimeInterval,
         updated: TimeInterval,
         state: FeatureThreadState = .idle,
-        isSettled: Bool = false
+        isSettled: Bool = false,
+        settlementEligible: Bool = true
     ) -> FeatureThread {
         FeatureThread(
             id: id,
@@ -539,6 +596,15 @@ struct DailyUXSidebarTests {
             updatedAt: now.addingTimeInterval(updated),
             state: state,
             isSettled: isSettled,
+            settlementInput: FeatureSettlementProjectionInput(
+                hasPendingApprovals: !settlementEligible,
+                hasPendingUserInput: false,
+                sessionStatus: nil,
+                latestUserMessageAt: nil,
+                latestTurnRequestedAt: nil,
+                latestTurnStartedAt: nil,
+                latestTurnCompletedAt: nil
+            ),
             lastActivityAt: now.addingTimeInterval(updated)
         )
     }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -189,6 +189,24 @@ struct DailyUXSidebarTests {
         #expect(!eligible)
     }
 
+    @Test
+    func fractionalSecondUserMessageBlocksSettlementProjection() {
+        let eligible = FeatureSettlementProjection.canSettle(
+            FeatureSettlementProjectionInput(
+                hasPendingApprovals: false,
+                hasPendingUserInput: false,
+                sessionStatus: nil,
+                latestUserMessageAt: "1970-01-24T03:32:50.000Z",
+                latestTurnRequestedAt: nil,
+                latestTurnStartedAt: nil,
+                latestTurnCompletedAt: nil
+            ),
+            now: now
+        )
+
+        #expect(!eligible)
+    }
+
     @Test(arguments: [FeatureThreadState.working, .monitoring])
     func backgroundOnlyShellsRemainSettlementEligible(state: FeatureThreadState) {
         let eligible = FeatureSettlementProjection.canSettle(
@@ -298,6 +316,24 @@ struct DailyUXSidebarTests {
 
         explicitlyUnsupported.pinnedAt = now
         #expect(explicitlyUnsupported.canTogglePin)
+    }
+
+    @Test
+    func pinnedBlockedThreadCanFullSwipeToUnpin() {
+        let pinned = thread(
+            id: "pinned-blocked",
+            created: -20,
+            updated: -10,
+            state: .queued,
+            pinned: -5,
+            settlementEligible: false
+        )
+
+        #expect(
+            HomeThreadSwipeActions.kinds(for: pinned, isArchived: false, now: now).first
+                == .unpin
+        )
+        #expect(HomeThreadSwipeActions.allowsFullSwipe(for: pinned, isArchived: false, now: now))
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -640,6 +640,7 @@ struct DailyUXSidebarTests {
             updatedAt: now.addingTimeInterval(updated),
             state: state,
             isSettled: isSettled,
+            lastActivityAt: now.addingTimeInterval(updated),
             settlementInput: FeatureSettlementProjectionInput(
                 hasPendingApprovals: !settlementEligible,
                 hasPendingUserInput: false,
@@ -648,8 +649,7 @@ struct DailyUXSidebarTests {
                 latestTurnRequestedAt: nil,
                 latestTurnStartedAt: nil,
                 latestTurnCompletedAt: nil
-            ),
-            lastActivityAt: now.addingTimeInterval(updated)
+            )
         )
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -118,6 +118,25 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func pinnedThreadSwipeIncludesUnpinAndSettle() {
+        var pinned = thread(
+            id: "pinned",
+            created: -100,
+            updated: -50,
+            state: .idle
+        )
+        pinned.pinnedAt = now
+
+        let actions = HomeThreadSwipeActions.kinds(
+            for: pinned,
+            isArchived: false,
+            now: now
+        )
+
+        #expect(actions == [.delete, .unpin, .settle])
+    }
+
+    @Test
     func pinActionsTolerateMissingCapabilitiesAndKeepPinsReversible() {
         var legacyDescriptor = thread(id: "legacy", created: -20, updated: -10)
         legacyDescriptor.supportsPinning = nil

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -139,6 +139,29 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func fullSwipeAlwaysChoosesAReversibleAction() {
+        let settled = thread(
+            id: "settled",
+            created: -100,
+            updated: -50,
+            state: .idle,
+            isSettled: true
+        )
+        var fallback = thread(id: "fallback", created: -100, updated: -50, state: .idle)
+        fallback.supportsSettlement = false
+        let shapes = [
+            HomeThreadSwipeActions.kinds(for: fallback, isArchived: true, now: now),
+            HomeThreadSwipeActions.kinds(for: settled, isArchived: false, now: now),
+            HomeThreadSwipeActions.kinds(for: fallback, isArchived: false, now: now),
+        ]
+
+        #expect(shapes[0] == [.restore, .delete])
+        #expect(shapes[1].first == .reopen)
+        #expect(shapes[2] == [.archive, .delete])
+        #expect(shapes.allSatisfy { $0.first != .delete })
+    }
+
+    @Test
     func pinActionsTolerateMissingCapabilitiesAndKeepPinsReversible() {
         var legacyDescriptor = thread(id: "legacy", created: -20, updated: -10)
         legacyDescriptor.supportsPinning = nil

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -133,7 +133,9 @@ struct DailyUXSidebarTests {
             now: now
         )
 
-        #expect(actions == [.delete, .unpin, .settle])
+        #expect(actions == [.settle, .unpin, .delete])
+        #expect(actions.first == .settle)
+        #expect(actions.last == .delete)
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -168,6 +168,112 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testResolvingVisibleApprovalPreservesShellOnlyBlockerWhenRefreshFails() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        await fixture.transport.setShell(
+            multiEnvironmentShell(
+                projectID: "project-one",
+                threadID: "thread-one",
+                title: "Pending approval",
+                hasPendingApprovals: true
+            ),
+            host: "one.example"
+        )
+        await fixture.transport.setDetail(
+            multiEnvironmentDetail(
+                projectID: "project-one",
+                threadID: "thread-one",
+                activities: [visibleApprovalActivity()]
+            ),
+            host: "one.example"
+        )
+
+        let snapshot = try await fixture.client.initialSnapshot()
+        let thread = try XCTUnwrap(snapshot.threads.first(where: { $0.wireID == "thread-one" }))
+        let initialDetail = try await fixture.client.loadThread(id: thread.id)
+        let approval = try XCTUnwrap(initialDetail.approvals.first)
+        let events = fixture.client.events()
+        var iterator = events.makeAsyncIterator()
+        await fixture.transport.failThreadReadsAfterNextDispatch(host: "one.example")
+
+        try await fixture.client.resolveApproval(id: approval.id, decision: .allowOnce)
+        var resolvedDetail: FeatureThreadDetail?
+        while let event = await iterator.next() {
+            if case let .detail(detail) = event,
+               detail.thread.id == thread.id,
+               detail.approvals.isEmpty {
+                resolvedDetail = detail
+                break
+            }
+        }
+
+        let detail = try XCTUnwrap(resolvedDetail)
+        XCTAssertEqual(detail.thread.state, .waitingForApproval)
+        XCTAssertFalse(detail.thread.canSettle)
+        XCTAssertFalse(
+            HomeThreadSwipeActions.allowsFullSwipe(
+                for: detail.thread,
+                isArchived: false,
+                now: .now
+            )
+        )
+        await fixture.client.disconnect()
+    }
+
+    func testResolvingVisibleInputPreservesShellOnlyBlockerWhenRefreshFails() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        await fixture.transport.setShell(
+            multiEnvironmentShell(
+                projectID: "project-one",
+                threadID: "thread-one",
+                title: "Pending input",
+                hasPendingUserInput: true
+            ),
+            host: "one.example"
+        )
+        await fixture.transport.setDetail(
+            multiEnvironmentDetail(
+                projectID: "project-one",
+                threadID: "thread-one",
+                activities: [visibleUserInputActivity()]
+            ),
+            host: "one.example"
+        )
+
+        let snapshot = try await fixture.client.initialSnapshot()
+        let thread = try XCTUnwrap(snapshot.threads.first(where: { $0.wireID == "thread-one" }))
+        let initialDetail = try await fixture.client.loadThread(id: thread.id)
+        let input = try XCTUnwrap(initialDetail.userInputs.first)
+        let events = fixture.client.events()
+        var iterator = events.makeAsyncIterator()
+        await fixture.transport.failThreadReadsAfterNextDispatch(host: "one.example")
+
+        try await fixture.client.resolveUserInput(id: input.id, answers: [:])
+        var resolvedDetail: FeatureThreadDetail?
+        while let event = await iterator.next() {
+            if case let .detail(detail) = event,
+               detail.thread.id == thread.id,
+               detail.userInputs.isEmpty {
+                resolvedDetail = detail
+                break
+            }
+        }
+
+        let detail = try XCTUnwrap(resolvedDetail)
+        XCTAssertEqual(detail.thread.state, .waitingForInput)
+        XCTAssertFalse(detail.thread.canSettle)
+        XCTAssertFalse(
+            HomeThreadSwipeActions.allowsFullSwipe(
+                for: detail.thread,
+                isArchived: false,
+                now: .now
+            )
+        )
+        await fixture.client.disconnect()
+    }
+
     func testSnapshotKeepsRepositoryIdentityForCrossComputerProjectGrouping() async throws {
         let identity = RepositoryIdentity(
             canonicalKey: "github.com/t3/example",
@@ -717,8 +823,11 @@ private struct MultiEnvironmentFixture {
 private actor MultiEnvironmentHTTPTransport: HTTPTransport {
     private let shells: [String: OrchestrationShellSnapshot]
     private var shellData: [String: Data]
+    private var detailData: [String: Data] = [:]
     private var reachableHosts: Set<String>
     private var shellReadsEnabledHosts: Set<String>
+    private var threadReadsEnabledHosts: Set<String>
+    private var hostsFailingThreadReadsAfterDispatch = Set<String>()
     private var dispatched: [MultiEnvironmentDispatchRecord] = []
     private var hostsDroppingNextCreateReply = Set<String>()
 
@@ -727,6 +836,7 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
         shellData = shells.mapValues { try! JSONEncoder.t3.encode($0) }
         reachableHosts = Set(shells.keys)
         shellReadsEnabledHosts = Set(shells.keys)
+        threadReadsEnabledHosts = Set(shells.keys)
     }
 
     func setReachable(_ reachable: Bool, host: String) {
@@ -747,6 +857,14 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
 
     func setShell(_ shell: OrchestrationShellSnapshot, host: String) {
         shellData[host] = try! JSONEncoder.t3.encode(shell)
+    }
+
+    func setDetail(_ detail: OrchestrationThreadDetailSnapshot, host: String) {
+        detailData[host] = try! JSONEncoder.t3.encode(detail)
+    }
+
+    func failThreadReadsAfterNextDispatch(host: String) {
+        hostsFailingThreadReadsAfterDispatch.insert(host)
     }
 
     func dispatchHosts() -> [String] {
@@ -772,7 +890,11 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
            let data = shellData[host] {
             return (data, multiEnvironmentResponse(request))
         }
-        if path.hasPrefix("/api/orchestration/threads/") {
+        if path.hasPrefix("/api/orchestration/threads/"),
+           threadReadsEnabledHosts.contains(host) {
+            if let detail = detailData[host] {
+                return (detail, multiEnvironmentResponse(request))
+            }
             let threadID = request.url?.lastPathComponent.removingPercentEncoding ?? "thread"
             let projectID = shells[host]?.threads
                 .first(where: { $0.id == threadID })?
@@ -790,6 +912,9 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
             dispatched.append(
                 MultiEnvironmentDispatchRecord(host: host, command: command)
             )
+            if hostsFailingThreadReadsAfterDispatch.remove(host) != nil {
+                threadReadsEnabledHosts.remove(host)
+            }
             if command["type"]?.stringValue == "thread.create",
                hostsDroppingNextCreateReply.remove(host) != nil,
                let projectID = command["projectId"]?.stringValue,
@@ -897,7 +1022,8 @@ private func multiEnvironmentShell(
 
 private func multiEnvironmentDetail(
     projectID: String,
-    threadID: String
+    threadID: String,
+    activities: [OrchestrationActivity] = []
 ) -> OrchestrationThreadDetailSnapshot {
     let timestamp = "2026-07-31T12:00:00.000Z"
     return OrchestrationThreadDetailSnapshot(
@@ -922,10 +1048,51 @@ private func multiEnvironmentDetail(
             pinnedAt: nil,
             deletedAt: nil,
             messages: [],
-            activities: [],
+            activities: activities,
             checkpoints: [],
             session: nil
         )
+    )
+}
+
+private func visibleApprovalActivity() -> OrchestrationActivity {
+    OrchestrationActivity(
+        id: "activity-approval",
+        tone: "warning",
+        kind: "approval.requested",
+        summary: "Approve command",
+        payload: .object([
+            "requestId": .string("approval-visible"),
+            "requestKind": .string("command"),
+            "detail": .string("Run focused tests"),
+        ]),
+        turnId: "turn-one",
+        sequence: 1,
+        createdAt: "2026-07-31T12:00:00.000Z"
+    )
+}
+
+private func visibleUserInputActivity() -> OrchestrationActivity {
+    OrchestrationActivity(
+        id: "activity-input",
+        tone: "warning",
+        kind: "user-input.requested",
+        summary: "Choose an option",
+        payload: .object([
+            "requestId": .string("input-visible"),
+            "questions": .array([
+                .object([
+                    "id": .string("choice"),
+                    "header": .string("Choice"),
+                    "question": .string("Continue?"),
+                    "options": .array([]),
+                    "multiSelect": .bool(false),
+                ]),
+            ]),
+        ]),
+        turnId: "turn-one",
+        sequence: 1,
+        createdAt: "2026-07-31T12:00:00.000Z"
     )
 }
 

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -137,6 +137,37 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testEmptyDetailPreservesShellPendingSettlementBlockers() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        await fixture.transport.setShell(
+            multiEnvironmentShell(
+                projectID: "project-one",
+                threadID: "thread-one",
+                title: "Pending work",
+                hasPendingApprovals: true,
+                hasPendingUserInput: true
+            ),
+            host: "one.example"
+        )
+
+        let snapshot = try await fixture.client.initialSnapshot()
+        let thread = try XCTUnwrap(snapshot.threads.first(where: { $0.wireID == "thread-one" }))
+        XCTAssertFalse(thread.canSettle)
+
+        let detail = try await fixture.client.loadThread(id: thread.id)
+        XCTAssertEqual(detail.thread.state, .waitingForApproval)
+        XCTAssertFalse(detail.thread.canSettle)
+        XCTAssertFalse(
+            HomeThreadSwipeActions.allowsFullSwipe(
+                for: detail.thread,
+                isArchived: false,
+                now: .now
+            )
+        )
+        await fixture.client.disconnect()
+    }
+
     func testSnapshotKeepsRepositoryIdentityForCrossComputerProjectGrouping() async throws {
         let identity = RepositoryIdentity(
             canonicalKey: "github.com/t3/example",
@@ -812,7 +843,9 @@ private func multiEnvironmentShell(
     providerID: String = "codex",
     modelID: String = "gpt-5.6-sol",
     repositoryIdentity: RepositoryIdentity? = nil,
-    backgroundLiveness: OrchestrationBackgroundLiveness? = nil
+    backgroundLiveness: OrchestrationBackgroundLiveness? = nil,
+    hasPendingApprovals: Bool = false,
+    hasPendingUserInput: Bool = false
 ) -> OrchestrationShellSnapshot {
     let timestamp = "2026-07-31T12:00:00.000Z"
     let model = ModelSelection(instanceId: providerID, model: modelID)
@@ -852,8 +885,8 @@ private func multiEnvironmentShell(
                 pinnedAt: nil,
                 session: nil,
                 latestUserMessageAt: nil,
-                hasPendingApprovals: false,
-                hasPendingUserInput: false,
+                hasPendingApprovals: hasPendingApprovals,
+                hasPendingUserInput: hasPendingUserInput,
                 hasActionableProposedPlan: false,
                 backgroundLiveness: backgroundLiveness
             ),


### PR DESCRIPTION
## Summary

Adds Settle/Reopen to pinned-thread swipe actions and enables full swipe. Reversible lifecycle actions are always first; Delete is structurally last and covered by an invariant test.

## Verification

- apps/swift-ios/Scripts/ci-test.sh — 220 tests passed
- Fresh independent Claude Opus 5 high review completed; all actionable findings were addressed and the final repair review found no blockers.
- Simulator visual evidence will be attached before marking this PR ready for review.

## Scope

Targets the active native SwiftUI owner branch (#5178).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Settle the primary swipe action for eligible threads in the home thread list
> - Introduces `HomeThreadSwipeActions` to compute ordered swipe actions and full-swipe eligibility based on thread state, pin status, archive state, and settlement eligibility; Settle is now the primary (first) action for eligible threads.
> - Adds `FeatureSettlementProjectionInput` and `FeatureSettlementProjection` to compute settlement eligibility from pending approvals, user input, session status, and turn/message timestamps.
> - Adds `FeatureThread.canSettle` and gates `isEffectivelySettled` on it, so threads with pending requests or recent unprocessed messages are not treated as settled.
> - Fixes `removeCachedApproval` and `removeCachedInput` in `NativeFeatureClient` to reconcile thread state against shell-reported pending flags before publishing, preventing premature idle/settled flips.
> - Behavioral Change: full-swipe now triggers a reversible action (Settle, Reopen, Unpin, Restore) rather than Delete; Delete is always last in the swipe list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb748e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread lifecycle UX and native client state reconciliation for approvals, settlement, and swipe defaults; behavior is heavily tested but wrong gating could block settle or allow premature full-swipe actions.
> 
> **Overview**
> Makes **Settle/Reopen** the primary trailing swipe on home thread rows (including pinned threads), with **full swipe** enabled only for reversible actions—**Delete** stays last and is never the full-swipe target.
> 
> Adds **`FeatureSettlementProjection`** and **`settlementInput`** on **`FeatureThread`** so settle/reopen and “effectively settled” UI respect blockers: pending approvals/input, live sessions, recent user messages (2‑minute grace), and turn timing. **`NativeFeatureClient`** merges shell **`hasPendingApprovals` / `hasPendingUserInput`** with cached detail when updating state and after resolving approvals/inputs (including when thread refresh fails).
> 
> Introduces **`HomeThreadSwipeActions`** to centralize swipe/menu ordering; context menus hide settle when blocked. Provider label resolution no longer falls back to legacy **`snapshot.providers`** when an environment’s catalog is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb748e66fe531808f5cd8d5f7641e2b7e69a68f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable with runnable checks green; requested review changes remain. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
