### PR TITLE
fix(web): keep active plan visible above composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2241,11 +2241,16 @@ function ChatViewContent(props: ChatViewProps) {
   const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
   const pinnedActiveTurnPlan = useMemo(() => {
     const activeTurnId = activeLatestTurn?.turnId ?? null;
-    if (!isWorking || activeTurnId === null || activePlan?.turnId !== activeTurnId) {
+    if (
+      phase !== "running" ||
+      activeLatestTurn?.state !== "running" ||
+      activeTurnId === null ||
+      activePlan?.turnId !== activeTurnId
+    ) {
       return null;
     }
     return turnPlans.find((turnPlan) => turnPlan.turnId === activeTurnId) ?? null;
-  }, [activeLatestTurn?.turnId, activePlan, isWorking, turnPlans]);
+  }, [activeLatestTurn?.state, activeLatestTurn?.turnId, activePlan, phase, turnPlans]);
   const turnPlansForTimeline = useMemo(
     () => excludePinnedTurnPlan(turnPlans, pinnedActiveTurnPlan?.turnId ?? null),
     [pinnedActiveTurnPlan?.turnId, turnPlans],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -243,8 +243,8 @@ import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
 import { DraftHeroHeadline } from "./chat/DraftHeroHeadline";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
-import { MessagesTimeline } from "./chat/MessagesTimeline";
-import { resolveTimelineIsAtEnd } from "./chat/MessagesTimeline.logic";
+import { MessagesTimeline, TurnPlanTimelineRow } from "./chat/MessagesTimeline";
+import { excludePinnedTurnPlan, resolveTimelineIsAtEnd } from "./chat/MessagesTimeline.logic";
 import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
@@ -2239,6 +2239,17 @@ function ChatViewContent(props: ChatViewProps) {
     threadError,
   });
   const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const pinnedActiveTurnPlan = useMemo(() => {
+    const activeTurnId = activeLatestTurn?.turnId ?? null;
+    if (!isWorking || activeTurnId === null || activePlan?.turnId !== activeTurnId) {
+      return null;
+    }
+    return turnPlans.find((turnPlan) => turnPlan.turnId === activeTurnId) ?? null;
+  }, [activeLatestTurn?.turnId, activePlan, isWorking, turnPlans]);
+  const turnPlansForTimeline = useMemo(
+    () => excludePinnedTurnPlan(turnPlans, pinnedActiveTurnPlan?.turnId ?? null),
+    [pinnedActiveTurnPlan?.turnId, turnPlans],
+  );
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
     activeThread?.session ?? null,
@@ -2490,9 +2501,9 @@ function ChatViewContent(props: ChatViewProps) {
         timelineMessages,
         activeThread?.proposedPlans ?? [],
         workLogEntries,
-        turnPlans,
+        turnPlansForTimeline,
       ),
-    [activeThread?.proposedPlans, timelineMessages, turnPlans, workLogEntries],
+    [activeThread?.proposedPlans, timelineMessages, turnPlansForTimeline, workLogEntries],
   );
   const [dockedDraftHeroThreadKey, setDockedDraftHeroThreadKey] = useState<string | null>(null);
   const draftHeroDockRequested =
