### PR TITLE
fix(swift-ios): keep usage refresh truthful

### DIFF
--- a/apps/swift-ios/Features/Usage/UsageModels.swift
+++ b/apps/swift-ios/Features/Usage/UsageModels.swift
@@ -88,6 +88,91 @@ struct MergedUsage: Equatable {
     var staleEnvironments: [String] = []
 }
 
+struct UsageLoadRequest: Equatable {
+    let id: UUID
+    let days: Int
+    let input: UsageSummaryInput
+}
+
+struct UsageLoadState: Equatable {
+    private(set) var windowDays: Int
+    private(set) var windowInput: UsageSummaryInput
+    private(set) var environments: [FeatureEnvironmentUsage] = []
+    private(set) var merged = MergedUsage()
+    private(set) var isLoading = true
+    private(set) var errorMessage: String?
+    private var activeLoadID: UUID?
+
+    init(
+        days: Int = 30,
+        now: Date = Date(),
+        timeZone: TimeZone = .current
+    ) {
+        windowDays = days
+        windowInput = UsageWindow.make(days: days, now: now, timeZone: timeZone)
+    }
+
+    mutating func begin(
+        days: Int,
+        now: Date = Date(),
+        timeZone: TimeZone = .current
+    ) -> UsageLoadRequest {
+        selectWindow(days: days, now: now, timeZone: timeZone)
+        let request = UsageLoadRequest(
+            id: UUID(),
+            days: days,
+            input: UsageWindow.make(days: days, now: now, timeZone: timeZone)
+        )
+        activeLoadID = request.id
+        isLoading = true
+        errorMessage = nil
+        return request
+    }
+
+    mutating func selectWindow(
+        days: Int,
+        now: Date = Date(),
+        timeZone: TimeZone = .current
+    ) {
+        guard days != windowDays else { return }
+        windowDays = days
+        windowInput = UsageWindow.make(days: days, now: now, timeZone: timeZone)
+        environments = []
+        merged = MergedUsage()
+        isLoading = true
+        errorMessage = nil
+    }
+
+    @discardableResult
+    mutating func receive(
+        _ result: [FeatureEnvironmentUsage],
+        for request: UsageLoadRequest
+    ) -> Bool {
+        guard activeLoadID == request.id, request.days == windowDays else { return false }
+        windowInput = request.input
+        environments = result
+        merged = UsageMerger.merge(result)
+        errorMessage = nil
+        return true
+    }
+
+    @discardableResult
+    mutating func fail(
+        _ error: any Error,
+        for request: UsageLoadRequest
+    ) -> Bool {
+        guard activeLoadID == request.id, request.days == windowDays else { return false }
+        errorMessage = error.localizedDescription
+        return true
+    }
+
+    mutating func finish(_ request: UsageLoadRequest) {
+        guard activeLoadID == request.id, request.days == windowDays else { return }
+        activeLoadID = nil
+        isLoading = false
+    }
+}
+
 enum UsageMerger {
     private struct OwnedContribution {
         let buckets: [UsageBucket]

--- a/apps/swift-ios/Features/Usage/UsageView.swift
+++ b/apps/swift-ios/Features/Usage/UsageView.swift
@@ -12,23 +12,29 @@ private enum UsageMetric: String, CaseIterable, Identifiable {
 public struct UsageView: View {
     private let client: any FeatureClient
 
-    @State private var windowDays = 30
-    @State private var windowInput = UsageWindow.make(days: 30)
+    @State private var loadState = UsageLoadState()
     @State private var metric = UsageMetric.cost
-    @State private var environments: [FeatureEnvironmentUsage] = []
-    @State private var merged = MergedUsage()
-    @State private var isLoading = true
-    @State private var errorMessage: String?
-    @State private var activeLoadID: UUID?
 
     public init(client: any FeatureClient) {
         self.client = client
     }
 
+    private var windowInput: UsageSummaryInput { loadState.windowInput }
+    private var environments: [FeatureEnvironmentUsage] { loadState.environments }
+    private var merged: MergedUsage { loadState.merged }
+    private var isLoading: Bool { loadState.isLoading }
+    private var errorMessage: String? { loadState.errorMessage }
+    private var windowDays: Binding<Int> {
+        Binding(
+            get: { loadState.windowDays },
+            set: { loadState.selectWindow(days: $0) }
+        )
+    }
+
     public var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 24) {
-                Picker("Usage window", selection: $windowDays) {
+                Picker("Usage window", selection: windowDays) {
                     Text("7 days").tag(7)
                     Text("30 days").tag(30)
                     Text("90 days").tag(90)
@@ -50,7 +56,7 @@ public struct UsageView: View {
                     } description: {
                         Text(errorMessage)
                     } actions: {
-                        Button("Try again") { Task { await load(input: windowInput) } }
+                        Button("Try again") { Task { await load() } }
                     }
                 } else if environments.isEmpty {
                     ContentUnavailableView {
@@ -64,7 +70,7 @@ public struct UsageView: View {
                     } description: {
                         Text("No compatible usage data is available.")
                     } actions: {
-                        Button("Try again") { Task { await load(input: windowInput) } }
+                        Button("Try again") { Task { await load() } }
                     }
                 } else {
                     chartCard
@@ -78,14 +84,14 @@ public struct UsageView: View {
             .padding(.bottom, 32)
         }
         .scrollIndicators(.hidden)
-        .refreshable { await load(input: windowInput) }
+        .refreshable { await load() }
         .background(T3Colors.background)
         .navigationTitle("Usage")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.visible, for: .navigationBar)
         .t3NavigationChrome()
-        .task(id: windowDays) {
-            await load(input: UsageWindow.make(days: windowDays))
+        .task(id: loadState.windowDays) {
+            await load()
         }
     }
 
@@ -348,32 +354,17 @@ public struct UsageView: View {
         }
     }
 
-    private func load(input: UsageSummaryInput) async {
-        let loadID = UUID()
-        activeLoadID = loadID
-        if input != windowInput {
-            windowInput = input
-            environments = []
-            merged = MergedUsage()
-        }
-        isLoading = true
-        defer {
-            if activeLoadID == loadID {
-                isLoading = false
-            }
-        }
+    private func load() async {
+        let request = loadState.begin(days: loadState.windowDays)
+        defer { loadState.finish(request) }
         do {
-            let result = try await client.usageSummaries(input)
+            let result = try await client.usageSummaries(request.input)
             try Task.checkCancellation()
-            guard activeLoadID == loadID else { return }
-            environments = result
-            merged = UsageMerger.merge(result)
-            errorMessage = nil
+            loadState.receive(result, for: request)
         } catch is CancellationError {
             return
         } catch {
-            guard activeLoadID == loadID else { return }
-            errorMessage = error.localizedDescription
+            loadState.fail(error, for: request)
         }
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/UsageModelsTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/UsageModelsTests.swift
@@ -108,6 +108,211 @@ struct UsageModelsTests {
         #expect(UsageWindow.days(in: window).count == 7)
     }
 
+    @Test
+    func refreshRecomputesTheSelectedWindowAfterMidnight() throws {
+        let timeZone = try #require(TimeZone(identifier: "Australia/Sydney"))
+        let beforeMidnight = try #require(
+            ISO8601DateFormatter().date(from: "2026-08-10T13:59:00Z")
+        )
+        let afterMidnight = try #require(
+            ISO8601DateFormatter().date(from: "2026-08-10T14:01:00Z")
+        )
+        var state = UsageLoadState(days: 30, now: beforeMidnight, timeZone: timeZone)
+        let initial = state.begin(days: 30, now: beforeMidnight, timeZone: timeZone)
+        let previous = FeatureEnvironmentUsage(
+            environmentID: "current",
+            label: "Current",
+            summary: summary(provider: .codex, costUsd: 10),
+            errorMessage: nil
+        )
+        let receivedInitial = state.receive([previous], for: initial)
+        #expect(receivedInitial)
+
+        let refresh = state.begin(days: 30, now: afterMidnight, timeZone: timeZone)
+
+        #expect(refresh.input.untilDay == "2026-08-11")
+        #expect(refresh.input.sinceDay == "2026-07-13")
+        #expect(state.windowInput.untilDay == "2026-08-10")
+        #expect(state.merged.costUsd == 10)
+
+        let current = FeatureEnvironmentUsage(
+            environmentID: "current",
+            label: "Current",
+            summary: summary(provider: .codex, costUsd: 11),
+            errorMessage: nil
+        )
+        let receivedRefresh = state.receive([current], for: refresh)
+        #expect(receivedRefresh)
+        #expect(state.windowInput.untilDay == "2026-08-11")
+        #expect(state.merged.costUsd == 11)
+    }
+
+    @Test(arguments: [7, 30, 90])
+    func refreshAndRetryRecomputeEveryWindowLength(days: Int) throws {
+        let timeZone = try #require(TimeZone(identifier: "Australia/Sydney"))
+        let firstDay = try #require(
+            ISO8601DateFormatter().date(from: "2026-08-10T12:00:00Z")
+        )
+        let nextDay = try #require(
+            ISO8601DateFormatter().date(from: "2026-08-11T12:00:00Z")
+        )
+        var state = UsageLoadState(days: 30, now: firstDay, timeZone: timeZone)
+
+        let refresh = state.begin(days: days, now: firstDay, timeZone: timeZone)
+        #expect(UsageWindow.days(in: refresh.input).count == days)
+        let recordedRefreshFailure = state.fail(TestUsageError.unavailable, for: refresh)
+        #expect(recordedRefreshFailure)
+
+        let retry = state.begin(days: days, now: nextDay, timeZone: timeZone)
+        #expect(UsageWindow.days(in: retry.input).count == days)
+        #expect(retry.input.untilDay == "2026-08-11")
+        #expect(state.errorMessage == nil)
+    }
+
+    @Test
+    func failedRefreshKeepsTheLastTruthfulTotalsAndWindow() throws {
+        let timeZone = try #require(TimeZone(identifier: "Australia/Sydney"))
+        let now = try #require(
+            ISO8601DateFormatter().date(from: "2026-08-10T12:00:00Z")
+        )
+        var state = UsageLoadState(days: 30, now: now, timeZone: timeZone)
+        let initial = state.begin(days: 30, now: now, timeZone: timeZone)
+        let previous = FeatureEnvironmentUsage(
+            environmentID: "current",
+            label: "Current",
+            summary: summary(provider: .codex, costUsd: 10),
+            errorMessage: nil
+        )
+        let receivedInitial = state.receive([previous], for: initial)
+        #expect(receivedInitial)
+        let truthfulWindow = state.windowInput
+
+        let refresh = state.begin(days: 30, now: now, timeZone: timeZone)
+        let recordedRefreshFailure = state.fail(TestUsageError.unavailable, for: refresh)
+        #expect(recordedRefreshFailure)
+
+        #expect(state.windowInput == truthfulWindow)
+        #expect(state.environments == [previous])
+        #expect(state.merged.costUsd == 10)
+        #expect(state.errorMessage != nil)
+    }
+
+    @Test
+    func staleOrCancelledLoadCannotOverwriteTheNewestLoad() throws {
+        let timeZone = try #require(TimeZone(identifier: "Australia/Sydney"))
+        let now = try #require(
+            ISO8601DateFormatter().date(from: "2026-08-10T12:00:00Z")
+        )
+        var state = UsageLoadState(days: 30, now: now, timeZone: timeZone)
+        let stale = state.begin(days: 30, now: now, timeZone: timeZone)
+        let previous = FeatureEnvironmentUsage(
+            environmentID: "previous",
+            label: "Previous",
+            summary: summary(provider: .codex, costUsd: 30),
+            errorMessage: nil
+        )
+        let receivedPrevious = state.receive([previous], for: stale)
+        #expect(receivedPrevious)
+        state.selectWindow(days: 7, now: now, timeZone: timeZone)
+        #expect(state.environments.isEmpty)
+        #expect(state.merged == MergedUsage())
+        #expect(state.errorMessage == nil)
+        #expect(state.isLoading)
+        #expect(UsageWindow.days(in: state.windowInput).count == 7)
+        let staleResult = FeatureEnvironmentUsage(
+            environmentID: "stale",
+            label: "Stale",
+            summary: summary(provider: .codex, costUsd: 99),
+            errorMessage: nil
+        )
+        let currentResult = FeatureEnvironmentUsage(
+            environmentID: "current",
+            label: "Current",
+            summary: summary(provider: .codex, costUsd: 7),
+            errorMessage: nil
+        )
+
+        let receivedStale = state.receive([staleResult], for: stale)
+        #expect(!receivedStale)
+        let recordedStaleFailure = state.fail(TestUsageError.unavailable, for: stale)
+        #expect(!recordedStaleFailure)
+        #expect(state.errorMessage == nil)
+        state.finish(stale)
+        #expect(state.isLoading)
+
+        let current = state.begin(days: 7, now: now, timeZone: timeZone)
+        let receivedCurrent = state.receive([currentResult], for: current)
+        #expect(receivedCurrent)
+        state.finish(current)
+
+        #expect(!state.isLoading)
+        #expect(state.environments == [currentResult])
+        #expect(state.merged.costUsd == 7)
+        #expect(UsageWindow.days(in: state.windowInput).count == 7)
+    }
+
+    @Test
+    func sameWindowOverlapOnlyLetsTheNewestLoadCommitOrFinish() throws {
+        let timeZone = try #require(TimeZone(identifier: "Australia/Sydney"))
+        let now = try #require(
+            ISO8601DateFormatter().date(from: "2026-08-10T12:00:00Z")
+        )
+        var state = UsageLoadState(days: 30, now: now, timeZone: timeZone)
+        let superseded = state.begin(days: 30, now: now, timeZone: timeZone)
+        let current = state.begin(days: 30, now: now, timeZone: timeZone)
+        let result = FeatureEnvironmentUsage(
+            environmentID: "current",
+            label: "Current",
+            summary: summary(provider: .codex, costUsd: 30),
+            errorMessage: nil
+        )
+
+        let receivedSuperseded = state.receive([result], for: superseded)
+        #expect(!receivedSuperseded)
+        let recordedSupersededFailure = state.fail(
+            TestUsageError.unavailable,
+            for: superseded
+        )
+        #expect(!recordedSupersededFailure)
+        state.finish(superseded)
+        #expect(state.isLoading)
+
+        let receivedCurrent = state.receive([result], for: current)
+        #expect(receivedCurrent)
+        state.finish(current)
+        #expect(!state.isLoading)
+        #expect(state.environments == [result])
+    }
+
+    @Test
+    func partialEnvironmentFailureRemainsVisibleBesideTruthfulTotals() throws {
+        let timeZone = try #require(TimeZone(identifier: "Australia/Sydney"))
+        let now = try #require(
+            ISO8601DateFormatter().date(from: "2026-08-10T12:00:00Z")
+        )
+        var state = UsageLoadState(days: 30, now: now, timeZone: timeZone)
+        let request = state.begin(days: 30, now: now, timeZone: timeZone)
+        let available = FeatureEnvironmentUsage(
+            environmentID: "available",
+            label: "Available",
+            summary: summary(provider: .codex, costUsd: 10),
+            errorMessage: nil
+        )
+        let unavailable = FeatureEnvironmentUsage(
+            environmentID: "unavailable",
+            label: "Unavailable",
+            summary: nil,
+            errorMessage: "This environment could not report usage."
+        )
+
+        let receivedPartial = state.receive([available, unavailable], for: request)
+        #expect(receivedPartial)
+
+        #expect(state.merged.costUsd == 10)
+        #expect(state.environments.filter { $0.errorMessage != nil } == [unavailable])
+        #expect(state.errorMessage == nil)
+    }
+
     private func summary(
         contractVersion: Int = usageContractVersion,
         provider: UsageProviderKind,
@@ -171,4 +376,8 @@ struct UsageModelsTests {
             scanDurationMs: 1
         )
     }
