### PR TITLE
fix(web): file tree no longer blanks on whitespace-padded duplicate paths

### DIFF
--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -137,26 +137,39 @@ function parentPathOf(input: string): string | undefined {
   return separatorIndex === -1 ? undefined : input.slice(0, separatorIndex);
 }
 
-function toProjectEntry(item: MixedItem): ProjectEntry | null {
-  const normalizedPath = trimDirectorySeparator(toPosixPath(item.item.relativePath));
-  if (!normalizedPath) {
+// ProjectEntry.path is trimmed by the wire schema, so a path with leading or
+// trailing whitespace would collapse onto its trimmed twin after encoding
+// (crashing the client's file tree on the duplicate) and cannot be addressed
+// by any path-based request. A path is wire-representable iff every segment
+// survives trimming — checking per segment (not just the whole string) keeps
+// every ancestor prefix of a kept path representable too, so files inside an
+// unrepresentable directory are dropped along with it rather than emitted as
+// orphans of a directory the server refuses to send.
+function isWireRepresentablePath(path: string): boolean {
+  return path.split("/").every((segment) => segment === segment.trim());
+}
+
+function toEntryPath(relativePath: string): string | null {
+  const normalizedPath = trimDirectorySeparator(toPosixPath(relativePath));
+  if (!normalizedPath || !isWireRepresentablePath(normalizedPath)) {
     return null;
   }
+  return normalizedPath;
+}
 
-  return {
-    path: normalizedPath,
-    kind: item.type,
-  };
+function toProjectEntry(item: MixedItem): ProjectEntry | null {
+  const path = toEntryPath(item.item.relativePath);
+  return path ? { path, kind: item.type } : null;
 }
 
 function toFileEntry(item: FileItem): ProjectEntry | null {
-  const normalizedPath = trimDirectorySeparator(toPosixPath(item.relativePath));
-  return normalizedPath ? { path: normalizedPath, kind: "file" } : null;
+  const path = toEntryPath(item.relativePath);
+  return path ? { path, kind: "file" } : null;
 }
 
 function toDirectoryEntry(item: DirItem): ProjectEntry | null {
-  const normalizedPath = trimDirectorySeparator(toPosixPath(item.relativePath));
-  return normalizedPath ? { path: normalizedPath, kind: "directory" } : null;
+  const path = toEntryPath(item.relativePath);
+  return path ? { path, kind: "directory" } : null;
 }
 
 function mapFileSearchResult(

--- a/apps/server/src/workspace/WorkspaceSearchIndex.wirePaths.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.wirePaths.test.ts
@@ -1,0 +1,68 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ProjectEntry } from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import * as WorkspaceSearchIndex from "./WorkspaceSearchIndex.ts";
+
+/**
+ * ProjectEntry.path is a TrimmedNonEmptyString, so a path segment with leading
+ * or trailing whitespace ("notes.txt\n") collapses onto its trimmed twin once
+ * it crosses the wire. The client's file tree throws `Duplicate path: "..."`
+ * on the resulting adjacent pair and renders nothing. The index must therefore
+ * only emit entries whose full ancestor chain the wire contract can represent.
+ */
+const listEntriesOf = Effect.fn(function* (files: ReadonlyArray<string>) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-dup-path-" });
+  for (const relativePath of files) {
+    const absolutePath = path.join(root, relativePath);
+    yield* fileSystem.makeDirectory(path.dirname(absolutePath), { recursive: true });
+    yield* fileSystem.writeFileString(absolutePath, "");
+  }
+  const index = yield* WorkspaceSearchIndex.make(root);
+  return yield* index.list();
+});
+
+function encodedPaths(entries: ReadonlyArray<ProjectEntry>): ReadonlyArray<string> {
+  const encode = Schema.encodeUnknownSync(Schema.Array(ProjectEntry));
+  return encode(entries).map((entry) => entry.path);
+}
+
+it.effect("drops a file whose name collapses onto a sibling's after trimming", () =>
+  Effect.gen(function* () {
+    const { entries } = yield* listEntriesOf(["pkg/notes.txt", "pkg/notes.txt\n"]);
+    const notes = entries.filter((entry) => entry.path.includes("notes.txt"));
+
+    expect(notes).toEqual([{ path: "pkg/notes.txt", kind: "file" }]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("drops the whole subtree under a directory the wire cannot represent", () =>
+  Effect.gen(function* () {
+    const { entries } = yield* listEntriesOf(["sub/inner.txt", "sub\n/inner.txt"]);
+
+    expect(entries).toEqual([
+      { path: "sub", kind: "directory" },
+      { path: "sub/inner.txt", kind: "file" },
+    ]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("never emits two entries that encode to the same wire path", () =>
+  Effect.gen(function* () {
+    const { entries } = yield* listEntriesOf([
+      "pkg/notes.txt",
+      "pkg/notes.txt\n",
+      "pkg/ notes.txt",
+    ]);
+    const wirePaths = encodedPaths(entries);
+    const duplicates = wirePaths.filter((path, index) => wirePaths.indexOf(path) !== index);
+
+    expect(duplicates).toEqual([]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -19,6 +19,7 @@ import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
 import { T3_PIERRE_ICONS } from "~/pierre-icons";
 
+import { buildTreePaths } from "./fileBrowserTreePaths";
 import { createFileTreeDragMentionController } from "./fileTreeDragMention";
 import { useProjectEntriesQuery } from "./projectFilesQueryState";
 
@@ -44,10 +45,6 @@ const TREE_UNSAFE_CSS = `
   }
   button[data-type='item'] { border-radius: 5px; }
 `;
-
-function treePath(entry: ProjectEntry): string {
-  return entry.kind === "directory" ? `${entry.path}/` : entry.path;
-}
 
 function RefreshFilesButton(props: { isPending: boolean; onRefresh: () => void }) {
   return (
@@ -115,7 +112,7 @@ export default function FileBrowserPanel({
     [entries],
   );
   const entryKindsRef = useRef<ReadonlyMap<string, ProjectEntry["kind"]>>(entryKinds);
-  const treePaths = useMemo(() => entries.map(treePath), [entries]);
+  const treePaths = useMemo(() => buildTreePaths(entries), [entries]);
   const previousTreePathsRef = useRef<readonly string[]>([]);
   const syncingSelectionRef = useRef(false);
   const treeSelectionPathRef = useRef<string | null>(null);
@@ -302,7 +299,7 @@ export default function FileBrowserPanel({
       model.getItem(path)?.deselect();
     }
 
-    // Directory rows are registered with a trailing slash (see treePath), so
+    // Directory rows are registered with a trailing slash (see buildTreePaths), so
     // ancestor lookups must use the same form to expand them.
     const segments = selectedPath.split("/");
     let ancestorPath = "";

--- a/apps/web/src/components/files/fileBrowserTreePaths.test.ts
+++ b/apps/web/src/components/files/fileBrowserTreePaths.test.ts
@@ -1,0 +1,28 @@
+import type { ProjectEntry } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildTreePaths } from "./fileBrowserTreePaths.ts";
+
+describe("buildTreePaths", () => {
+  it("maps files to plain paths and directories to trailing-slash paths", () => {
+    const entries: ProjectEntry[] = [
+      { path: "pkg", kind: "directory" },
+      { path: "pkg/notes.txt", kind: "file" },
+    ];
+
+    expect(buildTreePaths(entries)).toEqual(["pkg/", "pkg/notes.txt"]);
+  });
+
+  it("drops duplicate paths so one bad entry cannot crash the tree", () => {
+    // Duplicates should never arrive, but the tree model throws on them and
+    // takes the whole panel down, so the mapping must be defensive.
+    const entries: ProjectEntry[] = [
+      { path: "pkg", kind: "directory" },
+      { path: "pkg/notes.txt", kind: "file" },
+      { path: "pkg/notes.txt", kind: "file" },
+      { path: "pkg/other.txt", kind: "file" },
+    ];
+
+    expect(buildTreePaths(entries)).toEqual(["pkg/", "pkg/notes.txt", "pkg/other.txt"]);
+  });
+});

--- a/apps/web/src/components/files/fileBrowserTreePaths.ts
+++ b/apps/web/src/components/files/fileBrowserTreePaths.ts
@@ -1,0 +1,18 @@
+import type { ProjectEntry } from "@t3tools/contracts";
+
+/**
+ * Maps project entries to the path strings the file tree consumes. The tree
+ * model throws on duplicate paths and takes the whole panel down with it, so
+ * duplicates are dropped here even though the server should never send them.
+ */
+export function buildTreePaths(entries: ReadonlyArray<ProjectEntry>): string[] {
+  const paths: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const path = entry.kind === "directory" ? `${entry.path}/` : entry.path;
+    if (seen.has(path)) continue;
+    seen.add(path);
+    paths.push(path);
+  }
+  return paths;
+}


### PR DESCRIPTION
Fixes #5501

## What Changed

`WorkspaceSearchIndex` no longer emits entries the wire contract cannot represent. `ProjectEntry.path` is a `TrimmedNonEmptyString` (trimmed on encode), so two on-disk paths like `pkg/notes.txt` and `pkg/notes.txt\n` collapse to the same wire path; the client's file tree throws `Duplicate path` on the pair and the whole window dies to an error boundary.

- **Server** (`apps/server/src/workspace/WorkspaceSearchIndex.ts`): a path is wire-representable iff every segment survives trimming. Checking per segment (not just the whole string) keeps every ancestor prefix of an emitted entry emittable too, so subtrees under an unrepresentable directory are dropped consistently rather than emitted as orphans of a directory the server refuses to send.
- **Client** (`apps/web/src/components/files/fileBrowserTreePaths.ts`): the entry→tree-path mapping is extracted into a small pure helper that also de-dupes defensively, so one bad entry from an older/other server can never take the whole Files panel down again.

Both layers are covered by tests (`WorkspaceSearchIndex.wirePaths.test.ts` against the real file walker in a temp dir, plus unit tests for `buildTreePaths`).

## Why

A single whitespace-padded filename anywhere in a workspace — trivially created by e.g. `touch "$(pbpaste)"` — currently kills the entire app with `Duplicate path: "pkg/notes.txt"`, with no recovery from inside the app (refresh/reopen/restart all re-throw; you have to delete the file from a terminal). Repro script and full root-cause chain are in #5501.

Dropping unrepresentable paths server-side is the right layer: such paths can't be addressed by any path-based request after the schema trims them, so emitting them can only ever produce collisions. The client-side de-dupe is defense in depth for a component whose failure mode is "the panel throws and renders nothing."

## UI Changes

Both screenshots are against the issue's repro workspace (`/tmp/dup-path-repro` containing `pkg/notes.txt` and `pkg/notes.txt\n`), on a clean dev profile.

**Before** — opening the Files panel takes down the whole window:

<img width="1440" height="900" alt="before-duplicate-path-crash" src="https://github.com/user-attachments/assets/f7408017-b1a6-4e15-ab3d-dc45e752ae86" />

**After** — the panel renders; the whitespace-suffixed twin is dropped:

<img width="1440" height="900" alt="after-files-panel-renders" src="https://github.com/user-attachments/assets/4390b5be-9e9d-4381-a99c-ba6faea3595e" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (N/A — no motion changes)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file tree blanking on whitespace-padded duplicate paths in the file browser
> - Adds `buildTreePaths` in [fileBrowserTreePaths.ts](https://github.com/pingdotgg/t3code/pull/6064/files#diff-04f73a2750a43d870b2dd7eeb17be002531ec9c350a11e6123dcf04fc7cbf24e) to convert `ProjectEntry` items to tree paths, appending trailing slashes for directories and deduplicating via a `Set` to prevent the tree model from crashing on duplicate paths.
> - Adds `isWireRepresentablePath` and `toEntryPath` helpers in [WorkspaceSearchIndex.ts](https://github.com/pingdotgg/t3code/pull/6064/files#diff-c11793234fa6d81f052147cd8ae0b62e4e60366837e340f42279225a76704093) to filter out any file, directory, or project entries whose path segments contain leading or trailing whitespace before emitting them over the wire.
> - `FileBrowserPanel` now uses `buildTreePaths` instead of the local `treePath` helper.
> - Behavioral Change: paths with whitespace-padded segments are now silently dropped from the file tree rather than passed through, which may hide files with unusual names.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized da79dab. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->