### PR TITLE
feat(web): start and stop managed VM instances through hooks

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -39,6 +39,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverRemoveKeybinding]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverGetSettings]: AuthOrchestrationReadScope,
   [WS_METHODS.serverUpdateSettings]: AuthOrchestrationOperateScope,
+  [WS_METHODS.serverRunStopHook]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverDiscoverSourceControl]: AuthOrchestrationReadScope,
   [WS_METHODS.serverGetTraceDiagnostics]: AuthOrchestrationReadScope,
   [WS_METHODS.serverGetProcessDiagnostics]: AuthOrchestrationReadScope,

--- a/apps/server/src/instanceHooks.test.ts
+++ b/apps/server/src/instanceHooks.test.ts
@@ -1,0 +1,102 @@
+import { ServerStopHookError } from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+import * as InstanceHooks from "./instanceHooks.ts";
+import * as ServerSettings from "./serverSettings.ts";
+
+interface RecordedHookRequest {
+  readonly method: string;
+  readonly url: string;
+}
+
+const makeHookEndpointLayer = (requests: Array<RecordedHookRequest>, status: number) =>
+  Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) =>
+      Effect.sync(() => {
+        requests.push({ method: request.method, url: request.url });
+        return HttpClientResponse.fromWeb(request, new Response(null, { status }));
+      }),
+    ),
+  );
+
+const isStopHookError = Schema.is(ServerStopHookError);
+
+it.effect("DELETEs the stop hook and reports the instance as stopping on 204", () =>
+  Effect.gen(function* () {
+    const requests: Array<RecordedHookRequest> = [];
+    const result = yield* InstanceHooks.runStopHook.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          makeHookEndpointLayer(requests, 204),
+          ServerSettings.layerTest({ stopHookUrl: "https://mgmt.example.test/instances/1/stop" }),
+        ),
+      ),
+    );
+    assert.deepEqual(result, { outcome: "stopped" });
+    assert.deepEqual(requests, [
+      { method: "DELETE", url: "https://mgmt.example.test/instances/1/stop" },
+    ]);
+  }),
+);
+
+it.effect("clears the stop hook setting when the endpoint is gone", () =>
+  Effect.gen(function* () {
+    const requests: Array<RecordedHookRequest> = [];
+    const settingsLayer = ServerSettings.layerTest({
+      stopHookUrl: "https://mgmt.example.test/instances/1/stop",
+    });
+    const result = yield* Effect.gen(function* () {
+      const outcome = yield* InstanceHooks.runStopHook.pipe(
+        Effect.provide(makeHookEndpointLayer(requests, 404)),
+      );
+      const settings = yield* (yield* ServerSettings.ServerSettingsService).getSettings;
+      return { outcome, stopHookUrl: settings.stopHookUrl };
+    }).pipe(Effect.provide(settingsLayer));
+    assert.deepEqual(result.outcome, { outcome: "gone" });
+    assert.equal(result.stopHookUrl, null);
+  }),
+);
+
+it.effect("fails when no stop hook is configured", () =>
+  Effect.gen(function* () {
+    const requests: Array<RecordedHookRequest> = [];
+    const failure = yield* InstanceHooks.runStopHook.pipe(
+      Effect.provide(
+        Layer.mergeAll(makeHookEndpointLayer(requests, 204), ServerSettings.layerTest()),
+      ),
+      Effect.flip,
+    );
+    assert.isTrue(isStopHookError(failure));
+    assert.equal(isStopHookError(failure) ? failure.reason : null, "not-configured");
+    assert.deepEqual(requests, []);
+  }),
+);
+
+it.effect("surfaces unexpected statuses without clearing the hook", () =>
+  Effect.gen(function* () {
+    const requests: Array<RecordedHookRequest> = [];
+    const settingsLayer = ServerSettings.layerTest({
+      stopHookUrl: "https://mgmt.example.test/instances/1/stop",
+    });
+    const result = yield* Effect.gen(function* () {
+      const failure = yield* InstanceHooks.runStopHook.pipe(
+        Effect.provide(makeHookEndpointLayer(requests, 500)),
+        Effect.flip,
+      );
+      const settings = yield* (yield* ServerSettings.ServerSettingsService).getSettings;
+      return { failure, stopHookUrl: settings.stopHookUrl };
+    }).pipe(Effect.provide(settingsLayer));
+    assert.isTrue(isStopHookError(result.failure));
+    assert.equal(
+      isStopHookError(result.failure) ? result.failure.reason : null,
+      "unexpected-status",
+    );
+    assert.equal(result.stopHookUrl, "https://mgmt.example.test/instances/1/stop");
+  }),
+);

--- a/apps/server/src/instanceHooks.test.ts
+++ b/apps/server/src/instanceHooks.test.ts
@@ -1,6 +1,6 @@
 import {
+  ServerStopHookInvalidUrlError,
   ServerStopHookNotConfiguredError,
-  ServerStopHookRequestError,
   ServerStopHookUnexpectedStatusError,
 } from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
@@ -30,7 +30,7 @@ const makeHookEndpointLayer = (requests: Array<RecordedHookRequest>, status: num
   );
 
 const isNotConfiguredError = Schema.is(ServerStopHookNotConfiguredError);
-const isRequestError = Schema.is(ServerStopHookRequestError);
+const isInvalidUrlError = Schema.is(ServerStopHookInvalidUrlError);
 const isUnexpectedStatusError = Schema.is(ServerStopHookUnexpectedStatusError);
 
 it.effect("DELETEs the stop hook and reports the instance as stopping on 204", () =>
@@ -124,7 +124,26 @@ it.effect("refuses a stop hook that is not an http(s) URL without issuing a requ
       ),
       Effect.flip,
     );
-    assert.isTrue(isRequestError(failure));
+    assert.isTrue(isInvalidUrlError(failure));
+    assert.equal(isInvalidUrlError(failure) ? failure.protocol : null, "file:");
+    assert.deepEqual(requests, []);
+  }),
+);
+
+it.effect("reports an unparsable stop hook URL as invalid rather than a failed request", () =>
+  Effect.gen(function* () {
+    const requests: Array<RecordedHookRequest> = [];
+    const failure = yield* InstanceHooks.runStopHook.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          makeHookEndpointLayer(requests, 204),
+          ServerSettings.layerTest({ stopHookUrl: "not a url" }),
+        ),
+      ),
+      Effect.flip,
+    );
+    assert.isTrue(isInvalidUrlError(failure));
+    assert.equal(isInvalidUrlError(failure) ? failure.protocol : "unset", null);
     assert.deepEqual(requests, []);
   }),
 );

--- a/apps/server/src/instanceHooks.test.ts
+++ b/apps/server/src/instanceHooks.test.ts
@@ -1,4 +1,8 @@
-import { ServerStopHookError } from "@t3tools/contracts";
+import {
+  ServerStopHookNotConfiguredError,
+  ServerStopHookRequestError,
+  ServerStopHookUnexpectedStatusError,
+} from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -25,7 +29,9 @@ const makeHookEndpointLayer = (requests: Array<RecordedHookRequest>, status: num
     ),
   );
 
-const isStopHookError = Schema.is(ServerStopHookError);
+const isNotConfiguredError = Schema.is(ServerStopHookNotConfiguredError);
+const isRequestError = Schema.is(ServerStopHookRequestError);
+const isUnexpectedStatusError = Schema.is(ServerStopHookUnexpectedStatusError);
 
 it.effect("DELETEs the stop hook and reports the instance as stopping on 204", () =>
   Effect.gen(function* () {
@@ -63,6 +69,35 @@ it.effect("clears the stop hook setting when the endpoint is gone", () =>
   }),
 );
 
+it.effect("keeps a stop hook reconfigured while the 404 request was in flight", () =>
+  Effect.gen(function* () {
+    const staleUrl = "https://mgmt.example.test/instances/1/stop";
+    const replacementUrl = "https://mgmt.example.test/instances/2/stop";
+    const settingsLayer = ServerSettings.layerTest({ stopHookUrl: staleUrl });
+    const result = yield* Effect.gen(function* () {
+      const serverSettings = yield* ServerSettings.ServerSettingsService;
+      // The endpoint swaps the configured hook mid-request, before answering
+      // 404 for the stale URL.
+      const swappingEndpointLayer = Layer.succeed(
+        HttpClient.HttpClient,
+        HttpClient.make((request) =>
+          serverSettings.updateSettings({ stopHookUrl: replacementUrl }).pipe(
+            Effect.orDie,
+            Effect.map(() =>
+              HttpClientResponse.fromWeb(request, new Response(null, { status: 404 })),
+            ),
+          ),
+        ),
+      );
+      const outcome = yield* InstanceHooks.runStopHook.pipe(Effect.provide(swappingEndpointLayer));
+      const settings = yield* serverSettings.getSettings;
+      return { outcome, stopHookUrl: settings.stopHookUrl };
+    }).pipe(Effect.provide(settingsLayer));
+    assert.deepEqual(result.outcome, { outcome: "gone" });
+    assert.equal(result.stopHookUrl, replacementUrl);
+  }),
+);
+
 it.effect("fails when no stop hook is configured", () =>
   Effect.gen(function* () {
     const requests: Array<RecordedHookRequest> = [];
@@ -72,8 +107,24 @@ it.effect("fails when no stop hook is configured", () =>
       ),
       Effect.flip,
     );
-    assert.isTrue(isStopHookError(failure));
-    assert.equal(isStopHookError(failure) ? failure.reason : null, "not-configured");
+    assert.isTrue(isNotConfiguredError(failure));
+    assert.deepEqual(requests, []);
+  }),
+);
+
+it.effect("refuses a stop hook that is not an http(s) URL without issuing a request", () =>
+  Effect.gen(function* () {
+    const requests: Array<RecordedHookRequest> = [];
+    const failure = yield* InstanceHooks.runStopHook.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          makeHookEndpointLayer(requests, 204),
+          ServerSettings.layerTest({ stopHookUrl: "file:///etc/passwd" }),
+        ),
+      ),
+      Effect.flip,
+    );
+    assert.isTrue(isRequestError(failure));
     assert.deepEqual(requests, []);
   }),
 );
@@ -92,11 +143,8 @@ it.effect("surfaces unexpected statuses without clearing the hook", () =>
       const settings = yield* (yield* ServerSettings.ServerSettingsService).getSettings;
       return { failure, stopHookUrl: settings.stopHookUrl };
     }).pipe(Effect.provide(settingsLayer));
-    assert.isTrue(isStopHookError(result.failure));
-    assert.equal(
-      isStopHookError(result.failure) ? result.failure.reason : null,
-      "unexpected-status",
-    );
+    assert.isTrue(isUnexpectedStatusError(result.failure));
+    assert.equal(isUnexpectedStatusError(result.failure) ? result.failure.status : null, 500);
     assert.equal(result.stopHookUrl, "https://mgmt.example.test/instances/1/stop");
   }),
 );

