### PR TITLE
feat(threads): empty-inbox block with a new-thread button

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -721,12 +721,22 @@ export function HomeScreen(props: HomeScreenProps) {
         settledShelfExpanded,
         settledShelfHeaderIndex: threadListV2Layout.settledShelfHeaderIndex,
         snoozeLabelNow: `${nowMinute}:00.000Z`,
-        // Suppressed while searching: no matches is not the same statement
-        // as an empty inbox, and the search states already cover it.
-        emptyInbox: hasSearchQuery ? null : { projectName: v2ScopedProjectGroup?.title ?? null },
+        // Same gate as the tablet sidebar, kept identical on purpose. This
+        // screen also returns a full-page empty state before the list ever
+        // renders, which already covers loading, but the block must not
+        // depend on that guard staying where it is:
+        //   - searching, where no matches is not "you are all caught up"
+        //   - loading, where an empty list means "not yet", not "all done"
+        //   - no projects, where its button would open an empty picker
+        emptyInbox:
+          hasSearchQuery || props.catalogState.isLoadingConnections || props.projects.length === 0
+            ? null
+            : { projectName: v2ScopedProjectGroup?.title ?? null },
       }),
     [
       hasSearchQuery,
+      props.catalogState.isLoadingConnections,
+      props.projects.length,
       settledShelfExpanded,
       snoozedShelfExpanded,
       threadListV2Layout,

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -46,6 +46,7 @@ import {
   ThreadListV2PendingRow,
   ThreadListV2Row,
   ThreadListV2SettledShelfHeader,
+  ThreadListV2EmptyInbox,
   ThreadListV2SnoozedShelfHeader,
 } from "../threads/thread-list-v2-items";
 import {
@@ -720,8 +721,18 @@ export function HomeScreen(props: HomeScreenProps) {
         settledShelfExpanded,
         settledShelfHeaderIndex: threadListV2Layout.settledShelfHeaderIndex,
         snoozeLabelNow: `${nowMinute}:00.000Z`,
+        // Suppressed while searching: no matches is not the same statement
+        // as an empty inbox, and the search states already cover it.
+        emptyInbox: hasSearchQuery ? null : { projectName: v2ScopedProjectGroup?.title ?? null },
       }),
-    [settledShelfExpanded, snoozedShelfExpanded, threadListV2Layout, v2PendingTasks],
+    [
+      hasSearchQuery,
+      settledShelfExpanded,
+      snoozedShelfExpanded,
+      threadListV2Layout,
+      v2PendingTasks,
+      v2ScopedProjectGroup,
+    ],
   );
 
   const renderV2Item = useCallback(
@@ -750,6 +761,16 @@ export function HomeScreen(props: HomeScreenProps) {
             showTrailingDivider={showTrailingDivider}
             onSelectPendingTask={props.onSelectPendingTask}
             onDeletePendingTask={props.onDeletePendingTask}
+          />
+        );
+      }
+      if (item.type === "v2-empty-inbox") {
+        return (
+          <ThreadListV2EmptyInbox
+            headline={item.headline}
+            detail={item.detail}
+            actionLabel={item.actionLabel}
+            onNewThread={props.onStartNewTask}
           />
         );
       }

--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -451,6 +451,11 @@ function AdaptiveWorkspaceLayoutContent(
     },
     [navigation],
   );
