### PR TITLE
fix(web): render color swatches only on exact inline code matches

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -145,6 +145,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     ...defaultSchema.attributes,
     "*": (defaultSchema.attributes?.["*"] ?? []).filter((attribute) => attribute !== "title"),
     code: [...(defaultSchema.attributes?.code ?? []), "dataCodeMeta", "dataInlineCode"],
+    span: [...(defaultSchema.attributes?.span ?? [])],
   },
   protocols: {
     ...defaultSchema.protocols,
@@ -263,6 +264,8 @@ function remarkTagInlineCode() {
     visit(tree, false);
   };
 }
+
+const COLOR_LITERAL_REGEX = /^(#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b|(?:rgb|rgba|hsl|hsla)\([^)]+\))$/i;
 
 function nodeToPlainText(node: ReactNode): string {
   if (typeof node === "string" || typeof node === "number") {
@@ -1535,12 +1538,27 @@ function ChatMarkdown({
       },
       code({ node, children, className, ...props }) {
         if (node?.properties?.dataInlineCode != null) {
-          const codeText = nodeToPlainText(children);
+          const codeText = nodeToPlainText(children).trim();
           const fileLinkMeta =
-            inlineCodeFileLinkMetaByText.get(codeText.trim()) ??
+            inlineCodeFileLinkMetaByText.get(codeText) ??
             resolveInlineCodeFileLinkMeta(codeText, cwd);
           if (fileLinkMeta) {
             return fileLinkChip(fileLinkMeta, `\`${codeText}\``);
+          }
+          
+          const colorMatch = codeText.match(COLOR_LITERAL_REGEX);
+          if (colorMatch) {
+            return (
+              <span className="inline-flex items-center gap-1">
+                <span
+                  className="inline-block size-3 shrink-0 rounded-[3px] border border-border"
+                  style={{ backgroundColor: colorMatch[0] }}
+                />
+                <code {...props} className={className}>
+                  {children}
+                </code>
+              </span>
+            );
           }
         }
         return (


### PR DESCRIPTION
Fixes #5815d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat markdown rendering change with anchored regex matching; no auth, data, or API impact.
> 
> **Overview**
> **Chat markdown** now shows a small color preview next to inline code when the span is **only** a CSS color literal (hex, `rgb`/`rgba`, `hsl`/`hsla`), after file-link handling and with trimmed text so surrounding whitespace does not affect matching.
> 
> The sanitizer schema explicitly allows `span` attributes so the swatch wrapper survives `rehype-sanitize`. Inline code lookup for file chips uses the same trimmed string consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6585d2af592881481c743ca206b95d0f8884fde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render color swatches next to inline code matching color literals in chat markdown
> - Adds a `COLOR_LITERAL_REGEX` in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/5999/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to detect hex (`#rgb`, `#rrggbb`, etc.) and functional (`rgb()`, `hsl()`, etc.) color notation in inline code blocks.
> - When inline code matches a color literal, a small colored swatch is rendered adjacent to the code using the detected color as background.
> - Trims inline code text before file-link lookup, which can affect whether a file link chip is produced when code contains leading/trailing whitespace.
> - Extends the sanitize schema to explicitly include `span` tag attributes, required to support the swatch wrapper element.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6585d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->