### PR TITLE
fix(mobile): parse EAS fingerprint JSON

### DIFF
--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -195,7 +195,9 @@ jobs:
         run: |
           message="$(git log -1 --pretty=%s | head -c 120) ($(git rev-parse --short=9 HEAD))"
           for platform in ios android; do
-            hash="$(eas fingerprint:generate --platform "$platform" --environment production --json --non-interactive | jq -r '.hash')"
+            # eas-cli prints an environment-loaded notice to stdout before the
+            # JSON even with --json, so discard everything before the document.
+            hash="$(eas fingerprint:generate --platform "$platform" --environment production --json --non-interactive | sed -n '/^{/,$p' | jq -er '.hash | select(type == "string" and length > 0)')"
             matching="$(eas build:list --platform "$platform" --build-profile production --status finished --fingerprint-hash "$hash" --limit 1 --json --non-interactive | jq 'length')"
             if [ "$matching" -gt 0 ]; then
               eas update \


### PR DESCRIPTION
## Problem

The production OTA workflow pipes `eas fingerprint:generate --json` directly into `jq`. EAS still writes a human-readable environment notice to stdout before the JSON document, so the workflow fails with a parse error before publishing an OTA.

## Fix

Discard the stdout prefix before the JSON document, then require a non-empty string fingerprint hash before querying compatible production builds.

## Impact

Production OTA runs can compute their environment-aware fingerprint and continue to compatibility checking and publication.

## Validation

- Ran the exact EAS fingerprint-to-`jq` pipeline locally
- `vp fmt --check .github/workflows/mobile-eas-production.yml`
- `vp lint --report-unused-disable-directives`
- `git diff --check`

Implemented with Codex (GPT-5) in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix EAS fingerprint JSON parsing in mobile EAS production workflow
> The `eas fingerprint:generate` command sometimes emits non-JSON lines before the JSON object. The workflow now strips any leading non-JSON output via `sed` before piping to `jq`, and the `jq` filter is tightened to `-er ".hash | select(type == \"string\" and length > 0)"` so the step fails explicitly if no valid hash is extracted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0907fdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub Actions-only change to shell parsing in the mobile EAS production workflow; no app runtime, auth, or data paths.
> 
> **Overview**
> Fixes production **fingerprint-gated OTA** when `eas fingerprint:generate --json` prints a leading environment notice on stdout, which broke direct `jq` parsing and stopped OTAs from publishing.
> 
> The workflow now keeps only output from the first `{` (`sed -n '/^{/,$p'`) before `jq`, and uses **`-er`** with a filter that requires a **non-empty string** `.hash` so the step fails clearly instead of continuing with a bad fingerprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0907fdfa29349f2eb4e653e004b5a7d4082a6432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->