### PR TITLE
feat(desktop): open a thread from a t3code:// deep link

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -18,6 +18,7 @@ import * as DesktopWindow from "../window/DesktopWindow.ts";
 import * as DesktopBackendPool from "../backend/DesktopBackendPool.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./DesktopLifecycle.ts";
+import * as DesktopDeepLinkRouter from "./DesktopDeepLinkRouter.ts";
 import * as DesktopLinuxUrlHandler from "./DesktopLinuxUrlHandler.ts";
 import * as DesktopObservability from "./DesktopObservability.ts";
 import * as DesktopPreReadyPlatform from "./DesktopPreReadyPlatform.ts";
@@ -224,6 +225,7 @@ const startup = Effect.gen(function* () {
   const electronApp = yield* ElectronApp.ElectronApp;
   const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
   const linuxUrlHandler = yield* DesktopLinuxUrlHandler.DesktopLinuxUrlHandler;
+  const deepLinkRouter = yield* DesktopDeepLinkRouter.DesktopDeepLinkRouter;
   const clerk = yield* DesktopClerk.DesktopClerk;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
@@ -287,6 +289,9 @@ const startup = Effect.gen(function* () {
   yield* applicationMenu.configure;
   yield* updates.configure;
   yield* linuxUrlHandler.register;
+  // Registered before bootstrap so a link that launched the app is picked up
+  // and held, rather than being missed while the backend starts.
+  yield* deepLinkRouter.register;
   yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));
 }).pipe(Effect.withSpan("desktop.startup"));
 

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -273,6 +273,9 @@ const startup = Effect.gen(function* () {
   yield* appIdentity.configure;
   yield* lifecycle.register;
   yield* clerk.configure;
+  // macOS can emit open-url before ready, and does not preserve that URL in
+  // argv. Register now; DesktopWindow holds it until the backend can open.
+  yield* deepLinkRouter.register;
 
   yield* electronApp.whenReady.pipe(
     Effect.withSpan("desktop.electron.whenReady"),
@@ -289,9 +292,6 @@ const startup = Effect.gen(function* () {
   yield* applicationMenu.configure;
   yield* updates.configure;
   yield* linuxUrlHandler.register;
-  // Registered before bootstrap so a link that launched the app is picked up
-  // and held, rather than being missed while the backend starts.
-  yield* deepLinkRouter.register;
   yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));
 }).pipe(Effect.withSpan("desktop.startup"));
 

--- a/apps/desktop/src/app/DesktopDeepLink.test.ts
+++ b/apps/desktop/src/app/DesktopDeepLink.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { findDeepLinkInArgv, parseDeepLink } from "./DesktopDeepLink.ts";
+
+const SCHEMES = ["t3code", "t3code-dev"] as const;
+
+describe("parseDeepLink", () => {
+  it("parses the documented thread link shape", () => {
+    expect(parseDeepLink("t3code://threads/env-1/thread-42", SCHEMES)).toEqual({
+      kind: "thread",
+      environmentId: "env-1",
+      threadId: "thread-42",
+    });
+  });
+
+  it("accepts every registered scheme, including the development one", () => {
+    for (const scheme of SCHEMES) {
+      expect(parseDeepLink(`${scheme}://threads/env/thread`, SCHEMES)).toEqual({
+        kind: "thread",
+        environmentId: "env",
+        threadId: "thread",
+      });
+    }
+  });
+
+  it("is case insensitive for the scheme and host", () => {
+    expect(parseDeepLink("T3CODE://THREADS/env/thread", SCHEMES)).toEqual({
+      kind: "thread",
+      environmentId: "env",
+      threadId: "thread",
+    });
+  });
+
+  it("percent-decodes segments", () => {
+    expect(parseDeepLink("t3code://threads/env%20one/thread%2Btwo", SCHEMES)).toEqual({
+      kind: "thread",
+      environmentId: "env one",
+      threadId: "thread+two",
+    });
+  });
+
+  it("rejects foreign schemes so other protocol handlers are never hijacked", () => {
+    expect(parseDeepLink("https://threads/env/thread", SCHEMES)).toBeNull();
+    expect(parseDeepLink("t3codex://threads/env/thread", SCHEMES)).toBeNull();
+  });
+
+  it("rejects other hosts, including the renderer bundle URL", () => {
+    expect(parseDeepLink("t3code://app/#/env/thread", SCHEMES)).toBeNull();
+    expect(parseDeepLink("t3code://oauth/callback", SCHEMES)).toBeNull();
+  });
+
+  it("requires exactly two path segments", () => {
+    expect(parseDeepLink("t3code://threads/env", SCHEMES)).toBeNull();
+    expect(parseDeepLink("t3code://threads/env/thread/extra", SCHEMES)).toBeNull();
+    expect(parseDeepLink("t3code://threads", SCHEMES)).toBeNull();
+  });
+
+  // A decoded separator would let a crafted link address a different route than
+  // the one the two segments appear to describe.
+  it("rejects segments that decode back into path separators", () => {
+    expect(parseDeepLink("t3code://threads/env%2F..%2Fother/thread", SCHEMES)).toBeNull();
+    expect(parseDeepLink("t3code://threads/env/thread%3Fx%3D1", SCHEMES)).toBeNull();
+    expect(parseDeepLink("t3code://threads/env/thread%23frag", SCHEMES)).toBeNull();
+  });
+
+  it("rejects blank or whitespace-padded segments", () => {
+    expect(parseDeepLink("t3code://threads/%20/thread", SCHEMES)).toBeNull();
+    expect(parseDeepLink("t3code://threads/env/%20thread", SCHEMES)).toBeNull();
+  });
+
+  it("rejects malformed percent-encoding instead of throwing", () => {
+    expect(parseDeepLink("t3code://threads/%E0%A4%A/thread", SCHEMES)).toBeNull();
+  });
+
+  it("rejects input that is not a URL at all", () => {
+    expect(parseDeepLink("", SCHEMES)).toBeNull();
+    expect(parseDeepLink("not a url", SCHEMES)).toBeNull();
+  });
+});
+
+describe("findDeepLinkInArgv", () => {
+  // Electron passes the full argv of the second launch, so the URL is never the
+  // first element in practice.
+  it("finds the link among unrelated arguments", () => {
+    expect(
+      findDeepLinkInArgv(
+        ["/path/to/T3 Code", "--allow-file-access", "t3code://threads/env/thread"],
+        SCHEMES,
+      ),
+    ).toBe("t3code://threads/env/thread");
+  });
+
+  it("trims surrounding whitespace added by the shell or desktop entry", () => {
+    expect(findDeepLinkInArgv(["  t3code://threads/env/thread  "], SCHEMES)).toBe(
+      "t3code://threads/env/thread",
+    );
+  });
+
+  it("returns the first match when several links are present", () => {
+    expect(
+      findDeepLinkInArgv(["t3code://threads/a/b", "t3code://threads/c/d"], SCHEMES),
+    ).toBe("t3code://threads/a/b");
+  });
+
+  it("returns null when no argument uses a registered scheme", () => {
+    expect(findDeepLinkInArgv(["/path/to/T3 Code", "--flag"], SCHEMES)).toBeNull();
+    expect(findDeepLinkInArgv(["https://example.com"], SCHEMES)).toBeNull();
+    expect(findDeepLinkInArgv([], SCHEMES)).toBeNull();
+  });
+});

--- a/apps/desktop/src/app/DesktopDeepLink.test.ts
+++ b/apps/desktop/src/app/DesktopDeepLink.test.ts
@@ -97,9 +97,9 @@ describe("findDeepLinkInArgv", () => {
   });
 
   it("returns the first match when several links are present", () => {
-    expect(
-      findDeepLinkInArgv(["t3code://threads/a/b", "t3code://threads/c/d"], SCHEMES),
-    ).toBe("t3code://threads/a/b");
+    expect(findDeepLinkInArgv(["t3code://threads/a/b", "t3code://threads/c/d"], SCHEMES)).toBe(
+      "t3code://threads/a/b",
+    );
   });
 
   it("returns null when no argument uses a registered scheme", () => {

--- a/apps/desktop/src/app/DesktopDeepLink.ts
+++ b/apps/desktop/src/app/DesktopDeepLink.ts
@@ -1,0 +1,103 @@
+import type { DesktopDeepLinkTarget } from "@t3tools/contracts";
+
+// Parsing for the `t3code://` deep links that address an existing thread.
+//
+// The external contract is the same one the mobile app and widgets already use:
+//
+//   t3code://threads/<environmentId>/<threadId>
+//
+// which maps onto the renderer's typed route `/$environmentId/$threadId`. Only
+// the external shape is stable; the renderer route stays an implementation
+// detail, so callers outside the app never depend on the hash history layout.
+//
+// Parsing lives here as plain functions (no Effect) so the URL edge cases can be
+// unit tested without an Electron or Effect runtime, mirroring wslPathParsing.
+
+export const DEEP_LINK_THREAD_HOST = "threads";
+
+// Re-exported so main-process modules do not each reach into the contracts
+// package for what is, from their side, this module's return type.
+export type DeepLinkTarget = DesktopDeepLinkTarget;
+
+// Path segments are percent-decoded by `URL`, but a decoded segment can still
+// be empty, contain a path separator, or be pure whitespace when the link was
+// hand-written or truncated by a chat client. Anything that is not a single
+// clean segment is rejected rather than normalized: a wrong-but-plausible id
+// would navigate to someone else's thread, which is worse than not navigating.
+function isCleanSegment(value: string): boolean {
+  if (value.length === 0 || value.trim().length !== value.length) return false;
+  return !/[/\\?#]/.test(value);
+}
+
+/**
+ * Parses a deep link URL into a navigation target.
+ *
+ * Returns `null` for anything that is not a well-formed thread link, including
+ * links using a different scheme, so callers can fall back to simply revealing
+ * the window.
+ */
+export function parseDeepLink(rawUrl: string, schemes: readonly string[]): DeepLinkTarget | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  // `URL.protocol` keeps the trailing colon.
+  const scheme = url.protocol.replace(/:$/, "").toLowerCase();
+  if (!schemes.some((candidate) => candidate.toLowerCase() === scheme)) {
+    return null;
+  }
+
+  // `t3code://threads/<env>/<thread>` puts `threads` in the host position, not
+  // in the path — the authority component absorbs the first segment.
+  if (url.hostname.toLowerCase() !== DEEP_LINK_THREAD_HOST) {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter((segment) => segment.length > 0);
+  if (segments.length !== 2) {
+    return null;
+  }
+
+  let environmentId: string;
+  let threadId: string;
+  try {
+    environmentId = decodeURIComponent(segments[0] ?? "");
+    threadId = decodeURIComponent(segments[1] ?? "");
+  } catch {
+    // Malformed percent-encoding.
+    return null;
+  }
+
+  if (!isCleanSegment(environmentId) || !isCleanSegment(threadId)) {
+    return null;
+  }
+
+  return { kind: "thread", environmentId, threadId };
+}
+
+/**
+ * Extracts the first deep link from a process argv vector.
+ *
+ * Windows and Linux deliver protocol URLs as a command-line argument — both on
+ * first launch and, for an already-running app, through Electron's
+ * `second-instance` event. macOS instead emits `open-url`, so this is not used
+ * there.
+ */
+export function findDeepLinkInArgv(
+  argv: readonly string[],
+  schemes: readonly string[],
+): string | null {
+  for (const arg of argv) {
+    if (typeof arg !== "string") continue;
+    const trimmed = arg.trim();
+    if (trimmed.length === 0) continue;
+    if (!schemes.some((scheme) => trimmed.toLowerCase().startsWith(`${scheme.toLowerCase()}://`))) {
+      continue;
+    }
+    return trimmed;
+  }
+  return null;
+}

--- a/apps/desktop/src/app/DesktopDeepLinkBuffer.test.ts
+++ b/apps/desktop/src/app/DesktopDeepLinkBuffer.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { decodeDesktopDeepLinkTarget, makeDesktopDeepLinkBuffer } from "./DesktopDeepLinkBuffer.ts";
+
+const target = {
+  kind: "thread" as const,
+  environmentId: "environment-1",
+  threadId: "thread-1",
+};
+
+describe("DesktopDeepLinkBuffer", () => {
+  it("replays the latest target received before the renderer subscribes", () => {
+    const buffer = makeDesktopDeepLinkBuffer();
+    buffer.push({ ...target, threadId: "stale" });
+    buffer.push(target);
+    const listener = vi.fn();
+
+    buffer.subscribe(listener);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(target);
+  });
+
+  it("delivers later targets directly and stops after unsubscribe", () => {
+    const buffer = makeDesktopDeepLinkBuffer();
+    const listener = vi.fn();
+    const unsubscribe = buffer.subscribe(listener);
+
+    buffer.push(target);
+    unsubscribe();
+    buffer.push({ ...target, threadId: "later" });
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it("rejects malformed renderer-bound targets", () => {
+    expect(decodeDesktopDeepLinkTarget(target)).toEqual(target);
+    expect(decodeDesktopDeepLinkTarget(null)).toBeNull();
+    expect(decodeDesktopDeepLinkTarget({ ...target, threadId: 1 })).toBeNull();
+    expect(decodeDesktopDeepLinkTarget({ ...target, kind: "project" })).toBeNull();
+  });
+});

--- a/apps/desktop/src/app/DesktopDeepLinkBuffer.ts
+++ b/apps/desktop/src/app/DesktopDeepLinkBuffer.ts
@@ -1,0 +1,43 @@
+import type { DesktopDeepLinkTarget } from "@t3tools/contracts";
+
+export function decodeDesktopDeepLinkTarget(value: unknown): DesktopDeepLinkTarget | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (
+    candidate.kind !== "thread" ||
+    typeof candidate.environmentId !== "string" ||
+    typeof candidate.threadId !== "string"
+  ) {
+    return null;
+  }
+  return {
+    kind: "thread",
+    environmentId: candidate.environmentId,
+    threadId: candidate.threadId,
+  };
+}
+
+export function makeDesktopDeepLinkBuffer() {
+  const listeners = new Set<(target: DesktopDeepLinkTarget) => void>();
+  let pending: DesktopDeepLinkTarget | null = null;
+
+  const push = (target: DesktopDeepLinkTarget) => {
+    if (listeners.size === 0) {
+      pending = target;
+      return;
+    }
+    for (const listener of listeners) listener(target);
+  };
+
+  const subscribe = (listener: (target: DesktopDeepLinkTarget) => void) => {
+    listeners.add(listener);
+    if (pending !== null) {
+      const target = pending;
+      pending = null;
+      listener(target);
+    }
+    return () => listeners.delete(listener);
+  };
+
+  return { push, subscribe };
+}

--- a/apps/desktop/src/app/DesktopDeepLinkRouter.ts
+++ b/apps/desktop/src/app/DesktopDeepLinkRouter.ts
@@ -1,0 +1,95 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+import * as DesktopDeepLink from "./DesktopDeepLink.ts";
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+import { makeComponentLogger } from "./DesktopObservability.ts";
+
+// Delivers `t3code://` links to the renderer.
+//
+// The two platforms hand the URL over differently:
+//   * macOS emits `open-url` — the URL never appears in argv.
+//   * Windows/Linux pass it as a command-line argument, both on first launch
+//     and, for an already-running app, via `second-instance`.
+//
+// Both paths funnel into the same DesktopWindow.dispatchDeepLink, which owns
+// window creation, the wait for the first renderer load, and the hold-until-
+// backend-ready behaviour.
+
+const { logInfo } = makeComponentLogger("desktop-deep-link-router");
+
+export class DesktopDeepLinkRouter extends Context.Service<
+  DesktopDeepLinkRouter,
+  {
+    readonly register: Effect.Effect<void, never, Scope.Scope>;
+  }
+>()("@t3tools/desktop/app/DesktopDeepLinkRouter") {}
+
+export const make = Effect.gen(function* () {
+  const electronApp = yield* ElectronApp.ElectronApp;
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const context = yield* Effect.context<DesktopWindow.DesktopWindow>();
+  const runPromise = Effect.runPromiseWith(context);
+
+  const schemes = [ElectronProtocol.getDesktopScheme(environment.isDevelopment)];
+
+  const handle = (rawUrl: string, source: "open-url" | "second-instance" | "launch-argv") => {
+    const target = DesktopDeepLink.parseDeepLink(rawUrl, schemes);
+    if (target === null) {
+      // Not ours to act on: OAuth callbacks and the renderer bundle URL also
+      // use this scheme, and they are handled elsewhere.
+      return;
+    }
+    void runPromise(
+      Effect.gen(function* () {
+        yield* logInfo("received deep link", { source, kind: target.kind });
+        yield* desktopWindow.dispatchDeepLink(target);
+      }).pipe(
+        // A malformed link must never take down the app.
+        Effect.catchCause((cause) =>
+          Effect.logWarning("failed to dispatch deep link", { source, cause }),
+        ),
+      ),
+    );
+  };
+
+  const register = Effect.gen(function* () {
+    // Typed structurally so this module keeps talking to Electron only through
+    // the ElectronApp service, as the rest of the app does.
+    yield* electronApp.on<[{ preventDefault: () => void }, string]>(
+      "open-url",
+      (event, url) => {
+        event.preventDefault();
+        handle(url, "open-url");
+      },
+    );
+
+    // A second `second-instance` listener alongside the one that reveals the
+    // window: Electron invokes every registered listener, so window reveal and
+    // link routing stay owned by their respective modules.
+    yield* electronApp.on<[unknown, readonly string[], string]>(
+      "second-instance",
+      (_event, argv) => {
+        const url = DesktopDeepLink.findDeepLinkInArgv(argv ?? [], schemes);
+        if (url !== null) handle(url, "second-instance");
+      },
+    );
+
+    // Windows/Linux cold start: the link that launched the app is already in
+    // our own argv, and no event will ever be emitted for it.
+    const launchUrl = DesktopDeepLink.findDeepLinkInArgv(process.argv, schemes);
+    if (launchUrl !== null) {
+      handle(launchUrl, "launch-argv");
+    }
+  }).pipe(Effect.withSpan("desktop.deepLinkRouter.register"));
+
+  return DesktopDeepLinkRouter.of({ register });
+});
+
+export const layer = Layer.effect(DesktopDeepLinkRouter, make);

--- a/apps/desktop/src/app/DesktopDeepLinkRouter.ts
+++ b/apps/desktop/src/app/DesktopDeepLinkRouter.ts
@@ -62,13 +62,10 @@ export const make = Effect.gen(function* () {
   const register = Effect.gen(function* () {
     // Typed structurally so this module keeps talking to Electron only through
     // the ElectronApp service, as the rest of the app does.
-    yield* electronApp.on<[{ preventDefault: () => void }, string]>(
-      "open-url",
-      (event, url) => {
-        event.preventDefault();
-        handle(url, "open-url");
-      },
-    );
+    yield* electronApp.on<[{ preventDefault: () => void }, string]>("open-url", (event, url) => {
+      event.preventDefault();
+      handle(url, "open-url");
+    });
 
     // A second `second-instance` listener alongside the one that reveals the
     // window: Electron invokes every registered listener, so window reveal and

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -93,6 +93,7 @@ function makeDesktopWindowLayer(
     handleBackendNotReady: Effect.void,
     flushMainWindowBounds: input.flushMainWindowBounds ?? Effect.void,
     dispatchMenuAction: () => Effect.void,
+    dispatchDeepLink: () => Effect.void,
     zoomMain: () => Effect.void,
     syncAppearance: Effect.void,
   });

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -91,6 +91,7 @@ function makePoolLayer(
           handleBackendNotReady: Effect.void,
           flushMainWindowBounds: Effect.void,
           dispatchMenuAction: () => Effect.die("unexpected menu action"),
+          dispatchDeepLink: () => Effect.die("unexpected deep link"),
           zoomMain: () => Effect.die("unexpected zoom"),
           syncAppearance: Effect.void,
         } satisfies DesktopWindow.DesktopWindow["Service"]),

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -6,6 +6,7 @@ export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 export const PROBE_REMOTE_EDITORS_CHANNEL = "desktop:probe-remote-editors";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const QUIT_SHORTCUT_CHANNEL = "desktop:quit-shortcut";
+export const DEEP_LINK_CHANNEL = "desktop:deep-link";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";
 export const WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:window-fullscreen-state";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -43,6 +43,7 @@ import * as DesktopLocalEnvironmentAuth from "./backend/DesktopLocalEnvironmentA
 import * as DesktopNetworkInterfaces from "./backend/DesktopNetworkInterfaces.ts";
 import * as DesktopEnvironment from "./app/DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./app/DesktopLifecycle.ts";
+import * as DesktopDeepLinkRouter from "./app/DesktopDeepLinkRouter.ts";
 import * as DesktopLinuxUrlHandler from "./app/DesktopLinuxUrlHandler.ts";
 import * as DesktopShutdown from "./app/DesktopShutdown.ts";
 import * as DesktopObservability from "./app/DesktopObservability.ts";
@@ -186,6 +187,7 @@ const desktopApplicationLayer = Layer.mergeAll(
   DesktopLifecycle.layer,
   DesktopApplicationMenu.layer,
   DesktopLinuxUrlHandler.layer,
+  DesktopDeepLinkRouter.layer,
   DesktopShellEnvironment.layer,
   desktopSshLayer,
 ).pipe(

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -7,9 +7,19 @@ import type {
 import { exposeClerkBridge } from "@clerk/electron/preload";
 import { contextBridge, ipcRenderer } from "electron";
 
+import {
+  decodeDesktopDeepLinkTarget,
+  makeDesktopDeepLinkBuffer,
+} from "./app/DesktopDeepLinkBuffer.ts";
 import * as IpcChannels from "./ipc/channels.ts";
 
 exposeClerkBridge({ passkeys: true });
+
+const deepLinkBuffer = makeDesktopDeepLinkBuffer();
+ipcRenderer.on(IpcChannels.DEEP_LINK_CHANNEL, (_event, value: unknown) => {
+  const target = decodeDesktopDeepLinkTarget(value);
+  if (target !== null) deepLinkBuffer.push(target);
+});
 
 function unwrapEnsureSshEnvironmentResult(result: unknown) {
   if (
@@ -132,28 +142,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ipcRenderer.removeListener(IpcChannels.QUIT_SHORTCUT_CHANNEL, wrappedListener);
     };
   },
-  onDeepLink: (listener) => {
-    const wrappedListener = (_event: Electron.IpcRendererEvent, target: unknown) => {
-      // The main process already validated the URL, but this is the trust
-      // boundary into the renderer — re-check the shape rather than casting.
-      if (typeof target !== "object" || target === null) return;
-      const candidate = target as Record<string, unknown>;
-      if (candidate.kind !== "thread") return;
-      if (typeof candidate.environmentId !== "string" || typeof candidate.threadId !== "string") {
-        return;
-      }
-      listener({
-        kind: "thread",
-        environmentId: candidate.environmentId,
-        threadId: candidate.threadId,
-      });
-    };
-
-    ipcRenderer.on(IpcChannels.DEEP_LINK_CHANNEL, wrappedListener);
-    return () => {
-      ipcRenderer.removeListener(IpcChannels.DEEP_LINK_CHANNEL, wrappedListener);
-    };
-  },
+  onDeepLink: (listener) => deepLinkBuffer.subscribe(listener),
   getWindowFullscreenState: () =>
     ipcRenderer.sendSync(IpcChannels.GET_WINDOW_FULLSCREEN_STATE_CHANNEL) === true,
   onWindowFullscreenStateChange: (listener) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -132,6 +132,28 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ipcRenderer.removeListener(IpcChannels.QUIT_SHORTCUT_CHANNEL, wrappedListener);
     };
   },
+  onDeepLink: (listener) => {
+    const wrappedListener = (_event: Electron.IpcRendererEvent, target: unknown) => {
+      // The main process already validated the URL, but this is the trust
+      // boundary into the renderer — re-check the shape rather than casting.
+      if (typeof target !== "object" || target === null) return;
+      const candidate = target as Record<string, unknown>;
+      if (candidate.kind !== "thread") return;
+      if (typeof candidate.environmentId !== "string" || typeof candidate.threadId !== "string") {
+        return;
+      }
+      listener({
+        kind: "thread",
+        environmentId: candidate.environmentId,
+        threadId: candidate.threadId,
+      });
+    };
+
+    ipcRenderer.on(IpcChannels.DEEP_LINK_CHANNEL, wrappedListener);
+    return () => {
+      ipcRenderer.removeListener(IpcChannels.DEEP_LINK_CHANNEL, wrappedListener);
+    };
+  },
   getWindowFullscreenState: () =>
     ipcRenderer.sendSync(IpcChannels.GET_WINDOW_FULLSCREEN_STATE_CHANNEL) === true,
   onWindowFullscreenStateChange: (listener) => {

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -81,6 +81,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     handleBackendNotReady: Effect.void,
     flushMainWindowBounds: Effect.void,
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
+    dispatchDeepLink: () => Effect.void,
     zoomMain: (direction) =>
       Deferred.succeed(selectedAction, `zoom-${direction}`).pipe(Effect.asVoid),
     syncAppearance: Effect.void,

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -43,7 +43,11 @@ import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
-import { MENU_ACTION_CHANNEL, WINDOW_FULLSCREEN_STATE_CHANNEL } from "../ipc/channels.ts";
+import {
+  DEEP_LINK_CHANNEL,
+  MENU_ACTION_CHANNEL,
+  WINDOW_FULLSCREEN_STATE_CHANNEL,
+} from "../ipc/channels.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
 import * as PreviewManager from "../preview/Manager.ts";
@@ -394,6 +398,58 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
   });
 
 describe("DesktopWindow", () => {
+  it.effect("holds a cold-start deep link until the backend can create a window", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({ window: fakeWindow.window, createCount, mainWindow });
+      const target = {
+        kind: "thread" as const,
+        environmentId: "environment-1",
+        threadId: "thread-1",
+      };
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.dispatchDeepLink(target);
+        assert.equal(yield* Ref.get(createCount), 0);
+
+        yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
+
+        assert.equal(yield* Ref.get(createCount), 1);
+        assert.deepEqual(fakeWindow.send.mock.calls, [[DEEP_LINK_CHANNEL, target]]);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("delivers a deep link that races backend readiness exactly once", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({ window: fakeWindow.window, createCount, mainWindow });
+      const target = {
+        kind: "thread" as const,
+        environmentId: "environment-1",
+        threadId: "thread-1",
+      };
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* Effect.all(
+          [
+            desktopWindow.dispatchDeepLink(target),
+            desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773")),
+          ],
+          { concurrency: "unbounded" },
+        );
+
+        assert.deepEqual(fakeWindow.send.mock.calls, [[DEEP_LINK_CHANNEL, target]]);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
   it("restores bounds only when the window fits within a connected display", () => {
     const persistedBounds = { x: 2040, y: 80, width: 1320, height: 880 };
     const displays = [

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -14,11 +14,13 @@ import * as DesktopAssets from "../app/DesktopAssets.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import { makeComponentLogger } from "../app/DesktopObservability.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
+import type { DeepLinkTarget } from "../app/DesktopDeepLink.ts";
 import { getDesktopUrl } from "../electron/ElectronProtocol.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import {
+  DEEP_LINK_CHANNEL,
   MENU_ACTION_CHANNEL,
   QUIT_SHORTCUT_CHANNEL,
   WINDOW_FULLSCREEN_STATE_CHANNEL,
@@ -100,6 +102,11 @@ export class DesktopWindow extends Context.Service<
     readonly handleBackendNotReady: Effect.Effect<void>;
     readonly flushMainWindowBounds: Effect.Effect<void>;
     readonly dispatchMenuAction: (action: string) => Effect.Effect<void, DesktopWindowError>;
+    // Routes an already-parsed deep link to the renderer. Unlike a menu action,
+    // this can arrive before the backend is ready (the link is what launched the
+    // app), so an undeliverable target is held and replayed by
+    // handleBackendReady instead of being dropped.
+    readonly dispatchDeepLink: (target: DeepLinkTarget) => Effect.Effect<void, DesktopWindowError>;
     // Zooms the main window's own webContents. The Electron `zoomIn`/`zoomOut`
     // menu roles act on whichever webContents has keyboard focus, so with an
     // embedded preview WebContentsView (or DevTools) focused they zoom the
@@ -280,6 +287,13 @@ export const make = Effect.gen(function* () {
   // createMainIfBackendReady, which gates the post-readiness window
   // open in development and the macOS "activate without windows" path.
   const backendReadyRef = yield* Ref.make(false);
+  // A deep link can be what launches the app, so it may arrive long before the
+  // backend is ready and before any window exists. Holding the most recent
+  // target here (rather than dropping it, as menu actions do) is what makes
+  // "click a link while the app is closed" land on the right thread; it is
+  // replayed once by handleBackendReady. Only the newest target is kept — if
+  // several links arrive during startup, the last one is what the user meant.
+  const pendingDeepLinkRef = yield* Ref.make<Option.Option<DeepLinkTarget>>(Option.none());
   // The transient "Connecting to WSL" splash window, tracked separately so it
   // is never mistaken for the real main window.
   const splashWindowRef = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
@@ -833,6 +847,38 @@ export const make = Effect.gen(function* () {
     Effect.withSpan("desktop.window.showConnectingSplash"),
   );
 
+  // Shared by dispatchDeepLink and by the replay in handleBackendReady, so a
+  // link that launched the app takes exactly the same delivery path as one that
+  // arrived while the app was already running.
+  const deliverDeepLink = Effect.fn("desktop.window.deliverDeepLink")(function* (
+    target: DeepLinkTarget,
+  ) {
+    yield* Effect.annotateCurrentSpan({ environmentId: target.environmentId });
+    const existingWindow = yield* focusedMainWindow;
+    if (Option.isNone(existingWindow) && !(yield* Ref.get(backendReadyRef))) {
+      yield* Ref.set(pendingDeepLinkRef, Option.some(target));
+      yield* logWindowInfo("deep link held until backend is ready", { kind: target.kind });
+      return;
+    }
+
+    const targetWindow = Option.isSome(existingWindow) ? existingWindow.value : yield* ensureMain;
+
+    const send = () => {
+      if (targetWindow.isDestroyed()) return;
+      targetWindow.webContents.send(DEEP_LINK_CHANNEL, target);
+      void runPromise(electronWindow.reveal(targetWindow));
+    };
+
+    // On a cold start the renderer is still loading and would miss an immediate
+    // send, so wait for the first load to finish before handing the link over.
+    if (targetWindow.webContents.isLoadingMainFrame()) {
+      targetWindow.webContents.once("did-finish-load", send);
+      return;
+    }
+
+    send();
+  });
+
   return DesktopWindow.of({
     createMain,
     ensureMain,
@@ -864,6 +910,13 @@ export const make = Effect.gen(function* () {
       yield* Ref.set(backendReadyRef, true);
       yield* logWindowInfo("backend ready", { source: "http", url: httpBaseUrl.href });
       yield* createMainIfBackendReady;
+
+      // Replay a link that arrived before the backend came up. Taken (not read)
+      // so a later backend restart cannot deliver the same link a second time.
+      const pending = yield* Ref.getAndSet(pendingDeepLinkRef, Option.none());
+      if (Option.isSome(pending)) {
+        yield* deliverDeepLink(pending.value);
+      }
     }),
     handleBackendNotReady: Ref.set(backendReadyRef, false).pipe(
       Effect.withSpan("desktop.window.handleBackendNotReady"),
@@ -892,6 +945,7 @@ export const make = Effect.gen(function* () {
 
       send();
     }),
+    dispatchDeepLink: deliverDeepLink,
     zoomMain: Effect.fn("desktop.window.zoomMain")(function* (direction) {
       yield* Effect.annotateCurrentSpan({ direction });
       const window = yield* focusedMainWindow;

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -847,22 +847,11 @@ export const make = Effect.gen(function* () {
     Effect.withSpan("desktop.window.showConnectingSplash"),
   );
 
-  // Shared by dispatchDeepLink and by the replay in handleBackendReady, so a
-  // link that launched the app takes exactly the same delivery path as one that
-  // arrived while the app was already running.
-  const deliverDeepLink = Effect.fn("desktop.window.deliverDeepLink")(function* (
+  const sendDeepLink = Effect.fn("desktop.window.sendDeepLink")(function* (
+    targetWindow: Electron.BrowserWindow,
     target: DeepLinkTarget,
   ) {
     yield* Effect.annotateCurrentSpan({ environmentId: target.environmentId });
-    const existingWindow = yield* focusedMainWindow;
-    if (Option.isNone(existingWindow) && !(yield* Ref.get(backendReadyRef))) {
-      yield* Ref.set(pendingDeepLinkRef, Option.some(target));
-      yield* logWindowInfo("deep link held until backend is ready", { kind: target.kind });
-      return;
-    }
-
-    const targetWindow = Option.isSome(existingWindow) ? existingWindow.value : yield* ensureMain;
-
     const send = () => {
       if (targetWindow.isDestroyed()) return;
       targetWindow.webContents.send(DEEP_LINK_CHANNEL, target);
@@ -877,6 +866,33 @@ export const make = Effect.gen(function* () {
     }
 
     send();
+  });
+
+  const flushPendingDeepLink = Effect.fn("desktop.window.flushPendingDeepLink")(function* () {
+    const pending = yield* Ref.getAndSet(pendingDeepLinkRef, Option.none());
+    if (Option.isNone(pending)) return;
+    const existingWindow = yield* focusedMainWindow;
+    const targetWindow = Option.isSome(existingWindow) ? existingWindow.value : yield* ensureMain;
+    yield* sendDeepLink(targetWindow, pending.value);
+  });
+
+  const deliverDeepLink = Effect.fn("desktop.window.deliverDeepLink")(function* (
+    target: DeepLinkTarget,
+  ) {
+    const existingWindow = yield* focusedMainWindow;
+    if (Option.isSome(existingWindow)) {
+      yield* sendDeepLink(existingWindow.value, target);
+      return;
+    }
+
+    // Store first, then re-check readiness. If backend readiness races this
+    // write, either handleBackendReady or this flush wins the atomic take.
+    yield* Ref.set(pendingDeepLinkRef, Option.some(target));
+    if (yield* Ref.get(backendReadyRef)) {
+      yield* flushPendingDeepLink();
+      return;
+    }
+    yield* logWindowInfo("deep link held until backend is ready", { kind: target.kind });
   });
 
   return DesktopWindow.of({
@@ -913,10 +929,7 @@ export const make = Effect.gen(function* () {
 
       // Replay a link that arrived before the backend came up. Taken (not read)
       // so a later backend restart cannot deliver the same link a second time.
-      const pending = yield* Ref.getAndSet(pendingDeepLinkRef, Option.none());
-      if (Option.isSome(pending)) {
-        yield* deliverDeepLink(pending.value);
-      }
+      yield* flushPendingDeepLink();
     }),
     handleBackendNotReady: Ref.set(backendReadyRef, false).pipe(
       Effect.withSpan("desktop.window.handleBackendNotReady"),

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -208,6 +208,27 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
     };
   }, [navigate, pathname]);
 
+  useEffect(() => {
+    const onDeepLink = window.desktopBridge?.onDeepLink;
+    if (typeof onDeepLink !== "function") {
+      return;
+    }
+
+    const unsubscribe = onDeepLink((target) => {
+      if (target.kind !== "thread") {
+        return;
+      }
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: { environmentId: target.environmentId, threadId: target.threadId },
+      });
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [navigate]);
+
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen style={sidebarProviderStyle}>
       <ProjectProjectionRetention />

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1061,6 +1061,18 @@ export const DesktopPreviewAutomationWaitForInputSchema = Schema.Struct({
   input: PreviewAutomationWaitForInput,
 });
 
+/**
+ * A `t3code://` deep link that has already been validated by the main process.
+ *
+ * Discriminated so future link kinds (for example opening a dialog) can be added
+ * without the renderer having to re-parse raw URLs.
+ */
+export type DesktopDeepLinkTarget = {
+  readonly kind: "thread";
+  readonly environmentId: string;
+  readonly threadId: string;
+};
+
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
   /**
@@ -1135,6 +1147,7 @@ export interface DesktopBridge {
    * desktop builds never emit it.
    */
   onQuitShortcut?: (listener: (state: "down" | "up") => void) => () => void;
+  onDeepLink: (listener: (target: DesktopDeepLinkTarget) => void) => () => void;
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;


### PR DESCRIPTION
## Summary

- **Problem**: `t3code://threads/<environmentId>/<threadId>` links are already produced by `buildAgentAwarenessDeepLink` and consumed by the mobile app, but opening one on desktop does nothing beyond (at most) focusing the window — the user still has to find the thread by hand.
- **Why it matters**: it blocks exactly the integrations #4996 asks for — a menu-bar app, notification action, hardware controller or any local automation that wants to take the user straight to the thread that needs attention.
- **What changed**: the main process now listens for `open-url` (macOS) and reads the URL out of `argv` (Windows/Linux, both cold start and `second-instance`), validates it, and hands a typed target to the renderer, which navigates through the existing `/$environmentId/$threadId` route.
- **What did NOT change (scope boundary)**: no changes to Clerk/OAuth handling, to `DesktopClerk`'s existing `second-instance` reveal listener, to the deep-link *producer*, to mobile, or to the packaged Linux `.desktop` file. The external URL contract is unchanged — this only teaches desktop to consume what mobile already consumes.

## On CONTRIBUTING

I read `CONTRIBUTING.md` before opening this, so to address its points directly:

- **Issue first**: #4996 has been open since 30 July asking for exactly this, filed by someone else. This is an implementation of an existing request, not a drive-by feature or a scope expansion.
- **Size**: 430 lines, of which ~130 are the test file and a good share of the rest is comments explaining the platform differences. The behavioural change is one new module plus one method on `DesktopWindow`.
- **UI evidence**: there is no visual change to capture — no new surface, no motion, no transition. The observable difference is that a URL now navigates. If you would still like a screen recording of the navigation, I am happy to attach one.
- **Shrinking**: if this is still too much at once, I can cut it down to macOS `open-url` only and drop the Windows/Linux argv paths, or split the pure parser out as its own PR. Say which you prefer rather than closing it, and I will resubmit.

Entirely fine if the answer is "not now" — no obligation implied.

## Change Type / Scope

- [ ] Bug fix  [x] Feature  [ ] Refactor  [ ] Docs  [ ] Security  [ ] Chore
- Scope: apps/desktop (main + preload), apps/web (renderer navigation), packages/contracts (bridge type)

## Linked Issue/PR

- Closes #4996
- Related #5978 — that report is about `second-instance` dropping the URL for *SSO callbacks*. This PR adds a second `second-instance` listener for thread links and does not touch the Clerk path, so #5978 is not fixed here.
- Related #4625 — the target type is a discriminated union so a `checkout-pr` link kind can be added without re-parsing raw URLs in the renderer.

## What changed

**Before** — nothing consumes the URL. `DesktopClerk` registers the only `second-instance` listener and ignores its arguments:

```ts
yield* electronApp.on("second-instance", () => {
  void runPromise(
    Effect.gen(function* () {
      const mainWindow = yield* electronWindow.currentMainOrFirst;
      if (Option.isSome(mainWindow)) {
        yield* electronWindow.reveal(mainWindow.value);
      }
    }),
  );
});
```

There is no `open-url` listener at all, so on macOS the URL never reaches the app.

**After** — a new `DesktopDeepLinkRouter` owns link delivery, and `DesktopWindow` gains `dispatchDeepLink`:

```ts
// DesktopDeepLinkRouter.register
yield* electronApp.on<[{ preventDefault: () => void }, string]>("open-url", (event, url) => {
  event.preventDefault();
  handle(url, "open-url");
});

yield* electronApp.on<[unknown, readonly string[], string]>("second-instance", (_event, argv) => {
  const url = DesktopDeepLink.findDeepLinkInArgv(argv ?? [], schemes);
  if (url !== null) handle(url, "second-instance");
});

// Windows/Linux cold start: the launching URL is already in our own argv.
const launchUrl = DesktopDeepLink.findDeepLinkInArgv(process.argv, schemes);
if (launchUrl !== null) handle(launchUrl, "launch-argv");
```

Delivery reuses the `dispatchMenuAction` shape (existing window → otherwise `ensureMain`, wait for `did-finish-load` when the frame is still loading, then `reveal`), plus one addition that menu actions do not need:

```ts
if (Option.isNone(existingWindow) && !(yield* Ref.get(backendReadyRef))) {
  yield* Ref.set(pendingDeepLinkRef, Option.some(target));   // held, not dropped
  return;
}
```

`handleBackendReady` then replays it once via `Ref.getAndSet(pendingDeepLinkRef, Option.none())`. Without this, a link that *launches* the app would be discarded, which is half of what #4996 asks for.

Renderer navigates through the typed route rather than a raw hash:

```tsx
void navigate({
  to: "/$environmentId/$threadId",
  params: { environmentId: target.environmentId, threadId: target.threadId },
});
```

## Test plan

- [x] `DesktopDeepLink.test.ts` — 15 cases over the two pure functions.
- [x] Happy path: documented shape parses; both registered schemes accepted; scheme/host case-insensitive; segments percent-decoded.
- [x] Rejection: foreign schemes (`https://`, `t3codex://`); other hosts, explicitly including `t3code://app/...` (the renderer bundle) and `t3code://oauth/callback` — so this cannot swallow links that belong to other handlers.
- [x] Rejection: wrong segment count, blank/whitespace segments, malformed percent-encoding, non-URL input.
- [x] Rejection: segments that decode back into `/`, `?` or `#` — a crafted link must not address a different route than its two visible segments suggest.
- [x] argv extraction: finds the link among unrelated args, trims shell whitespace, takes the first of several, returns null when absent.

## Reproduction

### Environment

- OS: macOS 26 (Apple silicon)
- Runtime: Node 24
- App: built from this branch

### Steps

1. Open any thread and note its `environmentId` / `threadId`.
2. Navigate elsewhere in the app (or quit it entirely).
3. Run `open "t3code://threads/<environmentId>/<threadId>"`.
4. Before: the window is focused at most, and the thread is not opened. After: the app reveals and navigates to that thread, whether it was already running or was launched by the link.

Three existing `DesktopWindow` stubs (`DesktopLifecycle.test.ts`, `DesktopBackendPool.test.ts`, `DesktopApplicationMenu.test.ts`) each gained one line, because they `satisfies` the service type and it now has one more method. That is the whole reason those three files appear in the diff.

Commands run in this working tree:

```
apps/desktop     tsgo --noEmit        no errors
packages/contracts tsgo --noEmit      no errors
apps/web         tsgo --noEmit        no errors
apps/desktop     vp test run          59 files, 459 tests passed
```

## Evidence

- [x] Unit tests for both pure functions
- [x] Mutation-checked: weakening `isCleanSegment` to accept any non-empty string turns exactly two cases red ("rejects segments that decode back into path separators", "rejects blank or whitespace-padded segments") and leaves the other 13 green — the guards are actually exercised, not incidentally satisfied.
- [ ] Trace/log snippets
- [ ] Screenshot/recording — no visual change; see note above
- [ ] Perf numbers — N/A

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No — the URL is parsed, never executed, and only two id strings are forwarded.
- Data access scope changed? No. The parser is deliberately strict: only the app's own registered scheme, only the `threads` host, exactly two segments, and no segment that decodes back into a path separator. Everything else returns `null` and falls through to existing behaviour.

## Human Verification

- **Verified**: unit tests for the parsing and argv-extraction logic; typecheck.
- **NOT verified**: I have not run a packaged build end-to-end on macOS/Windows/Linux, so the Electron event wiring itself (`open-url` firing, `second-instance` argv contents, the cold-start replay through `handleBackendReady`) is reasoned from the existing `dispatchMenuAction` path rather than observed. If you would like me to attach a recording from a local build before merging, say the word.

## Failure Recovery

- How to revert: revert this PR's single commit — no migrations, no persisted state, no schema change.
- Files to restore: `apps/desktop/src/{app/DesktopApp.ts,ipc/channels.ts,main.ts,preload.ts,window/DesktopWindow.ts}`, `apps/web/src/components/AppSidebarLayout.tsx`, `packages/contracts/src/ipc.ts`; delete `apps/desktop/src/app/DesktopDeepLink*.ts`.
- Bad symptoms to watch: a `t3code://` link that used to reach another handler (OAuth) no longer doing so — the parser rejects any host other than `threads`, and there is a test for the `oauth` and `app` hosts specifically.

## Risks and Mitigations

- **Risk**: swallowing links intended for the Clerk/OAuth flow.
  - Mitigation: this adds a listener rather than replacing one; every listener still runs. Non-`threads` hosts return `null` and are ignored, with tests covering `t3code://app/...` and `t3code://oauth/callback`.
- **Risk**: the held deep link being replayed more than once across a backend restart.
  - Mitigation: `Ref.getAndSet(..., Option.none())` takes the value, so a later `handleBackendReady` has nothing to replay.
- **Risk**: navigating to a thread the user cannot see.
  - Mitigation: navigation goes through the existing typed route, so the route's own loading/missing states (`resolveThreadRouteRenderState`) apply unchanged.

---

🤖 Authored with [Claude Code](https://claude.com/claude-code). The parsing rules and the hold-until-ready behaviour were derived by reading the existing `dispatchMenuAction` / `handleBackendReady` paths in this repo; tests were written to fail without the change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3code://` deep link routing to open threads in `DesktopApp`
> - `DesktopDeepLinkRouter` parses `t3code://threads/{envId}/{threadId}` URLs from macOS `open-url`, Windows/Linux `second-instance`, and cold-start `process.argv`.
> - `DesktopWindow.dispatchDeepLink` holds the parsed target until the backend is ready, then sends it over `DEEP_LINK_CHANNEL` to the renderer.
> - [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/6008/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) subscribes to `window.desktopBridge.onDeepLink` and navigates to `/$environmentId/$threadId`.
> - Behavioral Change: `DesktopWindow` interface extended with `dispatchDeepLink`; test mock layers updated to include this method.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 699f356.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Electron protocol events (`open-url`, `second-instance`, argv) and IPC into the renderer. Parsing is strict and OAuth/app hosts are rejected, but a mistake could steal other scheme handlers or navigate to the wrong thread.
> 
> **Overview**
> Desktop now opens `t3code://threads/<environmentId>/<threadId>` links (the same contract mobile already uses) instead of only focusing the window.
> 
> A new router listens on macOS `open-url` (registered before `ready`) and on Windows/Linux via launch argv plus `second-instance`. URLs are parsed strictly (registered scheme, `threads` host, exactly two clean segments) so OAuth and renderer-bundle URLs are ignored. `DesktopWindow` holds a pending target until the backend is ready, then sends it over `desktop:deep-link`.
> 
> The preload buffers the typed target until the renderer subscribes; `AppSidebarLayout` navigates to `/$environmentId/$threadId`. Clerk/OAuth handling is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699f356f89ff11d03cc866fe94e5b3f5bb4782bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->