### PR TITLE
fix(mobile): keep chat composer above the Android gesture bar

### DIFF
--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -17,7 +17,11 @@ import type {
 import * as Haptics from "expo-haptics";
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Platform, View, type GestureResponderEvent } from "react-native";
-import { KeyboardController, KeyboardStickyView } from "react-native-keyboard-controller";
+import {
+  KeyboardController,
+  KeyboardStickyView,
+  useKeyboardState,
+} from "react-native-keyboard-controller";
 import Animated, { FadeInDown, FadeOut } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -183,7 +187,11 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const lastScrolledAnchorMessageIdRef = useRef<MessageId | null>(null);
   const [composerExpanded, setComposerExpanded] = useState(false);
   const [anchorMessageId, setAnchorMessageId] = useState<MessageId | null>(null);
-  const composerBottomInset = composerExpanded ? 0 : Math.max(insets.bottom, 12);
+  // Key the safe-area padding on keyboard visibility, not focus: on Android
+  // the back gesture closes the keyboard while the editor stays focused, and
+  // a focus-keyed inset would leave the toolbar under the gesture bar.
+  const isKeyboardVisible = useKeyboardState((state) => state.isVisible);
+  const composerBottomInset = isKeyboardVisible ? 0 : Math.max(insets.bottom, 12);
   const contentPresentationKind = props.contentPresentation.kind;
   // The raw sync status enters "synchronizing" on every full fetch, cached or
   // not. Whether messages are already on screen decides the pill label: no


### PR DESCRIPTION
## What Changed

Key the chat composer's bottom safe-area padding on keyboard visibility (`useKeyboardState`) instead of editor focus. This matches the convention already used by `NewTaskDraftScreen`.

## Why

`ThreadDetailScreen` zeroed `composerBottomInset` whenever the composer was expanded, assuming an expanded (focused) composer always has the keyboard under it. On Android the back gesture closes the keyboard **without blurring the editor**, so the composer stayed expanded with zero bottom padding and the toolbar row (+, model picker, send) landed under the gesture navigation bar.

## UI Changes

Tested on a Pixel emulator (API 35, gesture navigation), dev client + Metro, paired to a local backend.

### Screenshots

<table>
  <tr>
    <th>Before (expanded, keyboard closed)</th>
    <th>After (expanded, keyboard closed)</th>
  </tr>
  <tr>
    <td><img width="320" alt="before: toolbar under the gesture bar" src="https://raw.githubusercontent.com/PollyGlot/t3code/assets/android-chat-safearea/before-expanded-keyboard-closed.png" /></td>
    <td><img width="320" alt="after: toolbar clears the gesture bar" src="https://raw.githubusercontent.com/PollyGlot/t3code/assets/android-chat-safearea/after-expanded-keyboard-closed.png" /></td>
  </tr>
</table>

<details><summary>After: keyboard open (composer still rides the keyboard, no gap)</summary>
<img width="320" src="https://raw.githubusercontent.com/PollyGlot/t3code/assets/android-chat-safearea/after-keyboard-open.png" />
</details>

<details><summary>After: collapsed composer (unchanged)</summary>
<img width="320" src="https://raw.githubusercontent.com/PollyGlot/t3code/assets/android-chat-safearea/after-collapsed.png" />
</details>

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-screen layout tweak with no auth, data, or API changes; behavior is limited to composer padding on mobile.
> 
> **Overview**
> **Thread detail chat composer** bottom safe-area padding now follows **keyboard visibility** (`useKeyboardState`) instead of whether the composer is expanded.
> 
> On Android, dismissing the keyboard with the back gesture can leave the editor focused while the keyboard is hidden; tying inset to expansion zeroed bottom padding and pushed the toolbar under the gesture navigation bar. When the keyboard is open, inset stays at zero so the composer still sits flush on the keyboard; when it is closed, normal bottom inset is restored—matching **`NewTaskDraftScreen`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit becc7d0eff6616225f78f8c9ecd9ab5abdcd897d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chat composer position above Android gesture bar in ThreadDetailScreen
> The `composerBottomInset` in [`ThreadDetailScreen.tsx`](https://github.com/pingdotgg/t3code/pull/5988/files#diff-4a36307d6c720c14cd36832a71a74b980215a01d29282c4f03d82889219d2fae) was previously set to 0 when the composer was expanded, which caused it to overlap the Android gesture bar. It now uses keyboard visibility instead: `0` when the keyboard is visible, `Math.max(insets.bottom, 12)` otherwise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized becc7d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->