### PR TITLE
fix(web): center composer skill labels

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -72,8 +72,8 @@ import { cn, isMacPlatform } from "~/lib/utils";
 import { basenameOfPath } from "~/pierre-icons";
 import {
   COMPOSER_INLINE_CHIP_ICON_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME,
   COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME,
-  COMPOSER_INLINE_SKILL_CHIP_LABEL_CLASS_NAME,
   SKILL_CHIP_ICON_SVG,
 } from "./composerInlineChip";
 import { FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
@@ -256,7 +256,7 @@ function ComposerSkillDecorator(props: { skillLabel: string; skillDescription: s
         className={COMPOSER_INLINE_CHIP_ICON_CLASS_NAME}
         dangerouslySetInnerHTML={{ __html: SKILL_CHIP_ICON_SVG }}
       />
-      <span className={COMPOSER_INLINE_SKILL_CHIP_LABEL_CLASS_NAME}>{props.skillLabel}</span>
+      <span className={COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME}>{props.skillLabel}</span>
     </span>
   );
 

--- a/apps/web/src/components/composerInlineChip.ts
+++ b/apps/web/src/components/composerInlineChip.ts
@@ -14,10 +14,6 @@ export const CHAT_INLINE_CHIP_LABEL_CLASS_NAME = "truncate leading-tight";
 
 export const COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME = `${CHAT_INLINE_CHIP_LABEL_CLASS_NAME} select-none`;
 
-// The skill label is smaller than the surrounding prompt text; offset its
-// glyphs without moving the pill box or changing the editor's line height.
-export const COMPOSER_INLINE_SKILL_CHIP_LABEL_CLASS_NAME = `${COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME} relative top-[0.15em]`;
-
 export const COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME =
   "inline-flex max-w-full select-none items-center gap-[0.33em] rounded-[0.5em] border border-fuchsia-500/25 bg-fuchsia-500/12 px-[0.5em] py-[0.08em] font-medium text-[0.86em] leading-[1.1] text-fuchsia-700 align-middle dark:text-fuchsia-300";
 


### PR DESCRIPTION
## What Changed

Composer skill chips now use the shared inline chip label alignment. The skill-only `top-[0.15em]` offset was removed.

## Why

The chip flex container already centers the icon and label. A previous prompt baseline fix added an extra vertical offset to only the skill label, pushing it below the icon even though the outer chip alignment was correct. Removing that internal offset keeps the baseline behavior and centers the chip content.

## UI Changes

Before

![Skill chip before the fix](https://raw.githubusercontent.com/Gigioxx/t3code/pr-assets-composer-chip-dd4074b/before.png)

After

![Skill chip after the fix](https://raw.githubusercontent.com/Gigioxx/t3code/pr-assets-composer-chip-dd4074b/after.png)

## Verification

- Focused formatting and lint checks passed
- Composer prompt editor tests passed, 5 of 5
- Web typecheck passed
- Web production build passed
- React Doctor scored 92 out of 100 with one pre-existing manual memoization warning

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before and after screenshots for the UI change
- [x] Animation and interaction video is not applicable

Model and harness: GPT-5.6-Sol through Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic composer chip styling only; no logic, data, or API changes.
> 
> **Overview**
> **Composer skill chips** now use the shared `COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME` for their text instead of a skill-only label class that applied `relative top-[0.15em]`.
> 
> That extra vertical offset is removed from `composerInlineChip.ts`, so the skill name lines up with the icon the same way other inline chip labels do, relying on the chip’s flex alignment instead of a per-label nudge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4074b408ff56620855480c937e878519a650e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Center composer skill chip labels by removing skill-specific top offset
> Removes `COMPOSER_INLINE_SKILL_CHIP_LABEL_CLASS_NAME` from [composerInlineChip.ts](https://github.com/pingdotgg/t3code/pull/6043/files#diff-f147d6e9773ccf583558123809ae27ff81353b779a9c10add9bca4fdda2d9ff5), which applied a relative top offset to skill chip labels. [ComposerSkillDecorator](https://github.com/pingdotgg/t3code/pull/6043/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4) now uses the generic `COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME`, centering the label visually.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd4074b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->