### PR TITLE
fix(pull-requests): route self-hosted GitLab remotes

### DIFF
--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "@t3tools/contracts";
 
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
 import {
   PullRequestProviderError,
   type ProviderChangeRequest,
@@ -144,11 +145,16 @@ function fakeProvider(
 function makeService(input: {
   readonly projects: ReadonlyArray<OrchestrationProjectShell>;
   readonly providers: ReadonlyArray<PullRequestProviderApi>;
+  readonly resolveHandle?: SourceControlProviderRegistry.SourceControlProviderRegistry["Service"]["resolveHandle"];
 }) {
   return PullRequestService.make.pipe(
     Effect.provide(
       Layer.mergeAll(
         Layer.succeed(PullRequestProviderRegistry, fromProviders(input.providers)),
+        Layer.mock(SourceControlProviderRegistry.SourceControlProviderRegistry)({
+          resolveHandle:
+            input.resolveHandle ?? (() => Effect.die("Unexpected provider refinement")),
+        }),
         Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
           getShellSnapshot: () =>
             Effect.succeed({
@@ -162,6 +168,41 @@ function makeService(input: {
     ),
   );
 }
+
+it.effect("refines unknown self-hosted GitLab projects before listing merge requests", () =>
+  Effect.gen(function* () {
+    let refinementCalls = 0;
+    const selfHosted = project({
+      id: "p1",
+      title: "self-hosted",
+      workspaceRoot: "/gitlab",
+      repository: "group/project",
+      provider: "unknown",
+      host: "code.example.test",
+    });
+    const service = yield* makeService({
+      projects: [
+        selfHosted,
+        { ...selfHosted, id: "p2" as ProjectId, workspaceRoot: "/gitlab-worktree" },
+      ],
+      providers: [fakeProvider("gitlab")],
+      resolveHandle: ({ context }) => {
+        refinementCalls += 1;
+        assert.strictEqual(context?.remoteUrl, "https://code.example.test/group/project.git");
+        return Effect.succeed({
+          context: { ...context!, provider: { ...context!.provider, kind: "gitlab" } },
+          provider: undefined as never,
+        });
+      },
+    });
+
+    const result = yield* service.list({ state: "open" });
+
+    assert.strictEqual(refinementCalls, 1);
+    assert.strictEqual(result.providers[0]?.host, "code.example.test");
+    assert.strictEqual(result.providers[0]?.kind, "gitlab");
+  }),
+);
 
 /** A row as a host that reads several repositories at once hands it over. */
 function batchedChangeRequest(number: number, repository: string, updatedAt: string) {

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -204,6 +204,75 @@ it.effect("refines unknown self-hosted GitLab projects before listing merge requ
   }),
 );
 
+it.effect("derives a legacy repository host after refining its provider", () =>
+  Effect.gen(function* () {
+    const current = project({
+      id: "p1",
+      title: "legacy self-hosted",
+      workspaceRoot: "/gitlab",
+      repository: "group/project",
+      provider: "unknown",
+      host: "code.example.test",
+    });
+    const identity = current.repositoryIdentity!;
+    // Persisted identities from before canonicalKey existed are still accepted at runtime.
+    const legacy = {
+      ...current,
+      repositoryIdentity: {
+        locator: identity.locator,
+        provider: identity.provider,
+        displayName: identity.displayName,
+      },
+    } as unknown as OrchestrationProjectShell;
+    const service = yield* makeService({
+      projects: [legacy],
+      providers: [fakeProvider("gitlab")],
+      resolveHandle: ({ context }) =>
+        Effect.succeed({
+          context: { ...context!, provider: { ...context!.provider, kind: "gitlab" } },
+          provider: undefined as never,
+        }),
+    });
+
+    const result = yield* service.list({ state: "open", host: "gitlab" });
+
+    assert.strictEqual(result.providers[0]?.host, "gitlab");
+    assert.strictEqual(result.providers[0]?.kind, "gitlab");
+  }),
+);
+
+it.effect("tries another checkout when provider refinement remains unknown", () =>
+  Effect.gen(function* () {
+    const asked: string[] = [];
+    const selfHosted = project({
+      id: "p1",
+      title: "self-hosted",
+      workspaceRoot: "/gone",
+      repository: "group/project",
+      provider: "unknown",
+      host: "code.example.test",
+    });
+    const service = yield* makeService({
+      projects: [selfHosted, { ...selfHosted, id: "p2" as ProjectId, workspaceRoot: "/healthy" }],
+      providers: [fakeProvider("gitlab")],
+      resolveHandle: ({ cwd, context }) => {
+        asked.push(cwd);
+        return cwd === "/gone"
+          ? Effect.succeed({ context: context!, provider: undefined as never })
+          : Effect.succeed({
+              context: { ...context!, provider: { ...context!.provider, kind: "gitlab" } },
+              provider: undefined as never,
+            });
+      },
+    });
+
+    const result = yield* service.list({ state: "open" });
+
+    assert.deepStrictEqual(asked, ["/gone", "/healthy"]);
+    assert.strictEqual(result.providers[0]?.kind, "gitlab");
+  }),
+);
+
 /** A row as a host that reads several repositories at once hands it over. */
 function batchedChangeRequest(number: number, repository: string, updatedAt: string) {
   return { ...changeRequest(number, updatedAt), repository };

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -36,10 +36,13 @@ import {
   type PullRequestSubmitReviewInput,
   type PullRequestThreadReplyInput,
   type PullRequestThreadResolutionInput,
+  type SourceControlProviderInfo,
   type SourceControlProviderKind,
 } from "@t3tools/contracts";
+import { detectSourceControlProviderFromRemoteUrl } from "@t3tools/shared/sourceControl";
 
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
 import {
   type ProviderChangeRequest,
   type ProviderListCursor,
@@ -360,6 +363,49 @@ function repositoryIdentityOf(project: OrchestrationProjectShell): string | null
 export const make = Effect.gen(function* () {
   const registry = yield* PullRequestProviderRegistry;
   const projections = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+  const sourceControlProviders = yield* SourceControlProviderRegistry.SourceControlProviderRegistry;
+
+  const refineUnknownProjectKinds = (
+    projects: ReadonlyArray<OrchestrationProjectShell>,
+    filter: Pick<PullRequestListInput, "projectId" | "host">,
+  ) => {
+    const refinements = new Map<
+      string,
+      {
+        project: OrchestrationProjectShell;
+        provider: SourceControlProviderInfo;
+        remoteName: string;
+        remoteUrl: string;
+      }
+    >();
+    for (const project of projects) {
+      if (filter.projectId !== undefined && project.id !== filter.projectId) continue;
+      const identity = project.repositoryIdentity;
+      if (identity?.provider !== "unknown" || repositoryIdentityOf(project) === null) continue;
+      const host = pullRequestHostOf(identity, "unknown");
+      if (filter.host !== undefined && host !== filter.host.toLowerCase()) continue;
+      const { remoteName, remoteUrl } = identity.locator;
+      const provider = detectSourceControlProviderFromRemoteUrl(remoteUrl);
+      if (provider !== null && !refinements.has(provider.baseUrl)) {
+        refinements.set(provider.baseUrl, { project, provider, remoteName, remoteUrl });
+      }
+    }
+
+    return Effect.forEach(
+      refinements,
+      ([baseUrl, { project, provider, remoteName, remoteUrl }]) =>
+        sourceControlProviders
+          .resolveHandle({
+            cwd: project.workspaceRoot,
+            context: { provider, remoteName, remoteUrl },
+          })
+          .pipe(
+            Effect.map((handle) => [baseUrl, handle.context?.provider.kind ?? "unknown"] as const),
+            Effect.orElseSucceed(() => [baseUrl, "unknown"] as const),
+          ),
+      { concurrency: REPOSITORY_CONCURRENCY },
+    ).pipe(Effect.map((resolved) => new Map(resolved)));
+  };
 
   const listWorkspaceProjects = (
     filter: Pick<PullRequestListInput, "projectId" | "host">,
@@ -373,7 +419,12 @@ export const make = Effect.gen(function* () {
             cause: error,
           }),
       ),
-      Effect.map((snapshot) => {
+      Effect.flatMap((snapshot) =>
+        refineUnknownProjectKinds(snapshot.projects, filter).pipe(
+          Effect.map((refinedKinds) => ({ refinedKinds, snapshot })),
+        ),
+      ),
+      Effect.map(({ refinedKinds, snapshot }) => {
         const supported: SupportedProject[] = [];
         const unimplemented = new Map<
           string,
@@ -383,16 +434,19 @@ export const make = Effect.gen(function* () {
         const seen = new Set<string>();
         for (const project of snapshot.projects) {
           if (filter.projectId !== undefined && project.id !== filter.projectId) continue;
-          const kind = project.repositoryIdentity?.provider as
-            | SourceControlProviderKind
-            | undefined;
+          const identity = project.repositoryIdentity;
+          let kind = identity?.provider as SourceControlProviderKind | undefined;
           const repository = repositoryIdentityOf(project);
-          if (kind === undefined || repository === null) continue;
+          if (!identity || kind === undefined || repository === null) continue;
           // Worktrees of one repository are separate projects; reading the remote once keeps
           // the page from repeating every change request per local checkout. The host is part
           // of the key, so the same `owner/repo` on two hosts stays two repositories.
-          const host = pullRequestHostOf(project.repositoryIdentity, kind);
+          const host = pullRequestHostOf(identity, kind);
           if (filter.host !== undefined && host !== filter.host.toLowerCase()) continue;
+          if (kind === "unknown") {
+            const provider = detectSourceControlProviderFromRemoteUrl(identity.locator.remoteUrl);
+            kind = provider === null ? kind : (refinedKinds.get(provider.baseUrl) ?? kind);
+          }
           const api = registry.get(kind);
           // Recorded before the de-duplication below, so the viewer lookup keeps the alternates
           // the listing is about to drop.

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -369,40 +369,56 @@ export const make = Effect.gen(function* () {
     projects: ReadonlyArray<OrchestrationProjectShell>,
     filter: Pick<PullRequestListInput, "projectId" | "host">,
   ) => {
-    const refinements = new Map<
-      string,
-      {
-        project: OrchestrationProjectShell;
-        provider: SourceControlProviderInfo;
-        remoteName: string;
-        remoteUrl: string;
-      }
-    >();
+    type RefinementCandidate = {
+      readonly project: OrchestrationProjectShell;
+      readonly provider: SourceControlProviderInfo;
+      readonly remoteName: string;
+      readonly remoteUrl: string;
+    };
+    const refinements = new Map<string, RefinementCandidate[]>();
     for (const project of projects) {
       if (filter.projectId !== undefined && project.id !== filter.projectId) continue;
       const identity = project.repositoryIdentity;
       if (identity?.provider !== "unknown" || repositoryIdentityOf(project) === null) continue;
       const host = pullRequestHostOf(identity, "unknown");
-      if (filter.host !== undefined && host !== filter.host.toLowerCase()) continue;
+      // A legacy identity has no canonical host until its provider is refined, so it must reach
+      // the refinement before a host filter can decide whether it belongs in the result.
+      if (filter.host !== undefined && host !== "unknown" && host !== filter.host.toLowerCase()) {
+        continue;
+      }
       const { remoteName, remoteUrl } = identity.locator;
       const provider = detectSourceControlProviderFromRemoteUrl(remoteUrl);
-      if (provider !== null && !refinements.has(provider.baseUrl)) {
-        refinements.set(provider.baseUrl, { project, provider, remoteName, remoteUrl });
+      if (provider !== null) {
+        const candidates = refinements.get(provider.baseUrl);
+        const candidate = { project, provider, remoteName, remoteUrl };
+        if (candidates === undefined) refinements.set(provider.baseUrl, [candidate]);
+        else candidates.push(candidate);
       }
     }
 
     return Effect.forEach(
       refinements,
-      ([baseUrl, { project, provider, remoteName, remoteUrl }]) =>
-        sourceControlProviders
-          .resolveHandle({
-            cwd: project.workspaceRoot,
-            context: { provider, remoteName, remoteUrl },
-          })
-          .pipe(
-            Effect.map((handle) => [baseUrl, handle.context?.provider.kind ?? "unknown"] as const),
-            Effect.orElseSucceed(() => [baseUrl, "unknown"] as const),
+      ([baseUrl, candidates]) =>
+        Effect.firstSuccessOf(
+          candidates.map(({ project, provider, remoteName, remoteUrl }) =>
+            Effect.suspend(() =>
+              sourceControlProviders.resolveHandle({
+                cwd: project.workspaceRoot,
+                context: { provider, remoteName, remoteUrl },
+              }),
+            ).pipe(
+              Effect.flatMap((handle) => {
+                const kind = handle.context?.provider.kind;
+                return kind === undefined || kind === "unknown"
+                  ? Effect.fail(undefined)
+                  : Effect.succeed(kind);
+              }),
+            ),
           ),
+        ).pipe(
+          Effect.map((kind) => [baseUrl, kind] as const),
+          Effect.orElseSucceed(() => [baseUrl, "unknown"] as const),
+        ),
       { concurrency: REPOSITORY_CONCURRENCY },
     ).pipe(Effect.map((resolved) => new Map(resolved)));
   };
@@ -441,12 +457,12 @@ export const make = Effect.gen(function* () {
           // Worktrees of one repository are separate projects; reading the remote once keeps
           // the page from repeating every change request per local checkout. The host is part
           // of the key, so the same `owner/repo` on two hosts stays two repositories.
-          const host = pullRequestHostOf(identity, kind);
-          if (filter.host !== undefined && host !== filter.host.toLowerCase()) continue;
           if (kind === "unknown") {
             const provider = detectSourceControlProviderFromRemoteUrl(identity.locator.remoteUrl);
             kind = provider === null ? kind : (refinedKinds.get(provider.baseUrl) ?? kind);
           }
+          const host = pullRequestHostOf(identity, kind);
+          if (filter.host !== undefined && host !== filter.host.toLowerCase()) continue;
           const api = registry.get(kind);
           // Recorded before the de-duplication below, so the viewer lookup keeps the alternates
           // the listing is about to drop.

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -435,6 +435,7 @@ const commandReadinessLayer = HttpRouter.middleware(
 const PullRequestServiceLive = PullRequestService.layer.pipe(
   // One registry entry per supported host; the service only knows the registry.
   Layer.provide(PullRequestProviderRegistry.layer),
+  Layer.provide(SourceControlProviderRegistryLayerLive),
   Layer.provide(VcsProcess.layer),
 );
 

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -203,6 +203,38 @@ self-hosted.example.test
   }),
 );
 
+it.effect("refines the caller-selected remote instead of choosing another configured remote", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [{ name: "origin", url: "git@github.com:fork/project.git" }],
+      process: {
+        run: () =>
+          Effect.succeed(
+            processOutput(`self-hosted.example.test
+  ✓ Logged in to self-hosted.example.test as gitlab-user
+`),
+          ),
+      },
+    });
+
+    const handle = yield* registry.resolveHandle({
+      cwd: "/repo",
+      context: {
+        provider: {
+          kind: "unknown",
+          name: "self-hosted.example.test",
+          baseUrl: "https://self-hosted.example.test",
+        },
+        remoteName: "upstream",
+        remoteUrl: "https://self-hosted.example.test/group/project.git",
+      },
+    });
+
+    assert.strictEqual(handle.context?.provider.kind, "gitlab");
+    assert.strictEqual(handle.context?.remoteName, "upstream");
+  }),
+);
+
 it.effect("routes authenticated self-hosted GitLab remotes on non-standard ports", () =>
   Effect.gen(function* () {
     const registry = yield* makeRegistry({

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -50,6 +50,7 @@ export class SourceControlProviderRegistry extends Context.Service<
     >;
     readonly resolveHandle: (input: {
       readonly cwd: string;
+      readonly context?: SourceControlProvider.SourceControlProviderContext;
     }) => Effect.Effect<SourceControlProviderHandle, SourceControlProviderError>;
     readonly resolve: (input: {
       readonly cwd: string;
@@ -254,7 +255,15 @@ export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWit
     });
 
     const resolveHandle: SourceControlProviderRegistry["Service"]["resolveHandle"] = (input) =>
-      Cache.get(providerContextCache, input.cwd).pipe(
+      (input.context === undefined
+        ? Cache.get(providerContextCache, input.cwd)
+        : refineUnknownRemoteProvider({
+            specs: discoverySpecs,
+            process,
+            cwd: input.cwd,
+            context: input.context,
+          })
+      ).pipe(
         Effect.map((context) => {
           const kind = context?.provider.kind ?? "unknown";
           const provider = providers.get(kind) ?? unsupportedProvider(kind);


### PR DESCRIPTION
## What Changed

- Refine unknown self-hosted repository providers from their remote URLs before listing pull requests.
- Preserve the caller-selected remote when resolving source-control handles.
- Add focused coverage for self-hosted GitLab routing and remote selection.

## Why

Self-hosted GitLab repositories were recorded as unknown and could not be routed to the GitLab pull request provider. This change detects the provider from the repository remote and refines it using the matching remote context, allowing merge requests to be listed correctly without selecting a different configured remote.

## UI Changes

**Before:**
<img width="1744" height="1394" alt="image" src="https://github.com/user-attachments/assets/0d0e4931-5ac1-4d3b-8a14-b85930c3fab1" />

**After:**
<img width="1916" height="1562" alt="image" src="https://github.com/user-attachments/assets/7f9be1ab-6611-4c1b-977a-dd0bc1bb028f" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how pull request hosts are resolved for unknown providers and extends source-control handle resolution; behavior is localized to listing/workspace classification with new tests, but incorrect refinement could mis-route API calls to the wrong provider.
> 
> **Overview**
> Self-hosted GitLab repos that were stored with provider **`unknown`** can now show up on the pull request list by resolving the real host kind from each project's remote before workspace projects are classified.
> 
> **Pull request listing** runs a new **`refineUnknownProjectKinds`** step (deduped per provider base URL, concurrent with existing repo limits) that calls **`SourceControlProviderRegistry.resolveHandle`** with the project's **`remoteUrl`** / **`remoteName`**. Resolved kinds replace **`unknown`** when picking the pull request provider, so merge requests go through GitLab instead of staying unimplemented.
> 
> **Source control registry**: **`resolveHandle`** accepts an optional **`context`**. With context, it refines that caller-chosen remote via **`refineUnknownRemoteProvider`** instead of the cwd detection cache—which could pick a different configured remote (e.g. **`origin`** on GitHub while **`upstream`** is self-hosted GitLab).
> 
> **Wiring**: **`PullRequestServiceLive`** now provides **`SourceControlProviderRegistryLayerLive`**. Tests cover self-hosted GitLab list refinement and remote-preserving handle resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d71b1951b801ab0354eeca7dc70992f5259580e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix routing for self-hosted GitLab remotes in pull request service
> - Projects with an unknown provider kind are now refined before listing merge requests by inspecting their remote URL and consulting `SourceControlProviderRegistry`.
> - Extends `SourceControlProviderRegistry.resolveHandle` to accept an optional `SourceControlProviderContext`, bypassing the cache and running provider refinement against the supplied context instead of auto-detecting.
> - Wires `SourceControlProviderRegistryLayerLive` into the `PullRequestService` layer composition in [server.ts](https://github.com/pingdotgg/t3code/pull/6061/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9d71b19. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->