### PR TITLE
Fix for issue 4820

### DIFF
--- a/apps/server/src/environment/ServerEnvironmentLabel.test.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.test.ts
@@ -286,6 +286,19 @@ describe("resolveServerEnvironmentLabel", () => {
   );
   it.effect("appends WSL distro name when WSL_DISTRO_NAME is present", () =>
     Effect.gen(function* () {
+      runMock.mockReturnValueOnce(
+        Effect.succeed({
+          stdout: "",
+          stderr: "",
+          code: ChildProcessSpawner.ExitCode(1),
+          timedOut: false,
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
+        }),
+      );
+
       const WslLayer = Layer.merge(
         ProcessRunnerTest,
         FileSystem.layerNoop({
@@ -311,6 +324,19 @@ describe("resolveServerEnvironmentLabel", () => {
 
   it.effect("appends generic WSL label when WSL_DISTRO_NAME is absent", () =>
     Effect.gen(function* () {
+      runMock.mockReturnValueOnce(
+        Effect.succeed({
+          stdout: "",
+          stderr: "",
+          code: ChildProcessSpawner.ExitCode(1),
+          timedOut: false,
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          stdoutInvalidUtf8: false,
+          stderrInvalidUtf8: false,
+        }),
+      );
+
       const WslLayer = Layer.merge(
         ProcessRunnerTest,
         FileSystem.layerNoop({

--- a/apps/server/src/environment/ServerEnvironmentLabel.test.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.test.ts
@@ -7,7 +7,7 @@ import * as PlatformError from "effect/PlatformError";
 import * as References from "effect/References";
 import * as Schema from "effect/Schema";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
-import { HostProcessHostname, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessHostname, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { vi } from "vite-plus/test";
 
 import * as ProcessRunner from "../processRunner.ts";
@@ -49,11 +49,13 @@ const withHostPlatform = <ROut, E, RIn>(
   layer: Layer.Layer<ROut, E, RIn>,
   platform: NodeJS.Platform,
   hostname: string,
+  env: NodeJS.ProcessEnv = {},
 ) =>
   Layer.mergeAll(
     layer,
     Layer.succeed(HostProcessPlatform, platform),
     Layer.succeed(HostProcessHostname, hostname),
+    Layer.succeed(HostProcessEnvironment, env),
   );
 
 afterEach(() => {
@@ -280,6 +282,55 @@ describe("resolveServerEnvironmentLabel", () => {
       }).pipe(Effect.provide(withHostPlatform(TestLayer, "linux", "   ")));
 
       expect(result).toBe("t3code");
+    }),
+  );
+  it.effect("appends WSL distro name when WSL_DISTRO_NAME is present", () =>
+    Effect.gen(function* () {
+      const WslLayer = Layer.merge(
+        ProcessRunnerTest,
+        FileSystem.layerNoop({
+          exists: (path) => Effect.succeed(path === "/proc/sys/kernel/osrelease"),
+          readFileString: (path) =>
+            path === "/proc/sys/kernel/osrelease"
+              ? Effect.succeed("5.15.90.1-microsoft-standard-WSL2")
+              : Effect.succeed(""),
+        }),
+      );
+      
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
+        cwdBaseName: "t3code",
+      }).pipe(
+        Effect.provide(
+          withHostPlatform(WslLayer, "linux", "WINDOWS-HOST", { WSL_DISTRO_NAME: "Ubuntu-22.04" })
+        )
+      );
+
+      expect(result).toBe("WINDOWS-HOST (WSL: Ubuntu-22.04)");
+    }),
+  );
+
+  it.effect("appends generic WSL label when WSL_DISTRO_NAME is absent", () =>
+    Effect.gen(function* () {
+      const WslLayer = Layer.merge(
+        ProcessRunnerTest,
+        FileSystem.layerNoop({
+          exists: (path) => Effect.succeed(path === "/proc/sys/kernel/osrelease"),
+          readFileString: (path) =>
+            path === "/proc/sys/kernel/osrelease"
+              ? Effect.succeed("5.15.90.1-microsoft-standard-WSL2")
+              : Effect.succeed(""),
+        }),
+      );
+      
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
+        cwdBaseName: "t3code",
+      }).pipe(
+        Effect.provide(
+          withHostPlatform(WslLayer, "linux", "WINDOWS-HOST", {})
+        )
+      );
+
+      expect(result).toBe("WINDOWS-HOST (WSL)");
     }),
   );
 });

--- a/apps/server/src/environment/ServerEnvironmentLabel.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.ts
@@ -1,4 +1,4 @@
-import { HostProcessHostname, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessHostname, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -179,6 +179,28 @@ const resolveFriendlyHostLabel = Effect.fn("resolveFriendlyHostLabel")(function*
   return null;
 });
 
+const isWslEnvironment = Effect.fn("isWslEnvironment")(function* () {
+  const platform = yield* HostProcessPlatform;
+  if (platform !== "linux") {
+    return false;
+  }
+
+  const fileSystem = yield* FileSystem.FileSystem;
+  const osReleasePath = "/proc/sys/kernel/osrelease";
+  
+  const content = yield* fileSystem.exists(osReleasePath).pipe(
+    Effect.flatMap((exists) => 
+      exists 
+        ? fileSystem.readFileString(osReleasePath) 
+        : Effect.succeed("")
+    ),
+    Effect.catchAll(() => Effect.succeed(""))
+  );
+
+  const lowerContent = content.toLowerCase();
+  return lowerContent.includes("microsoft") || lowerContent.includes("wsl");
+});
+
 export const resolveServerEnvironmentLabel = Effect.fn("resolveServerEnvironmentLabel")(function* (
   input: ResolveServerEnvironmentLabelInput,
 ) {
@@ -189,6 +211,15 @@ export const resolveServerEnvironmentLabel = Effect.fn("resolveServerEnvironment
 
   const hostname = normalizeLabel(yield* HostProcessHostname);
   if (hostname) {
+    const isWsl = yield* isWslEnvironment();
+    if (isWsl) {
+      const env = yield* HostProcessEnvironment;
+      const distroName = env["WSL_DISTRO_NAME"];
+      if (distroName && distroName.trim().length > 0) {
+        return `${hostname} (WSL: ${distroName.trim()})`;
+      }
+      return `${hostname} (WSL)`;
+    }
     return hostname;
   }
 

--- a/apps/server/src/environment/ServerEnvironmentLabel.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.ts
@@ -189,12 +189,39 @@ const isWslEnvironment = Effect.fn("isWslEnvironment")(function* () {
   const osReleasePath = "/proc/sys/kernel/osrelease";
   
   const content = yield* fileSystem.exists(osReleasePath).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ServerEnvironmentLabelFileError({
+          operation: "inspect",
+          path: osReleasePath,
+          cause,
+        }),
+    ),
     Effect.flatMap((exists) => 
       exists 
-        ? fileSystem.readFileString(osReleasePath) 
+        ? fileSystem.readFileString(osReleasePath).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ServerEnvironmentLabelFileError({
+                  operation: "read",
+                  path: osReleasePath,
+                  cause,
+                }),
+            ),
+          )
         : Effect.succeed("")
     ),
-    Effect.catchAll(() => Effect.succeed(""))
+    Effect.catchTags({
+      ServerEnvironmentLabelFileError: (error) =>
+        Effect.logDebug(error.message).pipe(
+          Effect.annotateLogs({
+            operation: error.operation,
+            path: error.path,
+            cause: error,
+          }),
+          Effect.as(""),
+        ),
+    }),
   );
 
   const lowerContent = content.toLowerCase();


### PR DESCRIPTION
Fixes issue #4820

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only labeling change with file read and env lookup; no auth, security, or data-path impact.
> 
> **Overview**
> **Server environment labels** now distinguish Windows Subsystem for Linux when friendly host names are unavailable and the resolver falls back to the hostname.
> 
> On Linux, a new **`isWslEnvironment`** check reads `/proc/sys/kernel/osrelease` for `microsoft` or `wsl`. If WSL is detected, the label becomes `hostname (WSL: <distro>)` when **`WSL_DISTRO_NAME`** is set and non-empty, or `hostname (WSL)` otherwise. **`HostProcessEnvironment`** is wired in for distro name lookup; tests stub **`HostProcessEnvironment`** via an extended **`withHostPlatform`** helper and cover both named and generic WSL cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84346fe3a1074089ab9398e047887367eebfe2a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Append WSL distro info to server environment label when running under WSL
> - Adds `isWslEnvironment` in [`ServerEnvironmentLabel.ts`](https://github.com/pingdotgg/t3code/pull/6053/files#diff-b1aacbc192ffaacdfdd1ba5d7cbd3815df9976714c71601e826526144c769e59) that detects WSL by checking `/proc/sys/kernel/osrelease` for 'microsoft' or 'wsl' (case-insensitive); file errors are logged at debug level and treated as non-WSL.
> - Updates `resolveServerEnvironmentLabel` to append `(WSL: <distro>)` when `WSL_DISTRO_NAME` is set, or `(WSL)` when not, for Linux hosts running under WSL.
> - Adds tests covering both cases using a mocked `WslLayer` and `HostProcessEnvironment`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84346fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->