### PR TITLE
feat(codex): carry per-session config into app server

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -611,6 +611,9 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             interactionMode: event.payload.interactionMode,
             branch: event.payload.branch,
             worktreePath: event.payload.worktreePath,
+            ...(event.payload.sessionFlags !== undefined
+              ? { sessionFlags: event.payload.sessionFlags }
+              : {}),
             latestTurnId: null,
             createdAt: event.payload.createdAt,
             updatedAt: event.payload.updatedAt,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -82,6 +82,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           interaction_mode,
           branch,
           worktree_path,
+          session_flags_json,
           latest_turn_id,
           latest_user_message_at,
           pending_approval_count,
@@ -102,6 +103,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           'default',
           NULL,
           NULL,
+          '{"version":1,"provider":"codex","config":{"features.hooks":true,"bypass_hook_trust":true,"hooks.SessionStart":[],"hooks.PreCompact":[],"hooks.UserPromptSubmit":[]}}',
           'turn-1',
           '2026-02-24T00:00:04.000Z',
           1,
@@ -262,6 +264,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
       }
 
       const snapshot = yield* snapshotQuery.getSnapshot();
+      const commandReadModel = yield* snapshotQuery.getCommandReadModel();
 
       assert.equal(snapshot.snapshotSequence, 5);
       assert.equal(snapshot.updatedAt, "2026-02-24T00:00:09.000Z");
@@ -304,6 +307,17 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           runtimeMode: "full-access",
           branch: null,
           worktreePath: null,
+          sessionFlags: {
+            version: 1,
+            provider: "codex",
+            config: {
+              "features.hooks": true,
+              bypass_hook_trust: true,
+              "hooks.SessionStart": [],
+              "hooks.PreCompact": [],
+              "hooks.UserPromptSubmit": [],
+            },
+          },
           latestTurn: {
             turnId: asTurnId("turn-1"),
             state: "completed",
@@ -382,6 +396,17 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           },
         },
       ]);
+      assert.deepEqual(commandReadModel.threads[0]?.sessionFlags, {
+        version: 1,
+        provider: "codex",
+        config: {
+          "features.hooks": true,
+          bypass_hook_trust: true,
+          "hooks.SessionStart": [],
+          "hooks.PreCompact": [],
+          "hooks.UserPromptSubmit": [],
+        },
+      });
 
       const shellSnapshot = yield* snapshotQuery.getShellSnapshot();
       assert.equal(shellSnapshot.snapshotSequence, 5);
@@ -697,6 +722,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
       );
       assert.equal(thread?.settledOverride, "settled");
       assert.equal(thread?.settledAt, "2026-04-06T00:00:04.000Z");
+      assert.equal("sessionFlags" in (thread ?? {}), false);
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1,5 +1,6 @@
 import {
   ChatAttachment,
+  CodexSessionFlags,
   CheckpointRef,
   IsoDateTime,
   MessageId,
@@ -85,6 +86,7 @@ const ProjectionThreadProposedPlanDbRowSchema = ProjectionThreadProposedPlan;
 const ProjectionThreadDbRowSchema = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
+    sessionFlags: Schema.NullOr(Schema.fromJsonString(CodexSessionFlags)),
   }),
 );
 const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
@@ -418,6 +420,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          session_flags_json AS "sessionFlags",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -454,6 +457,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          session_flags_json AS "sessionFlags",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -492,6 +496,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          session_flags_json AS "sessionFlags",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -934,6 +939,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          session_flags_json AS "sessionFlags",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -1567,6 +1573,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 interactionMode: row.interactionMode,
                 branch: row.branch,
                 worktreePath: row.worktreePath,
+                ...(row.sessionFlags !== null ? { sessionFlags: row.sessionFlags } : {}),
                 latestTurn: latestTurnByThread.get(row.threadId) ?? null,
                 createdAt: row.createdAt,
                 updatedAt: row.updatedAt,
@@ -2455,6 +2462,9 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         interactionMode: threadRow.value.interactionMode,
         branch: threadRow.value.branch,
         worktreePath: threadRow.value.worktreePath,
+        ...(threadRow.value.sessionFlags !== null
+          ? { sessionFlags: threadRow.value.sessionFlags }
+          : {}),
         latestTurn: Option.isSome(latestTurnRow) ? mapLatestTurn(latestTurnRow.value) : null,
         createdAt: threadRow.value.createdAt,
         updatedAt: threadRow.value.updatedAt,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1781,6 +1781,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   interactionMode: row.interactionMode,
                   branch: row.branch,
                   worktreePath: row.worktreePath,
