### PR TITLE
fix(web): binary files get a real empty state instead of a raw read error

### DIFF
--- a/apps/web/src/components/files/FilePreviewPanel.test.ts
+++ b/apps/web/src/components/files/FilePreviewPanel.test.ts
@@ -5,7 +5,12 @@ import {
   normalizeFileCommentRange,
   remapFileCommentAnnotations,
 } from "./fileCommentAnnotations";
-import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
+import {
+  binaryFilePreviewDescription,
+  isBinaryFilePreviewError,
+  isMarkdownPreviewFile,
+  setMarkdownTaskChecked,
+} from "./filePreviewMode";
 
 describe("file comment annotations", () => {
   it("normalizes and formats selected line ranges", () => {
@@ -63,6 +68,32 @@ describe("isMarkdownPreviewFile", () => {
   it("does not treat other text files as markdown", () => {
     expect(isMarkdownPreviewFile("docs/guide.txt")).toBe(false);
     expect(isMarkdownPreviewFile("docs/markdown.ts")).toBe(false);
+  });
+});
+
+describe("isBinaryFilePreviewError", () => {
+  it("matches only the binary-file failure the read contract reports", () => {
+    expect(isBinaryFilePreviewError("binary_file")).toBe(true);
+    expect(isBinaryFilePreviewError("operation_failed")).toBe(false);
+    expect(isBinaryFilePreviewError("path_not_file")).toBe(false);
+    expect(isBinaryFilePreviewError(null)).toBe(false);
+  });
+});
+
+describe("binaryFilePreviewDescription", () => {
+  it("names the file instead of repeating the workspace root", () => {
+    expect(binaryFilePreviewDescription("dist/App_1.12.0_x64-setup.exe")).toBe(
+      "App_1.12.0_x64-setup.exe is a binary file, so it can't be shown as text.",
+    );
+  });
+
+  it("handles a bare filename and a trailing separator", () => {
+    expect(binaryFilePreviewDescription("recording.mp4")).toBe(
+      "recording.mp4 is a binary file, so it can't be shown as text.",
+    );
+    expect(binaryFilePreviewDescription("dist/bundle/")).toBe(
+      "bundle is a binary file, so it can't be shown as text.",
+    );
   });
 });
 

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -12,7 +12,17 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { ChevronRight, Code2, Eye, FolderTree, Globe2, LoaderCircle } from "lucide-react";
+import {
+  Check,
+  ChevronRight,
+  Code2,
+  Copy,
+  Eye,
+  FileQuestion,
+  FolderTree,
+  Globe2,
+  LoaderCircle,
+} from "lucide-react";
 import * as Schema from "effect/Schema";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -23,11 +33,20 @@ import { OpenInPicker } from "~/components/chat/OpenInPicker";
 import { useRemoteOpenState } from "~/remoteOpen";
 import { useClientSettings } from "~/hooks/useSettings";
 import { useTheme } from "~/hooks/useTheme";
+import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "~/hooks/useLocalStorage";
 import { DIFF_SURFACE_THEME_UNSAFE_CSS, resolveDiffThemeName } from "~/lib/diffRendering";
 import { cn } from "~/lib/utils";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
 import { resolvePathLinkTarget } from "~/terminal-links";
+import { Button } from "~/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyMedia,
+  EmptyTitle,
+} from "~/components/ui/empty";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Toggle } from "~/components/ui/toggle";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
@@ -56,7 +75,12 @@ import { resolveCenteredFileLineScrollTop } from "./fileLineReveal";
 import { DiffCommentAnnotation } from "../diffs/DiffCommentAnnotation";
 import { projectFileCacheKey, projectFileEditorCacheKey } from "./fileContentRevision";
 import { fileBreadcrumbs } from "./filePath";
-import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
+import {
+  binaryFilePreviewDescription,
+  isBinaryFilePreviewError,
+  isMarkdownPreviewFile,
+  setMarkdownTaskChecked,
+} from "./filePreviewMode";
 import { FileSaveCoordinator } from "./fileSaveCoordinator";
 import {
   confirmProjectFileQueryData,
@@ -162,6 +186,54 @@ function WorkspaceImagePreview(props: {
     <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
       <LoaderCircle className="size-5 animate-spin" />
     </div>
+  );
+}
+
+/**
+ * Agents routinely link build artifacts — installers, archives, recordings —
+ * that the text preview cannot render. Surfacing the raw server error left the
+ * panel a dead end, so name the file and hand back its path instead.
+ */
+function BinaryFilePreview({
+  relativePath,
+  absolutePath,
+}: {
+  readonly relativePath: string;
+  readonly absolutePath: string | null;
+}) {
+  const { copyToClipboard, isCopied } = useCopyToClipboard({
+    target: "path",
+    onError: (error) => {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Failed to copy path",
+          description: error.message,
+        }),
+      );
+    },
+  });
+
+  return (
+    <Empty>
+      <EmptyMedia variant="icon">
+        <FileQuestion className="size-4.5 text-muted-foreground" />
+      </EmptyMedia>
+      <EmptyTitle>Can't preview this file</EmptyTitle>
+      <EmptyDescription>{binaryFilePreviewDescription(relativePath)}</EmptyDescription>
+      {absolutePath ? (
+        <EmptyContent>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => copyToClipboard(absolutePath, undefined)}
+          >
+            {isCopied ? <Check /> : <Copy />}
+            {isCopied ? "Copied" : "Copy path"}
+          </Button>
+        </EmptyContent>
+      ) : null}
+    </Empty>
   );
 }
 
