### PR TITLE
Fix for issue 123

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -754,6 +754,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const storeNewTerminal = useTerminalUiStateStore((state) => state.newTerminal);
   const storeSetActiveTerminal = useTerminalUiStateStore((state) => state.setActiveTerminal);
   const storeCloseTerminal = useTerminalUiStateStore((state) => state.closeTerminal);
+  const storeSetTerminalOpen = useTerminalUiStateStore((state) => state.setTerminalOpen);
   const reconcileTerminalIds = useTerminalUiStateStore((state) => state.reconcileTerminalIds);
 
   useEffect(() => {
@@ -950,6 +951,10 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     [onAddTerminalContext, visible],
   );
 
+  const handleHideDrawer = useCallback(() => {
+    storeSetTerminalOpen(threadRef, false);
+  }, [storeSetTerminalOpen, threadRef]);
+
   if (!project || !terminalUiState.terminalOpen || !cwd) {
     return null;
   }
@@ -980,6 +985,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         keybindings={keybindings}
         onActiveTerminalChange={activateTerminal}
         onCloseTerminal={closeTerminal}
+        onHideDrawer={handleHideDrawer}
         onHeightChange={setTerminalHeight}
         onAddTerminalContext={handleAddTerminalContext}
         terminalLabelsById={terminalLabelsById}

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -11,6 +11,7 @@ import {
   TerminalSquare,
   Trash2,
   XIcon,
+  ChevronDown,
 } from "lucide-react";
 import {
   type ResolvedKeybindingsConfig,
@@ -887,6 +888,7 @@ interface ThreadTerminalDrawerProps {
   closeShortcutLabel?: string | undefined;
   onActiveTerminalChange: (terminalId: string) => void;
   onCloseTerminal: (terminalId: string) => void;
+  onHideDrawer?: () => void;
   onHeightChange: (height: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   keybindings: ResolvedKeybindingsConfig;
@@ -948,6 +950,7 @@ export default function ThreadTerminalDrawer({
   closeShortcutLabel,
   onActiveTerminalChange,
   onCloseTerminal,
+  onHideDrawer,
   onHeightChange,
   onAddTerminalContext,
   keybindings,
@@ -1347,6 +1350,18 @@ export default function ThreadTerminalDrawer({
               <Plus className="size-3.25" />
             </TerminalActionButton>
             <div className="h-4 w-px bg-border/80" />
+            {onHideDrawer && (
+              <>
+                <TerminalActionButton
+                  className="p-1 text-foreground/90 transition-colors hover:bg-accent"
+                  onClick={onHideDrawer}
+                  label="Hide Terminal"
+                >
+                  <ChevronDown className="size-3.25" />
+                </TerminalActionButton>
+                <div className="h-4 w-px bg-border/80" />
+              </>
+            )}
             <TerminalActionButton
               className="p-1 text-foreground/90 transition-colors hover:bg-accent"
               onClick={() => onCloseTerminal(resolvedActiveTerminalId)}
@@ -1482,6 +1497,15 @@ export default function ThreadTerminalDrawer({
                   >
                     <Plus className="size-3.25" />
                   </TerminalActionButton>
+                  {onHideDrawer && (
+                    <TerminalActionButton
+                      className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"
+                      onClick={onHideDrawer}
+                      label="Hide Terminal"
+                    >
+                      <ChevronDown className="size-3.25" />
+                    </TerminalActionButton>
+                  )}
                   <TerminalActionButton
                     className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"
                     onClick={() => onCloseTerminal(resolvedActiveTerminalId)}


### PR DESCRIPTION
Fixes issue #123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility toggle reusing existing `setTerminalOpen` state; no changes to terminal lifecycle or server behavior beyond hiding the drawer.
> 
> **Overview**
> Adds a **Hide Terminal** control to the thread terminal UI so users can collapse the drawer without closing terminal sessions.
> 
> `ChatView` wires a new `onHideDrawer` handler that sets `terminalOpen` to `false` via the terminal UI store for the current thread. `ThreadTerminalDrawer` accepts optional `onHideDrawer` and renders a chevron-down action in both the panel and compact toolbars (next to new/split/close), only when that callback is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d7886fd7390c2ddb93d9a648afa5f03137873aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Hide Terminal' button to `ThreadTerminalDrawer`
> Adds an optional `onHideDrawer` prop to [`ThreadTerminalDrawer`](https://github.com/pingdotgg/t3code/pull/6066/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636). When provided, a 'Hide Terminal' button (ChevronDown icon) appears in both drawer and panel action bars. [`PersistentThreadTerminalDrawer`](https://github.com/pingdotgg/t3code/pull/6066/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) supplies the handler, which sets `terminalOpen=false` for the thread via the terminal UI state store.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d7886f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->