### PR TITLE
fix(mobile): distinguish OpenCode model providers

### DIFF
--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -94,6 +94,11 @@ function ModelRow(props: {
   const primaryFg = useThemeColor("--color-primary-foreground");
   return (
     <Pressable
+      accessibilityLabel={
+        props.option.subProvider
+          ? `${props.option.label}, ${props.option.subProvider}`
+          : props.option.label
+      }
       accessibilityRole="button"
       accessibilityState={{ selected: props.selected }}
       onPress={props.onPress}
@@ -106,15 +111,28 @@ function ModelRow(props: {
         props.selected ? "bg-primary" : "bg-transparent",
       )}
     >
-      <Text
-        className={cn(
-          "shrink text-sm font-t3-medium",
-          props.selected ? "text-primary-foreground" : "text-foreground",
-        )}
-        numberOfLines={1}
-      >
-        {props.option.label}
-      </Text>
+      <View className="min-w-0 flex-1">
+        <Text
+          className={cn(
+            "text-sm font-t3-medium",
+            props.selected ? "text-primary-foreground" : "text-foreground",
+          )}
+          numberOfLines={1}
+        >
+          {props.option.label}
+        </Text>
+        {props.option.subProvider ? (
+          <Text
+            className={cn(
+              "mt-0.5 text-xs",
+              props.selected ? "text-primary-foreground" : "text-foreground-muted",
+            )}
+            numberOfLines={1}
+          >
+            {props.option.subProvider}
+          </Text>
+        ) : null}
+      </View>
       {props.option.isDefault ? (
         <View className="rounded-md bg-subtle-strong px-1.5 py-0.5">
           <Text className="text-3xs font-t3-bold text-foreground-muted">Default</Text>
@@ -125,7 +143,6 @@ function ModelRow(props: {
           <Text className="text-3xs font-t3-bold text-foreground-muted">Legacy</Text>
         </View>
       ) : null}
-      <View className="flex-1" />
       {props.selected ? (
         <SymbolView name="checkmark" size={14} tintColor={primaryFg} type="monochrome" />
       ) : null}

--- a/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
+++ b/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
@@ -12,7 +12,6 @@ function modelOption(
   return {
     key: `codex:${model}`,
     label: model,
-    subtitle: "Codex",
     providerKey: "codex",
     providerLabel: "Codex",
     providerDriver: "codex",

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -51,6 +51,68 @@ describe("mobile model options", () => {
     ]);
   });
 
+  it("preserves OpenCode sub-provider labels for duplicate model names", () => {
+    const config = {
+      providers: [
+        {
+          instanceId: "opencode",
+          driver: "opencode",
+          displayName: "OpenCode",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          models: [
+            {
+              slug: "opencode/grok-4.5",
+              name: "Grok 4.5",
+              subProvider: "OpenCode Go",
+              isCustom: false,
+              capabilities: null,
+            },
+            {
+              slug: "openrouter/x-ai/grok-4.5",
+              name: "Grok 4.5",
+              subProvider: "OpenRouter",
+              isCustom: false,
+              capabilities: null,
+            },
+            {
+              slug: "xai/grok-4.5",
+              name: "Grok 4.5",
+              subProvider: "xAI OAuth",
+              isCustom: false,
+              capabilities: null,
+            },
+          ],
+        },
+      ],
+    } as unknown as ServerConfig;
+
+    expect(
+      buildModelOptions(config, null).map(({ key, label, subProvider }) => ({
+        key,
+        label,
+        subProvider,
+      })),
+    ).toEqual([
+      {
+        key: "opencode:opencode/grok-4.5",
+        label: "Grok 4.5",
+        subProvider: "OpenCode Go",
+      },
+      {
+        key: "opencode:openrouter/x-ai/grok-4.5",
+        label: "Grok 4.5",
+        subProvider: "OpenRouter",
+      },
+      {
+        key: "opencode:xai/grok-4.5",
+        label: "Grok 4.5",
+        subProvider: "xAI OAuth",
+      },
+    ]);
+  });
+
   it("normalizes a legacy fallback selection against current capabilities", () => {
     const config = {
       providers: [

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -11,7 +11,7 @@ import {
 export type ModelOption = {
   readonly key: string;
   readonly label: string;
-  readonly subtitle: string;
+  readonly subProvider?: string | undefined;
   readonly providerKey: string;
   readonly providerLabel: string;
   readonly providerDriver: string;
@@ -121,7 +121,7 @@ export function buildModelOptions(
       options.set(key, {
         key,
         label: model.name,
-        subtitle: providerLabel,
+        ...(model.subProvider ? { subProvider: model.subProvider } : {}),
         providerKey: provider.instanceId,
         providerLabel,
         providerDriver: provider.driver,
@@ -152,7 +152,6 @@ export function buildModelOptions(
       options.set(key, {
         key,
         label: fallbackModelSelection.model,
-        subtitle: providerLabel,
         providerKey: fallbackModelSelection.instanceId,
         providerLabel,
         providerDriver: fallbackModelSelection.instanceId,


### PR DESCRIPTION
## Problem

OpenCode can expose the same model through multiple upstream providers. The mobile picker discarded the existing `subProvider` metadata, so entries such as Grok 4.5 appeared identical.

## Fix

Preserve the upstream provider name in mobile model options and render it as a secondary line in each model row. Include the provider in the VoiceOver label so identical model names are distinguishable visually and accessibly.

## Testing

- `vp test run apps/mobile/src/lib/modelOptions.test.ts apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts`
- `vp run --filter @t3tools/mobile typecheck`
- Targeted lint and formatting checks for all touched files

## UI evidence

Tested on an iPhone 17 Pro Max simulator (iOS 26.5, dark mode).

| Before | After |
| --- | --- |
| ![Before: three indistinguishable Grok 4.5 OpenCode model rows](https://raw.githubusercontent.com/jtyuill/t3code/pr-assets-6047/.github/pr-assets/6047/before.png) | ![After: Grok 4.5 rows labeled opencode-go, openrouter, and xai](https://raw.githubusercontent.com/jtyuill/t3code/pr-assets-6047/.github/pr-assets/6047/after.png) |

Before, the three `Grok 4.5` rows are indistinguishable. After, each row includes its upstream provider: `opencode-go`, `openrouter`, or `xai`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only model picker and option mapping changes with unit tests; no auth or persistence logic touched.
> 
> **Overview**
> OpenCode can list the same model name from multiple upstream providers; the mobile picker used to drop that metadata and show duplicate rows.
> 
> **`ModelOption`** now carries optional **`subProvider`** from server config instead of a generic **`subtitle`** (provider display name). **`buildModelOptions`** sets it only when the upstream sends **`model.subProvider`**.
> 
> **Thread settings** model rows show **`subProvider`** as a second muted line under the model name, and VoiceOver labels include it (`"Grok 4.5, OpenRouter"`) so identical names are distinguishable. Row layout wraps the title stack in a flex column so badges and the checkmark still align.
> 
> Tests cover duplicate Grok entries and drop **`subtitle`** from test fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d31498b5f9506c139b9cd62f4c8d22321977fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Display sub-provider name in mobile model selection rows
> - Replaces the `subtitle` field on `ModelOption` with an optional `subProvider` field, populated from the model config when present.
> - Model rows in [`ThreadSettingsSheet`](https://github.com/pingdotgg/t3code/pull/6047/files#diff-c7889046e38baae09b395b2fe1b43d588c686f9827763c7b5ff624f88481d6ea) now render a secondary muted text line showing the sub-provider name, helping users distinguish models with identical display names from different OpenCode providers.
> - Behavioral Change: `buildModelOptions` no longer sets a subtitle for every model; fallback entries (selections not found in config) never include a `subProvider`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3d3149.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


Wall time: 0.63 seconds