@@ -1003,9 +1075,13 @@ export default function FilePreviewPanel({
               alt={relativePath}
             />
           ) : relativePath && file.error && file.data === null ? (
-            <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-xs leading-relaxed text-destructive">
-              {file.error}
-            </div>
+            isBinaryFilePreviewError(file.errorFailure) ? (
+              <BinaryFilePreview relativePath={relativePath} absolutePath={absolutePath} />
+            ) : (
+              <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-xs leading-relaxed text-destructive">
+                {file.error}
+              </div>
+            )
           ) : relativePath && file.data === null ? (
             <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
               <LoaderCircle className="size-5 animate-spin" />

--- a/apps/web/src/components/files/filePreviewMode.ts
+++ b/apps/web/src/components/files/filePreviewMode.ts
@@ -1,4 +1,27 @@
+import type { ProjectFileFailure } from "@t3tools/contracts";
+
 export const isMarkdownPreviewFile = (path: string): boolean => /\.(?:md|mdx)$/i.test(path);
+
+/**
+ * `failure` the server reports when a workspace file's bytes are not UTF-8
+ * text, so the text preview has nothing to render. Typed against the contract
+ * so a renamed literal fails the build instead of silently never matching.
+ */
+const BINARY_FILE_PREVIEW_FAILURE: ProjectFileFailure = "binary_file";
+
+export const isBinaryFilePreviewError = (errorFailure: string | null): boolean =>
+  errorFailure === BINARY_FILE_PREVIEW_FAILURE;
+
+/**
+ * The raw server error repeats the workspace root and the internal reason,
+ * which is noise in a panel whose header already shows the path. Name just the
+ * file the user clicked.
+ */
+export function binaryFilePreviewDescription(relativePath: string): string {
+  const trimmed = relativePath.replace(/\/+$/, "");
+  const basename = trimmed.slice(trimmed.lastIndexOf("/") + 1);
+  return `${basename || relativePath} is a binary file, so it can't be shown as text.`;
+}
 
 export function setMarkdownTaskChecked(
   markdown: string,

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -25,6 +25,8 @@ function optimisticFileAtom(environmentId: EnvironmentId, cwd: string, relativeP
 interface ProjectQueryState<A> {
   readonly data: A | null;
   readonly error: string | null;
+  /** Lets callers branch on a specific failure instead of matching on `error`. */
+  readonly errorFailure: string | null;
   readonly isPending: boolean;
   readonly refresh: () => void;
 }
@@ -115,10 +117,30 @@ export function clearProjectFileQueryData(
   appAtomRegistry.set(optimisticFileAtom(environmentId, cwd, relativePath), null);
 }
 
-function errorMessage<A>(result: AsyncResult.AsyncResult<A, unknown>): string | null {
+interface ProjectQueryError {
+  readonly message: string;
+  /**
+   * Structured `failure` carried by the project error contracts. The server
+   * folds its typed workspace errors into one error per operation, so this is
+   * the only thing that distinguishes, say, an unreadable file from a binary
+   * one without matching on prose.
+   */
+  readonly failure: string | null;
+}
+
+function queryError<A>(result: AsyncResult.AsyncResult<A, unknown>): ProjectQueryError | null {
   if (result._tag !== "Failure") return null;
   const cause = Cause.squash(result.cause);
-  return cause instanceof Error ? cause.message : "Workspace query failed.";
+  return {
+    message: cause instanceof Error ? cause.message : "Workspace query failed.",
+    failure:
+      typeof cause === "object" &&
+      cause !== null &&
+      "failure" in cause &&
+      typeof cause.failure === "string"
+        ? cause.failure
+        : null,
+  };
 }
 
 export function useProjectEntriesQuery(
@@ -129,9 +151,11 @@ export function useProjectEntriesQuery(
   const result = useAtomValue(atom);
   const refreshAtom = useAtomRefresh(atom);
   const refresh = useCallback(() => refreshAtom(), [refreshAtom]);
+  const error = queryError(result);
   return {
     data: Option.getOrNull(AsyncResult.value(result)),
-    error: errorMessage(result),
+    error: error?.message ?? null,
+    errorFailure: error?.failure ?? null,
     isPending: result.waiting,
     refresh,
   };
@@ -189,10 +213,12 @@ export function useProjectFileQuery(
     optimisticFileAtom(environmentId, cwd, relativePath ?? EMPTY_PROJECT_FILE_PATH),
   );
   const optimisticFile = relativePath === null ? null : optimisticResult;
+  const error = queryError(result);
 
   return {
     data: optimisticFile?.data ?? data,
-    error: errorMessage(result),
+    error: error?.message ?? null,
+    errorFailure: error?.failure ?? null,
     isPending: result.waiting,
     refresh,
   };


### PR DESCRIPTION
Closes part of #4973.

## What changed

Clicking a chat file link for a build artifact — an installer, an archive, a recording — opened the file panel onto a dead end. The panel printed the read error verbatim in red: it named the internal failure, repeated the absolute workspace root, and offered nothing to do next.

The panel had no way to tell a binary file apart from any other read failure. The server raises a typed `WorkspaceBinaryFileError`, but `ws.ts` folds it into `ProjectReadFileError`, so the only thing that survives to the client is the structured `failure` discriminator — and the query state was dropping it on the floor. This surfaces that field, then renders a proper empty state for `binary_file` that names the file and hands back its path. Every other read failure keeps the message it shows today.

## Why

#4973 asks for artifacts T3 Code cannot open to stop being useless links. #5366 covers the context-menu half of that with "Open in folder". This is the other half: the state you actually land on when you click. The two compose — once #5366 lands, "Open in folder" is the natural second action to drop into this empty state.

Keying on `failure` rather than the error message also means the panel is no longer one prose edit away from silently falling back to the raw string.

## UI changes

| Before | After |
|---|---|
| <img width="536" src="https://raw.githubusercontent.com/tsouth89/t3code-upstream/pr-assets/before.png" /> | <img width="536" src="https://raw.githubusercontent.com/tsouth89/t3code-upstream/pr-assets/after.png" /> |

Captured in a real client against a 9.6 MB `.exe` in the workspace, dark theme, file explorer collapsed so the preview area is legible.

## Verification

- `vp test run src/components/files/FilePreviewPanel.test.ts --project unit` — 9 passed
- `pnpm --filter @t3tools/web typecheck`
- `vp lint` on the four changed files
- One integrated pass in a real client: opened a binary artifact in the file panel and confirmed the empty state renders and `Copy path` copies the absolute path. The before/after images above are from that pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [ ] I included a video for animation/interaction changes — not applicable, no motion

---

Written by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only branching on an existing server failure code; non-binary errors unchanged and behavior is covered by new unit tests.
> 
> **Overview**
> When a workspace file read fails because the content is not UTF-8 text (`binary_file`), the file preview panel now shows a dedicated **empty state** instead of the raw server error string.
> 
> Project file query hooks expose a structured **`errorFailure`** alongside the error message so the UI can branch on failure type without parsing prose. **`FilePreviewPanel`** uses that to render **`BinaryFilePreview`**: a short description naming the file (basename only) and an optional **Copy path** action when an absolute path is available. Other read failures still use the existing destructive error message.
> 
> Helpers **`isBinaryFilePreviewError`** and **`binaryFilePreviewDescription`** in `filePreviewMode.ts` centralize detection and copy; unit tests cover them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e167768bdd1e57cac2482526fcd87e607f8f30c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace raw read error with empty state UI for binary file previews
> - Adds `isBinaryFilePreviewError` and `binaryFilePreviewDescription` helpers in [filePreviewMode.ts](https://github.com/pingdotgg/t3code/pull/6038/files#diff-3d42bc71d49c181cfe059279ce1523d43b76136616f7c409c50622767f3a66fb) to detect and describe binary file failures using a structured `'binary_file'` failure code.
> - Introduces a `BinaryFilePreview` component in [FilePreviewPanel.tsx](https://github.com/pingdotgg/t3code/pull/6038/files#diff-776fa2f4352bbbf118206cfd39f4cf95c38e47b1629aa20a6c8c028cadf458ea) that shows an empty state with the filename and a 'Copy path' button (with clipboard feedback) instead of a raw error message.
> - Extends query state in [projectFilesQueryState.ts](https://github.com/pingdotgg/t3code/pull/6038/files#diff-806be0160895303d53e1626c9f2ae08183713de619da98a4d058c0eec96c622c) to surface a structured `errorFailure` field alongside `error`, enabling the panel to branch on failure type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e167768.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->