### PR TITLE
fix(web): improve built-in theme contrast

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -37,7 +37,7 @@
           light: {
             background: "#fdf7fd",
             foreground: "#501854",
-            accent: "#e33f86",
+            accent: "#db2777",
             chrome: "#fdf7fd",
           },
           dark: {
@@ -54,7 +54,7 @@
             light: {
               background: "#fdf7fd",
               foreground: "#501854",
-              accent: "#e33f86",
+              accent: "#db2777",
               chrome: "#fdf7fd",
             },
             dark: {

--- a/apps/web/src/components/chat/ModelPickerSidebar.tsx
+++ b/apps/web/src/components/chat/ModelPickerSidebar.tsx
@@ -29,7 +29,7 @@ const SELECTED_INDICATOR_CLASS =
   "pointer-events-none absolute -right-1 top-1/2 z-10 h-5 w-0.75 -translate-y-1/2 rounded-l-full bg-primary";
 const BADGE_BASE_CLASS =
   "pointer-events-none absolute -right-0.5 top-0.5 z-10 flex size-3.5 items-center justify-center rounded-full bg-transparent shadow-sm ";
-const NEW_BADGE_CLASS = `${BADGE_BASE_CLASS} text-update `;
+const NEW_BADGE_CLASS = `${BADGE_BASE_CLASS} text-update-foreground `;
 
 /** Opens toward the rail so the list stays readable (not over the model names). */
 const PICKER_TOOLTIP_SIDE = "left" as const;

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -619,7 +619,7 @@ export function ProviderInstanceCard({
                           "size-5 rounded-sm p-0",
                           versionAdvisory.emphasis === "strong"
                             ? "text-warning hover:text-warning"
-                            : "text-update hover:text-update",
+                            : "text-update-foreground hover:text-update-foreground",
                         )}
                         aria-label="Update available — view details"
                       >

--- a/apps/web/src/components/settings/themeInspector.test.ts
+++ b/apps/web/src/components/settings/themeInspector.test.ts
@@ -31,6 +31,9 @@ describe("changedThemePaintKinds", () => {
 describe("themeRoleFromUtilityClass", () => {
   it("maps semantic utilities to their actual palette role", () => {
     expect(themeRoleFromUtilityClass("text-foreground", "foreground")).toBe("text");
+    expect(themeRoleFromUtilityClass("text-muted-foreground", "foreground")).toBe(
+      "mutedForeground",
+    );
     expect(themeRoleFromUtilityClass("bg-primary/90", "background")).toBe("messageAction");
     expect(themeRoleFromUtilityClass("ring-ring", "border")).toBe("focus");
   });

--- a/apps/web/src/components/settings/themeInspector.ts
+++ b/apps/web/src/components/settings/themeInspector.ts
@@ -38,7 +38,7 @@ const THEME_UTILITY_ROLES: Readonly<Partial<Record<string, ThemeColorRole>>> = {
   secondary: "secondary",
   "secondary-foreground": "secondaryForeground",
   muted: "muted",
-  "muted-foreground": "textMuted",
+  "muted-foreground": "mutedForeground",
   placeholder: "placeholder",
   "secondary-label": "secondaryLabel",
   "icon-muted": "iconMuted",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -899,7 +899,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --destructive: var(--error);
   --border: var(--color-zinc-200);
   --input: var(--color-zinc-300);
-  --ring: oklch(0.488 0.217 264);
+  --ring: var(--primary);
   --destructive-foreground: var(--error-foreground);
   --info: var(--color-blue-500);
   --info-foreground: var(--color-blue-700);
@@ -943,7 +943,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     --card-foreground: var(--color-neutral-100);
     --popover: color-mix(in srgb, var(--background) 94%, var(--color-white));
     --popover-foreground: var(--color-neutral-100);
-    --primary: oklch(0.588 0.217 264);
+    --primary: oklch(0.571 0.21 264);
     --primary-foreground: var(--color-white);
     --secondary: --alpha(var(--color-white) / 4%);
     --secondary-foreground: var(--color-neutral-100);
@@ -965,7 +965,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     --destructive: var(--error);
     --border: --alpha(var(--color-white) / 6%);
     --input: --alpha(var(--color-white) / 8%);
-    --ring: oklch(0.588 0.217 264);
+    --ring: var(--primary);
     --destructive-foreground: var(--error-foreground);
     --info: var(--color-blue-500);
     --info-foreground: var(--color-blue-400);
@@ -1076,7 +1076,7 @@ html.dark[data-theme-id] {
   --secondary: var(--app-theme-secondary);
   --secondary-foreground: var(--app-theme-secondary-foreground);
   --muted: var(--app-theme-muted);
-  --muted-foreground: var(--app-theme-text-muted);
+  --muted-foreground: var(--app-theme-muted-foreground);
   --placeholder: var(--app-theme-placeholder);
   --secondary-label: var(--app-theme-secondary-label);
   --icon-muted: var(--app-theme-icon-muted);
@@ -1326,7 +1326,7 @@ html[data-theme-id] [data-app-sidebar] {
   --accent: var(--app-theme-accent-surface);
   --accent-foreground: var(--app-theme-accent-surface-foreground);
   --muted: var(--app-theme-muted);
-  --muted-foreground: var(--app-theme-text-muted);
+  --muted-foreground: var(--app-theme-muted-foreground);
   --border: var(--app-theme-border);
   --input: var(--app-theme-input);
   --sidebar: var(--app-theme-sidebar);

--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -113,6 +113,8 @@ describe("theme files", () => {
       expect(contrastRatio(colors.text, colors.canvas)).toBeGreaterThanOrEqual(7);
       expect(contrastRatio(colors.textMuted, colors.canvas)).toBeGreaterThanOrEqual(4.5);
       expect(contrastRatio(colors.textMuted, colors.canvas)).toBeLessThan(5.5);
+      expect(contrastRatio(colors.mutedForeground, colors.muted)).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio(colors.placeholder, colors.surfaceRaised)).toBeGreaterThanOrEqual(4.5);
       expect(colors.secondaryLabel).toBe(colors.textMuted);
       expect(contrastRatio(colors.accentForeground, colors.accent)).toBeGreaterThanOrEqual(4.5);
       expect(
@@ -169,7 +171,7 @@ describe("theme files", () => {
       colors: {
         canvas: "#07152f",
         accent: "#67c2ff",
-        placeholder: "#8f8699",
+        placeholder: "#968d9f",
       },
     });
   });
@@ -315,9 +317,7 @@ describe("theme files", () => {
         4.5,
       );
       expect(contrastRatio(colors.sidebarForeground, colors.sidebar)).toBeGreaterThanOrEqual(4.5);
-      // The live light primary is intended for filled controls and clears the
-      // non-text UI-component threshold rather than normal-text AA.
-      expect(contrastRatio(colors.accentForeground, colors.accent)).toBeGreaterThanOrEqual(3);
+      expect(contrastRatio(colors.accentForeground, colors.accent)).toBeGreaterThanOrEqual(4.5);
     }
   });
 
@@ -340,9 +340,7 @@ describe("theme files", () => {
             1,
           );
         }
-        expect(contrastRatio(colors!.accentForeground, colors!.accent)).toBeGreaterThanOrEqual(
-          theme === T3_CHAT_THEME ? 3 : 4.5,
-        );
+        expect(contrastRatio(colors!.accentForeground, colors!.accent)).toBeGreaterThanOrEqual(4.5);
         expect(
           contrastRatio(colors!.toolbarControlForeground, colors!.toolbarControl),
         ).toBeGreaterThanOrEqual(4.5);
@@ -351,7 +349,14 @@ describe("theme files", () => {
         ).toBeGreaterThanOrEqual(4.5);
         expect(
           contrastRatio(colors!.messageActionForeground, colors!.messageAction),
-        ).toBeGreaterThanOrEqual(theme === T3_CHAT_THEME ? 3 : 4.5);
+        ).toBeGreaterThanOrEqual(4.5);
+        expect(
+          contrastRatio(colors!.messageActionForeground, colors!.messageActionHover),
+        ).toBeGreaterThanOrEqual(4.5);
+        expect(contrastRatio(colors!.mutedForeground, colors!.muted)).toBeGreaterThanOrEqual(4.5);
+        expect(contrastRatio(colors!.placeholder, colors!.surfaceRaised)).toBeGreaterThanOrEqual(
+          4.5,
+        );
       }
     }
   });

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -325,6 +325,7 @@ function legacyThemeMode(theme: ThemePreference): ThemeAppearance | null {
 // Measured from the live t3.chat default theme. Translucent chat surfaces are
 // flattened over --chat-background so this opaque palette reproduces the
 // pixels users see after T3 Chat's blur and noise layers are composited.
+// Foreground pairs deviate where necessary to keep normal text at WCAG AA.
 const T3_CHAT_LIGHT_COLORS: ThemeColors = {
   canvas: "#fdf7fd",
   // T3 Code's workspace header belongs to the chat panel, so keep it seamless
@@ -346,31 +347,31 @@ const T3_CHAT_LIGHT_COLORS: ThemeColors = {
   border: "#eee1ed",
   input: "#e7c1dc",
   focus: "#db2777",
-  accent: "#e33f86",
+  accent: "#db2777",
   accentForeground: "#ffffff",
   secondary: "#f1c4e6",
   secondaryForeground: "#77347c",
   muted: "#eaa7cb",
-  mutedForeground: "#ac1668",
-  placeholder: "#ad83b0",
+  mutedForeground: "#8d1255",
+  placeholder: "#8b5f90",
   secondaryLabel: "#ac1668",
   iconMuted: "#ac1668",
   error: "#f7086c",
   errorForeground: "#9d174d",
   errorSurface: "#fde4f1",
   warning: "#f59e0b",
-  warningForeground: "#b45309",
+  warningForeground: "#b05109",
   warningSurface: "#fcf0ea",
-  update: "#e33f86",
+  update: "#db2777",
   updateForeground: "#ac1668",
   updateSurface: "#fadfef",
   accentSurface: "#f3e6f5",
   accentSurfaceForeground: "#454554",
   messageSurface: "#f7def2",
   messageForeground: "#492c61",
-  messageAction: "#e33f86",
+  messageAction: "#db2777",
   messageActionForeground: "#ffffff",
-  messageActionHover: "#d56698",
+  messageActionHover: "#c12269",
   // T3 Chat uses a light lavender code surface in light mode. Keeping the
   // dark plum pair here also leaked the dark palette into T3 Code's diffs.
   codeBackground: "#f5ecf9",
@@ -422,7 +423,7 @@ const T3_CHAT_DARK_COLORS: ThemeColors = {
   secondaryForeground: "#d4c7e1",
   muted: "#423a45",
   mutedForeground: "#e7d0dd",
-  placeholder: "#8f8699",
+  placeholder: "#968d9f",
   secondaryLabel: "#e7d0dd",
   iconMuted: "#d4c7e1",
   error: "#9d174d",
@@ -549,8 +550,8 @@ const T3_CODE_DARK_THEME_COLORS: ThemeColors = {
   textMuted: "#818181",
   border: "#191919",
   input: "#1e1e1e",
-  focus: "#366ffb",
-  accent: "#366ffb",
+  focus: "#346bf1",
+  accent: "#346bf1",
   accentForeground: "#ffffff",
   secondary: "#141414",
   secondaryForeground: "#f5f5f5",
@@ -565,16 +566,16 @@ const T3_CODE_DARK_THEME_COLORS: ThemeColors = {
   warning: "#fe9a00",
   warningForeground: "#ffb900",
   warningSurface: "#312108",
-  update: "#366ffb",
+  update: "#346bf1",
   updateForeground: "#51a2ff",
-  updateSurface: "#121c35",
+  updateSurface: "#121b34",
   accentSurface: "#141414",
   accentSurfaceForeground: "#f5f5f5",
   messageSurface: "#141414",
   messageForeground: "#f5f5f5",
-  messageAction: "#366ffb",
+  messageAction: "#346bf1",
   messageActionForeground: "#ffffff",
-  messageActionHover: "#3265e3",
+  messageActionHover: "#3061d9",
   codeBackground: "#111111",
   codeForeground: "#f5f5f5",
   sidebar: "#000000",
@@ -941,12 +942,14 @@ export function createVividThemeColors(
   const sidebarRgb = themeOklchToRgb(sidebar);
   const surface = surfaceAt(0.015);
   const surfaceRaised = surfaceAt(0.05);
+  const surfaceRaisedRgb = themeOklchToRgb(surfaceRaised);
   const surfaceOverlay = surfaceAt(0.075);
   const border = surfaceAt(dark ? 0.16 : 0.12, Math.min(0.07, accent.C * 0.35));
   const input = surfaceAt(dark ? 0.21 : 0.16, Math.min(0.08, accent.C * 0.4));
   const secondary = surfaceAt(dark ? 0.1 : 0.06, Math.min(0.09, accent.C * 0.5));
   const secondaryRgb = themeOklchToRgb(secondary);
   const muted = surfaceAt(dark ? 0.06 : 0.04, Math.min(0.06, accent.C * 0.35));
+  const mutedRgb = themeOklchToRgb(muted);
   const accentSurface = surfaceAt(dark ? 0.13 : 0.08, Math.min(0.11, accent.C * 0.55));
   const accentSurfaceRgb = themeOklchToRgb(accentSurface);
   const messageSurface = surfaceAt(dark ? 0.16 : 0.1, Math.min(0.13, accent.C * 0.6));
@@ -958,6 +961,8 @@ export function createVividThemeColors(
     themeRgbToHexColor(
       themeOklchToRgb(solveOklchLightness(textBase, surfaceRgb, 4.6, dark ? "lighter" : "darker")),
     );
+  const mutedForeground = foregroundOn(mutedRgb);
+  const placeholder = foregroundOn(surfaceRaisedRgb);
 
   const actionHover: ThemeOklch = { ...action, L: action.L + (dark ? 0.06 : -0.06) };
 
@@ -986,8 +991,8 @@ export function createVividThemeColors(
     secondary: hex(secondary),
     secondaryForeground: foregroundOn(secondaryRgb),
     muted: hex(muted),
-    mutedForeground: themeRgbToHexColor(textMutedRgb),
-    placeholder: themeRgbToHexColor(textMutedRgb),
+    mutedForeground,
+    placeholder,
     secondaryLabel: themeRgbToHexColor(textMutedRgb),
     iconMuted: themeRgbToHexColor(textMutedRgb),
     update: themeRgbToHexColor(accentRgb),
@@ -1174,6 +1179,8 @@ export function createManagedThemeColors(
   const surfaceOverlay = mixThemeRgbColors(canvas, text, appearance === "dark" ? 0.18 : 0.06);
   const secondary = mixThemeRgbColors(canvas, accent, appearance === "dark" ? 0.2 : 0.08);
   const muted = mixThemeRgbColors(canvas, accent, appearance === "dark" ? 0.13 : 0.06);
+  const mutedForeground = readableThemeText(muted, text, 1, 4.6);
+  const placeholder = readableThemeText(surfaceRaised, text, 1, 4.6);
   const accentSurface = mixThemeRgbColors(canvas, accent, appearance === "dark" ? 0.3 : 0.14);
   const messageSurface = mixThemeRgbColors(canvas, accent, appearance === "dark" ? 0.36 : 0.18);
   const toolbarControl = mixThemeRgbColors(chrome, accent, appearance === "dark" ? 0.2 : 0.08);
@@ -1244,8 +1251,8 @@ export function createManagedThemeColors(
     secondary: themeRgbToHexColor(secondary),
     secondaryForeground: themeRgbToHexColor(readableThemeForeground(secondary)),
     muted: themeRgbToHexColor(muted),
-    mutedForeground: themeRgbToHexColor(textMuted),
-    placeholder: themeRgbToHexColor(textMuted),
+    mutedForeground: themeRgbToHexColor(mutedForeground),
+    placeholder: themeRgbToHexColor(placeholder),
     secondaryLabel: themeRgbToHexColor(textMuted),
     iconMuted: themeRgbToHexColor(textMuted),
     accentSurface: themeRgbToHexColor(accentSurface),


### PR DESCRIPTION
## What Changed

- Improve foreground and surface contrast across all built-in themes.
- Preserve each theme’s hue and character while adjusting lightness for readability.
- Solve muted text and placeholders against their actual surfaces, including custom vivid themes.
- Keep boot-time and runtime palette values synchronized.

## Why

Several built-in theme color pairs fell below the WCAG 2.2 AA requirement of 4.5:1 for normal text.

This raises the audited core palette result from 275/300 to 300/300 passing pairs while retaining the intended visual character of each theme.

## UI Changes

| Theme | Before | After |
|---|---|---|
| T3 Code Dark | <img width="360" height="116" alt="image" src="https://github.com/user-attachments/assets/ade34506-a21b-4f8a-aa29-00b6ee12e51b" /> | <img width="360" height="116" alt="image" src="https://github.com/user-attachments/assets/646c861c-8611-4c83-90ac-ba334705c3dc" /> |
| T3 Chat Light | <img width="360" height="116" alt="image" src="https://github.com/user-attachments/assets/87ebc076-316c-4abd-a5e5-3cfa98ec9524" /> | <img width="360" height="116" alt="image" src="https://github.com/user-attachments/assets/52eb6d6e-2171-4234-8f19-b9054a9fb0db" /> |
| Grove Dark | <img width="896" height="138" alt="image" src="https://github.com/user-attachments/assets/34f9f1e2-b3aa-40f1-9add-ac079a6ce668" /> | <img width="896" height="138" alt="image" src="https://github.com/user-attachments/assets/b7a97f77-ef90-4903-9bc1-3f412eb2417b" /> |
| Ocean Dark | <img width="896" height="138" alt="image" src="https://github.com/user-attachments/assets/905ca638-b541-4d9e-bdd1-cf944c9767e1" /> | <img width="896" height="138" alt="image" src="https://github.com/user-attachments/assets/7e4104ff-33d6-4118-bccd-5cd54b3db5b9" /> |
| Ember Dark | <img width="896" height="138" alt="image" src="https://github.com/user-attachments/assets/e0654873-88a5-479d-bb79-98aad5c2a377" /> | <img width="896" height="138" alt="image" src="https://github.com/user-attachments/assets/5b790538-0f58-47fd-886f-5c8c8b1cac93" /> |
| Iris Dark | <img width="896" height="138" alt="image" src="https://github.com/user-attachments/assets/5f8eaa14-706a-4d2a-8563-356d55c2fff8" /> | <img width="896" height="138" alt="image" src="https://github.com/user-attachments/assets/15077ed4-c2f4-4713-a1a4-ce12ab249552" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] ~~I included a video for animation/interaction changes~~

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only theme and token changes with no auth, data, or API impact; users may notice slightly different muted text and accent shades across built-in and custom vivid themes.
> 
> **Overview**
> **Raises built-in and generated theme palettes to WCAG AA (4.5:1) for normal text** while keeping each theme’s hue and character.
> 
> **Palette generation** now computes `mutedForeground` and `placeholder` for contrast on `muted` and `surfaceRaised`, instead of reusing `textMuted`. **Maintainer themes** (T3 Chat light, T3 Code dark, etc.) get tuned accent/action hex values and darker muted/placeholder pairs where needed.
> 
> **CSS and boot** wire `--muted-foreground` to `--app-theme-muted-foreground` in themed modes, set `--ring` to `--primary`, and sync T3 Chat light accent in `index.html` boot palettes.
> 
> **UI** uses `text-update-foreground` for “new” and update-advisory icons so glyphs stay readable on filled controls. **Theme inspector** maps `muted-foreground` utilities to the `mutedForeground` role.
> 
> **Tests** enforce 4.5:1 on muted/placeholder pairs, message-action hover, and accent pairs (no more 3:1 exception for T3 Chat light).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6687796ac2b560ba9a04eee087a70f00ca2aad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve contrast for muted foreground, placeholder, and accent colors in built-in themes
> - `createVividThemeColors` and `createManagedThemeColors` in [themePalette.ts](https://github.com/pingdotgg/t3code/pull/6000/files#diff-064fba647ceaa3b988839d538985299275f3a7ab7bd18e98ad03158fa06d31ad) now derive `mutedForeground` and `placeholder` via contrast-aware algorithms against their respective surfaces (`muted` and `surfaceRaised`), replacing the previous `textMuted` reuse.
> - Updates T3 Chat light palette token values for `accent`, `update`, `messageAction`, `mutedForeground`, `placeholder`, and `warningForeground`; T3 Code dark palette primary-related tokens are slightly adjusted.
> - `--muted-foreground` in [index.css](https://github.com/pingdotgg/t3code/pull/6000/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) now maps to `--app-theme-muted-foreground` instead of `--app-theme-text-muted` in themed dark mode and the sidebar.
> - Focus ring (`--ring`) now follows `var(--primary)` in both light and dark instead of a fixed `oklch` value.
> - `NEW_BADGE_CLASS` and the version advisory button in settings now use `text-update-foreground` instead of `text-update` for legibility.
> - Behavioral Change: generated vivid and managed theme palettes may produce different `mutedForeground`/`placeholder` colors compared to previous builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e668779.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->