### PR TITLE
fix(web): show provider account accent badge in sidebar rows and hover card

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -238,13 +238,29 @@ function terminalProcessLabel(count: number): string {
   return `${count} terminal ${count === 1 ? "process" : "processes"} running`;
 }
 
+// Several accounts on the same provider share one glyph, so the account badge
+// is the only thing telling them apart.
+function hasDuplicateDriverInstances(
+  entries: ReadonlyMap<string, ProviderInstanceEntry>,
+  driverKind: ProviderInstanceEntry["driverKind"],
+): boolean {
+  let seen = false;
+  for (const entry of entries.values()) {
+    if (entry.driverKind !== driverKind) continue;
+    if (seen) return true;
+    seen = true;
+  }
+  return false;
+}
+
 function SidebarThreadTooltip({
   thread,
   projectTitle,
   projectCwd,
   projectFaviconPath,
   environmentLabel,
-  driverKind,
+  providerEntry,
+  showInstanceBadge,
   modelInstanceId,
   modelLabel,
   branchMismatch,
@@ -256,7 +272,8 @@ function SidebarThreadTooltip({
   projectCwd: string | null;
   projectFaviconPath: string | null;
   environmentLabel: string | null;
-  driverKind: ProviderInstanceEntry["driverKind"] | null;
+  providerEntry: ProviderInstanceEntry | null;
+  showInstanceBadge: boolean;
   modelInstanceId: string;
   modelLabel: string;
   branchMismatch: {
@@ -266,6 +283,7 @@ function SidebarThreadTooltip({
   terminalStatus: TerminalStatusIndicator | null;
   terminalProcessCount: number;
 }) {
+  const driverKind = providerEntry?.driverKind ?? null;
   return (
     <TooltipPopup
       side="right"
@@ -314,10 +332,22 @@ function SidebarThreadTooltip({
             <div className="flex min-w-0 items-center gap-2">
               <ProviderInstanceIcon
                 driverKind={driverKind}
-                displayName={thread.session?.providerName ?? modelInstanceId}
+                displayName={
+                  providerEntry?.displayName ?? thread.session?.providerName ?? modelInstanceId
+                }
+                accentColor={providerEntry?.accentColor}
+                // Initials would swallow a size-3 glyph, so the accent reads as
+                // a plain dot here and the account name lands in the label.
+                showBadge={showInstanceBadge && providerEntry?.accentColor !== undefined}
+                badgeContent="none"
+                badgeClassName="h-2 min-w-2 px-0"
                 iconClassName="size-3 shrink-0 grayscale opacity-60"
               />
-              <div className="min-w-0 truncate text-foreground/75">{modelLabel}</div>
+              <div className="min-w-0 truncate text-foreground/75">
+                {showInstanceBadge && providerEntry
+                  ? `${modelLabel} · ${providerEntry.displayName}`
+                  : modelLabel}
+              </div>
             </div>
           ) : null}
           {terminalStatus ? (
@@ -858,6 +888,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
   const driverKind = providerEntry?.driverKind ?? null;
+  const showInstanceBadge =
+    providerEntry !== null &&
+    (Boolean(providerEntry.accentColor) ||
+      hasDuplicateDriverInstances(props.providerEntryByInstanceId, providerEntry.driverKind));
   const selectedModel = providerEntry?.models.find(
     (model) => model.slug === thread.modelSelection.model,
   );
@@ -875,7 +909,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       projectCwd={props.projectCwd}
       projectFaviconPath={props.projectFaviconPath}
       environmentLabel={props.environmentLabel}
-      driverKind={driverKind}
+      providerEntry={providerEntry}
+      showInstanceBadge={showInstanceBadge}
       modelInstanceId={modelInstanceId}
       modelLabel={modelLabel}
       branchMismatch={branchMismatch}
@@ -1453,11 +1488,20 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                   </span>
                 ) : null}
                 {driverKind ? (
-                  <span className="inline-flex shrink-0 items-center opacity-60">
+                  <span className="inline-flex shrink-0 items-center">
                     <ProviderInstanceIcon
                       driverKind={driverKind}
-                      displayName={thread.session?.providerName ?? modelInstanceId}
-                      iconClassName="size-3.5"
+                      displayName={
+                        providerEntry?.displayName ??
+                        thread.session?.providerName ??
+                        modelInstanceId
+                      }
+                      accentColor={providerEntry?.accentColor}
+                      showBadge={showInstanceBadge}
+                      // Only the glyph dims; the accent badge has to stay
+                      // saturated to read as an account color.
+                      iconClassName="size-3.5 opacity-60"
+                      badgeClassName="h-3 min-w-3 px-0.5 text-[7px]"
                     />
                   </span>
                 ) : null}
@@ -1514,7 +1558,10 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
   });
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
-  const driverKind = providerEntry?.driverKind ?? null;
+  const showInstanceBadge =
+    providerEntry !== null &&
+    (Boolean(providerEntry.accentColor) ||
+      hasDuplicateDriverInstances(props.providerEntryByInstanceId, providerEntry.driverKind));
   const selectedModel = providerEntry?.models.find(
     (model) => model.slug === thread.modelSelection.model,
   );
@@ -1572,7 +1619,8 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
           projectCwd={props.projectCwd}
           projectFaviconPath={props.projectFaviconPath}
           environmentLabel={props.environmentLabel}
-          driverKind={driverKind}
+          providerEntry={providerEntry}
+          showInstanceBadge={showInstanceBadge}
           modelInstanceId={modelInstanceId}
           modelLabel={modelLabel}
           branchMismatch={branchMismatch}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -155,7 +155,11 @@ import {
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
-import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
+import {
+  deriveProviderInstanceEntries,
+  shouldShowInstanceBadge,
+  type ProviderInstanceEntry,
+} from "../providerInstances";
 import { primaryServerProvidersAtom } from "../state/server";
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { stackedThreadToast, toastManager } from "./ui/toast";
@@ -236,21 +240,6 @@ function WorkingDuration(props: { startedAt: string | null }) {
 
 function terminalProcessLabel(count: number): string {
   return `${count} terminal ${count === 1 ? "process" : "processes"} running`;
-}
-
-// Several accounts on the same provider share one glyph, so the account badge
-// is the only thing telling them apart.
-function hasDuplicateDriverInstances(
-  entries: ReadonlyMap<string, ProviderInstanceEntry>,
-  driverKind: ProviderInstanceEntry["driverKind"],
-): boolean {
-  let seen = false;
-  for (const entry of entries.values()) {
-    if (entry.driverKind !== driverKind) continue;
-    if (seen) return true;
-    seen = true;
-  }
-  return false;
 }
 
 function SidebarThreadTooltip({
@@ -336,8 +325,7 @@ function SidebarThreadTooltip({
                   providerEntry?.displayName ?? thread.session?.providerName ?? modelInstanceId
                 }
                 accentColor={providerEntry?.accentColor}
-                // Initials would swallow a size-3 glyph, so the accent reads as
-                // a plain dot here and the account name lands in the label.
+                // Initials would swallow a size-3 glyph: accent dot, name in label.
                 showBadge={showInstanceBadge && providerEntry?.accentColor !== undefined}
                 badgeContent="none"
                 badgeClassName="h-2 min-w-2 px-0"
@@ -890,8 +878,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   const driverKind = providerEntry?.driverKind ?? null;
   const showInstanceBadge =
     providerEntry !== null &&
-    (Boolean(providerEntry.accentColor) ||
-      hasDuplicateDriverInstances(props.providerEntryByInstanceId, providerEntry.driverKind));
+    shouldShowInstanceBadge(providerEntry, props.providerEntryByInstanceId.values());
   const selectedModel = providerEntry?.models.find(
     (model) => model.slug === thread.modelSelection.model,
   );
@@ -1498,10 +1485,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                       }
                       accentColor={providerEntry?.accentColor}
                       showBadge={showInstanceBadge}
-                      // Only the glyph dims; the accent badge has to stay
-                      // saturated to read as an account color.
+                      // Glyph dims, badge stays saturated; offset matches the composer trigger.
                       iconClassName="size-3.5 opacity-60"
-                      badgeClassName="h-3 min-w-3 px-0.5 text-[7px]"
+                      badgeClassName="right-[-0.1875rem] bottom-[-0.1875rem] h-3 min-w-3 px-0.5 text-[7px]"
                     />
                   </span>
                 ) : null}
@@ -1560,8 +1546,7 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
   const showInstanceBadge =
     providerEntry !== null &&
-    (Boolean(providerEntry.accentColor) ||
-      hasDuplicateDriverInstances(props.providerEntryByInstanceId, providerEntry.driverKind));
+    shouldShowInstanceBadge(providerEntry, props.providerEntryByInstanceId.values());
   const selectedModel = providerEntry?.models.find(
     (model) => model.slug === thread.modelSelection.model,
   );

--- a/apps/web/src/components/chat/ModelPickerSidebar.tsx
+++ b/apps/web/src/components/chat/ModelPickerSidebar.tsx
@@ -1,10 +1,14 @@
 import { type ProviderInstanceId } from "@t3tools/contracts";
-import { memo, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { memo, useLayoutEffect, useRef, useState } from "react";
 import { SparklesIcon, StarIcon } from "lucide-react";
 import { ProviderInstanceIcon } from "./ProviderInstanceIcon";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "~/lib/utils";
-import { isProviderInstancePickerReady, type ProviderInstanceEntry } from "../../providerInstances";
+import {
+  isProviderInstancePickerReady,
+  shouldShowInstanceBadge,
+  type ProviderInstanceEntry,
+} from "../../providerInstances";
 
 /**
  * Build the hover tooltip for an instance button. Mirrors the old
@@ -65,14 +69,6 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
   const [hoveredInstanceId, setHoveredInstanceId] = useState<ProviderInstanceId | null>(null);
   const sidebarContentRef = useRef<HTMLDivElement>(null);
   const [selectedIndicatorTop, setSelectedIndicatorTop] = useState<number | null>(null);
-  const duplicateDriverCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const entry of props.instanceEntries) {
-      counts.set(entry.driverKind, (counts.get(entry.driverKind) ?? 0) + 1);
-    }
-    return counts;
-  }, [props.instanceEntries]);
-
   useLayoutEffect(() => {
     const content = sidebarContentRef.current;
     if (!content) {
@@ -143,8 +139,7 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
             const isSelected = props.selectedInstanceId === entry.instanceId;
             const isHovered = hoveredInstanceId === entry.instanceId;
             const showNewBadge = props.newBadgeInstanceIds?.has(entry.instanceId) ?? false;
-            const showInstanceBadge =
-              Boolean(entry.accentColor) || (duplicateDriverCounts.get(entry.driverKind) ?? 0) > 1;
+            const showInstanceBadge = shouldShowInstanceBadge(entry, props.instanceEntries);
 
             const tooltip = isUnavailable
               ? describeUnavailableInstance(entry)

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -16,7 +16,7 @@ import {
   getTriggerDisplayModelLabel,
   getTriggerDisplayModelName,
 } from "./providerIconUtils";
-import type { ProviderInstanceEntry } from "../../providerInstances";
+import { shouldShowInstanceBadge, type ProviderInstanceEntry } from "../../providerInstances";
 import { ComposerControl, ComposerControlChevron } from "./ComposerControl";
 
 export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
@@ -67,10 +67,8 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
     selectedInstanceOptions[0];
   const triggerTitle = selectedModel ? getTriggerDisplayModelName(selectedModel) : props.model;
   const triggerLabel = selectedModel ? getTriggerDisplayModelLabel(selectedModel) : props.model;
-  const duplicateDriverCount = props.instanceEntries.filter(
-    (entry) => activeEntry !== null && entry.driverKind === activeEntry.driverKind,
-  ).length;
-  const showInstanceBadge = Boolean(activeEntry?.accentColor) || duplicateDriverCount > 1;
+  const showInstanceBadge =
+    activeEntry !== null && shouldShowInstanceBadge(activeEntry, props.instanceEntries);
 
   const setIsMenuOpen = (open: boolean) => {
     props.onOpenChange?.(open);

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -109,6 +109,23 @@ function driverKindLabel(driverKind: ProviderDriverKind): string {
   return PROVIDER_DISPLAY_NAMES[driverKind] ?? formatProviderDriverKindLabel(driverKind);
 }
 
+/**
+ * Whether an instance's icon carries the account badge: accent color set, or
+ * several instances sharing a driver so the brand glyph alone is ambiguous.
+ * Shared by the composer trigger, the picker rail, and sidebar rows.
+ */
+export function shouldShowInstanceBadge(
+  entry: ProviderInstanceEntry,
+  entries: Iterable<ProviderInstanceEntry>,
+): boolean {
+  if (entry.accentColor) return true;
+  let sharedDriverCount = 0;
+  for (const candidate of entries) {
+    if (candidate.driverKind === entry.driverKind && ++sharedDriverCount > 1) return true;
+  }
+  return false;
+}
+
 export function normalizeProviderAccentColor(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;


### PR DESCRIPTION
## What Changed

Sidebar v2 thread rows and their hover details card now show which provider *account* a thread runs on, exactly like the composer's model picker already does:

- The row's inline provider icon gets the account accent color + initials badge, using the same corner-offset geometry as the composer trigger (badge hangs off the glyph's corner instead of covering it).
- The hover card's provider line gets a small accent dot on the icon and names the account next to the model (`Claude Fable 5 · work-1@example.com`). Initials would swallow the card's `size-3` glyph, hence the dot + text there.
- The show-the-badge heuristic (accent color set, or several accounts sharing one provider) previously existed as three hand-rolled copies in `ProviderModelPicker` and `ModelPickerSidebar`; it is now one shared `shouldShowInstanceBadge` helper in `providerInstances.ts`, used by the composer trigger, the picker rail, and both sidebar row variants — so the badge appears consistently everywhere and can't drift.

Four files changed (+78/−28): `apps/web/src/components/Sidebar.tsx` (the fix), `apps/web/src/providerInstances.ts` (shared helper), and the two picker components (now consuming the helper, behavior unchanged). Both `SidebarThreadRow` and `SidebarSearchResultRow` already resolve the full `ProviderInstanceEntry` (which carries `accentColor`/`displayName`); the fix threads it into the two existing `ProviderInstanceIcon` call sites. `SidebarThreadTooltip`'s `driverKind` prop is replaced by that entry (its only consumer derived `driverKind` from it anyway). The row's `opacity-60` moves from the wrapper span onto the glyph so the accent badge keeps full saturation while the icon stays muted as before.

## Why

With multiple accounts on one provider (e.g. work and personal Claude Code subscriptions with separate quotas), the sidebar was the one place you couldn't tell them apart — the composer, picker rail, and settings all show the accent/initials badge, but sidebar rows rendered a bare glyph and the hover card was forced grayscale with only the model label. Fixes #5977.

Not touching #5289/#5300 (provider icon missing entirely for non-primary environments — a lookup-source bug); this change composes with that fix, since it only adds props where the icon already renders.

## UI Changes

Captured against a real multi-account setup (three Claude Code accounts, two with custom accent colors, one without).

| | Before | After |
|---|---|---|
| Sidebar rows | <img src="https://gist.githubusercontent.com/vitalyiegorov/e643fa28477c035bf155d43c3fa11a5f/raw/before-sidebar.png" width="290" alt="Sidebar rows before: plain dimmed provider glyph" /> | <img src="https://gist.githubusercontent.com/vitalyiegorov/e643fa28477c035bf155d43c3fa11a5f/raw/after2-sidebar.png" width="290" alt="Sidebar rows after: provider glyph with corner accent badges (VI, W1) and a neutral initials badge (CL) for the color-less duplicate account" /> |
| Hover details card | <img src="https://gist.githubusercontent.com/vitalyiegorov/e643fa28477c035bf155d43c3fa11a5f/raw/before-tooltip.png" width="420" alt="Hover card before: grayscale icon, model label only" /> | <img src="https://gist.githubusercontent.com/vitalyiegorov/e643fa28477c035bf155d43c3fa11a5f/raw/after2-tooltip.png" width="420" alt="Hover card after: accent dot on the icon and account name next to the model label" /> |

No motion/timing changes, so no video. The badge is the same static element the picker rail renders — no new animations.

Verified locally: `vp fmt --check` and `vp lint --report-unused-disable-directives` on the four changed files, `vp run --filter @t3tools/web typecheck`, and an integrated pass in the web client (screenshots above) covering rows with accent color, rows with duplicate accounts and no color, the hover card, and the composer trigger/rail after the refactor.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (n/a — no motion changes)

Made by Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only presentation changes in the sidebar and model picker; no auth, data, or routing logic changes.
> 
> **Overview**
> Sidebar thread rows and hover cards now match the composer model picker for **multi-account** provider instances: accent-colored corner badges on inline icons, and tooltip copy that can show **model · account display name** (with a small accent dot on the small tooltip icon when initials would crowd the glyph).
> 
> Badge visibility is centralized in **`shouldShowInstanceBadge`** in `providerInstances.ts` (show when the instance has an accent color or when more than one instance shares the same driver). The composer trigger and picker rail now call that helper instead of duplicating the same rules locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e106393ea70b649ee01d2a66a09b9f3ecbb9ea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show provider account accent badge in sidebar thread rows and hover cards
> - Adds a `shouldShowInstanceBadge` utility to [providerInstances.ts](https://github.com/pingdotgg/t3code/pull/5980/files#diff-366ee4ff966b3b9fefcc872cdc0d10484ac52c174b5ed0e8ed59e84e97f58d5b) that returns `true` when an entry has an `accentColor` or when multiple instances share the same driver kind.
> - Applies the accent badge to provider icons in sidebar thread rows, search result rows, and the thread tooltip hover card using this utility.
> - Appends the provider instance display name to the model label in tooltips when the badge is shown.
> - Replaces duplicate inline badge-visibility logic in `ModelPickerSidebar` and `ProviderModelPicker` with calls to `shouldShowInstanceBadge`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e10639.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->