### PR TITLE
fix(ssh): adopt installed service without session env

### DIFF
--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -1,17 +1,20 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import { HostProcessExecutablePath, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as NetService from "@t3tools/shared/Net";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { TestClock } from "effect/testing";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
-
 import { SshPasswordPrompt } from "./auth.ts";
 import {
   buildRemoteLaunchScript,
@@ -27,6 +30,9 @@ import {
 } from "./tunnel.ts";
 
 const TEST_NODE_ENGINE_RANGE = "^22.16 || ^23.11 || >=24.10";
+const TestRuntimeState = Schema.fromJsonString(
+  Schema.Struct({ pid: Schema.Number, port: Schema.Number }),
+);
 
 const makeSuccessfulProcess = (stdout: string) => {
   const stdoutStream = Stream.make(new TextEncoder().encode(stdout));
@@ -83,6 +89,65 @@ const testNetService = NetService.NetService.of({
   reserveLoopbackPort: () => Effect.succeed(41_773),
   findAvailablePort: (preferred) => Effect.succeed(preferred),
 });
+
+const installedServiceSource = `const fs = require("node:fs");
+const http = require("node:http");
+const path = require("node:path");
+const runtimePath = process.argv[2];
+const server = http.createServer((_request, response) => {
+  response.writeHead(200);
+  response.end("service");
+});
+function stop() {
+  try { fs.unlinkSync(runtimePath); } catch {}
+  if (server.listening) {
+    server.close(() => process.exit(0));
+  } else {
+    process.exit(0);
+  }
+}
+process.once("SIGTERM", stop);
+if (process.env.FAKE_SERVICE_UNREADY === "1") {
+  fs.mkdirSync(path.dirname(runtimePath), { recursive: true });
+  fs.writeFileSync(runtimePath, JSON.stringify({
+    version: 1,
+    pid: process.pid,
+    port: 1,
+    origin: "http://127.0.0.1:1",
+    startedAt: "2026-08-10T19:16:45.000Z",
+  }) + "\\n");
+  setInterval(() => {}, 1_000);
+  return;
+}
+server.listen(0, "127.0.0.1", () => {
+  const port = server.address().port;
+  fs.mkdirSync(path.dirname(runtimePath), { recursive: true });
+  fs.writeFileSync(runtimePath, JSON.stringify({
+    version: 1,
+    pid: process.pid,
+    port,
+    origin: "http://127.0.0.1:" + port,
+    startedAt: "2026-08-10T19:16:45.000Z",
+  }) + "\\n");
+});`;
+
+const fakeSystemctlSource = `#!/bin/sh
+set -eu
+[ "\${1:-}" = "--user" ] || exit 1
+printf '%s\\n%s\\n' "\${XDG_RUNTIME_DIR:-}" "\${DBUS_SESSION_BUS_ADDRESS:-}" >"$FAKE_SYSTEMD_ENV_LOG"
+case "\${2:-}:\${3:-}" in
+  cat:t3code.service)
+    exit 0
+    ;;
+  start:t3code.service)
+    printf 'start\\n' >>"$FAKE_SERVICE_START_LOG"
+    nohup "$FAKE_NODE" "$FAKE_SERVICE_SCRIPT" "$FAKE_RUNTIME_FILE" >>"$FAKE_SERVICE_LOG" 2>&1 < /dev/null &
+    printf '%s\\n' "$!" >"$FAKE_SERVICE_PID_FILE"
+    exit 0
+    ;;
+esac
+exit 1
+`;
 
 function commandArgs(command: ChildProcess.Command): ReadonlyArray<string> {
   return command._tag === "StandardCommand" ? command.args : [];
@@ -192,6 +257,22 @@ describe("ssh tunnel scripts", () => {
       'DEFAULT_RUNTIME_FILE="$DEFAULT_SERVER_HOME/userdata/server-runtime.json"',
     );
     assert.include(buildRemoteLaunchScript(), "resolve_default_runtime_port()");
+    assert.include(buildRemoteLaunchScript(), "ensure_systemd_user_environment()");
+    assert.include(buildRemoteLaunchScript(), 'XDG_RUNTIME_DIR="/run/user/$(id -u)"');
+    assert.include(
+      buildRemoteLaunchScript(),
+      'DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"',
+    );
+    assert.include(buildRemoteLaunchScript(), "systemctl --user cat t3code.service");
+    assert.include(buildRemoteLaunchScript(), "systemctl --user start t3code.service");
+    assert.include(
+      buildRemoteLaunchScript(),
+      'if [ -z "$DEFAULT_RUNTIME_INFO" ] && service_is_installed; then',
+    );
+    assert.isBelow(
+      buildRemoteLaunchScript().indexOf("start_and_resolve_installed_service"),
+      buildRemoteLaunchScript().indexOf('REMOTE_PORT="$(pick_port)"'),
+    );
     assert.include(
       buildRemoteLaunchScript(),
       'DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port',
@@ -214,6 +295,165 @@ describe("ssh tunnel scripts", () => {
       buildRemoteLaunchScript().indexOf('elif [ -n "$REMOTE_PID" ]'),
     );
   });
+
+  it.effect(
+    "adopts an installed service when an SSH session omits the user systemd environment",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          if ((yield* HostProcessPlatform) === "win32") return;
+
+          const fileSystem = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+          const executablePath = yield* HostProcessExecutablePath;
+          const home = yield* fileSystem.makeTempDirectoryScoped({
+            prefix: "t3-ssh-systemd-adoption-test-",
+          });
+          const stateKey = "systemd-adoption";
+          const stateDir = path.join(home, ".t3", "ssh-launch", stateKey);
+          const runtimePath = path.join(home, ".t3", "userdata", "server-runtime.json");
+          const fakeBin = path.join(home, "fake-bin");
+          const serviceScriptPath = path.join(home, "fake-t3-service.cjs");
+          const servicePidPath = path.join(home, "fake-t3-service.pid");
+          const serviceLogPath = path.join(home, "fake-t3-service.log");
+          const serviceStartLogPath = path.join(home, "fake-t3-service-starts.log");
+          const systemdEnvironmentLogPath = path.join(home, "fake-systemd-environment.log");
+          const expectedRuntimeDir = `/run/user/${process.getuid?.() ?? 0}`;
+
+          yield* fileSystem.makeDirectory(fakeBin, { recursive: true });
+          yield* fileSystem.writeFileString(path.join(fakeBin, "systemctl"), fakeSystemctlSource);
+          yield* fileSystem.chmod(path.join(fakeBin, "systemctl"), 0o755);
+          yield* fileSystem.writeFileString(serviceScriptPath, installedServiceSource);
+
+          const shell = yield* spawner.spawn(
+            ChildProcess.make("sh", ["-s", "--", stateKey], {
+              detached: false,
+              env: {
+                HOME: home,
+                PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+                XDG_RUNTIME_DIR: "",
+                DBUS_SESSION_BUS_ADDRESS: "",
+                FAKE_NODE: executablePath,
+                FAKE_SERVICE_SCRIPT: serviceScriptPath,
+                FAKE_RUNTIME_FILE: runtimePath,
+                FAKE_SERVICE_PID_FILE: servicePidPath,
+                FAKE_SERVICE_LOG: serviceLogPath,
+                FAKE_SERVICE_START_LOG: serviceStartLogPath,
+                FAKE_SYSTEMD_ENV_LOG: systemdEnvironmentLogPath,
+              },
+              extendEnv: true,
+              stdin: Stream.make(new TextEncoder().encode(buildRemoteLaunchScript())),
+            }),
+          );
+          const [stdout, stderr, exitCode] = yield* Effect.all(
+            [
+              Stream.mkString(Stream.decodeText(shell.stdout)),
+              Stream.mkString(Stream.decodeText(shell.stderr)),
+              shell.exitCode,
+            ],
+            { concurrency: "unbounded" },
+          );
+
+          assert.equal(exitCode, 0, stderr);
+          const runtime = yield* Schema.decodeUnknownEffect(TestRuntimeState)(
+            yield* fileSystem.readFileString(runtimePath),
+          );
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              try {
+                process.kill(runtime.pid, "SIGTERM");
+              } catch {}
+            }),
+          );
+          assert.include(stdout, `{"remotePort":${runtime.port},"serverKind":"external"}`);
+          assert.equal(yield* fileSystem.readFileString(serviceStartLogPath), "start\n");
+          assert.equal(
+            yield* fileSystem.readFileString(systemdEnvironmentLogPath),
+            `${expectedRuntimeDir}\nunix:path=${expectedRuntimeDir}/bus\n`,
+          );
+          assert.equal(
+            yield* fileSystem.readFileString(path.join(stateDir, "managed")),
+            "external\n",
+          );
+          assert.isFalse(yield* fileSystem.exists(path.join(stateDir, "pid")));
+          assert.isFalse(yield* fileSystem.exists(path.join(stateDir, "server.log")));
+        }).pipe(Effect.provide(NodeServices.layer)),
+      ),
+  );
+
+  it.effect("refuses to spawn a competing server when the installed service is not ready", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        if ((yield* HostProcessPlatform) === "win32") return;
+
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const executablePath = yield* HostProcessExecutablePath;
+        const home = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-ssh-systemd-unready-test-",
+        });
+        const stateKey = "systemd-unready";
+        const stateDir = path.join(home, ".t3", "ssh-launch", stateKey);
+        const runtimePath = path.join(home, ".t3", "userdata", "server-runtime.json");
+        const fakeBin = path.join(home, "fake-bin");
+        const serviceScriptPath = path.join(home, "fake-t3-service.cjs");
+        const servicePidPath = path.join(home, "fake-t3-service.pid");
+        const serviceLogPath = path.join(home, "fake-t3-service.log");
+        const serviceStartLogPath = path.join(home, "fake-t3-service-starts.log");
+        const systemdEnvironmentLogPath = path.join(home, "fake-systemd-environment.log");
+
+        yield* fileSystem.makeDirectory(fakeBin, { recursive: true });
+        yield* fileSystem.writeFileString(path.join(fakeBin, "systemctl"), fakeSystemctlSource);
+        yield* fileSystem.chmod(path.join(fakeBin, "systemctl"), 0o755);
+        yield* fileSystem.writeFileString(serviceScriptPath, installedServiceSource);
+
+        const shell = yield* spawner.spawn(
+          ChildProcess.make("sh", ["-s", "--", stateKey], {
+            detached: false,
+            env: {
+              HOME: home,
+              PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+              FAKE_NODE: executablePath,
+              FAKE_SERVICE_SCRIPT: serviceScriptPath,
+              FAKE_RUNTIME_FILE: runtimePath,
+              FAKE_SERVICE_PID_FILE: servicePidPath,
+              FAKE_SERVICE_LOG: serviceLogPath,
+              FAKE_SERVICE_START_LOG: serviceStartLogPath,
+              FAKE_SYSTEMD_ENV_LOG: systemdEnvironmentLogPath,
+              FAKE_SERVICE_UNREADY: "1",
+            },
+            extendEnv: true,
+            stdin: Stream.make(new TextEncoder().encode(buildRemoteLaunchScript())),
+          }),
+        );
+        const [stderr, exitCode] = yield* Effect.all(
+          [Stream.mkString(Stream.decodeText(shell.stderr)), shell.exitCode],
+          { concurrency: "unbounded" },
+        );
+        const runtime = yield* Schema.decodeUnknownEffect(TestRuntimeState)(
+          yield* fileSystem.readFileString(runtimePath),
+        );
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            try {
+              process.kill(runtime.pid, "SIGTERM");
+            } catch {}
+          }),
+        );
+
+        assert.notEqual(exitCode, 0);
+        assert.include(
+          stderr,
+          "Installed t3code.service did not become ready; refusing to start a competing SSH server.",
+        );
+        assert.equal(yield* fileSystem.readFileString(serviceStartLogPath), "start\n");
+        assert.isFalse(yield* fileSystem.exists(path.join(stateDir, "pid")));
+        assert.isFalse(yield* fileSystem.exists(path.join(stateDir, "server.log")));
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
 
   it.effect("accepts launch JSON after remote shell startup noise", () => {
     const target = {

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -505,10 +505,53 @@ try {
 }
 NODE
 }
+ensure_systemd_user_environment() {
+  if ! command -v systemctl >/dev/null 2>&1 || ! command -v id >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ -z "\${XDG_RUNTIME_DIR:-}" ]; then
+    XDG_RUNTIME_DIR="/run/user/$(id -u)"
+    export XDG_RUNTIME_DIR
+  fi
+  if [ -z "\${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+    DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+    export DBUS_SESSION_BUS_ADDRESS
+  fi
+}
+service_is_installed() {
+  ensure_systemd_user_environment
+  command -v systemctl >/dev/null 2>&1 && systemctl --user cat t3code.service >/dev/null 2>&1
+}
+start_and_resolve_installed_service() {
+  if ! systemctl --user start t3code.service; then
+    printf 'Failed to start installed t3code.service; refusing to start a competing SSH server.\n' >&2
+    exit 1
+  fi
+  SERVICE_WAIT_COUNT=0
+  SERVICE_RUNTIME_INFO=""
+  while [ "$SERVICE_WAIT_COUNT" -lt 150 ]; do
+    SERVICE_RUNTIME_INFO="$(resolve_default_runtime_port 2>/dev/null || true)"
+    if [ -n "$SERVICE_RUNTIME_INFO" ]; then
+      break
+    fi
+    SERVICE_WAIT_COUNT=$((SERVICE_WAIT_COUNT + 1))
+    sleep 0.1
+  done
+  if [ -z "$SERVICE_RUNTIME_INFO" ]; then
+    printf 'Installed t3code.service did not advertise a live runtime; refusing to start a competing SSH server.\n' >&2
+    exit 1
+  fi
+  printf '%s' "$SERVICE_RUNTIME_INFO"
+}
 REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
 REMOTE_PORT="$(cat "$PORT_FILE" 2>/dev/null || true)"
 REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
 DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port 2>/dev/null || true)"
+INSTALLED_SERVICE_SELECTED=0
+if [ -z "$DEFAULT_RUNTIME_INFO" ] && service_is_installed; then
+  INSTALLED_SERVICE_SELECTED=1
+  DEFAULT_RUNTIME_INFO="$(start_and_resolve_installed_service)"
+fi
 DEFAULT_RUNTIME_PID=""
 DEFAULT_REMOTE_PORT=""
 if [ -n "$DEFAULT_RUNTIME_INFO" ]; then
@@ -537,6 +580,10 @@ if [ -n "$DEFAULT_REMOTE_PORT" ]; then
       REMOTE_MANAGED="external"
     fi
   else
+    if [ "$INSTALLED_SERVICE_SELECTED" -eq 1 ]; then
+      printf 'Installed t3code.service did not become ready; refusing to start a competing SSH server.\n' >&2
+      exit 1
+    fi
     REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
     REMOTE_PORT="$(cat "$PORT_FILE" 2>/dev/null || true)"
     REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
@@ -544,6 +591,10 @@ if [ -n "$DEFAULT_REMOTE_PORT" ]; then
 fi
 if [ "$REMOTE_MANAGED" = "external" ]; then
   if [ -z "$REMOTE_PORT" ] || ! wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
+    if [ "$INSTALLED_SERVICE_SELECTED" -eq 1 ]; then
+      printf 'Installed t3code.service stopped responding; refusing to start a competing SSH server.\n' >&2
+      exit 1
+    fi
     REMOTE_PID=""
     REMOTE_PORT=""
     REMOTE_MANAGED=""


### PR DESCRIPTION
Prevents the desktop SSH launcher from starting a competing T3 server when an installed user service is restarting and the SSH session lacks XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS. The launcher reconstructs the canonical user-systemd environment, starts or waits for t3code.service, and adopts its advertised runtime. Includes a behavioral regression proving no second SSH server is spawned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote SSH launch behavior for hosts with an installed user service—wrong detection or timeouts could block connections or leave users without a fallback server, but the scope is limited to the SSH tunnel launch script.
> 
> **Overview**
> Fixes SSH desktop launches that used to spin up a second T3 server when an installed **`t3code.service`** was restarting and the non-interactive SSH session lacked **`XDG_RUNTIME_DIR`** / **`DBUS_SESSION_BUS_ADDRESS`**.
> 
> The generated **`buildRemoteLaunchScript`** path now sets those variables when missing, detects an installed user unit via **`systemctl --user cat`**, starts it and waits for **`server-runtime.json`** before **`pick_port`**, and marks the connection **`external`** when reusing that runtime. If the service was chosen but never becomes HTTP-ready (or stops responding), the script **exits with an error** instead of falling through to **`nohup … serve`**.
> 
> **`tunnel.test.ts`** adds integration-style runs with fake **`systemctl`** and a stub service: one case asserts adoption with **`serverKind: external`** and no SSH-managed **`pid`/`server.log`**, another asserts the “refusing to start a competing SSH server” failure when the service stays unready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49569091d8262e46c298cae477dcbdd5808d44c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SSH tunnel to adopt installed `t3code.service` without a user systemd session environment
> - The remote launch script emitted by `buildRemoteLaunchScript` now calls `ensure_systemd_user_environment` to reconstruct missing `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` variables when they are absent from the SSH session environment.
> - A new `service_is_installed` check runs `systemctl --user cat t3code.service`; when no default runtime is found and the service is installed, `start_and_resolve_installed_service` starts it and polls up to ~15s for the runtime file.
> - When the installed service is detected, the runtime is adopted as `serverKind: 'external'` with no managed PID or server log created.
> - If the service fails to start, does not advertise a live runtime, or does not become ready, the script exits with a descriptive error and refuses to spawn a competing SSH-managed server.
> - Tests in [tunnel.test.ts](https://github.com/pingdotgg/t3code/pull/6042/files#diff-76d3724ec8959625b119aff8272a5d733f73551706a487e303ddbd13e10a06ad) cover the happy path (service adopted) and the unready path (competing server refused).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4956909.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->