### PR TITLE
feat(grok): bridge native ACP capabilities

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -56,6 +56,36 @@ function makeThread(
 }
 
 describe("buildThreadFeed", () => {
+  it("keeps context-window telemetry out of the mobile work feed", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-context-telemetry"),
+      projectId: ProjectId.make("project-1"),
+      title: "Context telemetry",
+      activities: [
+        makeActivity({
+          id: EventId.make("context-window"),
+          kind: "context-window.updated",
+          summary: "Context window updated",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          payload: { usedTokens: 42000, maxTokens: 272000 },
+        }),
+        makeActivity({
+          id: EventId.make("task-completed"),
+          kind: "task.completed",
+          summary: "Task completed",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          payload: { taskId: "task-1" },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const activityIds = feed.flatMap((entry) =>
+      entry.type === "activity-group" ? entry.activities.map((activity) => activity.id) : [],
+    );
+    expect(activityIds).toEqual(["task-completed"]);
+  });
+
   it("keeps historic work entries attributed to their turns", () => {
     const thread = makeThread({
       id: ThreadId.make("thread-1"),

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -21,6 +21,8 @@ const emitAskQuestion = process.env.T3_ACP_EMIT_ASK_QUESTION === "1";
 const emitXAiAskUserQuestion = process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION === "1";
 const emitXAiPromptCompleteThenHang = process.env.T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG === "1";
 const emitForeignSessionUpdates = process.env.T3_ACP_EMIT_FOREIGN_SESSION_UPDATES === "1";
+const emitConfigOptionUpdates = process.env.T3_ACP_EMIT_CONFIG_OPTION_UPDATES === "1";
+const emitUsageUpdates = process.env.T3_ACP_EMIT_USAGE_UPDATES === "1";
 const hangPromptForever = process.env.T3_ACP_HANG_PROMPT_FOREVER === "1";
 const hangFirstPromptForever = process.env.T3_ACP_HANG_FIRST_PROMPT_FOREVER === "1";
 const emitLateUpdateAfterCancel = process.env.T3_ACP_EMIT_LATE_UPDATE_AFTER_CANCEL === "1";
@@ -46,9 +48,20 @@ const permissionOptionIds = {
   rejectOnce: process.env.T3_ACP_REJECT_ONCE_OPTION_ID ?? "reject-once",
 };
 const sessionId = "mock-session-1";
+const grokNativeFixture = process.env.T3_ACP_GROK_NATIVE_FIXTURE === "1";
+const configuredUsageSize = Number(process.env.T3_ACP_USAGE_SIZE ?? "272000");
+const configuredUsageUsed = Number(process.env.T3_ACP_USAGE_USED ?? "42000");
+const usageSize =
+  Number.isSafeInteger(configuredUsageSize) && configuredUsageSize >= 0
+    ? configuredUsageSize
+    : 272000;
+const usageUsed =
+  Number.isSafeInteger(configuredUsageUsed) && configuredUsageUsed >= 0
+    ? configuredUsageUsed
+    : 42000;
 
 let currentModeId = "ask";
-let currentModelId = "default";
+let currentModelId = grokNativeFixture ? "grok-build" : "default";
 let parameterizedModelPicker = false;
 let currentReasoning = "medium";
 let currentContext = "272k";
@@ -124,6 +137,23 @@ function configOptions(): ReadonlyArray<AcpSchema.SessionConfigOption> {
     ];
 
     switch (currentModelId) {
+      case "grok-build":
+      case "grok-mock-alt":
+        return [
+          ...baseOptions,
+          {
+            id: "reasoning",
+            name: "Reasoning",
+            category: "thought_level",
+            type: "select",
+            currentValue: currentReasoning,
+            options: [
+              { value: "low", name: "Low" },
+              { value: "medium", name: "Medium" },
+              { value: "high", name: "High" },
+            ],
+          },
+        ];
       case "gpt-5.4":
         return [
           ...baseOptions,
@@ -392,6 +422,13 @@ const program = Effect.gen(function* () {
         );
       }
       currentModelId = request.modelId;
+      yield* agent.client.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "config_option_update",
+          configOptions: configOptions(),
+        },
+      });
       return {};
     }),
   );
@@ -427,9 +464,17 @@ const program = Effect.gen(function* () {
       if (request.configId === "fast") {
         currentFast = request.value === true || request.value === "true";
       }
-      return {
-        configOptions: configOptions(),
-      };
+      const nextConfigOptions = configOptions();
+      if (emitConfigOptionUpdates) {
+        yield* agent.client.sessionUpdate({
+          sessionId,
+          update: {
+            sessionUpdate: "config_option_update",
+            configOptions: nextConfigOptions,
+          },
+        });
+      }
+      return { configOptions: nextConfigOptions };
     }),
   );
 
@@ -463,6 +508,17 @@ const program = Effect.gen(function* () {
 
       if (failPrompt) {
         return yield* AcpError.AcpRequestError.internalError("Mock prompt failure");
+      }
+
+      if (emitUsageUpdates) {
+        yield* agent.client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "usage_update",
+            size: usageSize,
+            used: usageUsed,
+          },
+        });
       }
 
       if (emitStaleXAiPromptCompleteBeforeSecondHang && promptCount === 1) {

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -14,6 +14,7 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
+import { expect } from "vite-plus/test";
 
 import {
   ApprovalRequestId,
@@ -35,16 +36,28 @@ const mockAgentCommand = process.execPath;
 
 async function makeMockGrokWrapper(extraEnv?: Record<string, string>) {
   const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-mock-"));
-  const wrapperPath = NodePath.join(dir, "fake-grok.sh");
-  const envExports = Object.entries(extraEnv ?? {})
-    .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
-    .join("\n");
-  const script = `#!/bin/sh
-${envExports}
+  const values = { T3_ACP_GROK_NATIVE_FIXTURE: "1", ...(extraEnv ?? {}) };
+  const isWindows = process.platform === "win32";
+  const wrapperPath = NodePath.join(dir, isWindows ? "fake-grok.cmd" : "fake-grok.sh");
+  const script = isWindows
+    ? [
+        "@echo off",
+        ...Object.entries(values).map(
+          ([key, value]) => `set "${key}=${value.replaceAll("%", "%%")}"`,
+        ),
+        `"${mockAgentCommand}" "${mockAgentPath}" %*`,
+        "",
+      ].join("\r\n")
+    : `#!/bin/sh
+${Object.entries(values)
+  .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
+  .join("\n")}
 exec ${JSON.stringify(mockAgentCommand)} ${JSON.stringify(mockAgentPath)} "$@"
 `;
   await NodeFSP.writeFile(wrapperPath, script, "utf8");
-  await NodeFSP.chmod(wrapperPath, 0o755);
+  if (!isWindows) {
+    await NodeFSP.chmod(wrapperPath, 0o755);
+  }
   return wrapperPath;
 }
 
@@ -188,6 +201,85 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("applies negotiated Plan mode and reasoning before the prompt", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-negotiated-capabilities");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-capabilities-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+          T3_ACP_EMIT_USAGE_UPDATES: "1",
+          T3_ACP_USAGE_SIZE: "272000",
+          T3_ACP_USAGE_USED: "42000",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const turnCompleted = yield* Deferred.make<void>();
+      const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)).pipe(
+          Effect.andThen(
+            event.type === "turn.completed"
+              ? Deferred.succeed(turnCompleted, undefined)
+              : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "use the negotiated capabilities",
+        attachments: [],
+        interactionMode: "plan",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-build",
+          options: [{ id: "reasoning", value: "high" }],
+        },
+      });
+      yield* Deferred.await(turnCompleted);
+
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      const requestMethods = requests.flatMap((request) =>
+        typeof request.method === "string" ? [request.method] : [],
+      );
+      const reasoningRequestIndex = requests.findIndex(
+        (request) =>
+          request.method === "session/set_config_option" &&
+          (request.params as { configId?: unknown } | undefined)?.configId === "reasoning",
+      );
+      const modeRequestIndex = requests.findIndex(
+        (request) =>
+          request.method === "session/set_config_option" &&
+          (request.params as { configId?: unknown } | undefined)?.configId === "mode",
+      );
+      const promptIndex = requestMethods.indexOf("session/prompt");
+      const turnStarted = runtimeEvents.find((event) => event.type === "turn.started");
+      const usage = runtimeEvents.find((event) => event.type === "thread.token-usage.updated");
+
+      expect(reasoningRequestIndex).toBeGreaterThan(-1);
+      expect(modeRequestIndex).toBeGreaterThan(reasoningRequestIndex);
+      expect(promptIndex).toBeGreaterThan(modeRequestIndex);
+      expect(turnStarted).toMatchObject({ payload: { effort: "high" } });
+      expect(usage).toMatchObject({
+        payload: { usage: { maxTokens: 272000, usedTokens: 42000 } },
+      });
+
+      yield* Fiber.interrupt(eventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("closes the ACP child process when a session stops", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-stop-session-close");
@@ -212,6 +304,10 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       });
 
       yield* adapter.stopSession(threadId);
+
+      // The mock observes the Unix signal handler. Windows tears down the
+      // command wrapper without delivering SIGTERM to the Node child.
+      if (process.platform === "win32") return;
 
       const exitLog = yield* waitForFileContent(exitLogPath);
       assert.include(exitLog, "SIGTERM");

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -2,6 +2,7 @@ import {
   ApprovalRequestId,
   type GrokSettings,
   EventId,
+  type ProviderInteractionMode,
   type ProviderApprovalDecision,
   type ProviderRuntimeEvent,
   type ProviderSession,
@@ -31,6 +32,7 @@ import * as SynchronizedRef from "effect/SynchronizedRef";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
+import { getProviderOptionStringSelectionValue } from "@t3tools/shared/model";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
@@ -50,13 +52,19 @@ import {
   makeAcpRequestOpenedEvent,
   makeAcpRequestResolvedEvent,
   makeAcpToolCallEvent,
+  makeAcpUsageUpdatedEvent,
 } from "../acp/AcpCoreRuntimeEvents.ts";
 import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
 import {
   applyGrokAcpModelSelection,
   currentGrokModelIdFromSessionSetup,
+  decodeGrokAcpModelReasoningCapabilities,
+  findGrokAcpReasoningConfigOption,
   makeGrokAcpRuntime,
+  resolveGrokAcpInteractionModeId,
+  resolveGrokAcpModelReasoningValue,
+  resolveGrokAcpReasoningValue,
   resolveGrokAcpBaseModelId,
 } from "../acp/GrokAcpSupport.ts";
 import {
@@ -116,7 +124,9 @@ interface GrokSessionContext {
    * >0 means a turn is actively running, so a new sendTurn is a steer that
    * continues it, and only the last remaining prompt settles the turn. */
   promptsInFlight: number;
+  readonly availableModels: ReadonlyArray<EffectAcpSchema.ModelInfo>;
   currentModelId: string | undefined;
+  currentReasoningEffort: string | undefined;
   stopped: boolean;
 }
 
@@ -746,6 +756,13 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
           });
 
+          const availableModels = started.sessionSetupResult.models?.availableModels ?? [];
+          const initialModelId =
+            boundModelId ?? currentGrokModelIdFromSessionSetup(started.sessionSetupResult);
+          const initialReasoning = decodeGrokAcpModelReasoningCapabilities(
+            availableModels.find((model) => model.modelId === initialModelId),
+          );
+
           const now = yield* nowIso;
           const session: ProviderSession = {
             provider: PROVIDER,
@@ -777,7 +794,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             activeTurnId: undefined,
             interruptedTurnIds: new Set(),
             promptsInFlight: 0,
-            currentModelId: boundModelId,
+            availableModels,
+            currentModelId: initialModelId,
+            currentReasoningEffort: initialReasoning?.currentValue,
             stopped: false,
           };
 
@@ -791,12 +810,35 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 if (
                   event._tag === "PlanUpdated" ||
                   event._tag === "ToolCallUpdated" ||
-                  event._tag === "ContentDelta"
+                  event._tag === "ContentDelta" ||
+                  event._tag === "ConfigOptionsChanged" ||
+                  event._tag === "UsageUpdated"
                 ) {
                   yield* logNative(ctx.threadId, "session/update", event.rawPayload);
                 }
 
                 if (event._tag === "ModeChanged") {
+                  return;
+                }
+
+                // Usage is session telemetry. It must not be dropped just
+                // because the root prompt has already settled (or because a
+                // turn was interrupted).
+                if (event._tag === "UsageUpdated") {
+                  yield* offerRuntimeEvent(
+                    makeAcpUsageUpdatedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: ctx.threadId,
+                      turnId: resolveNotificationTurnId(ctx),
+                      usage: event.usage,
+                      rawPayload: event.rawPayload,
+                    }),
+                  );
+                  return;
+                }
+
+                if (event._tag === "ConfigOptionsChanged") {
                   return;
                 }
 
@@ -950,6 +992,116 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
               });
 
+              // ACP configuration is negotiated per session and may change
+              // after a model selection. Resolve every T3-facing choice from
+              // the latest native state immediately before prompting.
+              let effort: string | undefined;
+              const configOptionsAfterModel = yield* ctx.acp.getConfigOptions;
+              const requestedReasoning = getProviderOptionStringSelectionValue(
+                turnModelSelection?.options,
+                "reasoning",
+              );
+              const reasoningOption = findGrokAcpReasoningConfigOption(configOptionsAfterModel);
+              const modelReasoning = decodeGrokAcpModelReasoningCapabilities(
+                ctx.availableModels.find((model) => model.modelId === currentModelId),
+              );
+              if (currentModelId !== ctx.currentModelId) {
+                ctx.currentReasoningEffort = modelReasoning?.currentValue;
+              }
+              if (requestedReasoning !== undefined) {
+                if (reasoningOption) {
+                  const nativeReasoningValue = resolveGrokAcpReasoningValue(
+                    reasoningOption,
+                    requestedReasoning,
+                  );
+                  if (!nativeReasoningValue) {
+                    return yield* new ProviderAdapterRequestError({
+                      provider: PROVIDER,
+                      method: "session/set_config_option",
+                      detail: `Grok did not advertise reasoning value '${requestedReasoning}'.`,
+                    });
+                  }
+                  yield* ctx.acp
+                    .setConfigOption(reasoningOption.id, nativeReasoningValue)
+                    .pipe(
+                      Effect.mapError((cause) =>
+                        mapAcpToAdapterError(
+                          PROVIDER,
+                          input.threadId,
+                          "session/set_config_option",
+                          cause,
+                        ),
+                      ),
+                    );
+                  const configOptionsAfterReasoning = yield* ctx.acp.getConfigOptions;
+                  const appliedReasoningOption = findGrokAcpReasoningConfigOption(
+                    configOptionsAfterReasoning,
+                  );
+                  effort =
+                    appliedReasoningOption?.type === "select"
+                      ? appliedReasoningOption.currentValue.trim() || nativeReasoningValue
+                      : nativeReasoningValue;
+                  ctx.currentReasoningEffort = effort;
+                } else {
+                  const nativeReasoningValue = resolveGrokAcpModelReasoningValue(
+                    ctx.availableModels.find((model) => model.modelId === currentModelId),
+                    requestedReasoning,
+                  );
+                  if (!nativeReasoningValue || !currentModelId || !modelReasoning) {
+                    return yield* new ProviderAdapterRequestError({
+                      provider: PROVIDER,
+                      method: "session/set_model",
+                      detail:
+                        "Grok advertised reasoning values but did not expose its verified live effort setter.",
+                    });
+                  }
+                  yield* ctx.acp
+                    .setSessionModel(currentModelId, {
+                      reasoningEffort: nativeReasoningValue,
+                    })
+                    .pipe(
+                      Effect.mapError((cause) =>
+                        mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+                      ),
+                    );
+                  effort = nativeReasoningValue;
+                  ctx.currentReasoningEffort = nativeReasoningValue;
+                }
+              } else if (reasoningOption?.type === "select") {
+                effort = reasoningOption.currentValue.trim() || undefined;
+                ctx.currentReasoningEffort = effort;
+              } else {
+                effort = ctx.currentReasoningEffort ?? modelReasoning?.currentValue;
+              }
+
+              const interactionMode: ProviderInteractionMode = input.interactionMode ?? "default";
+              const modeId = resolveGrokAcpInteractionModeId(
+                yield* ctx.acp.getModeState,
+                interactionMode,
+              );
+              if (interactionMode === "plan" && modeId === undefined) {
+                return yield* new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/set_config_option",
+                  detail:
+                    "Grok did not advertise a usable native Plan/Build mode pair for this session.",
+                });
+              }
+              if (modeId !== undefined) {
+                yield* ctx.acp
+                  .setMode(modeId)
+                  .pipe(
+                    Effect.mapError((cause) =>
+                      mapAcpToAdapterError(
+                        PROVIDER,
+                        input.threadId,
+                        "session/set_config_option",
+                        cause,
+                      ),
+                    ),
+                  );
+              }
+
               const text = input.input?.trim();
               const imagePromptParts = yield* Effect.forEach(
                 input.attachments ?? [],
@@ -1034,7 +1186,10 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   provider: PROVIDER,
                   threadId: input.threadId,
                   turnId,
-                  payload: displayModel ? { model: displayModel } : {},
+                  payload: {
+                    ...(displayModel ? { model: displayModel } : {}),
+                    ...(effort ? { effort } : {}),
+                  },
                 });
               }
 
@@ -1044,6 +1199,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 displayModel,
                 promptParts,
                 turnId,
+                effort,
               };
             }).pipe(
               Effect.tapCause(() =>

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -6,9 +6,25 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { GrokSettings } from "@t3tools/contracts";
 
-import { buildInitialGrokProviderSnapshot, checkGrokProviderStatus } from "./GrokProvider.ts";
+import {
+  buildGrokCapabilitiesFromConfigOptions,
+  buildGrokCapabilitiesFromModelInfo,
+  buildGrokDiscoveredModelsFromSessionModelState,
+  buildGrokPresentation,
+  buildInitialGrokProviderSnapshot,
+  checkGrokProviderStatus,
+} from "./GrokProvider.ts";
 
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
+
+const fakeGrokExecutableName = process.platform === "win32" ? "grok.cmd" : "grok";
+
+function makeFakeGrokScript(lines: ReadonlyArray<string>): string {
+  if (process.platform === "win32") {
+    return ["@echo off", ...lines.map((line) => line), ""].join("\r\n");
+  }
+  return ["#!/bin/sh", ...lines, ""].join("\n");
+}
 
 describe("buildInitialGrokProviderSnapshot", () => {
   it.effect("returns a disabled snapshot when settings.enabled is false", () =>
@@ -36,6 +52,94 @@ describe("buildInitialGrokProviderSnapshot", () => {
   );
 });
 
+describe("Grok ACP capability discovery", () => {
+  it("builds a reasoning descriptor from the negotiated native values", () => {
+    const capabilities = buildGrokCapabilitiesFromConfigOptions([
+      {
+        id: "native-thought-level",
+        name: "Reasoning",
+        category: "thought_level",
+        type: "select",
+        currentValue: "balanced",
+        options: [
+          { value: "quick", name: "Quick" },
+          { value: "balanced", name: "Balanced" },
+          { value: "deep-native", name: "Deep Native" },
+        ],
+      },
+    ]);
+
+    expect(capabilities.optionDescriptors).toEqual([
+      {
+        id: "reasoning",
+        label: "Reasoning",
+        type: "select",
+        currentValue: "balanced",
+        options: [
+          { id: "quick", label: "Quick" },
+          { id: "balanced", label: "Balanced", isDefault: true },
+          { id: "deep-native", label: "Deep Native" },
+        ],
+      },
+    ]);
+  });
+
+  it("builds a reasoning descriptor from Grok's verified model metadata", () => {
+    const capabilities = buildGrokCapabilitiesFromModelInfo({
+      modelId: "grok-4.5",
+      name: "Grok 4.5",
+      _meta: {
+        totalContextTokens: 500000,
+        supportsReasoningEffort: true,
+        reasoningEffort: "high",
+        reasoningEfforts: [
+          {
+            id: "high",
+            value: "high",
+            label: "High Effort",
+            description: "Highest implementation quality",
+            default: true,
+          },
+          { id: "medium", value: "medium", label: "Medium Effort", default: false },
+        ],
+      },
+    });
+
+    expect(capabilities.optionDescriptors?.[0]).toMatchObject({
+      id: "reasoning",
+      type: "select",
+      currentValue: "high",
+      options: [
+        { id: "high", label: "High Effort", isDefault: true },
+        { id: "medium", label: "Medium Effort" },
+      ],
+    });
+  });
+
+  it("keeps custom models empty and hides Plan until the pair is negotiated", () => {
+    const capabilities = buildGrokCapabilitiesFromConfigOptions([]);
+    const models = buildGrokDiscoveredModelsFromSessionModelState(
+      {
+        currentModelId: "grok-build",
+        availableModels: [{ modelId: "grok-build", name: "Grok Build" }],
+      },
+      capabilities,
+    );
+
+    expect(models[0]?.capabilities).toEqual({ optionDescriptors: [] });
+    expect(buildGrokPresentation(undefined).showInteractionModeToggle).toBe(false);
+    expect(
+      buildGrokPresentation({
+        currentModeId: "code",
+        availableModes: [
+          { id: "architect", name: "Architect" },
+          { id: "code", name: "Code" },
+        ],
+      }).showInteractionModeToggle,
+    ).toBe(true);
+  });
+});
+
 it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
   it.effect("reports the binary as missing when the binary path does not resolve", () =>
     Effect.gen(function* () {
@@ -60,10 +164,14 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
           const fs = yield* FileSystem.FileSystem;
           const path = yield* Path.Path;
           const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-version-" });
-          const grokPath = path.join(dir, "grok");
+          const grokPath = path.join(dir, fakeGrokExecutableName);
           yield* fs.writeFileString(
             grokPath,
-            ["#!/bin/sh", `printf "%s\\n" "${secretStderr}" >&2`, "exit 2", ""].join("\n"),
+            makeFakeGrokScript(
+              process.platform === "win32"
+                ? [`echo ${secretStderr} 1>&2`, "exit /b 2"]
+                : [`printf "%s\\n" "${secretStderr}" >&2`, "exit 2"],
+            ),
           );
           yield* fs.chmod(grokPath, 0o755);
 
@@ -88,10 +196,14 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
           const fs = yield* FileSystem.FileSystem;
           const path = yield* Path.Path;
           const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-success-" });
-          const grokPath = path.join(dir, "grok");
+          const grokPath = path.join(dir, fakeGrokExecutableName);
           yield* fs.writeFileString(
             grokPath,
-            ["#!/bin/sh", 'printf "grok-cli 0.0.99\\n"', "exit 0", ""].join("\n"),
+            makeFakeGrokScript(
+              process.platform === "win32"
+                ? ["echo grok-cli 0.0.99", "exit /b 0"]
+                : ['printf "grok-cli 0.0.99\\n"', "exit 0"],
+            ),
           );
           yield* fs.chmod(grokPath, 0o755);
 

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -19,6 +19,7 @@ import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
 import {
   buildServerProvider,
+  buildSelectOptionDescriptor,
   isCommandMissingCause,
   parseGenericCliVersion,
   providerModelsFromSettings,
@@ -29,7 +30,15 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
-import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
+import {
+  collectGrokAcpSelectOptions,
+  decodeGrokAcpModelReasoningCapabilities,
+  findGrokAcpReasoningConfigOption,
+  grokAcpHasPlanModePair,
+  makeGrokAcpRuntime,
+  resolveGrokAcpBaseModelId,
+} from "../acp/GrokAcpSupport.ts";
+import type { AcpSessionModeState } from "../acp/AcpRuntimeModel.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -37,6 +46,13 @@ const GROK_PRESENTATION = {
   showInteractionModeToggle: false,
   requiresNewThreadForModelChange: true,
 } as const;
+
+export function buildGrokPresentation(modeState: AcpSessionModeState | undefined) {
+  return {
+    ...GROK_PRESENTATION,
+    showInteractionModeToggle: grokAcpHasPlanModePair(modeState),
+  } as const;
+}
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
@@ -99,8 +115,60 @@ function grokModelsFromSettings(
   return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
 }
 
-function buildGrokDiscoveredModelsFromSessionModelState(
+export function buildGrokCapabilitiesFromConfigOptions(
+  configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption> | null | undefined,
+): ModelCapabilities {
+  const reasoningOption = findGrokAcpReasoningConfigOption(configOptions);
+  if (!reasoningOption || reasoningOption.type !== "select") {
+    return EMPTY_CAPABILITIES;
+  }
+  const choices = collectGrokAcpSelectOptions(reasoningOption).map((option) => ({
+    value: option.value,
+    label: option.name,
+    ...(option.value === reasoningOption.currentValue ? { isDefault: true } : {}),
+  }));
+  if (choices.length === 0) {
+    return EMPTY_CAPABILITIES;
+  }
+  return createModelCapabilities({
+    optionDescriptors: [
+      buildSelectOptionDescriptor({
+        id: "reasoning",
+        label: reasoningOption.name.trim() || "Reasoning",
+        options: choices,
+      }),
+    ],
+  });
+}
+
+export function buildGrokCapabilitiesFromModelInfo(
+  model: EffectAcpSchema.ModelInfo,
+): ModelCapabilities {
+  const reasoning = decodeGrokAcpModelReasoningCapabilities(model);
+  if (!reasoning) {
+    return EMPTY_CAPABILITIES;
+  }
+  return createModelCapabilities({
+    optionDescriptors: [
+      buildSelectOptionDescriptor({
+        id: "reasoning",
+        label: "Reasoning",
+        options: reasoning.options.map((option) => ({
+          value: option.value,
+          label: option.label,
+          ...(option.isDefault || option.value === reasoning.currentValue
+            ? { isDefault: true }
+            : {}),
+        })),
+        description: "Grok's negotiated reasoning effort",
+      }),
+    ],
+  });
+}
+
+export function buildGrokDiscoveredModelsFromSessionModelState(
   modelState: EffectAcpSchema.SessionModelState | null | undefined,
+  capabilities?: ModelCapabilities,
 ): ReadonlyArray<ServerProviderModel> {
   if (!modelState || modelState.availableModels.length === 0) {
     return [];
@@ -113,17 +181,24 @@ function buildGrokDiscoveredModelsFromSessionModelState(
         return undefined;
       }
       seen.add(slug);
+      const modelCapabilities = capabilities ?? buildGrokCapabilitiesFromModelInfo(model);
       return {
         slug,
         name: model.name.trim() || slug,
         isCustom: false,
-        capabilities: EMPTY_CAPABILITIES,
+        capabilities: modelCapabilities,
       };
     })
     .filter((model): model is ServerProviderModel => model !== undefined);
 }
 
-const discoverGrokModelsViaAcp = (
+export interface GrokAcpDiscoverySnapshot {
+  readonly models: ReadonlyArray<ServerProviderModel>;
+  readonly configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption>;
+  readonly modeState: AcpSessionModeState | undefined;
+}
+
+export const discoverGrokModelsViaAcp = (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
 ) =>
@@ -137,7 +212,19 @@ const discoverGrokModelsViaAcp = (
       clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
     });
     const started = yield* acp.start();
-    return buildGrokDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models);
+    const configOptions = yield* acp.getConfigOptions;
+    const modeState = yield* acp.getModeState;
+    const capabilities = buildGrokCapabilitiesFromConfigOptions(configOptions);
+    return {
+      models: buildGrokDiscoveredModelsFromSessionModelState(
+        started.sessionSetupResult.models,
+        capabilities.optionDescriptors && capabilities.optionDescriptors.length > 0
+          ? capabilities
+          : undefined,
+      ),
+      configOptions,
+      modeState,
+    } satisfies GrokAcpDiscoverySnapshot;
   }).pipe(Effect.scoped);
 
 const runGrokVersionCommand = (
@@ -291,14 +378,15 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       },
     });
   }
-  const discoveredModels = discoveryExit.value.value;
+  const discovery = discoveryExit.value.value;
+  const discoveredModels = discovery.models;
   const models =
     discoveredModels.length > 0
       ? grokModelsFromSettings(grokSettings.customModels, discoveredModels)
       : fallbackModels;
 
   return buildServerProvider({
-    presentation: GROK_PRESENTATION,
+    presentation: buildGrokPresentation(discovery.modeState),
     enabled: grokSettings.enabled,
     checkedAt,
     models,

--- a/apps/server/src/provider/acp/AcpCoreRuntimeEvents.test.ts
+++ b/apps/server/src/provider/acp/AcpCoreRuntimeEvents.test.ts
@@ -8,6 +8,7 @@ import {
   makeAcpRequestOpenedEvent,
   makeAcpRequestResolvedEvent,
   makeAcpToolCallEvent,
+  makeAcpUsageUpdatedEvent,
 } from "./AcpCoreRuntimeEvents.ts";
 
 describe("AcpCoreRuntimeEvents", () => {
@@ -189,6 +190,29 @@ describe("AcpCoreRuntimeEvents", () => {
       payload: {
         itemType: "assistant_message",
         status: "inProgress",
+      },
+    });
+  });
+
+  it("maps ACP usage to the canonical context-window event", () => {
+    const event = makeAcpUsageUpdatedEvent({
+      stamp: { eventId: "event-usage" as never, createdAt: "2026-03-27T00:00:00.000Z" },
+      provider: ProviderDriverKind.make("grok"),
+      threadId: "thread-1" as never,
+      turnId: TurnId.make("turn-1"),
+      usage: { size: 272000, used: 42000 },
+      rawPayload: {
+        sessionId: "session-1",
+        update: { sessionUpdate: "usage_update", size: 272000, used: 42000 },
+      },
+    });
+
+    expect(event).toMatchObject({
+      type: "thread.token-usage.updated",
+      payload: { usage: { maxTokens: 272000, usedTokens: 42000 } },
+      raw: {
+        source: "acp.jsonrpc",
+        method: "session/update",
       },
     });
   });

--- a/apps/server/src/provider/acp/AcpCoreRuntimeEvents.ts
+++ b/apps/server/src/provider/acp/AcpCoreRuntimeEvents.ts
@@ -12,7 +12,12 @@ import {
   type TurnId,
 } from "@t3tools/contracts";
 
-import type { AcpPermissionRequest, AcpPlanUpdate, AcpToolCallState } from "./AcpRuntimeModel.ts";
+import type {
+  AcpPermissionRequest,
+  AcpPlanUpdate,
+  AcpToolCallState,
+  AcpUsageUpdated,
+} from "./AcpRuntimeModel.ts";
 
 type AcpAdapterRawSource = Extract<
   RuntimeEventRawSource,
@@ -232,6 +237,34 @@ export function makeAcpContentDeltaEvent(input: {
     payload: {
       streamKind: "assistant_text",
       delta: input.text,
+    },
+    raw: {
+      source: "acp.jsonrpc",
+      method: "session/update",
+      payload: input.rawPayload,
+    },
+  };
+}
+
+export function makeAcpUsageUpdatedEvent(input: {
+  readonly stamp: AcpEventStamp;
+  readonly provider: ProviderDriverKind;
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId | undefined;
+  readonly usage: AcpUsageUpdated["usage"];
+  readonly rawPayload: unknown;
+}): ProviderRuntimeEvent {
+  return {
+    type: "thread.token-usage.updated",
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    payload: {
+      usage: {
+        usedTokens: input.usage.used,
+        ...(input.usage.size > 0 ? { maxTokens: input.usage.size } : {}),
+      },
     },
     raw: {
       source: "acp.jsonrpc",

--- a/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
@@ -336,6 +336,97 @@ describe("AcpRuntimeModel", () => {
     ]);
   });
 
+  it("projects standard config and usage updates while retaining their raw notification", () => {
+    const configPayload = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [
+          {
+            id: "reasoning",
+            name: "Reasoning",
+            category: "thought_level",
+            type: "select",
+            currentValue: "medium",
+            options: [
+              { value: "low", name: "Low" },
+              { value: "medium", name: "Medium" },
+            ],
+          },
+        ],
+      },
+    } satisfies EffectAcpSchema.SessionNotification;
+    const usagePayload = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "usage_update",
+        size: 272000,
+        used: 42000,
+      },
+    } satisfies EffectAcpSchema.SessionNotification;
+
+    expect(parseSessionUpdateEvent(configPayload)).toEqual({
+      events: [
+        {
+          _tag: "ConfigOptionsChanged",
+          configOptions: configPayload.update.configOptions,
+          rawPayload: configPayload,
+        },
+      ],
+    });
+    expect(parseSessionUpdateEvent(usagePayload)).toEqual({
+      events: [
+        {
+          _tag: "UsageUpdated",
+          usage: { size: 272000, used: 42000 },
+          rawPayload: usagePayload,
+        },
+      ],
+    });
+  });
+
+  it("ignores malformed or unknown config and usage updates", () => {
+    const malformedConfig = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [{ id: "reasoning", type: "select" }],
+      },
+    } as unknown as EffectAcpSchema.SessionNotification;
+    const malformedUsage = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "usage_update",
+        size: -1,
+        used: "42000",
+      },
+    } as unknown as EffectAcpSchema.SessionNotification;
+    const malformedGroup = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [
+          {
+            id: "reasoning",
+            name: "Reasoning",
+            type: "select",
+            currentValue: "medium",
+            options: [{ name: "Levels", options: [] }],
+          },
+        ],
+      },
+    } as unknown as EffectAcpSchema.SessionNotification;
+    const unknownUpdate = {
+      sessionId: "session-1",
+      update: { sessionUpdate: "future_update", payload: { value: true } },
+    } as unknown as EffectAcpSchema.SessionNotification;
+
+    expect(parseSessionUpdateEvent(malformedConfig).events).toEqual([]);
+    expect(parseSessionUpdateEvent(malformedUsage).events).toEqual([]);
+    expect(parseSessionUpdateEvent(malformedGroup).events).toEqual([]);
+    expect(parseSessionUpdateEvent(unknownUpdate).events).toEqual([]);
+  });
+
   it("keeps permission request parsing compatible with loose extension payloads", () => {
     const request = parsePermissionRequest({
       sessionId: "session-1",

--- a/apps/server/src/provider/acp/AcpRuntimeModel.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.ts
@@ -74,6 +74,21 @@ export interface AcpPlanUpdate {
   }>;
 }
 
+export interface AcpConfigOptionsChanged {
+  readonly _tag: "ConfigOptionsChanged";
+  readonly configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption>;
+  readonly rawPayload: unknown;
+}
+
+export interface AcpUsageUpdated {
+  readonly _tag: "UsageUpdated";
+  readonly usage: {
+    readonly size: number;
+    readonly used: number;
+  };
+  readonly rawPayload: unknown;
+}
+
 export interface AcpPermissionRequest {
   readonly kind: string | "unknown";
   readonly detail?: string;
@@ -108,7 +123,9 @@ export type AcpParsedSessionEvent =
       readonly itemId?: string;
       readonly text: string;
       readonly rawPayload: unknown;
-    };
+    }
+  | AcpConfigOptionsChanged
+  | AcpUsageUpdated;
 
 type AcpSessionSetupResponse =
   | EffectAcpSchema.LoadSessionResponse
@@ -505,10 +522,118 @@ export function syntheticLoadSessionResponseFromInitialize(
   };
 }
 
+function isSessionConfigSelectOption(
+  value: unknown,
+): value is EffectAcpSchema.SessionConfigSelectOption {
+  return (
+    isRecord(value) &&
+    typeof value.name === "string" &&
+    typeof value.value === "string" &&
+    (value.description === undefined ||
+      value.description === null ||
+      typeof value.description === "string")
+  );
+}
+
+function isSessionConfigSelectGroup(
+  value: unknown,
+): value is EffectAcpSchema.SessionConfigSelectGroup {
+  return (
+    isRecord(value) &&
+    typeof value.group === "string" &&
+    typeof value.name === "string" &&
+    Array.isArray(value.options) &&
+    value.options.every(isSessionConfigSelectOption)
+  );
+}
+
+function isSessionConfigOption(value: unknown): value is EffectAcpSchema.SessionConfigOption {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string") {
+    return false;
+  }
+  if (
+    value.category !== undefined &&
+    value.category !== null &&
+    typeof value.category !== "string"
+  ) {
+    return false;
+  }
+  if (
+    value.description !== undefined &&
+    value.description !== null &&
+    typeof value.description !== "string"
+  ) {
+    return false;
+  }
+  if (value.type === "boolean") {
+    return typeof value.currentValue === "boolean";
+  }
+  if (value.type !== "select" || typeof value.currentValue !== "string") {
+    return false;
+  }
+  return (
+    Array.isArray(value.options) &&
+    value.options.every(
+      (entry) => isSessionConfigSelectOption(entry) || isSessionConfigSelectGroup(entry),
+    )
+  );
+}
+
+function parseSessionConfigOptions(
+  value: unknown,
+): ReadonlyArray<EffectAcpSchema.SessionConfigOption> | undefined {
+  if (!Array.isArray(value) || !value.every(isSessionConfigOption)) {
+    return undefined;
+  }
+  return value;
+}
+
+function parseNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
 export function parseSessionUpdateEvent(params: EffectAcpSchema.SessionNotification): {
   readonly modeId?: string;
   readonly events: ReadonlyArray<AcpParsedSessionEvent>;
 } {
+  const rawUpdate: unknown = params.update;
+  if (!isRecord(rawUpdate) || typeof rawUpdate.sessionUpdate !== "string") {
+    return { events: [] };
+  }
+
+  // These updates are optional/unstable in ACP. Validate them at the boundary
+  // so malformed or provider-specific notifications never reach adapters as
+  // if they were negotiated standard data.
+  if (rawUpdate.sessionUpdate === "config_option_update") {
+    const configOptions = parseSessionConfigOptions(rawUpdate.configOptions);
+    return configOptions
+      ? {
+          events: [
+            {
+              _tag: "ConfigOptionsChanged",
+              configOptions,
+              rawPayload: params,
+            },
+          ],
+        }
+      : { events: [] };
+  }
+  if (rawUpdate.sessionUpdate === "usage_update") {
+    const size = parseNonNegativeInteger(rawUpdate.size);
+    const used = parseNonNegativeInteger(rawUpdate.used);
+    return size === undefined || used === undefined
+      ? { events: [] }
+      : {
+          events: [
+            {
+              _tag: "UsageUpdated",
+              usage: { size, used },
+              rawPayload: params,
+            },
+          ],
+        };
+  }
+
   const upd = params.update;
   const events: Array<AcpParsedSessionEvent> = [];
   let modeId: string | undefined;

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -71,6 +71,15 @@ export interface AcpSessionRuntimeOptions {
   readonly authMethodId: string;
   readonly mcpServers?: ReadonlyArray<EffectAcpSchema.McpServer>;
   readonly requestLogger?: (event: AcpSessionRequestLogEvent) => Effect.Effect<void, never>;
+  /**
+   * Opt-in sink for notifications belonging to a foreign ACP session.
+   *
+   * The default remains root-session-only routing. Providers may opt in only
+   * after they have negotiated explicit parent/child identity semantics.
+   */
+  readonly foreignSessionUpdateSink?: (
+    notification: EffectAcpSchema.SessionNotification,
+  ) => Effect.Effect<void, never>;
   readonly protocolLogging?: {
     readonly logIncoming?: boolean;
     readonly logOutgoing?: boolean;
@@ -226,6 +235,7 @@ export class AcpSessionRuntime extends Context.Service<
      */
     readonly setSessionModel: (
       modelId: string,
+      meta?: Readonly<Record<string, unknown>>,
     ) => Effect.Effect<EffectAcpSchema.SetSessionModelResponse, EffectAcpErrors.AcpError>;
     /**
      * Sends a generic ACP extension request and records it through the request logger.
@@ -385,17 +395,21 @@ export const make = (
           return;
         }
         const startState = yield* Ref.get(startStateRef);
+        if (startState._tag !== "Started") {
+          return;
+        }
         // One runtime projects one root ACP session. Child-session updates need
         // explicit lineage routing and must never be flattened into this stream.
-        if (
-          startState._tag !== "Started" ||
-          notification.sessionId !== startState.result.sessionId
-        ) {
+        if (notification.sessionId !== startState.result.sessionId) {
+          if (options.foreignSessionUpdateSink) {
+            yield* options.foreignSessionUpdateSink(notification);
+          }
           return;
         }
         yield* handleSessionUpdate({
           queue: eventQueue,
           modeStateRef,
+          configOptionsRef,
           toolCallsRef,
           assistantSegmentRef,
           assistantItemRuntimeId,
@@ -777,7 +791,14 @@ export const make = (
             if (modeState?.currentModeId === modeId) {
               return Effect.succeed({} satisfies EffectAcpSchema.SetSessionModeResponse);
             }
-            return setConfigOption("mode", modeId).pipe(
+            return Ref.get(configOptionsRef).pipe(
+              Effect.map(
+                (configOptions) =>
+                  configOptions.find(
+                    (option) => option.category === "mode" || option.id.trim() === "mode",
+                  )?.id ?? "mode",
+              ),
+              Effect.flatMap((modeConfigId) => setConfigOption(modeConfigId, modeId)),
               Effect.tap(() => updateCurrentModeId(modeId)),
               Effect.as({} satisfies EffectAcpSchema.SetSessionModeResponse),
             );
@@ -789,12 +810,13 @@ export const make = (
           Effect.flatMap((started) => setConfigOption(started.modelConfigId ?? "model", model)),
           Effect.asVoid,
         ),
-      setSessionModel: (modelId) =>
+      setSessionModel: (modelId, meta) =>
         getStartedState.pipe(
           Effect.flatMap((started) => {
             const requestPayload = {
               sessionId: started.sessionId,
               modelId,
+              ...(meta ? { _meta: meta } : {}),
             } satisfies EffectAcpSchema.SetSessionModelRequest;
             return runLoggedRequest(
               "session/set_model",
@@ -844,6 +866,7 @@ function configOptionCurrentValueMatches(
 const handleSessionUpdate = ({
   queue,
   modeStateRef,
+  configOptionsRef,
   toolCallsRef,
   assistantSegmentRef,
   assistantItemRuntimeId,
@@ -851,6 +874,7 @@ const handleSessionUpdate = ({
 }: {
   readonly queue: Queue.Queue<AcpSessionRuntimeEvent>;
   readonly modeStateRef: Ref.Ref<AcpSessionModeState | undefined>;
+  readonly configOptionsRef: Ref.Ref<ReadonlyArray<EffectAcpSchema.SessionConfigOption>>;
   readonly toolCallsRef: Ref.Ref<Map<string, AcpToolCallState>>;
   readonly assistantSegmentRef: Ref.Ref<AcpAssistantSegmentState>;
   readonly assistantItemRuntimeId: string;
@@ -864,6 +888,11 @@ const handleSessionUpdate = ({
       );
     }
     for (const event of parsed.events) {
+      if (event._tag === "ConfigOptionsChanged") {
+        yield* Ref.set(configOptionsRef, event.configOptions);
+        yield* Queue.offer(queue, event);
+        continue;
+      }
       if (event._tag === "ToolCallUpdated") {
         yield* closeActiveAssistantSegment({
           queue,

--- a/apps/server/src/provider/acp/GrokAcpCliProbe.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpCliProbe.test.ts
@@ -13,23 +13,28 @@ import * as Effect from "effect/Effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { describe, expect } from "vite-plus/test";
 
-import { makeGrokAcpRuntime } from "./GrokAcpSupport.ts";
+import { decodeGrokAcpModelReasoningCapabilities, makeGrokAcpRuntime } from "./GrokAcpSupport.ts";
+import type { AcpSessionRequestLogEvent } from "./AcpSessionRuntime.ts";
 
-const makeProbeRuntime = Effect.gen(function* () {
-  const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-  return yield* makeGrokAcpRuntime({
-    grokSettings: { binaryPath: "grok" },
-    environment: process.env,
-    childProcessSpawner,
-    cwd: process.cwd(),
-    clientInfo: { name: "t3-grok-probe", version: "0.0.0" },
+const makeProbeRuntime = (
+  requestLogger?: (event: AcpSessionRequestLogEvent) => Effect.Effect<void, never>,
+) =>
+  Effect.gen(function* () {
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    return yield* makeGrokAcpRuntime({
+      grokSettings: { binaryPath: "grok" },
+      environment: process.env,
+      childProcessSpawner,
+      cwd: process.cwd(),
+      clientInfo: { name: "t3-grok-probe", version: "0.0.0" },
+      ...(requestLogger ? { requestLogger } : {}),
+    });
   });
-});
 
 describe.runIf(process.env.T3_GROK_ACP_PROBE === "1")("Grok ACP CLI probe", () => {
   it.effect("initialize and authenticate against real grok agent stdio", () =>
     Effect.gen(function* () {
-      const runtime = yield* makeProbeRuntime;
+      const runtime = yield* makeProbeRuntime();
       const started = yield* runtime.start();
       expect(started.initializeResult).toBeDefined();
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
@@ -37,7 +42,7 @@ describe.runIf(process.env.T3_GROK_ACP_PROBE === "1")("Grok ACP CLI probe", () =
 
   it.effect("session/new advertises typed SessionModelState with at least one model", () =>
     Effect.gen(function* () {
-      const runtime = yield* makeProbeRuntime;
+      const runtime = yield* makeProbeRuntime();
       const started = yield* runtime.start();
       const result = started.sessionSetupResult;
 
@@ -55,7 +60,7 @@ describe.runIf(process.env.T3_GROK_ACP_PROBE === "1")("Grok ACP CLI probe", () =
 
   it.effect("session/set_model accepts a no-op switch to the current model", () =>
     Effect.gen(function* () {
-      const runtime = yield* makeProbeRuntime;
+      const runtime = yield* makeProbeRuntime();
       const started = yield* runtime.start();
       const currentModelId = started.sessionSetupResult.models?.currentModelId?.trim();
       expect(currentModelId).toBeDefined();
@@ -64,6 +69,44 @@ describe.runIf(process.env.T3_GROK_ACP_PROBE === "1")("Grok ACP CLI probe", () =
       // No-op switch — selecting the model the session already runs on must
       // succeed against every Grok build that implements `session/set_model`.
       yield* runtime.setSessionModel(currentModelId);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("session/set_model accepts the advertised reasoning effort metadata", () =>
+    Effect.gen(function* () {
+      const requestLog: Array<AcpSessionRequestLogEvent> = [];
+      const runtime = yield* makeProbeRuntime((event) =>
+        Effect.sync(() => {
+          requestLog.push(event);
+        }),
+      );
+      const started = yield* runtime.start();
+      const currentModelId = started.sessionSetupResult.models?.currentModelId?.trim();
+      const model = started.sessionSetupResult.models?.availableModels.find(
+        (candidate) => candidate.modelId === currentModelId,
+      );
+      const reasoning = decodeGrokAcpModelReasoningCapabilities(model);
+      const effort =
+        reasoning?.options.find((option) => option.value === "low")?.value ??
+        reasoning?.options[0]?.value;
+      expect(currentModelId).toBeDefined();
+      expect(effort).toBeDefined();
+      if (!currentModelId || !effort) return;
+
+      yield* runtime.setSessionModel(currentModelId, { reasoningEffort: effort });
+
+      expect(
+        requestLog.some(
+          (event) =>
+            event.method === "session/set_model" &&
+            event.status === "started" &&
+            event.payload !== null &&
+            typeof event.payload === "object" &&
+            "_meta" in event.payload &&
+            "reasoningEffort" in (event.payload._meta as Record<string, unknown>) &&
+            (event.payload._meta as Record<string, unknown>).reasoningEffort === effort,
+        ),
+      ).toBe(true);
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 });

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -5,6 +5,11 @@ import * as EffectAcpErrors from "effect-acp/errors";
 import {
   applyGrokAcpModelSelection,
   buildGrokAcpSpawnInput,
+  decodeGrokAcpModelReasoningCapabilities,
+  findGrokAcpReasoningConfigOption,
+  resolveGrokAcpInteractionModeId,
+  resolveGrokAcpModeIds,
+  resolveGrokAcpReasoningValue,
   resolveGrokAcpBaseModelId,
 } from "./GrokAcpSupport.ts";
 
@@ -106,4 +111,78 @@ describe("applyGrokAcpModelSelection", () => {
       expect(error).toBe(failure.message);
     }),
   );
+});
+
+describe("Grok ACP negotiated capabilities", () => {
+  const modeState = {
+    currentModeId: "code",
+    availableModes: [
+      { id: "architect", name: "Architect" },
+      { id: "code", name: "Code" },
+    ],
+  } as const;
+  const reasoningOption = {
+    id: "native-thought-level",
+    name: "Reasoning",
+    category: "thought_level",
+    type: "select" as const,
+    currentValue: "balanced",
+    options: [
+      { value: "quick", name: "Quick" },
+      { value: "balanced", name: "Balanced" },
+      { value: "deep-native", name: "Deep Native" },
+    ],
+  };
+
+  it("resolves the advertised plan/default pair without inventing values", () => {
+    expect(resolveGrokAcpModeIds(modeState)).toEqual({
+      planModeId: "architect",
+      defaultModeId: "code",
+    });
+    expect(resolveGrokAcpInteractionModeId(modeState, "plan")).toBe("architect");
+    expect(resolveGrokAcpInteractionModeId(modeState, "default")).toBe("code");
+    expect(
+      resolveGrokAcpModeIds({
+        currentModeId: "chat",
+        availableModes: [{ id: "chat", name: "Chat" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("resolves the exact native reasoning config id and value", () => {
+    expect(findGrokAcpReasoningConfigOption([reasoningOption])).toBe(reasoningOption);
+    expect(resolveGrokAcpReasoningValue(reasoningOption, "deep-native")).toBe("deep-native");
+    expect(resolveGrokAcpReasoningValue(reasoningOption, "Deep Native")).toBe("deep-native");
+    expect(resolveGrokAcpReasoningValue(reasoningOption, "unknown")).toBeUndefined();
+  });
+
+  it("decodes the verified Grok model reasoning metadata shape", () => {
+    expect(
+      decodeGrokAcpModelReasoningCapabilities({
+        modelId: "grok-4.5",
+        name: "Grok 4.5",
+        _meta: {
+          supportsReasoningEffort: true,
+          reasoningEffort: "high",
+          reasoningEfforts: [
+            { value: "high", label: "High Effort", default: true },
+            { value: "medium", label: "Medium Effort", default: false },
+          ],
+        },
+      }),
+    ).toEqual({
+      currentValue: "high",
+      options: [
+        { value: "high", label: "High Effort", isDefault: true },
+        { value: "medium", label: "Medium Effort" },
+      ],
+    });
+    expect(
+      decodeGrokAcpModelReasoningCapabilities({
+        modelId: "grok-legacy",
+        name: "Legacy Grok",
+        _meta: { supportsReasoningEffort: false },
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -9,6 +9,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 import { normalizeModelSlug } from "@t3tools/shared/model";
 
 import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
+import type { AcpSessionMode, AcpSessionModeState } from "./AcpRuntimeModel.ts";
 import { makeXAiPromptCompletionRuntime } from "./XAiAcpExtension.ts";
 
 const GROK_API_KEY_ENV = "XAI_API_KEY";
@@ -17,6 +18,34 @@ const T3_CODE_OAUTH_REFERRER = "t3code";
 const GROK_AUTH_METHOD_API_KEY = "xai.api_key";
 const GROK_AUTH_METHOD_CACHED_TOKEN = "cached_token";
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
+
+export const GROK_PARAMETERIZED_MODEL_PICKER_CAPABILITIES = {
+  _meta: {
+    parameterizedModelPicker: true,
+  },
+} satisfies NonNullable<EffectAcpSchema.InitializeRequest["clientCapabilities"]>;
+
+export interface GrokAcpModeIds {
+  readonly planModeId: string;
+  readonly defaultModeId: string;
+}
+
+export interface GrokAcpSelectOption {
+  readonly value: string;
+  readonly name: string;
+}
+
+export interface GrokAcpReasoningOption {
+  readonly value: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly isDefault?: boolean;
+}
+
+export interface GrokAcpModelReasoningCapabilities {
+  readonly currentValue?: string;
+  readonly options: ReadonlyArray<GrokAcpReasoningOption>;
+}
 
 type GrokAcpRuntimeGrokSettings = Pick<GrokSettings, "binaryPath">;
 
@@ -45,6 +74,194 @@ export function buildGrokAcpSpawnInput(
   };
 }
 
+function normalizeGrokCapabilityToken(value: string | null | undefined): string {
+  return (
+    value
+      ?.trim()
+      .toLowerCase()
+      .replace(/[\s_-]+/g, "-") ?? ""
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function decodeGrokAcpModelReasoningCapabilities(
+  model: EffectAcpSchema.ModelInfo | undefined,
+): GrokAcpModelReasoningCapabilities | undefined {
+  if (!model) {
+    return undefined;
+  }
+  const meta = model._meta;
+  if (!isRecord(meta) || meta.supportsReasoningEffort !== true) {
+    return undefined;
+  }
+  if (!Array.isArray(meta.reasoningEfforts) || meta.reasoningEfforts.length === 0) {
+    return undefined;
+  }
+  const options: Array<GrokAcpReasoningOption> = [];
+  const seen = new Set<string>();
+  for (const rawOption of meta.reasoningEfforts) {
+    if (!isRecord(rawOption)) {
+      return undefined;
+    }
+    const value = typeof rawOption.value === "string" ? rawOption.value.trim() : "";
+    const label = typeof rawOption.label === "string" ? rawOption.label.trim() : "";
+    if (!value || !label || seen.has(value)) {
+      return undefined;
+    }
+    seen.add(value);
+    const description =
+      typeof rawOption.description === "string" ? rawOption.description.trim() : undefined;
+    options.push({
+      value,
+      label,
+      ...(description ? { description } : {}),
+      ...(rawOption.default === true ? { isDefault: true } : {}),
+    });
+  }
+  const currentValue =
+    typeof meta.reasoningEffort === "string" &&
+    options.some((option) => option.value === meta.reasoningEffort)
+      ? meta.reasoningEffort
+      : undefined;
+  return {
+    options,
+    ...(currentValue ? { currentValue } : {}),
+  };
+}
+
+export function resolveGrokAcpModelReasoningValue(
+  model: EffectAcpSchema.ModelInfo | undefined,
+  requestedValue: string | undefined,
+): string | undefined {
+  if (!model || requestedValue === undefined) {
+    return undefined;
+  }
+  const reasoning = decodeGrokAcpModelReasoningCapabilities(model);
+  return reasoning?.options.find((option) => option.value === requestedValue.trim())?.value;
+}
+
+export function collectGrokAcpSelectOptions(
+  configOption: EffectAcpSchema.SessionConfigOption | null | undefined,
+): ReadonlyArray<GrokAcpSelectOption> {
+  if (!configOption || configOption.type !== "select") {
+    return [];
+  }
+  const seen = new Set<string>();
+  return configOption.options.flatMap((entry) => {
+    const options = "value" in entry ? [entry] : entry.options;
+    return options.flatMap((option) => {
+      const value = option.value.trim();
+      const name = option.name.trim();
+      if (!value || !name || seen.has(value)) {
+        return [];
+      }
+      seen.add(value);
+      return [{ value, name } satisfies GrokAcpSelectOption];
+    });
+  });
+}
+
+function isGrokReasoningConfigOption(option: EffectAcpSchema.SessionConfigOption): boolean {
+  const id = normalizeGrokCapabilityToken(option.id);
+  const name = normalizeGrokCapabilityToken(option.name);
+  const category = normalizeGrokCapabilityToken(option.category);
+  return (
+    option.type === "select" &&
+    (category === "thought-level" ||
+      id === "reasoning" ||
+      id === "effort" ||
+      name === "reasoning" ||
+      name === "effort" ||
+      name.includes("reasoning") ||
+      name.includes("effort"))
+  );
+}
+
+export function findGrokAcpReasoningConfigOption(
+  configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption> | null | undefined,
+): EffectAcpSchema.SessionConfigOption | undefined {
+  const candidates = configOptions?.filter(isGrokReasoningConfigOption) ?? [];
+  return (
+    candidates.find(
+      (option) => normalizeGrokCapabilityToken(option.category) === "thought-level",
+    ) ??
+    candidates.find((option) => normalizeGrokCapabilityToken(option.id) === "reasoning") ??
+    candidates[0]
+  );
+}
+
+export function resolveGrokAcpReasoningValue(
+  configOption: EffectAcpSchema.SessionConfigOption | undefined,
+  requestedValue: string | undefined,
+): string | undefined {
+  if (!configOption || configOption.type !== "select") {
+    return undefined;
+  }
+  const options = collectGrokAcpSelectOptions(configOption);
+  if (requestedValue !== undefined) {
+    const exact = options.find((option) => option.value === requestedValue.trim());
+    if (exact) {
+      return exact.value;
+    }
+    const normalizedRequested = normalizeGrokCapabilityToken(requestedValue);
+    return options.find(
+      (option) =>
+        normalizeGrokCapabilityToken(option.value) === normalizedRequested ||
+        normalizeGrokCapabilityToken(option.name) === normalizedRequested,
+    )?.value;
+  }
+  const currentValue = configOption.currentValue.trim();
+  return options.some((option) => option.value === currentValue) ? currentValue : undefined;
+}
+
+function modeText(mode: AcpSessionMode): string {
+  return [mode.id, mode.name, mode.description].filter(Boolean).join(" ");
+}
+
+function modeMatchesAnyToken(mode: AcpSessionMode, tokens: ReadonlySet<string>): boolean {
+  const normalizedText = normalizeGrokCapabilityToken(modeText(mode));
+  return Array.from(tokens).some((token) => normalizedText.split("-").includes(token));
+}
+
+export function resolveGrokAcpModeIds(
+  modeState: AcpSessionModeState | null | undefined,
+): GrokAcpModeIds | undefined {
+  if (!modeState || modeState.availableModes.length < 2) {
+    return undefined;
+  }
+  const planMode = modeState.availableModes.find((mode) =>
+    modeMatchesAnyToken(mode, new Set(["plan", "architect"])),
+  );
+  const defaultMode = modeState.availableModes.find((mode) =>
+    modeMatchesAnyToken(mode, new Set(["build", "code", "default", "implement", "normal"])),
+  );
+  if (!planMode || !defaultMode || planMode.id === defaultMode.id) {
+    return undefined;
+  }
+  return {
+    planModeId: planMode.id,
+    defaultModeId: defaultMode.id,
+  };
+}
+
+export function resolveGrokAcpInteractionModeId(
+  modeState: AcpSessionModeState | null | undefined,
+  interactionMode: "default" | "plan",
+): string | undefined {
+  const modeIds = resolveGrokAcpModeIds(modeState);
+  if (!modeIds) {
+    return undefined;
+  }
+  return interactionMode === "plan" ? modeIds.planModeId : modeIds.defaultModeId;
+}
+
+export function grokAcpHasPlanModePair(modeState: AcpSessionModeState | null | undefined): boolean {
+  return resolveGrokAcpModeIds(modeState) !== undefined;
+}
+
 function resolveGrokAuthMethodId(environment: NodeJS.ProcessEnv | undefined): string {
   return environment?.[GROK_API_KEY_ENV]?.trim()
     ? GROK_AUTH_METHOD_API_KEY
@@ -64,6 +281,7 @@ export const makeGrokAcpRuntime = (
         ...input,
         spawn: buildGrokAcpSpawnInput(input.grokSettings, input.cwd, input.environment),
         authMethodId: resolveGrokAuthMethodId(input.environment),
+        clientCapabilities: GROK_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
       }).pipe(
         Layer.provide(
           Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),

--- a/apps/server/src/provider/testFixtures/grokAcpNativeWire.json
+++ b/apps/server/src/provider/testFixtures/grokAcpNativeWire.json
@@ -1,0 +1,75 @@
+{
+  "fixture": "grok-acp-0.2.118-authenticated",
+  "notes": "The setup and effort setter fields below were captured from an authenticated Grok ACP session. This CLI advertises reasoning on model metadata, but does not advertise modes or configOptions in session/new. Standard usage/config updates remain deterministic parser fixtures; native child-task fields stay absent until a live payload proves their shape and lineage.",
+  "sessionSetup": {
+    "sessionId": "captured-session",
+    "models": {
+      "currentModelId": "grok-4.5",
+      "availableModels": [
+        {
+          "modelId": "grok-4.5",
+          "name": "Grok 4.5",
+          "description": "SpaceXAI's new frontier model",
+          "_meta": {
+            "totalContextTokens": 500000,
+            "agentType": "grok-build-plan",
+            "supportsReasoningEffort": true,
+            "reasoningEffort": "high",
+            "reasoningEfforts": [
+              {
+                "id": "high",
+                "value": "high",
+                "label": "High Effort",
+                "description": "Highest implementation quality with extensive reasoning",
+                "default": true
+              },
+              {
+                "id": "medium",
+                "value": "medium",
+                "label": "Medium Effort",
+                "description": "Balanced effort with standard reasoning and testing",
+                "default": false
+              },
+              {
+                "id": "low",
+                "value": "low",
+                "label": "Low Effort",
+                "description": "Quick, fast implementations",
+                "default": false
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "verifiedRequests": [
+    {
+      "method": "session/set_model",
+      "params": {
+        "sessionId": "captured-session",
+        "modelId": "grok-4.5",
+        "_meta": { "reasoningEffort": "low" }
+      }
+    }
+  ],
+  "deterministicStandardUpdates": [
+    {
+      "sessionId": "mock-session-1",
+      "update": {
+        "sessionUpdate": "config_option_update",
+        "configOptions": []
+      }
+    },
+    {
+      "sessionId": "mock-session-1",
+      "update": {
+        "sessionUpdate": "usage_update",
+        "size": 272000,
+        "used": 42000
+      }
+    }
+  ],
+  "nativeModes": null,
+  "nativeChildTasks": null
+}

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -75,6 +75,44 @@ spills the whole accumulated text as one delta. The buffer also flushes at inter
 when a request opens (approval) or user input is requested, via
 `flushBufferedAssistantMessagesForTurn`.
 
+### Grok ACP capability negotiation
+
+Grok is driven through its ACP stdio session. The adapter treats the session setup response and
+subsequent standard `session/update` notifications as the source of truth for optional features:
+
+- The provider advertises the Plan/Build control only when the negotiated mode list contains a
+  distinct plan-like mode and a distinct build/default-like mode. T3's persisted
+  `ProviderInteractionMode` is applied immediately before `session/prompt`; native mode-change
+  notifications are retained in the native log and do not overwrite T3 state.
+- A select option whose negotiated category/name identifies reasoning is exposed as the canonical
+  T3 `reasoning` descriptor. Grok builds that advertise `supportsReasoningEffort` instead expose
+  the exact `_meta.reasoningEfforts[].value` list on each model; the adapter applies those values
+  through Grok's verified `session/set_model` `_meta.reasoningEffort` request. Standard ACP
+  `session/set_config_option` remains the fallback for builds that advertise a reasoning option.
+  No model-specific effort list is assumed when neither surface is negotiated.
+- Standard ACP `config_option_update` notifications replace the runtime's negotiated configuration
+  snapshot. Standard `usage_update` notifications become the existing
+  `thread.token-usage.updated` runtime event, preserving the raw ACP notification for diagnostics.
+  Usage does not imply compaction, cost accounting, or automatic compaction behavior.
+
+One ACP runtime projects one root session. Foreign-session notifications remain filtered unless a
+provider supplies an explicit, negotiated lineage decoder through the opt-in foreign-session sink.
+Grok currently has no checked native child-session/task payload in this repository, so Grok native
+subagents and background tasks are intentionally not mapped to T3 `task.*` events. We do not infer
+parentage from session IDs, tool IDs, `_meta`, or text. If a future Grok payload proves explicit
+parent identity and lifecycle, its adapter may use the existing task events and background-liveness
+consumers; it must keep child content off the root transcript and emit terminal stopped events when
+the provider session is torn down.
+
+This feature-detection boundary keeps older or partially capable Grok CLIs working for normal ACP
+prompts, model selection, approvals, and existing plan notifications while leaving unsupported
+controls hidden or rejected before a prompt is sent.
+
+The authenticated Grok CLI payload currently checked into the probe advertises `grok-4.5` reasoning
+metadata and a context size, but no ACP mode pair or config-option list. Consequently its reasoning
+control is available through the model metadata setter, while the Plan/Build toggle remains hidden
+until a setup payload advertises distinct native modes.
+
 [drivers]: ../../apps/server/src/provider/builtInDrivers.ts
 [codex]: ../../apps/server/src/provider/Drivers/CodexDriver.ts
 [claude]: ../../apps/server/src/provider/Drivers/ClaudeDriver.ts

--- a/docs/user/providers-grok.md
+++ b/docs/user/providers-grok.md
@@ -1,0 +1,38 @@
+# Grok
+
+T3 Code connects to Grok through the Grok CLI's ACP session. Optional controls are shown only when
+that CLI advertises the corresponding capability during session setup.
+
+## Plan mode
+
+The Plan/Build toggle is available when the installed Grok CLI exposes a native plan mode and a
+separate build/default mode. T3 applies the selected mode to the ACP session before sending the
+turn; it does not add instructions to your prompt.
+
+If the toggle is missing, the CLI did not negotiate a usable native mode pair. Normal prompts and
+existing Grok plan updates continue to work.
+
+## Reasoning controls
+
+When Grok advertises reasoning choices—either as an ACP configuration option or as the model's
+native reasoning-effort metadata—T3 shows those choices in the model controls. The choices and
+values come from Grok, so they can differ between models and CLI versions. A custom model has no
+reasoning control unless Grok negotiates one for that session.
+
+## Context window
+
+Grok ACP usage updates populate T3's existing context-window dial when the CLI reports both the
+current usage and a positive context size. Missing values are left unavailable rather than
+estimated.
+
+## Subagents and background work
+
+T3 does not guess Grok child-task relationships. Native subagents or background work appear in T3's
+Agents and background state only after a Grok CLI version provides explicit child identity,
+parentage, task type, and lifecycle notifications that ACP can verify. Older or partially capable
+CLIs keep those notifications isolated from the root conversation and continue supporting ordinary
+Grok turns.
+
+Some current Grok CLI releases expose reasoning metadata without exposing a native ACP Plan/Build
+mode pair or child-task lifecycle. In that case T3 keeps Plan and native-agent UI unavailable while
+normal Grok prompts continue to work.


### PR DESCRIPTION
## Summary

- Bridge Grok ACP model discovery into T3 reasoning descriptors.
- Apply T3 reasoning selections and interaction mode before `session/prompt`.
- Normalize ACP config and usage updates into T3's existing context-window telemetry.
- Preserve root-only foreign-session routing until Grok exposes a verified child-task lineage contract.
- Add deterministic fixtures, focused tests, and provider documentation.

## Verified Grok contract

The authenticated Grok CLI probe checked Grok 0.2.118 with model `grok-4.5`. Its setup payload advertises exact reasoning values `high`, `medium`, and `low`, and the verified setter is `session/set_model` with `_meta.reasoningEffort`.

The checked setup did not advertise an ACP Plan/Build mode pair or native child/background task lifecycle. Plan UI and native task mapping therefore remain feature-gated/unsupported rather than guessing wire methods or lineage. Standard usage/config updates are implemented and covered by deterministic ACP fixtures; the live prompt probe timed out before verifying a current Grok usage payload.

## Validation

- Authenticated Grok ACP probe: 4/4.
- Grok adapter tests: 21/21.
- Grok provider tests: 8/8.
- ACP parser/core/support tests: 26/26.
- Cross-surface context, task, liveness, web, and mobile checks passed.
- `pnpm exec vp run --filter t3 typecheck` passed.
- `git diff --check` passed.

The full ProviderRuntimeIngestion file reached 45/45 passing tests but did not exit within the Windows runner timeout; its focused context-window test passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bridge native ACP capabilities for Grok including Plan mode, reasoning effort, and usage updates
> - The Grok adapter now negotiates and applies Plan/Build interaction mode and reasoning effort to the ACP session before each prompt, using config options or model metadata as available.
> - New `makeAcpUsageUpdatedEvent` maps ACP `usage_update` notifications to `thread.token-usage.updated` runtime events; `turn.started` now includes an `effort` field when available.
> - `AcpSessionRuntime` tracks negotiated config options from live notifications, resolves mode changes using the negotiated config option id, and forwards `_meta` (e.g. `reasoningEffort`) through `session/set_model` requests.
> - The mock agent gains environment flags (`T3_ACP_EMIT_CONFIG_OPTION_UPDATES`, `T3_ACP_EMIT_USAGE_UPDATES`, `T3_ACP_GROK_NATIVE_FIXTURE`) to simulate these flows during development and testing.
> - The Grok provider discovery path now captures config options and mode state, derives per-model reasoning capabilities, and sets `showInteractionModeToggle` in presentation when a plan/default mode pair is advertised.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d97ef65. 10 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added capability-aware Grok model selection and reasoning controls.
  - Added support for Plan/Build mode switching when supported by the connected Grok CLI.
  - Added context-window usage reporting and token usage updates.
  - Added improved session model changes and configuration synchronization.

- **Bug Fixes**
  - Filtered internal context-window updates from mobile work activity feeds.
  - Improved compatibility across supported platforms and Grok CLI versions.

- **Documentation**
  - Documented Grok session integration, controls, usage reporting, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->