### PR TITLE
Fix for issue 4507

### DIFF
--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -2,6 +2,7 @@ import { ClaudeSettings, ProviderInstanceId } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as nodePath from "node:path";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
@@ -30,40 +31,47 @@ function makeFakeClaudeBinary(dir: string) {
     yield* fs.writeFileString(
       claudePath,
       [
-        "#!/bin/sh",
-        'args="$*"',
-        'stdin_content="$(cat)"',
-        'if [ -n "$T3_FAKE_CLAUDE_ARGS_MUST_CONTAIN" ]; then',
-        '  printf "%s" "$args" | grep -F -- "$T3_FAKE_CLAUDE_ARGS_MUST_CONTAIN" >/dev/null || {',
-        '    printf "%s\\n" "args missing expected content" >&2',
-        "    exit 2",
+        "#!/usr/bin/env node",
+        "const fs = require('fs');",
+        "const args = process.argv.slice(2).join(' ');",
+        "const stdin_content = fs.readFileSync(0, 'utf-8');",
+        "if (process.env.T3_FAKE_CLAUDE_ARGS_MUST_CONTAIN) {",
+        "  if (!args.includes(process.env.T3_FAKE_CLAUDE_ARGS_MUST_CONTAIN)) {",
+        "    console.error('args missing expected content');",
+        "    process.exit(2);",
         "  }",
-        "fi",
-        'if [ -n "$T3_FAKE_CLAUDE_ARGS_MUST_NOT_CONTAIN" ]; then',
-        '  if printf "%s" "$args" | grep -F -- "$T3_FAKE_CLAUDE_ARGS_MUST_NOT_CONTAIN" >/dev/null; then',
-        '    printf "%s\\n" "args contained forbidden content" >&2',
-        "    exit 3",
-        "  fi",
-        "fi",
-        'if [ -n "$T3_FAKE_CLAUDE_STDIN_MUST_CONTAIN" ]; then',
-        '  printf "%s" "$stdin_content" | grep -F -- "$T3_FAKE_CLAUDE_STDIN_MUST_CONTAIN" >/dev/null || {',
-        '    printf "%s\\n" "stdin missing expected content" >&2',
-        "    exit 4",
+        "}",
+        "if (process.env.T3_FAKE_CLAUDE_ARGS_MUST_NOT_CONTAIN) {",
+        "  if (args.includes(process.env.T3_FAKE_CLAUDE_ARGS_MUST_NOT_CONTAIN)) {",
+        "    console.error('args contained forbidden content');",
+        "    process.exit(3);",
         "  }",
-        "fi",
-        'if [ -n "$T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE" ] && [ "$CLAUDE_CONFIG_DIR" != "$T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE" ]; then',
-        '  printf "%s\\n" "CLAUDE_CONFIG_DIR was $CLAUDE_CONFIG_DIR" >&2',
-        "  exit 5",
-        "fi",
-        'if [ -n "$T3_FAKE_CLAUDE_STDERR" ]; then',
-        '  printf "%s\\n" "$T3_FAKE_CLAUDE_STDERR" >&2',
-        "fi",
-        'printf "%s" "$T3_FAKE_CLAUDE_OUTPUT"',
-        'exit "${T3_FAKE_CLAUDE_EXIT_CODE:-0}"',
+        "}",
+        "if (process.env.T3_FAKE_CLAUDE_STDIN_MUST_CONTAIN) {",
+        "  if (!stdin_content.includes(process.env.T3_FAKE_CLAUDE_STDIN_MUST_CONTAIN)) {",
+        "    console.error('stdin missing expected content');",
+        "    process.exit(4);",
+        "  }",
+        "}",
+        "if (process.env.T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE && process.env.CLAUDE_CONFIG_DIR !== process.env.T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE) {",
+        "  console.error('CLAUDE_CONFIG_DIR was ' + process.env.CLAUDE_CONFIG_DIR);",
+        "  process.exit(5);",
+        "}",
+        "if (process.env.T3_FAKE_CLAUDE_STDERR) {",
+        "  console.error(process.env.T3_FAKE_CLAUDE_STDERR);",
+        "}",
+        "process.stdout.write(process.env.T3_FAKE_CLAUDE_OUTPUT || '');",
+        "process.exit(parseInt(process.env.T3_FAKE_CLAUDE_EXIT_CODE || '0', 10));",
         "",
       ].join("\n"),
     );
     yield* fs.chmod(claudePath, 0o755);
+
+    if (process.platform === "win32") {
+      const claudeCmdPath = path.join(binDir, "claude.cmd");
+      yield* fs.writeFileString(claudeCmdPath, `@echo off\r\nnode "%~dp0\\claude" %*\r\n`);
+    }
+
     return binDir;
   });
 }
@@ -96,7 +104,7 @@ function withFakeClaudeEnv<A, E, R>(
 
     yield* Effect.acquireRelease(
       Effect.sync(() => {
-        process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+        process.env.PATH = `${binDir}${nodePath.delimiter}${previousPath ?? ""}`;
         process.env.T3_FAKE_CLAUDE_OUTPUT = input.output;
 
         if (input.exitCode !== undefined) {


### PR DESCRIPTION
Fixes issue #4507

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in `ClaudeTextGeneration.test.ts` with no production runtime impact.
> 
> **Overview**
> Makes the **Claude text generation** test harness run on Windows by replacing the POSIX shell fake `claude` executable with a **Node** script that preserves the same env-driven assertions (args, stdin, `CLAUDE_CONFIG_DIR`, stderr, exit code, stdout).
> 
> On **win32**, the helper now also writes **`claude.cmd`** so resolution via `PATH` can invoke the fake CLI the way Windows expects. **`PATH`** prepending uses **`node:path`’s delimiter** instead of a hardcoded `:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e0ccc1f8115444766d1b9fd6e3b61e1d69eda94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fake Claude binary test util to run on Windows
> - Replaces the POSIX shell fake `claude` binary with a Node.js script (via `#!/usr/bin/env node`) that reads argv and stdin using Node APIs, so it runs cross-platform.
> - On Windows, writes a `claude.cmd` shim that delegates to the Node script, making the binary discoverable via PATH.
> - Fixes PATH construction in `withFakeClaudeEnv` to use `nodePath.delimiter` instead of a hardcoded `:`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e0ccc1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->