+}
+
+private enum TestUsageError: Error {
+    case unavailable
 }


### PR DESCRIPTION
## What Changed

- Recomputes the active 7/30/90-day usage window when refreshing or retrying, including across midnight.
- Keeps the last truthful totals and their original date labels visible until a same-window refresh succeeds.
- Prevents stale, cancelled, or different-window requests from overwriting the current selection.
- Preserves partial environment failures instead of flattening them into a misleading complete result.

## Why

The SwiftUI usage screen could refresh an old date range or let an earlier request replace a newer picker selection. That made totals and labels look current when they were not.

## UI Changes

The visible layout is unchanged. Refresh, retry, and 7/30/90-day picker state now remain internally consistent.

## Verification

- Focused Usage suite: 11 tests passed.
- `apps/swift-ios/Scripts/ci-test.sh`: 229 Swift Testing tests and 103 XCTest cases passed; one expected skip.
- `git diff --check`: passed.
- Final direct Claude Opus 5 high review: exit 0, no correctness, concurrency, or ordering findings.
- Base: `5b7ee58f6e62158559c6656d0ba581f10efced64`.
- Integrated iOS proof: clean dedicated iPhone 17 Pro simulator on iOS 26.5, exact head `064be3951f7a4a4859f213c6c34612af1fb7d819`.
- Verified 30 days (Jul 12–Aug 10) → 7 days (Aug 4–Aug 10) → 90 days (May 13–Aug 10) → 30 days, with each selected range producing matching date labels and distinct totals.
- Verified an interrupted refresh retained the last truthful 30-day total/date labels while the environment reconnected; restarting the backend and refreshing preserved the same-window truth.
- [Private Tailnet video evidence](https://alexs-macbook-pro-1.tail4e5636.ts.net:8766/swiftui-usage-window-truth-proof-20260810.mp4) — MP4, 8,786,127 bytes, SHA-256 `a1b17ffa07ccfdb79bbc9409047ae7925864790e27dd426a97113d7558838733`. Tailnet access is required; the endpoint does not support range seeking.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale usage data by gating load results on request ID and selected window
> - Introduces `UsageLoadRequest` and `UsageLoadState` in [UsageModels.swift](https://github.com/pingdotgg/t3code/pull/5992/files#diff-a81481bfe36c3f7127321212df72be204d481ba31daadd8f5a8cfb15537d9a26) to track in-flight usage requests by a unique ID and window selection.
> - Results are only committed when the request ID and window match the active load; stale or superseded responses are silently dropped.
> - Failed loads retain the last accepted data and window input instead of clearing them.
> - `UsageView` is refactored to drive all loading state through `UsageLoadState`, replacing individual `@State` properties.
> - Tests in [UsageModelsTests.swift](https://github.com/pingdotgg/t3code/pull/5992/files#diff-d8363d95a70e6a4495cdf8bf00bc38830b9ded64a5787e7cafbb665e66bb7c2f) cover mid-night refresh, stale load rejection, partial failures, and retry/refresh flows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 064be39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI usage feature refactor with explicit concurrency guards and broad unit tests; no auth, payments, or shared backend changes.
> 
> **Overview**
> Fixes the iOS **Usage** screen showing stale date ranges or letting older network responses overwrite a newer 7/30/90-day selection.
> 
> **`UsageLoadState`** and **`UsageLoadRequest`** now own window days, summary input, environments, merged totals, loading, and errors. Each fetch gets a unique request ID; **`receive`**, **`fail`**, and **`finish`** only apply when the ID and selected window still match the active load, so superseded, cancelled, or wrong-window work is ignored. **`begin`** recomputes the calendar window from “now” (including across midnight); failed refreshes keep the last successful totals and date labels until a same-window load succeeds. **`selectWindow`** clears displayed data when the picker changes.
> 
> **`UsageView`** collapses scattered `@State` into one `loadState` and a thinner **`load()`** that delegates to that lifecycle. New **`UsageModelsTests`** cover midnight refresh, stale overlap, failed refresh retention, and partial per-environment failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064be3951f7a4a4859f213c6c34612af1fb7d819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable; native/repository checks and current review are green. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
