### PR TITLE
feat(server): populate Grok slash commands and skills

### DIFF
--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -87,6 +87,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const crypto = yield* Crypto.Crypto;
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const httpClient = yield* HttpClient.HttpClient;
+      const { cwd } = yield* ServerConfig;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const processEnv = mergeProviderInstanceEnvironment(environment);
@@ -113,7 +114,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       });
       const textGeneration = yield* makeGrokTextGeneration(effectiveConfig, processEnv);
 
-      const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv).pipe(
+      const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Drivers/GrokSkills.test.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.test.ts
@@ -4,7 +4,11 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
-import { discoverGrokSkills, parseGrokInspectSkills, parseGrokInspectSkillsJson } from "./GrokSkills.ts";
+import {
+  discoverGrokSkills,
+  parseGrokInspectSkills,
+  parseGrokInspectSkillsJson,
+} from "./GrokSkills.ts";
 
 describe("parseGrokInspectSkills", () => {
   it("maps inspect skills into ServerProviderSkill entries", () => {
@@ -92,26 +96,83 @@ describe("parseGrokInspectSkills", () => {
     assert.deepEqual(parseGrokInspectSkills({ skills: "nope" }), []);
   });
 
-  it("dedupes by name, keeping the last occurrence", () => {
+  it("skips non-string name/path fields without throwing", () => {
+    const skills = parseGrokInspectSkills({
+      skills: [
+        { name: 1, source: { type: "user", path: "/tmp/num/SKILL.md" }, userInvocable: true },
+        {
+          name: "ok",
+          source: { type: "user", path: "/tmp/ok/SKILL.md" },
+          userInvocable: true,
+        },
+        {
+          name: "bad-path",
+          source: { type: "user", path: 42 },
+          userInvocable: true,
+        },
+      ],
+    });
+
+    assert.deepEqual(skills, [
+      {
+        name: "ok",
+        path: "/tmp/ok/SKILL.md",
+        scope: "user",
+        enabled: true,
+      },
+    ]);
+  });
+
+  it("dedupes by name with project scope beating user/bundled", () => {
+    const skills = parseGrokInspectSkills({
+      skills: [
+        {
+          name: "review",
+          description: "User last",
+          userInvocable: true,
+          source: { type: "user", path: "/user/review/SKILL.md" },
+        },
+        {
+          name: "review",
+          description: "Project first",
+          userInvocable: true,
+          source: { type: "project", path: "/repo/review/SKILL.md" },
+        },
+        {
+          name: "review",
+          description: "Bundled last",
+          userInvocable: true,
+          source: { type: "bundled", path: "/bundled/review/SKILL.md" },
+        },
+      ],
+    });
+
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0]?.path, "/repo/review/SKILL.md");
+    assert.equal(skills[0]?.scope, "project");
+    assert.equal(skills[0]?.description, "Project first");
+  });
+
+  it("dedupes same-scope names by keeping the later inspect entry", () => {
     const skills = parseGrokInspectSkills({
       skills: [
         {
           name: "review",
           description: "First",
           userInvocable: true,
-          source: { type: "bundled", path: "/bundled/review/SKILL.md" },
+          source: { type: "user", path: "/user/a/SKILL.md" },
         },
         {
           name: "review",
           description: "Second",
           userInvocable: true,
-          source: { type: "user", path: "/user/review/SKILL.md" },
+          source: { type: "user", path: "/user/b/SKILL.md" },
         },
       ],
     });
 
     assert.equal(skills.length, 1);
-    assert.equal(skills[0]?.path, "/user/review/SKILL.md");
+    assert.equal(skills[0]?.path, "/user/b/SKILL.md");
     assert.equal(skills[0]?.description, "Second");
   });
 });

--- a/apps/server/src/provider/Drivers/GrokSkills.test.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.test.ts
@@ -1,0 +1,181 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverGrokSkills, parseGrokInspectSkills, parseGrokInspectSkillsJson } from "./GrokSkills.ts";
+
+describe("parseGrokInspectSkills", () => {
+  it("maps inspect skills into ServerProviderSkill entries", () => {
+    const skills = parseGrokInspectSkills({
+      skills: [
+        {
+          name: "super-review",
+          description: "Bugs-only super review.",
+          userInvocable: true,
+          source: {
+            type: "user",
+            path: "/Users/me/.grok/skills/super-review/SKILL.md",
+          },
+        },
+        {
+          name: "docx",
+          description: "Office docs helper.",
+          userInvocable: false,
+          source: {
+            type: "bundled",
+            path: "/Users/me/.grok/bundled/skills/docx/SKILL.md",
+          },
+        },
+        {
+          name: "test-t3-app",
+          description: "Launch T3 for testing.",
+          userInvocable: true,
+          source: {
+            type: "project",
+            path: "/repo/.agents/skills/test-t3-app/SKILL.md",
+          },
+        },
+      ],
+    });
+
+    assert.deepEqual(skills, [
+      {
+        name: "docx",
+        description: "Office docs helper.",
+        path: "/Users/me/.grok/bundled/skills/docx/SKILL.md",
+        scope: "bundled",
+        enabled: false,
+      },
+      {
+        name: "super-review",
+        description: "Bugs-only super review.",
+        path: "/Users/me/.grok/skills/super-review/SKILL.md",
+        scope: "user",
+        enabled: true,
+      },
+      {
+        name: "test-t3-app",
+        description: "Launch T3 for testing.",
+        path: "/repo/.agents/skills/test-t3-app/SKILL.md",
+        scope: "project",
+        enabled: true,
+      },
+    ]);
+  });
+
+  it("skips entries missing a name or path", () => {
+    const skills = parseGrokInspectSkills({
+      skills: [
+        { name: "ok", source: { type: "user", path: "/tmp/ok/SKILL.md" }, userInvocable: true },
+        { name: "no-path", source: { type: "user" }, userInvocable: true },
+        { source: { type: "user", path: "/tmp/noname/SKILL.md" }, userInvocable: true },
+        "not-an-object",
+        null,
+      ],
+    });
+
+    assert.deepEqual(skills, [
+      {
+        name: "ok",
+        path: "/tmp/ok/SKILL.md",
+        scope: "user",
+        enabled: true,
+      },
+    ]);
+  });
+
+  it("returns an empty list for invalid JSON documents", () => {
+    assert.deepEqual(parseGrokInspectSkillsJson("{not json"), []);
+    assert.deepEqual(parseGrokInspectSkills(null), []);
+    assert.deepEqual(parseGrokInspectSkills({ skills: "nope" }), []);
+  });
+
+  it("dedupes by name, keeping the last occurrence", () => {
+    const skills = parseGrokInspectSkills({
+      skills: [
+        {
+          name: "review",
+          description: "First",
+          userInvocable: true,
+          source: { type: "bundled", path: "/bundled/review/SKILL.md" },
+        },
+        {
+          name: "review",
+          description: "Second",
+          userInvocable: true,
+          source: { type: "user", path: "/user/review/SKILL.md" },
+        },
+      ],
+    });
+
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0]?.path, "/user/review/SKILL.md");
+    assert.equal(skills[0]?.description, "Second");
+  });
+});
+
+it.layer(NodeServices.layer)("discoverGrokSkills", (it) => {
+  it.effect("parses skills from a fake grok inspect --json binary", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-skills-" });
+      const grokPath = path.join(dir, "grok");
+      const inspectPayload = JSON.stringify({
+        skills: [
+          {
+            name: "apple-design",
+            description: "Apple HIG skill.",
+            userInvocable: true,
+            source: {
+              type: "user",
+              path: "/Users/me/.grok/skills/apple-design/SKILL.md",
+            },
+          },
+        ],
+      });
+      yield* fs.writeFileString(
+        grokPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "inspect" ] && [ "$2" = "--json" ]; then',
+          `  printf '%s\\n' '${inspectPayload.replace(/'/g, `'\\''`)}'`,
+          "  exit 0",
+          "fi",
+          "echo unexpected >&2",
+          "exit 1",
+          "",
+        ].join("\n"),
+      );
+      yield* fs.chmod(grokPath, 0o755);
+
+      const skills = yield* discoverGrokSkills({ binaryPath: grokPath }, dir);
+
+      assert.deepEqual(skills, [
+        {
+          name: "apple-design",
+          description: "Apple HIG skill.",
+          path: "/Users/me/.grok/skills/apple-design/SKILL.md",
+          scope: "user",
+          enabled: true,
+        },
+      ]);
+    }),
+  );
+
+  it.effect("returns an empty list when inspect fails", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-skills-fail-" });
+      const grokPath = path.join(dir, "grok");
+      yield* fs.writeFileString(grokPath, ["#!/bin/sh", "exit 2", ""].join("\n"));
+      yield* fs.chmod(grokPath, 0o755);
+
+      const skills = yield* discoverGrokSkills({ binaryPath: grokPath }, dir);
+      assert.deepEqual(skills, []);
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/GrokSkills.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.ts
@@ -30,9 +30,42 @@ type GrokInspectSkill = {
   readonly source?: GrokInspectSkillSource;
 };
 
-function nonEmptyTrimmed(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+function nonEmptyTrimmed(value: unknown): string | undefined {
+  // Inspect JSON is untrusted; non-string fields must not throw.
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** Higher wins. Matches Grok/Claude “most specific scope first” preference. */
+const SKILL_SCOPE_RANK: Readonly<Record<string, number>> = {
+  project: 4,
+  local: 4,
+  user: 3,
+  plugin: 2,
+  bundled: 1,
+};
+
+function skillScopeRank(scope: string | undefined): number {
+  if (!scope) {
+    return 0;
+  }
+  return SKILL_SCOPE_RANK[scope] ?? 0;
+}
+
+function shouldReplaceSkill(
+  existing: ServerProviderSkill,
+  candidate: ServerProviderSkill,
+): boolean {
+  const existingRank = skillScopeRank(existing.scope);
+  const candidateRank = skillScopeRank(candidate.scope);
+  if (candidateRank !== existingRank) {
+    return candidateRank > existingRank;
+  }
+  // Same rank: later inspect entry wins (document order).
+  return true;
 }
 
 /**
@@ -75,21 +108,24 @@ export function parseGrokInspectSkills(
     // (and out of auto-invoke advertising in Grok itself).
     const enabled = skill.userInvocable !== false;
 
-    skillsByName.set(name, {
+    const parsed: ServerProviderSkill = {
       name,
       path: sourcePath,
       enabled,
       ...(scope ? { scope } : {}),
       ...(description ? { description } : {}),
-    });
+    };
+
+    const existing = skillsByName.get(name);
+    if (!existing || shouldReplaceSkill(existing, parsed)) {
+      skillsByName.set(name, parsed);
+    }
   }
 
   return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
 }
 
-export function parseGrokInspectSkillsJson(
-  raw: string,
-): ReadonlyArray<ServerProviderSkill> {
+export function parseGrokInspectSkillsJson(raw: string): ReadonlyArray<ServerProviderSkill> {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw) as unknown;

--- a/apps/server/src/provider/Drivers/GrokSkills.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.ts
@@ -1,0 +1,148 @@
+/**
+ * GrokSkills — discover Grok Build skills for the `$` picker.
+ *
+ * Grok resolves skills from many roots (user, project, bundled, plugins,
+ * Claude/Cursor compat, config paths). Rather than reimplement that graph,
+ * we run `grok inspect --json` with the workspace cwd and map its `skills`
+ * array into `ServerProviderSkill` entries.
+ *
+ * @module provider/Drivers/GrokSkills
+ */
+import type { GrokSettings, ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import { spawnAndCollect } from "../providerSnapshot.ts";
+
+const INSPECT_TIMEOUT_MS = 4_000;
+
+type GrokInspectSkillSource = {
+  readonly type?: string;
+  readonly path?: string;
+};
+
+type GrokInspectSkill = {
+  readonly name?: string;
+  readonly description?: string;
+  readonly userInvocable?: boolean;
+  readonly source?: GrokInspectSkillSource;
+};
+
+function nonEmptyTrimmed(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Parse the `skills` array from a `grok inspect --json` document into the
+ * provider snapshot shape. Malformed entries are skipped so a broken skill
+ * never degrades the whole list.
+ */
+export function parseGrokInspectSkills(
+  inspectDocument: unknown,
+): ReadonlyArray<ServerProviderSkill> {
+  if (typeof inspectDocument !== "object" || inspectDocument === null) {
+    return [];
+  }
+
+  const skillsValue = (inspectDocument as { readonly skills?: unknown }).skills;
+  if (!Array.isArray(skillsValue)) {
+    return [];
+  }
+
+  const skillsByName = new Map<string, ServerProviderSkill>();
+
+  for (const entry of skillsValue) {
+    if (typeof entry !== "object" || entry === null) {
+      continue;
+    }
+    const skill = entry as GrokInspectSkill;
+    const name = nonEmptyTrimmed(skill.name);
+    if (!name) {
+      continue;
+    }
+
+    const sourcePath = nonEmptyTrimmed(skill.source?.path);
+    if (!sourcePath) {
+      continue;
+    }
+
+    const description = nonEmptyTrimmed(skill.description);
+    const scope = nonEmptyTrimmed(skill.source?.type);
+    // userInvocable false keeps the skill listed but out of the `$` picker
+    // (and out of auto-invoke advertising in Grok itself).
+    const enabled = skill.userInvocable !== false;
+
+    skillsByName.set(name, {
+      name,
+      path: sourcePath,
+      enabled,
+      ...(scope ? { scope } : {}),
+      ...(description ? { description } : {}),
+    });
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function parseGrokInspectSkillsJson(
+  raw: string,
+): ReadonlyArray<ServerProviderSkill> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return [];
+  }
+  return parseGrokInspectSkills(parsed);
+}
+
+/**
+ * Enumerate Grok skills for a workspace by shelling out to `grok inspect --json`.
+ * Best-effort: spawn/timeout/parse failures yield an empty list so the provider
+ * snapshot still succeeds.
+ */
+export const discoverGrokSkills = Effect.fn("discoverGrokSkills")(function* (
+  grokSettings: Pick<GrokSettings, "binaryPath">,
+  cwd?: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): Effect.fn.Return<
+  ReadonlyArray<ServerProviderSkill>,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner
+> {
+  const command = grokSettings.binaryPath || "grok";
+  const spawnCommand = yield* resolveSpawnCommand(command, ["inspect", "--json"], {
+    env: environment,
+  }).pipe(Effect.orElseSucceed(() => undefined));
+  if (!spawnCommand) {
+    return [];
+  }
+
+  const resultOption = yield* spawnAndCollect(
+    command,
+    ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+      env: environment,
+      shell: spawnCommand.shell,
+      ...(cwd ? { cwd } : {}),
+    }),
+  ).pipe(
+    Effect.timeoutOption(INSPECT_TIMEOUT_MS),
+    Effect.orElseSucceed(() => Option.none()),
+  );
+
+  if (Option.isNone(resultOption)) {
+    return [];
+  }
+  const result = resultOption.value;
+  if (result.code !== 0) {
+    return [];
+  }
+
+  // inspect writes JSON on stdout; tolerate accidental stderr noise by
+  // preferring stdout and only falling back when stdout is empty.
+  const raw = result.stdout.trim().length > 0 ? result.stdout : result.stderr;
+  return parseGrokInspectSkillsJson(raw);
+});

--- a/apps/server/src/provider/Drivers/GrokSlashCommands.test.ts
+++ b/apps/server/src/provider/Drivers/GrokSlashCommands.test.ts
@@ -81,13 +81,19 @@ describe("slashCommandsFromGrokSkills", () => {
 });
 
 describe("resolveGrokSlashCommands", () => {
-  it("prefers ACP-advertised commands over skill fallback", () => {
+  it("merges ACP commands with invocable skills not already advertised", () => {
     const skills = [
       {
         name: "super-review",
         path: "/user/super-review/SKILL.md",
         enabled: true,
         description: "from skill",
+      },
+      {
+        name: "compact",
+        path: "/user/compact/SKILL.md",
+        enabled: true,
+        description: "skill should not replace acp",
       },
     ] satisfies ReadonlyArray<ServerProviderSkill>;
 
@@ -101,7 +107,10 @@ describe("resolveGrokSlashCommands", () => {
       skills,
     });
 
-    assert.deepEqual(commands, [{ name: "compact", description: "from acp" }]);
+    assert.deepEqual(commands, [
+      { name: "compact", description: "from acp" },
+      { name: "super-review", description: "from skill" },
+    ]);
   });
 
   it("falls back to invocable skills when ACP advertised none", () => {

--- a/apps/server/src/provider/Drivers/GrokSlashCommands.test.ts
+++ b/apps/server/src/provider/Drivers/GrokSlashCommands.test.ts
@@ -1,0 +1,124 @@
+import { assert, describe, it } from "@effect/vitest";
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import {
+  parseGrokAvailableCommands,
+  resolveGrokSlashCommands,
+  slashCommandsFromGrokSkills,
+} from "./GrokSlashCommands.ts";
+
+describe("parseGrokAvailableCommands", () => {
+  it("maps ACP available commands into slash commands with hints", () => {
+    const commands = parseGrokAvailableCommands([
+      {
+        name: "compact",
+        description: "Compress conversation history",
+        input: { hint: "optional context" },
+      },
+      {
+        name: "super-review",
+        description: "Bugs-only super review",
+      },
+      {
+        name: "  ",
+        description: "ignored empty name",
+      },
+    ] as ReadonlyArray<EffectAcpSchema.AvailableCommand>);
+
+    assert.deepEqual(commands, [
+      {
+        name: "compact",
+        description: "Compress conversation history",
+        input: { hint: "optional context" },
+      },
+      {
+        name: "super-review",
+        description: "Bugs-only super review",
+      },
+    ]);
+  });
+
+  it("dedupes by case-insensitive name and fills missing metadata", () => {
+    const commands = parseGrokAvailableCommands([
+      { name: "Review", description: "" },
+      { name: "review", description: "Run a review", input: { hint: "[--local]" } },
+    ] as ReadonlyArray<EffectAcpSchema.AvailableCommand>);
+
+    assert.equal(commands.length, 1);
+    assert.deepEqual(commands[0], {
+      name: "Review",
+      description: "Run a review",
+      input: { hint: "[--local]" },
+    });
+  });
+});
+
+describe("slashCommandsFromGrokSkills", () => {
+  it("only includes enabled skills", () => {
+    const skills = [
+      {
+        name: "super-review",
+        path: "/user/super-review/SKILL.md",
+        enabled: true,
+        description: "Bugs-only super review",
+      },
+      {
+        name: "docx",
+        path: "/bundled/docx/SKILL.md",
+        enabled: false,
+        description: "hidden",
+      },
+    ] satisfies ReadonlyArray<ServerProviderSkill>;
+
+    assert.deepEqual(slashCommandsFromGrokSkills(skills), [
+      {
+        name: "super-review",
+        description: "Bugs-only super review",
+      },
+    ]);
+  });
+});
+
+describe("resolveGrokSlashCommands", () => {
+  it("prefers ACP-advertised commands over skill fallback", () => {
+    const skills = [
+      {
+        name: "super-review",
+        path: "/user/super-review/SKILL.md",
+        enabled: true,
+        description: "from skill",
+      },
+    ] satisfies ReadonlyArray<ServerProviderSkill>;
+
+    const commands = resolveGrokSlashCommands({
+      availableCommands: [
+        {
+          name: "compact",
+          description: "from acp",
+        },
+      ] as ReadonlyArray<EffectAcpSchema.AvailableCommand>,
+      skills,
+    });
+
+    assert.deepEqual(commands, [{ name: "compact", description: "from acp" }]);
+  });
+
+  it("falls back to invocable skills when ACP advertised none", () => {
+    const skills = [
+      {
+        name: "apple-design",
+        path: "/user/apple-design/SKILL.md",
+        enabled: true,
+        description: "Apple HIG",
+      },
+    ] satisfies ReadonlyArray<ServerProviderSkill>;
+
+    const commands = resolveGrokSlashCommands({
+      availableCommands: [],
+      skills,
+    });
+
+    assert.deepEqual(commands, [{ name: "apple-design", description: "Apple HIG" }]);
+  });
+});

--- a/apps/server/src/provider/Drivers/GrokSlashCommands.ts
+++ b/apps/server/src/provider/Drivers/GrokSlashCommands.ts
@@ -10,9 +10,12 @@
 import type { ServerProviderSkill, ServerProviderSlashCommand } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
-function nonEmptyTrimmed(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+function nonEmptyTrimmed(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function availableCommandHint(
@@ -80,7 +83,8 @@ export function slashCommandsFromGrokSkills(
   return skills
     .filter((skill) => skill.enabled)
     .map((skill) => {
-      const description = nonEmptyTrimmed(skill.shortDescription) ?? nonEmptyTrimmed(skill.description);
+      const description =
+        nonEmptyTrimmed(skill.shortDescription) ?? nonEmptyTrimmed(skill.description);
       return {
         name: skill.name,
         ...(description ? { description } : {}),
@@ -89,17 +93,32 @@ export function slashCommandsFromGrokSkills(
 }
 
 /**
- * Prefer the ACP-advertised list (includes builtins + workflows + namespaced
- * skills). Fall back to invocable skills from inspect so the `/` menu is not
- * empty when the ACP probe times out after capturing models only.
+ * Prefer the ACP-advertised list (builtins, workflows, namespaced skills) and
+ * merge in any invocable inspect skills that ACP omitted (partial first
+ * emission). If ACP advertised nothing, fall back to skills alone.
  */
 export function resolveGrokSlashCommands(input: {
   readonly availableCommands: ReadonlyArray<EffectAcpSchema.AvailableCommand> | null | undefined;
   readonly skills: ReadonlyArray<ServerProviderSkill>;
 }): ReadonlyArray<ServerProviderSlashCommand> {
   const fromAcp = parseGrokAvailableCommands(input.availableCommands);
-  if (fromAcp.length > 0) {
+  const fromSkills = slashCommandsFromGrokSkills(input.skills);
+  if (fromAcp.length === 0) {
+    return fromSkills;
+  }
+  if (fromSkills.length === 0) {
     return fromAcp;
   }
-  return slashCommandsFromGrokSkills(input.skills);
+
+  const byName = new Map<string, ServerProviderSlashCommand>();
+  for (const command of fromAcp) {
+    byName.set(command.name.toLowerCase(), command);
+  }
+  for (const command of fromSkills) {
+    const key = command.name.toLowerCase();
+    if (!byName.has(key)) {
+      byName.set(key, command);
+    }
+  }
+  return [...byName.values()];
 }

--- a/apps/server/src/provider/Drivers/GrokSlashCommands.ts
+++ b/apps/server/src/provider/Drivers/GrokSlashCommands.ts
@@ -1,0 +1,105 @@
+/**
+ * Grok slash-command mapping for the `/` provider command menu.
+ *
+ * Grok ACP advertises the live command list via `available_commands_update`
+ * (shell builtins, user-invocable skills, workflows). We also fall back to
+ * mapping enabled skills from `grok inspect` when ACP has not advertised yet.
+ *
+ * @module provider/Drivers/GrokSlashCommands
+ */
+import type { ServerProviderSkill, ServerProviderSlashCommand } from "@t3tools/contracts";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+function nonEmptyTrimmed(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function availableCommandHint(
+  input: EffectAcpSchema.AvailableCommand["input"],
+): string | undefined {
+  if (!input || typeof input !== "object") {
+    return undefined;
+  }
+  if (!("hint" in input)) {
+    return undefined;
+  }
+  const hint = (input as { readonly hint?: unknown }).hint;
+  return typeof hint === "string" ? nonEmptyTrimmed(hint) : undefined;
+}
+
+/**
+ * Map ACP `AvailableCommand` entries into the provider snapshot slash-command
+ * shape, deduping by case-insensitive name (first wins, fills missing fields).
+ */
+export function parseGrokAvailableCommands(
+  commands: ReadonlyArray<EffectAcpSchema.AvailableCommand> | null | undefined,
+): ReadonlyArray<ServerProviderSlashCommand> {
+  if (!commands || commands.length === 0) {
+    return [];
+  }
+
+  const commandsByName = new Map<string, ServerProviderSlashCommand>();
+
+  for (const command of commands) {
+    const name = nonEmptyTrimmed(command.name);
+    if (!name) {
+      continue;
+    }
+
+    const description = nonEmptyTrimmed(command.description);
+    const hint = availableCommandHint(command.input);
+    const key = name.toLowerCase();
+    const existing = commandsByName.get(key);
+    if (!existing) {
+      commandsByName.set(key, {
+        name,
+        ...(description ? { description } : {}),
+        ...(hint ? { input: { hint } } : {}),
+      });
+      continue;
+    }
+
+    commandsByName.set(key, {
+      ...existing,
+      ...(existing.description ? {} : description ? { description } : {}),
+      ...(existing.input?.hint ? {} : hint ? { input: { hint } } : {}),
+    });
+  }
+
+  return [...commandsByName.values()];
+}
+
+/**
+ * Fallback when ACP has not advertised commands: every enabled skill is also a
+ * Grok slash command (`/skill-name`).
+ */
+export function slashCommandsFromGrokSkills(
+  skills: ReadonlyArray<ServerProviderSkill>,
+): ReadonlyArray<ServerProviderSlashCommand> {
+  return skills
+    .filter((skill) => skill.enabled)
+    .map((skill) => {
+      const description = nonEmptyTrimmed(skill.shortDescription) ?? nonEmptyTrimmed(skill.description);
+      return {
+        name: skill.name,
+        ...(description ? { description } : {}),
+      } satisfies ServerProviderSlashCommand;
+    });
+}
+
+/**
+ * Prefer the ACP-advertised list (includes builtins + workflows + namespaced
+ * skills). Fall back to invocable skills from inspect so the `/` menu is not
+ * empty when the ACP probe times out after capturing models only.
+ */
+export function resolveGrokSlashCommands(input: {
+  readonly availableCommands: ReadonlyArray<EffectAcpSchema.AvailableCommand> | null | undefined;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
+}): ReadonlyArray<ServerProviderSlashCommand> {
+  const fromAcp = parseGrokAvailableCommands(input.availableCommands);
+  if (fromAcp.length > 0) {
+    return fromAcp;
+  }
+  return slashCommandsFromGrokSkills(input.skills);
+}

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -105,6 +105,77 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
       expect(snapshot.installed).toBe(true);
       expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-build"]);
       expect(snapshot.message).toContain("ACP startup failed");
+      expect(snapshot.skills).toEqual([]);
+      expect(snapshot.slashCommands).toEqual([]);
+    }),
+  );
+
+  it.effect("still discovers skills when ACP fails but inspect succeeds", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-inspect-" });
+          const grokPath = path.join(dir, "grok");
+          const inspectPayload = JSON.stringify({
+            skills: [
+              {
+                name: "super-review",
+                description: "Bugs-only super review",
+                userInvocable: true,
+                source: {
+                  type: "user",
+                  path: "/Users/me/.grok/skills/super-review/SKILL.md",
+                },
+              },
+            ],
+          });
+          yield* fs.writeFileString(
+            grokPath,
+            [
+              "#!/bin/sh",
+              'if [ "$1" = "--version" ]; then',
+              '  printf "grok-cli 1.0.0\\n"',
+              "  exit 0",
+              "fi",
+              'if [ "$1" = "inspect" ] && [ "$2" = "--json" ]; then',
+              `  printf '%s\\n' '${inspectPayload.replace(/'/g, `'\\''`)}'`,
+              "  exit 0",
+              "fi",
+              // agent stdio path fails so ACP discovery errors
+              "exit 1",
+              "",
+            ].join("\n"),
+          );
+          yield* fs.chmod(grokPath, 0o755);
+
+          return yield* checkGrokProviderStatus(
+            decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+            process.env,
+            dir,
+          );
+        }),
+      );
+
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.message).toContain("ACP startup failed");
+      expect(snapshot.skills).toEqual([
+        {
+          name: "super-review",
+          description: "Bugs-only super review",
+          path: "/Users/me/.grok/skills/super-review/SKILL.md",
+          scope: "user",
+          enabled: true,
+        },
+      ]);
+      // Without ACP available_commands, slash commands fall back to invocable skills.
+      expect(snapshot.slashCommands).toEqual([
+        {
+          name: "super-review",
+          description: "Bugs-only super review",
+        },
+      ]);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -6,6 +6,7 @@ import {
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
+import * as Clock from "effect/Clock";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
@@ -134,31 +135,70 @@ type GrokAcpDiscoveryResult = {
   readonly availableCommands: ReadonlyArray<EffectAcpSchema.AvailableCommand>;
 };
 
+function availableCommandListSignature(
+  commands: ReadonlyArray<EffectAcpSchema.AvailableCommand>,
+): string {
+  return commands.map((command) => command.name).join("\0");
+}
+
+/**
+ * Poll for ACP available commands for up to GROK_AVAILABLE_COMMANDS_WAIT_MS.
+ *
+ * - Does not share the ACP start timeout budget.
+ * - Keeps the latest non-empty list so a later fuller emission wins over a
+ *   partial first snapshot.
+ * - Returns early once a non-empty list is stable across two consecutive polls.
+ * - Always performs a final read at the end of the window so a late update in
+ *   the last poll interval is not missed.
+ */
 const waitForGrokAvailableCommands = (
   getAvailableCommands: Effect.Effect<ReadonlyArray<EffectAcpSchema.AvailableCommand>>,
 ): Effect.Effect<ReadonlyArray<EffectAcpSchema.AvailableCommand>> =>
   Effect.gen(function* () {
-    const attempts = Math.max(
-      1,
-      Math.ceil(GROK_AVAILABLE_COMMANDS_WAIT_MS / GROK_AVAILABLE_COMMANDS_POLL_MS),
-    );
-    for (let attempt = 0; attempt < attempts; attempt += 1) {
-      const commands = yield* getAvailableCommands;
-      if (commands.length > 0) {
-        return commands;
+    const poll = Duration.millis(GROK_AVAILABLE_COMMANDS_POLL_MS);
+    const deadlineMillis = (yield* Clock.currentTimeMillis) + GROK_AVAILABLE_COMMANDS_WAIT_MS;
+
+    let latest = yield* getAvailableCommands;
+    let previousSignature = availableCommandListSignature(latest);
+    let stablePolls = latest.length > 0 ? 1 : 0;
+
+    while ((yield* Clock.currentTimeMillis) < deadlineMillis) {
+      if (latest.length > 0 && stablePolls >= 2) {
+        return latest;
       }
-      if (attempt + 1 < attempts) {
-        yield* Effect.sleep(Duration.millis(GROK_AVAILABLE_COMMANDS_POLL_MS));
+      yield* Effect.sleep(poll);
+      const current = yield* getAvailableCommands;
+      if (current.length === 0) {
+        continue;
+      }
+      const signature = availableCommandListSignature(current);
+      if (signature === previousSignature) {
+        stablePolls += 1;
+      } else {
+        latest = current;
+        previousSignature = signature;
+        stablePolls = 1;
       }
     }
-    return yield* getAvailableCommands;
+
+    const finalCommands = yield* getAvailableCommands;
+    return finalCommands.length > 0 ? finalCommands : latest;
   });
 
+/**
+ * Start ACP under the model-discovery timeout, then settle available commands
+ * under a separate short budget so a slow-but-successful start cannot be
+ * flipped into a timeout by the command wait.
+ */
 const discoverGrokModelsViaAcp = (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
   cwd: string = process.cwd(),
-) =>
+): Effect.Effect<
+  Option.Option<GrokAcpDiscoveryResult>,
+  unknown,
+  ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
+> =>
   Effect.gen(function* () {
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const acp = yield* makeGrokAcpRuntime({
@@ -168,12 +208,19 @@ const discoverGrokModelsViaAcp = (
       cwd,
       clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
     });
-    const started = yield* acp.start();
+    const startedOption = yield* acp
+      .start()
+      .pipe(Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS));
+    if (Option.isNone(startedOption)) {
+      return Option.none();
+    }
+    const started = startedOption.value;
+    // Best-effort: never fails discovery if commands never arrive.
     const availableCommands = yield* waitForGrokAvailableCommands(acp.getAvailableCommands);
-    return {
+    return Option.some({
       models: buildGrokDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models),
       availableCommands,
-    } satisfies GrokAcpDiscoveryResult;
+    } satisfies GrokAcpDiscoveryResult);
   }).pipe(Effect.scoped);
 
 const runGrokVersionCommand = (
@@ -291,12 +338,10 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
 
   // Skills and ACP discovery are independent: skills still populate when ACP
   // fails, and slash commands fall back to invocable skills when needed.
+  // ACP start has its own 15s budget; command settle is separate and best-effort.
   const [discoveryExit, skills] = yield* Effect.all(
     [
-      discoverGrokModelsViaAcp(grokSettings, environment, probeCwd).pipe(
-        Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
-        Effect.exit,
-      ),
+      discoverGrokModelsViaAcp(grokSettings, environment, probeCwd).pipe(Effect.exit),
       discoverGrokSkills(grokSettings, probeCwd, environment),
     ],
     { concurrency: "unbounded" },

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -135,21 +135,32 @@ type GrokAcpDiscoveryResult = {
   readonly availableCommands: ReadonlyArray<EffectAcpSchema.AvailableCommand>;
 };
 
-function availableCommandListSignature(
-  commands: ReadonlyArray<EffectAcpSchema.AvailableCommand>,
-): string {
-  return commands.map((command) => command.name).join("\0");
+/**
+ * Prefer the richer command snapshot: longer lists win (partial first
+ * emissions lose to later fuller ones); equal length keeps the newer read so
+ * description/hint enrichments for the same names still apply.
+ */
+function preferRicherAvailableCommands(
+  current: ReadonlyArray<EffectAcpSchema.AvailableCommand>,
+  candidate: ReadonlyArray<EffectAcpSchema.AvailableCommand>,
+): ReadonlyArray<EffectAcpSchema.AvailableCommand> {
+  if (candidate.length === 0) {
+    return current;
+  }
+  if (candidate.length >= current.length) {
+    return candidate;
+  }
+  return current;
 }
 
 /**
- * Poll for ACP available commands for up to GROK_AVAILABLE_COMMANDS_WAIT_MS.
+ * Poll for ACP available commands for the full GROK_AVAILABLE_COMMANDS_WAIT_MS
+ * window (does not share the ACP start timeout budget).
  *
- * - Does not share the ACP start timeout budget.
- * - Keeps the latest non-empty list so a later fuller emission wins over a
- *   partial first snapshot.
- * - Returns early once a non-empty list is stable across two consecutive polls.
- * - Always performs a final read at the end of the window so a late update in
- *   the last poll interval is not missed.
+ * Grok may emit a partial `available_commands_update` during `session/new` and
+ * a fuller list shortly after, so we never early-exit on the first non-empty
+ * snapshot. We keep the richest list seen and always take a final read at the
+ * end of the window so a late update in the last poll interval is not missed.
  */
 const waitForGrokAvailableCommands = (
   getAvailableCommands: Effect.Effect<ReadonlyArray<EffectAcpSchema.AvailableCommand>>,
@@ -158,31 +169,14 @@ const waitForGrokAvailableCommands = (
     const poll = Duration.millis(GROK_AVAILABLE_COMMANDS_POLL_MS);
     const deadlineMillis = (yield* Clock.currentTimeMillis) + GROK_AVAILABLE_COMMANDS_WAIT_MS;
 
-    let latest = yield* getAvailableCommands;
-    let previousSignature = availableCommandListSignature(latest);
-    let stablePolls = latest.length > 0 ? 1 : 0;
+    let best = yield* getAvailableCommands;
 
     while ((yield* Clock.currentTimeMillis) < deadlineMillis) {
-      if (latest.length > 0 && stablePolls >= 2) {
-        return latest;
-      }
       yield* Effect.sleep(poll);
-      const current = yield* getAvailableCommands;
-      if (current.length === 0) {
-        continue;
-      }
-      const signature = availableCommandListSignature(current);
-      if (signature === previousSignature) {
-        stablePolls += 1;
-      } else {
-        latest = current;
-        previousSignature = signature;
-        stablePolls = 1;
-      }
+      best = preferRicherAvailableCommands(best, yield* getAvailableCommands);
     }
 
-    const finalCommands = yield* getAvailableCommands;
-    return finalCommands.length > 0 ? finalCommands : latest;
+    return preferRicherAvailableCommands(best, yield* getAvailableCommands);
   });
 
 /**

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -167,11 +167,14 @@ const waitForGrokAvailableCommands = (
 ): Effect.Effect<ReadonlyArray<EffectAcpSchema.AvailableCommand>> =>
   Effect.gen(function* () {
     const poll = Duration.millis(GROK_AVAILABLE_COMMANDS_POLL_MS);
-    const deadlineMillis = (yield* Clock.currentTimeMillis) + GROK_AVAILABLE_COMMANDS_WAIT_MS;
+    // Monotonic deadline: wall clock can jump backward on NTP corrections and
+    // would otherwise stretch this settle window unboundedly.
+    const waitNanos = BigInt(GROK_AVAILABLE_COMMANDS_WAIT_MS) * 1_000_000n;
+    const deadlineNanos = (yield* Clock.monotonicTimeNanos) + waitNanos;
 
     let best = yield* getAvailableCommands;
 
-    while ((yield* Clock.currentTimeMillis) < deadlineMillis) {
+    while ((yield* Clock.monotonicTimeNanos) < deadlineNanos) {
       yield* Effect.sleep(poll);
       best = preferRicherAvailableCommands(best, yield* getAvailableCommands);
     }

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -8,6 +8,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
@@ -30,6 +31,8 @@ import {
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
 import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
+import { discoverGrokSkills } from "../Drivers/GrokSkills.ts";
+import { resolveGrokSlashCommands } from "../Drivers/GrokSlashCommands.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -43,6 +46,9 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
 
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+/** Grok emits available_commands during session/new; allow a short settle window. */
+const GROK_AVAILABLE_COMMANDS_WAIT_MS = 2_000;
+const GROK_AVAILABLE_COMMANDS_POLL_MS = 50;
 
 const GROK_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   {
@@ -123,9 +129,35 @@ function buildGrokDiscoveredModelsFromSessionModelState(
     .filter((model): model is ServerProviderModel => model !== undefined);
 }
 
+type GrokAcpDiscoveryResult = {
+  readonly models: ReadonlyArray<ServerProviderModel>;
+  readonly availableCommands: ReadonlyArray<EffectAcpSchema.AvailableCommand>;
+};
+
+const waitForGrokAvailableCommands = (
+  getAvailableCommands: Effect.Effect<ReadonlyArray<EffectAcpSchema.AvailableCommand>>,
+): Effect.Effect<ReadonlyArray<EffectAcpSchema.AvailableCommand>> =>
+  Effect.gen(function* () {
+    const attempts = Math.max(
+      1,
+      Math.ceil(GROK_AVAILABLE_COMMANDS_WAIT_MS / GROK_AVAILABLE_COMMANDS_POLL_MS),
+    );
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      const commands = yield* getAvailableCommands;
+      if (commands.length > 0) {
+        return commands;
+      }
+      if (attempt + 1 < attempts) {
+        yield* Effect.sleep(Duration.millis(GROK_AVAILABLE_COMMANDS_POLL_MS));
+      }
+    }
+    return yield* getAvailableCommands;
+  });
+
 const discoverGrokModelsViaAcp = (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
 ) =>
   Effect.gen(function* () {
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
@@ -133,11 +165,15 @@ const discoverGrokModelsViaAcp = (
       grokSettings,
       environment,
       childProcessSpawner,
-      cwd: process.cwd(),
+      cwd,
       clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
     });
     const started = yield* acp.start();
-    return buildGrokDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models);
+    const availableCommands = yield* waitForGrokAvailableCommands(acp.getAvailableCommands);
+    return {
+      models: buildGrokDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models),
+      availableCommands,
+    } satisfies GrokAcpDiscoveryResult;
   }).pipe(Effect.scoped);
 
 const runGrokVersionCommand = (
@@ -161,6 +197,7 @@ const runGrokVersionCommand = (
 export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(function* (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
+  cwd?: string,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -168,6 +205,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
 > {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const fallbackModels = grokModelsFromSettings(grokSettings.customModels);
+  const probeCwd = cwd && cwd.trim().length > 0 ? cwd : process.cwd();
 
   if (!grokSettings.enabled) {
     return buildServerProvider({
@@ -251,19 +289,34 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
-  const discoveryExit = yield* discoverGrokModelsViaAcp(grokSettings, environment).pipe(
-    Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
-    Effect.exit,
+  // Skills and ACP discovery are independent: skills still populate when ACP
+  // fails, and slash commands fall back to invocable skills when needed.
+  const [discoveryExit, skills] = yield* Effect.all(
+    [
+      discoverGrokModelsViaAcp(grokSettings, environment, probeCwd).pipe(
+        Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
+        Effect.exit,
+      ),
+      discoverGrokSkills(grokSettings, probeCwd, environment),
+    ],
+    { concurrency: "unbounded" },
   );
+
   if (Exit.isFailure(discoveryExit)) {
     yield* Effect.logWarning("Grok ACP model discovery failed", {
       errorTag: causeErrorTag(discoveryExit.cause),
+    });
+    const slashCommands = resolveGrokSlashCommands({
+      availableCommands: [],
+      skills,
     });
     return buildServerProvider({
       presentation: GROK_PRESENTATION,
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
+      slashCommands,
       probe: {
         installed: true,
         version,
@@ -277,11 +330,17 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     yield* Effect.logWarning(
       `Grok ACP model discovery timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
     );
+    const slashCommands = resolveGrokSlashCommands({
+      availableCommands: [],
+      skills,
+    });
     return buildServerProvider({
       presentation: GROK_PRESENTATION,
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
+      slashCommands,
       probe: {
         installed: true,
         version,
@@ -291,17 +350,24 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       },
     });
   }
-  const discoveredModels = discoveryExit.value.value;
+
+  const discovery = discoveryExit.value.value;
   const models =
-    discoveredModels.length > 0
-      ? grokModelsFromSettings(grokSettings.customModels, discoveredModels)
+    discovery.models.length > 0
+      ? grokModelsFromSettings(grokSettings.customModels, discovery.models)
       : fallbackModels;
+  const slashCommands = resolveGrokSlashCommands({
+    availableCommands: discovery.availableCommands,
+    skills,
+  });
 
   return buildServerProvider({
     presentation: GROK_PRESENTATION,
     enabled: grokSettings.enabled,
     checkedAt,
     models,
+    skills,
+    slashCommands,
     probe: {
       installed: true,
       version,

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -192,9 +192,7 @@ export class AcpSessionRuntime extends Context.Service<
      * Captured even during session startup (before the runtime is marked Started),
      * because agents such as Grok emit the first list during `session/new`.
      */
-    readonly getAvailableCommands: Effect.Effect<
-      ReadonlyArray<EffectAcpSchema.AvailableCommand>
-    >;
+    readonly getAvailableCommands: Effect.Effect<ReadonlyArray<EffectAcpSchema.AvailableCommand>>;
     /**
      * Sends a prompt turn to the active session.
      * @see https://agentclientprotocol.com/protocol/schema#session/prompt
@@ -380,13 +378,22 @@ export const make = (
 
     yield* acp.handleSessionUpdate((notification) =>
       Effect.gen(function* () {
-        // Capture available commands before startup/replay filters. Grok (and
-        // other agents) advertise the first command list during session setup,
-        // while startState is still Starting and session/update would otherwise
-        // be dropped for the event queue.
+        // Capture available commands before the event-queue Started gate. Grok
+        // (and other agents) advertise the first command list during session
+        // setup while startState is still Starting.
+        //
+        // While Starting/NotStarted: accept any sessionId so setup emissions
+        // are not dropped before we know the root id. Once Started: only the
+        // root session may update the ref (child sessions must not overwrite).
         const availableCommands = availableCommandsFromSessionUpdate(notification);
         if (availableCommands) {
-          yield* Ref.set(availableCommandsRef, availableCommands);
+          const startStateForCommands = yield* Ref.get(startStateRef);
+          const acceptCommands =
+            startStateForCommands._tag !== "Started" ||
+            notification.sessionId === startStateForCommands.result.sessionId;
+          if (acceptCommands) {
+            yield* Ref.set(availableCommandsRef, availableCommands);
+          }
         }
 
         const gate = yield* Ref.get(sessionLoadGateRef);
@@ -688,16 +695,23 @@ export const make = (
           case "Starting":
             return [Deferred.await(state.deferred), state] as const;
           case "NotStarted":
+            // Drop any commands left from a previous failed start attempt so a
+            // retry never surfaces a stale available-commands snapshot.
             return [
-              startOnce.pipe(
-                Effect.tap((result) =>
-                  Ref.set(startStateRef, { _tag: "Started", result }).pipe(
-                    Effect.andThen(Deferred.succeed(deferred, result)),
-                  ),
-                ),
-                Effect.onError((cause) =>
-                  Deferred.failCause(deferred, cause).pipe(
-                    Effect.andThen(Ref.set(startStateRef, { _tag: "NotStarted" })),
+              Ref.set(availableCommandsRef, []).pipe(
+                Effect.andThen(
+                  startOnce.pipe(
+                    Effect.tap((result) =>
+                      Ref.set(startStateRef, { _tag: "Started", result }).pipe(
+                        Effect.andThen(Deferred.succeed(deferred, result)),
+                      ),
+                    ),
+                    Effect.onError((cause) =>
+                      Deferred.failCause(deferred, cause).pipe(
+                        Effect.andThen(Ref.set(startStateRef, { _tag: "NotStarted" })),
+                        Effect.andThen(Ref.set(availableCommandsRef, [])),
+                      ),
+                    ),
                   ),
                 ),
               ),

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -188,6 +188,14 @@ export class AcpSessionRuntime extends Context.Service<
     /** Latest configuration options observed from session setup and configuration writes. */
     readonly getConfigOptions: Effect.Effect<ReadonlyArray<EffectAcpSchema.SessionConfigOption>>;
     /**
+     * Latest slash / available commands advertised via `available_commands_update`.
+     * Captured even during session startup (before the runtime is marked Started),
+     * because agents such as Grok emit the first list during `session/new`.
+     */
+    readonly getAvailableCommands: Effect.Effect<
+      ReadonlyArray<EffectAcpSchema.AvailableCommand>
+    >;
+    /**
      * Sends a prompt turn to the active session.
      * @see https://agentclientprotocol.com/protocol/schema#session/prompt
      */
@@ -291,6 +299,9 @@ export const make = (
     );
     const assistantSegmentRef = yield* Ref.make<AcpAssistantSegmentState>({ nextSegmentIndex: 0 });
     const configOptionsRef = yield* Ref.make(sessionConfigOptionsFromSetup(undefined));
+    const availableCommandsRef = yield* Ref.make<ReadonlyArray<EffectAcpSchema.AvailableCommand>>(
+      [],
+    );
     const startStateRef = yield* Ref.make<AcpStartState>({ _tag: "NotStarted" });
     const promptSerializationSemaphore = yield* Semaphore.make(1);
     const activePromptFiberRef = yield* Ref.make<
@@ -369,6 +380,15 @@ export const make = (
 
     yield* acp.handleSessionUpdate((notification) =>
       Effect.gen(function* () {
+        // Capture available commands before startup/replay filters. Grok (and
+        // other agents) advertise the first command list during session setup,
+        // while startState is still Starting and session/update would otherwise
+        // be dropped for the event queue.
+        const availableCommands = availableCommandsFromSessionUpdate(notification);
+        if (availableCommands) {
+          yield* Ref.set(availableCommandsRef, availableCommands);
+        }
+
         const gate = yield* Ref.get(sessionLoadGateRef);
         if (Option.isSome(gate) && gate.value.active) {
           const lastActivityAtMillis = yield* Clock.currentTimeMillis;
@@ -716,6 +736,7 @@ export const make = (
       }),
       getModeState: Ref.get(modeStateRef),
       getConfigOptions: Ref.get(configOptionsRef),
+      getAvailableCommands: Ref.get(availableCommandsRef),
       prompt: (payload) =>
         promptSerializationSemaphore.withPermit(
           Effect.gen(function* () {
@@ -839,6 +860,16 @@ function configOptionCurrentValueMatches(
     return false;
   }
   return currentValue.trim() === String(value).trim();
+}
+
+function availableCommandsFromSessionUpdate(
+  notification: EffectAcpSchema.SessionNotification,
+): ReadonlyArray<EffectAcpSchema.AvailableCommand> | undefined {
+  const update = notification.update;
+  if (update.sessionUpdate !== "available_commands_update") {
+    return undefined;
+  }
+  return update.availableCommands;
 }
 
 const handleSessionUpdate = ({


### PR DESCRIPTION
## Summary

Grok provider snapshots never filled `slashCommands` or `skills`, so the composer `/` and `$` menus stayed empty even though Grok Build already advertises both.

- Capture ACP `available_commands_update` during session setup (including before the runtime is marked Started, which is when Grok emits the list)
- Discover skills via `grok inspect --json` so user, project, bundled, and plugin skills land in the `$` picker with paths/scopes
- Prefer ACP-advertised slash commands; fall back to invocable skills when ACP discovery fails
- Pass workspace `cwd` into the Grok status check so project skills resolve correctly

No contract or UI changes — web and mobile already render provider slash commands and skills from the snapshot.

## Test plan

- [x] `vp test run apps/server/src/provider/Drivers/GrokSkills.test.ts apps/server/src/provider/Drivers/GrokSlashCommands.test.ts apps/server/src/provider/Layers/GrokProvider.test.ts`
- [x] Related Grok ACP/adapter tests still pass
- [ ] Dev: select Grok, type `/` and confirm builtins + user skills (e.g. `/super-review`) appear
- [ ] Dev: type `$` and confirm skills with scopes appear
- [ ] Selecting a slash command inserts `/name ` and sends correctly on a Grok turn

Made with Grok Build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared ACP session runtime and Grok status probing (subprocesses, timeouts, parallel discovery); behavior is best-effort but affects all Grok snapshot consumers.
> 
> **Overview**
> Grok provider health checks now fill **`skills`** and **`slashCommands`** on the snapshot so composer `/` and `$` menus can use Grok’s real command and skill lists.
> 
> **Skills** are discovered by running `grok inspect --json` in the workspace (with optional **`cwd`** from `GrokDriver` / `ServerConfig`), parsing the JSON defensively, deduping by name with project scope winning over user/bundled. **Slash commands** prefer ACP `available_commands_update` (mapped and merged with skills) and fall back to user-invocable skills when ACP advertises nothing.
> 
> **ACP runtime** now records `available_commands_update` during `session/new` (before Started), exposes **`getAvailableCommands`**, and clears stale commands on failed start retries. Grok probe runs skill inspect and ACP discovery **in parallel**; after ACP start it **polls ~2s** for the richest command list without eating the 15s start timeout. Failed or timed-out ACP still returns skills and skill-derived slash commands where possible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab8dc7d949abd0e46944814164dafaef9cf0661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Populate Grok slash commands and skills in provider status
> - Adds `discoverGrokSkills` in [GrokSkills.ts](https://github.com/pingdotgg/t3code/pull/6050/files#diff-b9a91917429e16fdadd1583ee3bb784e862cc270fd9ffa70002cf175bbef35ab) which spawns `grok inspect --json` with a 4s timeout, parses the output into a deduped, validated, sorted list of `ServerProviderSkill` entries.
> - Adds `resolveGrokSlashCommands` in [GrokSlashCommands.ts](https://github.com/pingdotgg/t3code/pull/6050/files#diff-acfee35e7388cbdf17678278402da8ca3d7028ff60c8164c0a96c2d609d27557) which merges ACP-advertised commands with skill-derived commands, preferring ACP and supplementing with enabled skills.
> - Updates `checkGrokProviderStatus` in [GrokProvider.ts](https://github.com/pingdotgg/t3code/pull/6050/files#diff-d88edf38a3399863fd884b8deb4f8eb57539ca15d41ce6ea03cad4baf62acf0f) to run ACP model discovery and skill discovery concurrently; ACP failure no longer prevents skills from populating the provider snapshot.
> - Updates `AcpSessionRuntime` in [AcpSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/6050/files#diff-947405407dc15b91fd18625aab3132939b58753dce5a014fe17c590f2abfa5d6) to track available commands advertised during session startup and expose them via `getAvailableCommands`; stale commands are cleared on start and error.
> - Behavioral Change: `checkGrokProviderStatus` now accepts an optional `cwd` parameter (passed from `ServerConfig`) that influences both ACP and binary-based discovery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ab8dc7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->