### PR TITLE
feat(web): add drag-to-reorder for sidebar thread sections

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1114,11 +1114,26 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     </span>
   ) : null;
 
+  const sortable = props.sortable;
+
   if (variant === "slim") {
     return (
       <li
         data-thread-item
-        className="list-none [content-visibility:auto] [contain-intrinsic-size:auto_34px]"
+        ref={sortable?.setNodeRef}
+        style={
+          sortable
+            ? {
+                transform: CSS.Translate.toString(sortable.transform),
+                transition: sortable.transition,
+              }
+            : undefined
+        }
+        {...(sortable?.listeners ?? {})}
+        className={cn(
+          "list-none [content-visibility:auto] [contain-intrinsic-size:auto_34px]",
+          sortable?.isDragging && "z-20 opacity-80",
+        )}
       >
         <Tooltip>
           <TooltipTrigger
@@ -1248,7 +1263,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
 
   const diff = latestTurnDiff(thread);
 
-  const sortable = props.sortable;
   return (
     <li
       data-thread-item

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -92,7 +92,11 @@ import {
   buildSidebarProjectSnapshots,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
-import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
+import {
+  legacyProjectCwdPreferenceKey,
+  type SidebarThreadSection,
+  useUiStateStore,
+} from "../uiStateStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
@@ -394,22 +398,24 @@ function SnoozePopoverButton(props: {
   );
 }
 
-// Subset of useSortable applied to a pinned card's root <li>. Listeners go
-// on the whole card (no dedicated handle): the pointer sensor's distance
+// Subset of useSortable applied to a thread row's root <li>. Listeners go
+// on the whole row (no dedicated handle): the pointer sensor's distance
 // constraint keeps plain clicks working, and we skip dnd-kit's aria
-// attributes since there is no keyboard sensor and the card body already
+// attributes since there is no keyboard sensor and the row body already
 // carries its own button semantics.
-type SortablePinnedRowBag = Pick<
+type SortableThreadRowBag = Pick<
   ReturnType<typeof useSortable>,
   "listeners" | "setNodeRef" | "transform" | "transition" | "isDragging"
 >;
 
-function SortablePinnedThreadRow(props: {
+function SortableSidebarThreadRow(props: {
   id: string;
-  children: (bag: SortablePinnedRowBag) => ReactNode;
+  section?: SidebarThreadSection | undefined;
+  children: (bag: SortableThreadRowBag) => ReactNode;
 }) {
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: props.id,
+    ...(props.section !== undefined ? { data: { section: props.section } } : {}),
   });
   return props.children({ listeners, setNodeRef, transform, transition, isDragging });
 }
@@ -664,7 +670,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // Present only on pinned cards whose server supports reordering: dnd-kit
   // sortable bag applied to the card root so the whole card drags (the
   // pointer sensor's distance constraint keeps plain clicks working).
-  sortable?: SortablePinnedRowBag | undefined;
+  sortable?: SortableThreadRowBag | undefined;
   // Compact wake countdown ("2h") for rows in the snoozed shelf.
   snoozeWakeLabelText: string | null;
   // When a snooze ended (timer or early wake); drives the Woke pill until
@@ -1582,6 +1588,8 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
 export default function Sidebar() {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
+  const threadOrderBySection = useUiStateStore((store) => store.threadOrderBySection);
+  const reorderThreads = useUiStateStore((store) => store.reorderThreads);
   const threads = useThreadShells();
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
@@ -1874,9 +1882,9 @@ export default function Sidebar() {
   const {
     pinnedThreads,
     reorderablePinnedKeys,
-    activeThreads,
-    snoozedThreads,
-    settledThreads,
+    activeThreads: defaultActiveThreads,
+    snoozedThreads: defaultSnoozedThreads,
+    settledThreads: defaultSettledThreads,
     snoozeNow,
   } = useMemo(() => {
     const now = `${nowMinute}:00.000Z`;
@@ -1965,6 +1973,34 @@ export default function Sidebar() {
     snoozeWakeTick,
     threads,
   ]);
+
+  const activeThreads = useMemo(
+    () =>
+      orderItemsByPreferredIds({
+        items: defaultActiveThreads,
+        preferredIds: threadOrderBySection.active,
+        getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      }),
+    [defaultActiveThreads, threadOrderBySection.active],
+  );
+  const snoozedThreads = useMemo(
+    () =>
+      orderItemsByPreferredIds({
+        items: defaultSnoozedThreads,
+        preferredIds: threadOrderBySection.snoozed,
+        getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      }),
+    [defaultSnoozedThreads, threadOrderBySection.snoozed],
+  );
+  const settledThreads = useMemo(
+    () =>
+      orderItemsByPreferredIds({
+        items: defaultSettledThreads,
+        preferredIds: threadOrderBySection.settled,
+        getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      }),
+    [defaultSettledThreads, threadOrderBySection.settled],
+  );
 
   const threadSearchInputRef = useRef<HTMLInputElement>(null);
   const [threadSearchQuery, setThreadSearchQuery] = useState("");
@@ -2133,6 +2169,37 @@ export default function Sidebar() {
   );
   const snoozedThreadKeysRef = useRef(snoozedThreadKeys);
   snoozedThreadKeysRef.current = snoozedThreadKeys;
+
+  const threadKeysBySection = useMemo(
+    () => ({
+      active: activeThreads.map((thread) =>
+        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      ),
+      snoozed: visibleSnoozedThreads.map((thread) =>
+        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      ),
+      settled: renderedSettledThreads.map((thread) =>
+        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      ),
+    }),
+    [activeThreads, renderedSettledThreads, visibleSnoozedThreads],
+  );
+  const threadSectionDndSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
+  const handleThreadSectionDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (event.over === null) return;
+      const activeSection = event.active.data.current?.section as SidebarThreadSection | undefined;
+      const overSection = event.over.data.current?.section as SidebarThreadSection | undefined;
+      if (activeSection === undefined || activeSection !== overSection) return;
+      const activeKey = String(event.active.id);
+      const overKey = String(event.over.id);
+      if (activeKey === overKey) return;
+      reorderThreads(activeSection, threadKeysBySection[activeSection], activeKey, overKey);
+    },
+    [reorderThreads, threadKeysBySection],
+  );
 
   const jumpLabelByKey = useMemo(() => {
     const mapping = new Map<string, string>();
@@ -3421,7 +3488,7 @@ export default function Sidebar() {
                   const renderThreadRow = (
                     thread: EnvironmentThreadShell,
                     section: "pinned" | "active" | "snoozed" | "settled",
-                    sortable?: SortablePinnedRowBag,
+                    sortable?: SortableThreadRowBag,
                   ) => {
                     const threadKey = scopedThreadKey(
                       scopeThreadRef(thread.environmentId, thread.id),
@@ -3518,6 +3585,24 @@ export default function Sidebar() {
                       />
                     );
                   };
+                  const renderSortableThreadRow = (
+                    thread: EnvironmentThreadShell,
+                    section: SidebarThreadSection,
+                  ) => {
+                    const threadKey = scopedThreadKey(
+                      scopeThreadRef(thread.environmentId, thread.id),
+                    );
+                    const rowVariant = section === "active" ? "card" : "slim";
+                    return (
+                      <SortableSidebarThreadRow
+                        key={`${threadKey}:${rowVariant}`}
+                        id={threadKey}
+                        section={section}
+                      >
+                        {(bag) => renderThreadRow(thread, section, bag)}
+                      </SortableSidebarThreadRow>
+                    );
+                  };
                   // Draft block above everything, then the pinned block:
                   // full cards above the inbox, closed by a thin divider (the
                   // pin glyphs carry the meaning, so no header text). Both
@@ -3558,9 +3643,9 @@ export default function Sidebar() {
                             return renderThreadRow(thread, "pinned");
                           }
                           return (
-                            <SortablePinnedThreadRow key={threadKey} id={threadKey}>
+                            <SortableSidebarThreadRow key={threadKey} id={threadKey}>
                               {(bag) => renderThreadRow(thread, "pinned", bag)}
-                            </SortablePinnedThreadRow>
+                            </SortableSidebarThreadRow>
                           );
                         })}
                       </SortableContext>
@@ -3576,82 +3661,96 @@ export default function Sidebar() {
                       />,
                     );
                   }
-                  for (const thread of activeThreads) {
-                    items.push(renderThreadRow(thread, "active"));
-                  }
-                  // Snoozed shelf: between the inbox and Settled — out of the
-                  // way, never gone. The header always renders while anything
-                  // is snoozed (the count is the whole footprint when
-                  // collapsed); rows only when expanded. Vanishes entirely at
-                  // count 0.
-                  if (snoozedThreads.length > 0) {
-                    items.push(
-                      <li
-                        key="snoozed-shelf-header"
-                        data-thread-selection-safe
-                        className="list-none"
+                  items.push(
+                    <DndContext
+                      key="thread-sections-dnd"
+                      sensors={threadSectionDndSensors}
+                      collisionDetection={closestCenter}
+                      modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
+                      onDragEnd={handleThreadSectionDragEnd}
+                    >
+                      <SortableContext
+                        items={threadKeysBySection.active}
+                        strategy={verticalListSortingStrategy}
                       >
-                        <button
-                          type="button"
-                          onClick={toggleSnoozedShelf}
-                          aria-expanded={snoozedShelfExpanded}
-                          data-testid="sidebar-snoozed-shelf-toggle"
-                          className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
+                        {activeThreads.map((thread) => renderSortableThreadRow(thread, "active"))}
+                      </SortableContext>
+                      {snoozedThreads.length > 0 ? (
+                        <li
+                          key="snoozed-shelf-header"
+                          data-thread-selection-safe
+                          className="list-none"
                         >
-                          <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
-                            {snoozedShelfExpanded
-                              ? "Snoozed"
-                              : `Snoozed (${snoozedThreads.length})`}
-                          </span>
-                          <span className="h-px flex-1 bg-blue-500/20 dark:bg-blue-400/15" />
-                          <ChevronDownIcon
-                            aria-hidden
-                            className={cn(
-                              "size-3 text-blue-600 transition-transform dark:text-blue-400",
-                              snoozedShelfExpanded && "rotate-180",
-                            )}
-                          />
-                        </button>
-                      </li>,
-                    );
-                    for (const thread of visibleSnoozedThreads) {
-                      items.push(renderThreadRow(thread, "snoozed"));
-                    }
-                  }
-                  if (settledThreads.length > 0) {
-                    items.push(
-                      <li
-                        key="settled-shelf-header"
-                        data-thread-selection-safe
-                        className="list-none"
+                          <button
+                            type="button"
+                            onClick={toggleSnoozedShelf}
+                            aria-expanded={snoozedShelfExpanded}
+                            data-testid="sidebar-snoozed-shelf-toggle"
+                            className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
+                          >
+                            <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
+                              {snoozedShelfExpanded
+                                ? "Snoozed"
+                                : `Snoozed (${snoozedThreads.length})`}
+                            </span>
+                            <span className="h-px flex-1 bg-blue-500/20 dark:bg-blue-400/15" />
+                            <ChevronDownIcon
+                              aria-hidden
+                              className={cn(
+                                "size-3 text-blue-600 transition-transform dark:text-blue-400",
+                                snoozedShelfExpanded && "rotate-180",
+                              )}
+                            />
+                          </button>
+                        </li>
+                      ) : null}
+                      <SortableContext
+                        items={threadKeysBySection.snoozed}
+                        strategy={verticalListSortingStrategy}
                       >
-                        <button
-                          type="button"
-                          onClick={toggleSettledShelf}
-                          aria-expanded={settledShelfExpanded}
-                          data-testid="sidebar-settled-shelf-toggle"
-                          className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
+                        {visibleSnoozedThreads.map((thread) =>
+                          renderSortableThreadRow(thread, "snoozed"),
+                        )}
+                      </SortableContext>
+                      {settledThreads.length > 0 ? (
+                        <li
+                          key="settled-shelf-header"
+                          data-thread-selection-safe
+                          className="list-none"
                         >
-                          <span className="text-xs font-medium text-muted-foreground/50">
-                            {settledShelfExpanded
-                              ? "Settled"
-                              : `Settled (${settledThreads.length})`}
-                          </span>
-                          <span className="h-px flex-1 bg-sidebar-border/60" />
-                          <ChevronDownIcon
-                            aria-hidden
-                            className={cn(
-                              "size-3 text-muted-foreground/50 transition-transform",
-                              settledShelfExpanded && "rotate-180",
-                            )}
-                          />
-                        </button>
-                      </li>,
-                    );
-                  }
-                  for (const thread of renderedSettledThreads) {
-                    items.push(renderThreadRow(thread, "settled"));
-                  }
+                          <button
+                            type="button"
+                            onClick={toggleSettledShelf}
+                            aria-expanded={settledShelfExpanded}
+                            data-testid="sidebar-settled-shelf-toggle"
+                            className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
+                          >
+                            <span className="text-xs font-medium text-muted-foreground/50">
+                              {settledShelfExpanded
+                                ? "Settled"
+                                : `Settled (${settledThreads.length})`}
+                            </span>
+                            <span className="h-px flex-1 bg-sidebar-border/60" />
+                            <ChevronDownIcon
+                              aria-hidden
+                              className={cn(
+                                "size-3 text-muted-foreground/50 transition-transform",
+                                settledShelfExpanded && "rotate-180",
+                              )}
+                            />
+                          </button>
+                        </li>
+                      ) : null}
+                      <SortableContext
+                        items={threadKeysBySection.settled}
+                        strategy={verticalListSortingStrategy}
+                      >
+                        {renderedSettledThreads.map((thread) =>
+                          renderSortableThreadRow(thread, "settled"),
+                        )}
+                      </SortableContext>
+                    </DndContext>,
+                  );
                   return items;
                 })()}
                 {settledShelfExpanded && hiddenSettledCount > 0 ? (

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -10,6 +10,7 @@ import {
   type PersistedUiState,
   persistState,
   reorderProjects,
+  reorderThreads,
   resolveProjectExpanded,
   setDefaultAdvertisedEndpointKey,
   setProjectExpanded,
@@ -21,6 +22,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
   return {
     projectExpandedById: {},
     projectOrder: [],
+    threadOrderBySection: { active: [], snoozed: [], settled: [] },
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
     defaultAdvertisedEndpointKey: null,
@@ -116,6 +118,53 @@ describe("uiStateStore pure functions", () => {
     );
   });
 
+  it("reorders threads independently within each sidebar section", () => {
+    const state = makeUiState({
+      threadOrderBySection: {
+        active: ["active-a", "active-b"],
+        snoozed: ["snoozed-a"],
+        settled: ["settled-a"],
+      },
+    });
+
+    const next = reorderThreads(
+      state,
+      "active",
+      ["active-a", "active-b", "active-c"],
+      "active-c",
+      "active-a",
+    );
+
+    expect(next.threadOrderBySection).toEqual({
+      active: ["active-c", "active-a", "active-b"],
+      snoozed: ["snoozed-a"],
+      settled: ["settled-a"],
+    });
+    expect(
+      reorderThreads(next, "active", next.threadOrderBySection.active, "active-a", "active-a"),
+    ).toBe(next);
+  });
+
+  it("preserves hidden thread positions when reordering a filtered section", () => {
+    const state = makeUiState({
+      threadOrderBySection: {
+        active: ["hidden-a", "visible-a", "hidden-b", "visible-b"],
+        snoozed: [],
+        settled: [],
+      },
+    });
+
+    expect(
+      reorderThreads(
+        state,
+        "active",
+        ["visible-a", "visible-b", "visible-new"],
+        "visible-new",
+        "visible-a",
+      ).threadOrderBySection.active,
+    ).toEqual(["hidden-a", "visible-new", "hidden-b", "visible-a", "visible-b"]);
+  });
+
   it("stores explicit changed-file expansion choices", () => {
     const threadId = ThreadId.make("thread-1");
     const collapsed = setThreadChangedFilesExpanded(makeUiState(), threadId, "turn-1", false);
@@ -154,6 +203,10 @@ describe("parsePersistedState", () => {
         invalid: "no" as unknown as boolean,
       },
       projectOrder: ["physical-b", "", "physical-a", "physical-b"],
+      threadOrderBySection: {
+        active: ["environment:thread-2", "", "environment:thread-1"],
+        snoozed: ["environment:thread-3", "environment:thread-3"],
+      },
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
         invalid: "not-a-date",
@@ -173,6 +226,11 @@ describe("parsePersistedState", () => {
         logical: false,
       },
       projectOrder: ["physical-b", "physical-a"],
+      threadOrderBySection: {
+        active: ["environment:thread-2", "environment:thread-1"],
+        snoozed: ["environment:thread-3"],
+        settled: [],
+      },
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
@@ -292,6 +350,7 @@ describe("uiStateStore persistence", () => {
         logical: false,
       },
       projectOrder: ["physical-b", "physical-a"],
+      threadOrderBySection: { active: [], snoozed: [], settled: [] },
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -17,9 +17,12 @@ const LEGACY_PERSISTED_STATE_KEYS = [
   "codething:renderer-state:v1",
 ] as const;
 
+export type SidebarThreadSection = "active" | "snoozed" | "settled";
+
 export interface PersistedUiState {
   projectExpandedById?: Record<string, boolean>;
   projectOrder?: string[];
+  threadOrderBySection?: Partial<Record<SidebarThreadSection, string[]>>;
   threadLastVisitedAtById?: Record<string, string>;
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
@@ -35,6 +38,7 @@ export interface UiProjectState {
 }
 
 export interface UiThreadState {
+  threadOrderBySection: Record<SidebarThreadSection, string[]>;
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
 }
@@ -48,6 +52,7 @@ export interface UiState extends UiProjectState, UiThreadState, UiEndpointState 
 const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
+  threadOrderBySection: { active: [], snoozed: [], settled: [] },
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
@@ -70,6 +75,16 @@ function sanitizeStringArray(value: unknown): string[] {
       value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0),
     ),
   ];
+}
+
+function sanitizeThreadOrderBySection(
+  value: PersistedUiState["threadOrderBySection"],
+): Record<SidebarThreadSection, string[]> {
+  return {
+    active: sanitizeStringArray(value?.active),
+    snoozed: sanitizeStringArray(value?.snoozed),
+    settled: sanitizeStringArray(value?.settled),
+  };
 }
 
 function sanitizeBooleanRecord(value: unknown): Record<string, boolean> {
@@ -125,6 +140,7 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
   return {
     projectExpandedById,
     projectOrder,
+    threadOrderBySection: sanitizeThreadOrderBySection(parsed.threadOrderBySection),
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
     threadChangedFilesExpandedById:
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
@@ -203,6 +219,7 @@ export function persistState(state: UiState): void {
       JSON.stringify({
         projectExpandedById,
         projectOrder: state.projectOrder,
+        threadOrderBySection: state.threadOrderBySection,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
@@ -337,6 +354,43 @@ export function setProjectExpanded(
   };
 }
 
+export function reorderThreads(
+  state: UiState,
+  section: SidebarThreadSection,
+  currentThreadOrder: readonly string[],
+  draggedThreadId: string,
+  targetThreadId: string,
+): UiState {
+  const draggedIndex = currentThreadOrder.indexOf(draggedThreadId);
+  const targetIndex = currentThreadOrder.indexOf(targetThreadId);
+  if (draggedIndex < 0 || targetIndex < 0 || draggedIndex === targetIndex) {
+    return state;
+  }
+
+  const reorderedVisibleThreads = [...currentThreadOrder];
+  const [dragged] = reorderedVisibleThreads.splice(draggedIndex, 1);
+  reorderedVisibleThreads.splice(targetIndex, 0, dragged!);
+
+  // A project filter can hide threads from this section. Keep those ids in
+  // their existing slots while replacing only the visible ids, then append
+  // any visible threads that did not have a persisted slot yet.
+  const visibleThreadIds = new Set(currentThreadOrder);
+  let nextVisibleIndex = 0;
+  const threadOrder = state.threadOrderBySection[section].map((threadId) => {
+    if (!visibleThreadIds.has(threadId)) return threadId;
+    return reorderedVisibleThreads[nextVisibleIndex++]!;
+  });
+  threadOrder.push(...reorderedVisibleThreads.slice(nextVisibleIndex));
+
+  return {
+    ...state,
+    threadOrderBySection: {
+      ...state.threadOrderBySection,
+      [section]: threadOrder,
+    },
+  };
+}
+
 export function reorderProjects(
   state: UiState,
   currentProjectOrder: readonly string[],
@@ -387,6 +441,12 @@ interface UiStateStore extends UiState {
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
+  reorderThreads: (
+    section: SidebarThreadSection,
+    currentThreadOrder: readonly string[],
+    draggedThreadId: string,
+    targetThreadId: string,
+  ) => void;
   reorderProjects: (
     currentProjectOrder: readonly string[],
     draggedProjectIds: readonly string[],
@@ -406,6 +466,10 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
   setProjectExpanded: (projectIds, expanded) =>
     set((state) => setProjectExpanded(state, projectIds, expanded)),
+  reorderThreads: (section, currentThreadOrder, draggedThreadId, targetThreadId) =>
+    set((state) =>
+      reorderThreads(state, section, currentThreadOrder, draggedThreadId, targetThreadId),
+    ),
   reorderProjects: (currentProjectOrder, draggedProjectIds, targetProjectIds) =>
     set((state) =>
       reorderProjects(state, currentProjectOrder, draggedProjectIds, targetProjectIds),

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -4,9 +4,11 @@ Pin a thread from its context menu to keep it in the pinned section above your a
 Pinned threads are shown independently of their project, including when you connect to more than
 one environment.
 
-On web and desktop, drag a pinned thread to change its position. On mobile, open the thread's menu
-and choose **Move up** or **Move down**. The order is stored by the server and appears on your
-other connected devices.
+On web and desktop, hold and drag a thread to change its position within its section
+(active inbox, snoozed shelf, settled history, or pinned block). There is no drag handle —
+just press, hold briefly, and drag. On mobile, open a pinned thread's menu and choose **Move up**
+or **Move down**. Pinned order is stored by the server and syncs across devices; other section
+orders are saved locally in this client.
 
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;


### PR DESCRIPTION
## Summary
- Adds hold-and-drag reordering for active, snoozed, and settled sidebar threads with no visible drag handles (6px activation threshold keeps clicks working)
- Persists per-section order locally via `threadOrderBySection` in UI state; pinned threads continue using server-synced `pinOrderKey` ordering
- Updates user docs to describe the new behavior

## Test plan
- [x] `pnpm exec vitest run src/uiStateStore.test.ts` (17 tests pass)
- [ ] Hold and drag threads within the active inbox; order should stick after reload
- [ ] Repeat for snoozed and settled shelves (expanded)
- [ ] Confirm pinned thread drag still works and syncs when server supports reorder
- [ ] Confirm plain clicks still navigate without accidental drags


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drag-to-reorder for active, snoozed, and settled sidebar thread sections
> - Wraps each sidebar thread section in a `DndContext` and `SortableContext` (via dnd-kit), allowing threads to be reordered by dragging within their section; cross-section drops are ignored.
> - Adds a `reorderThreads` pure function and store action in [uiStateStore.ts](https://github.com/pingdotgg/t3code/pull/6069/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8) that merges visible reordered ids with hidden thread positions to avoid losing filtered-out threads.
> - Per-section order is persisted to and restored from localStorage via `threadOrderBySection` in `PersistedUiState`.
> - Slim thread rows (snoozed/settled) gain drag transform styles and a dragging visual state (`z-20 opacity-80`); pinned rows continue to use the existing sortable path.
> - Behavioral Change: thread order in active, snoozed, and settled sections is now client-local, while pinned order continues to sync via the server.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7652a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->