### PR TITLE
fix(web): keep empty workspace draggable on Windows

### DIFF
--- a/apps/web/src/components/DesktopTitlebarSpacer.test.tsx
+++ b/apps/web/src/components/DesktopTitlebarSpacer.test.tsx
@@ -1,0 +1,18 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { DesktopTitlebarSpacer } from "./DesktopTitlebarSpacer";
+
+describe("DesktopTitlebarSpacer", () => {
+  it("renders a full workspace drag region in Electron", () => {
+    const markup = renderToStaticMarkup(<DesktopTitlebarSpacer enabled />);
+
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup).toContain("workspace-topbar");
+    expect(markup).toContain("drag-region");
+  });
+
+  it("does not reserve titlebar space in the browser", () => {
+    expect(renderToStaticMarkup(<DesktopTitlebarSpacer enabled={false} />)).toBe("");
+  });
+});

--- a/apps/web/src/components/DesktopTitlebarSpacer.tsx
+++ b/apps/web/src/components/DesktopTitlebarSpacer.tsx
@@ -1,0 +1,12 @@
+import { isElectron } from "../env";
+
+interface DesktopTitlebarSpacerProps {
+  readonly enabled?: boolean;
+}
+
+/** Keeps an otherwise empty Electron workspace draggable when the sidebar is closed. */
+export function DesktopTitlebarSpacer({ enabled = isElectron }: DesktopTitlebarSpacerProps) {
+  if (!enabled) return null;
+
+  return <div aria-hidden="true" className="workspace-topbar drag-region" />;
+}

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -4,6 +4,7 @@ import { LinkIcon, PlusIcon, RotateCcwIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { openCommandPalette } from "../commandPaletteBus";
+import { DesktopTitlebarSpacer } from "../components/DesktopTitlebarSpacer";
 import { sortScopedProjectsForSidebar } from "../components/Sidebar.logic";
 import { Button } from "../components/ui/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "../components/ui/empty";
@@ -110,6 +111,7 @@ function NoProjectsHero() {
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
+        <DesktopTitlebarSpacer />
         <Empty className="flex-1">
           <div className="w-full max-w-lg px-8 py-12">
             <EmptyHeader className="max-w-none">


### PR DESCRIPTION
## What Changed

- add an Electron-only workspace titlebar spacer for otherwise headerless views
- render it on the no-projects landing state
- cover Electron and browser rendering with focused regression tests

## Why

On Windows 11, the no-projects workspace has no `drag-region` in the main pane. The sidebar header is therefore the only place that moves the window, and collapsing the sidebar removes the last draggable surface entirely.

This reuses the existing `workspace-topbar` sizing and `drag-region` behavior, while rendering nothing in the browser. I searched the current open issues and PRs for the same no-projects/collapsed-sidebar drag failure and did not find an existing report or fix.

## UI Changes

There is no visual appearance change. This restores drag hit-testing across the empty workspace's titlebar-height strip on Electron; browser layout remains unchanged.

### Before — Windows 11 reporter capture

![Before: only the sidebar header is draggable; the main titlebar region is not](https://github.com/virtuscyber/t3code/releases/download/pr-6030-evidence-v1/before-windows11-reported.png)

The red-marked sidebar header was draggable. The purple-marked main titlebar was not; collapsing the sidebar removed the final drag surface.

### After — native Windows validation with the sidebar collapsed

![After: the workspace titlebar remains draggable with the sidebar collapsed](https://github.com/virtuscyber/t3code/releases/download/pr-6030-evidence-v1/after-windows-native-collapsed-annotated.png)

The green-marked strip is the new Electron-only drag surface. Native minimize, maximize, and close controls remain outside the highlighted region.

### Interaction video

![Windows interaction preview: collapse the sidebar, then drag the window from the main titlebar](https://github.com/virtuscyber/t3code/releases/download/pr-6030-evidence-v1/windows-collapse-and-main-titlebar-drag-preview.gif)

[View/download the full 9-second MP4](https://github.com/virtuscyber/t3code/releases/download/pr-6030-evidence-v1/windows-collapse-and-main-titlebar-drag.mp4).

A native Windows workflow built exact PR head `90662e296ad4716d72959c31ec06e051ed0aa2e6`, opened a clean no-projects state, collapsed the sidebar with `Ctrl+B`, and dragged from the main workspace titlebar. Win32 coordinates confirmed that the application moved from `(20, 40)` to `(136, 98)` — a verified **116 × 58 px** movement.

- [Windows capture workflow](https://github.com/virtuscyber/t3code/actions/runs/31454649097)
- [Machine-readable capture evidence](https://github.com/virtuscyber/t3code/releases/download/pr-6030-evidence-v1/windows-drag-evidence.json)
- Capture runner: Microsoft Windows Server 2025 Datacenter, build `10.0.26100` (`windows-latest`)

## Verification

- `vp check`
- `vp run typecheck`
- `vp test apps/web/src/components/DesktopTitlebarSpacer.test.tsx` (2 passed)
- `pnpm --filter @t3tools/web build`
- full `vp test`: 7,292 passed / 7 skipped; two unrelated suites fail identically on current `main` (`thread-transfer-report.test.cjs` discovery and `ghostty-vt.wasm?inline` import parsing)
- independent pre-commit review: passed with no security or logic findings
- native Windows interaction workflow: passed; sidebar collapsed and main-titlebar drag moved the OS window by 116 × 58 px

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only Electron hit-testing fix with no auth, data, or API changes; browser layout is unchanged.
> 
> **Overview**
> Restores **window dragging** on Electron when the main workspace has no chat header—especially the no-projects landing and collapsed sidebar on Windows 11.
> 
> Adds **`DesktopTitlebarSpacer`**, an Electron-only strip using existing `workspace-topbar` and `drag-region` classes; it renders nothing in the browser. The spacer is wired into **`NoProjectsHero`** on the chat index route. Regression tests cover Electron markup vs empty browser output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90662e296ad4716d72959c31ec06e051ed0aa2e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix empty workspace drag region on Windows by adding `DesktopTitlebarSpacer`
> On Windows (Electron), an empty workspace with no projects had no draggable titlebar region, making the window difficult to move. A new [`DesktopTitlebarSpacer`](https://github.com/pingdotgg/t3code/pull/6030/files#diff-a63f5ab78333ae29cdd63ddb30d822ee8f989e5e522a6d1bda928da31b2e39ba) component renders a hidden `div` with `workspace-topbar drag-region` classes when running in Electron, and nothing otherwise. This component is added to the [`NoProjectsHero`](https://github.com/pingdotgg/t3code/pull/6030/files#diff-c9e5cdb2398e999379ff02714b8e052c783c0e8359f609a9835df9d5d6754a0f) view so the titlebar remains draggable on empty workspaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90662e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->