### PR TITLE
feat(usage): add OpenCode usage reporting

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -119,7 +119,7 @@ export function UsageRouteScreen() {
 
         {isPending ? (
           <Text className="py-16 text-center text-base text-foreground-muted">
-            Scanning provider transcripts…
+            Scanning provider usage…
           </Text>
         ) : environments.length === 0 ? (
           <Text className="py-16 text-center text-base text-foreground-muted">

--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,11 +5,12 @@ import { useColorScheme } from "react-native";
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "opencode"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  opencode: "OpenCode",
 };
 
 /**
@@ -21,5 +22,6 @@ export function useProviderColors(): Record<UsageProviderKind, string> {
   return {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
+    opencode: scheme === "dark" ? "#8f8b8b" : "#8a8585",
   };
 }

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -39,7 +39,7 @@ import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
-import { readOpenCodeUsage } from "./usageOpenCode.ts";
+import { readOpenCodeUsage, resolveOpenCodeDatabasePaths } from "./usageOpenCode.ts";
 import {
   listTranscriptFiles,
   readDirectoryVolumeId,
@@ -223,6 +223,30 @@ export const make = Effect.gen(function* () {
       process.env.XDG_DATA_HOME?.trim() || path.join(NodeOS.homedir(), ".local", "share"),
       "opencode",
     );
+    const openCodeDatabaseOverride = process.env.OPENCODE_DB?.trim() || undefined;
+    const disableOpenCodeChannelDatabase = process.env.OPENCODE_DISABLE_CHANNEL_DB?.trim();
+    const shouldDiscoverOpenCodeDatabases =
+      !openCodeDatabaseOverride &&
+      !["1", "true"].includes(disableOpenCodeChannelDatabase?.toLowerCase() ?? "");
+    const openCodeDirectoryEntries = shouldDiscoverOpenCodeDatabases
+      ? yield* fileSystem
+          .readDirectory(openCodeDataDir)
+          .pipe(Effect.catchCause(() => Effect.succeed([] as string[])))
+      : [];
+    const openCodeDatabasePaths = resolveOpenCodeDatabasePaths({
+      dataDir: openCodeDataDir,
+      databaseOverride: openCodeDatabaseOverride,
+      disableChannelDatabase: disableOpenCodeChannelDatabase,
+      directoryEntries: openCodeDirectoryEntries,
+      path,
+    });
+    const openCodeResolvedHomePath =
+      openCodeDatabaseOverride !== undefined
+        ? (openCodeDatabasePaths[0] ?? ":memory:")
+        : openCodeDataDir;
+    const openCodeVolumeDir = openCodeDatabasePaths[0]
+      ? path.dirname(openCodeDatabasePaths[0])
+      : openCodeDataDir;
 
     return [
       { provider: "claude" as const, dir: claudeDir, kind: "jsonl" as const },
@@ -233,9 +257,10 @@ export const make = Effect.gen(function* () {
       },
       {
         provider: "opencode" as const,
-        dir: openCodeDataDir,
-        databasePath: path.join(openCodeDataDir, "opencode.db"),
+        dir: openCodeVolumeDir,
+        databasePaths: openCodeDatabasePaths,
         kind: "opencodeSqlite" as const,
+        resolvedHomePath: openCodeResolvedHomePath,
       },
     ];
   });
@@ -371,55 +396,83 @@ export const make = Effect.gen(function* () {
     for (const source of dirs) {
       const { provider, dir } = source;
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
-      const exists = yield* fileSystem
-        .exists(source.kind === "jsonl" ? dir : source.databasePath)
-        .pipe(Effect.catchCause(() => Effect.succeed(false)));
+      const resolvedHomePath = source.kind === "jsonl" ? source.dir : source.resolvedHomePath;
+      const existingOpenCodeDatabasePaths: string[] = [];
+      if (source.kind === "opencodeSqlite") {
+        for (const databasePath of source.databasePaths) {
+          const databaseExists = yield* fileSystem
+            .exists(databasePath)
+            .pipe(Effect.catchCause(() => Effect.succeed(false)));
+          if (databaseExists) existingOpenCodeDatabasePaths.push(databasePath);
+        }
+      }
+      const exists =
+        source.kind === "jsonl"
+          ? yield* fileSystem.exists(dir).pipe(Effect.catchCause(() => Effect.succeed(false)))
+          : existingOpenCodeDatabasePaths.length > 0;
 
       if (!exists) {
         sources.push({
-          fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
+          fingerprint: { hostId, provider, resolvedHomePath, volumeId },
           status: "missing",
           scannedFiles: 0,
           skippedFiles: 0,
           malformedRecords: 0,
           distinctSessions: 0,
-          message: "No transcript directory on this environment.",
+          message:
+            source.kind === "jsonl"
+              ? "No transcript directory on this environment."
+              : "OpenCode usage database was not found.",
         });
         continue;
       }
 
       if (source.kind === "opencodeSqlite") {
-        const result = yield* Effect.promise(() =>
-          readOpenCodeUsage(source.databasePath, windowStartMs),
-        );
-        if (result === null) {
-          sources.push({
-            fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
-            status: "failed",
-            scannedFiles: 0,
-            skippedFiles: 1,
-            malformedRecords: 0,
-            distinctSessions: 0,
-            message: "OpenCode usage database could not be read.",
-          });
-          continue;
-        }
-
         const sessionIds = new Set<string>();
-        for (const record of result.records) {
-          if (aggregator.add(record) && record.sessionId.length > 0) {
-            sessionIds.add(record.sessionId);
+        let scannedFiles = 0;
+        let skippedFiles = 0;
+        let malformedRecords = 0;
+        for (const databasePath of existingOpenCodeDatabasePaths) {
+          const result = yield* Effect.promise(() =>
+            readOpenCodeUsage(databasePath, windowStartMs),
+          );
+          if (result === null) {
+            skippedFiles += 1;
+            continue;
+          }
+
+          scannedFiles += 1;
+          malformedRecords += result.malformedRecords;
+          for (const record of result.records) {
+            if (aggregator.add(record) && record.sessionId.length > 0) {
+              sessionIds.add(record.sessionId);
+            }
           }
         }
+        const status =
+          scannedFiles === 0
+            ? "failed"
+            : skippedFiles > 0 || malformedRecords > 0
+              ? "partial"
+              : "ok";
+        const message =
+          scannedFiles === 0
+            ? "OpenCode usage database could not be read."
+            : skippedFiles > 0 && malformedRecords > 0
+              ? "Some OpenCode usage databases and records could not be read."
+              : skippedFiles > 0
+                ? "Some OpenCode usage databases could not be read."
+                : malformedRecords > 0
+                  ? "Some OpenCode usage records could not be parsed."
+                  : null;
         sources.push({
-          fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
-          status: result.malformedRecords > 0 ? "partial" : "ok",
-          scannedFiles: 1,
-          skippedFiles: 0,
-          malformedRecords: result.malformedRecords,
+          fingerprint: { hostId, provider, resolvedHomePath, volumeId },
+          status,
+          scannedFiles,
+          skippedFiles,
+          malformedRecords,
           distinctSessions: sessionIds.size,
-          message:
-            result.malformedRecords > 0 ? "Some OpenCode usage records could not be parsed." : null,
+          message,
         });
         continue;
       }
@@ -450,7 +503,7 @@ export const make = Effect.gen(function* () {
       }
 
       sources.push({
-        fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
+        fingerprint: { hostId, provider, resolvedHomePath, volumeId },
         status: "ok",
         scannedFiles,
         skippedFiles,

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -39,6 +39,7 @@ import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
+import { readOpenCodeUsage } from "./usageOpenCode.ts";
 import {
   listTranscriptFiles,
   readDirectoryVolumeId,
@@ -218,10 +219,24 @@ export const make = Effect.gen(function* () {
     const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
     const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
     const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
+    const openCodeDataDir = path.join(
+      process.env.XDG_DATA_HOME?.trim() || path.join(NodeOS.homedir(), ".local", "share"),
+      "opencode",
+    );
 
     return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
+      { provider: "claude" as const, dir: claudeDir, kind: "jsonl" as const },
+      {
+        provider: "codex" as const,
+        dir: path.join(codexLayout.sharedHomePath, "sessions"),
+        kind: "jsonl" as const,
+      },
+      {
+        provider: "opencode" as const,
+        dir: openCodeDataDir,
+        databasePath: path.join(openCodeDataDir, "opencode.db"),
+        kind: "opencodeSqlite" as const,
+      },
     ];
   });
 
@@ -353,10 +368,11 @@ export const make = Effect.gen(function* () {
     const livePaths = new Set<string>();
     const walkedRoots: string[] = [];
 
-    for (const { provider, dir } of dirs) {
+    for (const source of dirs) {
+      const { provider, dir } = source;
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
       const exists = yield* fileSystem
-        .exists(dir)
+        .exists(source.kind === "jsonl" ? dir : source.databasePath)
         .pipe(Effect.catchCause(() => Effect.succeed(false)));
 
       if (!exists) {
@@ -368,6 +384,42 @@ export const make = Effect.gen(function* () {
           malformedRecords: 0,
           distinctSessions: 0,
           message: "No transcript directory on this environment.",
+        });
+        continue;
+      }
+
+      if (source.kind === "opencodeSqlite") {
+        const result = yield* Effect.promise(() =>
+          readOpenCodeUsage(source.databasePath, windowStartMs),
+        );
+        if (result === null) {
+          sources.push({
+            fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
+            status: "failed",
+            scannedFiles: 0,
+            skippedFiles: 1,
+            malformedRecords: 0,
+            distinctSessions: 0,
+            message: "OpenCode usage database could not be read.",
+          });
+          continue;
+        }
+
+        const sessionIds = new Set<string>();
+        for (const record of result.records) {
+          if (aggregator.add(record) && record.sessionId.length > 0) {
+            sessionIds.add(record.sessionId);
+          }
+        }
+        sources.push({
+          fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
+          status: result.malformedRecords > 0 ? "partial" : "ok",
+          scannedFiles: 1,
+          skippedFiles: 0,
+          malformedRecords: result.malformedRecords,
+          distinctSessions: sessionIds.size,
+          message:
+            result.malformedRecords > 0 ? "Some OpenCode usage records could not be parsed." : null,
         });
         continue;
       }

--- a/apps/server/src/usage/usageOpenCode.test.ts
+++ b/apps/server/src/usage/usageOpenCode.test.ts
@@ -1,0 +1,129 @@
+// @effect-diagnostics nodeBuiltinImport:off -- SQLite integration coverage needs a real temporary file.
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+
+import { describe, expect, it } from "@effect/vitest";
+
+import { parseOpenCodeUsageRow, readOpenCodeUsage } from "./usageOpenCode.ts";
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    messageId: "msg_01",
+    sessionId: "ses_01",
+    timestampMs: 1_786_053_607_405,
+    providerId: "github-copilot",
+    modelId: "gpt-5.6-sol",
+    inputTokens: 4194,
+    outputTokens: 91,
+    reasoningTokens: 263,
+    cacheReadTokens: 22_912,
+    cacheWriteTokens: 17,
+    costUsd: 0.42,
+    ...overrides,
+  };
+}
+
+describe("parseOpenCodeUsageRow", () => {
+  it("maps OpenCode assistant usage into the shared token convention", () => {
+    const record = parseOpenCodeUsageRow(row());
+
+    expect(record).toEqual({
+      provider: "opencode",
+      timestampMs: 1_786_053_607_405,
+      model: "github-copilot/gpt-5.6-sol",
+      sessionId: "ses_01",
+      totals: {
+        uncachedInputTokens: 4194,
+        cachedInputTokens: 22_912,
+        cacheCreationTokens: 17,
+        outputTokens: 354,
+        reasoningTokens: 263,
+      },
+      reportedCostUsd: 0.42,
+      dedupeKey: "opencode:msg_01",
+    });
+  });
+
+  it("keeps a reported zero cost for free OpenCode models", () => {
+    expect(parseOpenCodeUsageRow(row({ costUsd: 0 }))?.reportedCostUsd).toBe(0);
+  });
+
+  it("falls back to model pricing when cost is absent", () => {
+    expect(parseOpenCodeUsageRow(row({ costUsd: null }))?.reportedCostUsd).toBeNull();
+  });
+
+  it("ignores malformed rows and empty assistant attempts", () => {
+    expect(parseOpenCodeUsageRow(row({ modelId: null }))).toBeNull();
+    expect(
+      parseOpenCodeUsageRow(
+        row({
+          inputTokens: 0,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          costUsd: null,
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("readOpenCodeUsage", () => {
+  it("reads assistant usage without selecting conversation content", async () => {
+    const directory = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-opencode-usage-"));
+    const databasePath = NodePath.join(directory, "opencode.db");
+    let database: NodeSqlite.DatabaseSync | undefined;
+    try {
+      database = new NodeSqlite.DatabaseSync(databasePath);
+      database.exec(`
+        CREATE TABLE message (
+          id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          time_created INTEGER NOT NULL,
+          data TEXT NOT NULL
+        )
+      `);
+      const insert = database.prepare(
+        "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+      );
+      insert.run(
+        "msg_01",
+        "ses_01",
+        2000,
+        JSON.stringify({
+          role: "assistant",
+          providerID: "openai",
+          modelID: "gpt-5",
+          tokens: { input: 10, output: 2, reasoning: 3, cache: { read: 4, write: 5 } },
+          cost: 0.25,
+          hiddenConversationContent: "must never be selected",
+        }),
+      );
+      insert.run(
+        "msg_user",
+        "ses_01",
+        2001,
+        JSON.stringify({ role: "user", content: "not usage" }),
+      );
+      database.close();
+      database = undefined;
+
+      const result = await readOpenCodeUsage(databasePath, 1500);
+
+      expect(result?.malformedRecords).toBe(0);
+      expect(result?.records).toHaveLength(1);
+      expect(result?.records[0]).toMatchObject({
+        provider: "opencode",
+        model: "openai/gpt-5",
+        totals: { outputTokens: 5, reasoningTokens: 3 },
+      });
+      expect(result?.records[0]).not.toHaveProperty("hiddenConversationContent");
+    } finally {
+      database?.close();
+      await NodeFSP.rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/src/usage/usageOpenCode.test.ts
+++ b/apps/server/src/usage/usageOpenCode.test.ts
@@ -148,7 +148,7 @@ describe("resolveOpenCodeDatabasePaths", () => {
 });
 
 describe("readOpenCodeUsage", () => {
-  it("reads assistant usage without selecting conversation content", async () => {
+  it("reads the legacy message schema without selecting conversation content", async () => {
     const directory = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-opencode-usage-"));
     const databasePath = NodePath.join(directory, "opencode.db");
     let database: NodeSqlite.DatabaseSync | undefined;
@@ -209,6 +209,166 @@ describe("readOpenCodeUsage", () => {
         totals: { outputTokens: 5, reasoningTokens: 3 },
       });
       expect(result?.records[0]).not.toHaveProperty("hiddenConversationContent");
+    } finally {
+      database?.close();
+      await NodeFSP.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("reads the current session_message schema", async () => {
+    const directory = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-opencode-usage-"));
+    const databasePath = NodePath.join(directory, "opencode.db");
+    let database: NodeSqlite.DatabaseSync | undefined;
+    try {
+      database = new NodeSqlite.DatabaseSync(databasePath);
+      database.exec(`
+        CREATE TABLE session_message (
+          id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          time_created INTEGER NOT NULL,
+          data TEXT NOT NULL
+        )
+      `);
+      const insert = database.prepare(
+        "INSERT INTO session_message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)",
+      );
+      insert.run(
+        "msg_current",
+        "ses_current",
+        "assistant",
+        3000,
+        JSON.stringify({
+          agent: "build",
+          model: { providerID: "anthropic", id: "claude-sonnet-4-5" },
+          tokens: { input: 20, output: 4, reasoning: 6, cache: { read: 8, write: 10 } },
+          cost: 0.5,
+          content: [{ type: "text", text: "must never be selected" }],
+        }),
+      );
+      insert.run("msg_user", "ses_current", "user", 3001, JSON.stringify({ text: "not usage" }));
+      database.close();
+      database = undefined;
+
+      const result = await readOpenCodeUsage(databasePath, 2500);
+
+      expect(result).toEqual({
+        malformedRecords: 0,
+        records: [
+          {
+            provider: "opencode",
+            timestampMs: 3000,
+            model: "anthropic/claude-sonnet-4-5",
+            sessionId: "ses_current",
+            totals: {
+              uncachedInputTokens: 20,
+              cachedInputTokens: 8,
+              cacheCreationTokens: 10,
+              outputTokens: 10,
+              reasoningTokens: 6,
+            },
+            reportedCostUsd: 0.5,
+            dedupeKey: "opencode:msg_current",
+          },
+        ],
+      });
+    } finally {
+      database?.close();
+      await NodeFSP.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("reads both projections and deduplicates message IDs", async () => {
+    const directory = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-opencode-usage-"));
+    const databasePath = NodePath.join(directory, "opencode.db");
+    let database: NodeSqlite.DatabaseSync | undefined;
+    try {
+      database = new NodeSqlite.DatabaseSync(databasePath);
+      database.exec(`
+        CREATE TABLE message (
+          id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          time_created INTEGER NOT NULL,
+          data TEXT NOT NULL
+        );
+        CREATE TABLE session_message (
+          id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          time_created INTEGER NOT NULL,
+          data TEXT NOT NULL
+        );
+      `);
+      const insertLegacy = database.prepare(
+        "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+      );
+      const insertCurrent = database.prepare(
+        "INSERT INTO session_message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)",
+      );
+      insertLegacy.run(
+        "msg_shared",
+        "ses_shared",
+        4000,
+        JSON.stringify({
+          role: "assistant",
+          providerID: "legacy-provider",
+          modelID: "legacy-model",
+          tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 1,
+        }),
+      );
+      insertLegacy.run(
+        "msg_legacy",
+        "ses_legacy",
+        4001,
+        JSON.stringify({
+          role: "assistant",
+          providerID: "openai",
+          modelID: "gpt-5",
+          tokens: { input: 2, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0.1,
+        }),
+      );
+      insertCurrent.run(
+        "msg_shared",
+        "ses_shared",
+        "assistant",
+        4000,
+        JSON.stringify({
+          model: { providerID: "current-provider", id: "current-model" },
+          tokens: { input: 3, output: 2, reasoning: 1, cache: { read: 0, write: 0 } },
+          cost: 2,
+        }),
+      );
+      insertCurrent.run(
+        "msg_current",
+        "ses_current",
+        "assistant",
+        4002,
+        JSON.stringify({
+          model: { providerID: "anthropic", id: "claude-sonnet-4-5" },
+          tokens: { input: 4, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0.2,
+        }),
+      );
+      database.close();
+      database = undefined;
+
+      const result = await readOpenCodeUsage(databasePath, 3500);
+
+      expect(result?.malformedRecords).toBe(0);
+      expect(result?.records).toHaveLength(3);
+      expect(result?.records.map((record) => record.model).sort()).toEqual([
+        "anthropic/claude-sonnet-4-5",
+        "current-provider/current-model",
+        "openai/gpt-5",
+      ]);
+      expect(
+        result?.records.find((record) => record.dedupeKey === "opencode:msg_shared"),
+      ).toMatchObject({
+        model: "current-provider/current-model",
+        reportedCostUsd: 2,
+      });
     } finally {
       database?.close();
       await NodeFSP.rm(directory, { recursive: true, force: true });

--- a/apps/server/src/usage/usageOpenCode.test.ts
+++ b/apps/server/src/usage/usageOpenCode.test.ts
@@ -6,7 +6,11 @@ import * as NodeSqlite from "node:sqlite";
 
 import { describe, expect, it } from "@effect/vitest";
 
-import { parseOpenCodeUsageRow, readOpenCodeUsage } from "./usageOpenCode.ts";
+import {
+  parseOpenCodeUsageRow,
+  readOpenCodeUsage,
+  resolveOpenCodeDatabasePaths,
+} from "./usageOpenCode.ts";
 
 function row(overrides: Record<string, unknown> = {}) {
   return {
@@ -64,10 +68,82 @@ describe("parseOpenCodeUsageRow", () => {
           reasoningTokens: 0,
           cacheReadTokens: 0,
           cacheWriteTokens: 0,
-          costUsd: null,
+          costUsd: 0,
         }),
       ),
     ).toBeNull();
+  });
+});
+
+describe("resolveOpenCodeDatabasePaths", () => {
+  const dataDir = NodePath.resolve("opencode-data");
+
+  it("honors absolute and data-directory-relative OPENCODE_DB overrides", () => {
+    const absoluteOverride = NodePath.resolve("custom-opencode.db");
+    expect(
+      resolveOpenCodeDatabasePaths({
+        dataDir,
+        databaseOverride: absoluteOverride,
+        disableChannelDatabase: undefined,
+        directoryEntries: ["opencode.db"],
+        path: NodePath,
+      }),
+    ).toEqual([absoluteOverride]);
+    expect(
+      resolveOpenCodeDatabasePaths({
+        dataDir,
+        databaseOverride: "custom/opencode.db",
+        disableChannelDatabase: undefined,
+        directoryEntries: ["opencode.db"],
+        path: NodePath,
+      }),
+    ).toEqual([NodePath.join(dataDir, "custom/opencode.db")]);
+  });
+
+  it("discovers stable and channel databases while ignoring SQLite sidecars", () => {
+    expect(
+      resolveOpenCodeDatabasePaths({
+        dataDir,
+        databaseOverride: undefined,
+        disableChannelDatabase: undefined,
+        directoryEntries: [
+          "opencode-nightly.db",
+          "opencode.db-wal",
+          "opencode.db",
+          "opencode-canary.db",
+          "notes.txt",
+        ],
+        path: NodePath,
+      }),
+    ).toEqual([
+      NodePath.join(dataDir, "opencode-canary.db"),
+      NodePath.join(dataDir, "opencode-nightly.db"),
+      NodePath.join(dataDir, "opencode.db"),
+    ]);
+  });
+
+  it("uses only the stable database when channels are disabled", () => {
+    expect(
+      resolveOpenCodeDatabasePaths({
+        dataDir,
+        databaseOverride: undefined,
+        disableChannelDatabase: "true",
+        directoryEntries: ["opencode-canary.db"],
+        path: NodePath,
+      }),
+    ).toEqual([NodePath.join(dataDir, "opencode.db")]);
+  });
+
+  it("does not try to attach to another process's in-memory database", () => {
+    expect(
+      resolveOpenCodeDatabasePaths({
+        dataDir,
+        databaseOverride: ":memory:",
+        disableChannelDatabase: undefined,
+        directoryEntries: [],
+        path: NodePath,
+      }),
+    ).toEqual([]);
   });
 });
 
@@ -107,6 +183,18 @@ describe("readOpenCodeUsage", () => {
         "ses_01",
         2001,
         JSON.stringify({ role: "user", content: "not usage" }),
+      );
+      insert.run(
+        "msg_placeholder",
+        "ses_placeholder",
+        2002,
+        JSON.stringify({
+          role: "assistant",
+          providerID: "openai",
+          modelID: "gpt-5",
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0,
+        }),
       );
       database.close();
       database = undefined;

--- a/apps/server/src/usage/usageOpenCode.ts
+++ b/apps/server/src/usage/usageOpenCode.ts
@@ -13,6 +13,9 @@ import type { UsageRecord } from "./usageTranscripts.ts";
 // external without asking its resolver to load a module Node cannot provide.
 const BUN_SQLITE_MODULE_ID: string = "bun:sqlite";
 
+const OPEN_CODE_STABLE_DATABASE = "opencode.db";
+const OPEN_CODE_CHANNEL_DATABASE = /^opencode-[a-zA-Z0-9._-]+\.db$/;
+
 const OPEN_CODE_USAGE_QUERY = `
   SELECT
     id AS messageId,
@@ -70,6 +73,47 @@ export interface OpenCodeUsageRead {
   readonly malformedRecords: number;
 }
 
+export interface ResolveOpenCodeDatabasePathsInput {
+  readonly dataDir: string;
+  readonly databaseOverride: string | undefined;
+  readonly disableChannelDatabase: string | undefined;
+  readonly directoryEntries: readonly string[];
+  readonly path: {
+    readonly isAbsolute: (value: string) => boolean;
+    readonly join: (first: string, ...segments: readonly string[]) => string;
+  };
+}
+
+/** Mirrors OpenCode's explicit override and discovers compile-time channel databases. */
+export function resolveOpenCodeDatabasePaths({
+  dataDir,
+  databaseOverride,
+  disableChannelDatabase,
+  directoryEntries,
+  path,
+}: ResolveOpenCodeDatabasePathsInput): readonly string[] {
+  const override = databaseOverride?.trim();
+  if (override) {
+    if (override === ":memory:") return [];
+    return [path.isAbsolute(override) ? override : path.join(dataDir, override)];
+  }
+
+  const stableDatabasePath = path.join(dataDir, OPEN_CODE_STABLE_DATABASE);
+  const channelsDisabled = ["1", "true"].includes(
+    disableChannelDatabase?.trim().toLowerCase() ?? "",
+  );
+  if (channelsDisabled) return [stableDatabasePath];
+
+  const databaseNames = directoryEntries.filter(
+    (entry) => entry === OPEN_CODE_STABLE_DATABASE || OPEN_CODE_CHANNEL_DATABASE.test(entry),
+  );
+  if (databaseNames.length === 0) return [stableDatabasePath];
+
+  return [...new Set(databaseNames)]
+    .sort((left, right) => left.localeCompare(right))
+    .map((entry) => path.join(dataDir, entry));
+}
+
 function nonNegativeInt(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
 }
@@ -78,9 +122,13 @@ function finiteNonNegative(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
-/** Converts one assistant-message projection into the shared usage shape. */
-export function parseOpenCodeUsageRow(value: unknown): UsageRecord | null {
-  if (typeof value !== "object" || value === null) return null;
+type OpenCodeUsageRowParse =
+  | { readonly _tag: "Malformed" }
+  | { readonly _tag: "Placeholder" }
+  | { readonly _tag: "Record"; readonly record: UsageRecord };
+
+function decodeOpenCodeUsageRow(value: unknown): OpenCodeUsageRowParse {
+  if (typeof value !== "object" || value === null) return { _tag: "Malformed" };
   const row = value as OpenCodeUsageRow;
   if (
     typeof row.messageId !== "string" ||
@@ -93,7 +141,7 @@ export function parseOpenCodeUsageRow(value: unknown): UsageRecord | null {
     typeof row.modelId !== "string" ||
     row.modelId.length === 0
   ) {
-    return null;
+    return { _tag: "Malformed" };
   }
 
   const uncachedInputTokens = nonNegativeInt(row.inputTokens);
@@ -106,28 +154,34 @@ export function parseOpenCodeUsageRow(value: unknown): UsageRecord | null {
   // shared contract treats reasoning as a subset of output, so combine them in
   // outputTokens while retaining the reasoning slice for the token-mix UI.
   const outputTokens = generatedOutputTokens + reasoningTokens;
-  if (
-    uncachedInputTokens + cachedInputTokens + cacheCreationTokens + outputTokens === 0 &&
-    finiteNonNegative(row.costUsd) === null
-  ) {
-    return null;
+  if (uncachedInputTokens + cachedInputTokens + cacheCreationTokens + outputTokens === 0) {
+    return { _tag: "Placeholder" };
   }
 
   return {
-    provider: "opencode",
-    timestampMs: row.timestampMs,
-    model: `${row.providerId}/${row.modelId}`,
-    sessionId: row.sessionId,
-    totals: {
-      uncachedInputTokens,
-      cachedInputTokens,
-      cacheCreationTokens,
-      outputTokens,
-      reasoningTokens,
+    _tag: "Record",
+    record: {
+      provider: "opencode",
+      timestampMs: row.timestampMs,
+      model: `${row.providerId}/${row.modelId}`,
+      sessionId: row.sessionId,
+      totals: {
+        uncachedInputTokens,
+        cachedInputTokens,
+        cacheCreationTokens,
+        outputTokens,
+        reasoningTokens,
+      },
+      reportedCostUsd: finiteNonNegative(row.costUsd),
+      dedupeKey: `opencode:${row.messageId}`,
     },
-    reportedCostUsd: finiteNonNegative(row.costUsd),
-    dedupeKey: `opencode:${row.messageId}`,
   };
+}
+
+/** Converts one assistant-message projection into the shared usage shape. */
+export function parseOpenCodeUsageRow(value: unknown): UsageRecord | null {
+  const parsed = decodeOpenCodeUsageRow(value);
+  return parsed._tag === "Record" ? parsed.record : null;
 }
 
 async function openDatabase(databasePath: string): Promise<SqliteDatabase> {
@@ -169,9 +223,9 @@ export async function readOpenCodeUsage(
     const records: UsageRecord[] = [];
     let malformedRecords = 0;
     for (const row of rows) {
-      const record = parseOpenCodeUsageRow(row);
-      if (record === null) malformedRecords += 1;
-      else records.push(record);
+      const parsed = decodeOpenCodeUsageRow(row);
+      if (parsed._tag === "Record") records.push(parsed.record);
+      else if (parsed._tag === "Malformed") malformedRecords += 1;
     }
 
     const [malformed] = database.statement(OPEN_CODE_MALFORMED_QUERY).all(sinceMs);

--- a/apps/server/src/usage/usageOpenCode.ts
+++ b/apps/server/src/usage/usageOpenCode.ts
@@ -2,8 +2,10 @@
  * Read-only OpenCode usage database access.
  *
  * OpenCode stores one usage-bearing JSON object per assistant message in its
- * global SQLite database. Only the scalar fields needed for usage reporting are
- * selected; prompts, responses, and tool output never leave the database.
+ * global SQLite database. Both its legacy `message` projection and current
+ * `session_message` projection are supported. Only the scalar fields needed for
+ * usage reporting are selected; prompts, responses, and tool output never leave
+ * the database.
  *
  * @module usageOpenCode
  */
@@ -16,7 +18,13 @@ const BUN_SQLITE_MODULE_ID: string = "bun:sqlite";
 const OPEN_CODE_STABLE_DATABASE = "opencode.db";
 const OPEN_CODE_CHANNEL_DATABASE = /^opencode-[a-zA-Z0-9._-]+\.db$/;
 
-const OPEN_CODE_USAGE_QUERY = `
+const OPEN_CODE_MESSAGE_TABLES_QUERY = `
+  SELECT name
+  FROM sqlite_master
+  WHERE type = 'table' AND name IN ('session_message', 'message')
+`;
+
+const OPEN_CODE_LEGACY_USAGE_QUERY = `
   SELECT
     id AS messageId,
     session_id AS sessionId,
@@ -35,11 +43,51 @@ const OPEN_CODE_USAGE_QUERY = `
     AND json_extract(data, '$.role') = 'assistant'
 `;
 
-const OPEN_CODE_MALFORMED_QUERY = `
+const OPEN_CODE_LEGACY_MALFORMED_QUERY = `
   SELECT COUNT(*) AS records
   FROM message
   WHERE time_created >= ? AND NOT json_valid(data)
 `;
+
+const OPEN_CODE_CURRENT_USAGE_QUERY = `
+  SELECT
+    id AS messageId,
+    session_id AS sessionId,
+    time_created AS timestampMs,
+    json_extract(data, '$.model.providerID') AS providerId,
+    json_extract(data, '$.model.id') AS modelId,
+    json_extract(data, '$.tokens.input') AS inputTokens,
+    json_extract(data, '$.tokens.output') AS outputTokens,
+    json_extract(data, '$.tokens.reasoning') AS reasoningTokens,
+    json_extract(data, '$.tokens.cache.read') AS cacheReadTokens,
+    json_extract(data, '$.tokens.cache.write') AS cacheWriteTokens,
+    json_extract(data, '$.cost') AS costUsd
+  FROM session_message
+  WHERE time_created >= ?
+    AND type = 'assistant'
+    AND json_valid(data)
+`;
+
+const OPEN_CODE_CURRENT_MALFORMED_QUERY = `
+  SELECT COUNT(*) AS records
+  FROM session_message
+  WHERE time_created >= ?
+    AND type = 'assistant'
+    AND NOT json_valid(data)
+`;
+
+const OPEN_CODE_TABLE_QUERIES = {
+  session_message: {
+    usage: OPEN_CODE_CURRENT_USAGE_QUERY,
+    malformed: OPEN_CODE_CURRENT_MALFORMED_QUERY,
+  },
+  message: {
+    usage: OPEN_CODE_LEGACY_USAGE_QUERY,
+    malformed: OPEN_CODE_LEGACY_MALFORMED_QUERY,
+  },
+} as const;
+
+type OpenCodeMessageTable = keyof typeof OPEN_CODE_TABLE_QUERIES;
 
 interface OpenCodeUsageRow {
   readonly messageId?: unknown;
@@ -59,8 +107,12 @@ interface CountRow {
   readonly records?: unknown;
 }
 
+interface TableNameRow {
+  readonly name?: unknown;
+}
+
 interface SqliteStatement {
-  readonly all: (sinceMs: number) => readonly unknown[];
+  readonly all: (...parameters: readonly number[]) => readonly unknown[];
 }
 
 interface SqliteDatabase {
@@ -191,7 +243,7 @@ async function openDatabase(databasePath: string): Promise<SqliteDatabase> {
     return {
       statement: (sql) => {
         const statement = database.query(sql);
-        return { all: (sinceMs) => statement.all(sinceMs) };
+        return { all: (...parameters) => statement.all(...parameters) };
       },
       close: () => database.close(),
     };
@@ -202,7 +254,7 @@ async function openDatabase(databasePath: string): Promise<SqliteDatabase> {
   return {
     statement: (sql) => {
       const statement = database.prepare(sql);
-      return { all: (sinceMs) => statement.all(sinceMs) };
+      return { all: (...parameters) => statement.all(...parameters) };
     },
     close: () => database.close(),
   };
@@ -219,18 +271,41 @@ export async function readOpenCodeUsage(
   let database: SqliteDatabase | undefined;
   try {
     database = await openDatabase(databasePath);
-    const rows = database.statement(OPEN_CODE_USAGE_QUERY).all(sinceMs);
-    const records: UsageRecord[] = [];
+    const tableRows = database.statement(OPEN_CODE_MESSAGE_TABLES_QUERY).all();
+    const tables = new Set<OpenCodeMessageTable>();
+    for (const row of tableRows) {
+      const name = (row as TableNameRow).name;
+      if (name === "session_message" || name === "message") tables.add(name);
+    }
+    if (tables.size === 0) return null;
+
+    // Current databases can contain both projections. Prefer the current row
+    // when an upgraded database carries the same message ID in each table.
+    const recordsByKey = new Map<string, UsageRecord>();
     let malformedRecords = 0;
-    for (const row of rows) {
-      const parsed = decodeOpenCodeUsageRow(row);
-      if (parsed._tag === "Record") records.push(parsed.record);
-      else if (parsed._tag === "Malformed") malformedRecords += 1;
+    for (const table of ["session_message", "message"] as const) {
+      if (!tables.has(table)) continue;
+      const queries = OPEN_CODE_TABLE_QUERIES[table];
+      const rows = database.statement(queries.usage).all(sinceMs);
+      for (const row of rows) {
+        const parsed = decodeOpenCodeUsageRow(row);
+        if (parsed._tag === "Record") {
+          const dedupeKey = parsed.record.dedupeKey;
+          if (dedupeKey === null) {
+            malformedRecords += 1;
+          } else if (!recordsByKey.has(dedupeKey)) {
+            recordsByKey.set(dedupeKey, parsed.record);
+          }
+        } else if (parsed._tag === "Malformed") {
+          malformedRecords += 1;
+        }
+      }
+
+      const [malformed] = database.statement(queries.malformed).all(sinceMs);
+      malformedRecords += nonNegativeInt((malformed as CountRow | undefined)?.records);
     }
 
-    const [malformed] = database.statement(OPEN_CODE_MALFORMED_QUERY).all(sinceMs);
-    const invalidJsonRecords = nonNegativeInt((malformed as CountRow | undefined)?.records);
-    return { records, malformedRecords: malformedRecords + invalidJsonRecords };
+    return { records: [...recordsByKey.values()], malformedRecords };
   } catch {
     return null;
   } finally {

--- a/apps/server/src/usage/usageOpenCode.ts
+++ b/apps/server/src/usage/usageOpenCode.ts
@@ -1,0 +1,189 @@
+/**
+ * Read-only OpenCode usage database access.
+ *
+ * OpenCode stores one usage-bearing JSON object per assistant message in its
+ * global SQLite database. Only the scalar fields needed for usage reporting are
+ * selected; prompts, responses, and tool output never leave the database.
+ *
+ * @module usageOpenCode
+ */
+import type { UsageRecord } from "./usageTranscripts.ts";
+
+// Kept non-literal so the Node-targeted bundle leaves Bun's runtime module
+// external without asking its resolver to load a module Node cannot provide.
+const BUN_SQLITE_MODULE_ID: string = "bun:sqlite";
+
+const OPEN_CODE_USAGE_QUERY = `
+  SELECT
+    id AS messageId,
+    session_id AS sessionId,
+    time_created AS timestampMs,
+    json_extract(data, '$.providerID') AS providerId,
+    json_extract(data, '$.modelID') AS modelId,
+    json_extract(data, '$.tokens.input') AS inputTokens,
+    json_extract(data, '$.tokens.output') AS outputTokens,
+    json_extract(data, '$.tokens.reasoning') AS reasoningTokens,
+    json_extract(data, '$.tokens.cache.read') AS cacheReadTokens,
+    json_extract(data, '$.tokens.cache.write') AS cacheWriteTokens,
+    json_extract(data, '$.cost') AS costUsd
+  FROM message
+  WHERE time_created >= ?
+    AND json_valid(data)
+    AND json_extract(data, '$.role') = 'assistant'
+`;
+
+const OPEN_CODE_MALFORMED_QUERY = `
+  SELECT COUNT(*) AS records
+  FROM message
+  WHERE time_created >= ? AND NOT json_valid(data)
+`;
+
+interface OpenCodeUsageRow {
+  readonly messageId?: unknown;
+  readonly sessionId?: unknown;
+  readonly timestampMs?: unknown;
+  readonly providerId?: unknown;
+  readonly modelId?: unknown;
+  readonly inputTokens?: unknown;
+  readonly outputTokens?: unknown;
+  readonly reasoningTokens?: unknown;
+  readonly cacheReadTokens?: unknown;
+  readonly cacheWriteTokens?: unknown;
+  readonly costUsd?: unknown;
+}
+
+interface CountRow {
+  readonly records?: unknown;
+}
+
+interface SqliteStatement {
+  readonly all: (sinceMs: number) => readonly unknown[];
+}
+
+interface SqliteDatabase {
+  readonly statement: (sql: string) => SqliteStatement;
+  readonly close: () => void;
+}
+
+export interface OpenCodeUsageRead {
+  readonly records: readonly UsageRecord[];
+  readonly malformedRecords: number;
+}
+
+function nonNegativeInt(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+function finiteNonNegative(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+/** Converts one assistant-message projection into the shared usage shape. */
+export function parseOpenCodeUsageRow(value: unknown): UsageRecord | null {
+  if (typeof value !== "object" || value === null) return null;
+  const row = value as OpenCodeUsageRow;
+  if (
+    typeof row.messageId !== "string" ||
+    row.messageId.length === 0 ||
+    typeof row.sessionId !== "string" ||
+    typeof row.timestampMs !== "number" ||
+    !Number.isFinite(row.timestampMs) ||
+    typeof row.providerId !== "string" ||
+    row.providerId.length === 0 ||
+    typeof row.modelId !== "string" ||
+    row.modelId.length === 0
+  ) {
+    return null;
+  }
+
+  const uncachedInputTokens = nonNegativeInt(row.inputTokens);
+  const cachedInputTokens = nonNegativeInt(row.cacheReadTokens);
+  const cacheCreationTokens = nonNegativeInt(row.cacheWriteTokens);
+  const generatedOutputTokens = nonNegativeInt(row.outputTokens);
+  const reasoningTokens = nonNegativeInt(row.reasoningTokens);
+
+  // OpenCode reports generated text and reasoning as disjoint counts. The
+  // shared contract treats reasoning as a subset of output, so combine them in
+  // outputTokens while retaining the reasoning slice for the token-mix UI.
+  const outputTokens = generatedOutputTokens + reasoningTokens;
+  if (
+    uncachedInputTokens + cachedInputTokens + cacheCreationTokens + outputTokens === 0 &&
+    finiteNonNegative(row.costUsd) === null
+  ) {
+    return null;
+  }
+
+  return {
+    provider: "opencode",
+    timestampMs: row.timestampMs,
+    model: `${row.providerId}/${row.modelId}`,
+    sessionId: row.sessionId,
+    totals: {
+      uncachedInputTokens,
+      cachedInputTokens,
+      cacheCreationTokens,
+      outputTokens,
+      reasoningTokens,
+    },
+    reportedCostUsd: finiteNonNegative(row.costUsd),
+    dedupeKey: `opencode:${row.messageId}`,
+  };
+}
+
+async function openDatabase(databasePath: string): Promise<SqliteDatabase> {
+  if (process.versions.bun !== undefined) {
+    const { Database } = (await import(BUN_SQLITE_MODULE_ID)) as typeof import("bun:sqlite");
+    const database = new Database(databasePath, { readonly: true, create: false });
+    return {
+      statement: (sql) => {
+        const statement = database.query(sql);
+        return { all: (sinceMs) => statement.all(sinceMs) };
+      },
+      close: () => database.close(),
+    };
+  }
+
+  const { DatabaseSync } = await import("node:sqlite");
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  return {
+    statement: (sql) => {
+      const statement = database.prepare(sql);
+      return { all: (sinceMs) => statement.all(sinceMs) };
+    },
+    close: () => database.close(),
+  };
+}
+
+/**
+ * Reads assistant usage at or after `sinceMs`, returning `null` when the
+ * database is unavailable or has an unsupported schema.
+ */
+export async function readOpenCodeUsage(
+  databasePath: string,
+  sinceMs: number,
+): Promise<OpenCodeUsageRead | null> {
+  let database: SqliteDatabase | undefined;
+  try {
+    database = await openDatabase(databasePath);
+    const rows = database.statement(OPEN_CODE_USAGE_QUERY).all(sinceMs);
+    const records: UsageRecord[] = [];
+    let malformedRecords = 0;
+    for (const row of rows) {
+      const record = parseOpenCodeUsageRow(row);
+      if (record === null) malformedRecords += 1;
+      else records.push(record);
+    }
+
+    const [malformed] = database.statement(OPEN_CODE_MALFORMED_QUERY).all(sinceMs);
+    const invalidJsonRecords = nonNegativeInt((malformed as CountRow | undefined)?.records);
+    return { records, malformedRecords: malformedRecords + invalidJsonRecords };
+  } catch {
+    return null;
+  } finally {
+    try {
+      database?.close();
+    } catch {
+      // A failed close must not turn a successful read into a failed RPC.
+    }
+  }
+}

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -394,7 +394,10 @@ export function UsagePage() {
                       <tbody>
                         {recentPeriods.length === 0 ? (
                           <tr>
-                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                            <td
+                              colSpan={PROVIDER_ORDER.length + 3}
+                              className="py-6 text-center text-muted-foreground"
+                            >
                               No activity in this window.
                             </td>
                           </tr>

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -52,6 +52,7 @@ describe("buildDayColumns", () => {
         byProvider: new Map([
           ["codex" as const, { costUsd: 10, totalTokens: 100 }],
           ["claude" as const, { costUsd: 20, totalTokens: 200 }],
+          ["opencode" as const, { costUsd: 3, totalTokens: 30 }],
         ]),
       },
     ],
@@ -68,12 +69,12 @@ describe("buildDayColumns", () => {
   ]);
 
   it("plots each day on its own", () => {
-    expect(buildDayColumns(days, byDay, "cost").map((column) => column.total)).toEqual([30, 0, 5]);
+    expect(buildDayColumns(days, byDay, "cost").map((column) => column.total)).toEqual([33, 0, 5]);
   });
 
   it("reads the requested metric", () => {
     expect(buildDayColumns(days, byDay, "tokens").map((column) => column.total)).toEqual([
-      300, 0, 50,
+      330, 0, 50,
     ]);
   });
 
@@ -85,6 +86,7 @@ describe("buildDayColumns", () => {
     expect(first?.bands).toEqual([
       { provider: "codex", value: 10 },
       { provider: "claude", value: 20 },
+      { provider: "opencode", value: 3 },
     ]);
   });
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,23 +1,25 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
 
 /**
- * Series and table order. The chart layers both providers from a shared zero
+ * Series and table order. The chart layers every provider from a shared zero
  * baseline, so this only fixes the reading order of legends, tables and hover
  * rows; it does not decide which series sits above the other.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "opencode"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  opencode: "OpenCode",
 };
 
-/** Claude's brand orange against a neutral white for Codex. */
+/** Claude orange and two distinct neutral tones for Codex and OpenCode. */
 export const PROVIDER_COLOR: Record<UsageProviderKind, string> = {
   claude: "#d97757",
   codex: "#e6e6e6",
+  opencode: "#8f8b8b",
 };
 
 /**
@@ -30,4 +32,5 @@ export const PROVIDER_COLOR: Record<UsageProviderKind, string> = {
 export const PROVIDER_MARK: Record<UsageProviderKind, Icon> = {
   claude: ClaudeAI,
   codex: OpenAI,
+  opencode: OpenCodeIcon,
 };

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - [Organizing threads](./user/thread-sidebar.md)
 - [Review usage](./user/usage.md)
 - [Customize a project icon](./user/project-settings.md)
+- [Understand usage reporting](./user/usage.md)
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -10,6 +10,9 @@ aggregated usage totals. Subscription billing is separate from the raw token cos
 provider records a cost, T3 Code uses it. Otherwise, it estimates cost from the available model rate
 table and marks models it cannot price.
 
+For OpenCode, T3 Code honors `OPENCODE_DB` and discovers databases created by channel installs in
+OpenCode's data directory. In-memory OpenCode databases cannot be inspected by another process.
+
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the
 headline and chart, and refreshing rescans every connected environment.

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,10 +1,18 @@
 # Review usage
 
-The Usage page combines Codex and Claude Code activity from your connected environments. It reads
-the providers' local session history and shows API-equivalent token cost, processed tokens, cache
-savings, provider shares, and model breakdowns. Subscription billing is separate from the raw token
-cost shown here.
+The Usage page combines Claude Code, Codex, and OpenCode activity from your connected environments.
+It reads the providers' local session history and shows API-equivalent token cost, processed tokens,
+cache savings, provider shares, and model breakdowns. It can therefore include work started outside
+T3 Code.
+
+Prompt text, responses, and tool output are not sent to the client; environments return only
+aggregated usage totals. Subscription billing is separate from the raw token cost shown here. When a
+provider records a cost, T3 Code uses it. Otherwise, it estimates cost from the available model rate
+table and marks models it cannot price.
 
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the
 headline and chart, and refreshing rescans every connected environment.
+
+When multiple connected environments point to the same provider data on one machine, T3 Code counts
+that source once to avoid duplicate totals.

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -3,9 +3,9 @@
  *
  * Each environment scans the provider CLIs' own on-disk session data
  * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`, and
- * OpenCode's `opencode.db`) rather than relying on T3 Code's own orchestration
- * projections, so usage stays complete even for turns that were never driven
- * through T3 Code. This mirrors the approach `ccusage` takes.
+ * OpenCode's SQLite databases) rather than relying on T3 Code's own
+ * orchestration projections, so usage stays complete even for turns that were
+ * never driven through T3 Code. This mirrors the approach `ccusage` takes.
  *
  * Environments return pre-aggregated `(day, hourStart?, provider, model)`
  * buckets. Raw transcript records never cross the wire.

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -21,7 +21,7 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 4 as const;
+export const USAGE_CONTRACT_VERSION = 5 as const;
 
 export const UsageProviderKind = Schema.Literals(["claude", "codex", "opencode"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -1,11 +1,11 @@
 /**
  * Usage reporting contract.
  *
- * Each environment scans the provider CLIs' own on-disk session transcripts
- * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`) rather than
- * relying on T3 Code's own orchestration projections, so usage stays complete
- * even for turns that were never driven through T3 Code. This mirrors the
- * approach `ccusage` takes.
+ * Each environment scans the provider CLIs' own on-disk session data
+ * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`, and
+ * OpenCode's `opencode.db`) rather than relying on T3 Code's own orchestration
+ * projections, so usage stays complete even for turns that were never driven
+ * through T3 Code. This mirrors the approach `ccusage` takes.
  *
  * Environments return pre-aggregated `(day, hourStart?, provider, model)`
  * buckets. Raw transcript records never cross the wire.
@@ -23,7 +23,7 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  */
 export const USAGE_CONTRACT_VERSION = 4 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex"]);
+export const UsageProviderKind = Schema.Literals(["claude", "codex", "opencode"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**


### PR DESCRIPTION
## What Changed

Add Opencode usage to t3 usage page

## Why

I use opencode as well as claude and codex so I can use open or alternative models. This will add opencode usage to the page as well. Opencode stores the data in a different way than claude or codex (sqlite), which forces us to slightly change the calculation mechanism. But it's basically the same.

## UI Changes

This is what it looks like now:
<img width="1153" height="482" alt="image" src="https://github.com/user-attachments/assets/d04de9ca-58d2-4a18-9543-8bf2f036d358" />


This is what it will look like:
<img width="921" height="413" alt="image" src="https://github.com/user-attachments/assets/14d1311d-f2a6-4d4b-b1c8-0d3b7311ecb1" />


## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New local SQLite reads and a contract version bump affect usage aggregation across clients; reads are scoped to usage scalars only, limiting exposure of prompt content.
> 
> **Overview**
> Adds **OpenCode** as a third usage provider alongside Claude Code and Codex, reading local SQLite assistant-message data instead of JSONL transcripts.
> 
> The server introduces `usageOpenCode` for read-only SQLite access (Bun and Node), maps legacy `message` and current `session_message` rows into shared `UsageRecord`s without selecting conversation content, and discovers databases under OpenCode’s data dir with support for `OPENCODE_DB`, channel DBs, and `OPENCODE_DISABLE_CHANNEL_DB`. `UsageService` branches on source kind (`jsonl` vs `opencodeSqlite`) and reports OpenCode-specific missing/partial/failed source status.
> 
> The shared contract adds `opencode` to `UsageProviderKind` and bumps **`USAGE_CONTRACT_VERSION` to 5**. Web and mobile charts/tables register OpenCode label, color, and icon; the web usage table’s empty-state `colSpan` now follows `PROVIDER_ORDER` length. User docs describe OpenCode sourcing and privacy boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd1517649997a9f24d619eb6b2148c05f01a7d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenCode usage reporting to usage summary and UI
> - Adds `readOpenCodeUsage` and `resolveOpenCodeDatabasePaths` in [`usageOpenCode.ts`](https://github.com/pingdotgg/t3code/pull/6040/files#diff-2f248b3569cade39e4ecb169cb877d020afb95a7ed28c59a8cea075e2164ae52) to read assistant usage from OpenCode SQLite databases, supporting both current and legacy schemas with deduplication by message ID.
> - Integrates OpenCode as a new source in [`UsageService`](https://github.com/pingdotgg/t3code/pull/6040/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70), discovering channel databases via directory scan and reporting partial/failed states per database.
> - Registers `opencode` in provider ordering, labels, colors, and icons across web and mobile UI, and adds an `OpenCodeIcon` mark to the chart legend.
> - Increments `USAGE_CONTRACT_VERSION` from 4 to 5 and adds `opencode` to the `UsageProviderKind` schema in [`packages/contracts/src/usage.ts`](https://github.com/pingdotgg/t3code/pull/6040/files#diff-9abc3595e224ffc63bc8ed068d884a2dad83ccb207f0b183e94259fb7f486a13).
> - Risk: version bump to contract v5 may cause version-mismatch warnings or partial-state handling in clients that validate the contract version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bd1517.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->