### PR TITLE
fix(web): keep completed thread status visible

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -244,11 +244,12 @@ describe("resolveSidebarStageBadgeLabel", () => {
 
 function makeLatestTurn(overrides?: {
   completedAt?: string | null;
+  state?: OrchestrationLatestTurn["state"];
   startedAt?: string | null;
 }): OrchestrationLatestTurn {
   return {
     turnId: "turn-1" as never,
-    state: "completed",
+    state: overrides?.state ?? "completed",
     assistantMessageId: null,
     requestedAt: "2026-03-09T10:00:00.000Z",
     startedAt:
@@ -639,7 +640,13 @@ describe("resolveSidebarThreadStatus", () => {
     updatedAt: "2026-03-09T10:00:00.000Z",
   };
 
-  const idle = { hasPendingApprovals: false, hasPendingUserInput: false };
+  const idle = {
+    hasActionableProposedPlan: false,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    interactionMode: "default" as const,
+    latestTurn: null,
+  };
 
   it("prioritizes approval over a running session", () => {
     expect(resolveSidebarThreadStatus({ ...idle, hasPendingApprovals: true, session })).toBe(
@@ -688,6 +695,39 @@ describe("resolveSidebarThreadStatus", () => {
       resolveSidebarThreadStatus({
         ...idle,
         session: { ...session, status: "ready" as const, lastError: "persisted" },
+      }),
+    ).toBe("ready");
+  });
+
+  it("keeps completed visible independently of read state", () => {
+    expect(
+      resolveSidebarThreadStatus({
+        ...idle,
+        latestTurn: makeLatestTurn(),
+        session: { ...session, status: "ready" as const, activeTurnId: null },
+      }),
+    ).toBe("completed");
+  });
+
+  it("reports an actionable settled plan as plan ready instead of completed", () => {
+    expect(
+      resolveSidebarThreadStatus({
+        ...idle,
+        backgroundLiveness: "working",
+        hasActionableProposedPlan: true,
+        interactionMode: "plan",
+        latestTurn: makeLatestTurn(),
+        session: { ...session, status: "ready" as const, activeTurnId: null },
+      }),
+    ).toBe("plan-ready");
+  });
+
+  it("does not report interrupted work as completed", () => {
+    expect(
+      resolveSidebarThreadStatus({
+        ...idle,
+        latestTurn: makeLatestTurn({ state: "interrupted" }),
+        session: { ...session, status: "ready" as const, activeTurnId: null },
       }),
     ).toBe("ready");
   });
@@ -1076,7 +1116,7 @@ describe("resolveThreadStatusPill", () => {
     ).toMatchObject({ label: "Plan Ready", pulse: false });
   });
 
-  it("does not manufacture completed state without a client visit marker", () => {
+  it("keeps completed visible without a client visit marker", () => {
     expect(
       resolveThreadStatusPill({
         thread: {
@@ -1089,7 +1129,7 @@ describe("resolveThreadStatusPill", () => {
           },
         },
       }),
-    ).toBeNull();
+    ).toMatchObject({ label: "Completed", pulse: false });
   });
 
   it("shows completed when there is an unseen completion and no active blocker", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -424,23 +424,27 @@ export function resolveThreadRowClassName(input: {
 }
 
 // ── Sidebar thread status model ─────────────────────────────────────
-// Five visual states, three colors: color is reserved for "act now"
-// (approval), "in motion" (working), and "broken" (failed). Ready is the
-// unlabeled resting state — the agent stopped and is waiting on the user,
-// whether it finished, asked a question, or proposed a plan.
-// Unread completion is tracked separately: it describes whether a ready
-// thread needs attention, not what the thread is currently doing.
+// Execution state and unread state are separate. Completion remains visible
+// after the user opens a thread; unread styling only indicates new output.
 export type SidebarThreadStatus =
   | "approval"
   | "input"
   | "working"
   | "monitoring"
   | "failed"
+  | "plan-ready"
+  | "completed"
   | "ready";
 
 type SidebarThreadStatusInput = Pick<
   SidebarThreadSummary,
-  "hasPendingApprovals" | "hasPendingUserInput" | "session" | "backgroundLiveness"
+  | "hasPendingApprovals"
+  | "hasPendingUserInput"
+  | "session"
+  | "backgroundLiveness"
+  | "latestTurn"
+  | "interactionMode"
+  | "hasActionableProposedPlan"
 >;
 
 export function resolveSidebarThreadStatus(thread: SidebarThreadStatusInput): SidebarThreadStatus {
@@ -458,6 +462,13 @@ export function resolveSidebarThreadStatus(thread: SidebarThreadStatusInput): Si
   if (thread.session?.status === "error") {
     return "failed";
   }
+  if (
+    thread.interactionMode === "plan" &&
+    isLatestTurnSettled(thread.latestTurn, thread.session) &&
+    thread.hasActionableProposedPlan
+  ) {
+    return "plan-ready";
+  }
   // Background work outlives the turn: fleets read as working; monitoring
   // only when watch loops are the sole live work.
   if (thread.backgroundLiveness === "working") {
@@ -465,6 +476,9 @@ export function resolveSidebarThreadStatus(thread: SidebarThreadStatusInput): Si
   }
   if (thread.backgroundLiveness === "monitoring") {
     return "monitoring";
+  }
+  if (thread.latestTurn?.state === "completed") {
+    return "completed";
   }
   return "ready";
 }
@@ -685,7 +699,7 @@ export function resolveThreadStatusPill(input: {
     };
   }
 
-  if (hasUnseenCompletion(thread)) {
+  if (thread.latestTurn?.state === "completed") {
     return {
       label: "Completed",
       colorClass: "text-emerald-600 dark:text-emerald-300/90",

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -769,13 +769,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     (lastVisitedDate === null || lastVisitedDate < wokeAtDate) &&
     prState !== "merged" &&
     prState !== "closed";
-  // In-flight rows (working, or waiting on approval/input) fade as a whole:
-  // there is nothing for the user to do yet, so prominence is reserved for
-  // rows that need a human — done (unread), read-but-unsettled, failed, and
-  // freshly woken. The status label keeps its hue, so waiting rows stay
-  // findable. In-flight rows recede the same as read-ready ones (inbox-zero:
-  // working threads aren't your problem yet) — only the colored status label
-  // stands out.
+  // In-flight rows (working, or waiting on approval/input) fade as a whole.
+  // Completed rows keep their status after being read; unread styling remains
+  // a separate indication that new output has not been opened yet.
   const isInFlight =
     status === "working" || status === "monitoring" || status === "approval" || status === "input";
   const shouldRecede =
@@ -821,19 +817,25 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                   icon: null,
                   className: "text-red-700 dark:text-red-300",
                 }
-              : isWoke
+              : status === "plan-ready"
                 ? {
-                    label: "Woke",
-                    icon: "woke" as const,
-                    className: "text-amber-700 dark:text-amber-300",
+                    label: "Plan Ready",
+                    icon: null,
+                    className: "text-violet-600 dark:text-violet-300",
                   }
-                : isUnread
+                : isWoke
                   ? {
-                      label: "Done",
-                      icon: "done" as const,
-                      className: "text-emerald-700 dark:text-emerald-300",
+                      label: "Woke",
+                      icon: "woke" as const,
+                      className: "text-amber-700 dark:text-amber-300",
                     }
-                  : null;
+                  : status === "completed"
+                    ? {
+                        label: "Done",
+                        icon: "done" as const,
+                        className: "text-emerald-700 dark:text-emerald-300",
+                      }
+                    : null;
   const isWokeStatus = topStatus?.icon === "woke";
 
   const branchMismatch = resolveLocalCheckoutBranchMismatch({


### PR DESCRIPTION
## Summary
- keep completed thread status visible after the result is opened
- preserve unread styling as a separate signal
- apply the behavior to both current and legacy sidebars

## Problem
The sidebar previously removed the Done/Completed label as soon as a thread was visited. Finished work then became indistinguishable from idle or waiting threads.

## Verification
- Sidebar logic tests: 99 passed
- web typecheck passed
- focused lint and format checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar labeling and status resolution in shared logic helpers; behavior is covered by updated unit tests with no auth or data-path changes.
> 
> **Overview**
> **Sidebar thread status** now treats *execution state* and *read/unread* as separate signals. Finished threads stay labeled **Done** / **Completed** after you open them; unread styling still reflects output you have not visited.
> 
> `resolveSidebarThreadStatus` gains **`completed`** and **`plan-ready`**. It returns **`completed`** when the latest turn’s state is `completed` (not when visit timing says “unseen”). **`plan-ready`** wins over completed when plan mode has a settled turn and an actionable proposed plan; interrupted turns no longer read as completed.
> 
> `resolveThreadStatusPill` shows **Completed** from `latestTurn.state === "completed"` instead of `hasUnseenCompletion`. **`SidebarThreadRow`** drives the top **Done** badge from `status === "completed"` rather than `isUnread`, and adds an explicit **Plan Ready** row label. Tests cover the new status matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb7cb109810147e07e3efcd4c229ec0dec74bb5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep completed thread status visible in sidebar after being read
> - `resolveSidebarThreadStatus` now returns `'completed'` when `latestTurn.state` is `'completed'`, and `'plan-ready'` when in plan mode with a settled, actionable proposed plan.
> - The `'Completed'` pill in `resolveThreadStatusPill` now renders based on `latestTurn.state === 'completed'` rather than the `hasUnseenCompletion` flag, so it persists after the thread is read.
> - `SidebarThreadRow` displays `'Done'` based on explicit `'completed'` status and adds a new `'Plan Ready'` label (violet) for `'plan-ready'` status.
> - Behavioral Change: completed threads previously reverted to `'ready'` once seen; they now remain visually marked as `'Done'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb7cb10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->