### PR TITLE
feat(threads): pin a thread from the row quick actions

### DIFF
--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -28,7 +28,11 @@ import { ProjectFavicon } from "../../components/ProjectFavicon";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { relativeTime } from "../../lib/time";
 import { useThemeColor } from "../../lib/useThemeColor";
-import { ThreadSwipeable } from "../home/thread-swipe-actions";
+import {
+  deleteSwipeAction,
+  SWIPE_ACTION_LIFECYCLE_COLOR,
+  ThreadSwipeable,
+} from "../home/thread-swipe-actions";
 import {
   createNativeMailSearchToolbarItem,
   NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED,
@@ -421,18 +425,23 @@ function ArchivedThreadRow(props: {
         borderBottomRightRadius: props.isLast ? 20 : 0,
         overflow: "hidden",
       }}
+      actions={[
+        {
+          accessibilityLabel: `Unarchive ${props.thread.title}`,
+          backgroundColor: SWIPE_ACTION_LIFECYCLE_COLOR,
+          icon: "arrow.uturn.backward",
+          label: "Unarchive",
+          onPress: props.onUnarchive,
+        },
+        deleteSwipeAction({ onDelete: props.onDelete, threadTitle: props.thread.title }),
+      ]}
+      // Delete sits at the screen edge and is what a full swipe commits, as
+      // it did when the tray built that action implicitly.
+      fullSwipeIndex={1}
       fullSwipeWidth={windowWidth - 32}
-      onDelete={props.onDelete}
       onSwipeableClose={props.onSwipeableClose}
       onSwipeableWillOpen={props.onSwipeableWillOpen}
-      primaryAction={{
-        accessibilityLabel: `Unarchive ${props.thread.title}`,
-        icon: "arrow.uturn.backward",
-        label: "Unarchive",
-        onPress: props.onUnarchive,
-      }}
       simultaneousWithExternalGesture={props.simultaneousSwipeGesture}
-      threadTitle={props.thread.title}
     >
       {() => (
         <View

--- a/apps/mobile/src/features/home/thread-swipe-actions.tsx
+++ b/apps/mobile/src/features/home/thread-swipe-actions.tsx
@@ -33,15 +33,13 @@ import Animated, {
 } from "react-native-reanimated";
 
 import { AppText as Text } from "../../components/AppText";
+import { ACTION_ITEM_WIDTH, swipeActionEntryRange, swipeActionsWidth } from "./thread-swipe-layout";
 
-// Wide enough for the longest action label ("Unarchive").
-const ACTION_ITEM_WIDTH = 58;
 const ACTION_CIRCLE_SIZE = 36;
 const ACTION_ICON_SIZE = 15;
 const COMPACT_ACTION_CIRCLE_SIZE = 28;
 const COMPACT_ACTION_ICON_SIZE = 13;
 
-export const THREAD_SWIPE_ACTIONS_WIDTH = ACTION_ITEM_WIDTH * 2;
 export const THREAD_SWIPE_SPRING = {
   damping: 26,
   mass: 0.7,
@@ -49,8 +47,17 @@ export const THREAD_SWIPE_SPRING = {
   stiffness: 330,
 };
 
-interface ThreadSwipeAction {
+// One color per action kind, not per tray position: the tray is an ordered
+// list now, so a color tied to a slot would repaint an action just because a
+// neighbour appeared beside it.
+export const SWIPE_ACTION_LIFECYCLE_COLOR = "#007aff";
+export const SWIPE_ACTION_SNOOZE_COLOR = "#5856d6";
+export const SWIPE_ACTION_PIN_COLOR = "#ff9500";
+export const SWIPE_ACTION_DELETE_COLOR = "#ff2d55";
+
+export interface ThreadSwipeAction {
   readonly accessibilityLabel: string;
+  readonly backgroundColor: string;
   readonly icon: ComponentProps<typeof SymbolView>["name"];
   readonly label: string;
   readonly menu?: {
@@ -61,52 +68,18 @@ interface ThreadSwipeAction {
   readonly onPress: () => void;
 }
 
-interface ThreadSwipeSecondaryAction extends ThreadSwipeAction {
-  readonly backgroundColor: string;
-}
-
-function swipeActionsWidth(hasSecondaryAction: boolean) {
-  return hasSecondaryAction ? THREAD_SWIPE_ACTIONS_WIDTH : ACTION_ITEM_WIDTH;
-}
-
-/** `undefined` keeps the v1 Delete default; `null` means one action only. */
-function resolveSecondaryAction(input: {
-  readonly close: () => void;
+/** The Delete action every list used to get implicitly, now built explicitly
+ * so its label, color and accessibility text cannot drift between callers. */
+export function deleteSwipeAction(input: {
   readonly onDelete: () => void;
-  readonly secondaryAction: ThreadSwipeAction | null | undefined;
   readonly threadTitle: string;
-}): ThreadSwipeSecondaryAction | null {
-  if (input.secondaryAction === null) return null;
-  if (input.secondaryAction === undefined) {
-    return {
-      accessibilityLabel: `Delete ${input.threadTitle}`,
-      backgroundColor: "#ff2d55",
-      icon: "trash",
-      label: "Delete",
-      onPress: () => {
-        input.close();
-        input.onDelete();
-      },
-    };
-  }
-  const action = input.secondaryAction;
+}): ThreadSwipeAction {
   return {
-    ...action,
-    backgroundColor: "#5856d6",
-    menu:
-      action.menu === undefined
-        ? undefined
-        : {
-            ...action.menu,
-            onPressAction: (event) => {
-              input.close();
-              action.menu?.onPressAction(event);
-            },
-          },
-    onPress: () => {
-      input.close();
-      action.onPress();
-    },
+    accessibilityLabel: `Delete ${input.threadTitle}`,
+    backgroundColor: SWIPE_ACTION_DELETE_COLOR,
+    icon: "trash",
+    label: "Delete",
+    onPress: input.onDelete,
   };
 }
 
@@ -219,6 +192,9 @@ export function useSwipeableScrollGate(options?: {
 }
 
 export function ThreadSwipeable(props: {
+  /** Tray order, innermost slot first. The last entry sits at the screen edge
+   * and is the first one a shallow swipe reveals. */
+  readonly actions: ReadonlyArray<ThreadSwipeAction>;
   readonly backgroundColor: ColorValue;
   readonly children: (close: () => void) => ReactNode;
   /** Uses action visuals that fit inside compact 44pt rows. The press target
@@ -229,22 +205,14 @@ export function ThreadSwipeable(props: {
   readonly enabled?: boolean;
   readonly enableTrackpadSwipe?: boolean;
   /**
-   * What a full swipe commits. Omitted keeps the v1 Delete behavior only when
-   * the built-in Delete secondary action is in use; custom or absent
-   * secondary actions default to the advertised primary action.
+   * Which entry of `actions` a full swipe commits, and which one stretches to
+   * cover the tray as the swipe passes the threshold. Defaults to the
+   * innermost action.
    */
-  readonly fullSwipeAction?: "delete" | "primary";
+  readonly fullSwipeIndex?: number;
   readonly fullSwipeWidth: number;
-  readonly onDelete: () => void;
   readonly onSwipeableClose?: (methods: SwipeableMethods) => void;
   readonly onSwipeableWillOpen?: (methods: SwipeableMethods) => void;
-  readonly primaryAction: ThreadSwipeAction;
-  /**
-   * Omitted keeps the v1 destructive Delete action. Explicit null opts out of
-   * a secondary action entirely so a gated Snooze can never fall back to an
-   * unadvertised Delete.
-   */
-  readonly secondaryAction?: ThreadSwipeAction | null;
   /**
    * Identity of the content being wrapped. When a recycled list reuses this
    * component for a different item, the swipeable snaps back to closed so an
@@ -254,15 +222,14 @@ export function ThreadSwipeable(props: {
   readonly simultaneousWithExternalGesture?: ComponentProps<
     typeof ReanimatedSwipeable
   >["simultaneousWithExternalGesture"];
-  readonly threadTitle: string;
 }) {
   const swipeableRef = useRef<SwipeableMethods | null>(null);
   const fullSwipeArmedRef = useRef(false);
-  const hasSecondaryAction = props.secondaryAction !== null;
-  const actionsWidth = swipeActionsWidth(hasSecondaryAction);
+  const actionsWidth = swipeActionsWidth(props.actions.length);
   const fullSwipeThreshold = Math.max(actionsWidth + 44, props.fullSwipeWidth * 0.58);
-  const fullSwipeAction =
-    props.fullSwipeAction ?? (props.secondaryAction === undefined ? "delete" : "primary");
+  // Clamped, not trusted: an out-of-range index would arm a full swipe that
+  // commits nothing, which reads to the user as a dead gesture.
+  const fullSwipeIndex = Math.min(Math.max(props.fullSwipeIndex ?? 0, 0), props.actions.length - 1);
   const close = useCallback(() => swipeableRef.current?.close(), []);
   const gateEnabled = use(SwipeableScrollGateContext);
   const resetKey = props.resetKey;
@@ -316,35 +283,38 @@ export function ThreadSwipeable(props: {
         if (fullSwipeArmedRef.current) {
           fullSwipeArmedRef.current = false;
           methods.close();
-          if (fullSwipeAction === "primary") {
-            props.primaryAction.onPress();
-          } else {
-            props.onDelete();
-          }
+          props.actions[fullSwipeIndex]?.onPress();
         }
       }}
       overshootFriction={1}
       overshootRight
       renderRightActions={(_progress, translation, methods) => (
         <ThreadSwipeActions
-          backgroundColor={props.backgroundColor}
-          compact={props.compactActions === true}
-          fullSwipeAction={fullSwipeAction}
-          fullSwipeThreshold={fullSwipeThreshold}
-          onFullSwipeArmedChange={handleFullSwipeArmedChange}
-          primaryAction={{
-            ...props.primaryAction,
+          // Closing is the tray's job, not each caller's: every action closes
+          // the row before it runs, and a menu action closes before the menu
+          // handler fires.
+          actions={props.actions.map((action) => ({
+            ...action,
+            menu:
+              action.menu === undefined
+                ? undefined
+                : {
+                    ...action.menu,
+                    onPressAction: (event) => {
+                      methods.close();
+                      action.menu?.onPressAction(event);
+                    },
+                  },
             onPress: () => {
               methods.close();
-              props.primaryAction.onPress();
+              action.onPress();
             },
-          }}
-          secondaryAction={resolveSecondaryAction({
-            close: () => methods.close(),
-            onDelete: props.onDelete,
-            secondaryAction: props.secondaryAction,
-            threadTitle: props.threadTitle,
-          })}
+          }))}
+          backgroundColor={props.backgroundColor}
+          compact={props.compactActions === true}
+          fullSwipeIndex={fullSwipeIndex}
+          fullSwipeThreshold={fullSwipeThreshold}
+          onFullSwipeArmedChange={handleFullSwipeArmedChange}
           translation={translation}
         />
       )}
@@ -523,18 +493,15 @@ function SwipeActionButton(props: {
 }
 
 export function ThreadSwipeActions(props: {
+  readonly actions: ReadonlyArray<ThreadSwipeAction>;
   readonly backgroundColor: ColorValue;
   readonly compact: boolean;
-  readonly fullSwipeAction?: "delete" | "primary";
+  readonly fullSwipeIndex: number;
   readonly fullSwipeThreshold: number;
   readonly onFullSwipeArmedChange: (armed: boolean) => void;
-  readonly primaryAction: ThreadSwipeAction;
-  readonly secondaryAction: ThreadSwipeSecondaryAction | null;
   readonly translation: SharedValue<number>;
 }) {
-  const secondaryAction = props.secondaryAction;
-  const fullSwipeIsPrimary = props.fullSwipeAction === "primary" || secondaryAction === null;
-  const actionsWidth = swipeActionsWidth(secondaryAction !== null);
+  const actionsWidth = swipeActionsWidth(props.actions.length);
   useAnimatedReaction(
     () => -props.translation.value >= props.fullSwipeThreshold,
     (armed, previous) => {
@@ -554,39 +521,25 @@ export function ThreadSwipeActions(props: {
         width: actionsWidth,
       }}
     >
-      <SwipeActionButton
-        accessibilityLabel={props.primaryAction.accessibilityLabel}
-        actionsWidth={actionsWidth}
-        backgroundColor="#007aff"
-        compact={props.compact}
-        entryRange={
-          secondaryAction === null
-            ? [8, ACTION_ITEM_WIDTH * 0.72]
-            : [ACTION_ITEM_WIDTH * 0.55, THREAD_SWIPE_ACTIONS_WIDTH * 0.85]
-        }
-        fullSwipeThreshold={props.fullSwipeThreshold}
-        icon={props.primaryAction.icon}
-        label={props.primaryAction.label}
-        onPress={props.primaryAction.onPress}
-        stretchesOnFullSwipe={fullSwipeIsPrimary}
-        translation={props.translation}
-      />
-      {secondaryAction === null ? null : (
+      {props.actions.map((action, index) => (
         <SwipeActionButton
-          accessibilityLabel={secondaryAction.accessibilityLabel}
+          key={action.label}
+          accessibilityLabel={action.accessibilityLabel}
           actionsWidth={actionsWidth}
-          backgroundColor={secondaryAction.backgroundColor}
+          backgroundColor={action.backgroundColor}
           compact={props.compact}
-          entryRange={[8, ACTION_ITEM_WIDTH * 0.72]}
+          // Slot counts outward from the screen edge, so the outermost button
+          // is the one a shallow swipe reveals first.
+          entryRange={swipeActionEntryRange(props.actions.length - 1 - index)}
           fullSwipeThreshold={props.fullSwipeThreshold}
-          icon={secondaryAction.icon}
-          label={secondaryAction.label}
-          menu={secondaryAction.menu}
-          onPress={secondaryAction.onPress}
-          stretchesOnFullSwipe={!fullSwipeIsPrimary}
+          icon={action.icon}
+          label={action.label}
+          menu={action.menu}
+          onPress={action.onPress}
+          stretchesOnFullSwipe={index === props.fullSwipeIndex}
           translation={props.translation}
         />
-      )}
+      ))}
     </View>
   );
 }

--- a/apps/mobile/src/features/home/thread-swipe-layout.test.ts
+++ b/apps/mobile/src/features/home/thread-swipe-layout.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { ACTION_ITEM_WIDTH, swipeActionEntryRange, swipeActionsWidth } from "./thread-swipe-layout";
+
+describe("swipeActionsWidth", () => {
+  it("gives one slot per action", () => {
+    expect(swipeActionsWidth(1)).toBe(ACTION_ITEM_WIDTH);
+    expect(swipeActionsWidth(2)).toBe(ACTION_ITEM_WIDTH * 2);
+    expect(swipeActionsWidth(3)).toBe(ACTION_ITEM_WIDTH * 3);
+  });
+
+  it("never collapses to zero width", () => {
+    expect(swipeActionsWidth(0)).toBe(ACTION_ITEM_WIDTH);
+  });
+});
+
+describe("swipeActionEntryRange", () => {
+  // The tray used to hardcode one range per slot. Widening it to three actions
+  // must not move the lists that still pass one or two, so these assert the
+  // exact numbers the two-slot tray shipped with.
+  it("reproduces the outermost slot's original range", () => {
+    expect(swipeActionEntryRange(0)).toEqual([8, ACTION_ITEM_WIDTH * 0.72]);
+  });
+
+  it("reproduces the second slot's original range", () => {
+    expect(swipeActionEntryRange(1)).toEqual([
+      ACTION_ITEM_WIDTH * 0.55,
+      ACTION_ITEM_WIDTH * 2 * 0.85,
+    ]);
+  });
+
+  it("keeps entering later the further a slot sits from the edge", () => {
+    const [firstStart] = swipeActionEntryRange(0);
+    const [secondStart] = swipeActionEntryRange(1);
+    const [thirdStart] = swipeActionEntryRange(2);
+    expect(firstStart).toBeLessThan(secondStart);
+    expect(secondStart).toBeLessThan(thirdStart);
+  });
+
+  it("opens each slot before the swipe has revealed the whole tray", () => {
+    // A slot that only finished entering past its own tray width would still
+    // be animating when the row is fully open.
+    for (const slot of [0, 1, 2]) {
+      const [start] = swipeActionEntryRange(slot);
+      expect(start).toBeLessThan(swipeActionsWidth(slot + 1));
+    }
+  });
+});

--- a/apps/mobile/src/features/home/thread-swipe-layout.ts
+++ b/apps/mobile/src/features/home/thread-swipe-layout.ts
@@ -1,0 +1,23 @@
+/**
+ * Geometry for the row swipe tray, kept apart from the component so the
+ * numbers can be asserted without loading React Native.
+ */
+
+// Wide enough for the longest action label ("Unarchive").
+export const ACTION_ITEM_WIDTH = 58;
+
+export function swipeActionsWidth(actionCount: number) {
+  return ACTION_ITEM_WIDTH * Math.max(actionCount, 1);
+}
+
+/**
+ * Reveal stagger for one button, by slot counted OUTWARD from the screen edge:
+ * slot 0 is the outermost button and enters first. The two branches reproduce
+ * the exact numbers the tray shipped with when it held one or two actions, so
+ * widening it to three moves nothing on the lists that still pass two.
+ */
+export function swipeActionEntryRange(slot: number): readonly [number, number] {
+  return slot === 0
+    ? [8, ACTION_ITEM_WIDTH * 0.72]
+    : [ACTION_ITEM_WIDTH * 0.55 * slot, ACTION_ITEM_WIDTH * 0.85 * (slot + 1)];
+}

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -21,7 +21,11 @@ import { useThemeColor } from "../../lib/useThemeColor";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 import { useThreadPr, type ThreadPr } from "../../state/use-thread-pr";
 import type { HomeGroupDisplayAction } from "../home/homeListItems";
-import { ThreadSwipeable } from "../home/thread-swipe-actions";
+import {
+  deleteSwipeAction,
+  SWIPE_ACTION_LIFECYCLE_COLOR,
+  ThreadSwipeable,
+} from "../home/thread-swipe-actions";
 import { resolveThreadStatus } from "./threadPresentation";
 import { ThreadSearchMatchExcerpt } from "./thread-search-match";
 
@@ -471,14 +475,20 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
 
   const handleDelete = useCallback(() => onDeleteThread(thread), [onDeleteThread, thread]);
   const handleArchive = useCallback(() => onArchiveThread(thread), [onArchiveThread, thread]);
-  const primaryAction = useMemo(
-    () => ({
-      accessibilityLabel: `Archive ${thread.title}`,
-      icon: "archivebox" as const,
-      label: "Archive",
-      onPress: handleArchive,
-    }),
-    [handleArchive, thread.title],
+  // Archive innermost, Delete at the screen edge. A full swipe commits Delete,
+  // which is what the tray did when it built that action implicitly.
+  const swipeActionList = useMemo(
+    () => [
+      {
+        accessibilityLabel: `Archive ${thread.title}`,
+        backgroundColor: SWIPE_ACTION_LIFECYCLE_COLOR,
+        icon: "archivebox" as const,
+        label: "Archive",
+        onPress: handleArchive,
+      },
+      deleteSwipeAction({ onDelete: handleDelete, threadTitle: thread.title }),
+    ],
+    [handleArchive, handleDelete, thread.title],
   );
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
@@ -654,15 +664,14 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
       containerStyle={
         compact ? undefined : { borderRadius: SIDEBAR_ROW_RADIUS, overflow: "hidden" }
       }
+      actions={swipeActionList}
       enableTrackpadSwipe
+      fullSwipeIndex={1}
       fullSwipeWidth={props.fullSwipeWidth ?? windowWidth - 32}
-      onDelete={handleDelete}
       onSwipeableClose={props.onSwipeableClose}
       onSwipeableWillOpen={props.onSwipeableWillOpen}
-      primaryAction={primaryAction}
       resetKey={`${thread.environmentId}:${thread.id}`}
       simultaneousWithExternalGesture={props.simultaneousSwipeGesture}
-      threadTitle={thread.title}
     >
       {(close) => (
         // Messages-style row actions on long-press. iOS: a real

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -26,13 +26,20 @@ import { relativeTime } from "../../lib/time";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 import { useThreadPr } from "../../state/use-thread-pr";
-import { ThreadSwipeable } from "../home/thread-swipe-actions";
+import {
+  SWIPE_ACTION_LIFECYCLE_COLOR,
+  SWIPE_ACTION_PIN_COLOR,
+  SWIPE_ACTION_SNOOZE_COLOR,
+  ThreadSwipeable,
+  type ThreadSwipeAction,
+} from "../home/thread-swipe-actions";
 import {
   resolveThreadListV2SnoozeMenuSelection,
   resolveThreadListV2SnoozeGateExpiryMs,
   resolveThreadListV2Status,
   resolveThreadListV2SwipeActions,
   type ThreadListV2Status,
+  type ThreadListV2SwipeAction,
 } from "./threadListV2";
 import { ThreadSearchMatchExcerpt } from "./thread-search-match";
 
@@ -456,6 +463,8 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     snoozeSupported: props.snoozeSupported,
     snoozable: canSnooze(thread, { now: new Date().toISOString() }),
     snoozed: snoozedRow,
+    pinningSupported: props.pinningSupported === true,
+    pinned: pinnedRow,
   });
   const snoozePresets = useMemo(
     () => (swipeActions.secondary === "snooze" ? resolveSnoozePresets(new Date()) : ([] as const)),
@@ -560,68 +569,81 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       snoozePresets,
     ],
   );
-  const primaryAction = useMemo(() => {
-    // Pre-settlement server: archive is the swipe action, as in v1. (Slim
-    // rows cannot occur here — unsupported environments never classify as
-    // settled.)
-    if (swipeActions.primary === "archive") {
-      return {
+  // One id-to-button map for the whole tray. Pre-settlement servers land on
+  // "archive", as in v1. (Slim rows cannot occur there: unsupported
+  // environments never classify as settled.)
+  const swipeActionById = useMemo(
+    (): Record<ThreadListV2SwipeAction, ThreadSwipeAction> => ({
+      archive: {
         accessibilityLabel: `Archive ${thread.title}`,
-        icon: "archivebox" as const,
+        backgroundColor: SWIPE_ACTION_LIFECYCLE_COLOR,
+        icon: "archivebox",
         label: "Archive",
         onPress: handleArchive,
-      };
-    }
-    if (swipeActions.primary === "unsnooze") {
-      return {
+      },
+      settle: {
+        accessibilityLabel: `Settle ${thread.title}`,
+        backgroundColor: SWIPE_ACTION_LIFECYCLE_COLOR,
+        icon: "checkmark",
+        label: "Settle",
+        onPress: handleSettle,
+      },
+      unsettle: {
+        accessibilityLabel: `Un-settle ${thread.title}`,
+        backgroundColor: SWIPE_ACTION_LIFECYCLE_COLOR,
+        icon: "arrow.uturn.backward",
+        label: "Un-settle",
+        onPress: handleUnsettle,
+      },
+      unsnooze: {
         accessibilityLabel: `Wake ${thread.title} now`,
-        icon: "clock" as const,
+        backgroundColor: SWIPE_ACTION_LIFECYCLE_COLOR,
+        icon: "clock",
         label: "Wake",
         onPress: handleUnsnooze,
-      };
-    }
-    return swipeActions.primary === "unsettle"
-      ? {
-          accessibilityLabel: `Un-settle ${thread.title}`,
-          icon: "arrow.uturn.backward" as const,
-          label: "Un-settle",
-          onPress: handleUnsettle,
-        }
-      : {
-          accessibilityLabel: `Settle ${thread.title}`,
-          icon: "checkmark" as const,
-          label: "Settle",
-          onPress: handleSettle,
-        };
-  }, [
-    handleArchive,
-    handleSettle,
-    handleUnsettle,
-    handleUnsnooze,
-    swipeActions.primary,
-    thread.title,
-  ]);
-  const secondaryAction = useMemo(
-    () =>
-      swipeActions.secondary === "snooze"
-        ? {
-            accessibilityLabel: `Choose when to snooze ${thread.title}`,
-            icon: "clock" as const,
-            label: "Snooze",
-            menu: {
-              actions: snoozePresetActions,
-              onPressAction: handleMenuAction,
-              title: "Snooze until",
-            },
-            onPress: () => undefined,
-          }
-        : null,
-    [handleMenuAction, snoozePresetActions, swipeActions.secondary, thread.title],
+      },
+      snooze: {
+        accessibilityLabel: `Choose when to snooze ${thread.title}`,
+        backgroundColor: SWIPE_ACTION_SNOOZE_COLOR,
+        icon: "clock",
+        label: "Snooze",
+        // The button opens the preset menu, so pressing it directly does
+        // nothing: the menu's own handler carries every outcome.
+        menu: {
+          actions: snoozePresetActions,
+          onPressAction: handleMenuAction,
+          title: "Snooze until",
+        },
+        onPress: () => undefined,
+      },
+      pin: {
+        accessibilityLabel: `Pin ${thread.title}`,
+        backgroundColor: SWIPE_ACTION_PIN_COLOR,
+        icon: "pin",
+        label: "Pin",
+        onPress: handlePin,
+      },
+    }),
+    [
+      handleArchive,
+      handleMenuAction,
+      handlePin,
+      handleSettle,
+      handleUnsettle,
+      handleUnsnooze,
+      snoozePresetActions,
+      thread.title,
+    ],
   );
+  const swipeActionList = useMemo(
+    () => swipeActions.actions.map((id) => swipeActionById[id]),
+    [swipeActionById, swipeActions.actions],
+  );
+  const swipeActionLabels = swipeActionList.map((action) => action.label.toLowerCase());
   const swipeAccessibilityHint =
-    secondaryAction === null
-      ? `Opens the thread. Swipe left to ${primaryAction.label.toLowerCase()}.`
-      : `Opens the thread. Swipe left for ${primaryAction.label.toLowerCase()} and snooze actions.`;
+    swipeActionLabels.length === 1
+      ? `Opens the thread. Swipe left to ${swipeActionLabels[0]}.`
+      : `Opens the thread. Swipe left for ${swipeActionLabels.slice(0, -1).join(", ")} and ${swipeActionLabels.at(-1)} actions.`;
 
   // The sidebar pane fills selected rows with the accent color (matching the
   // v1 sidebar), so every piece of row text needs a white-on-accent variant.
@@ -872,19 +894,16 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         containerStyle={
           sidebarPane ? { borderRadius: SIDEBAR_V2_ROW_RADIUS, overflow: "hidden" } : undefined
         }
+        actions={swipeActionList}
         enableTrackpadSwipe
         // Full swipe commits the advertised lifecycle action (Settle /
-        // Un-settle), never the secondary snooze action.
-        fullSwipeAction="primary"
+        // Un-settle), never the pin or snooze action beside it.
+        fullSwipeIndex={swipeActions.fullSwipeIndex}
         fullSwipeWidth={props.fullSwipeWidth ?? windowWidth - 32}
-        onDelete={handleDelete}
         onSwipeableClose={props.onSwipeableClose}
         onSwipeableWillOpen={props.onSwipeableWillOpen}
-        primaryAction={primaryAction}
-        secondaryAction={secondaryAction}
         resetKey={`${thread.environmentId}:${thread.id}`}
         simultaneousWithExternalGesture={props.simultaneousSwipeGesture}
-        threadTitle={thread.title}
       >
         {(close) => (
           <ControlPillMenu

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -161,7 +161,7 @@ describe("resolveThreadListV2SwipeActions", () => {
         snoozeSupported: true,
         snoozable: true,
       }),
-    ).toEqual({ primary: "settle", secondary: "snooze" });
+    ).toEqual({ actions: ["settle", "snooze"], fullSwipeIndex: 0, secondary: "snooze" });
   });
 
   it("offers un-settle and snooze for settled history", () => {
@@ -172,7 +172,7 @@ describe("resolveThreadListV2SwipeActions", () => {
         snoozeSupported: true,
         snoozable: true,
       }),
-    ).toEqual({ primary: "unsettle", secondary: "snooze" });
+    ).toEqual({ actions: ["unsettle", "snooze"], fullSwipeIndex: 0, secondary: "snooze" });
   });
 
   it("omits snooze when the server or thread does not allow it", () => {
@@ -183,7 +183,7 @@ describe("resolveThreadListV2SwipeActions", () => {
         snoozeSupported: false,
         snoozable: true,
       }),
-    ).toEqual({ primary: "settle", secondary: null });
+    ).toEqual({ actions: ["settle"], fullSwipeIndex: 0, secondary: null });
     expect(
       resolveThreadListV2SwipeActions({
         variant: "card",
@@ -191,7 +191,7 @@ describe("resolveThreadListV2SwipeActions", () => {
         snoozeSupported: true,
         snoozable: false,
       }),
-    ).toEqual({ primary: "settle", secondary: null });
+    ).toEqual({ actions: ["settle"], fullSwipeIndex: 0, secondary: null });
   });
 
   it("falls back to archive only for a pre-lifecycle server", () => {
@@ -202,7 +202,7 @@ describe("resolveThreadListV2SwipeActions", () => {
         snoozeSupported: false,
         snoozable: true,
       }),
-    ).toEqual({ primary: "archive", secondary: null });
+    ).toEqual({ actions: ["archive"], fullSwipeIndex: 0, secondary: null });
   });
 
   it("offers wake and no snooze on a snoozed row", () => {
@@ -214,7 +214,70 @@ describe("resolveThreadListV2SwipeActions", () => {
         snoozable: true,
         snoozed: true,
       }),
-    ).toEqual({ primary: "unsnooze", secondary: null });
+    ).toEqual({ actions: ["unsnooze"], fullSwipeIndex: 0, secondary: null });
+  });
+
+  it("puts pin innermost so settle and snooze keep their slots", () => {
+    const resolved = resolveThreadListV2SwipeActions({
+      variant: "card",
+      settlementSupported: true,
+      snoozeSupported: true,
+      snoozable: true,
+      pinningSupported: true,
+    });
+    expect(resolved.actions).toEqual(["pin", "settle", "snooze"]);
+    // Snooze stays at the screen edge, settle one slot in. Only pin is new.
+    expect(resolved.actions.at(-1)).toBe("snooze");
+    // A full swipe still settles. It must never pin.
+    expect(resolved.fullSwipeIndex).toBe(1);
+    expect(resolved.actions[resolved.fullSwipeIndex]).toBe("settle");
+  });
+
+  it("drops pin on a row that is already pinned", () => {
+    expect(
+      resolveThreadListV2SwipeActions({
+        variant: "card",
+        settlementSupported: true,
+        snoozeSupported: true,
+        snoozable: true,
+        pinningSupported: true,
+        pinned: true,
+      }).actions,
+    ).toEqual(["settle", "snooze"]);
+  });
+
+  it("drops pin on slim rows and on servers without pinning", () => {
+    expect(
+      resolveThreadListV2SwipeActions({
+        variant: "slim",
+        settlementSupported: true,
+        snoozeSupported: true,
+        snoozable: true,
+        pinningSupported: true,
+      }).actions,
+    ).toEqual(["unsettle", "snooze"]);
+    expect(
+      resolveThreadListV2SwipeActions({
+        variant: "card",
+        settlementSupported: true,
+        snoozeSupported: true,
+        snoozable: true,
+        pinningSupported: false,
+      }).actions,
+    ).toEqual(["settle", "snooze"]);
+  });
+
+  it("keeps pin off a snoozed row even when the server allows pinning", () => {
+    expect(
+      resolveThreadListV2SwipeActions({
+        variant: "card",
+        settlementSupported: true,
+        snoozeSupported: true,
+        snoozable: true,
+        snoozed: true,
+        pinningSupported: true,
+      }).actions,
+    ).toEqual(["unsnooze"]);
   });
 });
 

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -25,7 +25,13 @@ export { snoozeWakeLabel };
  * unlabeled resting state.
  */
 export type ThreadListV2Status = "approval" | "input" | "working" | "failed" | "ready";
-export type ThreadListV2SwipeAction = "archive" | "settle" | "unsettle" | "snooze" | "unsnooze";
+export type ThreadListV2SwipeAction =
+  | "archive"
+  | "settle"
+  | "unsettle"
+  | "snooze"
+  | "unsnooze"
+  | "pin";
 
 export function resolveThreadListV2SnoozeMenuSelection(input: {
   readonly event: string;
@@ -58,22 +64,37 @@ export function resolveThreadListV2SwipeActions(input: {
   readonly snoozable: boolean;
   /** Row is on the snoozed shelf. */
   readonly snoozed?: boolean;
+  /** Environment's server understands thread.pin/unpin. */
+  readonly pinningSupported?: boolean;
+  /** Row is already in the pinned block. */
+  readonly pinned?: boolean;
 }): {
-  readonly primary: Exclude<ThreadListV2SwipeAction, "snooze">;
+  /** Tray order, innermost slot first. The last entry sits at the screen edge. */
+  readonly actions: ReadonlyArray<ThreadListV2SwipeAction>;
+  /** Index of the lifecycle action, which is what a full swipe commits. */
+  readonly fullSwipeIndex: number;
+  /** Whether the snooze preset menu is reachable from this row. */
   readonly secondary: "snooze" | null;
 } {
   if (input.snoozed === true) {
-    return { primary: "unsnooze", secondary: null };
+    return { actions: ["unsnooze"], fullSwipeIndex: 0, secondary: null };
   }
   const primary = input.settlementSupported
     ? input.variant === "slim"
       ? "unsettle"
       : "settle"
     : "archive";
-  return {
-    primary,
-    secondary: input.snoozeSupported && input.snoozable ? "snooze" : null,
-  };
+  const secondary = input.snoozeSupported && input.snoozable ? "snooze" : null;
+  // Pin rides the card only. Slim rows are settled or snoozed, and pinning one
+  // clears that state server-side, which is too big a jump for a swipe.
+  const canPin =
+    input.pinningSupported === true && input.variant === "card" && input.pinned !== true;
+  // Appending Pin on the INSIDE keeps Settle and Snooze at their existing
+  // distance from the screen edge, so neither learned gesture moves.
+  const actions: ThreadListV2SwipeAction[] = canPin ? ["pin"] : [];
+  actions.push(primary);
+  if (secondary !== null) actions.push(secondary);
+  return { actions, fullSwipeIndex: actions.indexOf(primary), secondary };
 }
 
 /**

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -692,6 +692,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   onUnsettle: (threadRef: ScopedThreadRef) => void;
   onSnooze: (threadRef: ScopedThreadRef, preset: SnoozePreset) => void;
   onUnsnooze: (threadRef: ScopedThreadRef) => void;
+  onPin: (threadRef: ScopedThreadRef) => void;
   onUnpin: (threadRef: ScopedThreadRef) => void;
   onAcknowledgeWoke: (threadRef: ScopedThreadRef, visitedAt: string) => void;
   onChangeRequestState: (threadKey: string, state: "open" | "closed" | "merged" | null) => void;
@@ -711,6 +712,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     onThreadClick,
     onUnsettle,
     onUnsnooze,
+    onPin,
     onUnpin,
     renamingTitle,
     thread,
@@ -967,6 +969,14 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     },
     [onUnsnooze, threadRef],
   );
+  const handlePinClick = useCallback(
+    (event: ReactMouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onPin(threadRef);
+    },
+    [onPin, threadRef],
+  );
   const handleUnpinClick = useCallback(
     (event: ReactMouseEvent) => {
       event.preventDefault();
@@ -988,6 +998,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // on blocked-on-you work or queued turns (the server rejects both).
   const showSnoozeButton =
     props.snoozeSupported && canSnooze(thread, { now: new Date().toISOString() });
+  // Pin is a quick action only where it would change something: an already
+  // pinned card carries its own unpin glyph beside the project label, so a
+  // second control there would be two ways to say the same thing.
+  const showPinButton = props.pinningSupported && !props.isPinned;
   // If the thread becomes blocked while the popover is open, the button
   // unmounts without firing onOpenChange(false). Deriving the flag keeps a
   // stale true from permanently hiding the status label / pinning the
@@ -1365,7 +1379,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     threadTimeLabel(thread)
                   )}
                 </span>
-                {props.settlementSupported || showSnoozeButton ? (
+                {props.settlementSupported || showSnoozeButton || showPinButton ? (
                   <span
                     className={cn(
                       // focus-visible, not focus-within: a mouse click leaves
@@ -1377,6 +1391,19 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                       snoozeMenuOpen && "pointer-events-auto static opacity-100",
                     )}
                   >
+                    {showPinButton ? (
+                      // Leftmost on purpose: Settle keeps the right edge it
+                      // has always had, and snooze keeps its slot beside it.
+                      <button
+                        type="button"
+                        aria-label="Pin thread"
+                        title="Pin thread"
+                        onClick={handlePinClick}
+                        className="inline-flex cursor-pointer items-center gap-0.5 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground"
+                      >
+                        <PinIcon className="size-3.5" />
+                      </button>
+                    ) : null}
                     {showSnoozeButton ? (
                       <SnoozePopoverButton
                         open={snoozeMenuOpen}
@@ -3501,6 +3528,7 @@ export default function Sidebar() {
                         onUnsettle={attemptUnsettle}
                         onSnooze={attemptSnooze}
                         onUnsnooze={attemptUnsnooze}
+                        onPin={attemptPin}
                         onUnpin={attemptUnpin}
                         onAcknowledgeWoke={acknowledgeWoke}
                         onChangeRequestState={handleChangeRequestState}


### PR DESCRIPTION
Pinning took a context menu on web and a long-press on mobile, while snooze sat one click away on both. This closes that gap on the row itself.

## Web

An icon-only pin button joins the card's hover cluster, leftmost, so the order reads pin, snooze, Settle. Settle keeps the right edge it has always had and snooze keeps its slot, so neither learned target moves.

It shows only on unpinned cards. A pinned card already carries its own unpin glyph beside the project label, so a second control there would be two ways to say one thing. Slim rows are untouched: the cluster lives in the card branch only.

The button reuses the sidebar's existing pin command, so it stays silent on success and toasts only on failure, exactly as the context menu entry does.

## Mobile

The swipe tray took a `primaryAction` / `secondaryAction` prop pair and a width constant fixed at two slots. It now takes an ordered `actions` list, so it can hold three buttons.

The inbox card's tray becomes Pin, Settle, Snooze. Pin is appended on the **inside**, so Settle and Snooze keep their existing distance from the screen edge and no learned gesture moves. A full swipe still commits the lifecycle action and never pins.

Pin rides the card only. Slim rows are settled or snoozed, and pinning one clears that state server-side, which is too big a jump for a swipe.

## Risk, and what bounds it

The tray is shared with the v1 thread list and the archive screen, neither of which gains an action here. The reveal stagger used to be two hardcoded ranges; it is now a formula over the slot index whose one and two action cases reproduce those exact numbers. `thread-swipe-layout.test.ts` pins them down, so a future change to the formula cannot silently shift the two lists that were not meant to move.

The layout maths moved into `thread-swipe-layout.ts` so it can be asserted without loading React Native.

## Verification

- `tsc --noEmit` clean in both apps
- `vp test run` in mobile: 102 files, 633 tests passing
- `vp test run --project unit` in web: 221 files, 2002 tests passing
- `vp lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared mobile swipe component and every list that uses it, but two-action geometry is regression-tested and pin/full-swipe behavior is explicitly gated so existing gestures should stay stable.
> 
> **Overview**
> **Pin** is exposed on the thread row without opening a menu: web sidebar cards get a leftmost pin icon in the hover cluster (only when pinning is supported and the thread is not already pinned), wired to the existing `attemptPin` flow. On mobile Thread List v2 **card** rows, swipe reveals **Pin · Settle · Snooze** when eligible—pin is inserted innermost so settle/snooze stay at the same distance from the screen edge and a full swipe still commits the lifecycle action, not pin.
> 
> **`ThreadSwipeable`** no longer takes `primaryAction`, `secondaryAction`, `onDelete`, or `threadTitle`. Callers pass an ordered **`actions`** array (each action carries its own **`backgroundColor`**) plus optional **`fullSwipeIndex`**. Delete is built via **`deleteSwipeAction`** so label/color/a11y stay consistent. Tray width and reveal stagger move to **`thread-swipe-layout.ts`**, with **`thread-swipe-layout.test.ts`** locking the one- and two-action geometry so archive and v1 lists do not shift when a third slot exists.
> 
> **`resolveThreadListV2SwipeActions`** now returns **`actions`** and **`fullSwipeIndex`** (and still **`secondary`** for snooze menu wiring); pinning rules are covered by new unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f21a3fe84e342e980af39d3424891294df7837f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pin quick action to thread row swipe tray and sidebar
> - Adds a Pin action to the swipe tray in V2 thread list rows when pinning is supported, the variant is 'card', and the thread is not already pinned; the pin action appears as the innermost (rightmost) swipe button.
> - Adds a 'Pin thread' quick-action button to sidebar thread rows in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/6001/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), visible only on supported servers for unpinned threads.
> - Redesigns the `ThreadSwipeable` API to accept an ordered `actions` array and a `fullSwipeIndex` instead of separate primary/secondary props, allowing an arbitrary number of swipe actions with consistent per-action background colors.
> - Extracts swipe tray geometry into a new [thread-swipe-layout.ts](https://github.com/pingdotgg/t3code/pull/6001/files#diff-2f0ac68b81ce1572411a4d9ed6f1ffba83952a3909ae0ab1c94e09e971ca71ea) module and standardizes action colors via new exports in [thread-swipe-actions.tsx](https://github.com/pingdotgg/t3code/pull/6001/files#diff-49d535c68199a21330fbd5e7c019f130a9b0b760aec90d7ea8a45cad38789eb9).
> - Behavioral Change: all existing swipe rows (archived, v1 list, v2 list) are migrated to the new `actions` array API; `onDelete`, `primaryAction`, `secondaryAction`, and `threadTitle` props are removed from `ThreadSwipeable`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f21a3fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->