### PR TITLE
fix(web): prevent Windows titlebar shift after restore

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -553,7 +553,7 @@ export const make = Effect.gen(function* () {
       runFork(flushBoundsPersist);
     });
 
-    if (environment.platform === "darwin") {
+    if (environment.platform === "darwin" || environment.platform === "win32") {
       window.on("enter-full-screen", () => {
         window.webContents.send(WINDOW_FULLSCREEN_STATE_CHANNEL, true);
       });

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -13,7 +13,7 @@ function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
     "flex items-center justify-between gap-2",
     mode === "embedded" ? "px-2" : "px-4",
     shouldUseDragRegion
-      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]"
+      ? "workspace-topbar drag-region border-b border-border wco:pr-[var(--workspace-native-controls-inset)]"
       : "surface-subheader",
   );
 }

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -187,7 +187,7 @@ export function ProjectSettingsPage({ projectKey }: { projectKey: string }) {
         {isElectron && (
           <div
             className={cn(
-              "drag-region flex h-[52px] shrink-0 items-center px-5 transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]",
+              "workspace-topbar drag-region px-5 transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none wco:pr-[var(--workspace-native-controls-inset)]",
               COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
             )}
           >

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -81,7 +81,7 @@ export function UsagePage() {
         {isElectron && (
           <div
             className={cn(
-              "drag-region flex h-[52px] shrink-0 items-center px-5 transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]",
+              "workspace-topbar drag-region px-5 transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none wco:pr-[var(--workspace-native-controls-inset)]",
               COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
             )}
           >

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1407,6 +1407,18 @@ body {
 
 .electron-windows {
   --desktop-window-right-resize-inset: 6px;
+  /* Matches DesktopWindow TITLEBAR_HEIGHT; WCO height can be transitional during restore. */
+  --workspace-topbar-height: 40px;
+  --workspace-controls-top: 0px;
+  --workspace-controls-left: 0.75rem;
+  --workspace-native-controls-width: calc(
+    100vw - env(titlebar-area-width, 100vw) - env(titlebar-area-x, 0px)
+  );
+}
+
+.electron-windows.wco {
+  --workspace-controls-right: calc(var(--workspace-native-controls-width) + 0.75rem);
+  --workspace-native-controls-inset: var(--workspace-controls-right);
 }
 
 /* App-chrome grain. Baked into each surface's own background (behind

--- a/apps/web/src/lib/windowControlsOverlay.ts
+++ b/apps/web/src/lib/windowControlsOverlay.ts
@@ -6,6 +6,7 @@ const ELECTRON_WINDOWS_CLASS_NAME = "electron-windows";
 
 interface WindowControlsOverlayLike {
   readonly visible: boolean;
+  readonly getTitlebarAreaRect: () => Pick<DOMRect, "width" | "right">;
   addEventListener(type: "geometrychange", listener: EventListener): void;
   removeEventListener(type: "geometrychange", listener: EventListener): void;
 }
@@ -28,18 +29,59 @@ export function syncDocumentWindowControlsOverlayClass(): () => void {
   }
 
   const overlay = getWindowControlsOverlay();
-  const update = () => {
-    document.documentElement.classList.toggle(WCO_CLASS_NAME, overlay !== null && overlay.visible);
+  if (!overlay) return () => {};
+
+  const root = document.documentElement;
+  const isWindows = isWindowsPlatform(navigator.platform);
+  let wasVisible = overlay.visible;
+  let hasGeometry = false;
+  let fullscreen = isWindows && window.desktopBridge?.getWindowFullscreenState?.() === true;
+
+  const applyGeometry = () => {
+    const rect = overlay.getTitlebarAreaRect();
+    const rightInset = window.innerWidth - rect.right;
+    if (!(rect.width > 0 && rightInset > 0 && rightInset <= window.innerWidth)) return;
+
+    root.style.setProperty("--workspace-native-controls-width", `${rightInset}px`);
+    hasGeometry = true;
   };
 
+  const update = () => {
+    const visible = overlay.visible;
+    const preserveWindowsLayout = isWindows && !visible && hasGeometry && !fullscreen;
+    root.classList.toggle(WCO_CLASS_NAME, visible || preserveWindowsLayout);
+
+    if (!isWindows) return;
+
+    if (!visible) {
+      wasVisible = false;
+      return;
+    }
+
+    if (!wasVisible) {
+      wasVisible = true;
+      if (!hasGeometry) applyGeometry();
+      return;
+    }
+
+    applyGeometry();
+  };
+
+  const stopFullscreenListener = isWindows
+    ? window.desktopBridge?.onWindowFullscreenStateChange?.((value) => {
+        fullscreen = value;
+        update();
+      })
+    : undefined;
+
   update();
-  if (!overlay) {
-    return () => {};
-  }
 
   overlay.addEventListener("geometrychange", update);
   return () => {
+    stopFullscreenListener?.();
     overlay.removeEventListener("geometrychange", update);
+    root.classList.remove(WCO_CLASS_NAME);
+    root.style.removeProperty("--workspace-native-controls-width");
   };
 }
 

--- a/apps/web/src/rightPanelLayout.ts
+++ b/apps/web/src/rightPanelLayout.ts
@@ -1,3 +1,3 @@
 export const RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY = "(max-width: 980px)";
 export const RIGHT_PANEL_SHEET_CLASS_NAME =
-  "w-[min(42vw,28rem)] min-w-80 max-w-[28rem] p-0 max-[760px]:w-[min(88vw,24rem)] max-[760px]:min-w-0 wco:mt-[env(titlebar-area-height)] wco:h-[calc(100%-env(titlebar-area-height))] wco:max-h-[calc(100%-env(titlebar-area-height))]";
+  "w-[min(42vw,28rem)] min-w-80 max-w-[28rem] p-0 max-[760px]:w-[min(88vw,24rem)] max-[760px]:min-w-0 wco:mt-[var(--workspace-topbar-height)] wco:h-[calc(100%-var(--workspace-topbar-height))] wco:max-h-[calc(100%-var(--workspace-topbar-height))]";

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -93,7 +93,7 @@ function SettingsContentLayout() {
         {isElectron && (
           <div
             className={cn(
-              "drag-region flex h-[52px] shrink-0 items-center px-5 transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]",
+              "workspace-topbar drag-region px-5 transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none wco:pr-[var(--workspace-native-controls-inset)]",
               COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
             )}
           >


### PR DESCRIPTION
## What Changed

Stabilizes the Windows desktop titlebar layout across minimize → restore transitions.

The last valid native window-controls geometry is preserved while the Window Controls Overlay is temporarily unavailable during restore, then refreshed once the restored window has settled.

Diff, Usage, Settings, and right-panel headers now use the same stabilized titlebar geometry. Other platforms keep the existing WCO behavior.

## Why

On Windows desktop, restoring T3 Code after minimizing could briefly render titlebar content in the wrong position before snapping into place, including content shifting into the native minimize/maximize/close button area.

Preserving the last known-good geometry through the restore transition avoids rendering that intermediate layout while still allowing the native controls geometry to update normally afterwards.

## UI Changes

### Before

https://github.com/user-attachments/assets/add6d3e6-59b6-431e-9efc-2f6e36fd3e00


### After

https://github.com/user-attachments/assets/9754c964-5274-41f0-baf4-b2d785902eaa


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI/layout only on Windows Electron; no auth, data, or API changes. Risk is limited to titlebar geometry regressions on other platforms if WCO sync behavior diverges.
> 
> **Overview**
> Fixes a **Windows desktop** glitch where titlebar content jumped or overlapped the system buttons briefly after **minimize → restore**.
> 
> **`syncDocumentWindowControlsOverlayClass`** now keeps the last good native control geometry on Windows when the Window Controls Overlay is temporarily unavailable during restore: it can leave the **`wco`** class applied, writes **`--workspace-native-controls-width`** from **`getTitlebarAreaRect`**, and skips that preservation in fullscreen via new **win32** fullscreen IPC from **`DesktopWindow`**.
> 
> **CSS** adds **`.electron-windows`** / **`.wco`** variables (fixed **40px** topbar height, native-control insets) so layout does not depend on transitional **`env(titlebar-area-*)`** values during restore.
> 
> **Headers** (diff panel, settings, usage, right-panel sheet) switch from hardcoded **`h-[52px]`** / **`env(...)`** padding to **`workspace-topbar`** and **`--workspace-native-controls-inset`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 021bfb1ff3caab200ba14e426525880177690ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows titlebar shift after restore by preserving WCO layout during overlay hide
> - Revamps `syncDocumentWindowControlsOverlayClass` in [`windowControlsOverlay.ts`](https://github.com/pingdotgg/t3code/pull/5996/files#diff-0b4bc2286c6db8c805258eaec400a41bb45075d438330415672e821a0c99d9bf) to track fullscreen state and overlay geometry separately, keeping the `wco` class active on Windows when the overlay becomes temporarily hidden (e.g. after restore from maximized) to prevent layout shift
> - Adds CSS variables (`--workspace-topbar-height`, `--workspace-native-controls-inset`, etc.) under `.electron-windows` in [`index.css`](https://github.com/pingdotgg/t3code/pull/5996/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) so components can size/pad consistently without hardcoded heights or `calc()` expressions
> - Extends full-screen event listeners in [`DesktopWindow.ts`](https://github.com/pingdotgg/t3code/pull/5996/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) to cover `win32` in addition to `darwin`, so the renderer knows when to drop the preserved `wco` class during fullscreen
> - Updates header rows in diff panel, settings, usage, and project settings pages to use `workspace-topbar` and `var(--workspace-native-controls-inset)` instead of fixed heights and calc-based padding
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 021bfb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->