--- a/apps/server/src/instanceHooks.ts
+++ b/apps/server/src/instanceHooks.ts
@@ -1,0 +1,37 @@
+import * as Effect from "effect/Effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { ServerStopHookError, type ServerStopHookResult } from "@t3tools/contracts";
+
+import * as ServerSettings from "./serverSettings.ts";
+
+const STOP_HOOK_TIMEOUT = "20 seconds";
+
+/**
+ * Run the configured stop hook: DELETE the management endpoint that stops
+ * this instance. A 204 reports the instance as stopping. A 404 means the
+ * hook no longer exists, so the setting is cleared and clients drop their
+ * stop controls with it.
+ */
+export const runStopHook = Effect.gen(function* () {
+  const serverSettings = yield* ServerSettings.ServerSettingsService;
+  const httpClient = yield* HttpClient.HttpClient;
+  const settings = yield* serverSettings.getSettings;
+  if (settings.stopHookUrl === null) {
+    return yield* new ServerStopHookError({ reason: "not-configured" });
+  }
+  const response = yield* httpClient.execute(HttpClientRequest.delete(settings.stopHookUrl)).pipe(
+    Effect.timeout(STOP_HOOK_TIMEOUT),
+    Effect.mapError(
+      (error) => new ServerStopHookError({ reason: "request-failed", detail: String(error) }),
+    ),
+  );
+  if (response.status === 204) {
+    return { outcome: "stopped" } satisfies ServerStopHookResult;
+  }
+  if (response.status === 404) {
+    yield* serverSettings.updateSettings({ stopHookUrl: null });
+    return { outcome: "gone" } satisfies ServerStopHookResult;
+  }
+  return yield* new ServerStopHookError({ reason: "unexpected-status", status: response.status });
+});

