### PR TITLE
fix(server): let a draft retry after its worktree fails to create

### DIFF
--- a/apps/server/src/orchestration/commandInvariants.test.ts
+++ b/apps/server/src/orchestration/commandInvariants.test.ts
@@ -201,6 +201,37 @@ describe("commandInvariants", () => {
     ).rejects.toThrow("already exists");
   });
 
+  it("treats soft-deleted threads as absent for create flows", async () => {
+    const deletedThread = readModel.threads[0]!;
+    const readModelWithDeletedThread: OrchestrationReadModel = {
+      ...readModel,
+      threads: [{ ...deletedThread, deletedAt: now }, ...readModel.threads.slice(1)],
+    };
+
+    await Effect.runPromise(
+      requireThreadAbsent({
+        readModel: readModelWithDeletedThread,
+        command: {
+          type: "thread.create",
+          commandId: CommandId.make("cmd-4"),
+          threadId: deletedThread.id,
+          projectId: ProjectId.make("project-a"),
+          title: "recreated",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "full-access",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+        },
+        threadId: deletedThread.id,
+      }),
+    );
+  });
+
   it("requires non-negative integers", async () => {
     await Effect.runPromise(
       requireNonNegativeInteger({

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -156,7 +156,8 @@ export function requireThreadAbsent(input: {
   readonly command: OrchestrationCommand;
   readonly threadId: ThreadId;
 }): Effect.Effect<void, OrchestrationCommandInvariantError> {
-  if (!findThreadById(input.readModel, input.threadId)) {
+  const existingThread = findThreadById(input.readModel, input.threadId);
+  if (!existingThread || existingThread.deletedAt !== null) {
     return Effect.void;
   }
   return Effect.fail(

--- a/apps/web/src/routes/_chat.draft.$draftId.tsx
+++ b/apps/web/src/routes/_chat.draft.$draftId.tsx
@@ -31,11 +31,14 @@ function DraftChatThreadRouteView() {
   const canonicalThreadRef = serverThreadStarted ? serverThreadRef : null;
 
   useEffect(() => {
-    if (!inferredThreadRef || draftSession?.promotedTo) {
+    // A bootstrap send creates the thread before preparing its worktree and
+    // rolls it back when preparation fails. Marking on mere existence would
+    // stick `promotedTo` on the surviving draft, hiding it from the sidebar.
+    if (!inferredThreadRef || draftSession?.promotedTo || !serverThreadStarted) {
       return;
     }
     markPromotedDraftThreadByRef(inferredThreadRef);
-  }, [draftSession?.promotedTo, inferredThreadRef]);
+  }, [draftSession?.promotedTo, inferredThreadRef, serverThreadStarted]);
 
   useEffect(() => {
     if (!canonicalThreadRef) {


### PR DESCRIPTION
## Problem

When a draft's first send is in **New worktree** mode and `git worktree add` fails, every retry from that draft fails with `Thread 'X' already exists and cannot be created twice.` — including after switching the draft to **Current checkout** — until the user abandons the draft and starts a new one. The failed attempt also leaves the surviving draft hidden from the sidebar.

## Fix

The bootstrap flow dispatches `thread.create` before preparing the worktree and rolls back with `thread.delete` (a soft delete) when preparation fails. Two small changes:

- **server**: `requireThreadAbsent` now treats soft-deleted threads as absent, mirroring the existing project invariant, so the draft's pre-allocated thread id can be re-created on retry.
- **web**: the draft route only marks a draft as promoted once its thread has actually started, so a rolled-back bootstrap no longer sticks `promotedTo` on the draft and hides it from the sidebar.

## Verification

- New unit test: re-creating a soft-deleted thread id passes `requireThreadAbsent` (`commandInvariants.test.ts`).
- Reproduced live with a forced `git worktree add` failure: fail → retry in worktree mode → clean rollback again; switch to Current checkout → send succeeds on the same thread id (event log: `created → deleted → created → deleted → created`), and the normal worktree flow still creates worktrees when nothing is blocking it.

Fixed by Claude Fable 5 running in Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix draft retry after worktree creation failure by treating soft-deleted threads as absent
> - Updates `requireThreadAbsent` in [commandInvariants.ts](https://github.com/pingdotgg/t3code/pull/6041/files#diff-426dec65d7876b98b993600840e4b58dcca662d84f3a23e884ea72cc2783e6a0) to treat threads with a non-null `deletedAt` as absent, allowing `thread.create` commands to succeed when a prior thread was soft-deleted.
> - Fixes premature draft promotion in [_chat.draft.$draftId.tsx](https://github.com/pingdotgg/t3code/pull/6041/files#diff-81aad35683c56f7b68b13e851e82c9b2677cce9d19548633e91b9b93798e030a) by gating `markPromotedDraftThreadByRef` on `serverThreadStarted`, preventing promotion when the server thread exists but hasn't started yet.
> - Together these allow a draft to retry successfully after its worktree fails to create, leaving a soft-deleted thread behind.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9402a15. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->