### PR TITLE
feat(usage): include Grok Build in the usage view

### DIFF
--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,21 +5,23 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "grok"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  grok: "Grok Build",
 };
 
 /**
- * Claude's brand orange holds in both themes; Codex is neutral and must flip
- * with the theme or its bars vanish against the matching background.
+ * Claude's brand orange holds in both themes; Codex and Grok are neutral and
+ * must flip with the theme or their bars vanish against the matching background.
  */
 export function useProviderColors(): Record<UsageProviderKind, string> {
   const { themeAppearance: scheme } = useAppearancePreferences();
   return {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
+    grok: scheme === "dark" ? "#a1a1aa" : "#52525b",
   };
 }

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -1,9 +1,9 @@
 /**
  * UsageService - scans provider transcripts and returns priced usage buckets.
  *
- * The scan reads the provider CLIs' own session files rather than T3 Code's
- * orchestration projections, so usage covers turns driven outside T3 Code too.
- * This is the approach `ccusage` takes.
+ * The scan reads the provider CLIs' own session files (Claude Code, Codex, and
+ * Grok Build) rather than T3 Code's orchestration projections, so usage covers
+ * turns driven outside T3 Code too. This is the approach `ccusage` takes.
  *
  * Transcripts are append-only, so parsed records are memoised per file by
  * `(size, mtime)`. A cold 30-day scan of ~1.4 GB lands around 2-3 seconds; warm
@@ -34,6 +34,7 @@ import * as Schema from "effect/Schema";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { ServerConfig } from "../config.ts";
+import { expandHomePath } from "../pathExpansion.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
@@ -218,10 +219,17 @@ export const make = Effect.gen(function* () {
     const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
     const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
     const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
+    // Grok Settings only expose the binary path; home is `$GROK_HOME` or `~/.grok`.
+    const grokHomeEnv = process.env["GROK_HOME"]?.trim() ?? "";
+    const grokHome =
+      grokHomeEnv.length > 0
+        ? path.resolve(expandHomePath(grokHomeEnv))
+        : path.join(NodeOS.homedir(), ".grok");
 
     return [
       { provider: "claude" as const, dir: claudeDir },
       { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
+      { provider: "grok" as const, dir: path.join(grokHome, "sessions") },
     ];
   });
 
@@ -373,7 +381,16 @@ export const make = Effect.gen(function* () {
       }
 
       walkedRoots.push(dir);
-      const files = yield* Effect.promise(() => listTranscriptFiles(dir, windowStartMs));
+      // Grok sessions nest many large `.jsonl` logs; only `updates.jsonl` carries
+      // `turn_completed` usage. Restrict the walk so chat/events history never
+      // enters the scan or the cache.
+      const files = yield* Effect.promise(() =>
+        listTranscriptFiles(
+          dir,
+          windowStartMs,
+          provider === "grok" ? { fileName: "updates.jsonl" } : undefined,
+        ),
+      );
       let scannedFiles = 0;
       let skippedFiles = 0;
       // Distinct per directory. Buckets carry per-cell session counts, but a

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -134,7 +134,7 @@ export function decodeScanCache(document: unknown): ScanCache {
     if (typeof raw !== "object" || raw === null) continue;
     const entry = raw as Partial<SerializedFile>;
     if (typeof entry.s !== "number" || typeof entry.m !== "number") continue;
-    if (entry.p !== "claude" && entry.p !== "codex") continue;
+    if (entry.p !== "claude" && entry.p !== "codex" && entry.p !== "grok") continue;
     if (!isRecordArray(entry.r)) continue;
 
     const provider: UsageProviderKind = entry.p;

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -22,6 +22,7 @@ import {
   mightCarryUsage,
   parseClaudeLine,
   parseCodexLine,
+  parseGrokLine,
   type UsageRecord,
 } from "./usageTranscripts.ts";
 
@@ -37,12 +38,19 @@ export interface TranscriptFile {
  * Errors on individual entries are swallowed: session files rotate and get
  * removed while the walk is in flight, and a partial listing is far better than
  * failing the page.
+ *
+ * `fileName` restricts the walk to a single basename (e.g. Grok's
+ * `updates.jsonl`). Grok sessions also ship multi-megabyte `chat_history` and
+ * `events` logs that never carry usage, so the basename filter is what keeps a
+ * cold scan off those files entirely.
  */
 export async function listTranscriptFiles(
   root: string,
   sinceMs: number,
+  options?: { readonly fileName?: string },
 ): Promise<readonly TranscriptFile[]> {
   const found: TranscriptFile[] = [];
+  const fileName = options?.fileName;
 
   const walk = async (dir: string): Promise<void> => {
     let entries;
@@ -57,7 +65,11 @@ export async function listTranscriptFiles(
         await walk(child);
         continue;
       }
-      if (!entry.name.endsWith(".jsonl")) continue;
+      if (fileName !== undefined) {
+        if (entry.name !== fileName) continue;
+      } else if (!entry.name.endsWith(".jsonl")) {
+        continue;
+      }
       try {
         const stats = await NodeFSP.stat(child);
         if (stats.mtimeMs >= sinceMs) {
@@ -126,6 +138,12 @@ export async function readTranscriptRecords(
         }
         const record = parseCodexLine(line, codexState);
         if (record !== null) records.push(record);
+        continue;
+      }
+
+      if (provider === "grok") {
+        if (!mightCarryUsage(line, provider)) continue;
+        for (const record of parseGrokLine(line)) records.push(record);
         continue;
       }
 

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -432,6 +432,49 @@ describe("parseGrokLine", () => {
     expect(sum).toBeCloseTo(1, 12);
   });
 
+  it("pro-rates aggregate cost when a zero-token sibling carries costUsdTicks: 0", () => {
+    // Empty-usage modelUsage rows often ship costUsdTicks: 0. That must not
+    // count as "per-model ticks present" and suppress pro-rating for billable
+    // models that omit their own ticks — otherwise top-level provider cost is
+    // dropped entirely.
+    const records = parseGrokLine(
+      turnCompleted({
+        modelUsage: {
+          "grok-4.5": {
+            inputTokens: 300,
+            outputTokens: 0,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+          },
+          "grok-composer-2.5-fast": {
+            inputTokens: 100,
+            outputTokens: 0,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+          },
+          "empty-sibling": {
+            inputTokens: 0,
+            outputTokens: 0,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+            costUsdTicks: 0,
+          },
+        },
+        usage: { costUsdTicks: GROK_COST_USD_TICKS_PER_DOLLAR },
+      }),
+    );
+
+    expect(records).toHaveLength(2);
+    expect(records.every((record) => record.model !== "empty-sibling")).toBe(true);
+    const byModel = Object.fromEntries(records.map((record) => [record.model, record]));
+    expect(byModel["grok-4.5"]?.reportedCostUsd).toBeCloseTo(0.75, 12);
+    expect(byModel["grok-composer-2.5-fast"]?.reportedCostUsd).toBeCloseTo(0.25, 12);
+    const sum =
+      (byModel["grok-4.5"]?.reportedCostUsd ?? 0) +
+      (byModel["grok-composer-2.5-fast"]?.reportedCostUsd ?? 0);
+    expect(sum).toBeCloseTo(1, 12);
+  });
+
   it("ignores non-turn lines and empty usage", () => {
     expect(parseGrokLine(JSON.stringify({ method: "session/update", params: {} }))).toEqual([]);
     expect(parseGrokLine("not json")).toEqual([]);

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -324,9 +324,7 @@ describe("parseGrokLine", () => {
       reasoningTokens: 180,
     });
     expect(record?.reportedCostUsd).toBeCloseTo(230_272_000 / GROK_COST_USD_TICKS_PER_DOLLAR, 12);
-    expect(record?.dedupeKey).toBe(
-      "019fec1a-12f7-72f2-9b1f-7778a00aea3c:prompt-1:grok-4.5-build",
-    );
+    expect(record?.dedupeKey).toBe("019fec1a-12f7-72f2-9b1f-7778a00aea3c:prompt-1:grok-4.5-build");
   });
 
   it("emits one record per model when modelUsage has several entries", () => {
@@ -379,6 +377,59 @@ describe("parseGrokLine", () => {
 
     expect(records).toHaveLength(1);
     expect(records[0]?.reportedCostUsd).toBe(1);
+  });
+
+  it("falls back to a generic grok model when modelUsage is absent", () => {
+    // Older turns (or incomplete writes) only carry the aggregate usage blob.
+    const records = parseGrokLine(turnCompleted({ modelUsage: null }));
+
+    expect(records).toHaveLength(1);
+    const [record] = records;
+    expect(record?.provider).toBe("grok");
+    expect(record?.model).toBe("grok");
+    // Aggregate inputTokens is inclusive of cachedReadTokens.
+    expect(record?.totals).toEqual({
+      uncachedInputTokens: 20_272 - 11_264,
+      cachedInputTokens: 11_264,
+      cacheCreationTokens: 0,
+      outputTokens: 272,
+      reasoningTokens: 180,
+    });
+    expect(record?.reportedCostUsd).toBeCloseTo(230_272_000 / GROK_COST_USD_TICKS_PER_DOLLAR, 12);
+    expect(record?.dedupeKey).toBe("019fec1a-12f7-72f2-9b1f-7778a00aea3c:prompt-1:grok");
+  });
+
+  it("pro-rates top-level cost ticks across multi-model turns without per-model ticks", () => {
+    // Two models, only the aggregate carries costUsdTicks. Token shares are
+    // 3/4 and 1/4 so reported cost should split $1 → $0.75 / $0.25.
+    const records = parseGrokLine(
+      turnCompleted({
+        modelUsage: {
+          "grok-4.5": {
+            inputTokens: 300,
+            outputTokens: 0,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+          },
+          "grok-composer-2.5-fast": {
+            inputTokens: 100,
+            outputTokens: 0,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+          },
+        },
+        usage: { costUsdTicks: GROK_COST_USD_TICKS_PER_DOLLAR },
+      }),
+    );
+
+    expect(records).toHaveLength(2);
+    const byModel = Object.fromEntries(records.map((record) => [record.model, record]));
+    expect(byModel["grok-4.5"]?.reportedCostUsd).toBeCloseTo(0.75, 12);
+    expect(byModel["grok-composer-2.5-fast"]?.reportedCostUsd).toBeCloseTo(0.25, 12);
+    const sum =
+      (byModel["grok-4.5"]?.reportedCostUsd ?? 0) +
+      (byModel["grok-composer-2.5-fast"]?.reportedCostUsd ?? 0);
+    expect(sum).toBeCloseTo(1, 12);
   });
 
   it("ignores non-turn lines and empty usage", () => {

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
 
 import {
+  GROK_COST_USD_TICKS_PER_DOLLAR,
   initialCodexScanState,
   parseClaudeLine,
   parseCodexLine,
+  parseGrokLine,
   totalTokens,
 } from "./usageTranscripts.ts";
 
@@ -247,5 +249,179 @@ describe("totalTokens", () => {
         reasoningTokens: 25,
       }),
     ).toBe(100);
+  });
+});
+
+describe("parseGrokLine", () => {
+  /** Shaped after a real Grok Build `turn_completed` session update. */
+  function turnCompleted(overrides?: {
+    sessionId?: string;
+    promptId?: string;
+    timestamp?: number;
+    agentTimestampMs?: number;
+    usage?: Record<string, unknown>;
+    modelUsage?: Record<string, Record<string, unknown>> | null;
+  }): string {
+    const modelUsage =
+      overrides && "modelUsage" in overrides
+        ? overrides.modelUsage
+        : {
+            "grok-4.5-build": {
+              inputTokens: 20_272,
+              outputTokens: 272,
+              totalTokens: 20_544,
+              cachedReadTokens: 11_264,
+              cacheCreationTokens: 0,
+              reasoningTokens: 180,
+              costUsdTicks: 230_272_000,
+            },
+          };
+
+    return JSON.stringify({
+      timestamp: overrides?.timestamp ?? 1_786_372_566,
+      method: "_x.ai/session/update",
+      params: {
+        sessionId: overrides?.sessionId ?? "019fec1a-12f7-72f2-9b1f-7778a00aea3c",
+        update: {
+          sessionUpdate: "turn_completed",
+          prompt_id: overrides?.promptId ?? "prompt-1",
+          stop_reason: "end_turn",
+          usage: {
+            inputTokens: 20_272,
+            outputTokens: 272,
+            totalTokens: 20_544,
+            cachedReadTokens: 11_264,
+            cacheCreationTokens: 0,
+            reasoningTokens: 180,
+            costUsdTicks: 230_272_000,
+            ...(modelUsage === null ? {} : { modelUsage }),
+            ...(overrides?.usage ?? {}),
+          },
+        },
+        _meta: {
+          eventId: "event-1",
+          agentTimestampMs: overrides?.agentTimestampMs ?? 1_786_372_566_485,
+        },
+      },
+    });
+  }
+
+  it("extracts per-model totals and provider-reported cost ticks", () => {
+    const records = parseGrokLine(turnCompleted());
+
+    expect(records).toHaveLength(1);
+    const [record] = records;
+    expect(record?.provider).toBe("grok");
+    expect(record?.model).toBe("grok-4.5-build");
+    expect(record?.sessionId).toBe("019fec1a-12f7-72f2-9b1f-7778a00aea3c");
+    expect(record?.timestampMs).toBe(1_786_372_566_485);
+    // inputTokens is inclusive of the cached portion.
+    expect(record?.totals).toEqual({
+      uncachedInputTokens: 20_272 - 11_264,
+      cachedInputTokens: 11_264,
+      cacheCreationTokens: 0,
+      outputTokens: 272,
+      reasoningTokens: 180,
+    });
+    expect(record?.reportedCostUsd).toBeCloseTo(230_272_000 / GROK_COST_USD_TICKS_PER_DOLLAR, 12);
+    expect(record?.dedupeKey).toBe(
+      "019fec1a-12f7-72f2-9b1f-7778a00aea3c:prompt-1:grok-4.5-build",
+    );
+  });
+
+  it("emits one record per model when modelUsage has several entries", () => {
+    const records = parseGrokLine(
+      turnCompleted({
+        modelUsage: {
+          "grok-4.5": {
+            inputTokens: 1000,
+            outputTokens: 50,
+            cachedReadTokens: 400,
+            reasoningTokens: 20,
+            costUsdTicks: 50_000_000,
+          },
+          "grok-composer-2.5-fast": {
+            inputTokens: 200,
+            outputTokens: 30,
+            cachedReadTokens: 100,
+            reasoningTokens: 0,
+            costUsdTicks: 10_000_000,
+          },
+        },
+      }),
+    );
+
+    expect(records.map((record) => record.model).toSorted()).toEqual([
+      "grok-4.5",
+      "grok-composer-2.5-fast",
+    ]);
+    expect(records.every((record) => record.provider === "grok")).toBe(true);
+    expect(records.find((record) => record.model === "grok-4.5")?.reportedCostUsd).toBeCloseTo(
+      0.005,
+      12,
+    );
+  });
+
+  it("inherits top-level cost ticks for a single model without its own ticks", () => {
+    const records = parseGrokLine(
+      turnCompleted({
+        modelUsage: {
+          "grok-4.5-build": {
+            inputTokens: 1000,
+            outputTokens: 10,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+          },
+        },
+        usage: { costUsdTicks: GROK_COST_USD_TICKS_PER_DOLLAR },
+      }),
+    );
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.reportedCostUsd).toBe(1);
+  });
+
+  it("ignores non-turn lines and empty usage", () => {
+    expect(parseGrokLine(JSON.stringify({ method: "session/update", params: {} }))).toEqual([]);
+    expect(parseGrokLine("not json")).toEqual([]);
+    expect(
+      parseGrokLine(
+        turnCompleted({
+          modelUsage: {
+            "grok-4.5-build": {
+              inputTokens: 0,
+              outputTokens: 0,
+              cachedReadTokens: 0,
+              reasoningTokens: 0,
+              costUsdTicks: 0,
+            },
+          },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("falls back to the outer unix-seconds timestamp when agent meta is missing", () => {
+    const line = JSON.stringify({
+      timestamp: 1_786_372_566,
+      method: "_x.ai/session/update",
+      params: {
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "turn_completed",
+          prompt_id: "p1",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            modelUsage: {
+              "grok-4.5": { inputTokens: 10, outputTokens: 2 },
+            },
+          },
+        },
+      },
+    });
+
+    const records = parseGrokLine(line);
+    expect(records[0]?.timestampMs).toBe(1_786_372_566_000);
   });
 });

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -434,9 +434,8 @@ describe("parseGrokLine", () => {
 
   it("pro-rates aggregate cost when a zero-token sibling carries costUsdTicks: 0", () => {
     // Empty-usage modelUsage rows often ship costUsdTicks: 0. That must not
-    // count as "per-model ticks present" and suppress pro-rating for billable
-    // models that omit their own ticks — otherwise top-level provider cost is
-    // dropped entirely.
+    // count as used per-model ticks and must not suppress remainder allocation
+    // for billable models that omit their own ticks.
     const records = parseGrokLine(
       turnCompleted({
         modelUsage: {
@@ -469,6 +468,42 @@ describe("parseGrokLine", () => {
     const byModel = Object.fromEntries(records.map((record) => [record.model, record]));
     expect(byModel["grok-4.5"]?.reportedCostUsd).toBeCloseTo(0.75, 12);
     expect(byModel["grok-composer-2.5-fast"]?.reportedCostUsd).toBeCloseTo(0.25, 12);
+    const sum =
+      (byModel["grok-4.5"]?.reportedCostUsd ?? 0) +
+      (byModel["grok-composer-2.5-fast"]?.reportedCostUsd ?? 0);
+    expect(sum).toBeCloseTo(1, 12);
+  });
+
+  it("allocates leftover aggregate ticks to models that omit per-model ticks", () => {
+    // Mixed turn: model A reports its own ticks; model B omits them. The
+    // aggregate is larger than A's ticks — B must receive the remainder so
+    // summed reported cost still matches the provider total.
+    // A: $0.40 own ticks, B: 100 tokens unticked, aggregate: $1 → B gets $0.60.
+    const records = parseGrokLine(
+      turnCompleted({
+        modelUsage: {
+          "grok-4.5": {
+            inputTokens: 300,
+            outputTokens: 0,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+            costUsdTicks: 0.4 * GROK_COST_USD_TICKS_PER_DOLLAR,
+          },
+          "grok-composer-2.5-fast": {
+            inputTokens: 100,
+            outputTokens: 0,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+          },
+        },
+        usage: { costUsdTicks: GROK_COST_USD_TICKS_PER_DOLLAR },
+      }),
+    );
+
+    expect(records).toHaveLength(2);
+    const byModel = Object.fromEntries(records.map((record) => [record.model, record]));
+    expect(byModel["grok-4.5"]?.reportedCostUsd).toBeCloseTo(0.4, 12);
+    expect(byModel["grok-composer-2.5-fast"]?.reportedCostUsd).toBeCloseTo(0.6, 12);
     const sum =
       (byModel["grok-4.5"]?.reportedCostUsd ?? 0) +
       (byModel["grok-composer-2.5-fast"]?.reportedCostUsd ?? 0);

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -1,8 +1,8 @@
 /**
  * Pure parsers for the provider CLIs' on-disk session transcripts.
  *
- * Both parsers are line-at-a-time reducers so callers can stream large files
- * without materialising them. Neither touches the filesystem.
+ * Each parser is a line-at-a-time reducer so callers can stream large files
+ * without materialising them. None of them touch the filesystem.
  *
  * @module usageTranscripts
  */
@@ -68,7 +68,20 @@ export function totalTokens(totals: UsageTokenTotals): number {
  * an order of magnitude.
  */
 export function mightCarryUsage(line: string, provider: UsageProviderKind): boolean {
-  return provider === "claude" ? line.includes('"usage"') : line.includes('"token_count"');
+  if (provider === "claude") return line.includes('"usage"');
+  if (provider === "grok") return line.includes('"turn_completed"');
+  return line.includes('"token_count"');
+}
+
+/**
+ * Grok reports cost in integer ticks where `1 USD = 10^10` ticks (see Grok
+ * headless docs for `total_cost_usd_ticks`). Convert to dollars for pricing.
+ */
+export const GROK_COST_USD_TICKS_PER_DOLLAR = 10_000_000_000;
+
+export function grokCostTicksToUsd(ticks: unknown): number | null {
+  if (typeof ticks !== "number" || !Number.isFinite(ticks) || ticks < 0) return null;
+  return ticks / GROK_COST_USD_TICKS_PER_DOLLAR;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -295,6 +308,166 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     // rollout, so they need no global dedup.
     dedupeKey: null,
   };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Grok Build                                                                 */
+/* -------------------------------------------------------------------------- */
+
+interface GrokUsageTotals {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cachedReadTokens: number;
+  readonly cacheCreationTokens: number;
+  readonly reasoningTokens: number;
+  readonly costUsdTicks: number | null;
+}
+
+function readGrokUsageTotals(value: unknown): GrokUsageTotals | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  return {
+    inputTokens: int(record["inputTokens"]),
+    outputTokens: int(record["outputTokens"]),
+    cachedReadTokens: int(record["cachedReadTokens"]),
+    cacheCreationTokens: int(record["cacheCreationTokens"]),
+    reasoningTokens: int(record["reasoningTokens"]),
+    costUsdTicks:
+      typeof record["costUsdTicks"] === "number" && Number.isFinite(record["costUsdTicks"])
+        ? record["costUsdTicks"]
+        : null,
+  };
+}
+
+function grokTotalsToUsage(totals: GrokUsageTotals): UsageTokenTotals {
+  const cachedInputTokens = totals.cachedReadTokens;
+  const cacheCreationTokens = totals.cacheCreationTokens;
+  // Grok reports `inputTokens` inclusive of the cached portion, matching Codex.
+  const uncachedInputTokens = Math.max(
+    0,
+    totals.inputTokens - cachedInputTokens - cacheCreationTokens,
+  );
+  const outputTokens = totals.outputTokens;
+  return {
+    uncachedInputTokens,
+    cachedInputTokens,
+    cacheCreationTokens,
+    outputTokens,
+    reasoningTokens: Math.min(outputTokens, totals.reasoningTokens),
+  };
+}
+
+/**
+ * Parses one line of a Grok Build `updates.jsonl` session log.
+ *
+ * Usage lands on `turn_completed` session updates (method
+ * `_x.ai/session/update`). Per-model breakdowns live under `usage.modelUsage`;
+ * when present each model becomes its own record so the model table is exact.
+ *
+ * Returns every record for the line (0 or more). Callers stream line-by-line
+ * and flatten; multi-model turns are rare but real.
+ */
+export function parseGrokLine(line: string): readonly UsageRecord[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return [];
+  }
+  if (typeof parsed !== "object" || parsed === null) return [];
+
+  const record = parsed as Record<string, unknown>;
+  const params = record["params"];
+  if (typeof params !== "object" || params === null) return [];
+  const paramsRecord = params as Record<string, unknown>;
+
+  const update = paramsRecord["update"];
+  if (typeof update !== "object" || update === null) return [];
+  const updateRecord = update as Record<string, unknown>;
+  if (updateRecord["sessionUpdate"] !== "turn_completed") return [];
+
+  const usage = updateRecord["usage"];
+  if (typeof usage !== "object" || usage === null) return [];
+  const usageRecord = usage as Record<string, unknown>;
+
+  const sessionId =
+    typeof paramsRecord["sessionId"] === "string" ? paramsRecord["sessionId"] : "";
+  const promptId =
+    typeof updateRecord["prompt_id"] === "string" ? updateRecord["prompt_id"] : null;
+
+  // Prefer the high-resolution agent clock; fall back to the outer unix seconds.
+  const meta = paramsRecord["_meta"];
+  let timestampMs: number | null = null;
+  if (typeof meta === "object" && meta !== null) {
+    const agentTimestampMs = (meta as Record<string, unknown>)["agentTimestampMs"];
+    if (typeof agentTimestampMs === "number" && Number.isFinite(agentTimestampMs)) {
+      timestampMs = agentTimestampMs;
+    }
+  }
+  if (timestampMs === null) {
+    const timestamp = record["timestamp"];
+    if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+      // Outer timestamps are unix seconds on the files we have seen.
+      timestampMs = timestamp > 1e12 ? timestamp : timestamp * 1000;
+    }
+  }
+  if (timestampMs === null) return [];
+
+  const topLevel = readGrokUsageTotals(usageRecord);
+  if (topLevel === null) return [];
+
+  const modelUsage = usageRecord["modelUsage"];
+  const modelEntries: Array<{ model: string; totals: GrokUsageTotals }> = [];
+  if (typeof modelUsage === "object" && modelUsage !== null) {
+    for (const [model, raw] of Object.entries(modelUsage as Record<string, unknown>)) {
+      if (model.length === 0) continue;
+      const totals = readGrokUsageTotals(raw);
+      if (totals === null) continue;
+      modelEntries.push({ model, totals });
+    }
+  }
+
+  // Older turns (or incomplete writes) may only carry the aggregate usage blob.
+  if (modelEntries.length === 0) {
+    if (totalTokens(grokTotalsToUsage(topLevel)) === 0) return [];
+    return [
+      {
+        provider: "grok",
+        timestampMs,
+        model: "grok",
+        sessionId,
+        totals: grokTotalsToUsage(topLevel),
+        reportedCostUsd: grokCostTicksToUsd(topLevel.costUsdTicks),
+        dedupeKey: promptId === null ? null : `${sessionId}:${promptId}:grok`,
+      },
+    ];
+  }
+
+  const results: UsageRecord[] = [];
+  for (const entry of modelEntries) {
+    const totals = grokTotalsToUsage(entry.totals);
+    if (totalTokens(totals) === 0) continue;
+
+    // Per-model ticks when present; otherwise a single-model turn may inherit
+    // the aggregate. Multi-model turns without per-model ticks stay unpriced
+    // at the provider-reported layer and fall through to the rate table.
+    let reportedCostUsd = grokCostTicksToUsd(entry.totals.costUsdTicks);
+    if (reportedCostUsd === null && modelEntries.length === 1) {
+      reportedCostUsd = grokCostTicksToUsd(topLevel.costUsdTicks);
+    }
+
+    results.push({
+      provider: "grok",
+      timestampMs,
+      model: entry.model,
+      sessionId,
+      totals,
+      reportedCostUsd,
+      dedupeKey:
+        promptId === null ? null : `${sessionId}:${promptId}:${entry.model}`,
+    });
+  }
+  return results;
 }
 
 export { EMPTY_TOTALS };

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -445,7 +445,13 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
   // pro-rate the top-level ticks by each model's token share so provider cost
   // is not discarded on multi-model turns (rate-table fallback can still miss
   // slugs). Single-model turns simply inherit the aggregate below.
-  const anyPerModelTicks = modelEntries.some((entry) => entry.totals.costUsdTicks !== null);
+  // Only count ticks on entries the emit loop would keep: zero-token siblings
+  // (often costUsdTicks: 0) must not suppress aggregate pro-rating for
+  // billable models that omit per-model ticks.
+  const anyPerModelTicks = modelEntries.some(
+    (entry) =>
+      entry.totals.costUsdTicks !== null && totalTokens(grokTotalsToUsage(entry.totals)) > 0,
+  );
   const topLevelCostUsd = grokCostTicksToUsd(topLevel.costUsdTicks);
   let sharedTokenDenominator = 0;
   if (!anyPerModelTicks && topLevelCostUsd !== null && modelEntries.length > 1) {

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -390,10 +390,8 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
   if (typeof usage !== "object" || usage === null) return [];
   const usageRecord = usage as Record<string, unknown>;
 
-  const sessionId =
-    typeof paramsRecord["sessionId"] === "string" ? paramsRecord["sessionId"] : "";
-  const promptId =
-    typeof updateRecord["prompt_id"] === "string" ? updateRecord["prompt_id"] : null;
+  const sessionId = typeof paramsRecord["sessionId"] === "string" ? paramsRecord["sessionId"] : "";
+  const promptId = typeof updateRecord["prompt_id"] === "string" ? updateRecord["prompt_id"] : null;
 
   // Prefer the high-resolution agent clock; fall back to the outer unix seconds.
   const meta = paramsRecord["_meta"];
@@ -443,17 +441,34 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
     ];
   }
 
+  // When every per-model entry lacks ticks but the aggregate reports them,
+  // pro-rate the top-level ticks by each model's token share so provider cost
+  // is not discarded on multi-model turns (rate-table fallback can still miss
+  // slugs). Single-model turns simply inherit the aggregate below.
+  const anyPerModelTicks = modelEntries.some((entry) => entry.totals.costUsdTicks !== null);
+  const topLevelCostUsd = grokCostTicksToUsd(topLevel.costUsdTicks);
+  let sharedTokenDenominator = 0;
+  if (!anyPerModelTicks && topLevelCostUsd !== null && modelEntries.length > 1) {
+    for (const entry of modelEntries) {
+      sharedTokenDenominator += totalTokens(grokTotalsToUsage(entry.totals));
+    }
+  }
+
   const results: UsageRecord[] = [];
   for (const entry of modelEntries) {
     const totals = grokTotalsToUsage(entry.totals);
     if (totalTokens(totals) === 0) continue;
 
-    // Per-model ticks when present; otherwise a single-model turn may inherit
-    // the aggregate. Multi-model turns without per-model ticks stay unpriced
-    // at the provider-reported layer and fall through to the rate table.
+    // Per-model ticks when present; otherwise a single-model turn inherits the
+    // aggregate, and multi-model turns without per-model ticks take a token-
+    // share slice of the aggregate so reported cost is not dropped.
     let reportedCostUsd = grokCostTicksToUsd(entry.totals.costUsdTicks);
-    if (reportedCostUsd === null && modelEntries.length === 1) {
-      reportedCostUsd = grokCostTicksToUsd(topLevel.costUsdTicks);
+    if (reportedCostUsd === null && topLevelCostUsd !== null) {
+      if (modelEntries.length === 1) {
+        reportedCostUsd = topLevelCostUsd;
+      } else if (sharedTokenDenominator > 0) {
+        reportedCostUsd = topLevelCostUsd * (totalTokens(totals) / sharedTokenDenominator);
+      }
     }
 
     results.push({
@@ -463,8 +478,7 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
       sessionId,
       totals,
       reportedCostUsd,
-      dedupeKey:
-        promptId === null ? null : `${sessionId}:${promptId}:${entry.model}`,
+      dedupeKey: promptId === null ? null : `${sessionId}:${promptId}:${entry.model}`,
     });
   }
   return results;

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -441,40 +441,38 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
     ];
   }
 
-  // When every per-model entry lacks ticks but the aggregate reports them,
-  // pro-rate the top-level ticks by each model's token share so provider cost
-  // is not discarded on multi-model turns (rate-table fallback can still miss
-  // slugs). Single-model turns simply inherit the aggregate below.
-  // Only count ticks on entries the emit loop would keep: zero-token siblings
-  // (often costUsdTicks: 0) must not suppress aggregate pro-rating for
-  // billable models that omit per-model ticks.
-  const anyPerModelTicks = modelEntries.some(
-    (entry) =>
-      entry.totals.costUsdTicks !== null && totalTokens(grokTotalsToUsage(entry.totals)) > 0,
-  );
+  // Cost allocation:
+  // 1. Emitted models with their own costUsdTicks keep those values.
+  // 2. Remaining aggregate cost (top-level minus sum of those per-model
+  //    ticks, clamped at 0) is pro-rated across emitted models that lack
+  //    ticks, by token share among the unticked models only.
+  // 3. When no model has per-model ticks, remaining equals the full
+  //    aggregate and every emitted model gets a token-share slice.
+  // Zero-token rows are never emitted and never count toward used ticks
+  // (empty siblings often ship costUsdTicks: 0 and must not steal remainder).
   const topLevelCostUsd = grokCostTicksToUsd(topLevel.costUsdTicks);
-  let sharedTokenDenominator = 0;
-  if (!anyPerModelTicks && topLevelCostUsd !== null && modelEntries.length > 1) {
-    for (const entry of modelEntries) {
-      sharedTokenDenominator += totalTokens(grokTotalsToUsage(entry.totals));
+  let usedTickedCostUsd = 0;
+  let untickedTokenDenominator = 0;
+  for (const entry of modelEntries) {
+    const tokens = totalTokens(grokTotalsToUsage(entry.totals));
+    if (tokens === 0) continue;
+    if (entry.totals.costUsdTicks !== null) {
+      usedTickedCostUsd += grokCostTicksToUsd(entry.totals.costUsdTicks) ?? 0;
+    } else {
+      untickedTokenDenominator += tokens;
     }
   }
+  const remainingCostUsd =
+    topLevelCostUsd === null ? null : Math.max(0, topLevelCostUsd - usedTickedCostUsd);
 
   const results: UsageRecord[] = [];
   for (const entry of modelEntries) {
     const totals = grokTotalsToUsage(entry.totals);
     if (totalTokens(totals) === 0) continue;
 
-    // Per-model ticks when present; otherwise a single-model turn inherits the
-    // aggregate, and multi-model turns without per-model ticks take a token-
-    // share slice of the aggregate so reported cost is not dropped.
     let reportedCostUsd = grokCostTicksToUsd(entry.totals.costUsdTicks);
-    if (reportedCostUsd === null && topLevelCostUsd !== null) {
-      if (modelEntries.length === 1) {
-        reportedCostUsd = topLevelCostUsd;
-      } else if (sharedTokenDenominator > 0) {
-        reportedCostUsd = topLevelCostUsd * (totalTokens(totals) / sharedTokenDenominator);
-      }
+    if (reportedCostUsd === null && remainingCostUsd !== null && untickedTokenDenominator > 0) {
+      reportedCostUsd = remainingCostUsd * (totalTokens(totals) / untickedTokenDenominator);
     }
 
     results.push({

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -395,7 +395,10 @@ export function UsagePage() {
                       <tbody>
                         {recentPeriods.length === 0 ? (
                           <tr>
-                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                            <td
+                              colSpan={PROVIDER_ORDER.length + 3}
+                              className="py-6 text-center text-muted-foreground"
+                            >
                               No activity in this window.
                             </td>
                           </tr>

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -80,11 +80,13 @@ describe("buildDayColumns", () => {
   it("keeps band values absolute rather than cumulative", () => {
     // Regression: the bands were once stack offsets, which drew Claude Code
     // permanently above Codex regardless of which provider spent more.
+    // PROVIDER_ORDER is zero-filled, so providers with no spend still appear.
     const [first] = buildDayColumns(days, byDay, "cost");
 
     expect(first?.bands).toEqual([
       { provider: "codex", value: 10 },
       { provider: "claude", value: 20 },
+      { provider: "grok", value: 0 },
     ]);
   });
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, GrokIcon, type Icon, OpenAI } from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -23,6 +23,12 @@ export const PROVIDER_PRESENTATION = {
     label: "Claude Code",
     color: "#d97757",
     mark: ClaudeAI,
+  },
+  grok: {
+    label: "Grok Build",
+    // Mid zinc so the series stays visible on both light and dark chart surfaces.
+    color: "#a1a1aa",
+    mark: GrokIcon,
   },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -27,7 +27,7 @@ export const PROVIDER_PRESENTATION = {
   grok: {
     label: "Grok Build",
     // Mid zinc so the series stays visible on both light and dark chart surfaces.
-    color: "#a1a1aa",
+    color: "#71717a",
     mark: GrokIcon,
   },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -2,10 +2,10 @@
  * Usage reporting contract.
  *
  * Each environment scans the provider CLIs' own on-disk session transcripts
- * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`) rather than
- * relying on T3 Code's own orchestration projections, so usage stays complete
- * even for turns that were never driven through T3 Code. This mirrors the
- * approach `ccusage` takes.
+ * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`,
+ * `~/.grok/sessions/**\/updates.jsonl`) rather than relying on T3 Code's own
+ * orchestration projections, so usage stays complete even for turns that were
+ * never driven through T3 Code. This mirrors the approach `ccusage` takes.
  *
  * Environments return pre-aggregated `(day, hourStart?, provider, model)`
  * buckets. Raw transcript records never cross the wire.
@@ -21,9 +21,9 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 4 as const;
+export const USAGE_CONTRACT_VERSION = 5 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex"]);
+export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**


### PR DESCRIPTION
## Summary

The usage page only scanned Claude Code and Codex session transcripts, so Grok Build work never showed up even though sessions under `~/.grok` already carry per-turn token and cost data.

This adds Grok as a third usage provider end to end:

- Parse `turn_completed` usage from Grok `updates.jsonl` (per-model `modelUsage`, cache breakdown, `costUsdTicks` at 10^10 ticks per USD)
- Scan `$GROK_HOME/sessions` (default `~/.grok/sessions`), restricted to `updates.jsonl` so large chat/events logs stay out of the cold path
- Surface **Grok Build** in the web and mobile usage charts/labels
- Bump the usage contract version for the new provider kind

## Test plan

- [ ] Open Usage after pairing a local server that has Grok sessions in `~/.grok`
- [ ] Confirm **Grok Build** appears in the provider split, daily chart, and model table
- [ ] Confirm Claude/Codex totals still match the previous behavior
- [ ] `vp test run apps/server/src/usage/usageTranscripts.test.ts`

Made with Grok Build (xAI).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New transcript parsing and cost pro-rating logic could mis-attribute tokens or dollars for edge-case Grok logs, but changes are confined to usage scanning/aggregation with broad test coverage and a contract version bump for older clients.
> 
> **Overview**
> **Grok Build** is added as a third usage provider alongside Claude Code and Codex, so local Grok sessions under `~/.grok` (or `GROK_HOME`) show up on the usage page.
> 
> The server scans **`~/.grok/sessions/**/updates.jsonl`** only—skipping large `chat_history` / `events` logs—and parses **`turn_completed`** lines into per-model usage records with cache breakdowns and **`costUsdTicks`** converted to USD (10¹⁰ ticks per dollar). Multi-model turns get **pro-rated cost** when per-model ticks are missing or only partially reported. The usage contract adds **`grok`** to `UsageProviderKind` and bumps **`USAGE_CONTRACT_VERSION` to 5**; the scan cache accepts **`grok`** entries.
> 
> Web and mobile usage UI gain **Grok Build** labels, chart bands, icons, and theme-aware colors; the time breakdown table’s empty-state **`colSpan`** follows `PROVIDER_ORDER` so a third provider column doesn’t break layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c7a2762468c2db08e5498059fca12c17b761669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Grok Build as a provider in the usage view
> - Adds a `parseGrokLine` function in [usageTranscripts.ts](https://github.com/pingdotgg/t3code/pull/6051/files#diff-639e969b22f50fb1c28800a8caacb40faa709fb5b829f6c1e0a06a1be5fd5871) that parses Grok `updates.jsonl` session logs into per-model `UsageRecord` entries with cost tick-to-USD conversion and pro-rated cost attribution.
> - Extends the server-side usage scanner in [UsageService.ts](https://github.com/pingdotgg/t3code/pull/6051/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70) to discover Grok sessions via `$GROK_HOME` or `~/.grok`, filtering to `updates.jsonl` files only.
> - Adds `"grok"` to `UsageProviderKind` and bumps the contract version from 4 to 5 in [usage.ts](https://github.com/pingdotgg/t3code/pull/6051/files#diff-9abc3595e224ffc63bc8ed068d884a2dad83ccb207f0b183e94259fb7f486a13).
> - Updates mobile and web UI provider registries to display Grok Build with a label, color, and icon in charts and tables.
> - Fixes the empty-state table colspan in [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/6051/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) to compute dynamically from `PROVIDER_ORDER.length` instead of a hardcoded value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c7a276.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->