### PR TITLE
fix(web): support Shift+Insert terminal paste

### DIFF
--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -252,6 +252,22 @@ describe("isTerminalPasteShortcut", () => {
       true,
     );
   });
+
+  it("supports the conventional Shift+Insert paste shortcut", () => {
+    expect(isTerminalPasteShortcut(event({ key: "Insert", shiftKey: true }), "Linux x86_64")).toBe(
+      true,
+    );
+    expect(isTerminalPasteShortcut(event({ key: "Insert" }), "Linux x86_64")).toBe(false);
+    expect(
+      isTerminalPasteShortcut(
+        event({ key: "Insert", ctrlKey: true, shiftKey: true }),
+        "Linux x86_64",
+      ),
+    ).toBe(false);
+    expect(isTerminalPasteShortcut(event({ key: "Insert", shiftKey: true }), "MacIntel")).toBe(
+      false,
+    );
+  });
 });
 
 describe("isTerminalCompositionCommitInput", () => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -340,7 +340,11 @@ export function isTerminalPasteShortcut(
   event: Pick<KeyboardEvent, "ctrlKey" | "key" | "metaKey" | "shiftKey">,
   platform = navigator.platform,
 ) {
-  if (event.key.toLowerCase() !== "v") return false;
+  const key = event.key.toLowerCase();
+  if (key === "insert" && !isMacPlatform(platform)) {
+    return event.shiftKey && !event.ctrlKey && !event.metaKey;
+  }
+  if (key !== "v") return false;
   return isMacPlatform(platform) ? event.metaKey : event.ctrlKey && event.shiftKey;
 }
 


### PR DESCRIPTION
## What Changed

- Recognize exact `Shift+Insert` key presses as terminal paste shortcuts on non-macOS platforms.
- Reuse the existing clipboard-read/native-paste race and Ghostty bracketed-paste encoding path.
- Add regression coverage for `Shift+Insert`, plain `Insert`, modifier conflicts, and macOS behavior.

## Why

The integrated terminal only recognized Cmd+V and Ctrl+Shift+V. Linux desktop tools such as Omarchy's universal paste binding emit Shift+Insert, so those paste actions were silently ignored. Keeping this inside `isTerminalPasteShortcut` makes the existing paste pipeline handle the additional conventional shortcut without changing normal Insert or macOS behavior.

Closes #5936.

## UI Changes

This is a keyboard interaction change with no layout or visual-state difference. The behavior is covered by the focused shortcut regression test; no before/after screenshot applies.

## Verification

- `vp test run apps/web/src/terminal/ghostty/surface.test.ts` (35 passed)
- `vp lint --report-unused-disable-directives apps/web/src/terminal/ghostty/surface.ts apps/web/src/terminal/ghostty/surface.test.ts`
- `vp fmt --check apps/web/src/terminal/ghostty/surface.ts apps/web/src/terminal/ghostty/surface.test.ts`
- `vp run --filter @t3tools/web typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable: no visual change)
- [ ] I included a video for animation/interaction changes

Model: GPT-5. Harness: Codex desktop.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Shift+Insert paste shortcut support to terminal on non-macOS platforms
> Updates `isTerminalPasteShortcut` in [surface.ts](https://github.com/pingdotgg/t3code/pull/5982/files#diff-036d64ffe3b3b3d167137e8ea29edae7af74a9e0323fc798c4f291992235d267) to recognize Shift+Insert as a paste shortcut on non-macOS platforms, matching conventional terminal behavior. Plain Insert, Ctrl+Shift+Insert, and Shift+Insert on macOS all continue to return false. Existing Ctrl+Shift+V (Linux/Windows) and Meta+V (macOS) shortcuts are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2746139.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to keyboard shortcut detection only; existing paste encoding and platform rules for V-based shortcuts are unchanged.
> 
> **Overview**
> **Shift+Insert** is now treated as paste on **non-macOS** in `isTerminalPasteShortcut`, so Linux-style bindings (e.g. Omarchy) hit the same clipboard-read / native-paste path as **Ctrl+Shift+V** and **Cmd+V**.
> 
> Only **Shift+Insert** with no Ctrl/Meta counts; plain **Insert**, **Ctrl+Shift+Insert**, and **Shift+Insert** on macOS stay non-paste. Regression tests cover those cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2746139883df716929f5c77b7f20b551b5e387a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->