+                  ...(row.sessionFlags !== null ? { sessionFlags: row.sessionFlags } : {}),
                   latestTurn: latestTurnByThread.get(row.threadId) ?? null,
                   createdAt: row.createdAt,
                   updatedAt: row.updatedAt,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -20,6 +20,7 @@ import {
   ProjectId,
   ThreadId,
   TurnId,
+  type CodexSessionFlags,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Deferred from "effect/Deferred";
@@ -150,6 +151,7 @@ describe("ProviderCommandReactor", () => {
     readonly requiresNewThreadForModelChange?: boolean;
     readonly titleRegenerationCompletionDispatchFailures?: number;
     readonly titleRegenerationBeforeStart?: "one" | "two";
+    readonly sessionFlags?: CodexSessionFlags;
     readonly startSessionEffect?: (
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderAdapterRequestError>;
@@ -446,6 +448,7 @@ describe("ProviderCommandReactor", () => {
         runtimeMode: "approval-required",
         branch: null,
         worktreePath: null,
+        ...(input?.sessionFlags !== undefined ? { sessionFlags: input.sessionFlags } : {}),
         createdAt: now,
       }),
     );
@@ -551,6 +554,46 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.status).toBe("starting");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
   });
+
+  effectIt.effect("carries projected Codex session flags into provider session start", () =>
+    Effect.gen(function* () {
+      const sessionFlags: CodexSessionFlags = {
+        version: 1,
+        provider: "codex",
+        config: {
+          "features.hooks": true,
+          bypass_hook_trust: true,
+          "hooks.SessionStart": [
+            {
+              matcher: "startup",
+              hooks: [{ type: "command", command: "gc hook session-start" }],
+            },
+          ],
+          "hooks.PreCompact": [],
+          "hooks.UserPromptSubmit": [],
+        },
+      };
+      const harness = yield* Effect.promise(() => createHarness({ sessionFlags }));
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-session-flags"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-session-flags"),
+          role: "user",
+          text: "start generated hooks",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+
+      yield* Effect.promise(() => waitFor(() => harness.startSession.mock.calls.length === 1));
+      expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({ sessionFlags });
+    }),
+  );
 
   effectIt.effect("projects starting before a slow provider session finishes", () =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -627,6 +627,7 @@ const make = Effect.gen(function* () {
         providerInstanceId: desiredInstanceId,
         ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
         modelSelection: desiredModelSelection,
+        ...(thread.sessionFlags !== undefined ? { sessionFlags: thread.sessionFlags } : {}),
         ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
         runtimeMode: desiredRuntimeMode,
       });

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -377,6 +377,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           interactionMode: command.interactionMode,
           branch: command.branch,
           worktreePath: command.worktreePath,
+          ...(command.sessionFlags !== undefined ? { sessionFlags: command.sessionFlags } : {}),
           createdAt: command.createdAt,
           updatedAt: command.createdAt,
         },

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -297,6 +297,7 @@ export function projectEvent(
             interactionMode: payload.interactionMode,
             branch: payload.branch,
             worktreePath: payload.worktreePath,
+            ...(payload.sessionFlags !== undefined ? { sessionFlags: payload.sessionFlags } : {}),
             latestTurn: null,
             createdAt: payload.createdAt,
             updatedAt: payload.updatedAt,

--- a/apps/server/src/orchestration/sessionFlags.test.ts
+++ b/apps/server/src/orchestration/sessionFlags.test.ts
@@ -1,0 +1,130 @@
+import {
+  CommandId,
+  EventId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type CodexSessionFlags,
+  type OrchestrationEvent,
+} from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+import { createEmptyReadModel, projectEvent } from "./projector.ts";
+
+const now = "2026-01-01T00:00:00.000Z";
+const projectId = ProjectId.make("project-session-flags");
+
+const sessionFlags: CodexSessionFlags = {
+  version: 1,
+  provider: "codex",
+  config: {
+    "features.hooks": true,
+    bypass_hook_trust: true,
+    "hooks.SessionStart": [
+      { matcher: "startup", hooks: [{ type: "command", command: "gc hook session-start" }] },
+    ],
+    "hooks.PreCompact": [
+      { matcher: "", hooks: [{ type: "command", command: "gc hook pre-compact" }] },
+    ],
+    "hooks.UserPromptSubmit": [
+      {
+        matcher: "",
+        hooks: [
+          { type: "command", command: "gc hook nudge" },
+          { type: "command", command: "gc hook mail" },
+        ],
+      },
+    ],
+  },
+};
+
+const seedProjectCreated = (): OrchestrationEvent => ({
+  sequence: 1,
+  eventId: EventId.make("evt-project-session-flags"),
+  aggregateKind: "project",
+  aggregateId: projectId,
+  type: "project.created",
+  occurredAt: now,
+  commandId: CommandId.make("cmd-project-session-flags"),
+  causationEventId: null,
+  correlationId: CommandId.make("cmd-project-session-flags"),
+  metadata: {},
+  payload: {
+    projectId,
+    title: "Session flags",
+    workspaceRoot: "/tmp/session-flags",
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: now,
+    updatedAt: now,
+  },
+});
+
+it.layer(NodeServices.layer)("Codex session flags orchestration", (it) => {
+  it.effect("persists session flags from thread.create into the projected thread", () =>
+    Effect.gen(function* () {
+      const readModel = yield* projectEvent(createEmptyReadModel(now), seedProjectCreated());
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.create",
+          commandId: CommandId.make("cmd-thread-session-flags"),
+          threadId: ThreadId.make("thread-session-flags"),
+          projectId,
+          title: "Generated hooks",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          sessionFlags,
+          createdAt: now,
+        },
+        readModel,
+      });
+
+      const event = Array.isArray(result) ? result[0] : result;
+      expect(event.type).toBe("thread.created");
+      expect((event.payload as { sessionFlags?: unknown }).sessionFlags).toEqual(sessionFlags);
+
+      const projected = yield* projectEvent(readModel, { ...event, sequence: 2 });
+      expect(projected.threads[0]?.sessionFlags).toEqual(sessionFlags);
+    }),
+  );
+
+  it.effect("keeps session flags absent for ordinary threads", () =>
+    Effect.gen(function* () {
+      const readModel = yield* projectEvent(createEmptyReadModel(now), seedProjectCreated());
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.create",
+          commandId: CommandId.make("cmd-thread-ordinary"),
+          threadId: ThreadId.make("thread-ordinary"),
+          projectId,
+          title: "Ordinary thread",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+        },
+        readModel,
+      });
+
+      const event = Array.isArray(result) ? result[0] : result;
+      expect("sessionFlags" in (event.payload as object)).toBe(false);
+
+      const projected = yield* projectEvent(readModel, { ...event, sequence: 2 });
+      expect("sessionFlags" in (projected.threads[0] as object)).toBe(false);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Layers/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreads.ts
@@ -2,6 +2,7 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Struct from "effect/Struct";
 
