### PR TITLE
fix(web): use OS-native resize cursors so panel handles stay visible in light mode

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1270,7 +1270,7 @@ export default function ThreadTerminalDrawer({
       >
         {!isPanel ? (
           <div
-            className="absolute inset-x-0 top-0 z-20 h-1.5 cursor-row-resize"
+            className="absolute inset-x-0 top-0 z-20 h-1.5 cursor-ns-resize"
             onPointerDown={handleResizePointerDown}
             onPointerMove={handleResizePointerMove}
             onPointerUp={handleResizePointerEnd}
@@ -1304,7 +1304,7 @@ export default function ThreadTerminalDrawer({
     >
       {!isPanel ? (
         <div
-          className="absolute inset-x-0 top-0 z-20 h-1.5 cursor-row-resize"
+          className="absolute inset-x-0 top-0 z-20 h-1.5 cursor-ns-resize"
           onPointerDown={handleResizePointerDown}
           onPointerMove={handleResizePointerMove}
           onPointerUp={handleResizePointerEnd}

--- a/apps/web/src/components/preview/RightPanelResizeHandle.tsx
+++ b/apps/web/src/components/preview/RightPanelResizeHandle.tsx
@@ -20,7 +20,9 @@ export function RightPanelResizeHandle({ handlers, className }: Props) {
       role="separator"
       aria-orientation="vertical"
       className={cn(
-        "group absolute inset-y-0 -left-1 z-20 w-2 cursor-col-resize select-none",
+        // ew-resize maps to the OS-outlined SIZEWE cursor on Windows; Chromium's
+        // bundled col-resize bitmap has no dark outline and vanishes on light themes.
+        "group absolute inset-y-0 -left-1 z-20 w-2 cursor-ew-resize select-none",
         className,
       )}
       {...handlers}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -452,7 +452,7 @@ function SidebarRail({
       };
       wrapper.style.setProperty("--sidebar-width", `${initialWidth}px`);
       event.currentTarget.setPointerCapture(event.pointerId);
-      document.body.style.cursor = "col-resize";
+      document.body.style.cursor = "ew-resize";
       document.body.style.userSelect = "none";
     },
     [onPointerDown, open, resolvedResizable, sidebarInstance?.side],

--- a/apps/web/src/hooks/useResizableWidth.ts
+++ b/apps/web/src/hooks/useResizableWidth.ts
@@ -101,7 +101,7 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
       } catch {
         return;
       }
-      document.body.style.cursor = "col-resize";
+      document.body.style.cursor = "ew-resize";
       document.body.style.userSelect = "none";
       dragStateRef.current = {
         pointerId: event.pointerId,


### PR DESCRIPTION
## What Changed

- Right panel resize handle: `cursor-col-resize` → `cursor-ew-resize` (`preview/RightPanelResizeHandle.tsx`)
- Terminal drawer top edge: `cursor-row-resize` → `cursor-ns-resize` (`ThreadTerminalDrawer.tsx`, both drawer variants)
- Drag-in-progress body cursor while resizing the right panel and the sidebar: `"col-resize"` → `"ew-resize"` (`hooks/useResizableWidth.ts`, `ui/sidebar.tsx`)

Five changed lines total; no new assets, no behavior changes.

## Why

On Windows, Chromium has no OS cursor for `col-resize`/`row-resize`, so it substitutes its own bundled bitmaps (`ui/base/win/win_cursor_factory.cc` maps `kColumnResize`/`kRowResize` to `MAKEINTRESOURCE` resources, while `kEastWestResize`/`kNorthSouthResize` map to the system `IDC_SIZEWE`/`IDC_SIZENS`). The bundled bitmaps are white with no dark outline, so in light themes the pointer disappears exactly where you need to see it: hovering or dragging the right panel edge and the terminal drawer edge.

The OS resize cursors have a black outline and stay visible in both light and dark appearance. VS Code uses `ew-resize`/`ns-resize` for its sashes for the same reason, so the pointer shape stays familiar.

The sidebar rail's `e-resize`/`w-resize` cursors already map to `IDC_SIZEWE` and are left untouched. `cursor-grab`/`cursor-grabbing` come from the same white Chromium bitmap family, but they are left out to keep this PR focused.

## UI Changes

Screenshots cannot capture the mouse pointer, so these are the actual cursor bitmaps captured from Windows (`GetCursorInfo` + `DrawIconEx`) over white and light-grey backgrounds — this is exactly what the pointer looks like over a light theme:

<img width="432" alt="before/after cursor visibility on light backgrounds" src="https://raw.githubusercontent.com/SouthCarpet/t3code/assets/light-mode-cursor-evidence/cursor-before-after.png" />

Reproduced on Windows 11, 100% display scaling, default cursor scheme, T3 Code light mode.

## Testing

- Not run locally (cursor keyword swap only); lint/typecheck covered by CI.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] ~~I included a video for animation/interaction changes~~ (static pointer change, no motion)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic cursor keyword changes only; no logic, layout, or persistence behavior is modified.
> 
> **Overview**
> Swaps **resize cursors** on panel and terminal drag targets from Chromium’s `col-resize` / `row-resize` variants to **`ew-resize`** and **`ns-resize`**, so Windows uses the outlined system cursors instead of near-invisible bundled bitmaps on light backgrounds.
> 
> **Right panel** handle (`RightPanelResizeHandle`) and **in-drag** `document.body` cursors in `useResizableWidth` and sidebar rail resize now use `ew-resize`. **Terminal drawer** top resize strips in `ThreadTerminalDrawer` use `cursor-ns-resize`. Resize behavior and layout are unchanged—pointer styling only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95dce588b81b790f3b655f81dbe7a37a8fa022f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `col-resize`/`row-resize` cursors with OS-native `ew-resize`/`ns-resize` in panel handles
> The `col-resize` and `row-resize` CSS cursors render as solid black arrows on some OS/browser combinations, making them invisible in light mode. Switching to `ew-resize` and `ns-resize` uses the OS-native resize cursors, which remain visible regardless of theme. Changes affect [RightPanelResizeHandle.tsx](https://github.com/pingdotgg/t3code/pull/6060/files#diff-f15f96e227863578612bce3d9ad429b580cc608942dba21b7f6727314f3fc469), [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/6060/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636), [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/6060/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd), and [useResizableWidth.ts](https://github.com/pingdotgg/t3code/pull/6060/files#diff-96534394ed1a9752ea07421d71c603ca870fc3df1e986db149612b91fdf3db66).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95dce58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->