### PR TITLE
feat(web): distinguish provider instances in the sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -28,7 +28,7 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef } from "@t3tools/contracts";
+import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
 import type { TimestampFormat } from "@t3tools/contracts/settings";
 import {
   AlarmClockIcon,
@@ -154,7 +154,6 @@ import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
 import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
-import { primaryServerProvidersAtom } from "../state/server";
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { Button } from "./ui/button";
@@ -176,6 +175,9 @@ import {
 // stays behind an explicit Show more.
 const SETTLED_TAIL_INITIAL_COUNT = 10;
 const SETTLED_TAIL_PAGE_COUNT = 25;
+// Stable identity for environments whose config hasn't arrived yet, so a
+// row that can't resolve its provider doesn't re-render on every pass.
+const EMPTY_PROVIDER_ENTRIES: ReadonlyMap<string, ProviderInstanceEntry> = new Map();
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -1769,16 +1771,6 @@ export default function Sidebar() {
     () => sortLogicalProjectsForSidebar(unsortedProjectGroups, threads, sidebarProjectSortOrder),
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
-  const providerEntryByInstanceId = useMemo(
-    () =>
-      new Map(
-        deriveProviderInstanceEntries(serverProviders).map(
-          (entry) => [entry.instanceId as string, entry] as const,
-        ),
-      ),
-    [serverProviders],
-  );
   const projectCwdByKey = useMemo(
     () =>
       new Map(
@@ -1918,6 +1910,26 @@ export default function Sidebar() {
   // merging, no optimistic holds. Archived threads remain hidden here —
   // archive keeps its original "remove from sidebar" meaning.
   const serverConfigs = useAtomValue(environmentServerConfigsAtom);
+  // Provider metadata is per environment, never global. Instance ids are
+  // user-defined and a driver's default id is the driver kind itself, so
+  // `claudeAgent` exists on every server that runs Claude — with a
+  // different name and accent on each. Resolving a remote thread against
+  // the primary server's list would paint another machine's account onto
+  // it, which is exactly the confusion the badge exists to remove.
+  const providerEntriesByEnvironment = useMemo(() => {
+    const byEnvironment = new Map<EnvironmentId, ReadonlyMap<string, ProviderInstanceEntry>>();
+    for (const [environmentId, config] of serverConfigs) {
+      byEnvironment.set(
+        environmentId,
+        new Map(
+          deriveProviderInstanceEntries(config.providers).map(
+            (entry) => [entry.instanceId as string, entry] as const,
+          ),
+        ),
+      );
+    }
+    return byEnvironment;
+  }, [serverConfigs]);
   const {
     pinnedThreads,
     reorderablePinnedKeys,
@@ -3436,7 +3448,10 @@ export default function Sidebar() {
                           ) ?? null
                         }
                         environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
-                        providerEntryByInstanceId={providerEntryByInstanceId}
+                        providerEntryByInstanceId={
+                          providerEntriesByEnvironment.get(thread.environmentId) ??
+                          EMPTY_PROVIDER_ENTRIES
+                        }
                         isHighlighted={activeSearchResultIndex === index}
                         isRouteActive={routeThreadKey === threadKey}
                         resultId={`sidebar-thread-search-result-${index}`}
@@ -3543,7 +3558,10 @@ export default function Sidebar() {
                             `${thread.environmentId}:${thread.projectId}`,
                           ) ?? null
                         }
-                        providerEntryByInstanceId={providerEntryByInstanceId}
+                        providerEntryByInstanceId={
+                          providerEntriesByEnvironment.get(thread.environmentId) ??
+                          EMPTY_PROVIDER_ENTRIES
+                        }
                         timestampFormat={timestampFormat}
                         onThreadClick={handleThreadClick}
                         onThreadActivate={navigateToThread}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -233,6 +233,27 @@ function terminalProcessLabel(count: number): string {
   return `${count} terminal ${count === 1 ? "process" : "processes"} running`;
 }
 
+/**
+ * The driver logo alone cannot distinguish two configured instances of the
+ * same driver (e.g. `claudeAgent` + `claude_work`). Mirror the model picker:
+ * surface the accent badge when the instance has an accent color, or when
+ * its driver has more than one configured instance so the ambiguity is at
+ * least visible (hover reveals the instance name).
+ */
+function shouldShowInstanceBadge(
+  entry: ProviderInstanceEntry,
+  entries: ReadonlyMap<string, ProviderInstanceEntry>,
+): boolean {
+  if (entry.accentColor) return true;
+  let driverInstanceCount = 0;
+  for (const candidate of entries.values()) {
+    if (candidate.driverKind !== entry.driverKind) continue;
+    driverInstanceCount += 1;
+    if (driverInstanceCount > 1) return true;
+  }
+  return false;
+}
+
 function SidebarThreadTooltip({
   thread,
   projectTitle,
@@ -242,6 +263,9 @@ function SidebarThreadTooltip({
   driverKind,
   modelInstanceId,
   modelLabel,
+  instanceDisplayName,
+  instanceAccentColor,
+  showInstanceBadge,
   branchMismatch,
   terminalStatus,
   terminalProcessCount,
@@ -254,6 +278,9 @@ function SidebarThreadTooltip({
   driverKind: ProviderInstanceEntry["driverKind"] | null;
   modelInstanceId: string;
   modelLabel: string;
+  instanceDisplayName: string | null;
+  instanceAccentColor: string | undefined;
+  showInstanceBadge: boolean;
   branchMismatch: {
     threadBranch: string;
     currentBranch: string;
@@ -309,10 +336,17 @@ function SidebarThreadTooltip({
             <div className="flex min-w-0 items-center gap-2">
               <ProviderInstanceIcon
                 driverKind={driverKind}
-                displayName={thread.session?.providerName ?? modelInstanceId}
+                displayName={instanceDisplayName ?? thread.session?.providerName ?? modelInstanceId}
+                accentColor={instanceAccentColor}
+                showBadge={showInstanceBadge}
+                badgeContent="none"
                 iconClassName="size-3 shrink-0 grayscale opacity-60"
+                badgeClassName="-right-0.5 -bottom-0.5 h-1.5 min-w-1.5 px-0"
+                indicatorBackground="var(--popover)"
               />
-              <div className="min-w-0 truncate text-foreground/75">{modelLabel}</div>
+              <div className="min-w-0 truncate text-foreground/75">
+                {instanceDisplayName ? `${instanceDisplayName} · ${modelLabel}` : modelLabel}
+              </div>
             </div>
           ) : null}
           {terminalStatus ? (
@@ -857,6 +891,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   const modelLabel = selectedModel
     ? getTriggerDisplayModelLabel(selectedModel)
     : thread.modelSelection.model;
+  const instanceDisplayName = providerEntry?.displayName ?? thread.session?.providerName ?? null;
+  const instanceAccentColor = providerEntry?.accentColor;
+  const showInstanceBadge = providerEntry
+    ? shouldShowInstanceBadge(providerEntry, props.providerEntryByInstanceId)
+    : false;
 
   const isRemote =
     props.currentEnvironmentId !== null && thread.environmentId !== props.currentEnvironmentId;
@@ -871,6 +910,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       driverKind={driverKind}
       modelInstanceId={modelInstanceId}
       modelLabel={modelLabel}
+      instanceDisplayName={instanceDisplayName}
+      instanceAccentColor={instanceAccentColor}
+      showInstanceBadge={showInstanceBadge}
       branchMismatch={branchMismatch}
       terminalStatus={terminalStatus}
       terminalProcessCount={terminalProcessCount}
@@ -1438,11 +1480,18 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                   </span>
                 ) : null}
                 {driverKind ? (
-                  <span className="inline-flex shrink-0 items-center opacity-60">
+                  <span className="inline-flex shrink-0 items-center">
                     <ProviderInstanceIcon
                       driverKind={driverKind}
-                      displayName={thread.session?.providerName ?? modelInstanceId}
-                      iconClassName="size-3.5"
+                      displayName={
+                        instanceDisplayName ?? thread.session?.providerName ?? modelInstanceId
+                      }
+                      accentColor={instanceAccentColor}
+                      showBadge={showInstanceBadge}
+                      badgeContent="none"
+                      iconClassName="size-3.5 opacity-60"
+                      badgeClassName="-right-0.5 -bottom-0.5 h-1.5 min-w-1.5 px-0"
+                      indicatorBackground="var(--sidebar)"
                     />
                   </span>
                 ) : null}
@@ -1506,6 +1555,7 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
   const modelLabel = selectedModel
     ? getTriggerDisplayModelLabel(selectedModel)
     : thread.modelSelection.model;
+  const instanceDisplayName = providerEntry?.displayName ?? thread.session?.providerName ?? null;
   const runningTerminalIds = useThreadRunningTerminalIds({
     environmentId: thread.environmentId,
     threadId: thread.id,
@@ -1560,6 +1610,13 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
           driverKind={driverKind}
           modelInstanceId={modelInstanceId}
           modelLabel={modelLabel}
+          instanceDisplayName={instanceDisplayName}
+          instanceAccentColor={providerEntry?.accentColor}
+          showInstanceBadge={
+            providerEntry
+              ? shouldShowInstanceBadge(providerEntry, props.providerEntryByInstanceId)
+              : false
+          }
           branchMismatch={branchMismatch}
           terminalStatus={terminalStatus}
           terminalProcessCount={runningTerminalIds.length}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -11,3 +11,11 @@ other connected devices.
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.
+
+## Telling provider instances apart
+
+Each thread row shows the logo of the provider it runs on. When you have configured more than one
+instance of the same provider (for example two Claude accounts), the logo also carries a small
+colored dot matching the instance's accent color, so you can see at a glance which account a
+thread uses. Set the accent color and display name per instance in **Settings → Providers**.
+Hovering a thread shows the instance name next to the model, like "Claude Personal · Opus".


### PR DESCRIPTION
## Problem

If you configure more than one instance of the same provider — two Claude accounts, say a personal one and a work one — the sidebar cannot tell them apart. Every Claude thread shows the same Claude logo, so the only way to know which account a thread runs on is to open it. Provider instances already carry a user-set display name and accent color (Settings → Providers); the sidebar just never used them.

## Change

Thread rows now show the instance's accent color as a small dot on the provider logo, and the hover tooltip names the instance next to the model. The badge appears when an instance has an accent color, or when a driver has more than one configured instance, so the ambiguity is never silent.

This reuses the badge treatment `ProviderInstanceIcon` already provides for the model picker. No contract or server changes — the instance id is already on each thread and the instance metadata is already on the client.

### Thread rows

<!-- SCREENSHOT 1: drop before-sidebar.png and after-sidebar.png into the two table cells below -->

| Before | After |
| --- | --- |
| <img width="510" height="1080" alt="before-sidebar" src="https://github.com/user-attachments/assets/3668c8bb-911d-498f-8de9-2d73b63ce341" /> | <img width="510" height="1080" alt="after-sidebar" src="https://github.com/user-attachments/assets/790ce401-cb63-44f6-95a7-7423c3bf7a75" /> |

Three of these threads run on Claude and two on Codex. Before, the three Claude rows are identical; after, green marks the personal instance and red the work instance.

### Hover tooltip

<!-- SCREENSHOT 2: drop before-tooltip-crop.png and after-tooltip-crop.png into the two table cells below -->

| Before | After |
| --- | --- |
| <img width="960" height="330" alt="before-tooltip-crop" src="https://github.com/user-attachments/assets/2cb07c59-2e54-41ff-87fe-09f114460f1d" /> | <img width="960" height="330" alt="after-tooltip-crop" src="https://github.com/user-attachments/assets/33a8fd7c-751f-489c-9538-e610ac28dfd7" /> |

Project names and thread titles in these screenshots are anonymized test data.

## Scope

- Web sidebar only. The legacy sidebar shows no provider information at all today, and mobile has its own thread list; neither is touched here.
- `docs/user/thread-sidebar.md` gains a short section describing the badge.

## Verification

- `vp run --filter @t3tools/web typecheck`, `vp lint`, `vp fmt --check` clean.
- Web unit suite: 2002 tests passing.
- Checked in a local dev client against a copy of real state with three configured instances (two Claude, one Codex).

---

Made with Claude Opus 5 via Claude Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar-only presentation using existing thread and per-environment config data; no API or server changes.
> 
> **Overview**
> **Provider instance badges and names** now appear on web sidebar thread rows and hover tooltips, reusing `ProviderInstanceIcon`’s model-picker badge treatment (accent dot when configured, or when multiple instances share the same driver).
> 
> **Per-environment lookup** replaces resolving every thread against the primary server’s provider list: each row gets `providerEntriesByEnvironment.get(thread.environmentId)`, with a stable empty map fallback so rows don’t thrash before config loads.
> 
> **User docs** add a short **Telling provider instances apart** section in `thread-sidebar.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b869beffd432850a804000d1b2bf9d4647766e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distinguish provider instances in the sidebar with badges and instance names
> - Provider icons in thread rows and search result rows now show a colored dot badge when multiple instances of the same driver exist or when an instance has a custom accent color.
> - A new `shouldShowInstanceBadge` utility determines badge visibility based on accent color or duplicate driver kinds per environment.
> - Tooltips show the instance display name (prefixed before the model label) when available.
> - Provider instance metadata is now resolved per environment using `deriveProviderInstanceEntries`, replacing reliance on `primaryServerProvidersAtom`, so threads from remote environments show correct instance names and styling.
> - A stable `EMPTY_PROVIDER_ENTRIES` constant prevents unnecessary re-renders when an environment has no config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b869be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->