### PR TITLE
Fix for issue 3491

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -32,7 +32,7 @@ import {
 } from "react";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { writeTextToClipboard } from "~/hooks/useCopyToClipboard";
-import { cn } from "~/lib/utils";
+import { cn, isWindowsPlatform } from "~/lib/utils";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
 import {
   GhosttyTerminalSurface,
@@ -149,6 +149,49 @@ function terminalFontOptions(family: string, size: number): { family?: string; s
   return trimmed.length > 0 ? { family: trimmed, size } : { size };
 }
 
+let windowsTerminalPaletteCache: GhosttyColor[] | null = null;
+function getWindowsTerminalPalette(): GhosttyColor[] {
+  if (windowsTerminalPaletteCache) return windowsTerminalPaletteCache;
+  const colors: GhosttyColor[] = [];
+  // 0-15: Campbell palette (Windows default)
+  const CAMPBELL = [
+    { r: 12, g: 12, b: 12 },       // Black
+    { r: 197, g: 15, b: 31 },      // Red
+    { r: 19, g: 161, b: 14 },      // Green
+    { r: 193, g: 156, b: 0 },      // Yellow
+    { r: 0, g: 55, b: 218 },       // Blue
+    { r: 136, g: 23, b: 152 },     // Magenta
+    { r: 58, g: 150, b: 221 },     // Cyan
+    { r: 204, g: 204, b: 204 },    // White
+    { r: 118, g: 118, b: 118 },    // Bright Black
+    { r: 231, g: 72, b: 86 },      // Bright Red
+    { r: 22, g: 198, b: 12 },      // Bright Green
+    { r: 249, g: 241, b: 165 },    // Bright Yellow
+    { r: 59, g: 120, b: 255 },     // Bright Blue
+    { r: 180, g: 0, b: 158 },      // Bright Magenta
+    { r: 97, g: 214, b: 214 },     // Bright Cyan
+    { r: 242, g: 242, b: 242 },    // Bright White
+  ];
+  colors.push(...CAMPBELL);
+
+  // 16-231: 6x6x6 color cube
+  const v = [0, 95, 135, 175, 215, 255];
+  for (let i = 0; i < 216; i++) {
+    const r = v[Math.floor(i / 36)]!;
+    const g = v[Math.floor((i % 36) / 6)]!;
+    const b = v[i % 6]!;
+    colors.push({ r, g, b });
+  }
+
+  // 232-255: Grayscale
+  for (let i = 0; i < 24; i++) {
+    const c = 8 + i * 10;
+    colors.push({ r: c, g: c, b: c });
+  }
+  windowsTerminalPaletteCache = colors;
+  return colors;
+}
+
 export function terminalThemeFromApp(mountElement?: HTMLElement | null): GhosttyTheme {
   const isDark = document.documentElement.classList.contains("dark");
   const fallbackBackground = isDark ? "rgb(14, 18, 24)" : "rgb(255, 255, 255)";
@@ -180,6 +223,9 @@ export function terminalThemeFromApp(mountElement?: HTMLElement | null): Ghostty
     "--terminal-selection-background",
     isDark ? "rgba(180, 203, 255, 0.25)" : "rgba(37, 63, 99, 0.2)",
   );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+  const platform = (window.navigator as any).userAgentData?.platform || window.navigator.platform;
+  const isWindows = isWindowsPlatform(platform);
   return {
     background: parseTerminalColor(
       terminalBackground,
@@ -194,6 +240,7 @@ export function terminalThemeFromApp(mountElement?: HTMLElement | null): Ghostty
       isDark ? { r: 180, g: 203, b: 255 } : { r: 38, g: 56, b: 78 },
     ),
     selectionBackground: terminalSelection,
+    ...(isWindows ? { palette: getWindowsTerminalPalette() } : {}),
   };
 }
 

--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -69,6 +69,7 @@ export interface GhosttyTheme {
   readonly cursor: GhosttyColor;
   /** CSS color the renderer overlays on selected cells; not sent to Ghostty. */
   readonly selectionBackground?: string;
+  readonly palette?: ReadonlyArray<GhosttyColor>;
 }
 
 export interface GhosttyCell {
@@ -363,6 +364,16 @@ export class GhosttyTerminalCore {
       this.runtime.call("ghostty_terminal_set", this.terminal, option, color);
     }
     this.runtime.free(color, 3);
+
+    if (theme.palette && theme.palette.length === 256) {
+      const palettePtr = this.runtime.alloc(256 * 3);
+      for (let i = 0; i < 256; i++) {
+        const c = theme.palette[i]!;
+        this.runtime.bytes(palettePtr + i * 3, 3).set([c.r, c.g, c.b]);
+      }
+      this.runtime.call("ghostty_terminal_set", this.terminal, 14, palettePtr);
+      this.runtime.free(palettePtr, 256 * 3);
+    }
   }
 
   scroll(deltaRows: number): void {


### PR DESCRIPTION
Fixes issue #3491

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows-only terminal theming with no changes to PTY I/O or session handling; non-Windows paths are unchanged aside from optional palette support in the theme API.
> 
> **Overview**
> Fixes incorrect or missing ANSI colors in the thread terminal on **Windows** by pushing a full **256-color palette** into Ghostty when building the app theme.
> 
> `GhosttyTheme` gains an optional `palette`, and `setTheme` in the Ghostty core forwards a 256-entry RGB table to the WASM terminal (option **14**) when present. `terminalThemeFromApp` detects Windows via `isWindowsPlatform`, builds a cached **Campbell** (0–15) plus the usual **6×6×6 cube** and grayscale ramp (16–255), and includes that palette only on Windows; other platforms keep the previous behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f78a0115b3325e0446054eddb2e9be85c3b0708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 256-color palette rendering on Windows in the terminal
> - Adds a `getWindowsTerminalPalette` util in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/6055/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) that generates a cached 256-color palette (Campbell colors 0–15, 6×6×6 RGB cube 16–231, grayscale ramp 232–255).
> - `terminalThemeFromApp` detects Windows via `navigator.userAgentData?.platform` and attaches the palette to the returned `GhosttyTheme`; non-Windows behavior is unchanged.
> - `GhosttyTerminalCore` in [core.ts](https://github.com/pingdotgg/t3code/pull/6055/files#diff-40345426232e3feaf88713623c1f6cc40b4c1730f13cd935fbda4032577864fa) now reads an optional `palette` from the theme and applies it via `ghostty_terminal_set` option 14 when present.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1f78a01. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->