### PR TITLE
fix(web): account for Windows window controls in PR page header

### DIFF
--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1070,6 +1070,7 @@ function PullRequestsRouteView() {
     filtersMenu,
     rightPanelControl:
       !pullRequestsSupported || rightPanelState.isOpen ? null : panelToggleControls,
+    rightPanelOpen: rightPanelState.isOpen,
     listBody,
   };
 
@@ -1319,6 +1320,7 @@ function PullRequestsColumn({
   searchInput,
   filtersMenu,
   rightPanelControl,
+  rightPanelOpen,
   listBody,
 }: {
   refreshing: boolean;
@@ -1334,6 +1336,7 @@ function PullRequestsColumn({
   searchInput: ReactNode;
   filtersMenu: ReactNode;
   rightPanelControl: ReactNode;
+  rightPanelOpen: boolean;
   listBody: ReactNode;
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -1398,6 +1401,12 @@ function PullRequestsColumn({
       <header
         className={cn(
           "workspace-topbar drag-region gap-1.5 px-3 sm:px-5",
+          // A closed right panel leaves this column full-width, so its header runs
+          // underneath the native window controls on Windows; reserve the inset the
+          // way Settings and the chat view do. While the panel is open the column
+          // ends at the panel's left edge and the absolute controls strip (already
+          // WCO-aware) owns the top-right corner.
+          !rightPanelOpen && "wco:pr-[var(--workspace-native-controls-inset)]",
           COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
         )}
       >


### PR DESCRIPTION
## What Changed

The pull request page header now makes room for the Windows minimize, maximize, and close buttons.

Added WCO-aware right padding to the PR header, using the same --workspace-native-controls-inset mechanism the settings page header and the chat view already use. The padding is applied only while the right panel is closed, since that's the only state where the column spans the full window width and actually reaches under the OS buttons.

## Why

On Windows, window control buttons are drawn by the OS over the top-right of the window, and the PR header was the one surface that didn't reserve space for them, so the refresh button and the right sidebar toggle were rendering underneath them and colliding.

## UI Changes

Before:
<img width="292" height="166" alt="image" src="https://github.com/user-attachments/assets/a0ab30d7-0392-47d9-ab3f-596bc18f1a69" />

After:
<img width="357" height="69" alt="image" src="https://github.com/user-attachments/assets/fd4f374a-836b-4d39-983b-bd3093637dea" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Conditional CSS on the PR list header only; no auth, data, or API changes.
> 
> **Overview**
> On Windows, the pull requests list header could sit under the native minimize/maximize/close buttons when the right panel is closed and the column is full width.
> 
> **`PullRequestsColumn`** now receives **`rightPanelOpen`** from the route. The topbar applies **`wco:pr-[var(--workspace-native-controls-inset)]`** only when the panel is closed—the same inset chat and settings already use. When the panel is open, the list column no longer reaches the window edge, so that padding is skipped and the floating panel controls keep handling the corner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a131dda272c6fe77dae592e8f0ae09867d048284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Account for Windows window controls in the pull requests page header
> When the right panel is closed, the `PullRequestsColumn` header adds right padding equal to `--workspace-native-controls-inset` via the `wco:pr-[var(--workspace-native-controls-inset)]` class to avoid overlap with Windows window controls. When the right panel is open, the padding is omitted since the panel already fills that space.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a131dda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->