@@ -6184,6 +6195,11 @@ function ChatViewContent(props: ChatViewProps) {
                   )}
                   {threadSyncPhase && !activeEnvironmentUnavailable ? (
                     <ThreadSyncStatusPill phase={threadSyncPhase} />
+                  ) : null}
+                  {pinnedActiveTurnPlan ? (
+                    <div data-active-plan-bar="true" className="mx-auto mb-1.5 w-full max-w-3xl">
+                      <TurnPlanTimelineRow turnPlan={pinnedActiveTurnPlan} />
+                    </div>
                   ) : null}
                   <div
                     className="relative"

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,11 +1,45 @@
+import { TurnId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 import {
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
+  excludePinnedTurnPlan,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
 } from "./MessagesTimeline.logic";
+
+describe("excludePinnedTurnPlan", () => {
+  it("removes only the currently pinned turn plan", () => {
+    const turnPlans = [
+      {
+        id: "turn-plan:turn-1",
+        createdAt: "2026-01-01T00:00:00Z",
+        turnId: TurnId.make("turn-1"),
+        plan: {
+          createdAt: "2026-01-01T00:00:00Z",
+          turnId: TurnId.make("turn-1"),
+          steps: [{ step: "Inspect", status: "inProgress" as const }],
+        },
+      },
+      {
+        id: "turn-plan:turn-2",
+        createdAt: "2026-01-01T00:01:00Z",
+        turnId: TurnId.make("turn-2"),
+        plan: {
+          createdAt: "2026-01-01T00:01:00Z",
+          turnId: TurnId.make("turn-2"),
+          steps: [{ step: "Ship", status: "pending" as const }],
+        },
+      },
+    ];
+
+    expect(excludePinnedTurnPlan(turnPlans, TurnId.make("turn-1")).map((plan) => plan.id)).toEqual([
+      "turn-plan:turn-2",
+    ]);
+    expect(excludePinnedTurnPlan(turnPlans, null)).toHaveLength(2);
+  });
+});
 
 describe("computeMessageDurationStart", () => {
   it("returns message createdAt when there is no preceding user message", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -210,6 +210,20 @@ export type MessagesTimelineRow =
     }
   | { kind: "working"; id: string; createdAt: string | null };
 
+/**
+ * The active turn's plan is rendered in the composer overlay while it runs.
+ * Keep completed and historical turn plans in the chronological timeline.
+ */
+export function excludePinnedTurnPlan(
+  turnPlans: ReadonlyArray<TurnPlanEntry>,
+  pinnedTurnId: TurnId | null,
+): TurnPlanEntry[] {
+  if (pinnedTurnId === null) {
+    return [...turnPlans];
+  }
+  return turnPlans.filter((turnPlan) => turnPlan.turnId !== pinnedTurnId);
+}
+
 export interface StableMessagesTimelineRowsState {
   byId: Map<string, MessagesTimelineRow>;
   result: MessagesTimelineRow[];

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -37,6 +37,7 @@ import {
   workEntryIndicatesToolNeutralStatus,
   workEntryIndicatesToolSuccess,
   workLogEntryIsToolLike,
+  type TurnPlanEntry,
 } from "../../session-logic";
 import { type TurnDiffSummary } from "../../types";
 import {
@@ -952,7 +953,7 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
         <AssistantTimelineRow row={row} />
       ) : null}
       {row.kind === "proposed-plan" ? <ProposedPlanTimelineRow row={row} /> : null}
-      {row.kind === "turn-plan" ? <TurnPlanTimelineRow row={row} /> : null}
+      {row.kind === "turn-plan" ? <TurnPlanTimelineRow turnPlan={row.turnPlan} /> : null}
       {row.kind === "working" ? <WorkingTimelineRow row={row} /> : null}
     </div>
   );
@@ -1188,13 +1189,13 @@ function ProposedPlanTimelineRow({
  * Collapsed by default — a segment bar plus the in-progress step label —
  * and expands in place to the full step list. Replaces the old plan sidebar.
  */
-const TurnPlanTimelineRow = memo(function TurnPlanTimelineRow({
-  row,
+export const TurnPlanTimelineRow = memo(function TurnPlanTimelineRow({
+  turnPlan,
 }: {
-  row: Extract<TimelineRow, { kind: "turn-plan" }>;
+  turnPlan: TurnPlanEntry;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const { steps } = row.turnPlan.plan;
+  const { steps } = turnPlan.plan;
   const completedCount = steps.filter((step) => step.status === "completed").length;
   const allDone = completedCount === steps.length;
   // Label priority: the in-progress step, else the next pending step (plan


### PR DESCRIPTION
## Problem

The active turn plan is rendered in chronological order, so subsequent work-log entries can push it out of view while the agent is still working.

## Fix

- Reuse the existing plan-row UI directly above the composer.
- Remove only the active turn's plan from the chronological timeline while that turn is working.
- Keep completed and historical plans in their original timeline positions.
- Let the existing composer-overlay measurement account for the pinned plan's height in scroll and bottom spacing.

## Verification

- `vp run --filter @t3tools/web typecheck` — passed
- `vp fmt` on the four changed files — passed
- `git diff --check` — passed
- Isolated synthetic-thread browser check — passed; the plan row is immediately above the composer.
- Targeted Vite Plus test invocation is currently blocked before test execution by the checkout's runner error: `TypeError: Cannot read properties of undefined (reading 'config')`.

## Screenshots

Before — active plan can be pushed into the timeline:

![Before: inline plan](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/a852acc7-5987-4959-87a5-fd452fa047fd/t3code-plan-bar-before.png)

After — active plan stays above the composer:

![After: pinned plan](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/caa37a66-913a-4b8b-b7ed-1b0fc0568460/t3code-plan-bar-after.png)

Implemented and verified by GPT-5.6 Luna via Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chat UI layout and timeline filtering only; no auth, data, or API changes.
> 
> **Overview**
> While a turn is **running**, its plan is **pinned in a bar directly above the composer** instead of scrolling away with later work-log entries.
> 
> `ChatView` derives `pinnedActiveTurnPlan` when the thread phase and latest turn are running and match `activePlan`, renders it with the shared `TurnPlanTimelineRow`, and feeds timeline building through `excludePinnedTurnPlan` so only that active plan is omitted from the chronological list. **Completed and historical plans stay in the timeline.**
> 
> `TurnPlanTimelineRow` is **exported** and takes a `TurnPlanEntry` prop so the same UI works in the timeline and the pinned bar. Unit tests cover `excludePinnedTurnPlan`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53ce6b45e49329c754201c512d4cc4119d9d557a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep active turn plan visible above the composer during running turns
> - While a turn is running, the active plan is pinned above the timeline/composer using a new `pinnedActiveTurnPlan` memo in [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/6007/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), rendering `TurnPlanTimelineRow` outside the main timeline.
> - A new `excludePinnedTurnPlan` utility in [`MessagesTimeline.logic.ts`](https://github.com/pingdotgg/t3code/pull/6007/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) filters the pinned plan from the chronological timeline to avoid duplication.
> - `TurnPlanTimelineRow` in [`MessagesTimeline.tsx`](https://github.com/pingdotgg/t3code/pull/6007/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) is refactored to accept a `TurnPlanEntry` prop directly and is now exported for reuse.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53ce6b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->