### PR TITLE
fix(swift-ios): improve live duration accessibility

### DIFF
--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -192,6 +192,9 @@ public struct ThreadDetailView: View {
         .frame(maxWidth: horizontalSizeClass == .compact ? 260 : 460, alignment: .leading)
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isHeader)
+        .accessibilityAddTraits(
+            currentThread.hasLiveWorkingDuration ? .updatesFrequently : []
+        )
     }
 
     @ViewBuilder
@@ -212,6 +215,7 @@ public struct ThreadDetailView: View {
         .foregroundStyle(headerStatusColor)
         .lineLimit(1)
         .accessibilityElement(children: .combine)
+        .accessibilityLabel(currentThread.homeStatusAccessibilityLabel(at: now))
     }
 
     private var threadActionsMenu: some View {

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -584,6 +584,22 @@ enum HomeWorkingDuration {
         guard minutes >= 60 else { return "\(minutes)m" }
         return "\(minutes / 60)h \(minutes % 60)m"
     }
+
+    static func accessibility(since date: Date, now: Date) -> String {
+        let seconds = max(0, Int(now.timeIntervalSince(date)))
+        guard seconds >= 60 else { return unit(seconds, singular: "second") }
+        let minutes = seconds / 60
+        guard minutes >= 60 else { return unit(minutes, singular: "minute") }
+
+        let hours = minutes / 60
+        let remainingMinutes = minutes % 60
+        guard remainingMinutes > 0 else { return unit(hours, singular: "hour") }
+        return "\(unit(hours, singular: "hour")), \(unit(remainingMinutes, singular: "minute"))"
+    }
+
+    private static func unit(_ value: Int, singular: String) -> String {
+        "\(value) \(singular)\(value == 1 ? "" : "s")"
+    }
 }
 
 extension FeatureThread {
@@ -621,6 +637,20 @@ extension FeatureThread {
     func homeWorkingDuration(at now: Date) -> String? {
         guard homeStatus == .working, let workingStartedAt else { return nil }
         return HomeWorkingDuration.compact(since: workingStartedAt, now: now)
+    }
+
+    var hasLiveWorkingDuration: Bool {
+        homeStatus == .working && workingStartedAt != nil
+    }
+
+    func homeStatusAccessibilityLabel(at now: Date) -> String {
+        guard homeStatus == .working else {
+            return homeStatusLabel ?? "Ready"
+        }
+        guard let workingStartedAt else {
+            return "Agent is working"
+        }
+        return "Agent is working for \(HomeWorkingDuration.accessibility(since: workingStartedAt, now: now))"
     }
 
     func homeEnvironmentLabel(in snapshot: FeatureSnapshot) -> String? {

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -69,6 +69,55 @@ struct HomeThreadMetadataTests {
     }
 
     @Test
+    func accessibilityDurationSpellsOutUnitsAndClampsFutureDates() {
+        #expect(accessibilityDuration(startedAtOffset: 5) == "0 seconds")
+        #expect(accessibilityDuration(startedAtOffset: -1) == "1 second")
+        #expect(accessibilityDuration(startedAtOffset: -42) == "42 seconds")
+        #expect(accessibilityDuration(startedAtOffset: -60) == "1 minute")
+        #expect(accessibilityDuration(startedAtOffset: -120) == "2 minutes")
+        #expect(accessibilityDuration(startedAtOffset: -3_600) == "1 hour")
+        #expect(accessibilityDuration(startedAtOffset: -7_200) == "2 hours")
+        #expect(accessibilityDuration(startedAtOffset: -5_465) == "1 hour, 31 minutes")
+    }
+
+    @Test
+    func accessibilityStatusDescribesOnlyLiveWorkingDurations() {
+        let working = thread(state: .working, startedAtOffset: -90)
+        let queuedWithoutStart = thread(state: .queued)
+        let monitoring = thread(state: .monitoring, startedAtOffset: -90)
+        let idle = thread(state: .idle)
+
+        #expect(working.hasLiveWorkingDuration)
+        #expect(working.homeStatusAccessibilityLabel(at: now) == "Agent is working for 1 minute")
+        #expect(!queuedWithoutStart.hasLiveWorkingDuration)
+        #expect(queuedWithoutStart.homeStatusAccessibilityLabel(at: now) == "Agent is working")
+        #expect(!monitoring.hasLiveWorkingDuration)
+        #expect(monitoring.homeStatusAccessibilityLabel(at: now) == "Monitoring")
+        #expect(!idle.hasLiveWorkingDuration)
+        #expect(idle.homeStatusAccessibilityLabel(at: now) == "Ready")
+    }
+
+    private func accessibilityDuration(startedAtOffset: TimeInterval) -> String {
+        HomeWorkingDuration.accessibility(
+            since: now.addingTimeInterval(startedAtOffset),
+            now: now
+        )
+    }
+
+    private func thread(
+        state: FeatureThreadState,
+        startedAtOffset: TimeInterval? = nil
+    ) -> FeatureThread {
+        FeatureThread(
+            id: state.rawValue,
+            projectID: "project",
+            title: "Task",
+            state: state,
+            workingStartedAt: startedAtOffset.map(now.addingTimeInterval)
+        )
+    }
+
+    @Test
     func rowAttributionPrefersCurrentEnvironmentNameAndWireProviderName() {
         let thread = FeatureThread(
             id: "thread",


### PR DESCRIPTION
## Summary

Keeps Theo's existing visible live-duration UI unchanged and adds only the missing accessibility behavior:

- spells durations out for VoiceOver (for example, `1 hour, 31 minutes`)
- announces working state even when no start timestamp is available
- marks the combined thread header as frequently updating only while a known live duration is ticking

This is the focused replacement for #5611. The original PR now duplicates the visible duration behavior already on the target branch and also carries stale code conflicts.

## Verification

- Focused `HomeThreadMetadataTests`: 7/7 passed
- Full `apps/swift-ios/Scripts/ci-test.sh`: 225 tests across 28 suites passed
- `git diff --check`: passed
- Fresh direct Claude Opus 5 high review of the frozen final diff: exit 0, no actionable findings

## Conflict classification

#5611 is both a code conflict and a feature duplicate. This PR preserves only its unique useful accessibility outcome; it does not add a second visible timer, transcript timer, or scheduler.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility-only SwiftUI and model helpers with tests; no API, auth, or visible UI behavior changes.
> 
> **Overview**
> Improves **VoiceOver** for the thread detail navigation header’s live working timer while leaving the on-screen compact duration UI unchanged.
> 
> Adds `HomeWorkingDuration.accessibility` to spell out elapsed time (e.g. `1 hour, 31 minutes`) and `FeatureThread.homeStatusAccessibilityLabel` so working threads announce **“Agent is working”** even when `workingStartedAt` is missing, with full duration text when a start time exists. `ThreadDetailView` wires that label into the header status and applies **`.updatesFrequently`** on the combined header only when `hasLiveWorkingDuration` is true (working state with a known start). Unit tests cover the new duration and status accessibility strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d5c5a2e25756b22d1e8537065e076009d33c678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve live working duration accessibility in iOS thread detail view
> - Adds the `updatesFrequently` accessibility trait to the thread header in [`ThreadDetailView`](https://github.com/pingdotgg/t3code/pull/5993/files#diff-c987f84bf3746c99e23dc49057c113592bca2c0bce299b9dd80fe73c9495af30) when the thread has an active working duration, signaling assistive technologies that the content changes often.
> - Adds a descriptive accessibility label to the status line that spells out the working state or elapsed duration (e.g. "Agent is working for 2 hours, 5 minutes").
> - Introduces `FeatureThread.homeStatusAccessibilityLabel(at:)` and `HomeWorkingDuration.accessibility` in [`DailyUXModels.swift`](https://github.com/pingdotgg/t3code/pull/5993/files#diff-2bae36acfcaa822eaaa43aea2e36dd5ded98f236fd6c38e524e50fbd0c85331e) to produce human-readable, unit-spelled-out duration strings, clamping negative intervals to zero.
> - Covers the new logic with unit tests in [`HomeThreadMetadataTests.swift`](https://github.com/pingdotgg/t3code/pull/5993/files#diff-6c011ef0ee9b0b0c743e78ef9b0e374f0c5f74afb579f04439127d8bab79a2aa) across seconds, minutes, hours, combined durations, and future-date clamping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d5c5a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable; native/repository checks and current review are green. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
