### PR TITLE
Fix for issue 5917

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -443,6 +443,38 @@ export function TerminalViewport({
         onCopy: (text) => handleCopy(text),
         beforeKey: (event) => handleBeforeKey(event),
         onLinkActivate: (text, event) => handleLinkActivate(text, event),
+        onContextMenu: (event) => {
+          if (!localApi) return;
+          event.preventDefault();
+          const terminal = terminalRef.current;
+          const hasSelection = terminal?.hasSelection();
+          const items = hasSelection
+            ? [{ id: "copy", label: "Copy" }, { id: "paste", label: "Paste" }]
+            : [{ id: "paste", label: "Paste" }];
+          localApi.contextMenu
+            .show(items as any, { x: event.clientX, y: event.clientY })
+            .then((action) => {
+              if (action === "copy" && hasSelection) {
+                const text = terminal?.getSelection();
+                if (text) {
+                  handleCopy(text);
+                  terminal?.clearSelection();
+                  terminal?.focus();
+                }
+              } else if (action === "paste") {
+                navigator.clipboard
+                  .readText()
+                  .then((text) => {
+                    if (text && terminal) {
+                      handleData(terminal.core.encodePaste(text));
+                      terminal.focus();
+                    }
+                  })
+                  .catch(() => {});
+              }
+            })
+            .catch(() => {});
+        },
       };
       const terminal = await GhosttyTerminalSurface.create(mount, terminalOptions);
       if (cancelled) {

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -219,7 +219,9 @@ describe("isTerminalCopyShortcut", () => {
     expect(isTerminalCopyShortcut(event({ metaKey: true }), "MacIntel")).toBe(true);
   });
 
-  it("uses the conventional Ctrl+Shift+C shortcut elsewhere", () => {
+  it("preserves Ctrl+C on Windows and uses Ctrl+Shift+C on Linux", () => {
+    expect(isTerminalCopyShortcut(event({ ctrlKey: true }), "Win32")).toBe(true);
+    expect(isTerminalCopyShortcut(event({ ctrlKey: true, shiftKey: true }), "Win32")).toBe(true);
     expect(isTerminalCopyShortcut(event({ ctrlKey: true }), "Linux x86_64")).toBe(false);
     expect(isTerminalCopyShortcut(event({ ctrlKey: true, shiftKey: true }), "Linux x86_64")).toBe(
       true,
@@ -246,7 +248,9 @@ describe("isTerminalPasteShortcut", () => {
     expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "MacIntel")).toBe(false);
   });
 
-  it("preserves Ctrl+V and uses Ctrl+Shift+V elsewhere", () => {
+  it("preserves Ctrl+V on Windows and uses Ctrl+Shift+V on Linux", () => {
+    expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "Win32")).toBe(true);
+    expect(isTerminalPasteShortcut(event({ ctrlKey: true, shiftKey: true }), "Win32")).toBe(true);
     expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "Linux x86_64")).toBe(false);
     expect(isTerminalPasteShortcut(event({ ctrlKey: true, shiftKey: true }), "Linux x86_64")).toBe(
       true,

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -1,4 +1,4 @@
-import { isMacPlatform } from "../../lib/utils";
+import { isMacPlatform, isWindowsPlatform } from "../../lib/utils";
 import { collectWrappedTerminalLinkLine, extractTerminalLinks } from "../../terminal-links";
 import {
   GhosttyTerminalCore,
@@ -333,7 +333,9 @@ export function isTerminalCopyShortcut(
   platform = navigator.platform,
 ) {
   if (event.key.toLowerCase() !== "c") return false;
-  return isMacPlatform(platform) ? event.metaKey : event.ctrlKey && event.shiftKey;
+  if (isMacPlatform(platform)) return event.metaKey;
+  if (isWindowsPlatform(platform)) return event.ctrlKey;
+  return event.ctrlKey && event.shiftKey;
 }
 
 export function isTerminalPasteShortcut(
@@ -341,7 +343,9 @@ export function isTerminalPasteShortcut(
   platform = navigator.platform,
 ) {
   if (event.key.toLowerCase() !== "v") return false;
-  return isMacPlatform(platform) ? event.metaKey : event.ctrlKey && event.shiftKey;
+  if (isMacPlatform(platform)) return event.metaKey;
+  if (isWindowsPlatform(platform)) return event.ctrlKey;
+  return event.ctrlKey && event.shiftKey;
 }
 
 export function isTerminalCompositionCommitInput(event: Pick<InputEvent, "inputType">): boolean {
@@ -466,6 +470,7 @@ export interface GhosttyTerminalSurfaceOptions {
   readonly onCopy: (text: string) => void;
   readonly beforeKey: (event: KeyboardEvent) => boolean;
   readonly onLinkActivate: (text: string, event: MouseEvent) => void;
+  readonly onContextMenu?: (event: MouseEvent) => void;
 }
 
 export class GhosttyTerminalSurface {
@@ -1310,6 +1315,8 @@ export class GhosttyTerminalSurface {
   private readonly onContextMenu = (event: MouseEvent) => {
     if (shouldReportTerminalMouse(this.core.isMouseTracking(), event)) {
       event.preventDefault();
+    } else if (this.options.onContextMenu) {
+      this.options.onContextMenu(event);
     }
   };
 


### PR DESCRIPTION
Fixes issue #5917

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized terminal UX and shortcut logic with unit test updates; no auth, data, or API contract changes beyond an optional surface callback.
> 
> **Overview**
> **Right-click Copy/Paste** is wired through an optional `onContextMenu` on `GhosttyTerminalSurface`: when application mouse tracking is off, the thread terminal drawer shows the native `localApi` menu (Copy when there is a selection, always Paste) and routes actions through the existing copy handler and bracketed paste encoding.
> 
> **Keyboard copy/paste detection** now branches on platform: **Windows** uses `Ctrl+C` / `Ctrl+V` (including with Shift); **Linux** still requires `Ctrl+Shift+C` / `Ctrl+Shift+V` so plain `Ctrl+C` stays available for SIGINT; **macOS** is unchanged (`Cmd` for copy/paste, `Ctrl+C` not treated as copy). Tests in `surface.test.ts` were updated for the Windows vs Linux split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78eb7eaa1cc55d9e784dcb08fda0326478ad3c62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add right-click context menu and fix copy/paste shortcuts in terminal
> - Adds a right-click context menu in `ThreadTerminalDrawer`'s terminal viewport with Copy and Paste options. Copy is only shown when text is selected; Paste reads from the clipboard and writes to the terminal via `terminal.core.encodePaste`.
> - Updates `isTerminalCopyShortcut` and `isTerminalPasteShortcut` in [surface.ts](https://github.com/pingdotgg/t3code/pull/6056/files#diff-036d64ffe3b3b3d167137e8ea29edae7af74a9e0323fc798c4f291992235d267) to recognize Ctrl+C and Ctrl+V on Windows (previously required Ctrl+Shift+C/V on non-macOS platforms).
> - Adds an optional `onContextMenu` callback to `GhosttyTerminalSurfaceOptions`, forwarded from `GhosttyTerminalSurface.onContextMenu` when mouse tracking is not active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78eb7ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->