### PR TITLE
fix(web): restore reverted messages to composer

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -18,9 +18,11 @@ import {
   buildThreadTurnInterruptInput,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
+  deriveRevertedMessageContent,
   deriveRevertedMessagePrompt,
   dismissBranchMismatchForSession,
   ENVIRONMENT_RECONNECT_WARNING_GRACE_MS,
+  fetchRevertedMessageAttachmentBlob,
   getStartedThreadModelChangeBlockReason,
   hasEnvironmentReconnectWarningGraceElapsed,
   hasServerAcknowledgedLocalDispatch,
@@ -63,6 +65,61 @@ describe("reverted message prompt", () => {
     ].join("\n");
 
     expect(deriveRevertedMessagePrompt(prompt)).toBe("Please fix this");
+  });
+
+  it("only excludes screenshots tied to parsed preview annotations", () => {
+    const prompt = [
+      "Please fix this",
+      "",
+      "<preview_annotation>",
+      "Preview annotation:",
+      "Id: preview-1",
+      "Page: Button",
+      "The attached screenshot is the annotated preview crop.",
+      "</preview_annotation>",
+    ].join("\n");
+
+    const content = deriveRevertedMessageContent(prompt);
+
+    expect(content.prompt).toBe("Please fix this");
+    expect([...content.previewAnnotationImageNames]).toEqual(["preview-annotation-preview-1.png"]);
+    expect(content.previewAnnotationImageNames.has("preview-annotation-design.png")).toBe(false);
+  });
+});
+
+describe("reverted message attachment fetch", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("aborts a stalled attachment request after the timeout", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("Expected an abort signal.");
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    });
+
+    const pendingFetch = fetchRevertedMessageAttachmentBlob(
+      "https://example.test/image.png",
+      1_000,
+    );
+    const rejection = expect(pendingFetch).rejects.toMatchObject({ name: "AbortError" });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejection;
+  });
+
+  it("clears the timeout after an attachment request completes", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+
+    await fetchRevertedMessageAttachmentBlob("https://example.test/image.png", 1_000);
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -18,6 +18,7 @@ import {
   buildThreadTurnInterruptInput,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
+  deriveRevertedMessagePrompt,
   dismissBranchMismatchForSession,
   ENVIRONMENT_RECONNECT_WARNING_GRACE_MS,
   getStartedThreadModelChangeBlockReason,
@@ -33,6 +34,37 @@ import {
   shouldShowBranchMismatchBanner,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
+
+describe("reverted message prompt", () => {
+  it("restores editable text without sent-only context blocks", () => {
+    const prompt = [
+      "Please fix this",
+      "",
+      "<terminal_context>",
+      "- Terminal 1:",
+      "  npm test",
+      "</terminal_context>",
+      "",
+      "<element_context>",
+      "- <button>:",
+      "  url: http://localhost:5173",
+      "</element_context>",
+      "",
+      "<preview_annotation>",
+      '{"id":"preview-1","title":"Button","x":1,"y":2}',
+      "</preview_annotation>",
+      "",
+      '<review_comment sectionId="file:a.ts" filePath="a.ts" startIndex="1" endIndex="1">',
+      "Check this line",
+      "```diff",
+      "+const value = 1;",
+      "```",
+      "</review_comment>",
+    ].join("\n");
+
+    expect(deriveRevertedMessagePrompt(prompt)).toBe("Please fix this");
+  });
+});
 
 const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -16,10 +16,13 @@ import * as Schema from "effect/Schema";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentThreadDetails } from "../state/threads";
 import {
+  deriveDisplayedUserMessageState,
   filterTerminalContextsWithText,
   stripInlineTerminalContextPlaceholders,
   type TerminalContextDraft,
 } from "../lib/terminalContext";
+import { extractTrailingPreviewAnnotation } from "../lib/previewAnnotation";
+import { parseReviewCommentMessageSegments } from "../reviewCommentContext";
 import type { DraftThreadEnvMode } from "../composerDraftStore";
 
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
@@ -28,6 +31,22 @@ export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 export const ENVIRONMENT_RECONNECT_WARNING_GRACE_MS = 2_000;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
+
+export function deriveRevertedMessagePrompt(prompt: string): string {
+  const withoutReviewComments = parseReviewCommentMessageSegments(prompt)
+    .filter((segment) => segment.kind === "text")
+    .map((segment) => segment.text)
+    .join("");
+
+  let withoutPreviewAnnotations = withoutReviewComments;
+  while (true) {
+    const extracted = extractTrailingPreviewAnnotation(withoutPreviewAnnotations);
+    if (!extracted.annotation) break;
+    withoutPreviewAnnotations = extracted.promptText;
+  }
+
+  return deriveDisplayedUserMessageState(withoutPreviewAnnotations).visibleText;
+}
 
 export function scheduleEnvironmentReconnectWarning(showWarning: () => void): () => void {
   const timeoutId = globalThis.setTimeout(showWarning, ENVIRONMENT_RECONNECT_WARNING_GRACE_MS);

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -29,23 +29,55 @@ export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by
 export const MAX_HIDDEN_MOUNTED_TERMINAL_THREADS = 10;
 export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 export const ENVIRONMENT_RECONNECT_WARNING_GRACE_MS = 2_000;
+export const REVERTED_MESSAGE_ATTACHMENT_TIMEOUT_MS = 10_000;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 
-export function deriveRevertedMessagePrompt(prompt: string): string {
+export function deriveRevertedMessageContent(prompt: string): {
+  prompt: string;
+  previewAnnotationImageNames: ReadonlySet<string>;
+} {
   const withoutReviewComments = parseReviewCommentMessageSegments(prompt)
     .filter((segment) => segment.kind === "text")
     .map((segment) => segment.text)
     .join("");
 
   let withoutPreviewAnnotations = withoutReviewComments;
+  const previewAnnotationImageNames = new Set<string>();
   while (true) {
     const extracted = extractTrailingPreviewAnnotation(withoutPreviewAnnotations);
     if (!extracted.annotation) break;
+    if (extracted.annotation.hasScreenshot) {
+      previewAnnotationImageNames.add(`preview-annotation-${extracted.annotation.id}.png`);
+    }
     withoutPreviewAnnotations = extracted.promptText;
   }
 
-  return deriveDisplayedUserMessageState(withoutPreviewAnnotations).visibleText;
+  return {
+    prompt: deriveDisplayedUserMessageState(withoutPreviewAnnotations).visibleText,
+    previewAnnotationImageNames,
+  };
+}
+
+export function deriveRevertedMessagePrompt(prompt: string): string {
+  return deriveRevertedMessageContent(prompt).prompt;
+}
+
+export async function fetchRevertedMessageAttachmentBlob(
+  previewUrl: string,
+  timeoutMs = REVERTED_MESSAGE_ATTACHMENT_TIMEOUT_MS,
+): Promise<Blob> {
+  const controller = new AbortController();
+  const timeoutId = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    // The timeline may have already cached this URL from an <img> request,
+    // which carries no Origin header and therefore no CORS response header.
+    const response = await fetch(previewUrl, { cache: "reload", signal: controller.signal });
+    if (!response.ok) throw new Error("Could not load reverted message attachment.");
+    return await response.blob();
+  } finally {
+    globalThis.clearTimeout(timeoutId);
+  }
 }
 
 export function scheduleEnvironmentReconnectWarning(showWarning: () => void): () => void {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -206,6 +206,7 @@ import {
 import {
   appendTerminalContextsToPrompt,
   formatTerminalContextLabel,
+  stripInlineTerminalContextPlaceholders,
   type TerminalContextDraft,
   type TerminalContextSelection,
 } from "../lib/terminalContext";
@@ -292,6 +293,7 @@ import {
   collectUserMessageBlobPreviewUrls,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
+  deriveRevertedMessagePrompt,
   dismissBranchMismatchForSession,
   hasEnvironmentReconnectWarningGraceElapsed,
   scheduleEnvironmentReconnectWarning,
@@ -462,6 +464,71 @@ type EnvironmentUnavailableState = {
   readonly label: string;
   readonly connection: EnvironmentConnectionPresentation;
 };
+
+interface PendingRevertedMessageRestore {
+  threadId: ThreadId;
+  messageId: MessageId;
+  turnCount: number;
+  knownFailureActivityIds: ReadonlySet<string>;
+  draft: RevertedMessageDraft;
+}
+
+interface RevertedMessageDraft {
+  prompt: string;
+  images: ComposerImageAttachment[];
+  unavailableImageNames: string[];
+}
+
+async function prepareRevertedMessageDraft(message: ChatMessage): Promise<RevertedMessageDraft> {
+  const prepared = await Promise.all(
+    (message.attachments ?? [])
+      .filter((attachment) => !attachment.name.startsWith("preview-annotation-"))
+      .map(async (attachment) => {
+        if (!attachment.previewUrl) {
+          return { image: null, unavailableImageName: attachment.name };
+        }
+        try {
+          // The timeline may have already cached this URL from an <img>
+          // request, which carries no Origin header and therefore no CORS
+          // response header. Reload it so the fetch gets its own CORS-aware
+          // response instead of reusing that incompatible cache entry.
+          const response = await fetch(attachment.previewUrl, { cache: "reload" });
+          if (!response.ok) throw new Error(`Could not load ${attachment.name}.`);
+          const blob = await response.blob();
+          const file = new File([blob], attachment.name, {
+            type: blob.type || attachment.mimeType,
+          });
+          return {
+            image: {
+              type: "image" as const,
+              id: attachment.id,
+              name: attachment.name,
+              mimeType: file.type || attachment.mimeType,
+              sizeBytes: file.size,
+              previewUrl: URL.createObjectURL(file),
+              file,
+            },
+            unavailableImageName: null,
+          };
+        } catch {
+          return { image: null, unavailableImageName: attachment.name };
+        }
+      }),
+  );
+  return {
+    prompt: deriveRevertedMessagePrompt(message.text),
+    images: prepared.flatMap((entry) => (entry.image ? [entry.image] : [])),
+    unavailableImageNames: prepared.flatMap((entry) =>
+      entry.unavailableImageName ? [entry.unavailableImageName] : [],
+    ),
+  };
+}
+
+function releaseRevertedMessageDraft(draft: RevertedMessageDraft): void {
+  for (const image of draft.images) {
+    if (image.previewUrl.startsWith("blob:")) URL.revokeObjectURL(image.previewUrl);
+  }
+}
 
 function eventPathContainsSelector(event: Event, selector: string): boolean {
   const path = event.composedPath();
@@ -1338,6 +1405,11 @@ function ChatViewContent(props: ChatViewProps) {
   >({});
   const [isConnecting, _setIsConnecting] = useState(false);
   const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
+  const [pendingRevertedMessageRestore, setPendingRevertedMessageRestore] =
+    useState<PendingRevertedMessageRestore | null>(null);
+  const pendingRevertedMessageRestoreRef = useRef(pendingRevertedMessageRestore);
+  pendingRevertedMessageRestoreRef.current = pendingRevertedMessageRestore;
+  const chatViewMountedRef = useRef(true);
   const [maximizedRightPanelThreadKey, setMaximizedRightPanelThreadKey] = useState<string | null>(
     null,
   );
@@ -2319,7 +2391,11 @@ function ChatViewContent(props: ChatViewProps) {
     setAttachmentPreviewHandoffByMessageId({});
   }, []);
   useEffect(() => {
+    chatViewMountedRef.current = true;
     return () => {
+      chatViewMountedRef.current = false;
+      const pendingRevert = pendingRevertedMessageRestoreRef.current;
+      if (pendingRevert) releaseRevertedMessageDraft(pendingRevert.draft);
       clearAttachmentPreviewHandoffs();
       for (const message of optimisticUserMessagesRef.current) {
         revokeUserMessagePreviewUrls(message);
@@ -3984,9 +4060,120 @@ function ChatViewContent(props: ChatViewProps) {
     // activeThreadRef resets transitively with the active thread.
   }, [activeThread?.id]);
 
+  const revertObservedThreadId = activeThread?.id ?? null;
+  const revertObservedActivities = activeThread?.activities ?? null;
+  const revertObservedMessages = activeThread?.messages ?? null;
   useEffect(() => {
-    setIsRevertingCheckpoint(false);
-  }, [activeThread?.id]);
+    const pending = pendingRevertedMessageRestore;
+    if (
+      !pending ||
+      revertObservedThreadId !== pending.threadId ||
+      !revertObservedActivities ||
+      !revertObservedMessages
+    ) {
+      return;
+    }
+
+    const failed = revertObservedActivities.some((activity) => {
+      if (
+        activity.kind !== "checkpoint.revert.failed" ||
+        pending.knownFailureActivityIds.has(activity.id) ||
+        typeof activity.payload !== "object" ||
+        activity.payload === null
+      ) {
+        return false;
+      }
+      return (activity.payload as { turnCount?: unknown }).turnCount === pending.turnCount;
+    });
+    if (failed) {
+      releaseRevertedMessageDraft(pending.draft);
+      pendingRevertedMessageRestoreRef.current = null;
+      setPendingRevertedMessageRestore(null);
+      return;
+    }
+
+    if (revertObservedMessages.some((message) => message.id === pending.messageId)) {
+      return;
+    }
+
+    pendingRevertedMessageRestoreRef.current = null;
+    setPendingRevertedMessageRestore(null);
+
+    if (
+      pending.draft.prompt.length === 0 &&
+      pending.draft.images.length === 0 &&
+      pending.draft.unavailableImageNames.length === 0
+    ) {
+      releaseRevertedMessageDraft(pending.draft);
+      toastManager.add({
+        type: "warning",
+        title: "Message context was not restored",
+        description:
+          "The reverted message only contained attached context, which cannot be safely reused after a rewind.",
+        data: { hideCopyButton: true },
+      });
+      return;
+    }
+
+    const writeRevertedMessageToComposer = () => {
+      const currentDraft = useComposerDraftStore.getState().getComposerDraft(composerDraftTarget);
+      const existingPrompt = currentDraft?.prompt.trimEnd() ?? "";
+      const existingText = stripInlineTerminalContextPlaceholders(existingPrompt).trim();
+      const nextPrompt =
+        existingPrompt.length > 0 && pending.draft.prompt.length > 0
+          ? `${existingPrompt}${existingText.length > 0 ? "\n\n" : ""}${pending.draft.prompt}`
+          : existingPrompt || pending.draft.prompt;
+      setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+      if (pending.draft.images.length > 0) {
+        addComposerDraftImages(composerDraftTarget, pending.draft.images);
+      }
+      composerRef.current?.resetCursorState({ cursor: nextPrompt.length, prompt: nextPrompt });
+      window.requestAnimationFrame(() => composerRef.current?.focusAtEnd());
+      if (pending.draft.unavailableImageNames.length > 0) {
+        toastManager.add({
+          type: "warning",
+          title: "Some images could not be restored",
+          description: pending.draft.unavailableImageNames.join(", "),
+        });
+      }
+    };
+
+    const currentDraft = useComposerDraftStore.getState().getComposerDraft(composerDraftTarget);
+    const hasDraftToStash = Boolean(
+      currentDraft &&
+      (stripInlineTerminalContextPlaceholders(currentDraft.prompt).trim().length > 0 ||
+        currentDraft.images.length > 0),
+    );
+    if (hasDraftToStash && composerRef.current?.stashCurrentPrompt() !== true) {
+      writeRevertedMessageToComposer();
+      toastManager.add({
+        type: "warning",
+        title: "Reverted message appended",
+        description:
+          "Your current draft could not be stashed, so the reverted message was added after it instead.",
+        data: { hideCopyButton: true },
+      });
+      return;
+    }
+
+    writeRevertedMessageToComposer();
+    if (hasDraftToStash) {
+      toastManager.add({
+        type: "info",
+        title: "Current draft stashed",
+        description: "The reverted message is ready to edit in the composer.",
+        data: { hideCopyButton: true },
+      });
+    }
+  }, [
+    addComposerDraftImages,
+    composerDraftTarget,
+    pendingRevertedMessageRestore,
+    revertObservedActivities,
+    revertObservedMessages,
+    revertObservedThreadId,
+    setComposerDraftPrompt,
+  ]);
 
   useEffect(() => {
     if (!activeThread?.id || terminalUiState.terminalOpen) return;
@@ -4794,9 +4981,12 @@ function ChatViewContent(props: ChatViewProps) {
   ]);
 
   const onRevertToTurnCount = useCallback(
-    async (turnCount: number) => {
+    async (turnCount: number, message: ChatMessage) => {
       const localApi = readLocalApi();
-      if (!localApi || !activeThread || isRevertingCheckpoint) return;
+      if (!localApi || !activeThread || isRevertingCheckpoint || pendingRevertedMessageRestore) {
+        return;
+      }
+      const threadId = activeThread.id;
 
       if (activeEnvironmentUnavailable && activeEnvironmentUnavailableLabel) {
         setThreadError(
@@ -4809,6 +4999,10 @@ function ChatViewContent(props: ChatViewProps) {
         setThreadError(activeThread.id, "Interrupt the current turn before reverting checkpoints.");
         return;
       }
+      // Start copying image blobs before opening the confirmation dialog. The
+      // optimistic preview handoff can be promoted to its server URL while the
+      // dialog is open, which revokes the blob URL captured by this callback.
+      const draftPromise = prepareRevertedMessageDraft(message);
       const confirmed = await localApi.dialogs.confirm(
         [
           `Revert this thread to checkpoint ${turnCount}?`,
@@ -4818,24 +5012,49 @@ function ChatViewContent(props: ChatViewProps) {
         { variant: "destructive" },
       );
       if (!confirmed) {
+        releaseRevertedMessageDraft(await draftPromise);
         return;
       }
 
       setIsRevertingCheckpoint(true);
-      setThreadError(activeThread.id, null);
+      setThreadError(threadId, null);
+      const draft = await draftPromise;
+      if (!chatViewMountedRef.current) {
+        releaseRevertedMessageDraft(draft);
+        return;
+      }
+      const pendingRestore: PendingRevertedMessageRestore = {
+        threadId,
+        messageId: message.id,
+        turnCount,
+        knownFailureActivityIds: new Set(
+          activeThread.activities
+            .filter((activity) => activity.kind === "checkpoint.revert.failed")
+            .map((activity) => activity.id),
+        ),
+        draft,
+      };
+      setPendingRevertedMessageRestore(pendingRestore);
       const result = await revertThreadCheckpoint({
         environmentId,
         input: {
-          threadId: activeThread.id,
+          threadId,
           turnCount,
         },
       });
-      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-        const error = squashAtomCommandFailure(result);
-        setThreadError(
-          activeThread.id,
-          error instanceof Error ? error.message : "Failed to revert thread state.",
-        );
+      if (result._tag === "Failure") {
+        setPendingRevertedMessageRestore((current) => {
+          if (current !== pendingRestore) return current;
+          releaseRevertedMessageDraft(current.draft);
+          return null;
+        });
+        if (!isAtomCommandInterrupted(result)) {
+          const error = squashAtomCommandFailure(result);
+          setThreadError(
+            threadId,
+            error instanceof Error ? error.message : "Failed to revert thread state.",
+          );
+        }
       }
       setIsRevertingCheckpoint(false);
     },
@@ -4847,6 +5066,7 @@ function ChatViewContent(props: ChatViewProps) {
       isConnecting,
       isRevertingCheckpoint,
       isSendBusy,
+      pendingRevertedMessageRestore,
       phase,
       revertThreadCheckpoint,
       setThreadError,
@@ -5961,14 +6181,17 @@ function ChatViewContent(props: ChatViewProps) {
   // the callback reference is fully stable and never busts context identity.
   const revertTurnCountRef = useRef(revertTurnCountByUserMessageId);
   revertTurnCountRef.current = revertTurnCountByUserMessageId;
+  const timelineMessagesRef = useRef(timelineMessages);
+  timelineMessagesRef.current = timelineMessages;
   const onRevertToTurnCountRef = useRef(onRevertToTurnCount);
   onRevertToTurnCountRef.current = onRevertToTurnCount;
   const onRevertUserMessage = useCallback((messageId: MessageId) => {
     const targetTurnCount = revertTurnCountRef.current.get(messageId);
-    if (typeof targetTurnCount !== "number") {
+    const message = timelineMessagesRef.current.find((entry) => entry.id === messageId);
+    if (typeof targetTurnCount !== "number" || !message || message.role !== "user") {
       return;
     }
-    void onRevertToTurnCountRef.current(targetTurnCount);
+    void onRevertToTurnCountRef.current(targetTurnCount, message);
   }, []);
 
   // Empty state: no active thread

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2352,6 +2352,7 @@ function ChatViewContent(props: ChatViewProps) {
     activePendingUserInput: activePendingUserInput?.requestId ?? null,
     threadError,
   });
+  const hasRevertingCheckpoint = revertingCheckpointThreadKeys.size > 0;
   const isRevertingCheckpoint = revertingCheckpointThreadKeys.has(routeThreadKey);
   const isRestoringRevertedMessage =
     pendingRevertedMessageRestore !== null &&
@@ -4082,6 +4083,7 @@ function ChatViewContent(props: ChatViewProps) {
     const pending = pendingRevertedMessageRestore;
     if (
       !pending ||
+      threadDetailLoading ||
       revertObservedThreadId !== pending.threadRef.threadId ||
       !revertObservedActivities ||
       !revertObservedMessages
@@ -4259,6 +4261,7 @@ function ChatViewContent(props: ChatViewProps) {
     setComposerDraftPrompt,
     setComposerDraftReviewComments,
     setComposerDraftTerminalContexts,
+    threadDetailLoading,
   ]);
 
   useEffect(() => {
@@ -5069,7 +5072,7 @@ function ChatViewContent(props: ChatViewProps) {
   const onRevertToTurnCount = useCallback(
     async (turnCount: number, message: ChatMessage) => {
       const localApi = readLocalApi();
-      if (!localApi || !activeThread || isRevertingCheckpoint || pendingRevertedMessageRestore) {
+      if (!localApi || !activeThread || hasRevertingCheckpoint || pendingRevertedMessageRestore) {
         return;
       }
       const threadId = activeThread.id;
@@ -5169,7 +5172,7 @@ function ChatViewContent(props: ChatViewProps) {
       activeEnvironmentUnavailableLabel,
       environmentId,
       isConnecting,
-      isRevertingCheckpoint,
+      hasRevertingCheckpoint,
       isSendBusy,
       pendingRevertedMessageRestore,
       phase,
@@ -6542,7 +6545,7 @@ function ChatViewContent(props: ChatViewProps) {
                 onOpenTurnDiff={onOpenTurnDiff}
                 revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
                 onRevertUserMessage={onRevertUserMessage}
-                isRevertingCheckpoint={isRevertingCheckpoint}
+                isRevertingCheckpoint={hasRevertingCheckpoint}
                 onImageExpand={onExpandTimelineImage}
                 markdownCwd={gitCwd ?? undefined}
                 resolvedTheme={resolvedTheme}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -19,6 +19,7 @@ import {
   OrchestrationThreadActivity,
   ProviderInteractionMode,
   ProviderDriverKind,
+  PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   RuntimeMode,
   TerminalOpenInput,
 } from "@t3tools/contracts";
@@ -4138,16 +4139,54 @@ function ChatViewContent(props: ChatViewProps) {
           ? `${existingPrompt}${existingText.length > 0 ? "\n\n" : ""}${pending.draft.prompt}`
           : existingPrompt || pending.draft.prompt;
       setComposerDraftPrompt(composerDraftTarget, nextPrompt);
-      if (pending.draft.images.length > 0) {
-        addComposerDraftImages(composerDraftTarget, pending.draft.images);
+      const existingImages = currentDraft?.images ?? [];
+      const existingIds = new Set(existingImages.map((image) => image.id));
+      const existingDedupKeys = new Set(
+        existingImages.map((image) => `${image.mimeType}\0${image.sizeBytes}\0${image.name}`),
+      );
+      const imagesToAdd: ComposerImageAttachment[] = [];
+      const skippedImages: ComposerImageAttachment[] = [];
+      const overflowImageNames: string[] = [];
+      const capacity = Math.max(0, PROVIDER_SEND_TURN_MAX_ATTACHMENTS - existingImages.length);
+      for (const image of pending.draft.images) {
+        const dedupKey = `${image.mimeType}\0${image.sizeBytes}\0${image.name}`;
+        if (existingIds.has(image.id) || existingDedupKeys.has(dedupKey)) {
+          skippedImages.push(image);
+          continue;
+        }
+        existingIds.add(image.id);
+        existingDedupKeys.add(dedupKey);
+        if (imagesToAdd.length < capacity) {
+          imagesToAdd.push(image);
+        } else {
+          skippedImages.push(image);
+          overflowImageNames.push(image.name);
+        }
+      }
+      if (imagesToAdd.length > 0) {
+        addComposerDraftImages(composerDraftTarget, imagesToAdd);
+      }
+      for (const image of skippedImages) {
+        if (image.previewUrl.startsWith("blob:")) URL.revokeObjectURL(image.previewUrl);
       }
       composerRef.current?.resetCursorState({ cursor: nextPrompt.length, prompt: nextPrompt });
       window.requestAnimationFrame(() => composerRef.current?.focusAtEnd());
+      const missingImageReasons: string[] = [];
       if (pending.draft.unavailableImageNames.length > 0) {
+        missingImageReasons.push(
+          `${pending.draft.unavailableImageNames.join(", ")} could not be loaded.`,
+        );
+      }
+      if (overflowImageNames.length > 0) {
+        missingImageReasons.push(
+          `${overflowImageNames.join(", ")} could not be restored: the composer is at its ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS}-image limit.`,
+        );
+      }
+      if (missingImageReasons.length > 0) {
         toastManager.add({
           type: "warning",
           title: "Some images could not be restored",
-          description: pending.draft.unavailableImageNames.join(", "),
+          description: missingImageReasons.join(" "),
         });
       }
     };
@@ -5071,14 +5110,14 @@ function ChatViewContent(props: ChatViewProps) {
         return next;
       });
       setThreadError(threadId, null);
-      const resultPromise = revertThreadCheckpoint({
+      const draft = await draftPromise;
+      const result = await revertThreadCheckpoint({
         environmentId,
         input: {
           threadId,
           turnCount,
         },
       });
-      const [draft, result] = await Promise.all([draftPromise, resultPromise]);
       const finishRevert = () => {
         setRevertingCheckpointThreadKeys((current) => {
           const next = new Set(current);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1402,7 +1402,9 @@ function ChatViewContent(props: ChatViewProps) {
     Record<string, LocalThreadErrorEntry>
   >({});
   const [isConnecting, _setIsConnecting] = useState(false);
-  const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
+  const [revertingCheckpointThreadKeys, setRevertingCheckpointThreadKeys] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const [pendingRevertedMessageRestore, setPendingRevertedMessageRestore] =
     useState<PendingRevertedMessageRestore | null>(null);
   const pendingRevertedMessageRestoreRef = useRef(pendingRevertedMessageRestore);
@@ -2349,7 +2351,12 @@ function ChatViewContent(props: ChatViewProps) {
     activePendingUserInput: activePendingUserInput?.requestId ?? null,
     threadError,
   });
-  const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const isRevertingCheckpoint = revertingCheckpointThreadKeys.has(routeThreadKey);
+  const isRestoringRevertedMessage =
+    pendingRevertedMessageRestore !== null &&
+    scopedThreadKey(pendingRevertedMessageRestore.threadRef) === routeThreadKey;
+  const isRevertComposerBusy = isRevertingCheckpoint || isRestoringRevertedMessage;
+  const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertComposerBusy;
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
     activeThread?.session ?? null,
@@ -4151,20 +4158,48 @@ function ChatViewContent(props: ChatViewProps) {
       (stripInlineTerminalContextPlaceholders(currentDraft.prompt).trim().length > 0 ||
         currentDraft.images.length > 0),
     );
+    const hasDraftContextToClear = Boolean(
+      currentDraft &&
+      (currentDraft.terminalContexts.length > 0 ||
+        currentDraft.elementContexts.length > 0 ||
+        currentDraft.previewAnnotations.length > 0 ||
+        currentDraft.reviewComments.length > 0),
+    );
+    const clearDraftContexts = () => {
+      setComposerDraftTerminalContexts(composerDraftTarget, []);
+      setComposerDraftElementContexts(composerDraftTarget, []);
+      setComposerDraftPreviewAnnotations(composerDraftTarget, []);
+      setComposerDraftReviewComments(composerDraftTarget, []);
+    };
     if (hasDraftToStash && composerRef.current?.stashCurrentPrompt() !== true) {
+      if (hasDraftContextToClear) clearDraftContexts();
       writeRevertedMessageToComposer();
       toastManager.add({
         type: "warning",
         title: "Reverted message appended",
-        description:
-          "Your current draft could not be stashed, so the reverted message was added after it instead.",
+        description: hasDraftContextToClear
+          ? "Your current draft could not be stashed, so the reverted message was appended and attached context was cleared."
+          : "Your current draft could not be stashed, so the reverted message was added after it instead.",
         data: { hideCopyButton: true },
       });
       return;
     }
 
+    // Context attachments are session-bound and cannot be round-tripped by
+    // the stash. Clear them before replacing the composer so they cannot be
+    // sent accidentally with the reverted prompt.
+    clearComposerDraftContent(composerDraftTarget);
     writeRevertedMessageToComposer();
-    if (hasDraftToStash) {
+    if (hasDraftContextToClear) {
+      toastManager.add({
+        type: "warning",
+        title: hasDraftToStash ? "Draft stashed without attached context" : "Draft context cleared",
+        description: hasDraftToStash
+          ? "Your draft text and images were stashed. Its attached context cannot be reused after a rewind."
+          : "Attached context cannot be safely reused after a rewind.",
+        data: { hideCopyButton: true },
+      });
+    } else if (hasDraftToStash) {
       toastManager.add({
         type: "info",
         title: "Current draft stashed",
@@ -4174,12 +4209,17 @@ function ChatViewContent(props: ChatViewProps) {
     }
   }, [
     addComposerDraftImages,
+    clearComposerDraftContent,
     composerDraftTarget,
     pendingRevertedMessageRestore,
     revertObservedActivities,
     revertObservedMessages,
     revertObservedThreadId,
+    setComposerDraftElementContexts,
+    setComposerDraftPreviewAnnotations,
     setComposerDraftPrompt,
+    setComposerDraftReviewComments,
+    setComposerDraftTerminalContexts,
   ]);
 
   useEffect(() => {
@@ -5025,7 +5065,11 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
 
-      setIsRevertingCheckpoint(true);
+      setRevertingCheckpointThreadKeys((current) => {
+        const next = new Set(current);
+        next.add(sourceThreadKey);
+        return next;
+      });
       setThreadError(threadId, null);
       const draft = await draftPromise;
       if (!chatViewMountedRef.current) {
@@ -5034,7 +5078,11 @@ function ChatViewContent(props: ChatViewProps) {
       }
       if (routeThreadKeyRef.current !== sourceThreadKey) {
         releaseRevertedMessageDraft(draft);
-        setIsRevertingCheckpoint(false);
+        setRevertingCheckpointThreadKeys((current) => {
+          const next = new Set(current);
+          next.delete(sourceThreadKey);
+          return next;
+        });
         return;
       }
       const pendingRestore: PendingRevertedMessageRestore = {
@@ -5072,7 +5120,11 @@ function ChatViewContent(props: ChatViewProps) {
           );
         }
       }
-      setIsRevertingCheckpoint(false);
+      setRevertingCheckpointThreadKeys((current) => {
+        const next = new Set(current);
+        next.delete(sourceThreadKey);
+        return next;
+      });
     },
     [
       activeThread,
@@ -5111,6 +5163,7 @@ function ChatViewContent(props: ChatViewProps) {
       !activeThread ||
       isSendBusy ||
       isConnecting ||
+      isRevertComposerBusy ||
       threadDetailLoading ||
       sendInFlightRef.current
     ) {
@@ -6562,7 +6615,7 @@ function ChatViewContent(props: ChatViewProps) {
                             projectSelectionRequired={isLocalDraftThread && activeProject === null}
                             phase={phase}
                             isConnecting={isConnecting}
-                            isSendBusy={isSendBusy}
+                            isSendBusy={isSendBusy || isRevertComposerBusy}
                             sendDisabledReason={threadDetailLoading ? "Messages loading" : null}
                             isPreparingWorktree={isPreparingWorktree}
                             environmentUnavailable={activeEnvironmentUnavailableState}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -293,8 +293,9 @@ import {
   collectUserMessageBlobPreviewUrls,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
-  deriveRevertedMessagePrompt,
+  deriveRevertedMessageContent,
   dismissBranchMismatchForSession,
+  fetchRevertedMessageAttachmentBlob,
   hasEnvironmentReconnectWarningGraceElapsed,
   scheduleEnvironmentReconnectWarning,
   hasServerAcknowledgedLocalDispatch,
@@ -466,7 +467,7 @@ type EnvironmentUnavailableState = {
 };
 
 interface PendingRevertedMessageRestore {
-  threadId: ThreadId;
+  threadRef: ScopedThreadRef;
   messageId: MessageId;
   turnCount: number;
   knownFailureActivityIds: ReadonlySet<string>;
@@ -480,21 +481,16 @@ interface RevertedMessageDraft {
 }
 
 async function prepareRevertedMessageDraft(message: ChatMessage): Promise<RevertedMessageDraft> {
+  const content = deriveRevertedMessageContent(message.text);
   const prepared = await Promise.all(
     (message.attachments ?? [])
-      .filter((attachment) => !attachment.name.startsWith("preview-annotation-"))
+      .filter((attachment) => !content.previewAnnotationImageNames.has(attachment.name))
       .map(async (attachment) => {
         if (!attachment.previewUrl) {
           return { image: null, unavailableImageName: attachment.name };
         }
         try {
-          // The timeline may have already cached this URL from an <img>
-          // request, which carries no Origin header and therefore no CORS
-          // response header. Reload it so the fetch gets its own CORS-aware
-          // response instead of reusing that incompatible cache entry.
-          const response = await fetch(attachment.previewUrl, { cache: "reload" });
-          if (!response.ok) throw new Error(`Could not load ${attachment.name}.`);
-          const blob = await response.blob();
+          const blob = await fetchRevertedMessageAttachmentBlob(attachment.previewUrl);
           const file = new File([blob], attachment.name, {
             type: blob.type || attachment.mimeType,
           });
@@ -516,7 +512,7 @@ async function prepareRevertedMessageDraft(message: ChatMessage): Promise<Revert
       }),
   );
   return {
-    prompt: deriveRevertedMessagePrompt(message.text),
+    prompt: content.prompt,
     images: prepared.flatMap((entry) => (entry.image ? [entry.image] : [])),
     unavailableImageNames: prepared.flatMap((entry) =>
       entry.unavailableImageName ? [entry.unavailableImageName] : [],
@@ -1261,6 +1257,8 @@ function ChatViewContent(props: ChatViewProps) {
     [environmentId, threadId],
   );
   const routeThreadKey = useMemo(() => scopedThreadKey(routeThreadRef), [routeThreadRef]);
+  const routeThreadKeyRef = useRef(routeThreadKey);
+  routeThreadKeyRef.current = routeThreadKey;
   const updateProject = useAtomCommand(projectEnvironment.update, { reportFailure: false });
   const upsertKeybinding = useAtomCommand(serverEnvironment.upsertKeybinding, {
     reportFailure: false,
@@ -2402,6 +2400,15 @@ function ChatViewContent(props: ChatViewProps) {
       }
     };
   }, [clearAttachmentPreviewHandoffs]);
+  useEffect(() => {
+    const pendingRevert = pendingRevertedMessageRestoreRef.current;
+    if (!pendingRevert || scopedThreadKey(pendingRevert.threadRef) === routeThreadKey) {
+      return;
+    }
+    releaseRevertedMessageDraft(pendingRevert.draft);
+    pendingRevertedMessageRestoreRef.current = null;
+    setPendingRevertedMessageRestore(null);
+  }, [routeThreadKey]);
   const handoffAttachmentPreviews = useCallback((messageId: MessageId, previewUrls: string[]) => {
     if (previewUrls.length === 0) return;
 
@@ -4067,7 +4074,7 @@ function ChatViewContent(props: ChatViewProps) {
     const pending = pendingRevertedMessageRestore;
     if (
       !pending ||
-      revertObservedThreadId !== pending.threadId ||
+      revertObservedThreadId !== pending.threadRef.threadId ||
       !revertObservedActivities ||
       !revertObservedMessages
     ) {
@@ -4987,6 +4994,8 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
       const threadId = activeThread.id;
+      const sourceThreadRef = scopeThreadRef(environmentId, threadId);
+      const sourceThreadKey = scopedThreadKey(sourceThreadRef);
 
       if (activeEnvironmentUnavailable && activeEnvironmentUnavailableLabel) {
         setThreadError(
@@ -5023,8 +5032,13 @@ function ChatViewContent(props: ChatViewProps) {
         releaseRevertedMessageDraft(draft);
         return;
       }
+      if (routeThreadKeyRef.current !== sourceThreadKey) {
+        releaseRevertedMessageDraft(draft);
+        setIsRevertingCheckpoint(false);
+        return;
+      }
       const pendingRestore: PendingRevertedMessageRestore = {
-        threadId,
+        threadRef: sourceThreadRef,
         messageId: message.id,
         turnCount,
         knownFailureActivityIds: new Set(
@@ -5034,6 +5048,7 @@ function ChatViewContent(props: ChatViewProps) {
         ),
         draft,
       };
+      pendingRevertedMessageRestoreRef.current = pendingRestore;
       setPendingRevertedMessageRestore(pendingRestore);
       const result = await revertThreadCheckpoint({
         environmentId,
@@ -5046,6 +5061,7 @@ function ChatViewContent(props: ChatViewProps) {
         setPendingRevertedMessageRestore((current) => {
           if (current !== pendingRestore) return current;
           releaseRevertedMessageDraft(current.draft);
+          pendingRevertedMessageRestoreRef.current = null;
           return null;
         });
         if (!isAtomCommandInterrupted(result)) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5071,18 +5071,42 @@ function ChatViewContent(props: ChatViewProps) {
         return next;
       });
       setThreadError(threadId, null);
-      const draft = await draftPromise;
+      const resultPromise = revertThreadCheckpoint({
+        environmentId,
+        input: {
+          threadId,
+          turnCount,
+        },
+      });
+      const [draft, result] = await Promise.all([draftPromise, resultPromise]);
+      const finishRevert = () => {
+        setRevertingCheckpointThreadKeys((current) => {
+          const next = new Set(current);
+          next.delete(sourceThreadKey);
+          return next;
+        });
+      };
+      if (result._tag === "Failure") {
+        releaseRevertedMessageDraft(draft);
+        if (chatViewMountedRef.current) {
+          finishRevert();
+          if (!isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            setThreadError(
+              threadId,
+              error instanceof Error ? error.message : "Failed to revert thread state.",
+            );
+          }
+        }
+        return;
+      }
       if (!chatViewMountedRef.current) {
         releaseRevertedMessageDraft(draft);
         return;
       }
       if (routeThreadKeyRef.current !== sourceThreadKey) {
         releaseRevertedMessageDraft(draft);
-        setRevertingCheckpointThreadKeys((current) => {
-          const next = new Set(current);
-          next.delete(sourceThreadKey);
-          return next;
-        });
+        finishRevert();
         return;
       }
       const pendingRestore: PendingRevertedMessageRestore = {
@@ -5098,33 +5122,7 @@ function ChatViewContent(props: ChatViewProps) {
       };
       pendingRevertedMessageRestoreRef.current = pendingRestore;
       setPendingRevertedMessageRestore(pendingRestore);
-      const result = await revertThreadCheckpoint({
-        environmentId,
-        input: {
-          threadId,
-          turnCount,
-        },
-      });
-      if (result._tag === "Failure") {
-        setPendingRevertedMessageRestore((current) => {
-          if (current !== pendingRestore) return current;
-          releaseRevertedMessageDraft(current.draft);
-          pendingRevertedMessageRestoreRef.current = null;
-          return null;
-        });
-        if (!isAtomCommandInterrupted(result)) {
-          const error = squashAtomCommandFailure(result);
-          setThreadError(
-            threadId,
-            error instanceof Error ? error.message : "Failed to revert thread state.",
-          );
-        }
-      }
-      setRevertingCheckpointThreadKeys((current) => {
-        const next = new Set(current);
-        next.delete(sourceThreadKey);
-        return next;
-      });
+      finishRevert();
     },
     [
       activeThread,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4134,11 +4134,12 @@ function ChatViewContent(props: ChatViewProps) {
 
     const writeRevertedMessageToComposer = () => {
       const currentDraft = useComposerDraftStore.getState().getComposerDraft(composerDraftTarget);
-      const existingPrompt = currentDraft?.prompt.trimEnd() ?? "";
-      const existingText = stripInlineTerminalContextPlaceholders(existingPrompt).trim();
+      const existingPrompt = stripInlineTerminalContextPlaceholders(
+        currentDraft?.prompt ?? "",
+      ).trimEnd();
       const nextPrompt =
         existingPrompt.length > 0 && pending.draft.prompt.length > 0
-          ? `${existingPrompt}${existingText.length > 0 ? "\n\n" : ""}${pending.draft.prompt}`
+          ? `${existingPrompt}\n\n${pending.draft.prompt}`
           : existingPrompt || pending.draft.prompt;
       setComposerDraftPrompt(composerDraftTarget, nextPrompt);
       const existingImages = currentDraft?.images ?? [];

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -460,6 +460,8 @@ export interface ChatComposerHandle {
     expandedCursor: number;
     terminalContextIds: string[];
   };
+  /** Stash the current text and images, returning whether the initial write succeeded. */
+  stashCurrentPrompt: () => boolean;
   /** Reset composer cursor/trigger/highlight after external prompt mutations (e.g. onSend). */
   resetCursorState: (options?: {
     cursor?: number;
@@ -980,6 +982,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
    * thread) can still be stashed while an earlier encode is running.
    */
   const stashInFlightRef = useRef<Set<string>>(new Set());
+  const stashInitialWriteSucceededRef = useRef(false);
   /**
    * Count of pasted images still being compressed, per thread. Reserved
    * against the attachment limit so concurrent pastes can't overshoot it,
@@ -2065,6 +2068,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   );
 
   const stashCurrentPrompt = useCallback(async () => {
+    stashInitialWriteSucceededRef.current = false;
     // Terminal-context placeholders reference live sessions the stash can't
     // round-trip, so they are stripped from the stashed prompt.
     const prompt = promptRef.current.split(INLINE_TERMINAL_CONTEXT_PLACEHOLDER).join("").trim();
@@ -2137,6 +2141,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       setComposerCursor(0);
       setComposerTrigger(null);
       pulseStashBadge();
+      stashInitialWriteSucceededRef.current = true;
 
       if (evicted) {
         toastManager.add({
@@ -2548,6 +2553,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       readSnapshot: () => {
         return readComposerSnapshot();
       },
+      stashCurrentPrompt: () => {
+        void stashCurrentPrompt();
+        return stashInitialWriteSucceededRef.current;
+      },
       resetCursorState: (options?: {
         cursor?: number;
         prompt?: string;
@@ -2643,6 +2652,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       selectedPromptEffort,
       selectedProvider,
       selectedProviderModels,
+      stashCurrentPrompt,
     ],
   );
 

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -927,7 +927,7 @@ describe("applyThreadDetailEvent", () => {
           checkpointRef: CheckpointRef.make(`ref-${turnCount}`),
           status: "ready",
           files: [],
-          assistantMessageId: null,
+          assistantMessageId: MessageId.make(`assistant-${turnCount}`),
           completedAt: `2026-04-01T00:01:0${index}.000Z`,
         })),
       };
@@ -952,6 +952,76 @@ describe("applyThreadDetailEvent", () => {
           "assistant-90",
           "user-91",
           "assistant-91",
+        ]);
+      }
+    });
+
+    it("retains every message before the latest retained checkpoint", () => {
+      const message = (
+        id: string,
+        role: "user" | "assistant",
+        createdAt: string,
+      ): OrchestrationThread["messages"][number] => ({
+        id: MessageId.make(id),
+        role,
+        text: id,
+        turnId: null,
+        streaming: false,
+        createdAt,
+        updatedAt: createdAt,
+      });
+      const threadWithSteering: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          message("user-1", "user", "2026-04-01T01:00:00.000Z"),
+          message("assistant-commentary-1", "assistant", "2026-04-01T01:01:00.000Z"),
+          message("user-steering-1", "user", "2026-04-01T01:02:00.000Z"),
+          message("assistant-final-1", "assistant", "2026-04-01T01:03:00.000Z"),
+          message("user-2", "user", "2026-04-01T02:00:00.000Z"),
+          message("assistant-final-2", "assistant", "2026-04-01T02:01:00.000Z"),
+        ],
+        checkpoints: [
+          {
+            turnId: TurnId.make("turn-1"),
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("ref-1"),
+            status: "ready",
+            files: [],
+            assistantMessageId: null,
+            completedAt: "2026-04-01T01:04:00.000Z",
+          },
+          {
+            turnId: TurnId.make("turn-2"),
+            checkpointTurnCount: 2,
+            checkpointRef: CheckpointRef.make("ref-2"),
+            status: "ready",
+            files: [],
+            assistantMessageId: null,
+            completedAt: "2026-04-01T02:02:00.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(threadWithSteering, {
+        ...baseEventFields,
+        sequence: 16,
+        occurredAt: "2026-04-01T03:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 1,
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((entry) => entry.id)).toEqual([
+          "user-1",
+          "assistant-commentary-1",
+          "user-steering-1",
+          "assistant-final-1",
         ]);
       }
     });

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -890,6 +890,71 @@ describe("applyThreadDetailEvent", () => {
         expect(result.thread.latestTurn?.turnId).toBe("turn-1");
       }
     });
+
+    it("uses retained turns from the loaded pagination window", () => {
+      const loadedTurns = [90, 91, 92].map((turnCount) => ({
+        turnCount,
+        turnId: TurnId.make(`turn-${turnCount}`),
+      }));
+      const messages: OrchestrationThread["messages"] = loadedTurns.flatMap(
+        ({ turnCount }, index) => [
+          {
+            id: MessageId.make(`user-${turnCount}`),
+            role: "user" as const,
+            text: `Prompt ${turnCount}`,
+            turnId: null,
+            streaming: false,
+            createdAt: `2026-04-01T00:00:0${index * 2}.000Z`,
+            updatedAt: `2026-04-01T00:00:0${index * 2}.000Z`,
+          },
+          {
+            id: MessageId.make(`assistant-${turnCount}`),
+            role: "assistant" as const,
+            text: `Response ${turnCount}`,
+            turnId: null,
+            streaming: false,
+            createdAt: `2026-04-01T00:00:0${index * 2 + 1}.000Z`,
+            updatedAt: `2026-04-01T00:00:0${index * 2 + 1}.000Z`,
+          },
+        ],
+      );
+      const threadWithWindow: OrchestrationThread = {
+        ...baseThread,
+        messages,
+        checkpoints: loadedTurns.map(({ turnCount, turnId }, index) => ({
+          turnId,
+          checkpointTurnCount: turnCount,
+          checkpointRef: CheckpointRef.make(`ref-${turnCount}`),
+          status: "ready",
+          files: [],
+          assistantMessageId: null,
+          completedAt: `2026-04-01T00:01:0${index}.000Z`,
+        })),
+      };
+
+      const result = applyThreadDetailEvent(threadWithWindow, {
+        ...baseEventFields,
+        sequence: 15,
+        occurredAt: "2026-04-01T04:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 91,
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((message) => message.id)).toEqual([
+          "user-90",
+          "assistant-90",
+          "user-91",
+          "assistant-91",
+        ]);
+      }
+    });
   });
 
   describe("no-op events", () => {

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -827,6 +827,15 @@ describe("applyThreadDetailEvent", () => {
           },
           {
             id: MessageId.make("msg-3"),
+            role: "user",
+            text: "Second",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T02:30:00.000Z",
+            updatedAt: "2026-04-01T02:30:00.000Z",
+          },
+          {
+            id: MessageId.make("msg-4"),
             role: "assistant",
             text: "Response 2",
             turnId: TurnId.make("turn-2"),
@@ -851,7 +860,7 @@ describe("applyThreadDetailEvent", () => {
             checkpointRef: CheckpointRef.make("ref-2"),
             status: "ready",
             files: [],
-            assistantMessageId: MessageId.make("msg-3"),
+            assistantMessageId: MessageId.make("msg-4"),
             completedAt: "2026-04-01T03:00:00.000Z",
           },
         ],
@@ -875,8 +884,9 @@ describe("applyThreadDetailEvent", () => {
         // turn-2 checkpoint is filtered out (turnCount 2 > revert target 1)
         expect(result.thread.checkpoints).toHaveLength(1);
         expect(result.thread.checkpoints[0]?.turnId).toBe("turn-1");
-        // msg-3 (turn-2) is filtered, msg-1 (no turn) and msg-2 (turn-1) remain
+        // The second turnless user prompt and its turn-2 response are filtered.
         expect(result.thread.messages).toHaveLength(2);
+        expect(result.thread.messages.map((message) => message.id)).toEqual(["msg-1", "msg-2"]);
         expect(result.thread.latestTurn?.turnId).toBe("turn-1");
       }
     });

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -522,7 +522,11 @@ export function applyThreadDetailEvent(
       );
 
       const retainedTurnIds = new Set(Arr.map(checkpoints, (entry) => entry.turnId));
-      const messages = retainMessagesAfterRevert(thread.messages, retainedTurnIds);
+      const messages = retainMessagesAfterRevert(
+        thread.messages,
+        retainedTurnIds,
+        event.payload.turnCount,
+      );
       const proposedPlans = pipe(
         thread.proposedPlans,
         Arr.filter((plan) => plan.turnId === null || retainedTurnIds.has(plan.turnId)),
@@ -654,16 +658,66 @@ function rebindCheckpointAssistantMessage(
 function retainMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   retainedTurnIds: ReadonlySet<string>,
+  turnCount: number,
 ): OrchestrationMessage[] {
-  // Keep messages that belong to a retained turn, plus system messages and
-  // messages without a turn binding (pre-turn-0 user messages).
-  return Arr.filter(messages, (message) => {
+  const retainedMessageIds = new Set<string>();
+  for (const message of messages) {
     if (message.role === "system") {
-      return true;
+      retainedMessageIds.add(message.id);
+      continue;
     }
-    if (message.turnId === null) {
-      return true;
+    if (message.turnId !== null && retainedTurnIds.has(message.turnId)) {
+      retainedMessageIds.add(message.id);
     }
-    return retainedTurnIds.has(message.turnId);
-  });
+  }
+
+  // User messages are emitted before the provider assigns a turn id, so they
+  // remain turnless in the live client. Retain only the earliest messages
+  // needed to represent the surviving turns instead of treating every
+  // turnless prompt as pre-conversation state.
+  const retainedUserCount = messages.filter(
+    (message) => message.role === "user" && retainedMessageIds.has(message.id),
+  ).length;
+  const missingUserCount = Math.max(0, turnCount - retainedUserCount);
+  if (missingUserCount > 0) {
+    const fallbackUserMessages = messages
+      .filter(
+        (message) =>
+          message.role === "user" &&
+          !retainedMessageIds.has(message.id) &&
+          (message.turnId === null || retainedTurnIds.has(message.turnId)),
+      )
+      .toSorted(
+        (left, right) =>
+          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+      )
+      .slice(0, missingUserCount);
+    for (const message of fallbackUserMessages) {
+      retainedMessageIds.add(message.id);
+    }
+  }
+
+  const retainedAssistantCount = messages.filter(
+    (message) => message.role === "assistant" && retainedMessageIds.has(message.id),
+  ).length;
+  const missingAssistantCount = Math.max(0, turnCount - retainedAssistantCount);
+  if (missingAssistantCount > 0) {
+    const fallbackAssistantMessages = messages
+      .filter(
+        (message) =>
+          message.role === "assistant" &&
+          !retainedMessageIds.has(message.id) &&
+          (message.turnId === null || retainedTurnIds.has(message.turnId)),
+      )
+      .toSorted(
+        (left, right) =>
+          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+      )
+      .slice(0, missingAssistantCount);
+    for (const message of fallbackAssistantMessages) {
+      retainedMessageIds.add(message.id);
+    }
+  }
+
+  return messages.filter((message) => retainedMessageIds.has(message.id));
 }

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -522,7 +522,12 @@ export function applyThreadDetailEvent(
       );
 
       const retainedTurnIds = new Set(Arr.map(checkpoints, (entry) => entry.turnId));
-      const messages = retainMessagesAfterRevert(thread.messages, retainedTurnIds);
+      const latestCheckpoint = checkpoints.at(-1) ?? null;
+      const messages = retainMessagesAfterRevert(
+        thread.messages,
+        retainedTurnIds,
+        latestCheckpoint,
+      );
       const proposedPlans = pipe(
         thread.proposedPlans,
         Arr.filter((plan) => plan.turnId === null || retainedTurnIds.has(plan.turnId)),
@@ -531,8 +536,6 @@ export function applyThreadDetailEvent(
         thread.activities,
         Arr.filter((activity) => activity.turnId === null || retainedTurnIds.has(activity.turnId)),
       );
-      const latestCheckpoint = checkpoints.at(-1) ?? null;
-
       return {
         kind: "updated",
         thread: {
@@ -654,65 +657,18 @@ function rebindCheckpointAssistantMessage(
 function retainMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   retainedTurnIds: ReadonlySet<string>,
+  latestCheckpoint: OrchestrationCheckpointSummary | null,
 ): OrchestrationMessage[] {
-  const retainedMessageIds = new Set<string>();
-  for (const message of messages) {
-    if (message.role === "system") {
-      retainedMessageIds.add(message.id);
-      continue;
-    }
-    if (message.turnId !== null && retainedTurnIds.has(message.turnId)) {
-      retainedMessageIds.add(message.id);
-    }
-  }
+  const checkpointMessageId = latestCheckpoint?.assistantMessageId ?? null;
+  const checkpointMessageIndex =
+    checkpointMessageId === null
+      ? -1
+      : messages.findIndex((message) => message.id === checkpointMessageId);
 
-  // User messages are emitted before the provider assigns a turn id, so they
-  // remain turnless in the live client. Retain only the earliest messages
-  // needed to represent the surviving turns instead of treating every
-  // turnless prompt as pre-conversation state.
-  const retainedUserCount = messages.filter(
-    (message) => message.role === "user" && retainedMessageIds.has(message.id),
-  ).length;
-  const missingUserCount = Math.max(0, retainedTurnIds.size - retainedUserCount);
-  if (missingUserCount > 0) {
-    const fallbackUserMessages = messages
-      .filter(
-        (message) =>
-          message.role === "user" &&
-          !retainedMessageIds.has(message.id) &&
-          (message.turnId === null || retainedTurnIds.has(message.turnId)),
-      )
-      .toSorted(
-        (left, right) =>
-          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
-      )
-      .slice(0, missingUserCount);
-    for (const message of fallbackUserMessages) {
-      retainedMessageIds.add(message.id);
-    }
-  }
-
-  const retainedAssistantCount = messages.filter(
-    (message) => message.role === "assistant" && retainedMessageIds.has(message.id),
-  ).length;
-  const missingAssistantCount = Math.max(0, retainedTurnIds.size - retainedAssistantCount);
-  if (missingAssistantCount > 0) {
-    const fallbackAssistantMessages = messages
-      .filter(
-        (message) =>
-          message.role === "assistant" &&
-          !retainedMessageIds.has(message.id) &&
-          (message.turnId === null || retainedTurnIds.has(message.turnId)),
-      )
-      .toSorted(
-        (left, right) =>
-          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
-      )
-      .slice(0, missingAssistantCount);
-    for (const message of fallbackAssistantMessages) {
-      retainedMessageIds.add(message.id);
-    }
-  }
-
-  return messages.filter((message) => retainedMessageIds.has(message.id));
+  return messages.filter((message, index) => {
+    if (message.role === "system") return true;
+    if (message.turnId !== null) return retainedTurnIds.has(message.turnId);
+    if (checkpointMessageIndex >= 0) return index <= checkpointMessageIndex;
+    return latestCheckpoint !== null && message.createdAt <= latestCheckpoint.completedAt;
+  });
 }

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -522,11 +522,7 @@ export function applyThreadDetailEvent(
       );
 
       const retainedTurnIds = new Set(Arr.map(checkpoints, (entry) => entry.turnId));
-      const messages = retainMessagesAfterRevert(
-        thread.messages,
-        retainedTurnIds,
-        event.payload.turnCount,
-      );
+      const messages = retainMessagesAfterRevert(thread.messages, retainedTurnIds);
       const proposedPlans = pipe(
         thread.proposedPlans,
         Arr.filter((plan) => plan.turnId === null || retainedTurnIds.has(plan.turnId)),
@@ -658,7 +654,6 @@ function rebindCheckpointAssistantMessage(
 function retainMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   retainedTurnIds: ReadonlySet<string>,
-  turnCount: number,
 ): OrchestrationMessage[] {
   const retainedMessageIds = new Set<string>();
   for (const message of messages) {
@@ -678,7 +673,7 @@ function retainMessagesAfterRevert(
   const retainedUserCount = messages.filter(
     (message) => message.role === "user" && retainedMessageIds.has(message.id),
   ).length;
-  const missingUserCount = Math.max(0, turnCount - retainedUserCount);
+  const missingUserCount = Math.max(0, retainedTurnIds.size - retainedUserCount);
   if (missingUserCount > 0) {
     const fallbackUserMessages = messages
       .filter(
@@ -700,7 +695,7 @@ function retainMessagesAfterRevert(
   const retainedAssistantCount = messages.filter(
     (message) => message.role === "assistant" && retainedMessageIds.has(message.id),
   ).length;
-  const missingAssistantCount = Math.max(0, turnCount - retainedAssistantCount);
+  const missingAssistantCount = Math.max(0, retainedTurnIds.size - retainedAssistantCount);
   if (missingAssistantCount > 0) {
     const fallbackAssistantMessages = messages
       .filter(


### PR DESCRIPTION
## What Changed

Reverted user messages now return to the composer with their images. If a draft is already present, it is saved to Stash first.

The live timeline also removes the reverted message once the server confirms the rewind.

## Why

“Revert to this message” rewound the checkpoint, but left the selected message in the timeline and forced users to recreate the prompt before sending it again.

Closes https://github.com/pingdotgg/t3code/issues/5685

## UI Changes

Before | After
--- | ---
<img width="1280" alt="Before revert" src="https://github.com/user-attachments/assets/b88304ec-3f09-4c69-8559-fff18d5d1e43" /> | <img width="1280" alt="After revert" src="https://github.com/user-attachments/assets/fcc8585c-24fb-46a0-bfb2-1c295f323c2c" />


### Interaction

https://github.com/user-attachments/assets/66af7cd0-ec2a-41e2-88ed-7d98a82c5f8b

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with GPT-5.6-Sol through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore reverted user message prompt and attachments into the composer
> - When reverting a thread checkpoint, the user's original message prompt and image attachments are now fetched and written back into the composer after revert completes.
> - [`deriveRevertedMessageContent`](https://github.com/pingdotgg/t3code/pull/6044/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) strips review comment blocks and preview-annotation screenshots from the prompt before restoration; [`fetchRevertedMessageAttachmentBlob`](https://github.com/pingdotgg/t3code/pull/6044/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) fetches attachment blobs with a 10-second abort timeout.
> - The composer is disabled during revert preparation; attachments are deduplicated, capped at `PROVIDER_SEND_TURN_MAX_ATTACHMENTS`, and any existing stash or context attachments are cleared before writing.
> - Toasts surface warnings for missing images, attachment overflow, stash/clear behavior, and stash failures.
> - Turnless message retention in [`threadReducer`](https://github.com/pingdotgg/t3code/pull/6044/files#diff-a6a6ab655c6c6a6b67372b07b16e72473405daac411e93f5d651ce3dc5203e56) is now bounded by the latest retained checkpoint instead of keeping all turnless messages unconditionally.
> - Risk: blob URLs are created during draft preparation and must be revoked on cleanup; any fetch failure within the timeout marks that attachment as unavailable rather than blocking restoration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a216c72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint revert UX and client-side message retention after `thread.reverted`, plus blob URL lifecycle for restored attachments. Failures are mostly soft (toasts / unavailable images), but incorrect retention or cleanup would affect timeline correctness and composer state.
> 
> **Overview**
> **Reverting a checkpoint now puts the selected user message back into the composer** (editable text + images), so users can edit and resend instead of recreating the prompt.
> 
> Existing draft text/images are **stashed first** when possible; session-bound context (terminal/element/preview/review) is cleared because it cannot be safely reused after a rewind. Preview-annotation screenshots and review/context blocks are stripped from the restored prompt. Attachment blobs are fetched with a 10s abort timeout, deduped, and capped at the composer image limit, with toasts for missing/overflow images and stash/clear outcomes.
> 
> Separately, `retainMessagesAfterRevert` now **drops turnless messages after the latest retained checkpoint**, so the timeline actually removes the reverted prompt once the server confirms the rewind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a216c727fdd934115f86f742ed77fd228c9aa93a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->