@@ -14,14 +15,20 @@ import {
   ProjectionThreadRepository,
   type ProjectionThreadRepositoryShape,
 } from "../Services/ProjectionThreads.ts";
-import { ModelSelection } from "@t3tools/contracts";
+import { CodexSessionFlags, ModelSelection } from "@t3tools/contracts";
 
 const ProjectionThreadDbRow = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
+    sessionFlags: Schema.NullOr(Schema.fromJsonString(CodexSessionFlags)),
   }),
 );
 type ProjectionThreadDbRow = typeof ProjectionThreadDbRow.Type;
+
+function normalizeProjectionThread(row: ProjectionThreadDbRow): ProjectionThread {
+  const { sessionFlags, ...rest } = row;
+  return sessionFlags === null ? rest : { ...rest, sessionFlags };
+}
 
 const makeProjectionThreadRepository = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
@@ -39,6 +46,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           interaction_mode,
           branch,
           worktree_path,
+          session_flags_json,
           latest_turn_id,
           created_at,
           updated_at,
@@ -66,6 +74,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           ${row.interactionMode},
           ${row.branch},
           ${row.worktreePath},
+          ${row.sessionFlags === undefined ? null : JSON.stringify(row.sessionFlags)},
           ${row.latestTurnId},
           ${row.createdAt},
           ${row.updatedAt},
@@ -93,6 +102,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           interaction_mode = excluded.interaction_mode,
           branch = excluded.branch,
           worktree_path = excluded.worktree_path,
+          session_flags_json = excluded.session_flags_json,
           latest_turn_id = excluded.latest_turn_id,
           created_at = excluded.created_at,
           updated_at = excluded.updated_at,
