### PR TITLE
fix(web): record modified Tab keybindings

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -9,6 +9,7 @@ import {
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
   parseWhenExpressionDraft,
+  shouldSkipKeybindingCapture,
   shortcutToKeybindingInput,
   unknownWhenVariables,
   whenAstToExpression,
@@ -62,6 +63,24 @@ describe("KeybindingsSettings.logic", () => {
         "Win32",
       ),
     ).toBe("mod+shift+k");
+  });
+
+  it("preserves plain Tab navigation while capturing modified Tab chords", () => {
+    const plainTab = {
+      key: "Tab",
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+    };
+    const ctrlTab = { ...plainTab, ctrlKey: true };
+    const cmdOptionTab = { ...plainTab, metaKey: true, altKey: true };
+
+    expect(shouldSkipKeybindingCapture(plainTab)).toBe(true);
+    expect(shouldSkipKeybindingCapture(ctrlTab)).toBe(false);
+    expect(shouldSkipKeybindingCapture(cmdOptionTab)).toBe(false);
+    expect(keybindingFromKeyboardEvent(ctrlTab, "MacIntel")).toBe("ctrl+tab");
+    expect(keybindingFromKeyboardEvent(cmdOptionTab, "MacIntel")).toBe("mod+alt+tab");
   });
 
   it("serializes shortcuts and when expressions for upserts", () => {

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -338,3 +338,11 @@ export function keybindingFromKeyboardEvent(
   parts.push(keyToken);
   return parts.join("+");
 }
+
+export function shouldSkipKeybindingCapture(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey">,
+): boolean {
+  return (
+    event.key === "Tab" && !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+  );
+}

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -63,6 +63,7 @@ import {
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
   parseWhenExpressionDraft,
+  shouldSkipKeybindingCapture,
   type KeybindingCommandOption,
   type KeybindingRow,
   type WhenVariableOption,
@@ -802,7 +803,7 @@ function KeybindingTableRow({
   };
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Tab") return;
+    if (shouldSkipKeybindingCapture(event.nativeEvent)) return;
     event.preventDefault();
     if (event.key === "Escape") {
       setDraft({ keyDraft: row.key, isRecording: false });
@@ -974,7 +975,7 @@ function NewKeybindingTableRow({
   };
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Tab") return;
+    if (shouldSkipKeybindingCapture(event.nativeEvent)) return;
     event.preventDefault();
     if (event.key === "Escape") {
       setDraft({ keyDraft: "", isRecording: false });


### PR DESCRIPTION
The keybinding recorder treated every Tab press as focus navigation, so modified Tab chords such as Ctrl+Tab and Cmd+Option+Tab could not be selected even though the keybinding parser already supported them.

This skips capture only for unmodified Tab. Existing and new keybinding rows now accept modified Tab chords while plain Tab continues moving focus.

## Verification

- `vp test run apps/web/src/components/settings/KeybindingsSettings.logic.test.ts` — 10 passed
- targeted `vp lint` — passed
- `vp fmt --check` — passed
- `vp run --filter @t3tools/web typecheck` — passed
- Manual web check in disposable state: plain Tab moved focus without changing the shortcut; Cmd+Option+Tab recorded and saved as ⌘⌥Tab
- Screenshots were captured from an empty disposable environment; no personal thread names or data are present

## Screenshots

| Before customization | After customization |
| --- | --- |
| ![Default Thread Next keybinding](https://raw.githubusercontent.com/cheruvian/t3code/c153c1951/before-thread-next.png) | ![Thread Next using Cmd Option Tab](https://raw.githubusercontent.com/cheruvian/t3code/c153c1951/after-thread-next.png) |

Generated with GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to keybinding capture in settings UI with tests; no auth, data, or runtime dispatch changes.
> 
> **Overview**
> The keybindings settings recorder used to ignore **every** Tab keypress, so chords like **Ctrl+Tab** or **⌘⌥Tab** could not be assigned even though parsing already supported them.
> 
> This adds **`shouldSkipKeybindingCapture`** so capture is skipped only for **unmodified** Tab (focus navigation). Modified Tab chords are recorded in both existing-row and new-keybinding flows. Unit tests cover plain vs modified Tab and the resulting binding strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13aacc31f00c8597635199cd5d946df1b491a436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keybinding capture to record modified Tab chords like `Ctrl+Tab`
> Previously, any `Tab` keypress was skipped during keybinding capture, preventing modified chords like `Ctrl+Tab` from being recorded. A new `shouldSkipKeybindingCapture` predicate now returns `true` only for plain unmodified `Tab`, allowing modifier+Tab combinations to be captured and serialized normally. Both `KeybindingTableRow` and `NewKeybindingTableRow` in [KeybindingsSettings.tsx](https://github.com/pingdotgg/t3code/pull/6006/files#diff-12068495a79a13f54503fa3061aafb91f05537621626906b290ed059e660d4d4) are updated to use this predicate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13aacc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->