--- a/apps/server/src/instanceHooks.ts
+++ b/apps/server/src/instanceHooks.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import {
+  ServerStopHookInvalidUrlError,
   ServerStopHookNotConfiguredError,
   ServerStopHookRequestError,
   ServerStopHookUnexpectedStatusError,
@@ -12,13 +13,17 @@ import * as ServerSettings from "./serverSettings.ts";
 
 const STOP_HOOK_TIMEOUT = "20 seconds";
 
-function isHttpUrl(url: string): boolean {
+/** Null when the hook is a dialable http(s) URL, otherwise the rejection. */
+function rejectNonHttpUrl(url: string): ServerStopHookInvalidUrlError | null {
+  let protocol: string;
   try {
-    const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
+    protocol = new URL(url).protocol;
   } catch {
-    return false;
+    return new ServerStopHookInvalidUrlError({ protocol: null });
   }
+  return protocol === "http:" || protocol === "https:"
+    ? null
+    : new ServerStopHookInvalidUrlError({ protocol });
 }
 
 /**
@@ -34,10 +39,9 @@ export const runStopHook = Effect.gen(function* () {
   if (stopHookUrl === null) {
     return yield* new ServerStopHookNotConfiguredError({});
   }
-  if (!isHttpUrl(stopHookUrl)) {
-    return yield* new ServerStopHookRequestError({
-      cause: new Error("The configured stop hook is not an http(s) URL."),
-    });
+  const invalidUrl = rejectNonHttpUrl(stopHookUrl);
+  if (invalidUrl !== null) {
+    return yield* invalidUrl;
   }
   const response = yield* httpClient.execute(HttpClientRequest.delete(stopHookUrl)).pipe(
     Effect.timeout(STOP_HOOK_TIMEOUT),

--- a/apps/server/src/instanceHooks.ts
+++ b/apps/server/src/instanceHooks.ts
@@ -1,11 +1,25 @@
 import * as Effect from "effect/Effect";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
-import { ServerStopHookError, type ServerStopHookResult } from "@t3tools/contracts";
+import {
+  ServerStopHookNotConfiguredError,
+  ServerStopHookRequestError,
+  ServerStopHookUnexpectedStatusError,
+  type ServerStopHookResult,
+} from "@t3tools/contracts";
 
 import * as ServerSettings from "./serverSettings.ts";
 
 const STOP_HOOK_TIMEOUT = "20 seconds";
+
+function isHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Run the configured stop hook: DELETE the management endpoint that stops
@@ -16,22 +30,29 @@ const STOP_HOOK_TIMEOUT = "20 seconds";
 export const runStopHook = Effect.gen(function* () {
   const serverSettings = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
-  const settings = yield* serverSettings.getSettings;
-  if (settings.stopHookUrl === null) {
-    return yield* new ServerStopHookError({ reason: "not-configured" });
+  const stopHookUrl = (yield* serverSettings.getSettings).stopHookUrl;
+  if (stopHookUrl === null) {
+    return yield* new ServerStopHookNotConfiguredError({});
   }
-  const response = yield* httpClient.execute(HttpClientRequest.delete(settings.stopHookUrl)).pipe(
+  if (!isHttpUrl(stopHookUrl)) {
+    return yield* new ServerStopHookRequestError({
+      cause: new Error("The configured stop hook is not an http(s) URL."),
+    });
+  }
+  const response = yield* httpClient.execute(HttpClientRequest.delete(stopHookUrl)).pipe(
     Effect.timeout(STOP_HOOK_TIMEOUT),
-    Effect.mapError(
-      (error) => new ServerStopHookError({ reason: "request-failed", detail: String(error) }),
-    ),
+    Effect.mapError((error) => new ServerStopHookRequestError({ cause: error })),
   );
   if (response.status === 204) {
     return { outcome: "stopped" } satisfies ServerStopHookResult;
   }
   if (response.status === 404) {
-    yield* serverSettings.updateSettings({ stopHookUrl: null });
+    // Re-read before clearing: only forget the hook that actually returned
+    // the 404, not one reconfigured while the request was in flight.
+    if ((yield* serverSettings.getSettings).stopHookUrl === stopHookUrl) {
+      yield* serverSettings.updateSettings({ stopHookUrl: null });
+    }
     return { outcome: "gone" } satisfies ServerStopHookResult;
   }
-  return yield* new ServerStopHookError({ reason: "unexpected-status", status: response.status });
+  return yield* new ServerStopHookUnexpectedStatusError({ status: response.status });
 });

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -59,7 +59,12 @@ import {
   WsRpcGroup,
 } from "@t3tools/contracts";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
-import { HttpRouter, HttpServerRequest, HttpServerRespondable } from "effect/unstable/http";
+import {
+  HttpClient,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerRespondable,
+} from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 
 import * as CheckpointDiffQuery from "./checkpointing/CheckpointDiffQuery.ts";
@@ -83,6 +88,7 @@ import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner
 import * as ServerSelfUpdate from "./cloud/selfUpdate.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
+import * as InstanceHooks from "./instanceHooks.ts";
 import * as ServerSettings from "./serverSettings.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewAutomationBroker from "./mcp/PreviewAutomationBroker.ts";
@@ -373,6 +379,7 @@ const makeWsRpcLayer = (
       const config = yield* ServerConfig.ServerConfig;
       const lifecycleEvents = yield* ServerLifecycleEvents.ServerLifecycleEvents;
       const serverSettings = yield* ServerSettings.ServerSettingsService;
+      const stopHookHttpClient = yield* HttpClient.HttpClient;
       const startup = yield* ServerRuntimeStartup.ServerRuntimeStartup;
       const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
       const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
@@ -1518,6 +1525,17 @@ const makeWsRpcLayer = (
             serverSettings
               .updateSettings(patch)
               .pipe(Effect.map(ServerSettings.redactServerSettingsForClient)),
+            {
+              "rpc.aggregate": "server",
+            },
+          ),
+        [WS_METHODS.serverRunStopHook]: (_input) =>
+          observeRpcEffect(
+            WS_METHODS.serverRunStopHook,
+            InstanceHooks.runStopHook.pipe(
+              Effect.provideService(ServerSettings.ServerSettingsService, serverSettings),
+              Effect.provideService(HttpClient.HttpClient, stopHookHttpClient),
+            ),
             {
               "rpc.aggregate": "server",
             },

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -2367,6 +2367,9 @@ export function ConnectionsSettings() {
         setStartHookRun({ ...run, phase: "starting", form: null, submitting: false });
         await pollStartHookUntilReady(step.poll, { signal: controller.signal });
       }
+      // Cancel and unmount both detach the controller before aborting, so this
+      // check is also what stops a connect from being started after either.
+      // Nothing can interleave between it and the call below.
       if (!isCurrentStartHook(controller)) return;
       // Hold the run through the connect handoff. `retryNow` only signals the
       // supervisor, so clearing here would flash an enabled Connect button and
@@ -2417,7 +2420,9 @@ export function ConnectionsSettings() {
     controller?.abort();
   }, []);
 
-  // Leaving the page must not keep polling nor connect the environment later.
+  // Leaving the page stops the hook request/poll and prevents a connect from
+  // being started afterwards. A connect already dispatched is the user's
+  // committed intent and is owned by the supervisor, so it is left to finish.
   useEffect(() => handleCancelStartHook, [handleCancelStartHook]);
 
   const handleSubmitStartHookForm = useCallback(

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -6,7 +6,16 @@ import {
   TerminalIcon,
 } from "lucide-react";
 import { useAtomValue } from "@effect/atom-react";
-import { type ReactNode, memo, useCallback, useId, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   AuthAccessReadScope,
   AuthAccessWriteScope,
@@ -2307,15 +2316,19 @@ export function ConnectionsSettings() {
     [retryEnvironment],
   );
 
-  const finishStartHook = useCallback(() => {
-    startHookAbortRef.current = null;
-    setStartHookRun(null);
-  }, []);
+  // Every state write below is guarded by controller identity: a run that was
+  // superseded by a newer Connect click or cancelled must not clear or
+  // overwrite the newer run's state when its in-flight promise settles.
+  const isCurrentStartHook = useCallback(
+    (controller: AbortController) => startHookAbortRef.current === controller,
+    [],
+  );
 
   const failStartHook = useCallback(
-    (error: unknown, aborted: boolean) => {
-      finishStartHook();
-      if (aborted) return;
+    (controller: AbortController, error: unknown) => {
+      if (!isCurrentStartHook(controller)) return;
+      startHookAbortRef.current = null;
+      setStartHookRun(null);
       const message = error instanceof Error ? error.message : "Failed to start the instance.";
       setSavedBackendError(message);
       toastManager.add(
@@ -2326,7 +2339,7 @@ export function ConnectionsSettings() {
         }),
       );
     },
-    [finishStartHook],
+    [isCurrentStartHook],
   );
 
   const settleStartHookStep = useCallback(
@@ -2335,6 +2348,7 @@ export function ConnectionsSettings() {
       step: StartHookStep,
       controller: AbortController,
     ) => {
+      if (!isCurrentStartHook(controller)) return;
       if (step.kind === "form") {
         setStartHookRun({ ...run, phase: "form", form: step.form, submitting: false });
         return;
@@ -2343,10 +2357,12 @@ export function ConnectionsSettings() {
         setStartHookRun({ ...run, phase: "starting", form: null, submitting: false });
         await pollStartHookUntilReady(step.poll, { signal: controller.signal });
       }
-      finishStartHook();
+      if (!isCurrentStartHook(controller)) return;
+      startHookAbortRef.current = null;
+      setStartHookRun(null);
       await connectSavedBackendNow(run.environmentId);
     },
-    [connectSavedBackendNow, finishStartHook],
+    [connectSavedBackendNow, isCurrentStartHook],
   );
 
   const handleConnectSavedBackend = useCallback(
@@ -2367,16 +2383,23 @@ export function ConnectionsSettings() {
         const step = await requestStartHook(startHookUrl, { signal: controller.signal });
         await settleStartHookStep(run, step, controller);
       } catch (error) {
-        failStartHook(error, controller.signal.aborted);
+        failStartHook(controller, error);
       }
     },
     [environments, connectSavedBackendNow, settleStartHookStep, failStartHook],
   );
 
+  // Detach the controller before aborting so the run's pending rejection takes
+  // the superseded path instead of reporting a failure for a cancelled start.
   const handleCancelStartHook = useCallback(() => {
-    startHookAbortRef.current?.abort();
-    finishStartHook();
-  }, [finishStartHook]);
+    const controller = startHookAbortRef.current;
+    startHookAbortRef.current = null;
+    setStartHookRun(null);
+    controller?.abort();
+  }, []);
+
+  // Leaving the page must not keep polling nor connect the environment later.
+  useEffect(() => handleCancelStartHook, [handleCancelStartHook]);
 
   const handleSubmitStartHookForm = useCallback(
     async (values: ReadonlyArray<string>) => {
@@ -2388,7 +2411,7 @@ export function ConnectionsSettings() {
         const step = await submitStartHookForm(run.url, values, { signal: controller.signal });
         await settleStartHookStep(run, step, controller);
       } catch (error) {
-        failStartHook(error, controller.signal.aborted);
+        failStartHook(controller, error);
       }
     },
     [startHookRun, settleStartHookStep, failStartHook],

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -6,7 +6,7 @@ import {
   TerminalIcon,
 } from "lucide-react";
 import { useAtomValue } from "@effect/atom-react";
-import { type ReactNode, memo, useCallback, useId, useMemo, useState } from "react";
+import { type ReactNode, memo, useCallback, useId, useMemo, useRef, useState } from "react";
 import {
   AuthAccessReadScope,
   AuthAccessWriteScope,
@@ -27,6 +27,7 @@ import {
   type DesktopServerExposureState,
   type DesktopWslState,
   type EnvironmentId,
+  type StartHookForm,
 } from "@t3tools/contracts";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import {
@@ -40,6 +41,13 @@ import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { cn } from "../../lib/utils";
 import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestampFormat";
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
+import { StartHookFormDialog } from "./StartHookFormDialog";
+import {
+  type StartHookStep,
+  pollStartHookUntilReady,
+  requestStartHook,
+  submitStartHookForm,
+} from "./startHook";
 import {
   applyWslEnableSelection,
   isQrShareableEndpoint,
@@ -1331,23 +1339,43 @@ function NetworkAccessDescription({
   );
 }
 
+type StartHookRunState = {
+  environmentId: EnvironmentId;
+  url: string;
+  label: string;
+  phase: "requesting" | "form" | "starting";
+  form: StartHookForm | null;
+  submitting: boolean;
+};
+
 type SavedBackendListRowProps = {
   environment: EnvironmentPresentation;
   removingEnvironmentId: EnvironmentId | null;
+  startingEnvironmentId: EnvironmentId | null;
+  stoppingEnvironmentId: EnvironmentId | null;
   onConnect: (environmentId: EnvironmentId) => void;
+  onCancelStart: (environmentId: EnvironmentId) => void;
+  onStop: (environmentId: EnvironmentId) => void;
   onRemove: (environmentId: EnvironmentId) => void;
 };
 
 function SavedBackendListRow({
   environment,
   removingEnvironmentId,
+  startingEnvironmentId,
+  stoppingEnvironmentId,
   onConnect,
+  onCancelStart,
+  onStop,
   onRemove,
 }: SavedBackendListRowProps) {
   const environmentId = environment.environmentId;
   const connectionState = environment.connection.phase;
   const isConnected = connectionState === "connected";
   const isConnecting = connectionState === "connecting" || connectionState === "reconnecting";
+  const isStarting = startingEnvironmentId === environmentId;
+  const isStopping = stoppingEnvironmentId === environmentId;
+  const stopHookConfigured = environment.serverConfig?.settings.stopHookUrl != null;
   const stateDotClassName =
     connectionState === "connected"
       ? "bg-success"
@@ -1490,28 +1518,54 @@ function SavedBackendListRow({
                 <Button
                   size="xs"
                   variant="outline"
-                  disabled={removingEnvironmentId === environmentId}
+                  disabled={removingEnvironmentId === environmentId || isStarting}
                   onClick={() => void onRemove(environmentId)}
                 >
                   {removingEnvironmentId === environmentId ? "Removing…" : "Remove"}
                 </Button>
               ) : null}
-              <Button
-                size="xs"
-                variant="outline"
-                disabled={isConnecting || removingEnvironmentId === environmentId}
-                onClick={() =>
-                  void (isConnected ? onRemove(environmentId) : onConnect(environmentId))
-                }
-              >
-                {isConnected
-                  ? removingEnvironmentId === environmentId
-                    ? "Disconnecting…"
-                    : "Disconnect"
-                  : isConnecting
-                    ? "Connecting…"
-                    : "Connect"}
-              </Button>
+              {isConnected && stopHookConfigured ? (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="xs"
+                        variant="destructive-outline"
+                        disabled={isStopping}
+                        onClick={() => void onStop(environmentId)}
+                      >
+                        {isStopping ? "Stopping…" : "Stop"}
+                      </Button>
+                    }
+                  />
+                  <TooltipPopup side="top" className="max-w-80 whitespace-pre-wrap leading-tight">
+                    Ask the service managing this environment to stop the instance.
+                  </TooltipPopup>
+                </Tooltip>
+              ) : null}
+              {isStarting ? (
+                <Button size="xs" variant="outline" onClick={() => onCancelStart(environmentId)}>
+                  <Spinner className="size-3" />
+                  Cancel start
+                </Button>
+              ) : (
+                <Button
+                  size="xs"
+                  variant="outline"
+                  disabled={isConnecting || removingEnvironmentId === environmentId}
+                  onClick={() =>
+                    void (isConnected ? onRemove(environmentId) : onConnect(environmentId))
+                  }
+                >
+                  {isConnected
+                    ? removingEnvironmentId === environmentId
+                      ? "Disconnecting…"
+                      : "Disconnect"
+                    : isConnecting
+                      ? "Connecting…"
+                      : "Connect"}
+                </Button>
+              )}
             </>
           )}
         </div>
@@ -1734,6 +1788,9 @@ export function ConnectionsSettings() {
   });
   const removeEnvironment = useAtomCommand(environmentCatalog.remove, { reportFailure: false });
   const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, { reportFailure: false });
+  const runStopHookCommand = useAtomCommand(serverEnvironment.runStopHook, {
+    reportFailure: false,
+  });
   const primaryEnvironmentId = primaryEnvironment?.environmentId ?? null;
   const primarySessionState = usePrimarySessionState();
   const currentSessionScopes = desktopBridge
@@ -1811,6 +1868,10 @@ export function ConnectionsSettings() {
   const [isAddingSavedBackend, setIsAddingSavedBackend] = useState(false);
   const [removingSavedEnvironmentId, setRemovingSavedEnvironmentId] =
     useState<EnvironmentId | null>(null);
+  const [stoppingSavedEnvironmentId, setStoppingSavedEnvironmentId] =
+    useState<EnvironmentId | null>(null);
+  const [startHookRun, setStartHookRun] = useState<StartHookRunState | null>(null);
+  const startHookAbortRef = useRef<AbortController | null>(null);
   const [isUpdatingDesktopServerExposure, setIsUpdatingDesktopServerExposure] = useState(false);
   const [isDesktopServerExposureDialogOpen, setIsDesktopServerExposureDialogOpen] = useState(false);
   const [isUpdatingTailscaleServe, setIsUpdatingTailscaleServe] = useState(false);
@@ -2226,7 +2287,7 @@ export function ConnectionsSettings() {
     savedBackendSshUsername,
   ]);
 
-  const handleConnectSavedBackend = useCallback(
+  const connectSavedBackendNow = useCallback(
     async (environmentId: EnvironmentId) => {
       setSavedBackendError(null);
       const result = await retryEnvironment(environmentId);
@@ -2244,6 +2305,128 @@ export function ConnectionsSettings() {
       }
     },
     [retryEnvironment],
+  );
+
+  const finishStartHook = useCallback(() => {
+    startHookAbortRef.current = null;
+    setStartHookRun(null);
+  }, []);
+
+  const failStartHook = useCallback(
+    (error: unknown, aborted: boolean) => {
+      finishStartHook();
+      if (aborted) return;
+      const message = error instanceof Error ? error.message : "Failed to start the instance.";
+      setSavedBackendError(message);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not start instance",
+          description: message,
+        }),
+      );
+    },
+    [finishStartHook],
+  );
+
+  const settleStartHookStep = useCallback(
+    async (
+      run: Pick<StartHookRunState, "environmentId" | "url" | "label">,
+      step: StartHookStep,
+      controller: AbortController,
+    ) => {
+      if (step.kind === "form") {
+        setStartHookRun({ ...run, phase: "form", form: step.form, submitting: false });
+        return;
+      }
+      if (step.kind === "poll") {
+        setStartHookRun({ ...run, phase: "starting", form: null, submitting: false });
+        await pollStartHookUntilReady(step.poll, { signal: controller.signal });
+      }
+      finishStartHook();
+      await connectSavedBackendNow(run.environmentId);
+    },
+    [connectSavedBackendNow, finishStartHook],
+  );
+
+  const handleConnectSavedBackend = useCallback(
+    async (environmentId: EnvironmentId) => {
+      const environment = environments.find((entry) => entry.environmentId === environmentId);
+      const startHookUrl = environment?.serverConfig?.settings.startHookUrl ?? null;
+      if (startHookUrl === null) {
+        await connectSavedBackendNow(environmentId);
+        return;
+      }
+      startHookAbortRef.current?.abort();
+      const controller = new AbortController();
+      startHookAbortRef.current = controller;
+      const run = { environmentId, url: startHookUrl, label: environment?.label ?? "environment" };
+      setSavedBackendError(null);
+      setStartHookRun({ ...run, phase: "requesting", form: null, submitting: false });
+      try {
+        const step = await requestStartHook(startHookUrl, { signal: controller.signal });
+        await settleStartHookStep(run, step, controller);
+      } catch (error) {
+        failStartHook(error, controller.signal.aborted);
+      }
+    },
+    [environments, connectSavedBackendNow, settleStartHookStep, failStartHook],
+  );
+
+  const handleCancelStartHook = useCallback(() => {
+    startHookAbortRef.current?.abort();
+    finishStartHook();
+  }, [finishStartHook]);
+
+  const handleSubmitStartHookForm = useCallback(
+    async (values: ReadonlyArray<string>) => {
+      const run = startHookRun;
+      const controller = startHookAbortRef.current;
+      if (run === null || controller === null) return;
+      setStartHookRun({ ...run, submitting: true });
+      try {
+        const step = await submitStartHookForm(run.url, values, { signal: controller.signal });
+        await settleStartHookStep(run, step, controller);
+      } catch (error) {
+        failStartHook(error, controller.signal.aborted);
+      }
+    },
+    [startHookRun, settleStartHookStep, failStartHook],
+  );
+
+  const handleStopSavedBackend = useCallback(
+    async (environmentId: EnvironmentId) => {
+      setStoppingSavedEnvironmentId(environmentId);
+      const result = await runStopHookCommand({ environmentId, input: {} });
+      setStoppingSavedEnvironmentId(null);
+      if (result._tag === "Failure") {
+        if (isAtomCommandInterrupted(result)) return;
+        const error = squashAtomCommandFailure(result);
+        const message = error instanceof Error ? error.message : "Failed to stop the instance.";
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not stop instance",
+            description: message,
+          }),
+        );
+        return;
+      }
+      toastManager.add(
+        result.value.outcome === "gone"
+          ? {
+              type: "success",
+              title: "Stop hook removed",
+              description: "The management service no longer offers this stop hook.",
+            }
+          : {
+              type: "success",
+              title: "Stop requested",
+              description: "The management service is stopping this instance.",
+            },
+      );
+    },
+    [runStopHookCommand],
   );
 
   const handleRemoveSavedBackend = useCallback(
@@ -3422,10 +3605,23 @@ export function ConnectionsSettings() {
             key={environment.environmentId}
             environment={environment}
             removingEnvironmentId={removingSavedEnvironmentId}
+            startingEnvironmentId={startHookRun?.environmentId ?? null}
+            stoppingEnvironmentId={stoppingSavedEnvironmentId}
             onConnect={handleConnectSavedBackend}
+            onCancelStart={handleCancelStartHook}
+            onStop={handleStopSavedBackend}
             onRemove={handleRemoveSavedBackend}
           />
         ))}
+        {startHookRun !== null && startHookRun.phase === "form" && startHookRun.form !== null ? (
+          <StartHookFormDialog
+            environmentLabel={startHookRun.label}
+            form={startHookRun.form}
+            submitting={startHookRun.submitting}
+            onSubmit={(values) => void handleSubmitStartHookForm(values)}
+            onCancel={handleCancelStartHook}
+          />
+        ) : null}
         <CloudRemoteEnvironmentRows
           primaryEnvironmentId={primaryEnvironmentId}
           savedEnvironments={savedEnvironments}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1352,7 +1352,7 @@ type StartHookRunState = {
   environmentId: EnvironmentId;
   url: string;
   label: string;
-  phase: "requesting" | "form" | "starting";
+  phase: "requesting" | "form" | "starting" | "connecting";
   form: StartHookForm | null;
   submitting: boolean;
 };
@@ -1360,8 +1360,11 @@ type StartHookRunState = {
 type SavedBackendListRowProps = {
   environment: EnvironmentPresentation;
   removingEnvironmentId: EnvironmentId | null;
+  /** Set while the start hook is cancellable: requesting, form, or polling. */
   startingEnvironmentId: EnvironmentId | null;
-  stoppingEnvironmentId: EnvironmentId | null;
+  /** Set while a completed start hook hands off to the connect flow. */
+  startHookConnectingEnvironmentId: EnvironmentId | null;
+  stoppingEnvironmentIds: ReadonlySet<EnvironmentId>;
   onConnect: (environmentId: EnvironmentId) => void;
   onCancelStart: (environmentId: EnvironmentId) => void;
   onStop: (environmentId: EnvironmentId) => void;
@@ -1372,7 +1375,8 @@ function SavedBackendListRow({
   environment,
   removingEnvironmentId,
   startingEnvironmentId,
-  stoppingEnvironmentId,
+  startHookConnectingEnvironmentId,
+  stoppingEnvironmentIds,
   onConnect,
   onCancelStart,
   onStop,
@@ -1383,7 +1387,8 @@ function SavedBackendListRow({
   const isConnected = connectionState === "connected";
   const isConnecting = connectionState === "connecting" || connectionState === "reconnecting";
   const isStarting = startingEnvironmentId === environmentId;
-  const isStopping = stoppingEnvironmentId === environmentId;
+  const isHandingOffToConnect = startHookConnectingEnvironmentId === environmentId;
+  const isStopping = stoppingEnvironmentIds.has(environmentId);
   const stopHookConfigured = environment.serverConfig?.settings.stopHookUrl != null;
   const stateDotClassName =
     connectionState === "connected"
@@ -1561,7 +1566,9 @@ function SavedBackendListRow({
                 <Button
                   size="xs"
                   variant="outline"
-                  disabled={isConnecting || removingEnvironmentId === environmentId}
+                  disabled={
+                    isConnecting || isHandingOffToConnect || removingEnvironmentId === environmentId
+                  }
                   onClick={() =>
                     void (isConnected ? onRemove(environmentId) : onConnect(environmentId))
                   }
@@ -1570,7 +1577,7 @@ function SavedBackendListRow({
                     ? removingEnvironmentId === environmentId
                       ? "Disconnecting…"
                       : "Disconnect"
-                    : isConnecting
+                    : isConnecting || isHandingOffToConnect
                       ? "Connecting…"
                       : "Connect"}
                 </Button>
@@ -1877,8 +1884,11 @@ export function ConnectionsSettings() {
   const [isAddingSavedBackend, setIsAddingSavedBackend] = useState(false);
   const [removingSavedEnvironmentId, setRemovingSavedEnvironmentId] =
     useState<EnvironmentId | null>(null);
-  const [stoppingSavedEnvironmentId, setStoppingSavedEnvironmentId] =
-    useState<EnvironmentId | null>(null);
+  // Stops run per environment and can overlap, so track a set rather than a
+  // single slot that one finishing stop would clear for all the others.
+  const [stoppingSavedEnvironmentIds, setStoppingSavedEnvironmentIds] = useState<
+    ReadonlySet<EnvironmentId>
+  >(() => new Set());
   const [startHookRun, setStartHookRun] = useState<StartHookRunState | null>(null);
   const startHookAbortRef = useRef<AbortController | null>(null);
   const [isUpdatingDesktopServerExposure, setIsUpdatingDesktopServerExposure] = useState(false);
@@ -2358,9 +2368,18 @@ export function ConnectionsSettings() {
         await pollStartHookUntilReady(step.poll, { signal: controller.signal });
       }
       if (!isCurrentStartHook(controller)) return;
-      startHookAbortRef.current = null;
-      setStartHookRun(null);
-      await connectSavedBackendNow(run.environmentId);
+      // Hold the run through the connect handoff. `retryNow` only signals the
+      // supervisor, so clearing here would flash an enabled Connect button and
+      // let a second start-hook run begin under the first one.
+      setStartHookRun({ ...run, phase: "connecting", form: null, submitting: false });
+      try {
+        await connectSavedBackendNow(run.environmentId);
+      } finally {
+        if (isCurrentStartHook(controller)) {
+          startHookAbortRef.current = null;
+          setStartHookRun(null);
+        }
+      }
     },
     [connectSavedBackendNow, isCurrentStartHook],
   );
@@ -2419,9 +2438,13 @@ export function ConnectionsSettings() {
 
   const handleStopSavedBackend = useCallback(
     async (environmentId: EnvironmentId) => {
-      setStoppingSavedEnvironmentId(environmentId);
+      setStoppingSavedEnvironmentIds((current) => new Set(current).add(environmentId));
       const result = await runStopHookCommand({ environmentId, input: {} });
-      setStoppingSavedEnvironmentId(null);
+      setStoppingSavedEnvironmentIds((current) => {
+        const next = new Set(current);
+        next.delete(environmentId);
+        return next;
+      });
       if (result._tag === "Failure") {
         if (isAtomCommandInterrupted(result)) return;
         const error = squashAtomCommandFailure(result);
@@ -3628,8 +3651,15 @@ export function ConnectionsSettings() {
             key={environment.environmentId}
             environment={environment}
             removingEnvironmentId={removingSavedEnvironmentId}
-            startingEnvironmentId={startHookRun?.environmentId ?? null}
-            stoppingEnvironmentId={stoppingSavedEnvironmentId}
+            startingEnvironmentId={
+              startHookRun !== null && startHookRun.phase !== "connecting"
+                ? startHookRun.environmentId
+                : null
+            }
+            startHookConnectingEnvironmentId={
+              startHookRun?.phase === "connecting" ? startHookRun.environmentId : null
+            }
+            stoppingEnvironmentIds={stoppingSavedEnvironmentIds}
             onConnect={handleConnectSavedBackend}
             onCancelStart={handleCancelStartHook}
             onStop={handleStopSavedBackend}

--- a/apps/web/src/components/settings/StartHookFormDialog.tsx
+++ b/apps/web/src/components/settings/StartHookFormDialog.tsx
@@ -1,0 +1,171 @@
+import type { StartHookForm } from "@t3tools/contracts";
+import { useCallback, useId, useMemo, useState } from "react";
+
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "../ui/dialog";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
+import { isStartHookInputComponent, validateStartHookTextInput } from "./startHook";
+
+interface StartHookFormDialogProps {
+  readonly environmentLabel: string;
+  readonly form: StartHookForm;
+  readonly submitting: boolean;
+  readonly onSubmit: (values: ReadonlyArray<string>) => void;
+  readonly onCancel: () => void;
+}
+
+/**
+ * Renders the component form a start hook returns with a 400: the management
+ * solution needs input (instance size, region, …) before it starts the
+ * instance. Submitting sends the resolved values back as a JSON array.
+ */
+export function StartHookFormDialog({
+  environmentLabel,
+  form,
+  submitting,
+  onSubmit,
+  onCancel,
+}: StartHookFormDialogProps) {
+  const fieldIdPrefix = useId();
+  const initialValues = useMemo(() => {
+    const values: Record<number, string> = {};
+    form.components.forEach((component, index) => {
+      if (isStartHookInputComponent(component)) {
+        values[index] = component.type === "select" ? component.defaultValue : "";
+      }
+    });
+    return values;
+  }, [form]);
+  const [values, setValues] = useState<Record<number, string>>(initialValues);
+  const [errors, setErrors] = useState<Record<number, string>>({});
+  // The endpoint may re-prompt with a different form after a submission;
+  // reset the collected input when that happens.
+  const [renderedForm, setRenderedForm] = useState(form);
+  if (renderedForm !== form) {
+    setRenderedForm(form);
+    setValues(initialValues);
+    setErrors({});
+  }
+  // Hook forms carry no component ids, so the position doubles as identity;
+  // the title/text only disambiguates the key for readability.
+  const componentEntries = useMemo(
+    () =>
+      form.components.map((component, index) => ({
+        component,
+        index,
+        key: `${index}:${isStartHookInputComponent(component) ? component.title : component.text}`,
+      })),
+    [form],
+  );
+
+  const handleSubmit = useCallback(() => {
+    const nextErrors: Record<number, string> = {};
+    const resolved: Array<string> = [];
+    form.components.forEach((component, index) => {
+      if (!isStartHookInputComponent(component)) return;
+      const value = values[index] ?? "";
+      if (component.type === "text") {
+        const validationError = validateStartHookTextInput(component, value);
+        if (validationError !== null) {
+          nextErrors[index] = validationError;
+        }
+      }
+      resolved.push(value);
+    });
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length === 0) {
+      onSubmit(resolved);
+    }
+  }, [form, onSubmit, values]);
+
+  return (
+    <Dialog open onOpenChange={(open) => (open ? null : onCancel())}>
+      <DialogPopup className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Start {environmentLabel}</DialogTitle>
+          <DialogDescription>
+            The service managing this environment needs a few details before it starts the instance.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel className="space-y-4">
+          {componentEntries.map(({ component, index, key }) => {
+            if (!isStartHookInputComponent(component)) {
+              return (
+                <p key={key} className="text-sm text-muted-foreground">
+                  {component.text}
+                </p>
+              );
+            }
+            const fieldId = `${fieldIdPrefix}-${index}`;
+            return (
+              <div key={key} className="space-y-1.5">
+                <Label htmlFor={fieldId}>{component.title}</Label>
+                {component.description ? (
+                  <p className="text-xs text-muted-foreground">{component.description}</p>
+                ) : null}
+                {component.type === "select" ? (
+                  <Select
+                    value={values[index] ?? component.defaultValue}
+                    onValueChange={(nextValue) =>
+                      nextValue !== null &&
+                      setValues((current) => ({ ...current, [index]: nextValue }))
+                    }
+                  >
+                    <SelectTrigger id={fieldId} className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {component.values.map((option) => (
+                        <SelectItem key={option.content} value={option.content}>
+                          <span className="flex min-w-0 flex-col">
+                            <span className="truncate">{option.userTitle}</span>
+                            {option.userDescription ? (
+                              <span className="truncate text-xs text-muted-foreground">
+                                {option.userDescription}
+                              </span>
+                            ) : null}
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <>
+                    <Input
+                      id={fieldId}
+                      value={values[index] ?? ""}
+                      onChange={(event) =>
+                        setValues((current) => ({ ...current, [index]: event.target.value }))
+                      }
+                    />
+                    {errors[index] ? (
+                      <p className="text-destructive text-xs">{errors[index]}</p>
+                    ) : null}
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </DialogPanel>
+        <DialogFooter variant="bare">
+          <Button variant="outline" disabled={submitting} onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button disabled={submitting} onClick={handleSubmit}>
+            {submitting ? "Submitting…" : form.button_text}
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/settings/startHook.test.ts
+++ b/apps/web/src/components/settings/startHook.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  StartHookError,
+  isStartHookInputComponent,
+  pollStartHookUntilReady,
+  requestStartHook,
+  submitStartHookForm,
+  validateStartHookTextInput,
+} from "./startHook";
+
+interface RecordedRequest {
+  readonly url: string;
+  readonly method: string;
+  readonly body: string | null;
+}
+
+function makeFetch(responses: Array<Response>, requests: Array<RecordedRequest> = []) {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    requests.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      body: typeof init?.body === "string" ? init.body : null,
+    });
+    const next = responses.shift();
+    if (next === undefined) throw new Error("No stubbed response left.");
+    return next;
+  }) as typeof fetch;
+}
+
+const noSleep = () => Promise.resolve();
+
+const pollResponse = () =>
+  new Response(JSON.stringify({ poll_url: "https://mgmt.test/poll/1", retry_secs: 5 }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("requestStartHook", () => {
+  it("POSTs with no content and returns the poll state", async () => {
+    const requests: Array<RecordedRequest> = [];
+    const step = await requestStartHook("https://mgmt.test/start", {
+      fetchImpl: makeFetch([pollResponse()], requests),
+    });
+    expect(step).toEqual({
+      kind: "poll",
+      poll: { poll_url: "https://mgmt.test/poll/1", retry_secs: 5 },
+    });
+    expect(requests).toEqual([{ url: "https://mgmt.test/start", method: "POST", body: null }]);
+  });
+
+  it("returns the form on a 400 component response", async () => {
+    const form = {
+      button_text: "Boot",
+      components: [
+        { text: "Pick a size." },
+        {
+          type: "select",
+          title: "Size",
+          description: "Instance size",
+          defaultValue: "small",
+          values: [
+            { userTitle: "Small", userDescription: "2 vCPU", content: "small" },
+            { userTitle: "Large", userDescription: "8 vCPU", content: "large" },
+          ],
+        },
+      ],
+    };
+    const step = await requestStartHook("https://mgmt.test/start", {
+      fetchImpl: makeFetch([
+        new Response(JSON.stringify(form), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      ]),
+    });
+    expect(step.kind).toBe("form");
+    if (step.kind === "form") {
+      expect(step.form.button_text).toBe("Boot");
+      expect(step.form.components).toHaveLength(2);
+      expect(step.form.components.filter(isStartHookInputComponent)).toHaveLength(1);
+    }
+  });
+
+  it("treats an immediate 204 as already running", async () => {
+    const step = await requestStartHook("https://mgmt.test/start", {
+      fetchImpl: makeFetch([new Response(null, { status: 204 })]),
+    });
+    expect(step).toEqual({ kind: "ready" });
+  });
+
+  it("fails on unexpected statuses", async () => {
+    await expect(
+      requestStartHook("https://mgmt.test/start", {
+        fetchImpl: makeFetch([new Response("nope", { status: 503 })]),
+      }),
+    ).rejects.toBeInstanceOf(StartHookError);
+  });
+});
+
+describe("submitStartHookForm", () => {
+  it("POSTs the resolved values as a JSON array", async () => {
+    const requests: Array<RecordedRequest> = [];
+    const step = await submitStartHookForm("https://mgmt.test/start", ["large", "my-vm"], {
+      fetchImpl: makeFetch([pollResponse()], requests),
+    });
+    expect(step.kind).toBe("poll");
+    expect(requests).toEqual([
+      { url: "https://mgmt.test/start", method: "POST", body: '["large","my-vm"]' },
+    ]);
+  });
+});
+
+describe("pollStartHookUntilReady", () => {
+  it("polls until a 204 arrives", async () => {
+    const requests: Array<RecordedRequest> = [];
+    await pollStartHookUntilReady(
+      { poll_url: "https://mgmt.test/poll/1", retry_secs: 5 },
+      {
+        fetchImpl: makeFetch(
+          [
+            new Response(null, { status: 200 }),
+            new Response(null, { status: 202 }),
+            new Response(null, { status: 204 }),
+          ],
+          requests,
+        ),
+        sleep: noSleep,
+      },
+    );
+    expect(requests).toHaveLength(3);
+    expect(requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  it("fails when polling returns an error status", async () => {
+    await expect(
+      pollStartHookUntilReady(
+        { poll_url: "https://mgmt.test/poll/1", retry_secs: 5 },
+        { fetchImpl: makeFetch([new Response(null, { status: 500 })]), sleep: noSleep },
+      ),
+    ).rejects.toBeInstanceOf(StartHookError);
+  });
+});
+
+describe("validateStartHookTextInput", () => {
+  const component = {
+    type: "text",
+    title: "Name",
+    description: "Instance name",
+    regex: "^[a-z-]+$",
+    validationError: "Lowercase letters and dashes only.",
+  } as const;
+
+  it("accepts matching input", () => {
+    expect(validateStartHookTextInput(component, "my-vm")).toBeNull();
+  });
+
+  it("returns the component's validation error for mismatches", () => {
+    expect(validateStartHookTextInput(component, "My VM")).toBe(
+      "Lowercase letters and dashes only.",
+    );
+  });
+
+  it("does not lock the user out on an unparsable pattern", () => {
+    expect(validateStartHookTextInput({ ...component, regex: "(" }, "anything")).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/startHook.test.ts
+++ b/apps/web/src/components/settings/startHook.test.ts
@@ -96,6 +96,22 @@ describe("requestStartHook", () => {
       }),
     ).rejects.toBeInstanceOf(StartHookError);
   });
+
+  it("keeps third-party response text out of the message and on the cause", async () => {
+    const failure = await requestStartHook("https://mgmt.test/start", {
+      fetchImpl: makeFetch([
+        new Response("secret-ish upstream detail", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ]),
+    }).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(StartHookError);
+    const error = failure as StartHookError;
+    expect(error.message).toBe("The start hook returned status 200 without a readable JSON body.");
+    expect(error.message).not.toContain("secret-ish");
+    expect(error.cause).toBeDefined();
+  });
 });
 
 describe("submitStartHookForm", () => {
@@ -120,7 +136,7 @@ describe("pollStartHookUntilReady", () => {
         fetchImpl: makeFetch(
           [
             new Response(null, { status: 200 }),
-            new Response(null, { status: 202 }),
+            new Response(null, { status: 200 }),
             new Response(null, { status: 204 }),
           ],
           requests,
@@ -130,6 +146,20 @@ describe("pollStartHookUntilReady", () => {
     );
     expect(requests).toHaveLength(3);
     expect(requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  it("fails fast on a non-200 success status instead of retrying it", async () => {
+    const requests: Array<RecordedRequest> = [];
+    await expect(
+      pollStartHookUntilReady(
+        { poll_url: "https://mgmt.test/poll/1", retry_secs: 5 },
+        {
+          fetchImpl: makeFetch([new Response(null, { status: 304 })], requests),
+          sleep: noSleep,
+        },
+      ),
+    ).rejects.toThrow("status 304");
+    expect(requests).toHaveLength(1);
   });
 
   it("gives up when the deadline passes, counting slow requests against it", async () => {

--- a/apps/web/src/components/settings/startHook.test.ts
+++ b/apps/web/src/components/settings/startHook.test.ts
@@ -132,6 +132,31 @@ describe("pollStartHookUntilReady", () => {
     expect(requests.every((request) => request.method === "GET")).toBe(true);
   });
 
+  it("gives up when the deadline passes, counting slow requests against it", async () => {
+    const requests: Array<RecordedRequest> = [];
+    let clock = 0;
+    await expect(
+      pollStartHookUntilReady(
+        { poll_url: "https://mgmt.test/poll/1", retry_secs: 5 },
+        {
+          fetchImpl: makeFetch(
+            [new Response(null, { status: 200 }), new Response(null, { status: 200 })],
+            requests,
+          ),
+          sleep: noSleep,
+          // Each poll round trip "takes" eleven minutes, blowing the deadline
+          // even though only one interval of sleep has been requested.
+          now: () => {
+            const at = clock;
+            clock += 11 * 60_000;
+            return at;
+          },
+        },
+      ),
+    ).rejects.toThrow("did not report ready in time");
+    expect(requests).toHaveLength(1);
+  });
+
   it("fails when polling returns an error status", async () => {
     await expect(
       pollStartHookUntilReady(

--- a/apps/web/src/components/settings/startHook.ts
+++ b/apps/web/src/components/settings/startHook.ts
@@ -52,6 +52,7 @@ export interface StartHookRequestOptions {
   readonly signal?: AbortSignal;
   readonly fetchImpl?: typeof fetch;
   readonly sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  readonly now?: () => number;
 }
 
 function resolveFetch(options: StartHookRequestOptions): typeof fetch {
@@ -159,11 +160,14 @@ export async function pollStartHookUntilReady(
 ): Promise<void> {
   const fetchImpl = resolveFetch(options);
   const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? Date.now;
   const intervalMs = Math.min(
     Math.max(poll.retry_secs * 1_000, MIN_POLL_INTERVAL_MS),
     MAX_POLL_INTERVAL_MS,
   );
-  for (let elapsedMs = 0; elapsedMs <= POLL_DEADLINE_MS; elapsedMs += intervalMs) {
+  // Wall-clock deadline so slow poll requests count against it too.
+  const deadlineAt = now() + POLL_DEADLINE_MS;
+  while (true) {
     let response: Response;
     try {
       response = await fetchImpl(poll.poll_url, { method: "GET", signal: options.signal ?? null });
@@ -177,7 +181,9 @@ export async function pollStartHookUntilReady(
     if (response.status >= 400) {
       throw new StartHookError(`Polling the start hook failed with status ${response.status}.`);
     }
+    if (now() + intervalMs > deadlineAt) {
+      throw new StartHookError("The instance did not report ready in time.");
+    }
     await sleep(intervalMs, options.signal);
   }
-  throw new StartHookError("The instance did not report ready in time.");
 }

--- a/apps/web/src/components/settings/startHook.ts
+++ b/apps/web/src/components/settings/startHook.ts
@@ -23,6 +23,10 @@ export type StartHookStep =
   | { readonly kind: "poll"; readonly poll: StartHookPollState }
   | { readonly kind: "form"; readonly form: StartHookForm };
 
+/**
+ * Messages are derived from structural facts only. Underlying failures and
+ * third-party response text stay on `cause` so they never reach a toast.
+ */
 export class StartHookError extends Error {}
 
 export type StartHookInputComponent = StartHookSelectComponent | StartHookTextComponent;
@@ -69,7 +73,8 @@ async function interpretStartHookResponse(response: Response): Promise<StartHook
       body = await response.json();
     } catch (error) {
       throw new StartHookError(
-        `The start hook returned status ${response.status} without a readable JSON body: ${String(error)}`,
+        `The start hook returned status ${response.status} without a readable JSON body.`,
+        { cause: error },
       );
     }
   };
@@ -78,9 +83,9 @@ async function interpretStartHookResponse(response: Response): Promise<StartHook
     try {
       return { kind: "poll", poll: decodePollState(body) };
     } catch (error) {
-      throw new StartHookError(
-        `The start hook returned a malformed poll response: ${String(error)}`,
-      );
+      throw new StartHookError("The start hook returned a malformed poll response.", {
+        cause: error,
+      });
     }
   }
   if (response.status === 400) {
@@ -88,9 +93,9 @@ async function interpretStartHookResponse(response: Response): Promise<StartHook
     try {
       return { kind: "form", form: decodeForm(body) };
     } catch (error) {
-      throw new StartHookError(
-        `The start hook returned a malformed form response: ${String(error)}`,
-      );
+      throw new StartHookError("The start hook returned a malformed form response.", {
+        cause: error,
+      });
     }
   }
   throw new StartHookError(`The start hook responded with unexpected status ${response.status}.`);
@@ -111,7 +116,7 @@ async function postStartHook(
     });
   } catch (error) {
     if (options.signal?.aborted) throw error;
-    throw new StartHookError(`Could not reach the start hook: ${String(error)}`);
+    throw new StartHookError("Could not reach the start hook.", { cause: error });
   }
   return interpretStartHookResponse(response);
 }
@@ -173,12 +178,14 @@ export async function pollStartHookUntilReady(
       response = await fetchImpl(poll.poll_url, { method: "GET", signal: options.signal ?? null });
     } catch (error) {
       if (options.signal?.aborted) throw error;
-      throw new StartHookError(`Could not poll the start hook: ${String(error)}`);
+      throw new StartHookError("Could not poll the start hook.", { cause: error });
     }
     if (response.status === 204) {
       return;
     }
-    if (response.status >= 400) {
+    // Only a plain 200 means "still starting". Anything else — an error, a
+    // redirect, a 304 — is a misconfigured endpoint, not progress.
+    if (response.status !== 200) {
       throw new StartHookError(`Polling the start hook failed with status ${response.status}.`);
     }
     if (now() + intervalMs > deadlineAt) {

--- a/apps/web/src/components/settings/startHook.ts
+++ b/apps/web/src/components/settings/startHook.ts
@@ -1,0 +1,183 @@
+import {
+  StartHookForm,
+  type StartHookFormComponent,
+  StartHookPollState,
+  type StartHookSelectComponent,
+  type StartHookTextComponent,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+// Client side of the start hook protocol (see contracts/instanceHooks.ts).
+// The management endpoint is a third-party origin, so it must allow CORS for
+// the app origin; a preflight failure surfaces here as a network error.
+
+const decodePollState = Schema.decodeUnknownSync(StartHookPollState);
+const decodeForm = Schema.decodeUnknownSync(StartHookForm);
+
+const MIN_POLL_INTERVAL_MS = 1_000;
+const MAX_POLL_INTERVAL_MS = 60_000;
+const POLL_DEADLINE_MS = 10 * 60_000;
+
+export type StartHookStep =
+  | { readonly kind: "ready" }
+  | { readonly kind: "poll"; readonly poll: StartHookPollState }
+  | { readonly kind: "form"; readonly form: StartHookForm };
+
+export class StartHookError extends Error {}
+
+export type StartHookInputComponent = StartHookSelectComponent | StartHookTextComponent;
+
+export function isStartHookInputComponent(
+  component: StartHookFormComponent,
+): component is StartHookInputComponent {
+  return "type" in component;
+}
+
+export function validateStartHookTextInput(
+  component: StartHookTextComponent,
+  value: string,
+): string | null {
+  let pattern: RegExp;
+  try {
+    pattern = new RegExp(component.regex);
+  } catch {
+    // An unparsable pattern is the management solution's bug; do not let it
+    // lock the user out of starting the instance.
+    return null;
+  }
+  return pattern.test(value) ? null : component.validationError;
+}
+
+export interface StartHookRequestOptions {
+  readonly signal?: AbortSignal;
+  readonly fetchImpl?: typeof fetch;
+  readonly sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+}
+
+function resolveFetch(options: StartHookRequestOptions): typeof fetch {
+  return options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
+}
+
+async function interpretStartHookResponse(response: Response): Promise<StartHookStep> {
+  if (response.status === 204) {
+    return { kind: "ready" };
+  }
+  let body: unknown;
+  const readBody = async () => {
+    try {
+      body = await response.json();
+    } catch (error) {
+      throw new StartHookError(
+        `The start hook returned status ${response.status} without a readable JSON body: ${String(error)}`,
+      );
+    }
+  };
+  if (response.status === 200) {
+    await readBody();
+    try {
+      return { kind: "poll", poll: decodePollState(body) };
+    } catch (error) {
+      throw new StartHookError(
+        `The start hook returned a malformed poll response: ${String(error)}`,
+      );
+    }
+  }
+  if (response.status === 400) {
+    await readBody();
+    try {
+      return { kind: "form", form: decodeForm(body) };
+    } catch (error) {
+      throw new StartHookError(
+        `The start hook returned a malformed form response: ${String(error)}`,
+      );
+    }
+  }
+  throw new StartHookError(`The start hook responded with unexpected status ${response.status}.`);
+}
+
+async function postStartHook(
+  url: string,
+  body: string | null,
+  options: StartHookRequestOptions,
+): Promise<StartHookStep> {
+  const fetchImpl = resolveFetch(options);
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      signal: options.signal ?? null,
+      ...(body === null ? {} : { body, headers: { "content-type": "application/json" } }),
+    });
+  } catch (error) {
+    if (options.signal?.aborted) throw error;
+    throw new StartHookError(`Could not reach the start hook: ${String(error)}`);
+  }
+  return interpretStartHookResponse(response);
+}
+
+/** POST the start hook with no content, per the protocol's opening request. */
+export function requestStartHook(
+  url: string,
+  options: StartHookRequestOptions = {},
+): Promise<StartHookStep> {
+  return postStartHook(url, null, options);
+}
+
+/**
+ * POST the resolved component values back as a JSON array, in component
+ * order, input components only.
+ */
+export function submitStartHookForm(
+  url: string,
+  values: ReadonlyArray<string>,
+  options: StartHookRequestOptions = {},
+): Promise<StartHookStep> {
+  return postStartHook(url, JSON.stringify(values), options);
+}
+
+const defaultSleep = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason instanceof Error ? signal.reason : new Error("Aborted"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+
+/**
+ * Poll until the instance reports ready with a 204. Any error status fails
+ * the run; the management endpoint signals "still starting" with a non-204
+ * success response.
+ */
+export async function pollStartHookUntilReady(
+  poll: StartHookPollState,
+  options: StartHookRequestOptions = {},
+): Promise<void> {
+  const fetchImpl = resolveFetch(options);
+  const sleep = options.sleep ?? defaultSleep;
+  const intervalMs = Math.min(
+    Math.max(poll.retry_secs * 1_000, MIN_POLL_INTERVAL_MS),
+    MAX_POLL_INTERVAL_MS,
+  );
+  for (let elapsedMs = 0; elapsedMs <= POLL_DEADLINE_MS; elapsedMs += intervalMs) {
+    let response: Response;
+    try {
+      response = await fetchImpl(poll.poll_url, { method: "GET", signal: options.signal ?? null });
+    } catch (error) {
+      if (options.signal?.aborted) throw error;
+      throw new StartHookError(`Could not poll the start hook: ${String(error)}`);
+    }
+    if (response.status === 204) {
+      return;
+    }
+    if (response.status >= 400) {
+      throw new StartHookError(`Polling the start hook failed with status ${response.status}.`);
+    }
+    await sleep(intervalMs, options.signal);
+  }
+  throw new StartHookError("The instance did not report ready in time.");
+}

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -11,6 +11,7 @@ This is a living glossary for T3 Code. It explains what common terms mean in thi
 - [Orchestration](#orchestration)
 - [Provider runtime](#provider-runtime)
 - [Checkpointing](#checkpointing)
+- [Instance hooks](#instance-hooks)
 
 ## Concepts
 
@@ -139,6 +140,16 @@ The patch difference between two checkpoints. Query logic lives in [CheckpointDi
 #### Turn diff
 
 The file patch and changed-file summary for one turn. It is usually computed in [CheckpointDiffQuery.ts][20], represented in [the contracts][1], and recorded into thread state by [projector.ts][4].
+
+### Instance hooks
+
+#### Start hook
+
+A management-solution HTTP endpoint, stored as `startHookUrl` in server settings, that a client POSTs before connecting so the managing service can boot the instance first. The client polls until the instance reports ready, optionally after collecting user input through a component form. See [instance-hooks.md](./instance-hooks.md).
+
+#### Stop hook
+
+A management-solution HTTP endpoint, stored as `stopHookUrl` in server settings, that the server DELETEs when the user clicks Stop on a connected environment. A 404 clears the setting so clients drop the control. See [instance-hooks.md](./instance-hooks.md).
 
 ## Practical Shortcuts
 

--- a/docs/internals/instance-hooks.md
+++ b/docs/internals/instance-hooks.md
@@ -42,8 +42,9 @@ in [`apps/web/src/components/settings/startHook.ts`](../../apps/web/src/componen
    back to the start hook URL as a JSON array (input components only, in component order). The
    response is again interpreted per step 2, so an endpoint can re-prompt with another `400`.
 4. On a poll response, the client GETs `poll_url` every `retry_secs` seconds (clamped to 1–60s,
-   overall deadline 10 minutes) until a `204` says the instance is up. Error statuses (>= 400) fail
-   the run; "still starting" is any other success status.
+   wall-clock deadline 10 minutes) until a `204` says the instance is up. Only a plain `200` means
+   "still starting"; every other status, including redirects and `304`, fails the run rather than
+   being retried.
 5. The normal connect flow runs.
 
 The form response shape:
@@ -95,8 +96,9 @@ carry a `stopHookUrl`; clicking it calls the `server.runStopHook` RPC (scope
   streams to clients and removes the Stop button) and reports `outcome: "gone"`. The clear is
   compare-and-set: a hook reconfigured while the request was in flight is left alone.
 - Anything else fails the RPC with one of the `ServerStopHookError` union members
-  (`ServerStopHookNotConfiguredError`, `ServerStopHookRequestError`,
-  `ServerStopHookUnexpectedStatusError`). Only `http:`/`https:` URLs are dialed.
+  (`ServerStopHookNotConfiguredError`, `ServerStopHookInvalidUrlError`,
+  `ServerStopHookRequestError`, `ServerStopHookUnexpectedStatusError`). Only `http:`/`https:` URLs
+  are dialed; anything else fails as invalid without a request.
 
 After a stop, the saved environment keeps its registration, credentials, and cached config; the
 connection drops like any other server that went away, and the next Connect click runs the start

--- a/docs/internals/instance-hooks.md
+++ b/docs/internals/instance-hooks.md
@@ -92,8 +92,11 @@ carry a `stopHookUrl`; clicking it calls the `server.runStopHook` RPC (scope
 
 - `204` — the instance is stopping; the RPC reports `outcome: "stopped"`.
 - `404` — the hook no longer exists. The server clears `stopHookUrl` from its settings (which
-  streams to clients and removes the Stop button) and reports `outcome: "gone"`.
-- Anything else fails the RPC with `ServerStopHookError`.
+  streams to clients and removes the Stop button) and reports `outcome: "gone"`. The clear is
+  compare-and-set: a hook reconfigured while the request was in flight is left alone.
+- Anything else fails the RPC with one of the `ServerStopHookError` union members
+  (`ServerStopHookNotConfiguredError`, `ServerStopHookRequestError`,
+  `ServerStopHookUnexpectedStatusError`). Only `http:`/`https:` URLs are dialed.
 
 After a stop, the saved environment keeps its registration, credentials, and cached config; the
 connection drops like any other server that went away, and the next Connect click runs the start

--- a/docs/internals/instance-hooks.md
+++ b/docs/internals/instance-hooks.md
@@ -1,0 +1,106 @@
+# Instance Lifecycle Hooks
+
+> For maintainers. Using T3 Code? See [docs/user](../user/).
+
+Instance hooks let a VM management solution start and stop the machine hosting a T3 server from
+inside T3 Code, so the user never has to open the management app. The management solution owns two
+HTTP endpoints; T3 Code calls them at the right moments.
+
+## Configuration
+
+Both hooks live in the server's settings (`settings.json`, schema in
+[`packages/contracts/src/settings.ts`](../../packages/contracts/src/settings.ts)):
+
+```json
+{
+  "startHookUrl": "https://mgmt.example.com/instances/42/start",
+  "stopHookUrl": "https://mgmt.example.com/instances/42/stop"
+}
+```
+
+A management solution that provisions the VM writes these when it installs T3 Code, or sets them
+later through `server.updateSettings`. Both are nullable and null by default.
+
+Clients receive the URLs inside `ServerConfig.settings` and cache the config per environment
+(IndexedDB on web). That cache is what makes the start hook usable: when the instance is off, the
+server is unreachable, but the client still knows the start hook URL from the last time it was
+connected. The cache is only dropped when the user removes the environment.
+
+## Start hook
+
+Runs client-side, on the Connections settings page, when the user clicks Connect on a saved
+environment whose cached settings carry a `startHookUrl`. The protocol
+([`packages/contracts/src/instanceHooks.ts`](../../packages/contracts/src/instanceHooks.ts), client
+in [`apps/web/src/components/settings/startHook.ts`](../../apps/web/src/components/settings/startHook.ts)):
+
+1. `POST <startHookUrl>` with no body.
+2. The endpoint answers one of:
+   - `204` — the instance is already running; connect immediately.
+   - `200` with `{ "poll_url": "<url>", "retry_secs": 5 }` — the instance is starting.
+   - `400` with a component form (below) — the endpoint needs user input first.
+3. On a form response, the client renders the components in a dialog and POSTs the resolved values
+   back to the start hook URL as a JSON array (input components only, in component order). The
+   response is again interpreted per step 2, so an endpoint can re-prompt with another `400`.
+4. On a poll response, the client GETs `poll_url` every `retry_secs` seconds (clamped to 1–60s,
+   overall deadline 10 minutes) until a `204` says the instance is up. Error statuses (>= 400) fail
+   the run; "still starting" is any other success status.
+5. The normal connect flow runs.
+
+The form response shape:
+
+```json
+{
+  "button_text": "Start",
+  "components": [
+    { "text": "Informational copy rendered as-is." },
+    {
+      "type": "select",
+      "title": "Size",
+      "description": "Instance size to boot.",
+      "defaultValue": "small",
+      "values": [
+        { "userTitle": "Small", "userDescription": "2 vCPU", "content": "small" },
+        { "userTitle": "Large", "userDescription": "8 vCPU", "content": "large" }
+      ]
+    },
+    {
+      "type": "text",
+      "title": "Region",
+      "description": "Where to boot.",
+      "regex": "^[a-z]{2}-[a-z]+$",
+      "validationError": "Use a region id like eu-west."
+    }
+  ]
+}
+```
+
+A select resolves to the chosen value's `content`; a text input resolves to the entered string,
+validated against `regex` client-side with `validationError` shown on mismatch.
+
+Because the browser calls the management endpoint directly, that endpoint must allow CORS for the
+app origin (including the hosted app origin when connecting from `app.t3.codes`).
+
+The start hook runs only on an explicit Connect click. The connection supervisor's automatic
+retries never call it, so a stopped instance is not restarted by background reconnect attempts.
+
+## Stop hook
+
+Runs server-side. The Connections page shows a Stop button on connected environments whose settings
+carry a `stopHookUrl`; clicking it calls the `server.runStopHook` RPC (scope
+`orchestration:operate`). The server DELETEs the stop hook URL
+([`apps/server/src/instanceHooks.ts`](../../apps/server/src/instanceHooks.ts)):
+
+- `204` — the instance is stopping; the RPC reports `outcome: "stopped"`.
+- `404` — the hook no longer exists. The server clears `stopHookUrl` from its settings (which
+  streams to clients and removes the Stop button) and reports `outcome: "gone"`.
+- Anything else fails the RPC with `ServerStopHookError`.
+
+After a stop, the saved environment keeps its registration, credentials, and cached config; the
+connection drops like any other server that went away, and the next Connect click runs the start
+hook again.
+
+## Surfaces
+
+Web owns the UI today; desktop wraps web and gets both hooks with it. Mobile can dispatch
+`server.runStopHook` through the shared client-runtime command but has no start-hook UI yet — the
+connect gate belongs in its Connections screen when mobile picks this up.

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -206,6 +206,21 @@ Do not use hosted pairing for plain HTTP LAN URLs such as `http://192.168.x.y:37
 
 Hosted pairing does not proxy traffic through T3 Code. The browser still connects directly to the backend URL in the pairing link.
 
+## Starting and Stopping a Managed Instance
+
+If your server runs on a VM managed by a service that supports T3 Code instance hooks, you can
+start and stop the machine from **Settings** → **Connections** without opening the management app.
+
+- **Start.** Clicking **Connect** on the saved environment first asks the management service to
+  boot the instance, waits until it reports ready, then connects as usual. The service may ask a
+  few questions first — for example the instance size — in a short form.
+- **Stop.** Connected environments show a **Stop** button when the management service offers one.
+  Click it when work is done and the service shuts the instance down. Your saved environment stays
+  paired; the next **Connect** starts the instance again.
+
+The management service configures this by setting `startHookUrl` and `stopHookUrl` in the server's
+settings. If you don't use a managed VM, nothing changes.
+
 ## Managing Access Later
 
 Use `t3 auth` to manage access after the initial pairing flow.

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -756,6 +756,14 @@ export function createServerEnvironmentAtoms<R, E>(
       scheduler: configScheduler,
       concurrency: configConcurrency,
     }),
+    runStopHook: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:server:run-stop-hook",
+      tag: WS_METHODS.serverRunStopHook,
+      concurrency: {
+        mode: "singleFlight",
+        key: ({ environmentId }) => environmentId,
+      },
+    }),
     signalProcess: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:server:signal-process",
       tag: WS_METHODS.serverSignalProcess,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -15,6 +15,7 @@ export * from "./model.ts";
 export * from "./keybindings.ts";
 export * from "./server.ts";
 export * from "./settings.ts";
+export * from "./instanceHooks.ts";
 export * from "./git.ts";
 export * from "./vcs.ts";
 export * from "./sourceControl.ts";

--- a/packages/contracts/src/instanceHooks.ts
+++ b/packages/contracts/src/instanceHooks.ts
@@ -1,0 +1,100 @@
+import * as Schema from "effect/Schema";
+import { TrimmedNonEmptyString } from "./baseSchemas.ts";
+
+// ── Instance lifecycle hooks ─────────────────────────────────────────
+//
+// A VM management solution that hosts a T3 server can set `startHookUrl` and
+// `stopHookUrl` in the server's settings so users manage the instance from
+// T3 Code instead of opening the management app. Clients cache the server
+// settings with the rest of the server config, which keeps the start hook
+// reachable while the instance is off.
+//
+// Start hook (client → management endpoint): `POST <startHookUrl>` with no
+// body. A `200` carries `StartHookPollState`; poll `poll_url` every
+// `retry_secs` seconds until a `204`, then run the normal connect flow. A
+// `400` carries `StartHookForm`; render the components, POST back a JSON
+// array of the resolved component values, and expect `StartHookPollState`.
+//
+// Stop hook (server → management endpoint): `DELETE <stopHookUrl>`. A `204`
+// means the instance is stopping. A `404` means the hook no longer exists;
+// the server clears the setting so clients drop the stop control.
+
+export const StartHookPollState = Schema.Struct({
+  poll_url: TrimmedNonEmptyString,
+  retry_secs: Schema.Number,
+});
+export type StartHookPollState = typeof StartHookPollState.Type;
+
+/** Informational text rendered above or between input components. */
+export const StartHookTextResponse = Schema.Struct({
+  text: Schema.String,
+});
+export type StartHookTextResponse = typeof StartHookTextResponse.Type;
+
+export const StartHookSelectValue = Schema.Struct({
+  userTitle: Schema.String,
+  userDescription: Schema.String,
+  content: Schema.String,
+});
+export type StartHookSelectValue = typeof StartHookSelectValue.Type;
+
+export const StartHookSelectComponent = Schema.Struct({
+  type: Schema.Literal("select"),
+  title: Schema.String,
+  description: Schema.String,
+  defaultValue: Schema.String,
+  values: Schema.Array(StartHookSelectValue),
+});
+export type StartHookSelectComponent = typeof StartHookSelectComponent.Type;
+
+export const StartHookTextComponent = Schema.Struct({
+  type: Schema.Literal("text"),
+  title: Schema.String,
+  description: Schema.String,
+  regex: Schema.String,
+  validationError: Schema.String,
+});
+export type StartHookTextComponent = typeof StartHookTextComponent.Type;
+
+export const StartHookFormComponent = Schema.Union([
+  StartHookSelectComponent,
+  StartHookTextComponent,
+  StartHookTextResponse,
+]);
+export type StartHookFormComponent = typeof StartHookFormComponent.Type;
+
+export const StartHookForm = Schema.Struct({
+  button_text: Schema.String,
+  components: Schema.Array(StartHookFormComponent),
+});
+export type StartHookForm = typeof StartHookForm.Type;
+
+// ── Stop hook RPC shapes ─────────────────────────────────────────────
+
+export const ServerStopHookOutcome = Schema.Literals(["stopped", "gone"]);
+export type ServerStopHookOutcome = typeof ServerStopHookOutcome.Type;
+
+export const ServerStopHookResult = Schema.Struct({
+  outcome: ServerStopHookOutcome,
+});
+export type ServerStopHookResult = typeof ServerStopHookResult.Type;
+
+export class ServerStopHookError extends Schema.TaggedErrorClass<ServerStopHookError>()(
+  "ServerStopHookError",
+  {
+    reason: Schema.Literals(["not-configured", "request-failed", "unexpected-status"]),
+    status: Schema.optional(Schema.Number),
+    detail: Schema.optional(Schema.String),
+  },
+) {
+  override get message(): string {
+    switch (this.reason) {
+      case "not-configured":
+        return "No stop hook is configured on this server.";
+      case "request-failed":
+        return `The stop hook request failed${this.detail === undefined ? "" : `: ${this.detail}`}.`;
+      case "unexpected-status":
+        return `The stop hook responded with unexpected status ${this.status ?? 0}.`;
+    }
+  }
+}

--- a/packages/contracts/src/instanceHooks.ts
+++ b/packages/contracts/src/instanceHooks.ts
@@ -79,22 +79,40 @@ export const ServerStopHookResult = Schema.Struct({
 });
 export type ServerStopHookResult = typeof ServerStopHookResult.Type;
 
-export class ServerStopHookError extends Schema.TaggedErrorClass<ServerStopHookError>()(
-  "ServerStopHookError",
+export class ServerStopHookNotConfiguredError extends Schema.TaggedErrorClass<ServerStopHookNotConfiguredError>()(
+  "ServerStopHookNotConfiguredError",
+  {},
+) {
+  override get message(): string {
+    return "No stop hook is configured on this server.";
+  }
+}
+
+export class ServerStopHookRequestError extends Schema.TaggedErrorClass<ServerStopHookRequestError>()(
+  "ServerStopHookRequestError",
   {
-    reason: Schema.Literals(["not-configured", "request-failed", "unexpected-status"]),
-    status: Schema.optional(Schema.Number),
-    detail: Schema.optional(Schema.String),
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    switch (this.reason) {
-      case "not-configured":
-        return "No stop hook is configured on this server.";
-      case "request-failed":
-        return `The stop hook request failed${this.detail === undefined ? "" : `: ${this.detail}`}.`;
-      case "unexpected-status":
-        return `The stop hook responded with unexpected status ${this.status ?? 0}.`;
-    }
+    return "The stop hook request failed.";
   }
 }
+
+export class ServerStopHookUnexpectedStatusError extends Schema.TaggedErrorClass<ServerStopHookUnexpectedStatusError>()(
+  "ServerStopHookUnexpectedStatusError",
+  {
+    status: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `The stop hook responded with unexpected status ${this.status}.`;
+  }
+}
+
+export const ServerStopHookError = Schema.Union([
+  ServerStopHookNotConfiguredError,
+  ServerStopHookRequestError,
+  ServerStopHookUnexpectedStatusError,
+]);
+export type ServerStopHookError = typeof ServerStopHookError.Type;

--- a/packages/contracts/src/instanceHooks.ts
+++ b/packages/contracts/src/instanceHooks.ts
@@ -88,6 +88,20 @@ export class ServerStopHookNotConfiguredError extends Schema.TaggedErrorClass<Se
   }
 }
 
+export class ServerStopHookInvalidUrlError extends Schema.TaggedErrorClass<ServerStopHookInvalidUrlError>()(
+  "ServerStopHookInvalidUrlError",
+  {
+    /** Parsed scheme of the rejected URL, or null when it did not parse. */
+    protocol: Schema.NullOr(Schema.String),
+  },
+) {
+  override get message(): string {
+    return this.protocol === null
+      ? "The configured stop hook is not a valid URL."
+      : `The configured stop hook uses the unsupported scheme ${this.protocol}.`;
+  }
+}
+
 export class ServerStopHookRequestError extends Schema.TaggedErrorClass<ServerStopHookRequestError>()(
   "ServerStopHookRequestError",
   {
@@ -112,6 +126,7 @@ export class ServerStopHookUnexpectedStatusError extends Schema.TaggedErrorClass
 
 export const ServerStopHookError = Schema.Union([
   ServerStopHookNotConfiguredError,
+  ServerStopHookInvalidUrlError,
   ServerStopHookRequestError,
   ServerStopHookUnexpectedStatusError,
 ]);

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -154,6 +154,7 @@ import {
 } from "./resourceTelemetry.ts";
 import { UsageReadError, UsageSummary, UsageSummaryInput } from "./usage.ts";
 import { ServerSettings, ServerSettingsError, ServerSettingsPatch } from "./settings.ts";
+import { ServerStopHookError, ServerStopHookResult } from "./instanceHooks.ts";
 import {
   SourceControlCloneRepositoryInput,
   SourceControlCloneRepositoryResult,
@@ -235,6 +236,7 @@ export const WS_METHODS = {
   serverRemoveKeybinding: "server.removeKeybinding",
   serverGetSettings: "server.getSettings",
   serverUpdateSettings: "server.updateSettings",
+  serverRunStopHook: "server.runStopHook",
   serverDiscoverSourceControl: "server.discoverSourceControl",
   serverGetTraceDiagnostics: "server.getTraceDiagnostics",
   serverGetProcessDiagnostics: "server.getProcessDiagnostics",
@@ -339,6 +341,12 @@ export const WsServerUpdateSettingsRpc = Rpc.make(WS_METHODS.serverUpdateSetting
   payload: Schema.Struct({ patch: ServerSettingsPatch }),
   success: ServerSettings,
   error: Schema.Union([ServerSettingsError, EnvironmentAuthorizationError]),
+});
+
+export const WsServerRunStopHookRpc = Rpc.make(WS_METHODS.serverRunStopHook, {
+  payload: Schema.Struct({}),
+  success: ServerStopHookResult,
+  error: Schema.Union([ServerStopHookError, ServerSettingsError, EnvironmentAuthorizationError]),
 });
 
 export const WsServerDiscoverSourceControlRpc = Rpc.make(WS_METHODS.serverDiscoverSourceControl, {
@@ -821,6 +829,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerRemoveKeybindingRpc,
   WsServerGetSettingsRpc,
   WsServerUpdateSettingsRpc,
+  WsServerRunStopHookRpc,
   WsServerDiscoverSourceControlRpc,
   WsServerGetTraceDiagnosticsRpc,
   WsServerGetProcessDiagnosticsRpc,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -568,6 +568,15 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  // Instance lifecycle hooks, set by a VM management solution hosting this
+  // server. Clients POST the start hook before connecting and ask the server
+  // to DELETE the stop hook when work is done. See instanceHooks.ts.
+  startHookUrl: Schema.NullOr(TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed(null)),
+  ),
+  stopHookUrl: Schema.NullOr(TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed(null)),
+  ),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
       Effect.succeed({
@@ -722,6 +731,8 @@ export const ServerSettingsPatch = Schema.Struct({
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
+  startHookUrl: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
+  stopHookUrl: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(
     Schema.Struct({


### PR DESCRIPTION
## Problem

VM management solutions have no way to boot or shut down the machine hosting a T3 server from inside T3 Code — users must open the management app before and after every remote session.

## Solution

Instance lifecycle hooks, configured by the management solution in the server's settings (`startHookUrl` / `stopHookUrl`, nullable, null by default). Clients receive them inside `ServerConfig.settings`, which is already cached per environment, so the start hook URL stays known while the instance is off.

**Start hook** (client-side, on Settings → Connections where the Connect button lives): clicking Connect first POSTs the hook URL with no content.
- `200` with `{ "poll_url": ..., "retry_secs": ... }` → poll until a `204` says the instance is up, then run the normal connect flow.
- `400` with a component form → a dialog renders the components (informational text, selects, regex-validated text inputs), then POSTs the resolved values back as a JSON array; re-prompts are handled.
- Polling is clamped to 1–60s intervals with a 10-minute deadline, and the row button becomes "Cancel start". Only an explicit Connect click runs the hook — supervisor auto-retries never boot a stopped VM.

**Stop hook** (server-side): connected environments whose settings carry a stop hook show a Stop button backed by the new `server.runStopHook` RPC (`orchestration:operate`). The server DELETEs the endpoint: `204` reports the instance as stopping; `404` clears the setting, which streams to clients and removes the button. The saved environment keeps its pairing and cached config, so the next Connect starts it again.

Protocol reference for management-solution authors: `docs/internals/instance-hooks.md`. User docs in `docs/user/remote-access.md`.

## Notes

- The management endpoint is called from the browser, so it must allow CORS for the app origin.
- Desktop gets both hooks by wrapping web. Mobile can already dispatch the stop RPC through shared client-runtime but has no start-hook gate in its Connections screen yet (noted as follow-up in the internals doc).

## Testing

- `vp test run apps/server/src/instanceHooks.test.ts apps/web/src/components/settings/startHook.test.ts` — 14 tests covering the DELETE flow (204/404/500/unconfigured) and the client protocol (poll state, form parsing, immediate 204, JSON array submission, polling loop, regex validation).
- Targeted typecheck and lint clean on contracts, client-runtime, server, and web, re-verified after rebasing onto latest main.

Done by Claude Fable 5 on Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Server-initiated outbound HTTP and persisted hook URLs affect instance lifecycle; mitigations include http(s)-only validation, scoped RPC, and careful clearing on 404.
> 
> **Overview**
> Adds **instance lifecycle hooks** so VM management solutions can boot and shut down the machine hosting a T3 server from **Settings → Connections**, using nullable `startHookUrl` / `stopHookUrl` in server settings (cached in `ServerConfig` so start URLs stay known while the instance is off).
> 
> **Start hook (browser):** Connect on a saved backend with a start URL now runs a client protocol—POST, optional component form dialog, poll until `204`—then hands off to the normal connect flow. Cancellation, superseded runs, and “connecting” handoff are guarded so auto-reconnect never boots a stopped VM.
> 
> **Stop hook (server):** New `server.runStopHook` RPC (`orchestration:operate`) DELETEs the configured URL; `204` → stopping, `404` → clears the setting with compare-and-set if the URL changed mid-flight. Only `http:`/`https:` are dialed.
> 
> Contracts, client-runtime command, RPC auth, tests, and user/internals docs are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97585561f58c6e5d86d237d307ab6f46785435d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add start and stop managed VM instance hooks to Connections settings
> - Adds `startHookUrl` and `stopHookUrl` fields to `ServerSettings`; when configured, the Connections settings UI drives a start-hook protocol (POST → optional user form dialog → poll until ready) before connecting, and shows a Stop button for connected environments.
> - Implements `InstanceHooks.runStopHook` on the server: sends a DELETE to the configured URL with a 20s timeout, clears `stopHookUrl` on 404, and returns a structured outcome or error.
> - Exposes a new `server.runStopHook` WebSocket RPC (requires `orchestration:operate` scope) and wires it into the client atom API via `runStopHook` with single-flight semantics.
> - Adds `StartHookFormDialog` to collect user input (selects and validated text fields) when the start hook endpoint returns a form response.
> - Adds internal docs in `docs/internals/instance-hooks.md` and user-facing docs in `docs/user/remote-access.md` describing hook configuration and behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d975855.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->