@@ -127,6 +137,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          session_flags_json AS "sessionFlags",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -163,6 +174,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          session_flags_json AS "sessionFlags",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -203,11 +215,13 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
   const getById: ProjectionThreadRepositoryShape["getById"] = (input) =>
     getProjectionThreadRow(input).pipe(
       Effect.mapError(toPersistenceSqlError("ProjectionThreadRepository.getById:query")),
+      Effect.map(Option.map(normalizeProjectionThread)),
     );
 
   const listByProjectId: ProjectionThreadRepositoryShape["listByProjectId"] = (input) =>
     listProjectionThreadRows(input).pipe(
       Effect.mapError(toPersistenceSqlError("ProjectionThreadRepository.listByProjectId:query")),
+      Effect.map((rows) => rows.map(normalizeProjectionThread)),
     );
 
   const deleteById: ProjectionThreadRepositoryShape["deleteById"] = (input) =>

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -53,6 +53,7 @@ import Migration0037 from "./Migrations/037_ProjectionTurnsKeysetIndex.ts";
 import Migration0038 from "./Migrations/038_ProjectionThreadsPinOrderKey.ts";
 import Migration0039 from "./Migrations/039_ProjectionProjectsDefaultThreadEnvMode.ts";
 import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
+import Migration0041 from "./Migrations/041_ProjectionThreadSessionFlags.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -105,6 +106,7 @@ export const migrationEntries = [
   [38, "ProjectionThreadsPinOrderKey", Migration0038],
   [39, "ProjectionProjectsDefaultThreadEnvMode", Migration0039],
   [40, "ProjectionProjectFaviconPath", Migration0040],
