### PR TITLE
feat(web): add duplicate action to the T3 Code default theme

### DIFF
--- a/apps/web/src/components/settings/ThemeSettings.tsx
+++ b/apps/web/src/components/settings/ThemeSettings.tsx
@@ -475,6 +475,14 @@ export function ThemeLibrary({
             activeModes={pickedModesFor(null)}
             isActive={false}
             key={standardTheme.id}
+            onDuplicate={() =>
+              openThemeEditor({
+                editingThemeId: null,
+                seedThemeId: null,
+                seedName: `${standardTheme.label} copy`,
+                initialAppearance,
+              })
+            }
             onUse={() => persistTheme(appearanceMode === "system" ? "system" : appearanceMode)}
             onUseMode={handlePairPick(null)}
             theme={standardTheme}


### PR DESCRIPTION
## What Changed

The default T3 Code theme was the only theme without the option to copy, so customizing from the built-in look required Create theme plus a rename. Duplicate now opens the editor seeded from the default palette, named "T3 Code copy", matching the other built-in cards.

## Why

The T3 Code card was the only theme card without the copy icon, even though it ships with the app like Grove, Ocean, Ember, Iris, and T3 Chat. The default look isn't backed by a theme definition, so a duplicate had nothing to seed from, but the editor already starts new themes from the standard palette, which is that exact look. So wiring the copy icon there was a one-line-shaped change that made the library uniform. Saving the duplicate creates an installed custom theme and activates it, same as duplicating any other card.

## UI Changes

Before:
It was not possible to duplicate the default theme.
<img width="1344" height="466" alt="image" src="https://github.com/user-attachments/assets/5c3e8a7e-8176-474c-b2d2-7dbd3cba8d4f" />

After:
It is possible to duplicate the default theme.

https://github.com/user-attachments/assets/b423761c-4bd0-4c43-9961-01616b030968

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Theme Settings UI change reusing the existing theme editor flow; no auth, persistence, or security impact.
> 
> **Overview**
> Standard built-in theme cards (including **T3 Code**) now show the same **Duplicate** control as maintainer and custom themes.
> 
> Duplicating opens the theme editor as a **new** theme (`editingThemeId: null`) with the standard palette (`seedThemeId: null`) and a prefilled name like `T3 Code copy`, so users can fork the default look without using **Create theme** and renaming manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 139446ad5571f6d0af6dfaf945709802a935bee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add duplicate action to standard theme cards in the T3 Code default theme
> Adds an `onDuplicate` handler to `ThemeLibraryCard` instances in [ThemeSettings.tsx](https://github.com/pingdotgg/t3code/pull/6013/files#diff-4cc84a2ea71f7b5fef270e04a72f0110c8530ee83377e432642907950560b408) for standard themes. Clicking duplicate opens the theme editor with a pre-populated name in the format `'<theme> copy'`, creating a new custom theme based on the selected standard theme.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 139446a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->