### PR TITLE
fix(mobile): reserve the bottom safe area on Android surfaces

### DIFF
--- a/apps/mobile/src/components/AndroidAnchoredMenu.tsx
+++ b/apps/mobile/src/components/AndroidAnchoredMenu.tsx
@@ -6,6 +6,7 @@ import type { StyleProp, ViewStyle } from "react-native";
 import { BackHandler, Pressable, ScrollView, View } from "react-native";
 import { useKeyboardState } from "react-native-keyboard-controller";
 import Animated, { FadeIn } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { appBlurTargetRef } from "../lib/appBlurTarget";
 import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
@@ -81,6 +82,7 @@ export function AndroidAnchoredMenu(props: AndroidAnchoredMenuProps) {
 
   const { themeAppearance } = useAppearancePreferences();
   const isDarkMode = themeAppearance === "dark";
+  const insets = useSafeAreaInsets();
   const keyboardVisible = useKeyboardState((state) => state.isVisible);
   const keyboardHeight = useKeyboardState((state) => state.height);
   const close = useCallback(() => {
@@ -158,9 +160,13 @@ export function AndroidAnchoredMenu(props: AndroidAnchoredMenuProps) {
         );
   // The keyboard stays up while the menu is open (in-window overlay, no
   // focus change), so the space it covers is not usable — without this the
-  // composer-pill menus "open down" into the IME and can't be tapped.
+  // composer-pill menus "open down" into the IME and can't be tapped. The
+  // portal host spans the whole window, so the gesture bar is unusable too;
+  // the keyboard already covers it when up, hence the max rather than a sum.
   const usableBottom =
-    overlay === null ? 0 : overlay.height - (keyboardVisible ? keyboardHeight : 0);
+    overlay === null
+      ? 0
+      : overlay.height - Math.max(keyboardVisible ? keyboardHeight : 0, insets.bottom);
   const spaceBelow =
     local === null || overlay === null
       ? 0

--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -651,9 +651,11 @@ export function ArchivedThreadsScreen(props: {
         <LegendList
           className="flex-1"
           contentContainerStyle={{
-            // contentInsetAdjustmentBehavior only pads the safe area on iOS,
-            // so Android needs the bottom inset spelled out.
-            paddingBottom: Math.max(insets.bottom, 16) + 16,
+            // iOS is left alone: contentInsetAdjustmentBehavior="automatic"
+            // already adds the safe area to the content inset, and adding it
+            // here again would leave a dead strip below the last thread.
+            // Android ignores that prop, so it needs the inset spelled out.
+            paddingBottom: Platform.OS === "android" ? Math.max(insets.bottom, 16) + 16 : 32,
             paddingHorizontal: 16,
             paddingTop: 4,
           }}

--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -525,6 +525,7 @@ export function ArchivedThreadsScreen(props: {
   readonly onUnarchiveThread: (thread: EnvironmentThreadShell) => void;
 }) {
   const { onDeleteThread, onUnarchiveThread } = props;
+  const insets = useSafeAreaInsets();
   const openSwipeableRef = useRef<SwipeableMethods | null>(null);
   const archiveScrollGesture = useMemo(() => Gesture.Native(), []);
   const environmentLabelsById = useMemo(
@@ -650,7 +651,9 @@ export function ArchivedThreadsScreen(props: {
         <LegendList
           className="flex-1"
           contentContainerStyle={{
-            paddingBottom: 32,
+            // contentInsetAdjustmentBehavior only pads the safe area on iOS,
+            // so Android needs the bottom inset spelled out.
+            paddingBottom: Math.max(insets.bottom, 16) + 16,
             paddingHorizontal: 16,
             paddingTop: 4,
           }}

--- a/apps/mobile/src/features/files/FileTreeBrowser.tsx
+++ b/apps/mobile/src/features/files/FileTreeBrowser.tsx
@@ -252,7 +252,7 @@ export function FileTreeBrowser(props: {
       maxToRenderPerBatch={FILE_TREE_RENDER_BATCH_SIZE}
       updateCellsBatchingPeriod={16}
       windowSize={5}
-      contentContainerStyle={{ paddingTop: 8, paddingBottom: 8 }}
+      contentContainerStyle={{ paddingTop: 8, paddingBottom: Math.max(insets.bottom, 8) + 8 }}
       refreshControl={<RefreshControl refreshing={props.isPending} onRefresh={props.onRefresh} />}
       renderItem={renderItem}
       ListEmptyComponent={

--- a/apps/mobile/src/features/files/FileTreeBrowser.tsx
+++ b/apps/mobile/src/features/files/FileTreeBrowser.tsx
@@ -1,14 +1,7 @@
 import type { ProjectEntry } from "@t3tools/contracts";
 import { SymbolView } from "../../components/AppSymbol";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  ActivityIndicator,
-  FlatList,
-  Platform,
-  Pressable,
-  RefreshControl,
-  View,
-} from "react-native";
+import { ActivityIndicator, FlatList, Pressable, RefreshControl, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AppText as Text } from "../../components/AppText";
@@ -261,10 +254,10 @@ export function FileTreeBrowser(props: {
       windowSize={5}
       contentContainerStyle={{
         paddingTop: 8,
-        // On iOS the list runs under a native header with automatic content
-        // insets, which already reserve the bottom safe area; Android gets
-        // nothing from that prop and needs the inset here.
-        paddingBottom: Platform.OS === "android" ? Math.max(insets.bottom, 8) + 8 : 8,
+        // With automatic content insets iOS already reserves the bottom safe
+        // area; Android and pre-glass iOS (`"never"` above) get nothing from
+        // that prop and need the inset here.
+        paddingBottom: NATIVE_LIQUID_GLASS_SUPPORTED ? 8 : Math.max(insets.bottom, 8) + 8,
       }}
       refreshControl={<RefreshControl refreshing={props.isPending} onRefresh={props.onRefresh} />}
       renderItem={renderItem}

--- a/apps/mobile/src/features/files/FileTreeBrowser.tsx
+++ b/apps/mobile/src/features/files/FileTreeBrowser.tsx
@@ -1,7 +1,14 @@
 import type { ProjectEntry } from "@t3tools/contracts";
 import { SymbolView } from "../../components/AppSymbol";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ActivityIndicator, FlatList, Pressable, RefreshControl, View } from "react-native";
+import {
+  ActivityIndicator,
+  FlatList,
+  Platform,
+  Pressable,
+  RefreshControl,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AppText as Text } from "../../components/AppText";
@@ -252,7 +259,13 @@ export function FileTreeBrowser(props: {
       maxToRenderPerBatch={FILE_TREE_RENDER_BATCH_SIZE}
       updateCellsBatchingPeriod={16}
       windowSize={5}
-      contentContainerStyle={{ paddingTop: 8, paddingBottom: Math.max(insets.bottom, 8) + 8 }}
+      contentContainerStyle={{
+        paddingTop: 8,
+        // On iOS the list runs under a native header with automatic content
+        // insets, which already reserve the bottom safe area; Android gets
+        // nothing from that prop and needs the inset here.
+        paddingBottom: Platform.OS === "android" ? Math.max(insets.bottom, 8) + 8 : 8,
+      }}
       refreshControl={<RefreshControl refreshing={props.isPending} onRefresh={props.onRefresh} />}
       renderItem={renderItem}
       ListEmptyComponent={

--- a/apps/mobile/src/features/review/ReviewSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewSheet.tsx
@@ -277,7 +277,9 @@ function ReviewFileNavigator({
       keyExtractor={(file) => file.id}
       contentContainerStyle={{
         paddingHorizontal: 8,
-        paddingBottom: 8,
+        // iOS hosts this list in a native Screen whose content insets already
+        // cover the home indicator; Android needs the gesture bar reserved.
+        paddingBottom: Platform.OS === "android" ? Math.max(insets.bottom, 8) + 8 : 8,
         // The nested native header is translucent; start the list below it so
         // the scroll-edge effect can sample the content (same treatment as
         // FileTreeBrowser in the Files pane).

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -14,6 +14,7 @@ import {
   KeyboardStickyView,
   useKeyboardState,
 } from "react-native-keyboard-controller";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AndroidHeaderIconButton, AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import {
@@ -507,9 +508,13 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     height: state.height,
     isVisible: state.isVisible,
   }));
+  const insets = useSafeAreaInsets();
   const isAccessoryVisible = keyboardState.isVisible && !isAccessoryDismissed;
+  // With the keyboard up its height already clears the gesture bar and the
+  // home indicator; with it down the terminal owns the bottom edge, so the
+  // last rows need the safe area or they scroll under the system chrome.
   const terminalBottomInset =
-    (keyboardState.isVisible ? keyboardState.height : 0) +
+    (keyboardState.isVisible ? keyboardState.height : insets.bottom) +
     (isAccessoryVisible ? TERMINAL_ACCESSORY_HEIGHT : 0);
 
   useEffect(() => {
@@ -1331,7 +1336,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
                 accessibilityRole="button"
                 onPress={handleShowKeyboard}
                 style={({ pressed }) => ({
-                  bottom: 16,
+                  bottom: Math.max(insets.bottom, 16) + 16,
                   borderRadius: 28,
                   opacity: pressed ? 0.72 : 1,
                   position: "absolute",

--- a/oxlint-plugin-t3code/index.ts
+++ b/oxlint-plugin-t3code/index.ts
@@ -6,6 +6,7 @@ import noInlineSchemaCompile from "./rules/no-inline-schema-compile.ts";
 import noManualEffectRuntimeInTests from "./rules/no-manual-effect-runtime-in-tests.ts";
 import noMobileUniwindThemeEscapeHatches from "./rules/no-mobile-uniwind-theme-escape-hatches.ts";
 import noNativeTitleTooltip from "./rules/no-native-title-tooltip.ts";
+import requireBottomSafeAreaInset from "./rules/require-bottom-safe-area-inset.ts";
 
 export default definePlugin({
   meta: {
@@ -18,5 +19,6 @@ export default definePlugin({
     "no-manual-effect-runtime-in-tests": noManualEffectRuntimeInTests,
     "no-mobile-uniwind-theme-escape-hatches": noMobileUniwindThemeEscapeHatches,
     "no-native-title-tooltip": noNativeTitleTooltip,
+    "require-bottom-safe-area-inset": requireBottomSafeAreaInset,
   },
 });

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
@@ -66,6 +66,72 @@ describe("t3code/require-bottom-safe-area-inset", () => {
     `,
   );
 
+  rule.valid(
+    "allows a nested callback that closes over its component's inset",
+    `
+      import { FlatList, View } from "react-native";
+      import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+      export function FileList() {
+        const insets = useSafeAreaInsets();
+        return (
+          <FlatList
+            data={[]}
+            renderItem={() => <View style={{ position: "absolute", bottom: insets.bottom + 8 }} />}
+            contentContainerStyle={{ paddingBottom: insets.bottom }}
+          />
+        );
+      }
+    `,
+  );
+
+  rule.invalid(
+    "reports a component that ignores the inset even when a sibling component reads it",
+    `
+      import { Pressable, View } from "react-native";
+      import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+      function Header() {
+        const insets = useSafeAreaInsets();
+        return <View style={{ paddingBottom: insets.bottom }} />;
+      }
+
+      export function Screen() {
+        return (
+          <View>
+            <Header />
+            <Pressable style={{ position: "absolute", bottom: 16, right: 16 }} />
+          </View>
+        );
+      }
+    `,
+    (output) => {
+      assert.match(output, /safe-area inset/);
+    },
+  );
+
+  rule.invalid(
+    "reports a fixed bottom padding inside a style array",
+    `
+      import { FlatList, StyleSheet } from "react-native";
+
+      const styles = StyleSheet.create({ base: { paddingTop: 8 } });
+
+      export function FileList() {
+        return (
+          <FlatList
+            data={[]}
+            renderItem={() => null}
+            contentContainerStyle={[styles.base, { paddingBottom: 8 }]}
+          />
+        );
+      }
+    `,
+    (output) => {
+      assert.match(output, /safe-area inset/);
+    },
+  );
+
   rule.invalid(
     "reports a floating button pinned with a fixed bottom offset",
     `

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
@@ -1,0 +1,102 @@
+import { assert, describe } from "@effect/vitest";
+
+import { createOxlintRuleHarness } from "../test/utils.ts";
+
+const rule = createOxlintRuleHarness("t3code/require-bottom-safe-area-inset", {
+  filename: "fixture.tsx",
+});
+
+describe("t3code/require-bottom-safe-area-inset", () => {
+  rule.valid(
+    "allows bottom offsets outside React Native files",
+    `
+      export const style = { position: "absolute", bottom: 16, right: 16 };
+    `,
+  );
+
+  rule.valid(
+    "allows a floating button that reserves the safe-area inset",
+    `
+      import { Pressable } from "react-native";
+      import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+      export function ShowKeyboardButton() {
+        const insets = useSafeAreaInsets();
+        return (
+          <Pressable
+            style={{ position: "absolute", bottom: Math.max(insets.bottom, 16) + 16, right: 16 }}
+          />
+        );
+      }
+    `,
+  );
+
+  rule.valid(
+    "allows an edge-attached overlay whose child owns the padding",
+    `
+      import { View } from "react-native";
+      import { KeyboardStickyView } from "react-native-keyboard-controller";
+
+      export function ComposerOverlay(props: { readonly bottomInset: number }) {
+        return (
+          <KeyboardStickyView style={{ position: "absolute", bottom: 0, left: 0, right: 0 }}>
+            <View style={{ paddingBottom: props.bottomInset }} />
+          </KeyboardStickyView>
+        );
+      }
+    `,
+  );
+
+  rule.valid(
+    "allows list padding that is derived from the inset",
+    `
+      import { FlatList } from "react-native";
+      import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+      export function FileList() {
+        const insets = useSafeAreaInsets();
+        return (
+          <FlatList
+            data={[]}
+            renderItem={() => null}
+            contentContainerStyle={{ paddingTop: 8, paddingBottom: Math.max(insets.bottom, 18) + 18 }}
+          />
+        );
+      }
+    `,
+  );
+
+  rule.invalid(
+    "reports a floating button pinned with a fixed bottom offset",
+    `
+      import { Pressable } from "react-native";
+
+      export function ShowKeyboardButton() {
+        return <Pressable style={{ position: "absolute", bottom: 16, right: 16 }} />;
+      }
+    `,
+    (output) => {
+      assert.match(output, /safe-area inset/);
+    },
+  );
+
+  rule.invalid(
+    "reports list content padding that ignores the bottom inset",
+    `
+      import { FlatList } from "react-native";
+
+      export function FileList() {
+        return (
+          <FlatList
+            data={[]}
+            renderItem={() => null}
+            contentContainerStyle={{ paddingTop: 8, paddingBottom: 8 }}
+          />
+        );
+      }
+    `,
+    (output) => {
+      assert.match(output, /insets\.bottom/);
+    },
+  );
+});

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
@@ -129,6 +129,38 @@ describe("t3code/require-bottom-safe-area-inset", () => {
   );
 
   rule.invalid(
+    "reports an anchor guarded by a condition inside a style array",
+    `
+      import { Pressable } from "react-native";
+
+      export function ShowKeyboardButton(props: { readonly floating: boolean }) {
+        return (
+          <Pressable
+            style={[{ right: 16 }, props.floating && { position: "absolute", bottom: 16 }]}
+          />
+        );
+      }
+    `,
+    (output) => {
+      assert.match(output, /safe-area inset/);
+    },
+  );
+
+  rule.invalid(
+    "reports an anchor on JSX rendered inside an array",
+    `
+      import { View } from "react-native";
+
+      export function Overlays() {
+        return [<View key="fab" style={{ position: "absolute", bottom: 16 }} />];
+      }
+    `,
+    (output) => {
+      assert.match(output, /safe-area inset/);
+    },
+  );
+
+  rule.invalid(
     "reports a screen-filling list sized with a percentage height",
     `
       import { FlatList } from "react-native";

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
@@ -85,6 +85,24 @@ describe("t3code/require-bottom-safe-area-inset", () => {
     `,
   );
 
+  rule.valid(
+    "allows an inline scroll view bounded by an explicit height",
+    `
+      import { ScrollView, Text } from "react-native";
+
+      export function Caption(props: { readonly source: string }) {
+        return (
+          <ScrollView
+            style={{ maxHeight: 88, flexGrow: 0 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 8 }}
+          >
+            <Text>{props.source}</Text>
+          </ScrollView>
+        );
+      }
+    `,
+  );
+
   rule.invalid(
     "reports a component that ignores the inset even when a sibling component reads it",
     `

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts
@@ -103,6 +103,52 @@ describe("t3code/require-bottom-safe-area-inset", () => {
     `,
   );
 
+  rule.valid(
+    "allows a style array whose last element resets the anchor to the edge",
+    `
+      import { View } from "react-native";
+
+      export function Overlay() {
+        return <View style={[{ position: "absolute", bottom: 16 }, { bottom: 0 }]} />;
+      }
+    `,
+  );
+
+  rule.invalid(
+    "reports an anchor split across style array elements",
+    `
+      import { Pressable } from "react-native";
+
+      export function ShowKeyboardButton() {
+        return <Pressable style={[{ position: "absolute" }, { bottom: 16, right: 16 }]} />;
+      }
+    `,
+    (output) => {
+      assert.match(output, /safe-area inset/);
+    },
+  );
+
+  rule.invalid(
+    "reports a screen-filling list sized with a percentage height",
+    `
+      import { FlatList } from "react-native";
+
+      export function FileList() {
+        return (
+          <FlatList
+            data={[]}
+            renderItem={() => null}
+            style={{ height: "100%" }}
+            contentContainerStyle={{ paddingBottom: 8 }}
+          />
+        );
+      }
+    `,
+    (output) => {
+      assert.match(output, /safe-area inset/);
+    },
+  );
+
   rule.invalid(
     "reports a component that ignores the inset even when a sibling component reads it",
     `

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
@@ -27,9 +27,19 @@ const getLiteralValue = (node: unknown): Option.Option<string | number> => {
     : Option.none();
 };
 
+// Style props take an object or an array of them (`style={[base, {…}]}`), so
+// array elements are flattened; a non-literal element (a StyleSheet
+// reference) contributes nothing and is simply skipped.
 const getObjectProperties = (node: unknown): ReadonlyArray<unknown> => {
   const expression = unwrapExpression(node);
-  if (Option.isNone(expression) || expression.value.type !== "ObjectExpression") return [];
+  if (Option.isNone(expression)) return [];
+
+  if (expression.value.type === "ArrayExpression") {
+    const { elements } = expression.value;
+    return Array.isArray(elements) ? elements.flatMap(getObjectProperties) : [];
+  }
+
+  if (expression.value.type !== "ObjectExpression") return [];
   const { properties } = expression.value;
   return Array.isArray(properties) ? properties : [];
 };
@@ -88,17 +98,51 @@ export default defineRule({
   },
   createOnce(context) {
     let isReactNativeFile = false;
-    let readsSafeAreaInset = false;
-    const candidates: Array<unknown> = [];
+    // Inset reads are tracked per top-level function, not per file: a file
+    // holding a header component that reads the inset and a list component
+    // that does not must still report the list. Nested functions (renderItem,
+    // callbacks) share their component's id, since the hook is called once in
+    // the component body and closed over.
+    let functionDepth = 0;
+    let lastComponentId = 0;
+    let currentComponentId = 0;
+    const componentsReadingInset = new Set<number>();
+    const candidates: Array<{ readonly node: unknown; readonly componentId: number }> = [];
 
     const reset = () => {
       isReactNativeFile = false;
-      readsSafeAreaInset = false;
+      functionDepth = 0;
+      lastComponentId = 0;
+      currentComponentId = 0;
+      componentsReadingInset.clear();
       candidates.length = 0;
+    };
+
+    const enterFunction = () => {
+      if (functionDepth === 0) {
+        lastComponentId += 1;
+        currentComponentId = lastComponentId;
+      }
+      functionDepth += 1;
+    };
+
+    const exitFunction = () => {
+      functionDepth -= 1;
+      if (functionDepth === 0) {
+        // Module scope shares id 0: a style object declared there belongs to
+        // no component and can never be excused by a component's inset read.
+        currentComponentId = 0;
+      }
     };
 
     return {
       before: reset,
+      FunctionDeclaration: enterFunction,
+      "FunctionDeclaration:exit": exitFunction,
+      FunctionExpression: enterFunction,
+      "FunctionExpression:exit": exitFunction,
+      ArrowFunctionExpression: enterFunction,
+      "ArrowFunctionExpression:exit": exitFunction,
       ImportDeclaration(node) {
         const source = getLiteralValue(node.source);
         if (
@@ -113,7 +157,7 @@ export default defineRule({
       Identifier(node) {
         if (typeof node.name !== "string") return;
         if (SAFE_AREA_BOTTOM_IDENTIFIERS.has(node.name)) {
-          readsSafeAreaInset = true;
+          componentsReadingInset.add(currentComponentId);
         }
       },
       MemberExpression(node) {
@@ -123,7 +167,7 @@ export default defineRule({
         const object = unwrapExpression(node.object);
         if (Option.isNone(object) || object.value.type !== "Identifier") return;
         if (INSET_HOLDER_NAMES.has(object.value.name)) {
-          readsSafeAreaInset = true;
+          componentsReadingInset.add(currentComponentId);
         }
       },
       ObjectExpression(node) {
@@ -138,7 +182,7 @@ export default defineRule({
         // claims to have measured the bottom edge itself.
         const value = getLiteralValue(bottom.value.value);
         if (Option.exists(value, (literal) => typeof literal === "number" && literal !== 0)) {
-          candidates.push(bottom.value);
+          candidates.push({ node: bottom.value, componentId: currentComponentId });
         }
       },
       JSXAttribute(node) {
@@ -150,15 +194,16 @@ export default defineRule({
           const property = findProperty(properties, propertyName);
           if (Option.isNone(property)) continue;
           if (Option.isSome(getLiteralValue(property.value.value))) {
-            candidates.push(property.value);
+            candidates.push({ node: property.value, componentId: currentComponentId });
           }
         }
       },
       "Program:exit"() {
-        if (!isReactNativeFile || readsSafeAreaInset) return;
+        if (!isReactNativeFile) return;
 
         for (const candidate of candidates) {
-          context.report({ node: candidate as never, message: MESSAGE });
+          if (componentsReadingInset.has(candidate.componentId)) continue;
+          context.report({ node: candidate.node as never, message: MESSAGE });
         }
       },
     };

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
@@ -1,0 +1,166 @@
+import { defineRule } from "@oxlint/plugins";
+import * as Option from "effect/Option";
+
+import { getPropertyName, unwrapExpression } from "../utils.ts";
+
+// Chrome pinned to the bottom edge renders under the Android gesture bar and
+// the iOS home indicator unless it pads itself with the safe-area inset. The
+// house convention is `Math.max(insets.bottom, N)` (see AndroidHomeFab and
+// HomeScreen), so a React Native file that anchors content to the bottom and
+// never reads the inset is almost always missing it.
+const REACT_NATIVE_MODULE = /^react-native(\/|-|$)/u;
+// `useSafeAreaInsets` alone proves nothing: a screen that only reads
+// `insets.top` still leaves its bottom edge unpadded. Only a marker that
+// names the bottom counts — `SafeAreaView` (which pads every edge by
+// default), or a `bottomInset` prop handed down by whoever owns the inset.
+const SAFE_AREA_BOTTOM_IDENTIFIERS = new Set(["SafeAreaView", "bottomInset"]);
+const INSET_HOLDER_NAMES = new Set(["insets", "safeAreaInsets"]);
+const SCROLL_CONTENT_ATTRIBUTES = new Set(["contentContainerStyle", "contentInset"]);
+const SCROLL_BOTTOM_PROPERTIES = new Set(["bottom", "paddingBottom"]);
+
+const getLiteralValue = (node: unknown): Option.Option<string | number> => {
+  if (typeof node !== "object" || node === null) return Option.none();
+  if (!("type" in node) || node.type !== "Literal") return Option.none();
+  if (!("value" in node)) return Option.none();
+  return typeof node.value === "string" || typeof node.value === "number"
+    ? Option.some(node.value)
+    : Option.none();
+};
+
+const getObjectProperties = (node: unknown): ReadonlyArray<unknown> => {
+  const expression = unwrapExpression(node);
+  if (Option.isNone(expression) || expression.value.type !== "ObjectExpression") return [];
+  const { properties } = expression.value;
+  return Array.isArray(properties) ? properties : [];
+};
+
+const findProperty = (
+  properties: ReadonlyArray<unknown>,
+  name: string,
+): Option.Option<{ readonly value: unknown }> => {
+  for (const property of properties) {
+    if (typeof property !== "object" || property === null) continue;
+    if (!("key" in property) || !("value" in property)) continue;
+
+    const key = getPropertyName(property.key);
+    if (Option.isSome(key) && key.value === name) {
+      return Option.some(property as { readonly value: unknown });
+    }
+  }
+
+  return Option.none();
+};
+
+const isAbsolutelyPositioned = (properties: ReadonlyArray<unknown>): boolean =>
+  findProperty(properties, "position").pipe(
+    Option.flatMap((property) => getLiteralValue(property.value)),
+    Option.exists((value) => value === "absolute"),
+  );
+
+const getJsxAttributeName = (node: unknown): Option.Option<string> => {
+  if (typeof node !== "object" || node === null || !("name" in node)) return Option.none();
+  const name = node.name;
+  if (typeof name !== "object" || name === null || !("type" in name)) return Option.none();
+  return name.type === "JSXIdentifier" && "name" in name && typeof name.name === "string"
+    ? Option.some(name.name)
+    : Option.none();
+};
+
+const getJsxAttributeExpression = (node: unknown): unknown => {
+  if (typeof node !== "object" || node === null || !("value" in node)) return undefined;
+  const value = node.value;
+  if (typeof value !== "object" || value === null || !("type" in value)) return undefined;
+  return value.type === "JSXExpressionContainer" && "expression" in value
+    ? value.expression
+    : undefined;
+};
+
+const MESSAGE =
+  "Bottom-anchored chrome must reserve the safe-area inset: this file pins content to the bottom edge with a fixed offset but never reads insets.bottom, so it renders under the Android gesture bar and the iOS home indicator. Read useSafeAreaInsets() and pad with Math.max(insets.bottom, N), or take the inset from the parent as a bottomInset prop.";
+
+export default defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require React Native surfaces that anchor content to the bottom edge to account for the safe-area inset.",
+    },
+  },
+  createOnce(context) {
+    let isReactNativeFile = false;
+    let readsSafeAreaInset = false;
+    const candidates: Array<unknown> = [];
+
+    const reset = () => {
+      isReactNativeFile = false;
+      readsSafeAreaInset = false;
+      candidates.length = 0;
+    };
+
+    return {
+      before: reset,
+      ImportDeclaration(node) {
+        const source = getLiteralValue(node.source);
+        if (
+          Option.exists(
+            source,
+            (value) => typeof value === "string" && REACT_NATIVE_MODULE.test(value),
+          )
+        ) {
+          isReactNativeFile = true;
+        }
+      },
+      Identifier(node) {
+        if (typeof node.name !== "string") return;
+        if (SAFE_AREA_BOTTOM_IDENTIFIERS.has(node.name)) {
+          readsSafeAreaInset = true;
+        }
+      },
+      MemberExpression(node) {
+        const property = getPropertyName(node.property);
+        if (Option.isNone(property) || property.value !== "bottom") return;
+
+        const object = unwrapExpression(node.object);
+        if (Option.isNone(object) || object.value.type !== "Identifier") return;
+        if (INSET_HOLDER_NAMES.has(object.value.name)) {
+          readsSafeAreaInset = true;
+        }
+      },
+      ObjectExpression(node) {
+        const properties = getObjectProperties(node);
+        if (!isAbsolutelyPositioned(properties)) return;
+
+        const bottom = findProperty(properties, "bottom");
+        if (Option.isNone(bottom)) return;
+
+        // `bottom: 0` is how a keyboard-synced overlay attaches to the very
+        // edge while its child owns the padding; only a fixed non-zero gap
+        // claims to have measured the bottom edge itself.
+        const value = getLiteralValue(bottom.value.value);
+        if (Option.exists(value, (literal) => typeof literal === "number" && literal !== 0)) {
+          candidates.push(bottom.value);
+        }
+      },
+      JSXAttribute(node) {
+        const name = getJsxAttributeName(node);
+        if (Option.isNone(name) || !SCROLL_CONTENT_ATTRIBUTES.has(name.value)) return;
+
+        const properties = getObjectProperties(getJsxAttributeExpression(node));
+        for (const propertyName of SCROLL_BOTTOM_PROPERTIES) {
+          const property = findProperty(properties, propertyName);
+          if (Option.isNone(property)) continue;
+          if (Option.isSome(getLiteralValue(property.value.value))) {
+            candidates.push(property.value);
+          }
+        }
+      },
+      "Program:exit"() {
+        if (!isReactNativeFile || readsSafeAreaInset) return;
+
+        for (const candidate of candidates) {
+          context.report({ node: candidate as never, message: MESSAGE });
+        }
+      },
+    };
+  },
+});

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
@@ -115,16 +115,17 @@ export default defineRule({
     let functionDepth = 0;
     let lastComponentId = 0;
     let currentComponentId = 0;
-    // Style arrays are judged once, merged, so an element never speaks for
-    // itself: `[{ position: "absolute" }, { bottom: 16 }]` is one anchor.
-    let arrayDepth = 0;
+    // Style arrays are judged once, merged, so a direct element never speaks
+    // for itself: `[{ position: "absolute" }, { bottom: 16 }]` is one anchor.
+    // An object wrapped deeper (`cond && {…}`, a ternary, JSX inside the
+    // array) contributes nothing to the merge and is judged on its own.
+    const mergedArrayElements = new WeakSet<object>();
     const componentsReadingInset = new Set<number>();
     const candidates: Array<{ readonly node: unknown; readonly componentId: number }> = [];
 
     const reset = () => {
       isReactNativeFile = false;
       functionDepth = 0;
-      arrayDepth = 0;
       lastComponentId = 0;
       currentComponentId = 0;
       componentsReadingInset.clear();
@@ -200,14 +201,14 @@ export default defineRule({
         }
       },
       ArrayExpression(node) {
-        arrayDepth += 1;
-        if (arrayDepth === 1) checkAbsoluteAnchor(node);
-      },
-      "ArrayExpression:exit"() {
-        arrayDepth -= 1;
+        const elements = Array.isArray(node.elements) ? node.elements : [];
+        for (const element of elements) {
+          if (typeof element === "object" && element !== null) mergedArrayElements.add(element);
+        }
+        checkAbsoluteAnchor(node);
       },
       ObjectExpression(node) {
-        if (arrayDepth === 0) checkAbsoluteAnchor(node);
+        if (!mergedArrayElements.has(node)) checkAbsoluteAnchor(node);
       },
       JSXOpeningElement(node) {
         const attributes = Array.isArray(node.attributes) ? node.attributes : [];

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
@@ -19,7 +19,8 @@ const SCROLL_CONTENT_ATTRIBUTES = new Set(["contentContainerStyle", "contentInse
 const SCROLL_BOTTOM_PROPERTIES = new Set(["bottom", "paddingBottom"]);
 // A scroll view sized inline (`style={{ maxHeight: 88 }}`) is a widget inside
 // the layout, not the screen's primary scroller, so its bottom padding is
-// internal spacing and never meets the screen edge.
+// internal spacing and never meets the screen edge. Only a numeric size
+// counts: `height: "100%"` still fills the screen.
 const INLINE_SCROLL_SIZE_PROPERTIES = new Set(["height", "maxHeight"]);
 
 const getLiteralValue = (node: unknown): Option.Option<string | number> => {
@@ -48,21 +49,25 @@ const getObjectProperties = (node: unknown): ReadonlyArray<unknown> => {
   return Array.isArray(properties) ? properties : [];
 };
 
+// React Native merges style arrays left to right, so the last declaration
+// of a property wins; the lookup mirrors that so `[{ bottom: 16 }, { bottom: 0 }]`
+// resolves to `bottom: 0`.
 const findProperty = (
   properties: ReadonlyArray<unknown>,
   name: string,
 ): Option.Option<{ readonly value: unknown }> => {
+  let match: Option.Option<{ readonly value: unknown }> = Option.none();
   for (const property of properties) {
     if (typeof property !== "object" || property === null) continue;
     if (!("key" in property) || !("value" in property)) continue;
 
     const key = getPropertyName(property.key);
     if (Option.isSome(key) && key.value === name) {
-      return Option.some(property as { readonly value: unknown });
+      match = Option.some(property as { readonly value: unknown });
     }
   }
 
-  return Option.none();
+  return match;
 };
 
 const isAbsolutelyPositioned = (properties: ReadonlyArray<unknown>): boolean =>
@@ -110,12 +115,16 @@ export default defineRule({
     let functionDepth = 0;
     let lastComponentId = 0;
     let currentComponentId = 0;
+    // Style arrays are judged once, merged, so an element never speaks for
+    // itself: `[{ position: "absolute" }, { bottom: 16 }]` is one anchor.
+    let arrayDepth = 0;
     const componentsReadingInset = new Set<number>();
     const candidates: Array<{ readonly node: unknown; readonly componentId: number }> = [];
 
     const reset = () => {
       isReactNativeFile = false;
       functionDepth = 0;
+      arrayDepth = 0;
       lastComponentId = 0;
       currentComponentId = 0;
       componentsReadingInset.clear();
@@ -136,6 +145,22 @@ export default defineRule({
         // Module scope shares id 0: a style object declared there belongs to
         // no component and can never be excused by a component's inset read.
         currentComponentId = 0;
+      }
+    };
+
+    const checkAbsoluteAnchor = (node: unknown) => {
+      const properties = getObjectProperties(node);
+      if (!isAbsolutelyPositioned(properties)) return;
+
+      const bottom = findProperty(properties, "bottom");
+      if (Option.isNone(bottom)) return;
+
+      // `bottom: 0` is how a keyboard-synced overlay attaches to the very
+      // edge while its child owns the padding; only a fixed non-zero gap
+      // claims to have measured the bottom edge itself.
+      const value = getLiteralValue(bottom.value.value);
+      if (Option.exists(value, (literal) => typeof literal === "number" && literal !== 0)) {
+        candidates.push({ node: bottom.value, componentId: currentComponentId });
       }
     };
 
@@ -174,20 +199,15 @@ export default defineRule({
           componentsReadingInset.add(currentComponentId);
         }
       },
+      ArrayExpression(node) {
+        arrayDepth += 1;
+        if (arrayDepth === 1) checkAbsoluteAnchor(node);
+      },
+      "ArrayExpression:exit"() {
+        arrayDepth -= 1;
+      },
       ObjectExpression(node) {
-        const properties = getObjectProperties(node);
-        if (!isAbsolutelyPositioned(properties)) return;
-
-        const bottom = findProperty(properties, "bottom");
-        if (Option.isNone(bottom)) return;
-
-        // `bottom: 0` is how a keyboard-synced overlay attaches to the very
-        // edge while its child owns the padding; only a fixed non-zero gap
-        // claims to have measured the bottom edge itself.
-        const value = getLiteralValue(bottom.value.value);
-        if (Option.exists(value, (literal) => typeof literal === "number" && literal !== 0)) {
-          candidates.push({ node: bottom.value, componentId: currentComponentId });
-        }
+        if (arrayDepth === 0) checkAbsoluteAnchor(node);
       },
       JSXOpeningElement(node) {
         const attributes = Array.isArray(node.attributes) ? node.attributes : [];
@@ -203,10 +223,10 @@ export default defineRule({
 
         const style = attributeProperties.get("style") ?? [];
         for (const propertyName of INLINE_SCROLL_SIZE_PROPERTIES) {
-          const property = findProperty(style, propertyName);
-          if (Option.isSome(property) && Option.isSome(getLiteralValue(property.value.value))) {
-            return;
-          }
+          const size = findProperty(style, propertyName);
+          if (Option.isNone(size)) continue;
+          const value = getLiteralValue(size.value.value);
+          if (Option.exists(value, (literal) => typeof literal === "number")) return;
         }
 
         for (const attributeName of SCROLL_CONTENT_ATTRIBUTES) {

--- a/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
+++ b/oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.ts
@@ -17,6 +17,10 @@ const SAFE_AREA_BOTTOM_IDENTIFIERS = new Set(["SafeAreaView", "bottomInset"]);
 const INSET_HOLDER_NAMES = new Set(["insets", "safeAreaInsets"]);
 const SCROLL_CONTENT_ATTRIBUTES = new Set(["contentContainerStyle", "contentInset"]);
 const SCROLL_BOTTOM_PROPERTIES = new Set(["bottom", "paddingBottom"]);
+// A scroll view sized inline (`style={{ maxHeight: 88 }}`) is a widget inside
+// the layout, not the screen's primary scroller, so its bottom padding is
+// internal spacing and never meets the screen edge.
+const INLINE_SCROLL_SIZE_PROPERTIES = new Set(["height", "maxHeight"]);
 
 const getLiteralValue = (node: unknown): Option.Option<string | number> => {
   if (typeof node !== "object" || node === null) return Option.none();
@@ -185,16 +189,35 @@ export default defineRule({
           candidates.push({ node: bottom.value, componentId: currentComponentId });
         }
       },
-      JSXAttribute(node) {
-        const name = getJsxAttributeName(node);
-        if (Option.isNone(name) || !SCROLL_CONTENT_ATTRIBUTES.has(name.value)) return;
+      JSXOpeningElement(node) {
+        const attributes = Array.isArray(node.attributes) ? node.attributes : [];
+        const attributeProperties = new Map<string, ReadonlyArray<unknown>>();
+        for (const attribute of attributes) {
+          const name = getJsxAttributeName(attribute);
+          if (Option.isNone(name)) continue;
+          attributeProperties.set(
+            name.value,
+            getObjectProperties(getJsxAttributeExpression(attribute)),
+          );
+        }
 
-        const properties = getObjectProperties(getJsxAttributeExpression(node));
-        for (const propertyName of SCROLL_BOTTOM_PROPERTIES) {
-          const property = findProperty(properties, propertyName);
-          if (Option.isNone(property)) continue;
-          if (Option.isSome(getLiteralValue(property.value.value))) {
-            candidates.push({ node: property.value, componentId: currentComponentId });
+        const style = attributeProperties.get("style") ?? [];
+        for (const propertyName of INLINE_SCROLL_SIZE_PROPERTIES) {
+          const property = findProperty(style, propertyName);
+          if (Option.isSome(property) && Option.isSome(getLiteralValue(property.value.value))) {
+            return;
+          }
+        }
+
+        for (const attributeName of SCROLL_CONTENT_ATTRIBUTES) {
+          const properties = attributeProperties.get(attributeName);
+          if (properties === undefined) continue;
+          for (const propertyName of SCROLL_BOTTOM_PROPERTIES) {
+            const property = findProperty(properties, propertyName);
+            if (Option.isNone(property)) continue;
+            if (Option.isSome(getLiteralValue(property.value.value))) {
+              candidates.push({ node: property.value, componentId: currentComponentId });
+            }
           }
         }
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,7 @@ export default defineConfig({
       "t3code/no-manual-effect-runtime-in-tests": "error",
       "t3code/no-native-title-tooltip": "error",
       "t3code/namespace-node-imports": "error",
+      "t3code/require-bottom-safe-area-inset": "error",
     },
     overrides: [
       {


### PR DESCRIPTION
## What Changed

Four Android surfaces that anchor content to the bottom edge now reserve the safe-area inset, and a new `t3code/require-bottom-safe-area-inset` lint rule keeps the next one from shipping without it.

| Surface | Before | After |
| --- | --- | --- |
| Terminal floating keyboard button | `bottom: 16` | `Math.max(insets.bottom, 16) + 16` (same as `AndroidHomeFab`) |
| Terminal surface, keyboard down | `paddingBottom: 0` | `insets.bottom` |
| File tree list | `paddingBottom: 8` | `Math.max(insets.bottom, 8) + 8` |
| Archived threads list | `paddingBottom: 32` | `Math.max(insets.bottom, 16) + 16` |
| `AndroidAnchoredMenu` | usable height ignored the gesture bar | subtracts `max(keyboard, insets.bottom)` |

## Why

Follow-up to the chat composer fix (#5988), which was one instance of a pattern. `contentInsetAdjustmentBehavior="automatic"` only pads the safe area on iOS, so Android lists that relied on it ended flush against the gesture bar; the terminal button and the anchored menu never accounted for it at all.

The lint rule fires only on React Native files that pin content to the bottom edge (`position: "absolute"` with a fixed non-zero `bottom`, or a literal `paddingBottom` in `contentContainerStyle`/`contentInset`) **and** never read `insets.bottom`. `bottom: 0` is exempt: that is how a keyboard-synced overlay attaches to the edge while its child owns the padding. Across the whole repo it flagged exactly the three code sites fixed here and nothing else.

## UI Changes

Pixel emulator, API 35, gesture navigation, dev client against a local backend.

<table>
  <tr><th>File tree — before</th><th>File tree — after</th></tr>
  <tr>
    <td><img width="320" alt="the gesture bar crosses through README.md" src="https://raw.githubusercontent.com/PollyGlot/t3code/assets/android-bottom-safe-area/before-file-tree.png" /></td>
    <td><img width="320" alt="the last row clears the gesture bar" src="https://raw.githubusercontent.com/PollyGlot/t3code/assets/android-bottom-safe-area/after-file-tree.png" /></td>
  </tr>
  <tr><th>Terminal button — before</th><th>Terminal button — after</th></tr>
  <tr>
    <td><img width="320" alt="the keyboard button sits on the gesture bar" src="https://raw.githubusercontent.com/PollyGlot/t3code/assets/android-bottom-safe-area/before-terminal-fab.png" /></td>
    <td><img width="320" alt="the keyboard button clears the gesture bar" src="https://raw.githubusercontent.com/PollyGlot/t3code/assets/android-bottom-safe-area/after-terminal-fab.png" /></td>
  </tr>
</table>

Verified on device: file tree, terminal button, and the anchored menu (no placement regression). The archived-threads padding is a code-level change I did not reproduce on screen; its previous 32 happened to exceed this device's 24dp inset, so it was fragile rather than visibly broken.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] New lint rule ships with tests (`oxlint-plugin-t3code/rules/require-bottom-safe-area-inset.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout and lint-only changes on mobile; no auth, data, or API behavior. Main risk is incorrect double-padding on iOS if a branch mis-detects automatic insets.
> 
> **Overview**
> Android surfaces that sat flush with the gesture bar now pad or position using **`useSafeAreaInsets()`**, following the existing **`Math.max(insets.bottom, N)`** convention. iOS paths are left alone where **`contentInsetAdjustmentBehavior="automatic"`** or native screen insets already handle the home indicator.
> 
> **`AndroidAnchoredMenu`** treats the bottom safe area like keyboard overlap when computing usable height (`max(keyboard, insets.bottom)`). **Terminal** adds bottom inset when the keyboard is hidden and lifts the show-keyboard FAB. **File tree**, **archived threads**, and **review sheet** lists get explicit Android bottom **`paddingBottom`** (with platform/glass-specific branches so iOS is not double-padded).
> 
> A new **`t3code/require-bottom-safe-area-inset`** Oxlint rule flags React Native files that pin bottom chrome with fixed offsets or literal scroll **`paddingBottom`** without reading **`insets.bottom`**, **`SafeAreaView`**, or **`bottomInset`**; it is enabled at error severity in **`vite.config.ts`** with fixture tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd55270f76b32bd7ba7cb88cc79be7f2e711af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reserve bottom safe area inset in `AndroidAnchoredMenu` overlay boundary
> The overlay's usable bottom boundary now subtracts the larger of the keyboard height and the bottom safe-area inset, instead of only the keyboard height. This keeps Android anchored menus from overlapping the gesture-bar region when it extends past the keyboard exclusion area.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cc3cd5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android mobile layouts to respect bottom safe-area and gesture-bar insets across menus, archived threads, file browsing, reviews, and terminal screens.
  - Prevented anchored menus from opening behind the keyboard or device gesture area.
  - Improved terminal controls and list spacing on devices with bottom screen insets.

- **Chores**
  - Added linting safeguards to detect bottom-anchored mobile content that does not account for safe-area insets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->