+  [41, "ProjectionThreadSessionFlags", Migration0041],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionFlags.test.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionFlags.test.ts
@@ -1,0 +1,28 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("041_ProjectionThreadSessionFlags", (it) => {
+  it.effect("adds nullable per-session flags to thread projections", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 40 });
+      yield* runMigrations({ toMigrationInclusive: 41 });
+
+      const columns = yield* sql<{ readonly name: string; readonly notnull: number }>`
+        PRAGMA table_info(projection_threads)
+      `;
+      const sessionFlags = columns.find((column) => column.name === "session_flags_json");
+
+      assert.equal(sessionFlags?.name, "session_flags_json");
+      assert.equal(sessionFlags?.notnull, 0);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionFlags.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionFlags.ts
@@ -1,0 +1,16 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_threads)
+  `;
+
+  if (!columns.some((column) => column.name === "session_flags_json")) {
+    yield* sql`
+      ALTER TABLE projection_threads
+      ADD COLUMN session_flags_json TEXT
+    `;
+  }
+});

--- a/apps/server/src/persistence/Services/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreads.ts
@@ -8,6 +8,7 @@
  */
 import {
   CommandId,
+  CodexSessionFlags,
   IsoDateTime,
   ModelSelection,
   NonNegativeInt,
@@ -33,6 +34,7 @@ export const ProjectionThread = Schema.Struct({
   interactionMode: ProviderInteractionMode,
   branch: Schema.NullOr(Schema.String),
   worktreePath: Schema.NullOr(Schema.String),
+  sessionFlags: Schema.optional(CodexSessionFlags),
   latestTurnId: Schema.NullOr(TurnId),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -11,6 +11,7 @@ import {
   ProviderInstanceId,
   ProviderItemId,
   type ProviderApprovalDecision,
+  type CodexSessionFlags,
   type ProviderEvent,
   type ProviderSession,
   type ProviderTurnStartResult,
@@ -388,6 +389,51 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
       const runtime = runtimeFactory.lastRuntime;
       NodeAssert.ok(runtime);
       NodeAssert.equal(runtime.options.launchArgs, "--strict-config --enable foo");
+      NodeAssert.equal(runtime.options.sessionConfig, undefined);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("maps per-session Codex flags into runtime config without launch args", () => {
+    const runtimeFactory = makeRuntimeFactory();
+    const layer = Layer.effect(
+      CodexAdapter,
+      Effect.gen(function* () {
+        const codexConfig = decodeCodexSettings({});
+        return yield* makeCodexAdapter(codexConfig, {
+          makeRuntime: runtimeFactory.factory,
+        });
+      }),
+    ).pipe(
+      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(providerSessionDirectoryTestLayer),
+      Layer.provideMerge(NodeServices.layer),
+    );
+    const sessionFlags: CodexSessionFlags = {
+      version: 1,
+      provider: "codex",
+      config: {
+        "features.hooks": true,
+        bypass_hook_trust: true,
+        "hooks.SessionStart": [],
+        "hooks.PreCompact": [],
+        "hooks.UserPromptSubmit": [],
+      },
+    };
+
+    return Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("sess-session-config"),
+        runtimeMode: "full-access",
+        sessionFlags,
+      });
+
+      const runtime = runtimeFactory.lastRuntime;
+      NodeAssert.ok(runtime);
+      NodeAssert.deepStrictEqual(runtime.options.sessionConfig, sessionFlags.config);
+      NodeAssert.equal(runtime.options.launchArgs, "");
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1679,6 +1679,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             ? { model: input.modelSelection.model }
             : {}),
           ...(serviceTier ? { serviceTier } : {}),
+          ...(input.sessionFlags !== undefined ? { sessionConfig: input.sessionFlags.config } : {}),
           ...(mcpSession
             ? {
                 environment: {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -4,7 +4,7 @@ import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { describe } from "vite-plus/test";
-import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
+import { DEFAULT_MODEL, ThreadId, type CodexSessionConfig } from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 
@@ -393,6 +393,82 @@ describe("isRecoverableThreadResumeError", () => {
 });
 
 describe("openCodexThread", () => {
+  const sessionConfig: CodexSessionConfig = {
+    "features.hooks": true,
+    bypass_hook_trust: true,
+    "hooks.SessionStart": [],
+    "hooks.PreCompact": [],
+    "hooks.UserPromptSubmit": [],
+  };
+
+  it.effect("forwards per-session config to a fresh thread/start", () =>
+    Effect.gen(function* () {
+      const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
+      const client = {
+        request: <M extends "thread/start" | "thread/resume">(
+          method: M,
+          payload: CodexRpc.ClientRequestParamsByMethod[M],
+        ) => {
+          calls.push({ method, payload });
+          return Effect.succeed(
+            makeThreadOpenResponse("fresh-thread") as CodexRpc.ClientRequestResponsesByMethod[M],
+          );
+        },
+      };
+
+      yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        sessionConfig,
+        resumeThreadId: undefined,
+      });
+
+      NodeAssert.equal(calls[0]?.method, "thread/start");
+      NodeAssert.deepStrictEqual(
+        (calls[0]?.payload as { config?: unknown } | undefined)?.config,
+        sessionConfig,
+      );
+    }),
+  );
+
+  it.effect("forwards per-session config to thread/resume", () =>
+    Effect.gen(function* () {
+      const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
+      const client = {
+        request: <M extends "thread/start" | "thread/resume">(
+          method: M,
+          payload: CodexRpc.ClientRequestParamsByMethod[M],
+        ) => {
+          calls.push({ method, payload });
+          return Effect.succeed(
+            makeThreadOpenResponse("resumed-thread") as CodexRpc.ClientRequestResponsesByMethod[M],
+          );
+        },
+      };
+
+      yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        sessionConfig,
+        resumeThreadId: "resumed-thread",
+      });
+
+      NodeAssert.equal(calls[0]?.method, "thread/resume");
+      NodeAssert.deepStrictEqual(
+        (calls[0]?.payload as { config?: unknown } | undefined)?.config,
+        sessionConfig,
+      );
+    }),
+  );
+
   it.effect("falls back to thread/start when resume fails recoverably", () =>
     Effect.gen(function* () {
       const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
@@ -422,6 +498,7 @@ describe("openCodexThread", () => {
         cwd: "/tmp/project",
         requestedModel: "gpt-5.3-codex",
         serviceTier: undefined,
+        sessionConfig,
         resumeThreadId: "stale-thread",
       });
 
@@ -429,6 +506,14 @@ describe("openCodexThread", () => {
       NodeAssert.deepStrictEqual(
         calls.map((call) => call.method),
         ["thread/resume", "thread/start"],
+      );
+      NodeAssert.deepStrictEqual(
+        (calls[0]?.payload as { config?: unknown } | undefined)?.config,
+        sessionConfig,
+      );
+      NodeAssert.deepStrictEqual(
+        (calls[1]?.payload as { config?: unknown } | undefined)?.config,
+        sessionConfig,
       );
     }),
   );

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -1,5 +1,6 @@
 import {
   ApprovalRequestId,
+  type CodexSessionConfig,
   DEFAULT_MODEL,
   EventId,
   ProviderDriverKind,
@@ -106,6 +107,7 @@ export interface CodexSessionRuntimeOptions {
   readonly serviceTier?: CodexServiceTier | undefined;
   readonly resumeCursor?: CodexResumeCursor;
   readonly appServerArgs?: ReadonlyArray<string>;
+  readonly sessionConfig?: CodexSessionConfig;
 }
 
 export interface CodexSessionRuntimeSendTurnInput {
@@ -302,6 +304,7 @@ function buildThreadStartParams(input: {
   readonly runtimeMode: RuntimeMode;
   readonly model: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
+  readonly sessionConfig: CodexSessionConfig | undefined;
 }): EffectCodexSchema.V2ThreadStartParams {
   const config = runtimeModeToThreadConfig(input.runtimeMode);
   return {
@@ -311,6 +314,7 @@ function buildThreadStartParams(input: {
     approvalsReviewer: config.approvalsReviewer,
     ...(input.model ? { model: input.model } : {}),
     ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
+    ...(input.sessionConfig !== undefined ? { config: input.sessionConfig } : {}),
   };
 }
 
@@ -461,6 +465,7 @@ export const openCodexThread = (input: {
   readonly cwd: string;
   readonly requestedModel: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
+  readonly sessionConfig?: CodexSessionConfig;
   readonly resumeThreadId: string | undefined;
 }): Effect.Effect<CodexThreadOpenResponse, CodexErrors.CodexAppServerError> => {
   const resumeThreadId = input.resumeThreadId;
@@ -469,6 +474,7 @@ export const openCodexThread = (input: {
     runtimeMode: input.runtimeMode,
     model: input.requestedModel,
     serviceTier: input.serviceTier,
+    sessionConfig: input.sessionConfig,
   });
 
   if (resumeThreadId === undefined) {
@@ -1695,6 +1701,7 @@ export const makeCodexSessionRuntime = (
         cwd: options.cwd,
         requestedModel,
         serviceTier: options.serviceTier,
+        ...(options.sessionConfig !== undefined ? { sessionConfig: options.sessionConfig } : {}),
         resumeThreadId: readResumeCursorThreadId(options.resumeCursor),
       });
 

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -54,6 +54,36 @@ const decodeOrchestrationCommand = Schema.decodeUnknownEffect(OrchestrationComma
 const decodeOrchestrationEvent = Schema.decodeUnknownEffect(OrchestrationEvent);
 const decodeThreadMetaUpdatedPayload = Schema.decodeUnknownEffect(ThreadMetaUpdatedPayload);
 
+const codexSessionFlags = {
+  version: 1,
+  provider: "codex",
+  config: {
+    "features.hooks": true,
+    bypass_hook_trust: true,
+    "hooks.SessionStart": [
+      {
+        matcher: "startup",
+        hooks: [{ type: "command", command: "gc hook session-start" }],
+      },
+    ],
+    "hooks.PreCompact": [
+      {
+        matcher: "",
+        hooks: [{ type: "command", command: "gc hook pre-compact" }],
+      },
+    ],
+    "hooks.UserPromptSubmit": [
+      {
+        matcher: "",
+        hooks: [
+          { type: "command", command: "gc hook nudge" },
+          { type: "command", command: "gc hook mail" },
+        ],
+      },
+    ],
+  },
+} as const;
+
 it.effect("parses turn diff input when fromTurnCount <= toTurnCount", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeTurnDiffInput({
@@ -615,6 +645,97 @@ it.effect(
       const encoded = yield* encodeThreadCreatedPayload(decoded);
       assert.deepStrictEqual(encoded.modelSelection.options, [{ id: "fastMode", value: true }]);
     }),
+);
+
+it.effect("preserves typed Codex session flags across thread command and event boundaries", () =>
+  Effect.gen(function* () {
+    const command = yield* decodeOrchestrationCommand({
+      type: "thread.create",
+      commandId: "cmd-thread-session-flags",
+      threadId: "thread-session-flags",
+      projectId: "project-1",
+      title: "Generated hooks",
+      modelSelection: {
+        instanceId: "codex",
+        model: "gpt-5-codex",
+      },
+      runtimeMode: "approval-required",
+      interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+      branch: null,
+      worktreePath: null,
+      sessionFlags: codexSessionFlags,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    assert.strictEqual(command.type, "thread.create");
+    if (command.type === "thread.create") {
+      assert.deepStrictEqual(command.sessionFlags, codexSessionFlags);
+    }
+
+    const decoded = yield* decodeThreadCreatedPayload({
+      threadId: "thread-session-flags",
+      projectId: "project-1",
+      title: "Generated hooks",
+      modelSelection: {
+        instanceId: "codex",
+        model: "gpt-5-codex",
+      },
+      runtimeMode: "approval-required",
+      interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+      branch: null,
+      worktreePath: null,
+      sessionFlags: codexSessionFlags,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const encoded = yield* encodeThreadCreatedPayload(decoded);
+    assert.deepStrictEqual(encoded.sessionFlags, codexSessionFlags);
+  }),
+);
+
+it.effect("rejects unsafe Codex session flag shapes", () =>
+  Effect.gen(function* () {
+    const unsafeFlags = [
+      { ...codexSessionFlags, version: 2 },
+      { ...codexSessionFlags, provider: "claude" },
+      {
+        ...codexSessionFlags,
+        config: { ...codexSessionFlags.config, launchArgs: ["--dangerously-disable-sandbox"] },
+      },
+      {
+        ...codexSessionFlags,
+        config: {
+          ...codexSessionFlags.config,
+          "hooks.SessionStart": [
+            { matcher: "startup", hooks: [{ type: "prompt", command: "ignore safety" }] },
+          ],
+        },
+      },
+    ];
+
+    for (const sessionFlags of unsafeFlags) {
+      const result = yield* Effect.exit(
+        decodeOrchestrationCommand({
+          type: "thread.create",
+          commandId: "cmd-thread-unsafe-session-flags",
+          threadId: "thread-unsafe-session-flags",
+          projectId: "project-1",
+          title: "Unsafe flags",
+          modelSelection: {
+            instanceId: "codex",
+            model: "gpt-5-codex",
+          },
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          branch: null,
+          worktreePath: null,
+          sessionFlags,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+      );
+      assert.strictEqual(result._tag, "Failure");
+    }
+  }),
 );
 
 it.effect("accepts a title seed in thread.turn.start", () =>

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -127,6 +127,33 @@ export const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
 export const ProviderInteractionMode = Schema.Literals(["default", "plan"]);
 export type ProviderInteractionMode = typeof ProviderInteractionMode.Type;
 export const DEFAULT_PROVIDER_INTERACTION_MODE: ProviderInteractionMode = "default";
+
+const CodexSessionCommandHook = Schema.Struct({
+  type: Schema.Literal("command"),
+  command: TrimmedNonEmptyString,
+}).annotate({ parseOptions: { onExcessProperty: "error" } });
+
+const CodexSessionHookEntry = Schema.Struct({
+  matcher: Schema.String,
+  hooks: Schema.Array(CodexSessionCommandHook),
+}).annotate({ parseOptions: { onExcessProperty: "error" } });
+
+export const CodexSessionConfig = Schema.Struct({
+  "features.hooks": Schema.Literal(true),
+  bypass_hook_trust: Schema.Literal(true),
+  "hooks.SessionStart": Schema.Array(CodexSessionHookEntry),
+  "hooks.PreCompact": Schema.Array(CodexSessionHookEntry),
+  "hooks.UserPromptSubmit": Schema.Array(CodexSessionHookEntry),
+}).annotate({ parseOptions: { onExcessProperty: "error" } });
+export type CodexSessionConfig = typeof CodexSessionConfig.Type;
+
+export const CodexSessionFlags = Schema.Struct({
+  version: Schema.Literal(1),
+  provider: Schema.Literal("codex"),
+  config: CodexSessionConfig,
+}).annotate({ parseOptions: { onExcessProperty: "error" } });
+export type CodexSessionFlags = typeof CodexSessionFlags.Type;
+
 export const ProviderRequestKind = Schema.Literals(["command", "file-read", "file-change"]);
 export type ProviderRequestKind = typeof ProviderRequestKind.Type;
 export const AssistantDeliveryMode = Schema.Literals(["buffered", "streaming"]);
@@ -372,6 +399,7 @@ export const OrchestrationThread = Schema.Struct({
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  sessionFlags: Schema.optional(CodexSessionFlags),
   latestTurn: Schema.NullOr(OrchestrationLatestTurn),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
@@ -663,6 +691,7 @@ const ThreadCreateCommand = Schema.Struct({
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  sessionFlags: Schema.optional(CodexSessionFlags),
   createdAt: IsoDateTime,
 });
 
@@ -1119,6 +1148,7 @@ export const ThreadCreatedPayload = Schema.Struct({
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  sessionFlags: Schema.optional(CodexSessionFlags),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
 });

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -10,6 +10,7 @@ import {
 } from "./baseSchemas.ts";
 import {
   ChatAttachment,
+  CodexSessionFlags,
   ModelSelection,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
@@ -60,6 +61,7 @@ export const ProviderSessionStartInput = Schema.Struct({
   resumeCursor: Schema.optional(Schema.Unknown),
   approvalPolicy: Schema.optional(ProviderApprovalPolicy),
   sandboxMode: Schema.optional(ProviderSandboxMode),
+  sessionFlags: Schema.optional(CodexSessionFlags),
   runtimeMode: RuntimeMode,
 });
 export type ProviderSessionStartInput = typeof ProviderSessionStartInput.Type;


### PR DESCRIPTION
Problem

T3 threads cannot currently carry narrowly scoped provider session configuration into Codex app-server thread creation. Integrations that need Codex hooks must therefore mutate user/project files or misuse provider-global launch arguments, and resume/fallback can diverge from fresh starts.

Fix

- add a strict, versioned Codex session-flags contract to thread creation and provider session start
- persist the optional field in the thread projection via a nullable JSON migration
- map it only in CodexAdapter, leaving ordinary threads unchanged
- pass the same generated `V2ThreadStartParams.config` to thread/start, thread/resume, and recoverable resume-to-fresh fallback
- keep generated effect-codex-app-server request types authoritative

Validation

- 200 focused tests across contracts, projections, migration, reactor, adapter, and runtime
- contracts and server typechecks pass
- mutation checks proved tests fail when command persistence, adapter mapping, or app-server config forwarding is removed

Model/harness: OpenAI Codex (GPT-5), using TDD and explicit mutation testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider session startup and accepts hook command definitions at the orchestration boundary; schema validation limits unsafe shapes, but mis-specified hooks could still affect Codex runtime behavior for flagged threads only.
> 
> **Overview**
> Threads can optionally carry **versioned `CodexSessionFlags`** from `thread.create` through orchestration into Codex session startup, so integrations can use Codex hooks without mutating user config or global launch args.
> 
> A strict **`CodexSessionFlags` / `CodexSessionConfig` contract** is added (command-only hooks, fixed hook feature flags, `onExcessProperty: error`) and wired through `thread.created`, the in-memory projector, and optional `ProviderSessionStartInput.sessionFlags`. **`projection_threads.session_flags_json`** (migration 041) stores the field; snapshots and the command read model include `sessionFlags` only when non-null.
> 
> **`ProviderCommandReactor`** passes projected flags into **`providerService.startSession`**. **`CodexAdapter`** maps them to runtime **`sessionConfig`** (not launch args); **`CodexSessionRuntime`** sends that `config` on **`thread/start`**, **`thread/resume`**, and recoverable resume-to-fresh fallback. Threads without flags behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f96c89b10c298a70e99389b53adff030d88d3f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry per-session Codex config through thread creation to the app server
> - Introduces `CodexSessionFlags` and `CodexSessionConfig` schemas in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/6028/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af) and [provider.ts](https://github.com/pingdotgg/t3code/pull/6028/files#diff-6aa0be5ddcd97c0010b09b87bf387c0149973771b760df0565e908f262a4a95f), allowing per-session config to be attached to `thread.create` commands and `thread.created` events.
> - Adds a `session_flags_json` column to `projection_threads` via [migration 041](https://github.com/pingdotgg/t3code/pull/6028/files#diff-05fd84966b9c4c11a5028cb461095c1ed5ec1b994bbc396a882a0a19d971d34c), and updates the repository and snapshot queries to persist and retrieve `sessionFlags`.
> - Forwards `sessionFlags` from the thread read model into `ProviderCommandReactor.startProviderSession`, then maps them to `sessionConfig` in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/6028/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) and passes them through to `thread/start` and `thread/resume` requests in [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/6028/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c).
> - Risk: decoding `session_flags_json` now fails hard on invalid JSON where previously it was ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f96c89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->