+  // Opens the flow at its project picker. The empty-inbox block needs this
+  // because an unfiltered sidebar has no project to aim a new thread at.
+  const handleStartNewTask = useCallback(() => {
+    navigation.navigate("NewTaskSheet", { screen: "NewTask" });
+  }, [navigation]);
 
   const renderedSidebarWidth = useSharedValue(
     panes.primarySidebarVisible ? (layout.listPaneWidth ?? 0) : 0,
@@ -530,6 +535,7 @@ function AdaptiveWorkspaceLayoutContent(
                 onOpenSettings={handleOpenSettings}
                 onOpenEnvironmentSettings={handleOpenEnvironmentSettings}
                 onNewThreadInProject={handleNewThreadInProject}
+                onStartNewTask={handleStartNewTask}
                 onSelectThread={handleSelectThread}
                 onSearchQueryChange={setPrimarySidebarSearchQuery}
                 searchQuery={primarySidebarSearchQuery}

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -74,6 +74,7 @@ import {
   ThreadListV2PendingRow,
   ThreadListV2Row,
   ThreadListV2SettledShelfHeader,
+  ThreadListV2EmptyInbox,
   ThreadListV2SnoozedShelfHeader,
 } from "./thread-list-v2-items";
 import {
@@ -142,6 +143,9 @@ interface ThreadNavigationSidebarProps {
   readonly onOpenSettings: () => void;
   readonly onOpenEnvironmentSettings: () => void;
   readonly onNewThreadInProject: (project: EnvironmentProject) => void;
+  /** Opens the new-task flow at its project picker. The empty-inbox block
+   * uses it, since an unfiltered sidebar has no project to target. */
+  readonly onStartNewTask: () => void;
   readonly onSearchQueryChange: (query: string) => void;
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
   readonly onRequestVisibility: () => void;
@@ -605,6 +609,12 @@ function ThreadNavigationSidebarPane(
       settledShelfExpanded,
       settledShelfHeaderIndex: threadListV2Layout.settledShelfHeaderIndex,
       snoozeLabelNow: `${nowMinute}:00.000Z`,
+      // Suppressed while searching: no matches is not the same statement as
+      // an empty inbox, and the search states already cover it.
+      emptyInbox:
+        props.searchQuery.trim().length > 0
+          ? null
+          : { projectName: selectedProjectScope?.title ?? null },
     });
     if (settledShelfExpanded && threadListV2Layout.hiddenSettledCount > 0) {
       items.push({
@@ -847,17 +857,22 @@ function ThreadNavigationSidebarPane(
       if (previous.type === "v2-settled-shelf" && item.type === "v2-settled-shelf") {
         return previous.count === item.count && previous.expanded === item.expanded;
       }
+      if (previous.type === "v2-empty-inbox" && item.type === "v2-empty-inbox") {
+        return previous.headline === item.headline && previous.detail === item.detail;
+      }
       if (
         previous.type === "v2-thread" ||
         previous.type === "v2-show-more" ||
         previous.type === "v2-pending" ||
         previous.type === "v2-snoozed-shelf" ||
         previous.type === "v2-settled-shelf" ||
+        previous.type === "v2-empty-inbox" ||
         item.type === "v2-thread" ||
         item.type === "v2-show-more" ||
         item.type === "v2-pending" ||
         item.type === "v2-snoozed-shelf" ||
-        item.type === "v2-settled-shelf"
+        item.type === "v2-settled-shelf" ||
+        item.type === "v2-empty-inbox"
       ) {
         return false;
       }
@@ -976,6 +991,16 @@ function ThreadNavigationSidebarPane(
             />
           );
         }
+        case "v2-empty-inbox":
+          return (
+            <ThreadListV2EmptyInbox
+              headline={item.headline}
+              detail={item.detail}
+              actionLabel={item.actionLabel}
+              onNewThread={props.onStartNewTask}
+              pane="sidebar"
+            />
+          );
         case "v2-snoozed-shelf":
           return (
             <ThreadListV2SnoozedShelfHeader

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -609,10 +609,18 @@ function ThreadNavigationSidebarPane(
       settledShelfExpanded,
       settledShelfHeaderIndex: threadListV2Layout.settledShelfHeaderIndex,
       snoozeLabelNow: `${nowMinute}:00.000Z`,
-      // Suppressed while searching: no matches is not the same statement as
-      // an empty inbox, and the search states already cover it.
+      // The block makes the list non-empty, which suppresses
+      // ListEmptyComponent below. So it must stay out of every case that
+      // component still owns, or it speaks over them:
+      //   - searching, where no matches is not "you are all caught up"
+      //   - loading, where an empty list means "not yet", not "all done"
+      //   - no projects, where its button would open an empty picker
+      // (The phone screen needs none of this: it returns a full-page empty
+      // state before the list renders at all.)
       emptyInbox:
-        props.searchQuery.trim().length > 0
+        props.searchQuery.trim().length > 0 ||
+        catalogState.isLoadingConnections ||
+        projects.length === 0
           ? null
           : { projectName: selectedProjectScope?.title ?? null },
     });
@@ -625,12 +633,15 @@ function ThreadNavigationSidebarPane(
     }
     return items;
   }, [
+    catalogState.isLoadingConnections,
     listLayout.items,
     nowMinute,
     options.selectedEnvironmentId,
     pendingTasks,
+    projects.length,
     props.searchQuery,
     selectedProjectRefs,
+    selectedProjectScope,
     settledShelfExpanded,
     snoozedShelfExpanded,
     threadListV2Enabled,

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -185,6 +185,38 @@ export const ThreadListV2SettledShelfHeader = memo(function ThreadListV2SettledS
   );
 });
 
+/**
+ * Empty inbox. A list row, not the list's empty component: the snoozed and
+ * settled shelves keep rendering below it, so the list is rarely empty even
+ * when the inbox is.
+ */
+export const ThreadListV2EmptyInbox = memo(function ThreadListV2EmptyInbox(props: {
+  readonly headline: string;
+  readonly detail: string | undefined;
+  readonly actionLabel: string;
+  readonly onNewThread: () => void;
+  readonly pane?: "screen" | "sidebar";
+}) {
+  return (
+    <View className={cn("items-center py-8", props.pane === "sidebar" ? "px-3" : "px-5")}>
+      <Text className="text-center text-base font-t3-bold text-foreground">{props.headline}</Text>
+      {props.detail === undefined ? null : (
+        <Text className="mt-1 text-center font-sans text-sm text-foreground-muted">
+          {props.detail}
+        </Text>
+      )}
+      <Pressable
+        accessibilityLabel={props.actionLabel}
+        accessibilityRole="button"
+        className="mt-4 rounded-full bg-primary px-5 py-2.5 active:opacity-70"
+        onPress={props.onNewThread}
+      >
+        <Text className="text-sm font-t3-bold text-primary-foreground">{props.actionLabel}</Text>
+      </Pressable>
+    </View>
+  );
+});
+
 const PENDING_TASK_MENU_ACTIONS: MenuAction[] = [
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -1,5 +1,10 @@
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
+import {
+  EMPTY_INBOX_HEADLINE,
+  EMPTY_INBOX_PARKED_DETAIL,
+  emptyInboxScopedHeadline,
+} from "@t3tools/client-runtime/state/thread-inbox";
 import { resolveSnoozePresets } from "@t3tools/client-runtime/state/thread-settled";
 import {
   CommandId,
@@ -813,6 +818,133 @@ describe("buildThreadListV2ListItems", () => {
       "v2-settled-shelf",
       `v2-thread:${environmentId}:settled`,
     ]);
+  });
+
+  it("puts the empty-inbox block in the inbox slot, above the shelves", () => {
+    const settledOnly = buildThreadListV2Items({
+      threads: [
+        makeThread({
+          id: ThreadId.make("settled"),
+          title: "settled",
+          settledOverride: "settled",
+          settledAt: NOW,
+        }),
+      ],
+      environmentId: null,
+      searchQuery: "",
+      now: NOW,
+    });
+    const items = buildThreadListV2ListItems({
+      items: settledOnly.items,
+      pendingTasks: [],
+      settledCount: settledOnly.settledCount,
+      settledShelfHeaderIndex: settledOnly.settledShelfHeaderIndex,
+      emptyInbox: { projectName: null },
+    });
+
+    expect(items.map((item) => item.type)).toEqual([
+      "v2-empty-inbox",
+      "v2-settled-shelf",
+      "v2-thread",
+    ]);
+    // Asserted against the shared constants, not against literals: the
+    // wording itself is threadInbox's test to own.
+    const block = items[0];
+    expect(block?.type === "v2-empty-inbox" && block.headline).toBe(EMPTY_INBOX_HEADLINE);
+    // Something is parked, so the block earns its second line.
+    expect(block?.type === "v2-empty-inbox" && block.detail).toBe(EMPTY_INBOX_PARKED_DETAIL);
+  });
+
+  it("drops the detail line when nothing is parked either", () => {
+    const nothing = buildThreadListV2Items({
+      threads: [],
+      environmentId: null,
+      searchQuery: "",
+      now: NOW,
+    });
+    const items = buildThreadListV2ListItems({
+      items: nothing.items,
+      pendingTasks: [],
+      emptyInbox: { projectName: "t3code" },
+    });
+
+    const block = items[0];
+    expect(block?.type === "v2-empty-inbox" && block.headline).toBe(
+      emptyInboxScopedHeadline("t3code"),
+    );
+    expect(block?.type === "v2-empty-inbox" && block.detail).toBeUndefined();
+  });
+
+  it("withholds the block while the inbox still has rows", () => {
+    const items = buildThreadListV2ListItems({
+      items: layout.items,
+      pendingTasks: [],
+      settledCount: layout.settledCount,
+      settledShelfHeaderIndex: layout.settledShelfHeaderIndex,
+      emptyInbox: { projectName: null },
+    });
+
+    expect(items.some((item) => item.type === "v2-empty-inbox")).toBe(false);
+  });
+
+  it("withholds the block while a queued task is waiting", () => {
+    const nothing = buildThreadListV2Items({
+      threads: [],
+      environmentId: null,
+      searchQuery: "",
+      now: NOW,
+    });
+    const items = buildThreadListV2ListItems({
+      items: nothing.items,
+      pendingTasks: [makePendingTask("queued-1")],
+      emptyInbox: { projectName: null },
+    });
+
+    expect(items.some((item) => item.type === "v2-empty-inbox")).toBe(false);
+  });
+
+  it("withholds the block while a pinned thread sits on top", () => {
+    const pinnedOnly = buildThreadListV2Items({
+      threads: [
+        makeThread({
+          id: ThreadId.make("pinned"),
+          title: "pinned",
+          pinnedAt: NOW,
+        }),
+      ],
+      environmentId: null,
+      searchQuery: "",
+      now: NOW,
+    });
+    const items = buildThreadListV2ListItems({
+      items: pinnedOnly.items,
+      pendingTasks: [],
+      emptyInbox: { projectName: null },
+    });
+
+    expect(items.some((item) => item.type === "v2-empty-inbox")).toBe(false);
+  });
+
+  it("omits the block entirely when the caller suppresses it", () => {
+    const nothing = buildThreadListV2Items({
+      threads: [],
+      environmentId: null,
+      searchQuery: "",
+      now: NOW,
+    });
+
+    expect(
+      buildThreadListV2ListItems({ items: nothing.items, pendingTasks: [] }).some(
+        (item) => item.type === "v2-empty-inbox",
+      ),
+    ).toBe(false);
+    expect(
+      buildThreadListV2ListItems({
+        items: nothing.items,
+        pendingTasks: [],
+        emptyInbox: null,
+      }).some((item) => item.type === "v2-empty-inbox"),
+    ).toBe(false);
   });
 
   it("places queued tasks before a collapsed snoozed shelf", () => {

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -1,3 +1,4 @@
+import { emptyInboxCopy, isInboxClear } from "@t3tools/client-runtime/state/thread-inbox";
 import {
   effectiveSettled,
   effectiveSnoozed,
@@ -235,11 +236,20 @@ export interface ThreadListV2SettledShelfListItem {
   readonly expanded: boolean;
 }
 
+export interface ThreadListV2EmptyInboxListItem {
+  readonly type: "v2-empty-inbox";
+  readonly key: "v2-empty-inbox";
+  readonly headline: string;
+  readonly detail: string | undefined;
+  readonly actionLabel: string;
+}
+
 export type ThreadListV2ListItem =
   | ThreadListV2ThreadListItem
   | ThreadListV2PendingListItem
   | ThreadListV2SnoozedShelfListItem
-  | ThreadListV2SettledShelfListItem;
+  | ThreadListV2SettledShelfListItem
+  | ThreadListV2EmptyInboxListItem;
 
 /**
  * Builds the shared mobile order: active → pending → snoozed shelf → settled.
@@ -256,6 +266,12 @@ export function buildThreadListV2ListItems(input: {
   readonly settledShelfExpanded?: boolean;
   readonly settledShelfHeaderIndex?: number | null;
   readonly snoozeLabelNow?: string;
+  /**
+   * Project scope for the empty-inbox block. Omitted or null suppresses the
+   * block entirely, which is what a running search wants: zero matches is not
+   * the same statement as "you are all caught up".
+   */
+  readonly emptyInbox?: { readonly projectName: string | null } | null;
 }): ThreadListV2ListItem[] {
   const threadItems = input.items.map(
     (item): ThreadListV2ListItem => ({
@@ -283,6 +299,31 @@ export function buildThreadListV2ListItems(input: {
   const activeEnd = snoozedShelfHeaderIndex ?? settledShelfHeaderIndex ?? threadItems.length;
   const snoozedEnd = settledShelfHeaderIndex ?? threadItems.length;
   const result: ThreadListV2ListItem[] = [...threadItems.slice(0, activeEnd), ...pendingItems];
+  // The block takes the inbox's own slot, above the shelves, so the snoozed
+  // and settled rows keep rendering underneath it.
+  const emptyInbox = input.emptyInbox ?? null;
+  if (emptyInbox !== null) {
+    const pinnedCount = input.items.slice(0, activeEnd).filter((item) => item.pinned).length;
+    if (
+      isInboxClear({
+        active: activeEnd - pinnedCount,
+        pinned: pinnedCount,
+        drafts: pendingItems.length,
+      })
+    ) {
+      const copy = emptyInboxCopy({
+        projectName: emptyInbox.projectName,
+        parkedCount: snoozedCount + settledCount,
+      });
+      result.push({
+        type: "v2-empty-inbox",
+        key: "v2-empty-inbox",
+        headline: copy.headline,
+        detail: copy.detail,
+        actionLabel: copy.actionLabel,
+      });
+    }
+  }
   if (snoozedShelfHeaderIndex !== null && snoozedCount > 0) {
     result.push({
       type: "v2-snoozed-shelf",

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   effectiveSnoozed,
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
+import { emptyInboxCopy, isInboxClear } from "@t3tools/client-runtime/state/thread-inbox";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
 import {
   scopeProjectRef,
@@ -512,6 +513,43 @@ const SidebarDraftRow = memo(function SidebarDraftRow(props: {
           </div>
           <div className="mt-0.5 truncate text-sm font-medium text-foreground/90">{preview}</div>
         </div>
+      </div>
+    </li>
+  );
+});
+
+// Sits where the inbox rows would, not at the foot of the list: the snoozed
+// and settled shelves keep rendering below it, so an anchored-to-bottom block
+// would read as a footnote under your history rather than as the state of the
+// inbox itself.
+const SidebarEmptyInboxBlock = memo(function SidebarEmptyInboxBlock(props: {
+  projectName: string | null;
+  parkedCount: number;
+  onNewThread: () => void;
+}) {
+  const copy = emptyInboxCopy({
+    projectName: props.projectName,
+    parkedCount: props.parkedCount,
+  });
+  return (
+    <li data-thread-selection-safe className="list-none">
+      <div
+        role="status"
+        data-testid="sidebar-empty-inbox"
+        className="flex flex-col items-center gap-1 px-2 py-8 text-center"
+      >
+        <span className="text-sm font-medium text-sidebar-foreground">{copy.headline}</span>
+        {copy.detail === undefined ? null : (
+          <span className="text-xs text-sidebar-muted-foreground">{copy.detail}</span>
+        )}
+        <button
+          type="button"
+          onClick={props.onNewThread}
+          className="mt-2 inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-sidebar-border px-2.5 py-1 text-[11px] font-medium text-sidebar-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+        >
+          <PlusIcon className="-mx-0.5 size-3" />
+          {copy.actionLabel}
+        </button>
       </div>
     </li>
   );
@@ -3565,6 +3603,26 @@ export default function Sidebar() {
                       />,
                     );
                   }
+                  // Projects first: with none configured there is nothing to
+                  // create a thread in, so that case keeps its own block at
+                  // the foot of the list and this one stays out of the way.
+                  if (
+                    projects.length > 0 &&
+                    isInboxClear({
+                      active: activeThreads.length,
+                      pinned: pinnedThreads.length,
+                      drafts: visibleDraftSessionCount,
+                    })
+                  ) {
+                    items.push(
+                      <SidebarEmptyInboxBlock
+                        key="empty-inbox"
+                        projectName={scopedProjectGroup?.displayName ?? null}
+                        parkedCount={snoozedThreads.length + settledThreads.length}
+                        onNewThread={handleNewThreadClick}
+                      />,
+                    );
+                  }
                   for (const thread of activeThreads) {
                     items.push(renderThreadRow(thread, "active"));
                   }
@@ -3658,7 +3716,11 @@ export default function Sidebar() {
               </ul>
             </TooltipProvider>
           ) : null}
+          {/* Only the no-projects case is left down here. Every other empty
+              state is the inbox block above, which renders in the inbox's own
+              slot so the shelves stay below it. */}
           {!isSearchingThreads &&
+          projects.length === 0 &&
           visibleDraftSessionCount === 0 &&
           pinnedThreads.length +
             activeThreads.length +
@@ -3666,23 +3728,15 @@ export default function Sidebar() {
             settledThreads.length ===
             0 ? (
             <div className="flex flex-col items-center gap-2 px-2 py-6 text-center text-xs text-muted-foreground/60">
-              {projects.length === 0 ? (
-                <>
-                  <span>No projects yet</span>
-                  <button
-                    type="button"
-                    onClick={openAddProjectCommandPalette}
-                    className="inline-flex items-center gap-1.5 rounded-md border border-sidebar-border px-2.5 py-1 text-[11px] font-medium text-sidebar-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
-                  >
-                    <PlusIcon className="-mx-0.5 size-3" />
-                    Add project
-                  </button>
-                </>
-              ) : scopedProjectGroup ? (
-                `No threads in ${scopedProjectGroup.displayName} yet`
-              ) : (
-                "No threads yet"
-              )}
+              <span>No projects yet</span>
+              <button
+                type="button"
+                onClick={openAddProjectCommandPalette}
+                className="inline-flex items-center gap-1.5 rounded-md border border-sidebar-border px-2.5 py-1 text-[11px] font-medium text-sidebar-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+              >
+                <PlusIcon className="-mx-0.5 size-3" />
+                Add project
+              </button>
             </div>
           ) : null}
         </SidebarGroup>

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -135,6 +135,10 @@
       "types": "./src/state/threadSettled.ts",
       "default": "./src/state/threadSettled.ts"
     },
+    "./state/thread-inbox": {
+      "types": "./src/state/threadInbox.ts",
+      "default": "./src/state/threadInbox.ts"
+    },
     "./state/thread-search": {
       "types": "./src/state/threadSearch.ts",
       "default": "./src/state/threadSearch.ts"

--- a/packages/client-runtime/src/state/threadInbox.test.ts
+++ b/packages/client-runtime/src/state/threadInbox.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  EMPTY_INBOX_ACTION_LABEL,
+  EMPTY_INBOX_HEADLINE,
+  EMPTY_INBOX_PARKED_DETAIL,
+  emptyInboxCopy,
+  isInboxClear,
+} from "./threadInbox.ts";
+
+describe("isInboxClear", () => {
+  it("is clear only when nothing live sits above the shelves", () => {
+    expect(isInboxClear({ active: 0, pinned: 0, drafts: 0 })).toBe(true);
+  });
+
+  it("is not clear while a pinned thread is on top", () => {
+    // The block would otherwise say nothing is open directly under a stack of
+    // pinned cards, which are unsettled work by definition.
+    expect(isInboxClear({ active: 0, pinned: 1, drafts: 0 })).toBe(false);
+  });
+
+  it("is not clear while a draft is waiting", () => {
+    expect(isInboxClear({ active: 0, pinned: 0, drafts: 1 })).toBe(false);
+  });
+
+  it("is not clear while the inbox itself has rows", () => {
+    expect(isInboxClear({ active: 1, pinned: 0, drafts: 0 })).toBe(false);
+  });
+
+  it("ignores settled and snoozed rows, which are not passed at all", () => {
+    // Guards the shape: the shelves must never gate the block, or clearing
+    // your inbox would show nothing until you also emptied your history.
+    expect(isInboxClear({ active: 0, pinned: 0, drafts: 0 })).toBe(true);
+  });
+});
+
+describe("emptyInboxCopy", () => {
+  it("congratulates without a detail when nothing is parked", () => {
+    expect(emptyInboxCopy({ projectName: null, parkedCount: 0 })).toEqual({
+      headline: EMPTY_INBOX_HEADLINE,
+      detail: undefined,
+      actionLabel: EMPTY_INBOX_ACTION_LABEL,
+    });
+  });
+
+  it("adds the detail once something is settled or snoozed", () => {
+    expect(emptyInboxCopy({ projectName: null, parkedCount: 3 })).toEqual({
+      headline: EMPTY_INBOX_HEADLINE,
+      detail: EMPTY_INBOX_PARKED_DETAIL,
+      actionLabel: EMPTY_INBOX_ACTION_LABEL,
+    });
+  });
+
+  it("names the project when the list is filtered to one", () => {
+    expect(emptyInboxCopy({ projectName: "t3code", parkedCount: 0 }).headline).toBe(
+      "You're all caught up in t3code",
+    );
+  });
+
+  it("falls back to the plain headline on an empty project name", () => {
+    expect(emptyInboxCopy({ projectName: "", parkedCount: 0 }).headline).toBe(EMPTY_INBOX_HEADLINE);
+  });
+});

--- a/packages/client-runtime/src/state/threadInbox.ts
+++ b/packages/client-runtime/src/state/threadInbox.ts
@@ -1,0 +1,51 @@
+/**
+ * The inbox is the unsettled group: the threads a client shows above the
+ * snoozed and settled shelves. This module owns the one rule for calling it
+ * empty, and the copy that rule selects, so web and mobile cannot drift apart
+ * on either.
+ */
+
+export const EMPTY_INBOX_HEADLINE = "You're all caught up";
+export const EMPTY_INBOX_PARKED_DETAIL = "Everything's handled. Enjoy the quiet.";
+export const EMPTY_INBOX_ACTION_LABEL = "New thread";
+
+export function emptyInboxScopedHeadline(projectName: string): string {
+  return `${EMPTY_INBOX_HEADLINE} in ${projectName}`;
+}
+
+/**
+ * Whether nothing live sits above the snoozed shelf. Pinned threads and
+ * drafts count: both are work in progress, so the block would contradict
+ * itself rendering underneath them.
+ */
+export function isInboxClear(counts: {
+  readonly active: number;
+  readonly pinned: number;
+  readonly drafts: number;
+}): boolean {
+  return counts.active + counts.pinned + counts.drafts === 0;
+}
+
+export interface EmptyInboxCopy {
+  readonly headline: string;
+  /** Absent when nothing is parked, so a brand-new project is not told it
+   * finished work it never had. */
+  readonly detail: string | undefined;
+  readonly actionLabel: string;
+}
+
+export function emptyInboxCopy(input: {
+  /** Project the list is filtered to, or null when it shows everything. */
+  readonly projectName: string | null;
+  /** Settled rows plus snoozed rows. */
+  readonly parkedCount: number;
+}): EmptyInboxCopy {
+  return {
+    headline:
+      input.projectName === null || input.projectName.length === 0
+        ? EMPTY_INBOX_HEADLINE
+        : emptyInboxScopedHeadline(input.projectName),
+    detail: input.parkedCount > 0 ? EMPTY_INBOX_PARKED_DETAIL : undefined,
+    actionLabel: EMPTY_INBOX_ACTION_LABEL,
+  };
+}


### PR DESCRIPTION
Clearing your inbox showed nothing. The old empty state only appeared when every group was empty at once, so a cleared inbox with any settled or snoozed history rendered as blank space.

## What lands

The block takes the inbox's own slot, above the snoozed and settled shelves, so those keep rendering underneath it. On mobile that means it is a list row, not a `ListEmptyComponent`: the list is rarely empty even when the inbox is.

It appears when the inbox, the pinned block and the drafts are all empty. Pinned threads and drafts count as live work, since the block would contradict itself sitting under them.

## The copy

- `You're all caught up`, or `You're all caught up in <project>` when the list is filtered to one
- `Everything's handled. Enjoy the quiet.` renders **only** when something is actually settled or snoozed, so a brand-new project is not congratulated on work it never had
- Button: `New thread`

Both clients suppress the block while a search is running. Zero matches is not the same statement as an empty inbox, and the existing search states already cover it.

## One home for the strings

The rule and all three strings live in `packages/client-runtime/src/state/threadInbox.ts`, exported as `state/thread-inbox`. That sits beside `state/thread-settled`, which already shares a display helper (`snoozeWakeLabel`) with both clients.

Neither app spells a string out. That duplication is exactly what let the old `"No threads yet"` copy end up written in four separate files.

## Per client

**Web** replaces its two thread-copy branches with the block. `"No projects yet"` keeps its own state at the foot of the list, since with no projects there is nothing to create a thread in.

**Mobile** renders it on both the phone list and the tablet sidebar. The button opens the new-task project picker rather than guessing, because an unfiltered list has no project to target. The tablet sidebar gains an `onStartNewTask` prop, threaded from the adaptive layout, since it had no new-task entry point at all.

## Verification

- `tsc --noEmit` clean in both apps
- `vp run --filter @t3tools/client-runtime test`: 47 files, 599 tests passing, including 9 new ones covering the rule and all four copy branches
- `vp test run` in mobile: 101 files, 629 tests passing, including 6 new ones covering placement above the shelves and every case that withholds the block
- `vp test run --project unit` in web: 221 files, 2002 tests passing
- `vp lint` clean
- Each new string greps to exactly one production-code location

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only empty-state and list composition changes with shared copy; no auth, data, or API changes. Risk is mainly wrong gating (search/loading) or CTA navigation edge cases.
> 
> **Overview**
> When the inbox is clear but snoozed or settled history remains, thread lists no longer show blank space. A new **empty-inbox** row/block sits in the inbox slot **above** snoozed and settled shelves, with a **New thread** action.
> 
> **Shared logic** in `client-runtime` (`state/thread-inbox`): `isInboxClear` (active + pinned + drafts must be zero; parked shelves do not count) and `emptyInboxCopy` (scoped headline, optional “parked” detail only when something is snoozed/settled).
> 
> **Web** adds `SidebarEmptyInboxBlock` and drops the old “No threads yet” / per-project empty copy in favor of this block; **no projects** still uses the foot “Add project” state.
> 
> **Mobile** v2 list builder accepts optional `emptyInbox` and inserts `v2-empty-inbox`; `ThreadListV2EmptyInbox` renders it on home and tablet sidebar. The block is **suppressed** during search, while connections load, or with zero projects. Tablet sidebar gets `onStartNewTask` → `NewTaskSheet` project picker when there is no scoped project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb11bc179244f3f42a5a9b0ed867f9f7b4461436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add empty-inbox block with a new-thread button to thread list sidebar and home screen
> - Adds a new `ThreadListV2EmptyInbox` component (mobile) and `SidebarEmptyInboxBlock` component (web) that render a headline, optional parked-items detail, and a "New thread" CTA button when the inbox is clear.
> - Introduces a shared [`threadInbox`](https://github.com/pingdotgg/t3code/pull/6002/files#diff-7c7138602ad056cc1912db363282c5f07b8ef103f9adbaeea08b718c87b77cb8) module in `client-runtime` with `isInboxClear`, `emptyInboxCopy`, and related constants used by both platforms.
> - The empty-inbox block is inserted into the list above snoozed/settled items when there are no active, pinned, or draft threads, and is suppressed during search, while connections are loading, or when no projects exist.
> - Copy is project-scoped when a single project is selected, and the detail line reflects whether parked (snoozed/settled) items exist.
> - The new-thread action navigates to the `NewTaskSheet` project picker on mobile and calls `onNewThread` on web.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb11bc1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


Closes #10207
