### PR TITLE
feat: allow selecting terminal shell on Windows

### DIFF
--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -52,6 +52,7 @@ import * as Semaphore from "effect/Semaphore";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import * as ServerConfig from "../config.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
 import {
   increment,
   terminalRestartsTotal,
@@ -81,7 +82,11 @@ const DEFAULT_PROCESS_KILL_GRACE_MS = 1_000;
 const DEFAULT_MAX_RETAINED_INACTIVE_SESSIONS = 128;
 const DEFAULT_OPEN_COLS = 120;
 const DEFAULT_OPEN_ROWS = 30;
-const TERMINAL_ENV_BLOCKLIST = new Set(["PORT", "ELECTRON_RENDERER_PORT", "ELECTRON_RUN_AS_NODE"]);
+const TERMINAL_ENV_BLOCKLIST = new Set([
+  "PORT",
+  "ELECTRON_RENDERER_PORT",
+  "ELECTRON_RUN_AS_NODE",
+]);
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const MAX_TERMINAL_LABEL_LENGTH = 128;
 
@@ -140,17 +145,23 @@ export class TerminalManager extends Context.Service<
     /**
      * Write input bytes to a terminal session.
      */
-    readonly write: (input: TerminalWriteInput) => Effect.Effect<void, TerminalError>;
+    readonly write: (
+      input: TerminalWriteInput,
+    ) => Effect.Effect<void, TerminalError>;
 
     /**
      * Resize the PTY backing a terminal session.
      */
-    readonly resize: (input: TerminalResizeInput) => Effect.Effect<void, TerminalError>;
+    readonly resize: (
+      input: TerminalResizeInput,
+    ) => Effect.Effect<void, TerminalError>;
 
     /**
      * Clear terminal output history.
      */
-    readonly clear: (input: TerminalClearInput) => Effect.Effect<void, TerminalError>;
+    readonly clear: (
+      input: TerminalClearInput,
+    ) => Effect.Effect<void, TerminalError>;
 
     /**
      * Restart a terminal session in place.
@@ -166,7 +177,9 @@ export class TerminalManager extends Context.Service<
      *
      * When `terminalId` is omitted, closes all sessions for the thread.
      */
-    readonly close: (input: TerminalCloseInput) => Effect.Effect<void, TerminalError>;
+    readonly close: (
+      input: TerminalCloseInput,
+    ) => Effect.Effect<void, TerminalError>;
 
     /**
      * Subscribe to terminal runtime events with a direct callback.
@@ -197,7 +210,10 @@ interface TerminalSubprocessInspectResult {
 interface TerminalSubprocessInspector {
   (
     terminalPid: number,
-  ): Effect.Effect<TerminalSubprocessInspectResult, TerminalSubprocessCheckError>;
+  ): Effect.Effect<
+    TerminalSubprocessInspectResult,
+    TerminalSubprocessCheckError
+  >;
 }
 
 const resizePtyProcess = (
@@ -295,7 +311,10 @@ function truncateTerminalWireLabel(value: string): string {
   return value.slice(0, MAX_TERMINAL_LABEL_LENGTH);
 }
 
-function normalizeChildCommandName(raw: string, platform: NodeJS.Platform): string | null {
+function normalizeChildCommandName(
+  raw: string,
+  platform: NodeJS.Platform,
+): string | null {
   let trimmed = raw.trim();
   if (trimmed.length === 0) return null;
   if (
@@ -309,7 +328,9 @@ function normalizeChildCommandName(raw: string, platform: NodeJS.Platform): stri
   const separators = platform === "win32" ? /[\\/]/ : /\//;
   const base = firstToken.split(separators).at(-1) ?? firstToken;
   const withoutExe =
-    platform === "win32" && base.toLowerCase().endsWith(".exe") ? base.slice(0, -4) : base;
+    platform === "win32" && base.toLowerCase().endsWith(".exe")
+      ? base.slice(0, -4)
+      : base;
   return withoutExe.length > 0 ? withoutExe : null;
 }
 
@@ -371,7 +392,9 @@ function shouldPublishTerminalMetadataEvent(event: TerminalEvent): boolean {
   }
 }
 
-function terminalEventToAttachEvent(event: TerminalEvent): TerminalAttachStreamEvent | null {
+function terminalEventToAttachEvent(
+  event: TerminalEvent,
+): TerminalAttachStreamEvent | null {
   switch (event.type) {
     case "started":
       return {
@@ -393,7 +416,8 @@ function isDuplicateAttachSnapshotEvent(
   event: TerminalEvent,
   initialSnapshot: TerminalSessionSnapshot,
 ) {
-  return typeof event.sequence === "number" && typeof initialSnapshot.sequence === "number"
+  return typeof event.sequence === "number" &&
+    typeof initialSnapshot.sequence === "number"
     ? event.sequence <= initialSnapshot.sequence
     : event.type === "started" &&
         event.snapshot.threadId === initialSnapshot.threadId &&
@@ -423,7 +447,11 @@ function enqueueProcessEvent(
   expectedPid: number,
   event: PendingProcessEvent,
 ): boolean {
-  if (!session.process || session.status !== "running" || session.pid !== expectedPid) {
+  if (
+    !session.process ||
+    session.status !== "running" ||
+    session.pid !== expectedPid
+  ) {
     return false;
   }
 
@@ -436,7 +464,10 @@ function enqueueProcessEvent(
   return true;
 }
 
-function defaultShellResolver(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
+function defaultShellResolver(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
   if (platform === "win32") {
     return "pwsh.exe";
   }
@@ -460,9 +491,14 @@ function normalizeShellCommand(
   return firstToken.replace(/^['"]|['"]$/g, "");
 }
 
-function basenameForPlatform(command: string, platform: NodeJS.Platform): string {
+function basenameForPlatform(
+  command: string,
+  platform: NodeJS.Platform,
+): string {
   const normalized =
-    platform === "win32" ? command.replaceAll("/", "\\") : command.replaceAll("\\", "/");
+    platform === "win32"
+      ? command.replaceAll("/", "\\")
+      : command.replaceAll("\\", "/");
   const parts = normalized
     .split(platform === "win32" ? /\\+/ : /\/+/)
     .filter((part) => part.length > 0);
@@ -485,7 +521,10 @@ function shellCandidateFromCommand(
 ): ShellCandidate | null {
   if (!command || command.length === 0) return null;
   const shellName = basenameForPlatform(command, platform).toLowerCase();
-  if (platform === "win32" && (shellName === "pwsh.exe" || shellName === "powershell.exe")) {
+  if (
+    platform === "win32" &&
+    (shellName === "pwsh.exe" || shellName === "powershell.exe")
+  ) {
     return { shell: command, args: ["-NoLogo"] };
   }
   if (platform !== "win32" && shellName === "zsh") {
@@ -517,7 +556,9 @@ function formatShellCandidate(candidate: ShellCandidate): string {
   return `${candidate.shell} ${candidate.args.join(" ")}`;
 }
 
-function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellCandidate[] {
+function uniqueShellCandidates(
+  candidates: Array<ShellCandidate | null>,
+): ShellCandidate[] {
   const seen = new Set<string>();
   const ordered: ShellCandidate[] = [];
   for (const candidate of candidates) {
@@ -531,12 +572,12 @@ function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellC
 }
 
 function resolveShellCandidates(
-  shellResolver: () => string,
+  preferredShell: string,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
 ): ShellCandidate[] {
   const requested = shellCandidateFromCommand(
-    normalizeShellCommand(shellResolver(), platform),
+    normalizeShellCommand(preferredShell, platform),
     platform,
   );
 
@@ -554,7 +595,10 @@ function resolveShellCandidates(
 
   return uniqueShellCandidates([
     requested,
-    shellCandidateFromCommand(normalizeShellCommand(env.SHELL, platform), platform),
+    shellCandidateFromCommand(
+      normalizeShellCommand(env.SHELL, platform),
+      platform,
+    ),
     shellCandidateFromCommand("/bin/zsh", platform),
     shellCandidateFromCommand("/bin/bash", platform),
     shellCandidateFromCommand("/bin/sh", platform),
@@ -646,7 +690,11 @@ function windowsInspectSubprocess(
   }).pipe(
     Effect.map((result) => {
       if (result.code !== 0) {
-        return { hasRunningSubprocess: false, childCommand: null, processIds: [] } as const;
+        return {
+          hasRunningSubprocess: false,
+          childCommand: null,
+          processIds: [],
+        } as const;
       }
       const processNameById = new Map<number, string>();
       const childrenByParent = new Map<number, number[]>();
@@ -663,7 +711,11 @@ function windowsInspectSubprocess(
       const directChildren = childrenByParent.get(terminalPid) ?? [];
       const childPid = directChildren[0];
       if (childPid === undefined) {
-        return { hasRunningSubprocess: false, childCommand: null, processIds: [] } as const;
+        return {
+          hasRunningSubprocess: false,
+          childCommand: null,
+          processIds: [],
+        } as const;
       }
       const processIds = new Set<number>([terminalPid]);
       const pending = [terminalPid];
@@ -676,7 +728,10 @@ function windowsInspectSubprocess(
           pending.push(pid);
         }
       }
-      const normalized = normalizeChildCommandName(processNameById.get(childPid) ?? "", platform);
+      const normalized = normalizeChildCommandName(
+        processNameById.get(childPid) ?? "",
+        platform,
+      );
       return {
         hasRunningSubprocess: true,
         childCommand: normalized ? truncateTerminalWireLabel(normalized) : null,
@@ -694,156 +749,186 @@ function windowsInspectSubprocess(
   );
 }
 
-const posixInspectSubprocess = Effect.fn("terminal.posixInspectSubprocess")(function* (
-  terminalPid: number,
-  platform: NodeJS.Platform,
-): Effect.fn.Return<
-  TerminalSubprocessInspectResult,
-  TerminalSubprocessCheckError,
-  ProcessRunner.ProcessRunner
-> {
-  const processRunner = yield* ProcessRunner.ProcessRunner;
-  const runPgrep = processRunner
-    .run({
-      command: "pgrep",
-      args: ["-P", String(terminalPid)],
-      timeout: "1 second",
-      maxOutputBytes: 32_768,
-      outputMode: "truncate",
-      timeoutBehavior: "timedOutResult",
-    })
-    .pipe(
-      Effect.mapError(
-        (cause) =>
-          new TerminalSubprocessCheckError({
-            cause,
-            terminalPid,
-            command: "pgrep",
-          }),
-      ),
-    );
+const posixInspectSubprocess = Effect.fn("terminal.posixInspectSubprocess")(
+  function* (
+    terminalPid: number,
+    platform: NodeJS.Platform,
+  ): Effect.fn.Return<
+    TerminalSubprocessInspectResult,
+    TerminalSubprocessCheckError,
+    ProcessRunner.ProcessRunner
+  > {
+    const processRunner = yield* ProcessRunner.ProcessRunner;
+    const runPgrep = processRunner
+      .run({
+        command: "pgrep",
+        args: ["-P", String(terminalPid)],
+        timeout: "1 second",
+        maxOutputBytes: 32_768,
+        outputMode: "truncate",
+        timeoutBehavior: "timedOutResult",
+      })
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new TerminalSubprocessCheckError({
+              cause,
+              terminalPid,
+              command: "pgrep",
+            }),
+        ),
+      );
 
-  const runPs = processRunner
-    .run({
-      command: "ps",
-      args: ["-eo", "pid=,ppid="],
-      timeout: "1 second",
-      maxOutputBytes: 262_144,
-      outputMode: "truncate",
-      timeoutBehavior: "timedOutResult",
-    })
-    .pipe(
-      Effect.mapError(
-        (cause) =>
-          new TerminalSubprocessCheckError({
-            cause,
-            terminalPid,
-            command: "ps",
-          }),
-      ),
-    );
+    const runPs = processRunner
+      .run({
+        command: "ps",
+        args: ["-eo", "pid=,ppid="],
+        timeout: "1 second",
+        maxOutputBytes: 262_144,
+        outputMode: "truncate",
+        timeoutBehavior: "timedOutResult",
+      })
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new TerminalSubprocessCheckError({
+              cause,
+              terminalPid,
+              command: "ps",
+            }),
+        ),
+      );
 
-  let childPid: number | null = null;
+    let childPid: number | null = null;
 
-  const pgrepResult = yield* Effect.exit(runPgrep);
-  if (pgrepResult._tag === "Success") {
-    if (pgrepResult.value.code === 0) {
-      childPid = parseFirstChildPidFromPgrep(pgrepResult.value.stdout);
-    } else if (pgrepResult.value.code === 1) {
-      return { hasRunningSubprocess: false, childCommand: null, processIds: [] };
-    }
-  }
-
-  if (childPid === null) {
-    const psResult = yield* Effect.exit(runPs);
-    if (psResult._tag === "Failure" || psResult.value.code !== 0) {
-      return { hasRunningSubprocess: false, childCommand: null, processIds: [] };
-    }
-    for (const line of psResult.value.stdout.split(/\r?\n/g)) {
-      const [pidRaw, ppidRaw] = line.trim().split(/\s+/g);
-      const pid = Number(pidRaw);
-      const ppid = Number(ppidRaw);
-      if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
-      if (ppid === terminalPid) {
-        childPid = pid;
-        break;
+    const pgrepResult = yield* Effect.exit(runPgrep);
+    if (pgrepResult._tag === "Success") {
+      if (pgrepResult.value.code === 0) {
+        childPid = parseFirstChildPidFromPgrep(pgrepResult.value.stdout);
+      } else if (pgrepResult.value.code === 1) {
+        return {
+          hasRunningSubprocess: false,
+          childCommand: null,
+          processIds: [],
+        };
       }
     }
-  }
 
-  if (childPid === null) {
-    return { hasRunningSubprocess: false, childCommand: null, processIds: [] };
-  }
+    if (childPid === null) {
+      const psResult = yield* Effect.exit(runPs);
+      if (psResult._tag === "Failure" || psResult.value.code !== 0) {
+        return {
+          hasRunningSubprocess: false,
+          childCommand: null,
+          processIds: [],
+        };
+      }
+      for (const line of psResult.value.stdout.split(/\r?\n/g)) {
+        const [pidRaw, ppidRaw] = line.trim().split(/\s+/g);
+        const pid = Number(pidRaw);
+        const ppid = Number(ppidRaw);
+        if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+        if (ppid === terminalPid) {
+          childPid = pid;
+          break;
+        }
+      }
+    }
 
-  const runComm = processRunner.run({
-    command: "ps",
-    args: ["-p", String(childPid), "-o", "comm="],
-    timeout: "1 second",
-    maxOutputBytes: 8_192,
-    outputMode: "truncate",
-    timeoutBehavior: "timedOutResult",
-  });
+    if (childPid === null) {
+      return {
+        hasRunningSubprocess: false,
+        childCommand: null,
+        processIds: [],
+      };
+    }
 
-  const commResult = yield* Effect.exit(runComm);
-  let rawComm: string | null = null;
-  if (commResult._tag === "Success" && commResult.value && commResult.value.code === 0) {
-    rawComm = commResult.value.stdout.trim();
-  }
-
-  if (!rawComm || rawComm.length === 0) {
-    const runArgs = processRunner.run({
+    const runComm = processRunner.run({
       command: "ps",
-      args: ["-p", String(childPid), "-o", "args="],
+      args: ["-p", String(childPid), "-o", "comm="],
       timeout: "1 second",
-      maxOutputBytes: 16_384,
+      maxOutputBytes: 8_192,
       outputMode: "truncate",
       timeoutBehavior: "timedOutResult",
     });
-    const argsResult = yield* Effect.exit(runArgs);
-    if (argsResult._tag === "Success" && argsResult.value && argsResult.value.code === 0) {
-      const first = argsResult.value.stdout.trim().split(/\s+/)[0] ?? "";
-      rawComm = first.length > 0 ? first : null;
-    }
-  }
 
-  const normalized = rawComm ? normalizeChildCommandName(rawComm, platform) : null;
-  const processIds = new Set<number>([terminalPid]);
-  const psResult = yield* Effect.exit(runPs);
-  if (psResult._tag === "Success" && psResult.value.code === 0) {
-    const childrenByParent = new Map<number, number[]>();
-    for (const line of psResult.value.stdout.split(/\r?\n/g)) {
-      const [pidRaw, ppidRaw] = line.trim().split(/\s+/g);
-      const pid = Number(pidRaw);
-      const ppid = Number(ppidRaw);
-      if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
-      const children = childrenByParent.get(ppid) ?? [];
-      children.push(pid);
-      childrenByParent.set(ppid, children);
+    const commResult = yield* Effect.exit(runComm);
+    let rawComm: string | null = null;
+    if (
+      commResult._tag === "Success" &&
+      commResult.value &&
+      commResult.value.code === 0
+    ) {
+      rawComm = commResult.value.stdout.trim();
     }
-    const pending = [terminalPid];
-    while (pending.length > 0) {
-      const parentPid = pending.pop();
-      if (parentPid === undefined) continue;
-      for (const child of childrenByParent.get(parentPid) ?? []) {
-        if (processIds.has(child)) continue;
-        processIds.add(child);
-        pending.push(child);
+
+    if (!rawComm || rawComm.length === 0) {
+      const runArgs = processRunner.run({
+        command: "ps",
+        args: ["-p", String(childPid), "-o", "args="],
+        timeout: "1 second",
+        maxOutputBytes: 16_384,
+        outputMode: "truncate",
+        timeoutBehavior: "timedOutResult",
+      });
+      const argsResult = yield* Effect.exit(runArgs);
+      if (
+        argsResult._tag === "Success" &&
+        argsResult.value &&
+        argsResult.value.code === 0
+      ) {
+        const first = argsResult.value.stdout.trim().split(/\s+/)[0] ?? "";
+        rawComm = first.length > 0 ? first : null;
       }
     }
-  } else {
-    processIds.add(childPid);
-  }
-  return {
-    hasRunningSubprocess: true,
-    childCommand: normalized ? truncateTerminalWireLabel(normalized) : null,
-    processIds: [...processIds],
-  };
-});
+
+    const normalized = rawComm
+      ? normalizeChildCommandName(rawComm, platform)
+      : null;
+    const processIds = new Set<number>([terminalPid]);
+    const psResult = yield* Effect.exit(runPs);
+    if (psResult._tag === "Success" && psResult.value.code === 0) {
+      const childrenByParent = new Map<number, number[]>();
+      for (const line of psResult.value.stdout.split(/\r?\n/g)) {
+        const [pidRaw, ppidRaw] = line.trim().split(/\s+/g);
+        const pid = Number(pidRaw);
+        const ppid = Number(ppidRaw);
+        if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+        const children = childrenByParent.get(ppid) ?? [];
+        children.push(pid);
+        childrenByParent.set(ppid, children);
+      }
+      const pending = [terminalPid];
+      while (pending.length > 0) {
+        const parentPid = pending.pop();
+        if (parentPid === undefined) continue;
+        for (const child of childrenByParent.get(parentPid) ?? []) {
+          if (processIds.has(child)) continue;
+          processIds.add(child);
+          pending.push(child);
+        }
+      }
+    } else {
+      processIds.add(childPid);
+    }
+    return {
+      hasRunningSubprocess: true,
+      childCommand: normalized ? truncateTerminalWireLabel(normalized) : null,
+      processIds: [...processIds],
+    };
+  },
+);
 
 function defaultSubprocessInspectorForPlatform(platform: NodeJS.Platform) {
-  return Effect.fn("terminal.defaultSubprocessInspector")(function* (terminalPid: number) {
+  return Effect.fn("terminal.defaultSubprocessInspector")(function* (
+    terminalPid: number,
+  ) {
     if (!Number.isInteger(terminalPid) || terminalPid <= 0) {
-      return { hasRunningSubprocess: false, childCommand: null, processIds: [] };
+      return {
+        hasRunningSubprocess: false,
+        childCommand: null,
+        processIds: [],
+      };
     }
     if (platform === "win32") {
       return yield* windowsInspectSubprocess(terminalPid, platform);
@@ -918,7 +1003,10 @@ function stripStringTerminator(value: string): string {
   return value;
 }
 
-function findStringTerminatorIndex(input: string, start: number): number | null {
+function findStringTerminatorIndex(
+  input: string,
+  start: number,
+): number | null {
   for (let index = start; index < input.length; index += 1) {
     const codePoint = input.charCodeAt(index);
     if (codePoint === 0x07 || codePoint === 0x9c) {
@@ -939,9 +1027,15 @@ function isEscapeFinalByte(codePoint: number): boolean {
   return codePoint >= 0x30 && codePoint <= 0x7e;
 }
 
-function findEscapeSequenceEndIndex(input: string, start: number): number | null {
+function findEscapeSequenceEndIndex(
+  input: string,
+  start: number,
+): number | null {
   let cursor = start;
-  while (cursor < input.length && isEscapeIntermediateByte(input.charCodeAt(cursor))) {
+  while (
+    cursor < input.length &&
+    isEscapeIntermediateByte(input.charCodeAt(cursor))
+  ) {
     cursor += 1;
   }
   if (cursor >= input.length) {
@@ -1002,7 +1096,9 @@ function sanitizeTerminalHistoryChunk(
           return { visibleText, pendingControlSequence: input.slice(index) };
         }
         const sequence = input.slice(index, terminatorIndex);
-        const content = stripStringTerminator(input.slice(index + 2, terminatorIndex));
+        const content = stripStringTerminator(
+          input.slice(index + 2, terminatorIndex),
+        );
         const strip =
           (nextCodePoint === 0x5d && shouldStripOscSequence(content)) ||
           (nextCodePoint === 0x50 && shouldStripDcsSequence(content));
@@ -1013,7 +1109,10 @@ function sanitizeTerminalHistoryChunk(
         continue;
       }
 
-      const escapeSequenceEndIndex = findEscapeSequenceEndIndex(input, index + 1);
+      const escapeSequenceEndIndex = findEscapeSequenceEndIndex(
+        input,
+        index + 1,
+      );
       if (escapeSequenceEndIndex === null) {
         return { visibleText, pendingControlSequence: input.slice(index) };
       }
@@ -1042,13 +1141,20 @@ function sanitizeTerminalHistoryChunk(
       continue;
     }
 
-    if (codePoint === 0x9d || codePoint === 0x90 || codePoint === 0x9e || codePoint === 0x9f) {
+    if (
+      codePoint === 0x9d ||
+      codePoint === 0x90 ||
+      codePoint === 0x9e ||
+      codePoint === 0x9f
+    ) {
       const terminatorIndex = findStringTerminatorIndex(input, index + 1);
       if (terminatorIndex === null) {
         return { visibleText, pendingControlSequence: input.slice(index) };
       }
       const sequence = input.slice(index, terminatorIndex);
-      const content = stripStringTerminator(input.slice(index + 1, terminatorIndex));
+      const content = stripStringTerminator(
+        input.slice(index + 1, terminatorIndex),
+      );
       const strip =
         (codePoint === 0x9d && shouldStripOscSequence(content)) ||
         (codePoint === 0x90 && shouldStripDcsSequence(content));
@@ -1096,7 +1202,12 @@ function shouldExcludeTerminalEnvKey(key: string): boolean {
 // Marker variables the AppImage runtime injects into the process it launches.
 // They describe the AppImage itself, not the user's session, so terminals must
 // not inherit them.
-const APPIMAGE_RUNTIME_ENV_KEYS = ["APPIMAGE", "APPDIR", "ARGV0", "OWD"] as const;
+const APPIMAGE_RUNTIME_ENV_KEYS = [
+  "APPIMAGE",
+  "APPDIR",
+  "ARGV0",
+  "OWD",
+] as const;
 // Colon-separated search-path variables the AppImage runtime points at its
 // temporary mount (e.g. /tmp/.mount_T3-XXXX/usr/bin, the bundled glib schemas,
 // and an $APPDIR/usr/share XDG data entry). Only the mount segments are
@@ -1137,7 +1248,10 @@ function stripAppImageRuntimeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
       if (value === undefined) continue;
       const kept = value
         .split(":")
-        .filter((segment) => segment.length > 0 && !isPathSegmentUnderAppDir(segment, appDir));
+        .filter(
+          (segment) =>
+            segment.length > 0 && !isPathSegmentUnderAppDir(segment, appDir),
+        );
       if (kept.length > 0) {
         scrubbed[key] = kept.join(":");
       } else {
@@ -1173,14 +1287,16 @@ function normalizedRuntimeEnv(
   if (!env) return null;
   const entries = Object.entries(env);
   if (entries.length === 0) return null;
-  return Object.fromEntries(entries.toSorted(([left], [right]) => left.localeCompare(right)));
+  return Object.fromEntries(
+    entries.toSorted(([left], [right]) => left.localeCompare(right)),
+  );
 }
 
 interface TerminalManagerOptions {
   logsDir: string;
   historyLineLimit?: number;
   ptyAdapter: PtyAdapter.PtyAdapter["Service"];
-  shellResolver?: () => string;
+  shellResolver?: Effect.Effect<string, never, never>;
   env?: NodeJS.ProcessEnv;
   subprocessInspector?: TerminalSubprocessInspector;
   subprocessPollIntervalMs?: number;
@@ -1209,449 +1325,529 @@ export const make = Effect.fn("TerminalManager.make")(function* () {
   });
 });
 
-export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(function* (
-  options: TerminalManagerOptions,
-) {
-  const fileSystem = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const context = yield* Effect.context<never>();
-  const runFork = Effect.runForkWith(context);
+export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(
+  function* (options: TerminalManagerOptions) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const context = yield* Effect.context<never>();
+    const runFork = Effect.runForkWith(context);
 
-  const logsDir = options.logsDir;
-  const historyLineLimit = options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
-  const platform = yield* HostProcessPlatform;
-  // Terminals must inherit the user's full environment (minus the blocklist
-  // applied in createTerminalSpawnEnv) — an allowlist here silently strips
-  // things like PSModulePath, DISPLAY, proxies, and toolchain variables.
-  // `options.env` is the test seam.
-  const baseEnv = options.env ?? process.env;
-  const shellResolver = options.shellResolver ?? (() => defaultShellResolver(platform, baseEnv));
-  const processRunner = yield* ProcessRunner.ProcessRunner;
-  const subprocessInspector =
-    options.subprocessInspector ??
-    ((terminalPid) =>
-      defaultSubprocessInspectorForPlatform(platform)(terminalPid).pipe(
-        Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
-      ));
-  const subprocessPollIntervalMs =
-    options.subprocessPollIntervalMs ?? DEFAULT_SUBPROCESS_POLL_INTERVAL_MS;
-  const processKillGraceMs = options.processKillGraceMs ?? DEFAULT_PROCESS_KILL_GRACE_MS;
-  const maxRetainedInactiveSessions =
-    options.maxRetainedInactiveSessions ?? DEFAULT_MAX_RETAINED_INACTIVE_SESSIONS;
-  const registerTerminalProcesses = options.registerTerminalProcesses ?? (() => Effect.void);
-  const unregisterTerminal = options.unregisterTerminal ?? (() => Effect.void);
+    const logsDir = options.logsDir;
+    const historyLineLimit =
+      options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
+    const platform = yield* HostProcessPlatform;
+    // Terminals must inherit the user's full environment (minus the blocklist
+    // applied in createTerminalSpawnEnv) — an allowlist here silently strips
+    // things like PSModulePath, DISPLAY, proxies, and toolchain variables.
+    // `options.env` is the test seam.
+    const baseEnv = options.env ?? process.env;
+    const shellResolver =
+      options.shellResolver ??
+      Effect.succeed(defaultShellResolver(platform, baseEnv));
+    const processRunner = yield* ProcessRunner.ProcessRunner;
+    const subprocessInspector =
+      options.subprocessInspector ??
+      ((terminalPid) =>
+        defaultSubprocessInspectorForPlatform(platform)(terminalPid).pipe(
+          Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
+        ));
+    const subprocessPollIntervalMs =
+      options.subprocessPollIntervalMs ?? DEFAULT_SUBPROCESS_POLL_INTERVAL_MS;
+    const processKillGraceMs =
+      options.processKillGraceMs ?? DEFAULT_PROCESS_KILL_GRACE_MS;
+    const maxRetainedInactiveSessions =
+      options.maxRetainedInactiveSessions ??
+      DEFAULT_MAX_RETAINED_INACTIVE_SESSIONS;
+    const registerTerminalProcesses =
+      options.registerTerminalProcesses ?? (() => Effect.void);
+    const unregisterTerminal =
+      options.unregisterTerminal ?? (() => Effect.void);
 
-  yield* fileSystem.makeDirectory(logsDir, { recursive: true }).pipe(Effect.orDie);
+    yield* fileSystem
+      .makeDirectory(logsDir, { recursive: true })
+      .pipe(Effect.orDie);
 
-  const managerStateRef = yield* SynchronizedRef.make<TerminalManagerState>({
-    sessions: new Map(),
-    killFibers: new Map(),
-  });
-  const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
-  const terminalEventListeners = new Set<(event: TerminalEvent) => Effect.Effect<void>>();
-  const workerScope = yield* Scope.make("sequential");
-  yield* Effect.addFinalizer(() => Scope.close(workerScope, Exit.void));
+    const managerStateRef = yield* SynchronizedRef.make<TerminalManagerState>({
+      sessions: new Map(),
+      killFibers: new Map(),
+    });
+    const threadLocksRef = yield* SynchronizedRef.make(
+      new Map<string, Semaphore.Semaphore>(),
+    );
+    const terminalEventListeners = new Set<
+      (event: TerminalEvent) => Effect.Effect<void>
+    >();
+    const workerScope = yield* Scope.make("sequential");
+    yield* Effect.addFinalizer(() => Scope.close(workerScope, Exit.void));
 
-  const publishEvent = (event: TerminalEvent) =>
-    Effect.gen(function* () {
-      for (const listener of terminalEventListeners) {
-        yield* listener(event).pipe(Effect.ignoreCause({ log: true }));
+    const publishEvent = (event: TerminalEvent) =>
+      Effect.gen(function* () {
+        for (const listener of terminalEventListeners) {
+          yield* listener(event).pipe(Effect.ignoreCause({ log: true }));
+        }
+      });
+
+    const historyPath = (threadId: string, terminalId: string) => {
+      const threadPart = toSafeThreadId(threadId);
+      if (terminalId === DEFAULT_TERMINAL_ID) {
+        return path.join(logsDir, `${threadPart}.log`);
+      }
+      return path.join(
+        logsDir,
+        `${threadPart}_${toSafeTerminalId(terminalId)}.log`,
+      );
+    };
+
+    const legacyHistoryPath = (threadId: string) =>
+      path.join(logsDir, `${legacySafeThreadId(threadId)}.log`);
+
+    const readManagerState = SynchronizedRef.get(managerStateRef);
+
+    const modifyManagerState = <A>(
+      f: (state: TerminalManagerState) => readonly [A, TerminalManagerState],
+    ) => SynchronizedRef.modify(managerStateRef, f);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing: Option.Option<Semaphore.Semaphore> =
+          Option.fromNullishOr(current.get(threadId));
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(
+      threadId: string,
+      effect: Effect.Effect<A, E, R>,
+    ): Effect.Effect<A, E, R> =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) =>
+        semaphore.withPermit(effect),
+      );
+
+    const clearKillFiber = Effect.fn("terminal.clearKillFiber")(function* (
+      process: PtyAdapter.PtyProcess | null,
+    ) {
+      if (!process) return;
+      const fiber: Option.Option<Fiber.Fiber<void, never>> =
+        yield* modifyManagerState<Option.Option<Fiber.Fiber<void, never>>>(
+          (state) => {
+            const existing: Option.Option<Fiber.Fiber<void, never>> =
+              Option.fromNullishOr(state.killFibers.get(process));
+            if (Option.isNone(existing)) {
+              return [Option.none<Fiber.Fiber<void, never>>(), state] as const;
+            }
+            const killFibers = new Map(state.killFibers);
+            killFibers.delete(process);
+            return [existing, { ...state, killFibers }] as const;
+          },
+        );
+      if (Option.isSome(fiber)) {
+        yield* Fiber.interrupt(fiber.value).pipe(Effect.ignore);
       }
     });
 
-  const historyPath = (threadId: string, terminalId: string) => {
-    const threadPart = toSafeThreadId(threadId);
-    if (terminalId === DEFAULT_TERMINAL_ID) {
-      return path.join(logsDir, `${threadPart}.log`);
-    }
-    return path.join(logsDir, `${threadPart}_${toSafeTerminalId(terminalId)}.log`);
-  };
+    const registerKillFiber = Effect.fn("terminal.registerKillFiber")(
+      function* (
+        process: PtyAdapter.PtyProcess,
+        fiber: Fiber.Fiber<void, never>,
+      ) {
+        yield* modifyManagerState((state) => {
+          const killFibers = new Map(state.killFibers);
+          killFibers.set(process, fiber);
+          return [undefined, { ...state, killFibers }] as const;
+        });
+      },
+    );
 
-  const legacyHistoryPath = (threadId: string) =>
-    path.join(logsDir, `${legacySafeThreadId(threadId)}.log`);
+    const runKillEscalation = Effect.fn("terminal.runKillEscalation")(
+      function* (
+        process: PtyAdapter.PtyProcess,
+        threadId: string,
+        terminalId: string,
+      ) {
+        const terminated = yield* Effect.try({
+          try: () => process.kill("SIGTERM"),
+          catch: (cause) =>
+            new TerminalProcessSignalError({
+              cause,
+              signal: "SIGTERM",
+              terminalPid: process.pid,
+            }),
+        }).pipe(
+          Effect.as(true),
+          Effect.catch((error) =>
+            Effect.logWarning("failed to kill terminal process", {
+              threadId,
+              terminalId,
+              signal: "SIGTERM",
+              cause: error,
+            }).pipe(Effect.as(false)),
+          ),
+        );
+        if (!terminated) {
+          return;
+        }
 
-  const readManagerState = SynchronizedRef.get(managerStateRef);
+        yield* Effect.sleep(processKillGraceMs);
 
-  const modifyManagerState = <A>(
-    f: (state: TerminalManagerState) => readonly [A, TerminalManagerState],
-  ) => SynchronizedRef.modify(managerStateRef, f);
-
-  const getThreadSemaphore = (threadId: string) =>
-    SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
-      const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
-        current.get(threadId),
-      );
-      return Option.match(existing, {
-        onNone: () =>
-          Semaphore.make(1).pipe(
-            Effect.map((semaphore) => {
-              const next = new Map(current);
-              next.set(threadId, semaphore);
-              return [semaphore, next] as const;
+        yield* Effect.try({
+          try: () => process.kill("SIGKILL"),
+          catch: (cause) =>
+            new TerminalProcessSignalError({
+              cause,
+              signal: "SIGKILL",
+              terminalPid: process.pid,
+            }),
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("failed to force-kill terminal process", {
+              threadId,
+              terminalId,
+              signal: "SIGKILL",
+              cause: error,
             }),
           ),
-        onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        );
+      },
+    );
+
+    const startKillEscalation = Effect.fn("terminal.startKillEscalation")(
+      function* (
+        process: PtyAdapter.PtyProcess,
+        threadId: string,
+        terminalId: string,
+      ) {
+        const fiber = yield* runKillEscalation(
+          process,
+          threadId,
+          terminalId,
+        ).pipe(
+          Effect.ensuring(
+            modifyManagerState((state) => {
+              if (!state.killFibers.has(process)) {
+                return [undefined, state] as const;
+              }
+              const killFibers = new Map(state.killFibers);
+              killFibers.delete(process);
+              return [undefined, { ...state, killFibers }] as const;
+            }),
+          ),
+          Effect.forkIn(workerScope),
+        );
+
+        yield* registerKillFiber(process, fiber);
+      },
+    );
+
+    const persistWorker = yield* makeKeyedCoalescingWorker<
+      string,
+      PersistHistoryRequest,
+      never,
+      never
+    >({
+      merge: (current, next) => ({
+        history: next.history,
+        immediate: current.immediate || next.immediate,
+      }),
+      process: Effect.fn("terminal.persistHistoryWorker")(
+        function* (sessionKey, request) {
+          if (!request.immediate) {
+            yield* Effect.sleep(DEFAULT_PERSIST_DEBOUNCE_MS);
+          }
+
+          const [threadId, terminalId] = sessionKey.split("\u0000");
+          if (!threadId || !terminalId) {
+            return;
+          }
+
+          yield* fileSystem
+            .writeFileString(historyPath(threadId, terminalId), request.history)
+            .pipe(
+              Effect.catch((error) =>
+                Effect.logWarning("failed to persist terminal history", {
+                  threadId,
+                  terminalId,
+                  error,
+                }),
+              ),
+            );
+        },
+      ),
+    });
+
+    const queuePersist = Effect.fn("terminal.queuePersist")(function* (
+      threadId: string,
+      terminalId: string,
+      history: string,
+    ) {
+      yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
+        history,
+        immediate: false,
       });
     });
 
-  const withThreadLock = <A, E, R>(
-    threadId: string,
-    effect: Effect.Effect<A, E, R>,
-  ): Effect.Effect<A, E, R> =>
-    Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
-
-  const clearKillFiber = Effect.fn("terminal.clearKillFiber")(function* (
-    process: PtyAdapter.PtyProcess | null,
-  ) {
-    if (!process) return;
-    const fiber: Option.Option<Fiber.Fiber<void, never>> = yield* modifyManagerState<
-      Option.Option<Fiber.Fiber<void, never>>
-    >((state) => {
-      const existing: Option.Option<Fiber.Fiber<void, never>> = Option.fromNullishOr(
-        state.killFibers.get(process),
-      );
-      if (Option.isNone(existing)) {
-        return [Option.none<Fiber.Fiber<void, never>>(), state] as const;
-      }
-      const killFibers = new Map(state.killFibers);
-      killFibers.delete(process);
-      return [existing, { ...state, killFibers }] as const;
-    });
-    if (Option.isSome(fiber)) {
-      yield* Fiber.interrupt(fiber.value).pipe(Effect.ignore);
-    }
-  });
-
-  const registerKillFiber = Effect.fn("terminal.registerKillFiber")(function* (
-    process: PtyAdapter.PtyProcess,
-    fiber: Fiber.Fiber<void, never>,
-  ) {
-    yield* modifyManagerState((state) => {
-      const killFibers = new Map(state.killFibers);
-      killFibers.set(process, fiber);
-      return [undefined, { ...state, killFibers }] as const;
-    });
-  });
-
-  const runKillEscalation = Effect.fn("terminal.runKillEscalation")(function* (
-    process: PtyAdapter.PtyProcess,
-    threadId: string,
-    terminalId: string,
-  ) {
-    const terminated = yield* Effect.try({
-      try: () => process.kill("SIGTERM"),
-      catch: (cause) =>
-        new TerminalProcessSignalError({
-          cause,
-          signal: "SIGTERM",
-          terminalPid: process.pid,
-        }),
-    }).pipe(
-      Effect.as(true),
-      Effect.catch((error) =>
-        Effect.logWarning("failed to kill terminal process", {
-          threadId,
-          terminalId,
-          signal: "SIGTERM",
-          cause: error,
-        }).pipe(Effect.as(false)),
-      ),
-    );
-    if (!terminated) {
-      return;
-    }
-
-    yield* Effect.sleep(processKillGraceMs);
-
-    yield* Effect.try({
-      try: () => process.kill("SIGKILL"),
-      catch: (cause) =>
-        new TerminalProcessSignalError({
-          cause,
-          signal: "SIGKILL",
-          terminalPid: process.pid,
-        }),
-    }).pipe(
-      Effect.catch((error) =>
-        Effect.logWarning("failed to force-kill terminal process", {
-          threadId,
-          terminalId,
-          signal: "SIGKILL",
-          cause: error,
-        }),
-      ),
-    );
-  });
-
-  const startKillEscalation = Effect.fn("terminal.startKillEscalation")(function* (
-    process: PtyAdapter.PtyProcess,
-    threadId: string,
-    terminalId: string,
-  ) {
-    const fiber = yield* runKillEscalation(process, threadId, terminalId).pipe(
-      Effect.ensuring(
-        modifyManagerState((state) => {
-          if (!state.killFibers.has(process)) {
-            return [undefined, state] as const;
-          }
-          const killFibers = new Map(state.killFibers);
-          killFibers.delete(process);
-          return [undefined, { ...state, killFibers }] as const;
-        }),
-      ),
-      Effect.forkIn(workerScope),
-    );
-
-    yield* registerKillFiber(process, fiber);
-  });
-
-  const persistWorker = yield* makeKeyedCoalescingWorker<
-    string,
-    PersistHistoryRequest,
-    never,
-    never
-  >({
-    merge: (current, next) => ({
-      history: next.history,
-      immediate: current.immediate || next.immediate,
-    }),
-    process: Effect.fn("terminal.persistHistoryWorker")(function* (sessionKey, request) {
-      if (!request.immediate) {
-        yield* Effect.sleep(DEFAULT_PERSIST_DEBOUNCE_MS);
-      }
-
-      const [threadId, terminalId] = sessionKey.split("\u0000");
-      if (!threadId || !terminalId) {
-        return;
-      }
-
-      yield* fileSystem.writeFileString(historyPath(threadId, terminalId), request.history).pipe(
-        Effect.catch((error) =>
-          Effect.logWarning("failed to persist terminal history", {
-            threadId,
-            terminalId,
-            error,
-          }),
-        ),
-      );
-    }),
-  });
-
-  const queuePersist = Effect.fn("terminal.queuePersist")(function* (
-    threadId: string,
-    terminalId: string,
-    history: string,
-  ) {
-    yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
-      history,
-      immediate: false,
-    });
-  });
-
-  const flushPersist = Effect.fn("terminal.flushPersist")(function* (
-    threadId: string,
-    terminalId: string,
-  ) {
-    yield* persistWorker.drainKey(toSessionKey(threadId, terminalId));
-  });
-
-  const persistHistory = Effect.fn("terminal.persistHistory")(function* (
-    threadId: string,
-    terminalId: string,
-    history: string,
-  ) {
-    yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
-      history,
-      immediate: true,
-    });
-    yield* flushPersist(threadId, terminalId);
-  });
-
-  const readHistory = Effect.fn("terminal.readHistory")(function* (
-    threadId: string,
-    terminalId: string,
-  ) {
-    const nextPath = historyPath(threadId, terminalId);
-    if (
-      yield* fileSystem
-        .exists(nextPath)
-        .pipe(
-          Effect.mapError(
-            (cause) => new TerminalHistoryError({ operation: "read", threadId, terminalId, cause }),
-          ),
-        )
+    const flushPersist = Effect.fn("terminal.flushPersist")(function* (
+      threadId: string,
+      terminalId: string,
     ) {
-      const raw = yield* fileSystem
-        .readFileString(nextPath)
-        .pipe(
-          Effect.mapError(
-            (cause) => new TerminalHistoryError({ operation: "read", threadId, terminalId, cause }),
-          ),
-        );
-      const capped = capHistory(raw, historyLineLimit);
-      if (capped !== raw) {
+      yield* persistWorker.drainKey(toSessionKey(threadId, terminalId));
+    });
+
+    const persistHistory = Effect.fn("terminal.persistHistory")(function* (
+      threadId: string,
+      terminalId: string,
+      history: string,
+    ) {
+      yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
+        history,
+        immediate: true,
+      });
+      yield* flushPersist(threadId, terminalId);
+    });
+
+    const readHistory = Effect.fn("terminal.readHistory")(function* (
+      threadId: string,
+      terminalId: string,
+    ) {
+      const nextPath = historyPath(threadId, terminalId);
+      if (
         yield* fileSystem
-          .writeFileString(nextPath, capped)
+          .exists(nextPath)
           .pipe(
             Effect.mapError(
               (cause) =>
-                new TerminalHistoryError({ operation: "truncate", threadId, terminalId, cause }),
+                new TerminalHistoryError({
+                  operation: "read",
+                  threadId,
+                  terminalId,
+                  cause,
+                }),
+            ),
+          )
+      ) {
+        const raw = yield* fileSystem
+          .readFileString(nextPath)
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new TerminalHistoryError({
+                  operation: "read",
+                  threadId,
+                  terminalId,
+                  cause,
+                }),
             ),
           );
+        const capped = capHistory(raw, historyLineLimit);
+        if (capped !== raw) {
+          yield* fileSystem
+            .writeFileString(nextPath, capped)
+            .pipe(
+              Effect.mapError(
+                (cause) =>
+                  new TerminalHistoryError({
+                    operation: "truncate",
+                    threadId,
+                    terminalId,
+                    cause,
+                  }),
+              ),
+            );
+        }
+        return capped;
       }
-      return capped;
-    }
 
-    if (terminalId !== DEFAULT_TERMINAL_ID) {
-      return "";
-    }
+      if (terminalId !== DEFAULT_TERMINAL_ID) {
+        return "";
+      }
 
-    const legacyPath = legacyHistoryPath(threadId);
-    if (
-      !(yield* fileSystem
-        .exists(legacyPath)
+      const legacyPath = legacyHistoryPath(threadId);
+      if (
+        !(yield* fileSystem
+          .exists(legacyPath)
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new TerminalHistoryError({
+                  operation: "migrate",
+                  threadId,
+                  terminalId,
+                  cause,
+                }),
+            ),
+          ))
+      ) {
+        return "";
+      }
+
+      const raw = yield* fileSystem
+        .readFileString(legacyPath)
         .pipe(
           Effect.mapError(
             (cause) =>
-              new TerminalHistoryError({ operation: "migrate", threadId, terminalId, cause }),
+              new TerminalHistoryError({
+                operation: "migrate",
+                threadId,
+                terminalId,
+                cause,
+              }),
           ),
-        ))
-    ) {
-      return "";
-    }
-
-    const raw = yield* fileSystem
-      .readFileString(legacyPath)
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new TerminalHistoryError({ operation: "migrate", threadId, terminalId, cause }),
-        ),
-      );
-    const capped = capHistory(raw, historyLineLimit);
-    yield* fileSystem
-      .writeFileString(nextPath, capped)
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new TerminalHistoryError({ operation: "migrate", threadId, terminalId, cause }),
-        ),
-      );
-    yield* fileSystem.remove(legacyPath, { force: true }).pipe(
-      Effect.catch((cleanupError) =>
-        Effect.logWarning("failed to remove legacy terminal history", {
-          threadId,
-          error: cleanupError,
-        }),
-      ),
-    );
-    return capped;
-  });
-
-  const deleteHistory = Effect.fn("terminal.deleteHistory")(function* (
-    threadId: string,
-    terminalId: string,
-  ) {
-    yield* fileSystem.remove(historyPath(threadId, terminalId), { force: true }).pipe(
-      Effect.catch((error) =>
-        Effect.logWarning("failed to delete terminal history", {
-          threadId,
-          terminalId,
-          error,
-        }),
-      ),
-    );
-    if (terminalId === DEFAULT_TERMINAL_ID) {
-      yield* fileSystem.remove(legacyHistoryPath(threadId), { force: true }).pipe(
-        Effect.catch((error) =>
-          Effect.logWarning("failed to delete terminal history", {
+        );
+      const capped = capHistory(raw, historyLineLimit);
+      yield* fileSystem
+        .writeFileString(nextPath, capped)
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new TerminalHistoryError({
+                operation: "migrate",
+                threadId,
+                terminalId,
+                cause,
+              }),
+          ),
+        );
+      yield* fileSystem.remove(legacyPath, { force: true }).pipe(
+        Effect.catch((cleanupError) =>
+          Effect.logWarning("failed to remove legacy terminal history", {
             threadId,
-            terminalId,
-            error,
+            error: cleanupError,
           }),
         ),
       );
-    }
-  });
+      return capped;
+    });
 
-  const deleteAllHistoryForThread = Effect.fn("terminal.deleteAllHistoryForThread")(function* (
-    threadId: string,
-  ) {
-    const threadPrefix = `${toSafeThreadId(threadId)}_`;
-    const entries = yield* fileSystem
-      .readDirectory(logsDir, { recursive: false })
-      .pipe(Effect.orElseSucceed(() => [] as Array<string>));
-    yield* Effect.forEach(
-      entries.filter(
-        (name) =>
-          name === `${toSafeThreadId(threadId)}.log` ||
-          name === `${legacySafeThreadId(threadId)}.log` ||
-          name.startsWith(threadPrefix),
-      ),
-      (name) =>
-        fileSystem.remove(path.join(logsDir, name), { force: true }).pipe(
+    const deleteHistory = Effect.fn("terminal.deleteHistory")(function* (
+      threadId: string,
+      terminalId: string,
+    ) {
+      yield* fileSystem
+        .remove(historyPath(threadId, terminalId), { force: true })
+        .pipe(
           Effect.catch((error) =>
-            Effect.logWarning("failed to delete terminal histories for thread", {
+            Effect.logWarning("failed to delete terminal history", {
               threadId,
+              terminalId,
               error,
             }),
           ),
+        );
+      if (terminalId === DEFAULT_TERMINAL_ID) {
+        yield* fileSystem
+          .remove(legacyHistoryPath(threadId), { force: true })
+          .pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("failed to delete terminal history", {
+                threadId,
+                terminalId,
+                error,
+              }),
+            ),
+          );
+      }
+    });
+
+    const deleteAllHistoryForThread = Effect.fn(
+      "terminal.deleteAllHistoryForThread",
+    )(function* (threadId: string) {
+      const threadPrefix = `${toSafeThreadId(threadId)}_`;
+      const entries = yield* fileSystem
+        .readDirectory(logsDir, { recursive: false })
+        .pipe(Effect.orElseSucceed(() => [] as Array<string>));
+      yield* Effect.forEach(
+        entries.filter(
+          (name) =>
+            name === `${toSafeThreadId(threadId)}.log` ||
+            name === `${legacySafeThreadId(threadId)}.log` ||
+            name.startsWith(threadPrefix),
         ),
-      { discard: true },
-    );
-  });
-
-  const assertValidCwd = Effect.fn("terminal.assertValidCwd")(function* (cwd: string) {
-    const stats = yield* fileSystem.stat(cwd).pipe(
-      Effect.catchTags({
-        PlatformError: (cause) =>
-          cause.reason._tag === "NotFound"
-            ? new TerminalCwdNotFoundError({ cwd })
-            : new TerminalCwdStatError({ cwd, cause }),
-      }),
-    );
-    if (stats.type !== "Directory") {
-      return yield* new TerminalCwdNotDirectoryError({ cwd });
-    }
-  });
-
-  const getSession = Effect.fn("terminal.getSession")(function* (
-    threadId: string,
-    terminalId: string,
-  ): Effect.fn.Return<Option.Option<TerminalSessionState>> {
-    return yield* Effect.map(readManagerState, (state) =>
-      Option.fromNullishOr(state.sessions.get(toSessionKey(threadId, terminalId))),
-    );
-  });
-
-  const requireSession = Effect.fn("terminal.requireSession")(function* (
-    threadId: string,
-    terminalId: string,
-  ): Effect.fn.Return<TerminalSessionState, TerminalSessionLookupError> {
-    return yield* Effect.flatMap(getSession(threadId, terminalId), (session) =>
-      Option.match(session, {
-        onNone: () =>
-          Effect.fail(
-            new TerminalSessionLookupError({
-              threadId,
-              terminalId,
-            }),
+        (name) =>
+          fileSystem.remove(path.join(logsDir, name), { force: true }).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning(
+                "failed to delete terminal histories for thread",
+                {
+                  threadId,
+                  error,
+                },
+              ),
+            ),
           ),
-        onSome: Effect.succeed,
-      }),
-    );
-  });
+        { discard: true },
+      );
+    });
 
-  const sessionsForThread = Effect.fn("terminal.sessionsForThread")(function* (threadId: string) {
-    return yield* readManagerState.pipe(
-      Effect.map((state) =>
-        [...state.sessions.values()].filter((session) => session.threadId === threadId),
-      ),
-    );
-  });
+    const assertValidCwd = Effect.fn("terminal.assertValidCwd")(function* (
+      cwd: string,
+    ) {
+      const stats = yield* fileSystem.stat(cwd).pipe(
+        Effect.catchTags({
+          PlatformError: (cause) =>
+            cause.reason._tag === "NotFound"
+              ? new TerminalCwdNotFoundError({ cwd })
+              : new TerminalCwdStatError({ cwd, cause }),
+        }),
+      );
+      if (stats.type !== "Directory") {
+        return yield* new TerminalCwdNotDirectoryError({ cwd });
+      }
+    });
 
-  const evictInactiveSessionsIfNeeded = Effect.fn("terminal.evictInactiveSessionsIfNeeded")(
-    function* () {
+    const getSession = Effect.fn("terminal.getSession")(function* (
+      threadId: string,
+      terminalId: string,
+    ): Effect.fn.Return<Option.Option<TerminalSessionState>> {
+      return yield* Effect.map(readManagerState, (state) =>
+        Option.fromNullishOr(
+          state.sessions.get(toSessionKey(threadId, terminalId)),
+        ),
+      );
+    });
+
+    const requireSession = Effect.fn("terminal.requireSession")(function* (
+      threadId: string,
+      terminalId: string,
+    ): Effect.fn.Return<TerminalSessionState, TerminalSessionLookupError> {
+      return yield* Effect.flatMap(
+        getSession(threadId, terminalId),
+        (session) =>
+          Option.match(session, {
+            onNone: () =>
+              Effect.fail(
+                new TerminalSessionLookupError({
+                  threadId,
+                  terminalId,
+                }),
+              ),
+            onSome: Effect.succeed,
+          }),
+      );
+    });
+
+    const sessionsForThread = Effect.fn("terminal.sessionsForThread")(
+      function* (threadId: string) {
+        return yield* readManagerState.pipe(
+          Effect.map((state) =>
+            [...state.sessions.values()].filter(
+              (session) => session.threadId === threadId,
+            ),
+          ),
+        );
+      },
+    );
+
+    const evictInactiveSessionsIfNeeded = Effect.fn(
+      "terminal.evictInactiveSessionsIfNeeded",
+    )(function* () {
       yield* modifyManagerState((state) => {
         const inactiveSessions = [...state.sessions.values()].filter(
           (session) => session.status !== "running",
@@ -1677,61 +1873,147 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
         return [undefined, { ...state, sessions }] as const;
       });
-    },
-  );
+    });
 
-  const drainProcessEvents = Effect.fn("terminal.drainProcessEvents")(function* (
-    session: TerminalSessionState,
-    expectedPid: number,
-  ) {
-    while (true) {
-      const action: DrainProcessEventAction = yield* Effect.sync(() => {
-        if (session.pid !== expectedPid || !session.process || session.status !== "running") {
-          session.pendingProcessEvents = [];
-          session.pendingProcessEventIndex = 0;
-          session.processEventDrainRunning = false;
-          return { type: "idle" } as const;
-        }
+    const drainProcessEvents = Effect.fn("terminal.drainProcessEvents")(
+      function* (session: TerminalSessionState, expectedPid: number) {
+        while (true) {
+          const action: DrainProcessEventAction = yield* Effect.sync(() => {
+            if (
+              session.pid !== expectedPid ||
+              !session.process ||
+              session.status !== "running"
+            ) {
+              session.pendingProcessEvents = [];
+              session.pendingProcessEventIndex = 0;
+              session.processEventDrainRunning = false;
+              return { type: "idle" } as const;
+            }
 
-        const nextEvent = session.pendingProcessEvents[session.pendingProcessEventIndex];
-        if (!nextEvent) {
-          session.pendingProcessEvents = [];
-          session.pendingProcessEventIndex = 0;
-          session.processEventDrainRunning = false;
-          return { type: "idle" } as const;
-        }
+            const nextEvent =
+              session.pendingProcessEvents[session.pendingProcessEventIndex];
+            if (!nextEvent) {
+              session.pendingProcessEvents = [];
+              session.pendingProcessEventIndex = 0;
+              session.processEventDrainRunning = false;
+              return { type: "idle" } as const;
+            }
 
-        session.pendingProcessEventIndex += 1;
-        if (session.pendingProcessEventIndex >= session.pendingProcessEvents.length) {
-          session.pendingProcessEvents = [];
-          session.pendingProcessEventIndex = 0;
-        }
+            session.pendingProcessEventIndex += 1;
+            if (
+              session.pendingProcessEventIndex >=
+              session.pendingProcessEvents.length
+            ) {
+              session.pendingProcessEvents = [];
+              session.pendingProcessEventIndex = 0;
+            }
 
-        if (nextEvent.type === "output") {
-          const sanitized = sanitizeTerminalHistoryChunk(
-            session.pendingHistoryControlSequence,
-            nextEvent.data,
-          );
-          session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
-          if (sanitized.visibleText.length > 0) {
-            session.history = capHistory(
-              `${session.history}${sanitized.visibleText}`,
-              historyLineLimit,
-            );
+            if (nextEvent.type === "output") {
+              const sanitized = sanitizeTerminalHistoryChunk(
+                session.pendingHistoryControlSequence,
+                nextEvent.data,
+              );
+              session.pendingHistoryControlSequence =
+                sanitized.pendingControlSequence;
+              if (sanitized.visibleText.length > 0) {
+                session.history = capHistory(
+                  `${session.history}${sanitized.visibleText}`,
+                  historyLineLimit,
+                );
+              }
+              const eventStamp = advanceEventSequence(session);
+
+              return {
+                type: "output",
+                threadId: session.threadId,
+                terminalId: session.terminalId,
+                sequence: eventStamp.sequence,
+                history:
+                  sanitized.visibleText.length > 0 ? session.history : null,
+                data: nextEvent.data,
+              } as const;
+            }
+
+            const process = session.process;
+            cleanupProcessHandles(session);
+            session.process = null;
+            session.pid = null;
+            session.hasRunningSubprocess = false;
+            session.childCommandLabel = null;
+            session.status = "exited";
+            session.pendingHistoryControlSequence = "";
+            session.pendingProcessEvents = [];
+            session.pendingProcessEventIndex = 0;
+            session.processEventDrainRunning = false;
+            session.exitCode = Number.isInteger(nextEvent.event.exitCode)
+              ? nextEvent.event.exitCode
+              : null;
+            session.exitSignal = Number.isInteger(nextEvent.event.signal)
+              ? nextEvent.event.signal
+              : null;
+            const eventStamp = advanceEventSequence(session);
+
+            return {
+              type: "exit",
+              process,
+              threadId: session.threadId,
+              terminalId: session.terminalId,
+              sequence: eventStamp.sequence,
+              exitCode: session.exitCode,
+              exitSignal: session.exitSignal,
+            } as const;
+          });
+
+          if (action.type === "idle") {
+            return;
           }
-          const eventStamp = advanceEventSequence(session);
 
-          return {
-            type: "output",
-            threadId: session.threadId,
-            terminalId: session.terminalId,
-            sequence: eventStamp.sequence,
-            history: sanitized.visibleText.length > 0 ? session.history : null,
-            data: nextEvent.data,
-          } as const;
+          if (action.type === "output") {
+            if (action.history !== null) {
+              yield* queuePersist(
+                action.threadId,
+                action.terminalId,
+                action.history,
+              );
+            }
+
+            yield* publishEvent({
+              type: "output",
+              threadId: action.threadId,
+              terminalId: action.terminalId,
+              sequence: action.sequence,
+              data: action.data,
+            });
+            continue;
+          }
+
+          yield* clearKillFiber(action.process);
+          yield* unregisterTerminal({
+            threadId: action.threadId,
+            terminalId: action.terminalId,
+          });
+          yield* publishEvent({
+            type: "exited",
+            threadId: action.threadId,
+            terminalId: action.terminalId,
+            sequence: action.sequence,
+            exitCode: action.exitCode,
+            exitSignal: action.exitSignal,
+          });
+          yield* evictInactiveSessionsIfNeeded();
+          return;
         }
+      },
+    );
 
-        const process = session.process;
+    const stopProcess = Effect.fn("terminal.stopProcess")(function* (
+      session: TerminalSessionState,
+    ) {
+      const process = session.process;
+      if (!process) return;
+
+      const updatedAt = yield* nowIso;
+      yield* modifyManagerState((state) => {
         cleanupProcessHandles(session);
         session.process = null;
         session.pid = null;
@@ -1742,966 +2024,1000 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
-        session.exitCode = Number.isInteger(nextEvent.event.exitCode)
-          ? nextEvent.event.exitCode
-          : null;
-        session.exitSignal = Number.isInteger(nextEvent.event.signal)
-          ? nextEvent.event.signal
-          : null;
-        const eventStamp = advanceEventSequence(session);
-
-        return {
-          type: "exit",
-          process,
-          threadId: session.threadId,
-          terminalId: session.terminalId,
-          sequence: eventStamp.sequence,
-          exitCode: session.exitCode,
-          exitSignal: session.exitSignal,
-        } as const;
+        session.updatedAt = updatedAt;
+        return [undefined, state] as const;
       });
 
-      if (action.type === "idle") {
-        return;
-      }
-
-      if (action.type === "output") {
-        if (action.history !== null) {
-          yield* queuePersist(action.threadId, action.terminalId, action.history);
-        }
-
-        yield* publishEvent({
-          type: "output",
-          threadId: action.threadId,
-          terminalId: action.terminalId,
-          sequence: action.sequence,
-          data: action.data,
-        });
-        continue;
-      }
-
-      yield* clearKillFiber(action.process);
+      yield* clearKillFiber(process);
       yield* unregisterTerminal({
-        threadId: action.threadId,
-        terminalId: action.terminalId,
+        threadId: session.threadId,
+        terminalId: session.terminalId,
       });
-      yield* publishEvent({
-        type: "exited",
-        threadId: action.threadId,
-        terminalId: action.terminalId,
-        sequence: action.sequence,
-        exitCode: action.exitCode,
-        exitSignal: action.exitSignal,
-      });
+      yield* startKillEscalation(process, session.threadId, session.terminalId);
       yield* evictInactiveSessionsIfNeeded();
-      return;
-    }
-  });
-
-  const stopProcess = Effect.fn("terminal.stopProcess")(function* (session: TerminalSessionState) {
-    const process = session.process;
-    if (!process) return;
-
-    const updatedAt = yield* nowIso;
-    yield* modifyManagerState((state) => {
-      cleanupProcessHandles(session);
-      session.process = null;
-      session.pid = null;
-      session.hasRunningSubprocess = false;
-      session.childCommandLabel = null;
-      session.status = "exited";
-      session.pendingHistoryControlSequence = "";
-      session.pendingProcessEvents = [];
-      session.pendingProcessEventIndex = 0;
-      session.processEventDrainRunning = false;
-      session.updatedAt = updatedAt;
-      return [undefined, state] as const;
     });
 
-    yield* clearKillFiber(process);
-    yield* unregisterTerminal({
-      threadId: session.threadId,
-      terminalId: session.terminalId,
-    });
-    yield* startKillEscalation(process, session.threadId, session.terminalId);
-    yield* evictInactiveSessionsIfNeeded();
-  });
+    const trySpawn = Effect.fn("terminal.trySpawn")(function* (
+      shellCandidates: ReadonlyArray<ShellCandidate>,
+      spawnEnv: NodeJS.ProcessEnv,
+      session: TerminalSessionState,
+      index = 0,
+      lastError: PtyAdapter.PtySpawnError | null = null,
+    ): Effect.fn.Return<
+      { process: PtyAdapter.PtyProcess; shellLabel: string },
+      PtyAdapter.PtySpawnError
+    > {
+      if (index >= shellCandidates.length) {
+        return yield* new PtyAdapter.PtySpawnError({
+          adapter: "terminal-manager",
+          attemptedShells: shellCandidates.map((candidate) =>
+            formatShellCandidate(candidate),
+          ),
+          ...(lastError ? { cause: lastError } : {}),
+        });
+      }
 
-  const trySpawn = Effect.fn("terminal.trySpawn")(function* (
-    shellCandidates: ReadonlyArray<ShellCandidate>,
-    spawnEnv: NodeJS.ProcessEnv,
-    session: TerminalSessionState,
-    index = 0,
-    lastError: PtyAdapter.PtySpawnError | null = null,
-  ): Effect.fn.Return<
-    { process: PtyAdapter.PtyProcess; shellLabel: string },
-    PtyAdapter.PtySpawnError
-  > {
-    if (index >= shellCandidates.length) {
-      return yield* new PtyAdapter.PtySpawnError({
-        adapter: "terminal-manager",
-        attemptedShells: shellCandidates.map((candidate) => formatShellCandidate(candidate)),
-        ...(lastError ? { cause: lastError } : {}),
-      });
-    }
-
-    const candidate = shellCandidates[index];
-    if (!candidate) {
-      return yield* (
-        lastError ??
+      const candidate = shellCandidates[index];
+      if (!candidate) {
+        return yield* lastError ??
           new PtyAdapter.PtySpawnError({
             adapter: "terminal-manager",
             attemptedShells: [],
-          })
-      );
-    }
-
-    const attempt = yield* Effect.result(
-      options.ptyAdapter.spawn({
-        shell: candidate.shell,
-        ...(candidate.args ? { args: candidate.args } : {}),
-        cwd: session.cwd,
-        cols: session.cols,
-        rows: session.rows,
-        env: spawnEnv,
-      }),
-    );
-
-    if (attempt._tag === "Success") {
-      return {
-        process: attempt.success,
-        shellLabel: formatShellCandidate(candidate),
-      };
-    }
-
-    const spawnError = attempt.failure;
-    if (!isRetryableShellSpawnError(spawnError)) {
-      return yield* spawnError;
-    }
-
-    return yield* trySpawn(shellCandidates, spawnEnv, session, index + 1, spawnError);
-  });
-
-  const startSession = Effect.fn("terminal.startSession")(function* (
-    session: TerminalSessionState,
-    input: TerminalStartInput,
-    eventType: "started" | "restarted",
-  ) {
-    yield* stopProcess(session);
-    yield* Effect.annotateCurrentSpan({
-      "terminal.thread_id": session.threadId,
-      "terminal.id": session.terminalId,
-      "terminal.event_type": eventType,
-      "terminal.cwd": input.cwd,
-    });
-
-    const startingAt = yield* nowIso;
-    yield* modifyManagerState((state) => {
-      session.status = "starting";
-      session.cwd = input.cwd;
-      session.worktreePath = input.worktreePath ?? null;
-      session.cols = input.cols;
-      session.rows = input.rows;
-      session.exitCode = null;
-      session.exitSignal = null;
-      session.hasRunningSubprocess = false;
-      session.childCommandLabel = null;
-      session.pendingProcessEvents = [];
-      session.pendingProcessEventIndex = 0;
-      session.processEventDrainRunning = false;
-      session.updatedAt = startingAt;
-      return [undefined, state] as const;
-    });
-
-    let ptyProcess: PtyAdapter.PtyProcess | null = null;
-    let startedShell: string | null = null;
-
-    const startResult = yield* Effect.result(
-      increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
-        Effect.andThen(
-          Effect.gen(function* () {
-            const shellCandidates = resolveShellCandidates(shellResolver, platform, baseEnv);
-            const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
-            const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
-            ptyProcess = spawnResult.process;
-            startedShell = spawnResult.shellLabel;
-
-            const processPid = ptyProcess.pid;
-            const unsubscribeData = ptyProcess.onData((data) => {
-              if (!enqueueProcessEvent(session, processPid, { type: "output", data })) {
-                return;
-              }
-              runFork(drainProcessEvents(session, processPid));
-            });
-            const unsubscribeExit = ptyProcess.onExit((event) => {
-              if (!enqueueProcessEvent(session, processPid, { type: "exit", event })) {
-                return;
-              }
-              runFork(drainProcessEvents(session, processPid));
-            });
-
-            let eventStamp: ReturnType<typeof advanceEventSequence> = {
-              updatedAt: session.updatedAt,
-              sequence: session.eventSequence,
-            };
-            yield* modifyManagerState((state) => {
-              session.process = ptyProcess;
-              session.pid = processPid;
-              session.status = "running";
-              session.unsubscribeData = unsubscribeData;
-              session.unsubscribeExit = unsubscribeExit;
-              eventStamp = advanceEventSequence(session);
-              return [undefined, state] as const;
-            });
-
-            yield* publishEvent({
-              type: eventType,
-              threadId: session.threadId,
-              terminalId: session.terminalId,
-              sequence: eventStamp.sequence,
-              snapshot: snapshot(session),
-            });
-          }),
-        ),
-      ),
-    );
-
-    if (startResult._tag === "Success") {
-      return;
-    }
-
-    {
-      const error = startResult.failure;
-      if (ptyProcess) {
-        yield* startKillEscalation(ptyProcess, session.threadId, session.terminalId);
+          });
       }
 
+      const attempt = yield* Effect.result(
+        options.ptyAdapter.spawn({
+          shell: candidate.shell,
+          ...(candidate.args ? { args: candidate.args } : {}),
+          cwd: session.cwd,
+          cols: session.cols,
+          rows: session.rows,
+          env: spawnEnv,
+        }),
+      );
+
+      if (attempt._tag === "Success") {
+        return {
+          process: attempt.success,
+          shellLabel: formatShellCandidate(candidate),
+        };
+      }
+
+      const spawnError = attempt.failure;
+      if (!isRetryableShellSpawnError(spawnError)) {
+        return yield* spawnError;
+      }
+
+      return yield* trySpawn(
+        shellCandidates,
+        spawnEnv,
+        session,
+        index + 1,
+        spawnError,
+      );
+    });
+
+    const startSession = Effect.fn("terminal.startSession")(function* (
+      session: TerminalSessionState,
+      input: TerminalStartInput,
+      eventType: "started" | "restarted",
+    ) {
+      yield* stopProcess(session);
+      yield* Effect.annotateCurrentSpan({
+        "terminal.thread_id": session.threadId,
+        "terminal.id": session.terminalId,
+        "terminal.event_type": eventType,
+        "terminal.cwd": input.cwd,
+      });
+
+      const startingAt = yield* nowIso;
       yield* modifyManagerState((state) => {
-        cleanupProcessHandles(session);
-        session.status = "error";
-        session.pid = null;
-        session.process = null;
+        session.status = "starting";
+        session.cwd = input.cwd;
+        session.worktreePath = input.worktreePath ?? null;
+        session.cols = input.cols;
+        session.rows = input.rows;
+        session.exitCode = null;
+        session.exitSignal = null;
         session.hasRunningSubprocess = false;
         session.childCommandLabel = null;
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
-        advanceEventSequence(session);
+        session.updatedAt = startingAt;
         return [undefined, state] as const;
       });
-      yield* unregisterTerminal({
-        threadId: session.threadId,
-        terminalId: session.terminalId,
-      });
 
-      yield* evictInactiveSessionsIfNeeded();
+      let ptyProcess: PtyAdapter.PtyProcess | null = null;
+      let startedShell: string | null = null;
 
-      const message = error.message;
-      yield* publishEvent({
-        type: "error",
-        threadId: session.threadId,
-        terminalId: session.terminalId,
-        sequence: session.eventSequence,
-        message,
-      });
-      yield* Effect.logError("failed to start terminal", {
-        threadId: session.threadId,
-        terminalId: session.terminalId,
-        cause: error,
-        ...(startedShell ? { shell: startedShell } : {}),
-      });
-    }
-  });
+      const startResult = yield* Effect.result(
+        increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
+          Effect.andThen(
+            Effect.gen(function* () {
+              const preferredShell = yield* shellResolver;
+              const shellCandidates = resolveShellCandidates(
+                preferredShell,
+                platform,
+                baseEnv,
+              );
+              const terminalEnv = createTerminalSpawnEnv(
+                baseEnv,
+                session.runtimeEnv,
+              );
+              const spawnResult = yield* trySpawn(
+                shellCandidates,
+                terminalEnv,
+                session,
+              );
+              ptyProcess = spawnResult.process;
+              startedShell = spawnResult.shellLabel;
 
-  const closeSession = Effect.fn("terminal.closeSession")(function* (
-    threadId: string,
-    terminalId: string,
-    deleteHistoryOnClose: boolean,
-  ) {
-    const key = toSessionKey(threadId, terminalId);
-    const session = yield* getSession(threadId, terminalId);
-    const closedEventSequence = Option.isSome(session) ? session.value.eventSequence + 1 : 0;
+              const processPid = ptyProcess.pid;
+              const unsubscribeData = ptyProcess.onData((data) => {
+                if (
+                  !enqueueProcessEvent(session, processPid, {
+                    type: "output",
+                    data,
+                  })
+                ) {
+                  return;
+                }
+                runFork(drainProcessEvents(session, processPid));
+              });
+              const unsubscribeExit = ptyProcess.onExit((event) => {
+                if (
+                  !enqueueProcessEvent(session, processPid, {
+                    type: "exit",
+                    event,
+                  })
+                ) {
+                  return;
+                }
+                runFork(drainProcessEvents(session, processPid));
+              });
 
-    if (Option.isSome(session)) {
-      yield* stopProcess(session.value);
-      yield* unregisterTerminal({ threadId, terminalId });
-      yield* persistHistory(threadId, terminalId, session.value.history);
-    }
+              let eventStamp: ReturnType<typeof advanceEventSequence> = {
+                updatedAt: session.updatedAt,
+                sequence: session.eventSequence,
+              };
+              yield* modifyManagerState((state) => {
+                session.process = ptyProcess;
+                session.pid = processPid;
+                session.status = "running";
+                session.unsubscribeData = unsubscribeData;
+                session.unsubscribeExit = unsubscribeExit;
+                eventStamp = advanceEventSequence(session);
+                return [undefined, state] as const;
+              });
 
-    yield* flushPersist(threadId, terminalId);
-
-    const removed = yield* modifyManagerState((state) => {
-      if (!state.sessions.has(key)) {
-        return [false, state] as const;
-      }
-      const sessions = new Map(state.sessions);
-      sessions.delete(key);
-      return [true, { ...state, sessions }] as const;
-    });
-
-    if (removed) {
-      yield* publishEvent({
-        type: "closed",
-        threadId,
-        terminalId,
-        sequence: closedEventSequence,
-      });
-    }
-
-    if (deleteHistoryOnClose) {
-      yield* deleteHistory(threadId, terminalId);
-    }
-  });
-
-  const pollSubprocessActivity = Effect.fn("terminal.pollSubprocessActivity")(function* () {
-    const state = yield* readManagerState;
-    const runningSessions = [...state.sessions.values()].filter(
-      (session): session is TerminalSessionState & { pid: number } =>
-        session.status === "running" && Number.isInteger(session.pid),
-    );
-
-    if (runningSessions.length === 0) {
-      return;
-    }
-
-    const checkSubprocessActivity = Effect.fn("terminal.checkSubprocessActivity")(function* (
-      session: TerminalSessionState & { pid: number },
-    ) {
-      const terminalPid = session.pid;
-      const inspectResult = yield* subprocessInspector(terminalPid).pipe(
-        Effect.map(Option.some),
-        Effect.catch((reason) =>
-          Effect.logWarning("failed to check terminal subprocess activity", {
-            threadId: session.threadId,
-            terminalId: session.terminalId,
-            terminalPid,
-            reason,
-          }).pipe(Effect.as(Option.none<TerminalSubprocessInspectResult>())),
+              yield* publishEvent({
+                type: eventType,
+                threadId: session.threadId,
+                terminalId: session.terminalId,
+                sequence: eventStamp.sequence,
+                snapshot: snapshot(session),
+              });
+            }),
+          ),
         ),
       );
 
-      if (Option.isNone(inspectResult)) {
+      if (startResult._tag === "Success") {
         return;
       }
 
-      const next = inspectResult.value;
-      yield* registerTerminalProcesses({
-        threadId: session.threadId,
-        terminalId: session.terminalId,
-        processIds: next.processIds,
-      });
-      const nextChildLabel = next.hasRunningSubprocess ? next.childCommand : null;
-      const event = yield* modifyManagerState((state) => {
-        const liveSession: Option.Option<TerminalSessionState> = Option.fromNullishOr(
-          state.sessions.get(toSessionKey(session.threadId, session.terminalId)),
-        );
-        if (
-          Option.isNone(liveSession) ||
-          liveSession.value.status !== "running" ||
-          liveSession.value.pid !== terminalPid ||
-          (liveSession.value.hasRunningSubprocess === next.hasRunningSubprocess &&
-            liveSession.value.childCommandLabel === nextChildLabel)
-        ) {
-          return [Option.none(), state] as const;
+      {
+        const error = startResult.failure;
+        if (ptyProcess) {
+          yield* startKillEscalation(
+            ptyProcess,
+            session.threadId,
+            session.terminalId,
+          );
         }
 
-        liveSession.value.hasRunningSubprocess = next.hasRunningSubprocess;
-        liveSession.value.childCommandLabel = nextChildLabel;
-        const eventStamp = advanceEventSequence(liveSession.value);
+        yield* modifyManagerState((state) => {
+          cleanupProcessHandles(session);
+          session.status = "error";
+          session.pid = null;
+          session.process = null;
+          session.hasRunningSubprocess = false;
+          session.childCommandLabel = null;
+          session.pendingProcessEvents = [];
+          session.pendingProcessEventIndex = 0;
+          session.processEventDrainRunning = false;
+          advanceEventSequence(session);
+          return [undefined, state] as const;
+        });
+        yield* unregisterTerminal({
+          threadId: session.threadId,
+          terminalId: session.terminalId,
+        });
 
-        return [
-          Option.some({
-            type: "activity" as const,
-            threadId: liveSession.value.threadId,
-            terminalId: liveSession.value.terminalId,
-            sequence: eventStamp.sequence,
-            hasRunningSubprocess: next.hasRunningSubprocess,
-            label: terminalWireLabel(liveSession.value),
-          }),
-          state,
-        ] as const;
-      });
+        yield* evictInactiveSessionsIfNeeded();
 
-      if (Option.isSome(event)) {
-        yield* publishEvent(event.value);
+        const message = error.message;
+        yield* publishEvent({
+          type: "error",
+          threadId: session.threadId,
+          terminalId: session.terminalId,
+          sequence: session.eventSequence,
+          message,
+        });
+        yield* Effect.logError("failed to start terminal", {
+          threadId: session.threadId,
+          terminalId: session.terminalId,
+          cause: error,
+          ...(startedShell ? { shell: startedShell } : {}),
+        });
       }
     });
 
-    yield* Effect.forEach(runningSessions, checkSubprocessActivity, {
-      concurrency: "unbounded",
-      discard: true,
-    });
-  });
+    const closeSession = Effect.fn("terminal.closeSession")(function* (
+      threadId: string,
+      terminalId: string,
+      deleteHistoryOnClose: boolean,
+    ) {
+      const key = toSessionKey(threadId, terminalId);
+      const session = yield* getSession(threadId, terminalId);
+      const closedEventSequence = Option.isSome(session)
+        ? session.value.eventSequence + 1
+        : 0;
 
-  const hasRunningSessions = readManagerState.pipe(
-    Effect.map((state) =>
-      [...state.sessions.values()].some((session) => session.status === "running"),
-    ),
-  );
+      if (Option.isSome(session)) {
+        yield* stopProcess(session.value);
+        yield* unregisterTerminal({ threadId, terminalId });
+        yield* persistHistory(threadId, terminalId, session.value.history);
+      }
 
-  yield* Effect.forever(
-    hasRunningSessions.pipe(
-      Effect.flatMap((active) =>
-        active
-          ? pollSubprocessActivity().pipe(
-              Effect.flatMap(() => Effect.sleep(subprocessPollIntervalMs)),
-            )
-          : Effect.sleep(subprocessPollIntervalMs),
-      ),
-    ),
-  ).pipe(Effect.forkIn(workerScope));
+      yield* flushPersist(threadId, terminalId);
 
-  yield* Effect.addFinalizer(() =>
-    Effect.gen(function* () {
-      const sessions = yield* modifyManagerState(
-        (state) =>
-          [
-            [...state.sessions.values()],
-            {
-              ...state,
-              sessions: new Map(),
-            },
-          ] as const,
-      );
-
-      const cleanupSession = Effect.fn("terminal.cleanupSession")(function* (
-        session: TerminalSessionState,
-      ) {
-        cleanupProcessHandles(session);
-        if (!session.process) return;
-        yield* clearKillFiber(session.process);
-        yield* runKillEscalation(session.process, session.threadId, session.terminalId);
-      });
-
-      yield* Effect.forEach(sessions, cleanupSession, {
-        concurrency: "unbounded",
-        discard: true,
-      });
-    }).pipe(Effect.ignoreCause({ log: true })),
-  );
-
-  const openLocked = Effect.fn("terminal.openLocked")(function* (input: TerminalOpenInput) {
-    const terminalId = input.terminalId;
-    yield* assertValidCwd(input.cwd);
-
-    const sessionKey = toSessionKey(input.threadId, terminalId);
-    const existing = yield* getSession(input.threadId, terminalId);
-    if (Option.isNone(existing)) {
-      yield* flushPersist(input.threadId, terminalId);
-      const history = yield* readHistory(input.threadId, terminalId);
-      const cols = input.cols ?? DEFAULT_OPEN_COLS;
-      const rows = input.rows ?? DEFAULT_OPEN_ROWS;
-      const session: TerminalSessionState = {
-        threadId: input.threadId,
-        terminalId,
-        cwd: input.cwd,
-        worktreePath: input.worktreePath ?? null,
-        status: "starting",
-        pid: null,
-        history,
-        pendingHistoryControlSequence: "",
-        pendingProcessEvents: [],
-        pendingProcessEventIndex: 0,
-        processEventDrainRunning: false,
-        exitCode: null,
-        exitSignal: null,
-        updatedAt: yield* nowIso,
-        eventSequence: 0,
-        cols,
-        rows,
-        process: null,
-        unsubscribeData: null,
-        unsubscribeExit: null,
-        hasRunningSubprocess: false,
-        childCommandLabel: null,
-        runtimeEnv: normalizedRuntimeEnv(input.env),
-      };
-
-      const createdSession = session;
-      yield* modifyManagerState((state) => {
+      const removed = yield* modifyManagerState((state) => {
+        if (!state.sessions.has(key)) {
+          return [false, state] as const;
+        }
         const sessions = new Map(state.sessions);
-        sessions.set(sessionKey, createdSession);
-        return [undefined, { ...state, sessions }] as const;
+        sessions.delete(key);
+        return [true, { ...state, sessions }] as const;
       });
 
-      yield* evictInactiveSessionsIfNeeded();
-      yield* startSession(
-        session,
-        {
-          threadId: input.threadId,
+      if (removed) {
+        yield* publishEvent({
+          type: "closed",
+          threadId,
           terminalId,
-          cwd: input.cwd,
-          ...(input.worktreePath !== undefined ? { worktreePath: input.worktreePath } : {}),
-          cols,
-          rows,
-          ...(input.env ? { env: input.env } : {}),
-        },
-        "started",
-      );
-      return snapshot(session);
-    }
+          sequence: closedEventSequence,
+        });
+      }
 
-    const liveSession = existing.value;
-    const nextRuntimeEnv = normalizedRuntimeEnv(input.env);
-    const currentRuntimeEnv = liveSession.runtimeEnv;
-    const targetCols = input.cols ?? liveSession.cols;
-    const targetRows = input.rows ?? liveSession.rows;
-    const runtimeEnvChanged = !Equal.equals(currentRuntimeEnv, nextRuntimeEnv);
-    const nextWorktreePath =
-      input.worktreePath !== undefined ? (input.worktreePath ?? null) : liveSession.worktreePath;
-    const launchContextChanged =
-      liveSession.cwd !== input.cwd ||
-      runtimeEnvChanged ||
-      liveSession.worktreePath !== nextWorktreePath;
+      if (deleteHistoryOnClose) {
+        yield* deleteHistory(threadId, terminalId);
+      }
+    });
 
-    if (launchContextChanged) {
-      yield* stopProcess(liveSession);
-      liveSession.cwd = input.cwd;
-      liveSession.worktreePath = nextWorktreePath;
-      liveSession.runtimeEnv = nextRuntimeEnv;
-      liveSession.history = "";
-      liveSession.pendingHistoryControlSequence = "";
-      liveSession.pendingProcessEvents = [];
-      liveSession.pendingProcessEventIndex = 0;
-      liveSession.processEventDrainRunning = false;
-      yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
-    } else if (liveSession.status === "exited" || liveSession.status === "error") {
-      liveSession.runtimeEnv = nextRuntimeEnv;
-      liveSession.worktreePath = nextWorktreePath;
-      liveSession.history = "";
-      liveSession.pendingHistoryControlSequence = "";
-      liveSession.pendingProcessEvents = [];
-      liveSession.pendingProcessEventIndex = 0;
-      liveSession.processEventDrainRunning = false;
-      yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
-    }
+    const pollSubprocessActivity = Effect.fn("terminal.pollSubprocessActivity")(
+      function* () {
+        const state = yield* readManagerState;
+        const runningSessions = [...state.sessions.values()].filter(
+          (session): session is TerminalSessionState & { pid: number } =>
+            session.status === "running" && Number.isInteger(session.pid),
+        );
 
-    if (!liveSession.process) {
-      yield* startSession(
-        liveSession,
-        {
-          threadId: input.threadId,
-          terminalId,
-          cwd: input.cwd,
-          worktreePath: liveSession.worktreePath,
-          cols: targetCols,
-          rows: targetRows,
-          ...(input.env ? { env: input.env } : {}),
-        },
-        "started",
-      );
-      return snapshot(liveSession);
-    }
+        if (runningSessions.length === 0) {
+          return;
+        }
 
-    if (liveSession.cols !== targetCols || liveSession.rows !== targetRows) {
-      yield* resizePtyProcess(liveSession, liveSession.process, targetCols, targetRows);
-      liveSession.cols = targetCols;
-      liveSession.rows = targetRows;
-      liveSession.updatedAt = yield* nowIso;
-    }
+        const checkSubprocessActivity = Effect.fn(
+          "terminal.checkSubprocessActivity",
+        )(function* (session: TerminalSessionState & { pid: number }) {
+          const terminalPid = session.pid;
+          const inspectResult = yield* subprocessInspector(terminalPid).pipe(
+            Effect.map(Option.some),
+            Effect.catch((reason) =>
+              Effect.logWarning(
+                "failed to check terminal subprocess activity",
+                {
+                  threadId: session.threadId,
+                  terminalId: session.terminalId,
+                  terminalPid,
+                  reason,
+                },
+              ).pipe(Effect.as(Option.none<TerminalSubprocessInspectResult>())),
+            ),
+          );
 
-    return snapshot(liveSession);
-  });
-
-  const open: TerminalManager["Service"]["open"] = (input) =>
-    withThreadLock(input.threadId, openLocked(input));
-
-  const openOrAttachForStream = (input: TerminalAttachInput) =>
-    withThreadLock(
-      input.threadId,
-      Effect.gen(function* () {
-        const terminalId = input.terminalId;
-        const existing = yield* getSession(input.threadId, terminalId);
-
-        if (Option.isNone(existing)) {
-          if (!input.cwd) {
-            return yield* new TerminalSessionLookupError({
-              threadId: input.threadId,
-              terminalId,
-            });
+          if (Option.isNone(inspectResult)) {
+            return;
           }
 
-          return yield* openLocked({
-            ...input,
-            terminalId,
-            cwd: input.cwd,
+          const next = inspectResult.value;
+          yield* registerTerminalProcesses({
+            threadId: session.threadId,
+            terminalId: session.terminalId,
+            processIds: next.processIds,
           });
-        }
-
-        const session = existing.value;
-        const targetCols = input.cols ?? session.cols;
-        const targetRows = input.rows ?? session.rows;
-
-        if (!session.process && input.cwd && input.restartIfNotRunning === true) {
-          return yield* openLocked({
-            ...input,
-            terminalId,
-            cwd: input.cwd,
-          });
-        }
-
-        if (
-          session.process &&
-          session.status === "running" &&
-          (session.cols !== targetCols || session.rows !== targetRows)
-        ) {
-          const process = session.process;
-          yield* resizePtyProcess(session, process, targetCols, targetRows);
-          session.cols = targetCols;
-          session.rows = targetRows;
-          session.updatedAt = yield* nowIso;
-        }
-
-        return snapshot(session);
-      }),
-    );
-
-  const readAllTerminalMetadata = () =>
-    readManagerState.pipe(
-      Effect.map((state) =>
-        [...state.sessions.values()]
-          .map(summary)
-          .sort(
-            (left, right) =>
-              right.updatedAt.localeCompare(left.updatedAt) ||
-              left.threadId.localeCompare(right.threadId) ||
-              left.terminalId.localeCompare(right.terminalId),
-          ),
-      ),
-    );
-
-  const readTerminalMetadata = (input: {
-    readonly threadId: string;
-    readonly terminalId: string;
-  }) =>
-    getSession(input.threadId, input.terminalId).pipe(
-      Effect.map((session) => (Option.isSome(session) ? summary(session.value) : null)),
-    );
-
-  const subscribe: TerminalManager["Service"]["subscribe"] = (listener) =>
-    Effect.sync(() => {
-      terminalEventListeners.add(listener);
-      return () => {
-        terminalEventListeners.delete(listener);
-      };
-    });
-
-  const attachStream: TerminalManager["Service"]["attachStream"] = (input, listener) => {
-    let unsubscribe: (() => void) | null = null;
-
-    return Effect.gen(function* () {
-      const bufferedEvents: TerminalEvent[] = [];
-      let deliverLive = false;
-
-      unsubscribe = yield* subscribe((event) => {
-        if (event.threadId !== input.threadId || event.terminalId !== input.terminalId) {
-          return Effect.void;
-        }
-
-        if (!deliverLive) {
-          bufferedEvents.push(event);
-          return Effect.void;
-        }
-
-        const attachEvent = terminalEventToAttachEvent(event);
-        return attachEvent ? listener(attachEvent) : Effect.void;
-      });
-
-      const initialSnapshot = yield* openOrAttachForStream(input);
-
-      yield* listener({
-        type: "snapshot",
-        snapshot: initialSnapshot,
-      });
-
-      for (const event of bufferedEvents) {
-        if (isDuplicateAttachSnapshotEvent(event, initialSnapshot)) {
-          continue;
-        }
-
-        const attachEvent = terminalEventToAttachEvent(event);
-        if (attachEvent) {
-          yield* listener(attachEvent);
-        }
-      }
-
-      deliverLive = true;
-      return () => {
-        unsubscribe?.();
-        unsubscribe = null;
-      };
-    }).pipe(
-      Effect.catchCause((cause) =>
-        Effect.flatMap(
-          Effect.sync(() => {
-            unsubscribe?.();
-            unsubscribe = null;
-          }),
-          () => Effect.failCause(cause),
-        ),
-      ),
-    );
-  };
-
-  const metadataEventFromTerminalEvent = (
-    event: TerminalEvent,
-  ): Effect.Effect<TerminalMetadataStreamEvent | null> => {
-    if (!shouldPublishTerminalMetadataEvent(event)) {
-      return Effect.succeed(null);
-    }
-
-    if (event.type === "closed") {
-      return Effect.succeed({
-        type: "remove" as const,
-        threadId: event.threadId,
-        terminalId: event.terminalId,
-      });
-    }
-
-    return readTerminalMetadata({
-      threadId: event.threadId,
-      terminalId: event.terminalId,
-    }).pipe(
-      Effect.map((terminal) =>
-        terminal
-          ? {
-              type: "upsert" as const,
-              terminal,
+          const nextChildLabel = next.hasRunningSubprocess
+            ? next.childCommand
+            : null;
+          const event = yield* modifyManagerState((state) => {
+            const liveSession: Option.Option<TerminalSessionState> =
+              Option.fromNullishOr(
+                state.sessions.get(
+                  toSessionKey(session.threadId, session.terminalId),
+                ),
+              );
+            if (
+              Option.isNone(liveSession) ||
+              liveSession.value.status !== "running" ||
+              liveSession.value.pid !== terminalPid ||
+              (liveSession.value.hasRunningSubprocess ===
+                next.hasRunningSubprocess &&
+                liveSession.value.childCommandLabel === nextChildLabel)
+            ) {
+              return [Option.none(), state] as const;
             }
-          : null,
-      ),
+
+            liveSession.value.hasRunningSubprocess = next.hasRunningSubprocess;
+            liveSession.value.childCommandLabel = nextChildLabel;
+            const eventStamp = advanceEventSequence(liveSession.value);
+
+            return [
+              Option.some({
+                type: "activity" as const,
+                threadId: liveSession.value.threadId,
+                terminalId: liveSession.value.terminalId,
+                sequence: eventStamp.sequence,
+                hasRunningSubprocess: next.hasRunningSubprocess,
+                label: terminalWireLabel(liveSession.value),
+              }),
+              state,
+            ] as const;
+          });
+
+          if (Option.isSome(event)) {
+            yield* publishEvent(event.value);
+          }
+        });
+
+        yield* Effect.forEach(runningSessions, checkSubprocessActivity, {
+          concurrency: "unbounded",
+          discard: true,
+        });
+      },
     );
-  };
 
-  const offerMetadataEvent = (
-    listener: (event: TerminalMetadataStreamEvent) => Effect.Effect<void>,
-    event: TerminalEvent,
-  ) =>
-    metadataEventFromTerminalEvent(event).pipe(
-      Effect.flatMap((metadataEvent) => (metadataEvent ? listener(metadataEvent) : Effect.void)),
-    );
-
-  const subscribeMetadata: TerminalManager["Service"]["subscribeMetadata"] = (listener) => {
-    let unsubscribe: (() => void) | null = null;
-
-    return Effect.gen(function* () {
-      const bufferedEvents: TerminalEvent[] = [];
-      let deliverLive = false;
-
-      unsubscribe = yield* subscribe((event) => {
-        if (!deliverLive) {
-          bufferedEvents.push(event);
-          return Effect.void;
-        }
-
-        return offerMetadataEvent(listener, event);
-      });
-
-      const terminals = yield* readAllTerminalMetadata();
-      yield* listener({
-        type: "snapshot",
-        terminals,
-      });
-
-      for (const event of bufferedEvents) {
-        yield* offerMetadataEvent(listener, event);
-      }
-
-      deliverLive = true;
-      return () => {
-        unsubscribe?.();
-        unsubscribe = null;
-      };
-    }).pipe(
-      Effect.catchCause((cause) =>
-        Effect.flatMap(
-          Effect.sync(() => {
-            unsubscribe?.();
-            unsubscribe = null;
-          }),
-          () => Effect.failCause(cause),
+    const hasRunningSessions = readManagerState.pipe(
+      Effect.map((state) =>
+        [...state.sessions.values()].some(
+          (session) => session.status === "running",
         ),
       ),
     );
-  };
 
-  const write: TerminalManager["Service"]["write"] = Effect.fn("terminal.write")(function* (input) {
-    const terminalId = input.terminalId;
-    const session = yield* requireSession(input.threadId, terminalId);
-    const process = session.process;
-    if (!process || session.status !== "running") {
-      if (session.status === "exited") return;
-      return yield* new TerminalNotRunningError({
-        threadId: input.threadId,
-        terminalId,
-      });
-    }
-    yield* Effect.try({
-      try: () => process.write(input.data),
-      catch: (cause) =>
-        new TerminalWriteError({
-          threadId: input.threadId,
-          terminalId,
-          terminalPid: process.pid,
-          cause,
-        }),
-    });
-  });
+    yield* Effect.forever(
+      hasRunningSessions.pipe(
+        Effect.flatMap((active) =>
+          active
+            ? pollSubprocessActivity().pipe(
+                Effect.flatMap(() => Effect.sleep(subprocessPollIntervalMs)),
+              )
+            : Effect.sleep(subprocessPollIntervalMs),
+        ),
+      ),
+    ).pipe(Effect.forkIn(workerScope));
 
-  const resizeLocked = Effect.fn("terminal.resize")(function* (input: TerminalResizeInput) {
-    const session = yield* getSession(input.threadId, input.terminalId);
-    // ResizeObserver traffic can already be in flight when the UI closes the session.
-    if (Option.isNone(session)) {
-      return;
-    }
-    const process = session.value.process;
-    if (!process || session.value.status !== "running") {
-      return;
-    }
-    yield* resizePtyProcess(session.value, process, input.cols, input.rows);
-    session.value.cols = input.cols;
-    session.value.rows = input.rows;
-    session.value.updatedAt = yield* nowIso;
-  });
-
-  const resize: TerminalManager["Service"]["resize"] = (input) =>
-    withThreadLock(input.threadId, resizeLocked(input));
-
-  const clear: TerminalManager["Service"]["clear"] = (input) =>
-    withThreadLock(
-      input.threadId,
+    yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {
-        const terminalId = input.terminalId;
-        const session = yield* requireSession(input.threadId, terminalId);
-        session.history = "";
-        session.pendingHistoryControlSequence = "";
-        session.pendingProcessEvents = [];
-        session.pendingProcessEventIndex = 0;
-        session.processEventDrainRunning = false;
-        const eventStamp = advanceEventSequence(session);
-        yield* persistHistory(input.threadId, terminalId, session.history);
-        yield* publishEvent({
-          type: "cleared",
-          threadId: input.threadId,
-          terminalId,
-          sequence: eventStamp.sequence,
+        const sessions = yield* modifyManagerState(
+          (state) =>
+            [
+              [...state.sessions.values()],
+              {
+                ...state,
+                sessions: new Map(),
+              },
+            ] as const,
+        );
+
+        const cleanupSession = Effect.fn("terminal.cleanupSession")(function* (
+          session: TerminalSessionState,
+        ) {
+          cleanupProcessHandles(session);
+          if (!session.process) return;
+          yield* clearKillFiber(session.process);
+          yield* runKillEscalation(
+            session.process,
+            session.threadId,
+            session.terminalId,
+          );
         });
-      }),
+
+        yield* Effect.forEach(sessions, cleanupSession, {
+          concurrency: "unbounded",
+          discard: true,
+        });
+      }).pipe(Effect.ignoreCause({ log: true })),
     );
 
-  const restart: TerminalManager["Service"]["restart"] = (input) =>
-    withThreadLock(
-      input.threadId,
-      Effect.gen(function* () {
-        yield* increment(terminalRestartsTotal, { scope: "thread" });
-        const terminalId = input.terminalId;
-        yield* assertValidCwd(input.cwd);
+    const openLocked = Effect.fn("terminal.openLocked")(function* (
+      input: TerminalOpenInput,
+    ) {
+      const terminalId = input.terminalId;
+      yield* assertValidCwd(input.cwd);
 
-        const sessionKey = toSessionKey(input.threadId, terminalId);
-        const existingSession = yield* getSession(input.threadId, terminalId);
-        let session: TerminalSessionState;
-        if (Option.isNone(existingSession)) {
-          const cols = input.cols ?? DEFAULT_OPEN_COLS;
-          const rows = input.rows ?? DEFAULT_OPEN_ROWS;
-          session = {
-            threadId: input.threadId,
-            terminalId,
-            cwd: input.cwd,
-            worktreePath: input.worktreePath ?? null,
-            status: "starting",
-            pid: null,
-            history: "",
-            pendingHistoryControlSequence: "",
-            pendingProcessEvents: [],
-            pendingProcessEventIndex: 0,
-            processEventDrainRunning: false,
-            exitCode: null,
-            exitSignal: null,
-            updatedAt: yield* nowIso,
-            eventSequence: 0,
-            cols,
-            rows,
-            process: null,
-            unsubscribeData: null,
-            unsubscribeExit: null,
-            hasRunningSubprocess: false,
-            childCommandLabel: null,
-            runtimeEnv: normalizedRuntimeEnv(input.env),
-          };
-          const createdSession = session;
-          yield* modifyManagerState((state) => {
-            const sessions = new Map(state.sessions);
-            sessions.set(sessionKey, createdSession);
-            return [undefined, { ...state, sessions }] as const;
-          });
-          yield* evictInactiveSessionsIfNeeded();
-        } else {
-          session = existingSession.value;
-          yield* stopProcess(session);
-          session.cwd = input.cwd;
-          session.worktreePath = input.worktreePath ?? null;
-          session.runtimeEnv = normalizedRuntimeEnv(input.env);
-        }
+      const sessionKey = toSessionKey(input.threadId, terminalId);
+      const existing = yield* getSession(input.threadId, terminalId);
+      if (Option.isNone(existing)) {
+        yield* flushPersist(input.threadId, terminalId);
+        const history = yield* readHistory(input.threadId, terminalId);
+        const cols = input.cols ?? DEFAULT_OPEN_COLS;
+        const rows = input.rows ?? DEFAULT_OPEN_ROWS;
+        const session: TerminalSessionState = {
+          threadId: input.threadId,
+          terminalId,
+          cwd: input.cwd,
+          worktreePath: input.worktreePath ?? null,
+          status: "starting",
+          pid: null,
+          history,
+          pendingHistoryControlSequence: "",
+          pendingProcessEvents: [],
+          pendingProcessEventIndex: 0,
+          processEventDrainRunning: false,
+          exitCode: null,
+          exitSignal: null,
+          updatedAt: yield* nowIso,
+          eventSequence: 0,
+          cols,
+          rows,
+          process: null,
+          unsubscribeData: null,
+          unsubscribeExit: null,
+          hasRunningSubprocess: false,
+          childCommandLabel: null,
+          runtimeEnv: normalizedRuntimeEnv(input.env),
+        };
 
-        const cols = input.cols ?? session.cols;
-        const rows = input.rows ?? session.rows;
+        const createdSession = session;
+        yield* modifyManagerState((state) => {
+          const sessions = new Map(state.sessions);
+          sessions.set(sessionKey, createdSession);
+          return [undefined, { ...state, sessions }] as const;
+        });
 
-        session.history = "";
-        session.pendingHistoryControlSequence = "";
-        session.pendingProcessEvents = [];
-        session.pendingProcessEventIndex = 0;
-        session.processEventDrainRunning = false;
-        yield* persistHistory(input.threadId, terminalId, session.history);
+        yield* evictInactiveSessionsIfNeeded();
         yield* startSession(
           session,
           {
             threadId: input.threadId,
             terminalId,
             cwd: input.cwd,
-            ...(input.worktreePath !== undefined ? { worktreePath: input.worktreePath } : {}),
+            ...(input.worktreePath !== undefined
+              ? { worktreePath: input.worktreePath }
+              : {}),
             cols,
             rows,
             ...(input.env ? { env: input.env } : {}),
           },
-          "restarted",
+          "started",
         );
         return snapshot(session);
-      }),
-    );
+      }
 
-  const close: TerminalManager["Service"]["close"] = (input) =>
-    withThreadLock(
-      input.threadId,
-      Effect.gen(function* () {
-        if (input.terminalId) {
-          yield* closeSession(input.threadId, input.terminalId, input.deleteHistory === true);
-          return;
-        }
+      const liveSession = existing.value;
+      const nextRuntimeEnv = normalizedRuntimeEnv(input.env);
+      const currentRuntimeEnv = liveSession.runtimeEnv;
+      const targetCols = input.cols ?? liveSession.cols;
+      const targetRows = input.rows ?? liveSession.rows;
+      const runtimeEnvChanged = !Equal.equals(
+        currentRuntimeEnv,
+        nextRuntimeEnv,
+      );
+      const nextWorktreePath =
+        input.worktreePath !== undefined
+          ? (input.worktreePath ?? null)
+          : liveSession.worktreePath;
+      const launchContextChanged =
+        liveSession.cwd !== input.cwd ||
+        runtimeEnvChanged ||
+        liveSession.worktreePath !== nextWorktreePath;
 
-        const threadSessions = yield* sessionsForThread(input.threadId);
-        yield* Effect.forEach(
-          threadSessions,
-          (session) => closeSession(input.threadId, session.terminalId, false),
-          { discard: true },
+      if (launchContextChanged) {
+        yield* stopProcess(liveSession);
+        liveSession.cwd = input.cwd;
+        liveSession.worktreePath = nextWorktreePath;
+        liveSession.runtimeEnv = nextRuntimeEnv;
+        liveSession.history = "";
+        liveSession.pendingHistoryControlSequence = "";
+        liveSession.pendingProcessEvents = [];
+        liveSession.pendingProcessEventIndex = 0;
+        liveSession.processEventDrainRunning = false;
+        yield* persistHistory(
+          liveSession.threadId,
+          liveSession.terminalId,
+          liveSession.history,
         );
+      } else if (
+        liveSession.status === "exited" ||
+        liveSession.status === "error"
+      ) {
+        liveSession.runtimeEnv = nextRuntimeEnv;
+        liveSession.worktreePath = nextWorktreePath;
+        liveSession.history = "";
+        liveSession.pendingHistoryControlSequence = "";
+        liveSession.pendingProcessEvents = [];
+        liveSession.pendingProcessEventIndex = 0;
+        liveSession.processEventDrainRunning = false;
+        yield* persistHistory(
+          liveSession.threadId,
+          liveSession.terminalId,
+          liveSession.history,
+        );
+      }
 
-        if (input.deleteHistory) {
-          yield* deleteAllHistoryForThread(input.threadId);
+      if (!liveSession.process) {
+        yield* startSession(
+          liveSession,
+          {
+            threadId: input.threadId,
+            terminalId,
+            cwd: input.cwd,
+            worktreePath: liveSession.worktreePath,
+            cols: targetCols,
+            rows: targetRows,
+            ...(input.env ? { env: input.env } : {}),
+          },
+          "started",
+        );
+        return snapshot(liveSession);
+      }
+
+      if (liveSession.cols !== targetCols || liveSession.rows !== targetRows) {
+        yield* resizePtyProcess(
+          liveSession,
+          liveSession.process,
+          targetCols,
+          targetRows,
+        );
+        liveSession.cols = targetCols;
+        liveSession.rows = targetRows;
+        liveSession.updatedAt = yield* nowIso;
+      }
+
+      return snapshot(liveSession);
+    });
+
+    const open: TerminalManager["Service"]["open"] = (input) =>
+      withThreadLock(input.threadId, openLocked(input));
+
+    const openOrAttachForStream = (input: TerminalAttachInput) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          const terminalId = input.terminalId;
+          const existing = yield* getSession(input.threadId, terminalId);
+
+          if (Option.isNone(existing)) {
+            if (!input.cwd) {
+              return yield* new TerminalSessionLookupError({
+                threadId: input.threadId,
+                terminalId,
+              });
+            }
+
+            return yield* openLocked({
+              ...input,
+              terminalId,
+              cwd: input.cwd,
+            });
+          }
+
+          const session = existing.value;
+          const targetCols = input.cols ?? session.cols;
+          const targetRows = input.rows ?? session.rows;
+
+          if (
+            !session.process &&
+            input.cwd &&
+            input.restartIfNotRunning === true
+          ) {
+            return yield* openLocked({
+              ...input,
+              terminalId,
+              cwd: input.cwd,
+            });
+          }
+
+          if (
+            session.process &&
+            session.status === "running" &&
+            (session.cols !== targetCols || session.rows !== targetRows)
+          ) {
+            const process = session.process;
+            yield* resizePtyProcess(session, process, targetCols, targetRows);
+            session.cols = targetCols;
+            session.rows = targetRows;
+            session.updatedAt = yield* nowIso;
+          }
+
+          return snapshot(session);
+        }),
+      );
+
+    const readAllTerminalMetadata = () =>
+      readManagerState.pipe(
+        Effect.map((state) =>
+          [...state.sessions.values()]
+            .map(summary)
+            .sort(
+              (left, right) =>
+                right.updatedAt.localeCompare(left.updatedAt) ||
+                left.threadId.localeCompare(right.threadId) ||
+                left.terminalId.localeCompare(right.terminalId),
+            ),
+        ),
+      );
+
+    const readTerminalMetadata = (input: {
+      readonly threadId: string;
+      readonly terminalId: string;
+    }) =>
+      getSession(input.threadId, input.terminalId).pipe(
+        Effect.map((session) =>
+          Option.isSome(session) ? summary(session.value) : null,
+        ),
+      );
+
+    const subscribe: TerminalManager["Service"]["subscribe"] = (listener) =>
+      Effect.sync(() => {
+        terminalEventListeners.add(listener);
+        return () => {
+          terminalEventListeners.delete(listener);
+        };
+      });
+
+    const attachStream: TerminalManager["Service"]["attachStream"] = (
+      input,
+      listener,
+    ) => {
+      let unsubscribe: (() => void) | null = null;
+
+      return Effect.gen(function* () {
+        const bufferedEvents: TerminalEvent[] = [];
+        let deliverLive = false;
+
+        unsubscribe = yield* subscribe((event) => {
+          if (
+            event.threadId !== input.threadId ||
+            event.terminalId !== input.terminalId
+          ) {
+            return Effect.void;
+          }
+
+          if (!deliverLive) {
+            bufferedEvents.push(event);
+            return Effect.void;
+          }
+
+          const attachEvent = terminalEventToAttachEvent(event);
+          return attachEvent ? listener(attachEvent) : Effect.void;
+        });
+
+        const initialSnapshot = yield* openOrAttachForStream(input);
+
+        yield* listener({
+          type: "snapshot",
+          snapshot: initialSnapshot,
+        });
+
+        for (const event of bufferedEvents) {
+          if (isDuplicateAttachSnapshotEvent(event, initialSnapshot)) {
+            continue;
+          }
+
+          const attachEvent = terminalEventToAttachEvent(event);
+          if (attachEvent) {
+            yield* listener(attachEvent);
+          }
         }
-      }),
-    );
 
-  return TerminalManager.of({
-    open,
-    attachStream,
-    write,
-    resize,
-    clear,
-    restart,
-    close,
-    subscribe,
-    subscribeMetadata,
-  });
-});
+        deliverLive = true;
+        return () => {
+          unsubscribe?.();
+          unsubscribe = null;
+        };
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.flatMap(
+            Effect.sync(() => {
+              unsubscribe?.();
+              unsubscribe = null;
+            }),
+            () => Effect.failCause(cause),
+          ),
+        ),
+      );
+    };
 
-export const layer = Layer.effect(TerminalManager, make()).pipe(Layer.provide(ProcessRunner.layer));
+    const metadataEventFromTerminalEvent = (
+      event: TerminalEvent,
+    ): Effect.Effect<TerminalMetadataStreamEvent | null> => {
+      if (!shouldPublishTerminalMetadataEvent(event)) {
+        return Effect.succeed(null);
+      }
+
+      if (event.type === "closed") {
+        return Effect.succeed({
+          type: "remove" as const,
+          threadId: event.threadId,
+          terminalId: event.terminalId,
+        });
+      }
+
+      return readTerminalMetadata({
+        threadId: event.threadId,
+        terminalId: event.terminalId,
+      }).pipe(
+        Effect.map((terminal) =>
+          terminal
+            ? {
+                type: "upsert" as const,
+                terminal,
+              }
+            : null,
+        ),
+      );
+    };
+
+    const offerMetadataEvent = (
+      listener: (event: TerminalMetadataStreamEvent) => Effect.Effect<void>,
+      event: TerminalEvent,
+    ) =>
+      metadataEventFromTerminalEvent(event).pipe(
+        Effect.flatMap((metadataEvent) =>
+          metadataEvent ? listener(metadataEvent) : Effect.void,
+        ),
+      );
+
+    const subscribeMetadata: TerminalManager["Service"]["subscribeMetadata"] = (
+      listener,
+    ) => {
+      let unsubscribe: (() => void) | null = null;
+
+      return Effect.gen(function* () {
+        const bufferedEvents: TerminalEvent[] = [];
+        let deliverLive = false;
+
+        unsubscribe = yield* subscribe((event) => {
+          if (!deliverLive) {
+            bufferedEvents.push(event);
+            return Effect.void;
+          }
+
+          return offerMetadataEvent(listener, event);
+        });
+
+        const terminals = yield* readAllTerminalMetadata();
+        yield* listener({
+          type: "snapshot",
+          terminals,
+        });
+
+        for (const event of bufferedEvents) {
+          yield* offerMetadataEvent(listener, event);
+        }
+
+        deliverLive = true;
+        return () => {
+          unsubscribe?.();
+          unsubscribe = null;
+        };
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.flatMap(
+            Effect.sync(() => {
+              unsubscribe?.();
+              unsubscribe = null;
+            }),
+            () => Effect.failCause(cause),
+          ),
+        ),
+      );
+    };
+
+    const write: TerminalManager["Service"]["write"] = Effect.fn(
+      "terminal.write",
+    )(function* (input) {
+      const terminalId = input.terminalId;
+      const session = yield* requireSession(input.threadId, terminalId);
+      const process = session.process;
+      if (!process || session.status !== "running") {
+        if (session.status === "exited") return;
+        return yield* new TerminalNotRunningError({
+          threadId: input.threadId,
+          terminalId,
+        });
+      }
+      yield* Effect.try({
+        try: () => process.write(input.data),
+        catch: (cause) =>
+          new TerminalWriteError({
+            threadId: input.threadId,
+            terminalId,
+            terminalPid: process.pid,
+            cause,
+          }),
+      });
+    });
+
+    const resizeLocked = Effect.fn("terminal.resize")(function* (
+      input: TerminalResizeInput,
+    ) {
+      const session = yield* getSession(input.threadId, input.terminalId);
+      // ResizeObserver traffic can already be in flight when the UI closes the session.
+      if (Option.isNone(session)) {
+        return;
+      }
+      const process = session.value.process;
+      if (!process || session.value.status !== "running") {
+        return;
+      }
+      yield* resizePtyProcess(session.value, process, input.cols, input.rows);
+      session.value.cols = input.cols;
+      session.value.rows = input.rows;
+      session.value.updatedAt = yield* nowIso;
+    });
+
+    const resize: TerminalManager["Service"]["resize"] = (input) =>
+      withThreadLock(input.threadId, resizeLocked(input));
+
+    const clear: TerminalManager["Service"]["clear"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          const terminalId = input.terminalId;
+          const session = yield* requireSession(input.threadId, terminalId);
+          session.history = "";
+          session.pendingHistoryControlSequence = "";
+          session.pendingProcessEvents = [];
+          session.pendingProcessEventIndex = 0;
+          session.processEventDrainRunning = false;
+          const eventStamp = advanceEventSequence(session);
+          yield* persistHistory(input.threadId, terminalId, session.history);
+          yield* publishEvent({
+            type: "cleared",
+            threadId: input.threadId,
+            terminalId,
+            sequence: eventStamp.sequence,
+          });
+        }),
+      );
+
+    const restart: TerminalManager["Service"]["restart"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          yield* increment(terminalRestartsTotal, { scope: "thread" });
+          const terminalId = input.terminalId;
+          yield* assertValidCwd(input.cwd);
+
+          const sessionKey = toSessionKey(input.threadId, terminalId);
+          const existingSession = yield* getSession(input.threadId, terminalId);
+          let session: TerminalSessionState;
+          if (Option.isNone(existingSession)) {
+            const cols = input.cols ?? DEFAULT_OPEN_COLS;
+            const rows = input.rows ?? DEFAULT_OPEN_ROWS;
+            session = {
+              threadId: input.threadId,
+              terminalId,
+              cwd: input.cwd,
+              worktreePath: input.worktreePath ?? null,
+              status: "starting",
+              pid: null,
+              history: "",
+              pendingHistoryControlSequence: "",
+              pendingProcessEvents: [],
+              pendingProcessEventIndex: 0,
+              processEventDrainRunning: false,
+              exitCode: null,
+              exitSignal: null,
+              updatedAt: yield* nowIso,
+              eventSequence: 0,
+              cols,
+              rows,
+              process: null,
+              unsubscribeData: null,
+              unsubscribeExit: null,
+              hasRunningSubprocess: false,
+              childCommandLabel: null,
+              runtimeEnv: normalizedRuntimeEnv(input.env),
+            };
+            const createdSession = session;
+            yield* modifyManagerState((state) => {
+              const sessions = new Map(state.sessions);
+              sessions.set(sessionKey, createdSession);
+              return [undefined, { ...state, sessions }] as const;
+            });
+            yield* evictInactiveSessionsIfNeeded();
+          } else {
+            session = existingSession.value;
+            yield* stopProcess(session);
+            session.cwd = input.cwd;
+            session.worktreePath = input.worktreePath ?? null;
+            session.runtimeEnv = normalizedRuntimeEnv(input.env);
+          }
+
+          const cols = input.cols ?? session.cols;
+          const rows = input.rows ?? session.rows;
+
+          session.history = "";
+          session.pendingHistoryControlSequence = "";
+          session.pendingProcessEvents = [];
+          session.pendingProcessEventIndex = 0;
+          session.processEventDrainRunning = false;
+          yield* persistHistory(input.threadId, terminalId, session.history);
+          yield* startSession(
+            session,
+            {
+              threadId: input.threadId,
+              terminalId,
+              cwd: input.cwd,
+              ...(input.worktreePath !== undefined
+                ? { worktreePath: input.worktreePath }
+                : {}),
+              cols,
+              rows,
+              ...(input.env ? { env: input.env } : {}),
+            },
+            "restarted",
+          );
+          return snapshot(session);
+        }),
+      );
+
+    const close: TerminalManager["Service"]["close"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.terminalId) {
+            yield* closeSession(
+              input.threadId,
+              input.terminalId,
+              input.deleteHistory === true,
+            );
+            return;
+          }
+
+          const threadSessions = yield* sessionsForThread(input.threadId);
+          yield* Effect.forEach(
+            threadSessions,
+            (session) =>
+              closeSession(input.threadId, session.terminalId, false),
+            { discard: true },
+          );
+
+          if (input.deleteHistory) {
+            yield* deleteAllHistoryForThread(input.threadId);
+          }
+        }),
+      );
+
+    return TerminalManager.of({
+      open,
+      attachStream,
+      write,
+      resize,
+      clear,
+      restart,
+      close,
+      subscribe,
+      subscribeMetadata,
+    });
+  },
+);
+
+export const layer = Layer.effect(TerminalManager, make()).pipe(
+  Layer.provide(ProcessRunner.layer),
+);

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1,4 +1,10 @@
-import { ArchiveIcon, ArchiveX, ChevronRightIcon, LoaderIcon, SettingsIcon } from "lucide-react";
+import {
+  ArchiveIcon,
+  ArchiveX,
+  ChevronRightIcon,
+  LoaderIcon,
+  SettingsIcon,
+} from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { CSSProperties, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -38,7 +44,11 @@ import { createModelSelection } from "@t3tools/shared/model";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
 import * as Schema from "effect/Schema";
-import { APP_VERSION, HOSTED_APP_CHANNEL, HOSTED_APP_CHANNEL_LABEL } from "../../branding";
+import {
+  APP_VERSION,
+  HOSTED_APP_CHANNEL,
+  HOSTED_APP_CHANNEL_LABEL,
+} from "../../branding";
 import {
   canCheckForUpdate,
   getDesktopUpdateButtonTooltip,
@@ -53,7 +63,10 @@ import {
   useEnvironmentStageLabel,
 } from "../SidebarStageBackdrop";
 import { isElectron } from "../../env";
-import { buildHostedChannelSelectionUrl, type HostedAppChannel } from "../../hostedPairing";
+import {
+  buildHostedChannelSelectionUrl,
+  type HostedAppChannel,
+} from "../../hostedPairing";
 import { useCustomThemes } from "../../hooks/useCustomThemes";
 import {
   readAppearanceModePreference,
@@ -62,7 +75,10 @@ import {
   useTheme,
 } from "../../hooks/useTheme";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import {
+  usePrimarySettings,
+  useUpdatePrimarySettings,
+} from "../../hooks/useSettings";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -76,12 +92,19 @@ import {
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
 import { isMacPlatform } from "../../lib/utils";
-import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
+import {
+  primaryServerObservabilityAtom,
+  primaryServerProvidersAtom,
+} from "../../state/server";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel } from "../../timestampFormat";
 import { Button } from "../ui/button";
-import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
+import {
+  Collapsible,
+  CollapsiblePanel,
+  CollapsibleTrigger,
+} from "../ui/collapsible";
 import {
   Dialog,
   DialogDescription,
@@ -103,8 +126,16 @@ import {
   resolveTerminalFontSizePreference,
   TYPOGRAPHY_ADVANCED_STORAGE_KEY,
 } from "../../appearanceFonts";
-import { CodeFontPreview, PromptFontPreview, TerminalFontPreview } from "./SettingsFontPreviews";
-import { discoverInstalledFonts, FontFamilyPicker, useFontEnumeration } from "./FontFamilyPicker";
+import {
+  CodeFontPreview,
+  PromptFontPreview,
+  TerminalFontPreview,
+} from "./SettingsFontPreviews";
+import {
+  discoverInstalledFonts,
+  FontFamilyPicker,
+  useFontEnumeration,
+} from "./FontFamilyPicker";
 import {
   NumberField,
   NumberFieldDecrement,
@@ -112,7 +143,13 @@ import {
   NumberFieldIncrement,
   NumberFieldInput,
 } from "../ui/number-field";
-import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { Switch } from "../ui/switch";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -142,7 +179,10 @@ import {
 import { searchableSetting } from "./settingsSearch";
 import { ProjectFavicon } from "../ProjectFavicon";
 
-const ENVIRONMENT_IDENTIFICATION_LABELS: Record<EnvironmentIdentificationMode, string> = {
+const ENVIRONMENT_IDENTIFICATION_LABELS: Record<
+  EnvironmentIdentificationMode,
+  string
+> = {
   artwork: "Artwork",
   pill: "Version pill",
   none: "None",
@@ -154,7 +194,10 @@ const TIMESTAMP_FORMAT_LABELS = {
   "24-hour": "24-hour",
 } as const;
 
-const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<BackgroundActivityProfile, string> = {
+const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<
+  BackgroundActivityProfile,
+  string
+> = {
   balanced: "Balanced",
   performance: "Performance",
   "battery-saver": "Battery saver",
@@ -162,16 +205,24 @@ const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<BackgroundActivityProfile, stri
 
 type BackgroundActivityProfileOption = BackgroundActivityProfile | "advanced";
 
-const BACKGROUND_ACTIVITY_PROFILE_OPTION_LABELS: Record<BackgroundActivityProfileOption, string> = {
+const BACKGROUND_ACTIVITY_PROFILE_OPTION_LABELS: Record<
+  BackgroundActivityProfileOption,
+  string
+> = {
   ...BACKGROUND_ACTIVITY_PROFILE_LABELS,
   advanced: "Advanced",
 };
 
-const BACKGROUND_ACTIVITY_PROFILE_DESCRIPTIONS: Record<BackgroundActivityProfile, string> = {
+const BACKGROUND_ACTIVITY_PROFILE_DESCRIPTIONS: Record<
+  BackgroundActivityProfile,
+  string
+> = {
   balanced:
     "Pauses background probes when clients are idle, the host is locked, or low power mode is active.",
-  performance: "Allows scoped background probes while any subscribed client remains connected.",
-  "battery-saver": "Also pauses background probes when the host or client is on battery.",
+  performance:
+    "Allows scoped background probes while any subscribed client remains connected.",
+  "battery-saver":
+    "Also pauses background probes when the host or client is on battery.",
 };
 
 const ADVANCED_BACKGROUND_ACTIVITY_DESCRIPTION =
@@ -212,7 +263,9 @@ function AboutVersionTitle() {
   return (
     <span className="inline-flex items-center gap-2">
       <span>Version</span>
-      <code className="text-[11px] font-medium text-muted-foreground">{APP_VERSION}</code>
+      <code className="text-[11px] font-medium text-muted-foreground">
+        {APP_VERSION}
+      </code>
     </span>
   );
 }
@@ -222,7 +275,8 @@ function AboutVersionSection() {
   const [isChangingUpdateChannel, setIsChangingUpdateChannel] = useState(false);
   const [isUpdateActionPending, setIsUpdateActionPending] = useState(false);
 
-  const hasDesktopBridge = typeof window !== "undefined" && Boolean(window.desktopBridge);
+  const hasDesktopBridge =
+    typeof window !== "undefined" && Boolean(window.desktopBridge);
   const selectedUpdateChannel = updateState?.channel ?? "latest";
   const selectedHostedAppChannel = hasDesktopBridge ? null : HOSTED_APP_CHANNEL;
 
@@ -245,7 +299,10 @@ function AboutVersionSection() {
             stackedThreadToast({
               type: "error",
               title: "Could not change update track",
-              description: error instanceof Error ? error.message : "Update track change failed.",
+              description:
+                error instanceof Error
+                  ? error.message
+                  : "Update track change failed.",
             }),
           );
         })
@@ -260,7 +317,9 @@ function AboutVersionSection() {
     const bridge = window.desktopBridge;
     if (!bridge) return;
 
-    const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
+    const action = updateState
+      ? resolveDesktopUpdateButtonAction(updateState)
+      : "none";
 
     if (action === "download") {
       void bridge.downloadUpdate().catch((error: unknown) => {
@@ -268,7 +327,8 @@ function AboutVersionSection() {
           stackedThreadToast({
             type: "error",
             title: "Could not download update",
-            description: error instanceof Error ? error.message : "Download failed.",
+            description:
+              error instanceof Error ? error.message : "Download failed.",
           }),
         );
       });
@@ -292,7 +352,10 @@ function AboutVersionSection() {
           stackedThreadToast({
             type: "error",
             title: "Could not confirm update",
-            description: error instanceof Error ? error.message : "Update confirmation failed.",
+            description:
+              error instanceof Error
+                ? error.message
+                : "Update confirmation failed.",
           }),
         );
         return;
@@ -308,7 +371,8 @@ function AboutVersionSection() {
             stackedThreadToast({
               type: "error",
               title: "Could not install update",
-              description: error instanceof Error ? error.message : "Install failed.",
+              description:
+                error instanceof Error ? error.message : "Install failed.",
             }),
           );
         })
@@ -326,7 +390,8 @@ function AboutVersionSection() {
               type: "error",
               title: "Could not check for updates",
               description:
-                result.state.message ?? "Automatic updates are not available in this build.",
+                result.state.message ??
+                "Automatic updates are not available in this build.",
             }),
           );
         }
@@ -336,27 +401,37 @@ function AboutVersionSection() {
           stackedThreadToast({
             type: "error",
             title: "Could not check for updates",
-            description: error instanceof Error ? error.message : "Update check failed.",
+            description:
+              error instanceof Error ? error.message : "Update check failed.",
           }),
         );
       });
   }, [isUpdateActionPending, updateState]);
 
-  const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
-  const buttonTooltip = updateState ? getDesktopUpdateButtonTooltip(updateState) : null;
+  const action = updateState
+    ? resolveDesktopUpdateButtonAction(updateState)
+    : "none";
+  const buttonTooltip = updateState
+    ? getDesktopUpdateButtonTooltip(updateState)
+    : null;
   const buttonDisabled =
     action === "none"
       ? !canCheckForUpdate(updateState)
       : isDesktopUpdateButtonDisabled(updateState);
 
-  const actionLabel: Record<string, string> = { download: "Download", install: "Install" };
+  const actionLabel: Record<string, string> = {
+    download: "Download",
+    install: "Install",
+  };
   const statusLabel: Record<string, string> = {
     checking: "Checking…",
     downloading: "Downloading…",
     "up-to-date": "Up to Date",
   };
   const buttonLabel =
-    actionLabel[action] ?? statusLabel[updateState?.status ?? ""] ?? "Check for Updates";
+    actionLabel[action] ??
+    statusLabel[updateState?.status ?? ""] ??
+    "Check for Updates";
   const description =
     action === "download" || action === "install"
       ? "Update available."
@@ -381,7 +456,9 @@ function AboutVersionSection() {
                 </Button>
               }
             />
-            {buttonTooltip ? <TooltipPopup>{buttonTooltip}</TooltipPopup> : null}
+            {buttonTooltip ? (
+              <TooltipPopup>{buttonTooltip}</TooltipPopup>
+            ) : null}
           </Tooltip>
         }
       />
@@ -426,11 +503,16 @@ function AboutVersionSection() {
               onValueChange={(value) => {
                 if (value === selectedHostedAppChannel) return;
                 window.location.assign(
-                  buildHostedChannelSelectionUrl({ channel: value as HostedAppChannel }),
+                  buildHostedChannelSelectionUrl({
+                    channel: value as HostedAppChannel,
+                  }),
                 );
               }}
             >
-              <SelectTrigger className="w-full sm:w-40" aria-label="Update track">
+              <SelectTrigger
+                className="w-full sm:w-40"
+                aria-label="Update track"
+              >
                 <SelectValue>{HOSTED_APP_CHANNEL_LABEL}</SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
@@ -466,22 +548,30 @@ export function useSettingsRestore(onRestored?: () => void) {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
-  const isBackgroundActivityDirty = hasChangedBackgroundActivitySettings(settings);
+  const isBackgroundActivityDirty =
+    hasChangedBackgroundActivitySettings(settings);
 
   const changedSettingLabels = useMemo(
     () => [
       ...(theme !== "system" ? ["Theme"] : []),
       ...(!followSystem ? ["Follow system"] : []),
       ...(themeHalves !== null ? ["Theme mix"] : []),
-      ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? ["Glass opacity"] : []),
+      ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity
+        ? ["Glass opacity"]
+        : []),
       ...(settings.environmentIdentificationMode !==
       DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode
         ? ["Environment identification"]
         : []),
+      ...(settings.windowsTerminalShell !==
+      DEFAULT_UNIFIED_SETTINGS.windowsTerminalShell
+        ? ["Terminal shell"]
+        : []),
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
-      ...(settings.sidebarThreadPreviewCount !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount
+      ...(settings.sidebarThreadPreviewCount !==
+      DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount
         ? ["Visible threads"]
         : []),
       ...(settings.sidebarProjectGroupingMode !==
@@ -492,18 +582,25 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays
         ? ["Auto-settle inactive threads"]
         : []),
-      ...(settings.wordWrap !== DEFAULT_UNIFIED_SETTINGS.wordWrap ? ["Word wrap"] : []),
+      ...(settings.wordWrap !== DEFAULT_UNIFIED_SETTINGS.wordWrap
+        ? ["Word wrap"]
+        : []),
       ...(settings.fontFamilySans !== DEFAULT_UNIFIED_SETTINGS.fontFamilySans
         ? ["Interface font"]
         : []),
-      ...(settings.fontFamilyComposer !== DEFAULT_UNIFIED_SETTINGS.fontFamilyComposer
+      ...(settings.fontFamilyComposer !==
+      DEFAULT_UNIFIED_SETTINGS.fontFamilyComposer
         ? ["Prompt font"]
         : []),
-      ...(settings.fontFamilyCode !== DEFAULT_UNIFIED_SETTINGS.fontFamilyCode ? ["Code font"] : []),
-      ...(settings.fontFamilyTerminal !== DEFAULT_UNIFIED_SETTINGS.fontFamilyTerminal
+      ...(settings.fontFamilyCode !== DEFAULT_UNIFIED_SETTINGS.fontFamilyCode
+        ? ["Code font"]
+        : []),
+      ...(settings.fontFamilyTerminal !==
+      DEFAULT_UNIFIED_SETTINGS.fontFamilyTerminal
         ? ["Terminal font"]
         : []),
-      ...(settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace
+      ...(settings.diffIgnoreWhitespace !==
+      DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace
         ? ["Diff whitespace changes"]
         : []),
       ...(settings.enableLegacyTokenStreaming !==
@@ -515,20 +612,24 @@ export function useSettingsRestore(onRestored?: () => void) {
         ? ["Provider update checks"]
         : []),
       ...(isBackgroundActivityDirty ? ["Background activity"] : []),
-      ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
+      ...(settings.defaultThreadEnvMode !==
+      DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
         ? ["New thread mode"]
         : []),
       ...(settings.newWorktreesStartFromOrigin !==
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
-      ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
+      ...(settings.addProjectBaseDirectory !==
+      DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
-      ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
+      ...(settings.confirmThreadArchive !==
+      DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
         ? ["Archive confirmation"]
         : []),
-      ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
+      ...(settings.confirmThreadDelete !==
+      DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
       ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
@@ -569,9 +670,10 @@ export function useSettingsRestore(onRestored?: () => void) {
     if (changedSettingLabels.length === 0) return;
     const api = readLocalApi();
     const confirmed = await (api ?? ensureLocalApi()).dialogs.confirm(
-      ["Restore default settings?", `This will reset: ${changedSettingLabels.join(", ")}.`].join(
-        "\n",
-      ),
+      [
+        "Restore default settings?",
+        `This will reset: ${changedSettingLabels.join(", ")}.`,
+      ].join("\n"),
       { variant: "destructive" },
     );
     if (!confirmed) return;
@@ -594,7 +696,8 @@ export function useSettingsRestore(onRestored?: () => void) {
     const needsMixReset = liveHalves !== null;
     // Same for the appearance mode: trusting the render-time value would skip
     // the reset and report success while a non-system mode stayed in storage.
-    const needsFollowSystemReset = readAppearanceModePreference(previousTheme) !== "system";
+    const needsFollowSystemReset =
+      readAppearanceModePreference(previousTheme) !== "system";
     const notifyThemeRestoreFailure = () => {
       toastManager.add(
         stackedThreadToast({
@@ -630,24 +733,36 @@ export function useSettingsRestore(onRestored?: () => void) {
     updateSettings({
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
+      windowsTerminalShell: DEFAULT_UNIFIED_SETTINGS.windowsTerminalShell,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
-      environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
+      environmentIdentificationMode:
+        DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
-      sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
-      sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
-      sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
-      enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
-      enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+      sidebarThreadPreviewCount:
+        DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+      sidebarProjectGroupingMode:
+        DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
+      sidebarAutoSettleAfterDays:
+        DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
+      enableLegacyTokenStreaming:
+        DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
+      enableProviderUpdateChecks:
+        DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
       backgroundActivity: DEFAULT_UNIFIED_SETTINGS.backgroundActivity,
-      backgroundActivityProfile: DEFAULT_UNIFIED_SETTINGS.backgroundActivityProfile,
-      automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
-      providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
+      backgroundActivityProfile:
+        DEFAULT_UNIFIED_SETTINGS.backgroundActivityProfile,
+      automaticGitFetchInterval:
+        DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
+      providerHealthRefreshInterval:
+        DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
-      newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      newWorktreesStartFromOrigin:
+        DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
-      textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+      textGenerationModelSelection:
+        DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
       fontFamilySans: DEFAULT_UNIFIED_SETTINGS.fontFamilySans,
       fontFamilyComposer: DEFAULT_UNIFIED_SETTINGS.fontFamilyComposer,
       fontFamilyCode: DEFAULT_UNIFIED_SETTINGS.fontFamilyCode,
@@ -681,7 +796,8 @@ function BackgroundActivityAdvancedDialog({
 }) {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
-  const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
+  const resolvedBackgroundActivity =
+    resolveServerBackgroundActivitySettings(settings);
   const activeProfile = resolvedBackgroundActivity.profile;
   const automaticGitFetchIntervalSeconds = durationToSeconds(
     resolvedBackgroundActivity.automaticGitFetchInterval,
@@ -702,7 +818,8 @@ function BackgroundActivityAdvancedDialog({
         <DialogHeader>
           <DialogTitle>Background Activity</DialogTitle>
           <DialogDescription>
-            Tune the shared power policy and the background intervals that feed it.
+            Tune the shared power policy and the background intervals that feed
+            it.
           </DialogDescription>
         </DialogHeader>
         <DialogPanel className="space-y-0 px-6 pb-5">
@@ -711,7 +828,8 @@ function BackgroundActivityAdvancedDialog({
               <div className="min-w-0 space-y-1">
                 <div className="text-sm font-medium">Shared policy</div>
                 <p className="text-xs leading-relaxed text-muted-foreground">
-                  Controls whether background work may run after a subscribed interval fires.
+                  Controls whether background work may run after a subscribed
+                  interval fires.
                 </p>
               </div>
               <Select
@@ -723,13 +841,19 @@ function BackgroundActivityAdvancedDialog({
                     value === "battery-saver"
                   ) {
                     updateSettings({
-                      backgroundActivity: backgroundActivitySharedPolicySettings(settings, value),
+                      backgroundActivity:
+                        backgroundActivitySharedPolicySettings(settings, value),
                     });
                   }
                 }}
               >
-                <SelectTrigger className="w-full sm:w-40" aria-label="Shared background policy">
-                  <SelectValue>{BACKGROUND_ACTIVITY_PROFILE_LABELS[activeProfile]}</SelectValue>
+                <SelectTrigger
+                  className="w-full sm:w-40"
+                  aria-label="Shared background policy"
+                >
+                  <SelectValue>
+                    {BACKGROUND_ACTIVITY_PROFILE_LABELS[activeProfile]}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
                   <SelectItem hideIndicator value="balanced">
@@ -785,9 +909,12 @@ function BackgroundActivityAdvancedDialog({
 
             <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="min-w-0 space-y-1">
-                <div className="text-sm font-medium">Provider health interval</div>
+                <div className="text-sm font-medium">
+                  Provider health interval
+                </div>
                 <p className="text-xs leading-relaxed text-muted-foreground">
-                  Refresh provider availability, versions, auth state, and model metadata.
+                  Refresh provider availability, versions, auth state, and model
+                  metadata.
                 </p>
               </div>
               <div className="flex shrink-0 items-center gap-2">
@@ -957,7 +1084,8 @@ export function AppearanceSettingsPanel() {
   const showEnvironmentIdentification =
     resolveEnvironmentIdentificationPillLabel(environmentStageLabel) !== null;
   const glassOpacityRatio =
-    (settings.glassOpacity - MIN_GLASS_OPACITY) / (MAX_GLASS_OPACITY - MIN_GLASS_OPACITY);
+    (settings.glassOpacity - MIN_GLASS_OPACITY) /
+    (MAX_GLASS_OPACITY - MIN_GLASS_OPACITY);
   const glassOpacitySliderStyle = {
     "--settings-slider-progress": `${glassOpacityRatio * 100}%`,
     "--settings-slider-fill-offset": `${0.5 - glassOpacityRatio}rem`,
@@ -990,7 +1118,9 @@ export function AppearanceSettingsPanel() {
               <SettingResetButton
                 label="glass opacity"
                 onClick={() =>
-                  updateSettings({ glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity })
+                  updateSettings({
+                    glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
+                  })
                 }
               />
             ) : null
@@ -1033,12 +1163,14 @@ export function AppearanceSettingsPanel() {
             {...searchableSetting("environment-identification")}
             description="Choose how Dev and Nightly environments are identified."
             resetAction={
-              settings.environmentIdentificationMode !== DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE ? (
+              settings.environmentIdentificationMode !==
+              DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE ? (
                 <SettingResetButton
                   label="environment identification"
                   onClick={() =>
                     updateSettings({
-                      environmentIdentificationMode: DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE,
+                      environmentIdentificationMode:
+                        DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE,
                     })
                   }
                 />
@@ -1048,22 +1180,35 @@ export function AppearanceSettingsPanel() {
               <Select
                 value={settings.environmentIdentificationMode}
                 onValueChange={(value) => {
-                  if (value === "artwork" || value === "pill" || value === "none") {
+                  if (
+                    value === "artwork" ||
+                    value === "pill" ||
+                    value === "none"
+                  ) {
                     updateSettings({ environmentIdentificationMode: value });
                   }
                 }}
               >
-                <SelectTrigger className="w-full sm:w-40" aria-label="Environment identification">
+                <SelectTrigger
+                  className="w-full sm:w-40"
+                  aria-label="Environment identification"
+                >
                   <SelectValue>
-                    {ENVIRONMENT_IDENTIFICATION_LABELS[settings.environmentIdentificationMode]}
+                    {
+                      ENVIRONMENT_IDENTIFICATION_LABELS[
+                        settings.environmentIdentificationMode
+                      ]
+                    }
                   </SelectValue>
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
-                  {Object.entries(ENVIRONMENT_IDENTIFICATION_LABELS).map(([value, label]) => (
-                    <SelectItem hideIndicator key={value} value={value}>
-                      {label}
-                    </SelectItem>
-                  ))}
+                  {Object.entries(ENVIRONMENT_IDENTIFICATION_LABELS).map(
+                    ([value, label]) => (
+                      <SelectItem hideIndicator key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ),
+                  )}
                 </SelectPopup>
               </Select>
             }
@@ -1083,8 +1228,11 @@ function useFontDefaultFamilies() {
   // hardcoded.
   const defaults = useMemo(
     () => ({
-      sans: resolveDefaultFamilyLabel(DEFAULT_SANS_FONT_STACK) ?? "System default",
-      code: resolveDefaultFamilyLabel(DEFAULT_CODE_FONT_STACK) ?? "System monospace",
+      sans:
+        resolveDefaultFamilyLabel(DEFAULT_SANS_FONT_STACK) ?? "System default",
+      code:
+        resolveDefaultFamilyLabel(DEFAULT_CODE_FONT_STACK) ??
+        "System monospace",
     }),
     [],
   );
@@ -1129,7 +1277,9 @@ function PromptFontRow() {
       description="Only the box you write prompts in. Mono works well here."
       defaultFamily={defaults.interfaceFamily}
       value={settings.fontFamilyComposer}
-      onValueChange={(fontFamilyComposer) => updateSettings({ fontFamilyComposer })}
+      onValueChange={(fontFamilyComposer) =>
+        updateSettings({ fontFamilyComposer })
+      }
       size={{
         label: "Prompt font size",
         min: MIN_PROMPT_FONT_SIZE,
@@ -1185,7 +1335,9 @@ function TerminalFontRow() {
       description="Terminal output, independent from code blocks and diffs."
       defaultFamily={defaults.code}
       value={settings.fontFamilyTerminal}
-      onValueChange={(fontFamilyTerminal) => updateSettings({ fontFamilyTerminal })}
+      onValueChange={(fontFamilyTerminal) =>
+        updateSettings({ fontFamilyTerminal })
+      }
       requireMonospace
       size={{
         label: "Terminal font size",
@@ -1221,7 +1373,9 @@ function FontSmoothingRow() {
           <SettingResetButton
             label="font smoothing"
             onClick={() =>
-              updateSettings({ fontSmoothing: DEFAULT_UNIFIED_SETTINGS.fontSmoothing })
+              updateSettings({
+                fontSmoothing: DEFAULT_UNIFIED_SETTINGS.fontSmoothing,
+              })
             }
           />
         ) : null
@@ -1229,7 +1383,9 @@ function FontSmoothingRow() {
       control={
         <Switch
           checked={settings.fontSmoothing}
-          onCheckedChange={(checked) => updateSettings({ fontSmoothing: Boolean(checked) })}
+          onCheckedChange={(checked) =>
+            updateSettings({ fontSmoothing: Boolean(checked) })
+          }
           aria-label="Font smoothing"
         />
       }
@@ -1248,14 +1404,18 @@ function WordWrapRow() {
         settings.wordWrap !== DEFAULT_UNIFIED_SETTINGS.wordWrap ? (
           <SettingResetButton
             label="word wrapping"
-            onClick={() => updateSettings({ wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap })}
+            onClick={() =>
+              updateSettings({ wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap })
+            }
           />
         ) : null
       }
       control={
         <Switch
           checked={settings.wordWrap}
-          onCheckedChange={(checked) => updateSettings({ wordWrap: Boolean(checked) })}
+          onCheckedChange={(checked) =>
+            updateSettings({ wordWrap: Boolean(checked) })
+          }
           aria-label="Wrap code, tables, diffs, and file previews by default"
         />
       }
@@ -1339,7 +1499,11 @@ function TypographySection() {
   // the still-set target immediately re-expanding the section.
   const lastExpandedTargetRef = useRef<string | null>(null);
   useEffect(() => {
-    if (searchTargetId === null || !ADVANCED_TYPOGRAPHY_TARGET_IDS.has(searchTargetId)) return;
+    if (
+      searchTargetId === null ||
+      !ADVANCED_TYPOGRAPHY_TARGET_IDS.has(searchTargetId)
+    )
+      return;
     if (lastExpandedTargetRef.current === searchTargetId) return;
     lastExpandedTargetRef.current = searchTargetId;
     setAdvanced(true);
@@ -1384,7 +1548,13 @@ function FontFamilySettingsRow({
   value: string;
   onValueChange: (value: string) => void;
   requireMonospace?: boolean;
-  size: { label: string; min: number; max: number; value: number; onChange: (v: number) => void };
+  size: {
+    label: string;
+    min: number;
+    max: number;
+    value: number;
+    onChange: (v: number) => void;
+  };
 }) {
   const trimmed = value.trim();
   // The fallback input edits a draft; the preference only commits once typing
@@ -1407,12 +1577,14 @@ function FontFamilySettingsRow({
   }
   useEffect(
     () => () => {
-      if (commitTimerRef.current !== null) window.clearTimeout(commitTimerRef.current);
+      if (commitTimerRef.current !== null)
+        window.clearTimeout(commitTimerRef.current);
     },
     [],
   );
   const acceptsFamily = (candidate: string) =>
-    isFontFamilyAvailable(candidate) && (!requireMonospace || isMonospaceFamily(candidate));
+    isFontFamilyAvailable(candidate) &&
+    (!requireMonospace || isMonospaceFamily(candidate));
   const commitDraft = (next: string) => {
     setDraftSettled(true);
     // A rejected name stays in the field, flagged: the terminal would silently
@@ -1430,7 +1602,8 @@ function FontFamilySettingsRow({
   const draftTrimmed = draft.trim();
   // Flag an unknown name only once typing pauses, and never for an empty
   // field - that is the starting state, not a rejected entry.
-  const draftPending = draftSettled && draftTrimmed.length > 0 && draftTrimmed !== trimmed;
+  const draftPending =
+    draftSettled && draftTrimmed.length > 0 && draftTrimmed !== trimmed;
   const resetAction =
     trimmed.length > 0 ? (
       <SettingResetButton
@@ -1510,7 +1683,11 @@ function FontFamilySettingsRow({
         onValueChange={(next) => {
           if (typeof next !== "string") return;
           const parsed = Number(next);
-          if (Number.isInteger(parsed) && parsed >= size.min && parsed <= size.max) {
+          if (
+            Number.isInteger(parsed) &&
+            parsed >= size.min &&
+            parsed <= size.max
+          ) {
             size.onChange(parsed);
           }
         }}
@@ -1519,13 +1696,14 @@ function FontFamilySettingsRow({
           <SelectValue>{size.value} px</SelectValue>
         </SelectTrigger>
         <SelectPopup align="end" alignItemWithTrigger={false}>
-          {Array.from({ length: size.max - size.min + 1 }, (_, index) => size.min + index).map(
-            (px) => (
-              <SelectItem hideIndicator key={px} value={String(px)}>
-                {px} px
-              </SelectItem>
-            ),
-          )}
+          {Array.from(
+            { length: size.max - size.min + 1 },
+            (_, index) => size.min + index,
+          ).map((px) => (
+            <SelectItem hideIndicator key={px} value={String(px)}>
+              {px} px
+            </SelectItem>
+          ))}
         </SelectPopup>
       </Select>
     </div>
@@ -1543,7 +1721,8 @@ function FontFamilySettingsRow({
   );
 }
 
-const AUTO_SETTLE_DEFAULT_DAYS = DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays ?? 3;
+const AUTO_SETTLE_DEFAULT_DAYS =
+  DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays ?? 3;
 
 function AutoSettleDaysInput({
   value,
@@ -1657,13 +1836,16 @@ function LegacyFeaturesSection() {
                     }
                     void (async () => {
                       const api = readLocalApi();
-                      const confirmed = await (api ?? ensureLocalApi()).dialogs.confirm(
+                      const confirmed = await (
+                        api ?? ensureLocalApi()
+                      ).dialogs.confirm(
                         [
                           "Turn on token-by-token output?",
                           "It is significantly slower than the default buffered output and hurts the reading experience. This switch exists only for backwards compatibility.",
                         ].join("\n"),
                       );
-                      if (confirmed) updateSettings({ enableLegacyTokenStreaming: true });
+                      if (confirmed)
+                        updateSettings({ enableLegacyTokenStreaming: true });
                     })();
                   }}
                   aria-label="Stream token by token (legacy)"
@@ -1689,11 +1871,77 @@ function LegacyFeaturesSection() {
     </section>
   );
 }
+const TERMINAL_SHELL_OPTIONS = [
+  { value: "", label: "Default" },
+  { value: "pwsh.exe", label: "PowerShell" },
+  { value: "powershell.exe", label: "Windows PowerShell" },
+  { value: "cmd.exe", label: "Command Prompt" },
+  { value: "bash.exe", label: "Git Bash" },
+  { value: "wsl.exe", label: "WSL" },
+];
+
+function WindowsTerminalShellRow() {
+  const settings = usePrimarySettings();
+  const updateSettings = useUpdatePrimarySettings();
+
+  if (
+    typeof navigator !== "undefined" &&
+    !isWindowsPlatform(navigator.platform)
+  ) {
+    return null;
+  }
+
+  return (
+    <SettingsRow
+      {...searchableSetting("windows-terminal-shell")}
+      title="Terminal shell"
+      description="Select the default shell for the integrated terminal on Windows."
+      resetAction={
+        settings.windowsTerminalShell !==
+        DEFAULT_UNIFIED_SETTINGS.windowsTerminalShell ? (
+          <SettingResetButton
+            label="terminal shell"
+            onClick={() =>
+              updateSettings({
+                windowsTerminalShell:
+                  DEFAULT_UNIFIED_SETTINGS.windowsTerminalShell,
+              })
+            }
+          />
+        ) : null
+      }
+      control={
+        <Select
+          value={settings.windowsTerminalShell || ""}
+          onValueChange={(value) =>
+            updateSettings({ windowsTerminalShell: value })
+          }
+        >
+          <SelectTrigger className="w-full sm:w-48" aria-label="Terminal shell">
+            <SelectValue>
+              {TERMINAL_SHELL_OPTIONS.find(
+                (opt) => opt.value === (settings.windowsTerminalShell || ""),
+              )?.label ?? "Default"}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectPopup align="end" alignItemWithTrigger={false}>
+            {TERMINAL_SHELL_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} hideIndicator value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectPopup>
+        </Select>
+      }
+    />
+  );
+}
 
 export function GeneralSettingsPanel() {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
-  const [backgroundActivityDialogOpen, setBackgroundActivityDialogOpen] = useState(false);
+  const [backgroundActivityDialogOpen, setBackgroundActivityDialogOpen] =
+    useState(false);
   const lastEnabledProjectGroupingMode = useRef<SidebarProjectGroupingMode>(
     readLastEnabledProjectGroupingMode(),
   );
@@ -1707,12 +1955,18 @@ export function GeneralSettingsPanel() {
     otlpMetricsUrl: observability?.otlpMetricsUrl,
   });
 
-  const textGenerationModelSelection = resolveAppModelSelectionState(settings, serverProviders);
+  const textGenerationModelSelection = resolveAppModelSelectionState(
+    settings,
+    serverProviders,
+  );
   const textGenInstanceId = textGenerationModelSelection.instanceId;
   const textGenModel = textGenerationModelSelection.model;
   const textGenModelOptions = textGenerationModelSelection.options;
   const textGenerationModelInstanceEntries = sortProviderInstanceEntries(
-    applyProviderInstanceSettings(deriveProviderInstanceEntries(serverProviders), settings),
+    applyProviderInstanceSettings(
+      deriveProviderInstanceEntries(serverProviders),
+      settings,
+    ),
   );
   const textGenInstanceEntry = textGenerationModelInstanceEntries.find(
     (entry) => entry.instanceId === textGenInstanceId,
@@ -1729,15 +1983,19 @@ export function GeneralSettingsPanel() {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
-  const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
+  const resolvedBackgroundActivity =
+    resolveServerBackgroundActivitySettings(settings);
   const activeBackgroundActivityProfile = resolvedBackgroundActivity.profile;
-  const backgroundActivityProfileOption = resolveBackgroundActivityProfileOption(settings);
+  const backgroundActivityProfileOption =
+    resolveBackgroundActivityProfileOption(settings);
   const backgroundActivityDescription =
     backgroundActivityProfileOption === "advanced"
       ? `${ADVANCED_BACKGROUND_ACTIVITY_DESCRIPTION} Current shared policy: ${
           BACKGROUND_ACTIVITY_PROFILE_LABELS[activeBackgroundActivityProfile]
         }.`
-      : BACKGROUND_ACTIVITY_PROFILE_DESCRIPTIONS[resolvedBackgroundActivity.profile];
+      : BACKGROUND_ACTIVITY_PROFILE_DESCRIPTIONS[
+          resolvedBackgroundActivity.profile
+        ];
   const canResetBackgroundActivity = !Equal.equals(
     settings.backgroundActivity,
     DEFAULT_UNIFIED_SETTINGS.backgroundActivity,
@@ -1756,7 +2014,8 @@ export function GeneralSettingsPanel() {
                 label="project grouping"
                 onClick={() =>
                   updateSettings({
-                    sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
+                    sidebarProjectGroupingMode:
+                      DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
                   })
                 }
               />
@@ -1764,11 +2023,19 @@ export function GeneralSettingsPanel() {
           }
           control={
             <Switch
-              checked={isProjectGroupingEnabled(settings.sidebarProjectGroupingMode)}
+              checked={isProjectGroupingEnabled(
+                settings.sidebarProjectGroupingMode,
+              )}
               onCheckedChange={(checked) => {
-                if (!checked && settings.sidebarProjectGroupingMode !== "separate") {
-                  lastEnabledProjectGroupingMode.current = settings.sidebarProjectGroupingMode;
-                  rememberEnabledProjectGroupingMode(settings.sidebarProjectGroupingMode);
+                if (
+                  !checked &&
+                  settings.sidebarProjectGroupingMode !== "separate"
+                ) {
+                  lastEnabledProjectGroupingMode.current =
+                    settings.sidebarProjectGroupingMode;
+                  rememberEnabledProjectGroupingMode(
+                    settings.sidebarProjectGroupingMode,
+                  );
                 }
                 updateSettings({
                   sidebarProjectGroupingMode: projectGroupingModeFromToggle(
@@ -1792,7 +2059,8 @@ export function GeneralSettingsPanel() {
                 label="auto-settle"
                 onClick={() =>
                   updateSettings({
-                    sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
+                    sidebarAutoSettleAfterDays:
+                      DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
                   })
                 }
               />
@@ -1803,7 +2071,9 @@ export function GeneralSettingsPanel() {
               checked={settings.sidebarAutoSettleAfterDays !== null}
               onCheckedChange={(checked) =>
                 updateSettings({
-                  sidebarAutoSettleAfterDays: checked ? AUTO_SETTLE_DEFAULT_DAYS : null,
+                  sidebarAutoSettleAfterDays: checked
+                    ? AUTO_SETTLE_DEFAULT_DAYS
+                    : null,
                 })
               }
               aria-label="Auto-settle inactive threads"
@@ -1817,17 +2087,21 @@ export function GeneralSettingsPanel() {
             control={
               <AutoSettleDaysInput
                 value={settings.sidebarAutoSettleAfterDays}
-                onCommit={(days) => updateSettings({ sidebarAutoSettleAfterDays: days })}
+                onCommit={(days) =>
+                  updateSettings({ sidebarAutoSettleAfterDays: days })
+                }
               />
             }
           />
         ) : null}
 
+        <WindowsTerminalShellRow />
         <SettingsRow
           {...searchableSetting("time-format")}
           description="System default follows your browser or OS clock preference."
           resetAction={
-            settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat ? (
+            settings.timestampFormat !==
+            DEFAULT_UNIFIED_SETTINGS.timestampFormat ? (
               <SettingResetButton
                 label="time format"
                 onClick={() =>
@@ -1842,13 +2116,22 @@ export function GeneralSettingsPanel() {
             <Select
               value={settings.timestampFormat}
               onValueChange={(value) => {
-                if (value === "locale" || value === "12-hour" || value === "24-hour") {
+                if (
+                  value === "locale" ||
+                  value === "12-hour" ||
+                  value === "24-hour"
+                ) {
                   updateSettings({ timestampFormat: value });
                 }
               }}
             >
-              <SelectTrigger className="w-full sm:w-40" aria-label="Timestamp format">
-                <SelectValue>{TIMESTAMP_FORMAT_LABELS[settings.timestampFormat]}</SelectValue>
+              <SelectTrigger
+                className="w-full sm:w-40"
+                aria-label="Timestamp format"
+              >
+                <SelectValue>
+                  {TIMESTAMP_FORMAT_LABELS[settings.timestampFormat]}
+                </SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
                 <SelectItem hideIndicator value="locale">
@@ -1869,12 +2152,14 @@ export function GeneralSettingsPanel() {
           {...searchableSetting("hide-whitespace-changes")}
           description="Set whether the diff panel ignores whitespace-only edits by default."
           resetAction={
-            settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace ? (
+            settings.diffIgnoreWhitespace !==
+            DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace ? (
               <SettingResetButton
                 label="diff whitespace changes"
                 onClick={() =>
                   updateSettings({
-                    diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+                    diffIgnoreWhitespace:
+                      DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
                   })
                 }
               />
@@ -1901,7 +2186,8 @@ export function GeneralSettingsPanel() {
                 label="provider update checks"
                 onClick={() =>
                   updateSettings({
-                    enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+                    enableProviderUpdateChecks:
+                      DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
                   })
                 }
               />
@@ -1923,8 +2209,9 @@ export function GeneralSettingsPanel() {
             <span className="inline-flex items-center gap-1.5">
               Background activity
               <PolicyTooltip>
-                This shared policy gates background work such as Git refreshes and provider health
-                probes after their individual intervals elapse.
+                This shared policy gates background work such as Git refreshes
+                and provider health probes after their individual intervals
+                elapse.
               </PolicyTooltip>
             </span>
           }
@@ -1933,7 +2220,9 @@ export function GeneralSettingsPanel() {
             canResetBackgroundActivity ? (
               <SettingResetButton
                 label="background activity"
-                onClick={() => updateSettings(resetBackgroundActivitySettings())}
+                onClick={() =>
+                  updateSettings(resetBackgroundActivitySettings())
+                }
               />
             ) : null
           }
@@ -1955,9 +2244,16 @@ export function GeneralSettingsPanel() {
                   }
                 }}
               >
-                <SelectTrigger className="w-full sm:w-40" aria-label="Background activity profile">
+                <SelectTrigger
+                  className="w-full sm:w-40"
+                  aria-label="Background activity profile"
+                >
                   <SelectValue>
-                    {BACKGROUND_ACTIVITY_PROFILE_OPTION_LABELS[backgroundActivityProfileOption]}
+                    {
+                      BACKGROUND_ACTIVITY_PROFILE_OPTION_LABELS[
+                        backgroundActivityProfileOption
+                      ]
+                    }
                   </SelectValue>
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
@@ -1989,7 +2285,9 @@ export function GeneralSettingsPanel() {
                       </Button>
                     }
                   />
-                  <TooltipPopup side="top">Configure background activity</TooltipPopup>
+                  <TooltipPopup side="top">
+                    Configure background activity
+                  </TooltipPopup>
                 </Tooltip>
               ) : null}
               <BackgroundActivityAdvancedDialog
@@ -2004,14 +2302,16 @@ export function GeneralSettingsPanel() {
           {...searchableSetting("new-threads")}
           description="Pick the default workspace mode for newly created draft threads."
           resetAction={
-            settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||
+            settings.defaultThreadEnvMode !==
+              DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||
             settings.newWorktreesStartFromOrigin !==
               DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
               <SettingResetButton
                 label="new threads"
                 onClick={() =>
                   updateSettings({
-                    defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+                    defaultThreadEnvMode:
+                      DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
                     newWorktreesStartFromOrigin:
                       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
                   })
@@ -2028,9 +2328,14 @@ export function GeneralSettingsPanel() {
                 }
               }}
             >
-              <SelectTrigger className="w-full sm:w-44" aria-label="Default thread mode">
+              <SelectTrigger
+                className="w-full sm:w-44"
+                aria-label="Default thread mode"
+              >
                 <SelectValue>
-                  {settings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Local"}
+                  {settings.defaultThreadEnvMode === "worktree"
+                    ? "New worktree"
+                    : "Local"}
                 </SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
@@ -2068,7 +2373,9 @@ export function GeneralSettingsPanel() {
               <Switch
                 checked={settings.newWorktreesStartFromOrigin}
                 onCheckedChange={(checked) =>
-                  updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
+                  updateSettings({
+                    newWorktreesStartFromOrigin: Boolean(checked),
+                  })
                 }
                 aria-label="Start new worktrees from origin by default"
               />
@@ -2086,7 +2393,8 @@ export function GeneralSettingsPanel() {
                 label="add project base directory"
                 onClick={() =>
                   updateSettings({
-                    addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+                    addProjectBaseDirectory:
+                      DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
                   })
                 }
               />
@@ -2096,7 +2404,9 @@ export function GeneralSettingsPanel() {
             <DraftInput
               className="w-full sm:w-72"
               value={settings.addProjectBaseDirectory}
-              onCommit={(next) => updateSettings({ addProjectBaseDirectory: next })}
+              onCommit={(next) =>
+                updateSettings({ addProjectBaseDirectory: next })
+              }
               placeholder="~/"
               spellCheck={false}
               aria-label="Add project base directory"
@@ -2108,12 +2418,14 @@ export function GeneralSettingsPanel() {
           {...searchableSetting("archive-confirmation")}
           description="Require a second click on the inline archive action before a thread is archived."
           resetAction={
-            settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive ? (
+            settings.confirmThreadArchive !==
+            DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive ? (
               <SettingResetButton
                 label="archive confirmation"
                 onClick={() =>
                   updateSettings({
-                    confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
+                    confirmThreadArchive:
+                      DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
                   })
                 }
               />
@@ -2134,12 +2446,14 @@ export function GeneralSettingsPanel() {
           {...searchableSetting("delete-confirmation")}
           description="Ask before deleting a thread and its chat history."
           resetAction={
-            settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete ? (
+            settings.confirmThreadDelete !==
+            DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete ? (
               <SettingResetButton
                 label="delete confirmation"
                 onClick={() =>
                   updateSettings({
-                    confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+                    confirmThreadDelete:
+                      DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
                   })
                 }
               />
@@ -2187,7 +2501,10 @@ export function GeneralSettingsPanel() {
                     textGenerationModelSelection: resolveAppModelSelectionState(
                       {
                         ...settings,
-                        textGenerationModelSelection: createModelSelection(instanceId, model),
+                        textGenerationModelSelection: createModelSelection(
+                          instanceId,
+                          model,
+                        ),
                       },
                       serverProviders,
                     ),
@@ -2244,7 +2561,11 @@ export function GeneralSettingsPanel() {
           {...searchableSetting("diagnostics")}
           description={diagnosticsDescription}
           control={
-            <Button render={<Link to="/settings/diagnostics" />} size="xs" variant="outline">
+            <Button
+              render={<Link to="/settings/diagnostics" />}
+              size="xs"
+              variant="outline"
+            >
               View diagnostics
             </Button>
           }
@@ -2303,7 +2624,10 @@ export function ArchivedThreadsPanel() {
     for (const project of archivedProjects) {
       const projectThreads: Array<(typeof threads)[number]> = [];
       for (const thread of threads) {
-        if (thread.projectId === project.id && thread.environmentId === project.environmentId) {
+        if (
+          thread.projectId === project.id &&
+          thread.environmentId === project.environmentId
+        ) {
           projectThreads.push(thread);
         }
       }
@@ -2313,7 +2637,9 @@ export function ArchivedThreadsPanel() {
           threads: projectThreads.toSorted((left, right) => {
             const leftKey = left.archivedAt ?? left.createdAt;
             const rightKey = right.archivedAt ?? right.createdAt;
-            return rightKey.localeCompare(leftKey) || right.id.localeCompare(left.id);
+            return (
+              rightKey.localeCompare(leftKey) || right.id.localeCompare(left.id)
+            );
           }),
         });
       }
@@ -2343,7 +2669,8 @@ export function ArchivedThreadsPanel() {
             stackedThreadToast({
               type: "error",
               title: "Failed to unarchive thread",
-              description: error instanceof Error ? error.message : "An error occurred.",
+              description:
+                error instanceof Error ? error.message : "An error occurred.",
             }),
           );
         }
@@ -2360,7 +2687,8 @@ export function ArchivedThreadsPanel() {
             stackedThreadToast({
               type: "error",
               title: "Failed to delete thread",
-              description: error instanceof Error ? error.message : "An error occurred.",
+              description:
+                error instanceof Error ? error.message : "An error occurred.",
             }),
           );
         }
@@ -2434,7 +2762,9 @@ export function ArchivedThreadsPanel() {
                           type: "error",
                           title: "Archived thread action failed",
                           description:
-                            error instanceof Error ? error.message : "An error occurred.",
+                            error instanceof Error
+                              ? error.message
+                              : "An error occurred.",
                         }),
                       );
                     }
@@ -2443,7 +2773,10 @@ export function ArchivedThreadsPanel() {
                 title={thread.title}
                 description={
                   <>
-                    Archived {formatRelativeTimeLabel(thread.archivedAt ?? thread.createdAt)}
+                    Archived{" "}
+                    {formatRelativeTimeLabel(
+                      thread.archivedAt ?? thread.createdAt,
+                    )}
                     {" \u00b7 Created "}
                     {formatRelativeTimeLabel(thread.createdAt)}
                   </>
@@ -2470,7 +2803,9 @@ export function ArchivedThreadsPanel() {
                               type: "error",
                               title: "Failed to unarchive thread",
                               description:
-                                error instanceof Error ? error.message : "An error occurred.",
+                                error instanceof Error
+                                  ? error.message
+                                  : "An error occurred.",
                             }),
                           );
                         }

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -104,10 +104,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
-    id: "time-format",
-    title: "Time format",
+    id: "windows-terminal-shell",
+    title: "Terminal shell",
     to: "/settings/general",
   },
+  { id: "time-format", title: "Time format", to: "/settings/general" },
   {
     id: "hide-whitespace-changes",
     title: "Hide whitespace changes",
@@ -231,5 +232,7 @@ export function searchSettings(
   const normalizedQuery = normalizeSearchText(query);
   if (normalizedQuery.length === 0) return [];
 
-  return items.filter((item) => normalizeSearchText(item.title).includes(normalizedQuery));
+  return items.filter((item) =>
+    normalizeSearchText(item.title).includes(normalizedQuery),
+  );
 }

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -10,21 +10,37 @@ import {
   ProviderOptionSelections,
 } from "./model.ts";
 import { ModelSelection } from "./orchestration.ts";
-import { ProviderInstanceConfig, ProviderInstanceId } from "./providerInstance.ts";
+import {
+  ProviderInstanceConfig,
+  ProviderInstanceId,
+} from "./providerInstance.ts";
 
 // ── Client Settings (local-only) ───────────────────────────────
 
-export const TimestampFormat = Schema.Literals(["locale", "12-hour", "24-hour"]);
+export const TimestampFormat = Schema.Literals([
+  "locale",
+  "12-hour",
+  "24-hour",
+]);
 export type TimestampFormat = typeof TimestampFormat.Type;
 export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
 
-export const SidebarProjectSortOrder = Schema.Literals(["updated_at", "created_at", "manual"]);
+export const SidebarProjectSortOrder = Schema.Literals([
+  "updated_at",
+  "created_at",
+  "manual",
+]);
 export type SidebarProjectSortOrder = typeof SidebarProjectSortOrder.Type;
-export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "updated_at";
+export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder =
+  "updated_at";
 
-export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
+export const SidebarThreadSortOrder = Schema.Literals([
+  "updated_at",
+  "created_at",
+]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
-export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
+export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder =
+  "updated_at";
 
 export const SidebarProjectGroupingMode = Schema.Literals([
   "repository",
@@ -32,7 +48,8 @@ export const SidebarProjectGroupingMode = Schema.Literals([
   "separate",
 ]);
 export type SidebarProjectGroupingMode = typeof SidebarProjectGroupingMode.Type;
-export const DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE: SidebarProjectGroupingMode = "repository";
+export const DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE: SidebarProjectGroupingMode =
+  "repository";
 export const MIN_SIDEBAR_THREAD_PREVIEW_COUNT = 1;
 export const MAX_SIDEBAR_THREAD_PREVIEW_COUNT = 15;
 export const SidebarThreadPreviewCount = Schema.Int.check(
@@ -71,7 +88,10 @@ export const DEFAULT_GLASS_OPACITY: GlassOpacity = 80;
 export const MIN_INTERFACE_FONT_SIZE = 12;
 export const MAX_INTERFACE_FONT_SIZE = 20;
 export const InterfaceFontSize = Schema.Int.check(
-  Schema.isBetween({ minimum: MIN_INTERFACE_FONT_SIZE, maximum: MAX_INTERFACE_FONT_SIZE }),
+  Schema.isBetween({
+    minimum: MIN_INTERFACE_FONT_SIZE,
+    maximum: MAX_INTERFACE_FONT_SIZE,
+  }),
 );
 export type InterfaceFontSize = typeof InterfaceFontSize.Type;
 export const DEFAULT_INTERFACE_FONT_SIZE: InterfaceFontSize = 16;
@@ -79,7 +99,10 @@ export const DEFAULT_INTERFACE_FONT_SIZE: InterfaceFontSize = 16;
 export const MIN_PROMPT_FONT_SIZE = 12;
 export const MAX_PROMPT_FONT_SIZE = 20;
 export const PromptFontSize = Schema.Int.check(
-  Schema.isBetween({ minimum: MIN_PROMPT_FONT_SIZE, maximum: MAX_PROMPT_FONT_SIZE }),
+  Schema.isBetween({
+    minimum: MIN_PROMPT_FONT_SIZE,
+    maximum: MAX_PROMPT_FONT_SIZE,
+  }),
 );
 export type PromptFontSize = typeof PromptFontSize.Type;
 export const DEFAULT_PROMPT_FONT_SIZE: PromptFontSize = 14;
@@ -87,7 +110,10 @@ export const DEFAULT_PROMPT_FONT_SIZE: PromptFontSize = 14;
 export const MIN_CODE_FONT_SIZE = 10;
 export const MAX_CODE_FONT_SIZE = 18;
 export const CodeFontSize = Schema.Int.check(
-  Schema.isBetween({ minimum: MIN_CODE_FONT_SIZE, maximum: MAX_CODE_FONT_SIZE }),
+  Schema.isBetween({
+    minimum: MIN_CODE_FONT_SIZE,
+    maximum: MAX_CODE_FONT_SIZE,
+  }),
 );
 export type CodeFontSize = typeof CodeFontSize.Type;
 export const DEFAULT_CODE_FONT_SIZE: CodeFontSize = 13;
@@ -95,31 +121,50 @@ export const DEFAULT_CODE_FONT_SIZE: CodeFontSize = 13;
 export const MIN_TERMINAL_FONT_SIZE = 8;
 export const MAX_TERMINAL_FONT_SIZE = 20;
 export const TerminalFontSize = Schema.Int.check(
-  Schema.isBetween({ minimum: MIN_TERMINAL_FONT_SIZE, maximum: MAX_TERMINAL_FONT_SIZE }),
+  Schema.isBetween({
+    minimum: MIN_TERMINAL_FONT_SIZE,
+    maximum: MAX_TERMINAL_FONT_SIZE,
+  }),
 );
 export type TerminalFontSize = typeof TerminalFontSize.Type;
 export const DEFAULT_TERMINAL_FONT_SIZE: TerminalFontSize = 12;
 
-export const EnvironmentIdentificationMode = Schema.Literals(["artwork", "pill", "none"]);
-export type EnvironmentIdentificationMode = typeof EnvironmentIdentificationMode.Type;
-export const DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE: EnvironmentIdentificationMode = "artwork";
+export const EnvironmentIdentificationMode = Schema.Literals([
+  "artwork",
+  "pill",
+  "none",
+]);
+export type EnvironmentIdentificationMode =
+  typeof EnvironmentIdentificationMode.Type;
+export const DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE: EnvironmentIdentificationMode =
+  "artwork";
 
 /**
  * A user-chosen font family (a single name or a comma-separated list). Empty
  * means "use the app default"; clients compose their own fallback stacks.
  */
-export const FontFamilyPreference = Schema.String.check(Schema.isMaxLength(200));
+export const FontFamilyPreference = Schema.String.check(
+  Schema.isMaxLength(200),
+);
 export type FontFamilyPreference = typeof FontFamilyPreference.Type;
 
 export const ClientSettingsSchema = Schema.Struct({
-  confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
-  confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
-  dismissedProviderUpdateNotificationKeys: Schema.Array(TrimmedNonEmptyString).pipe(
-    Schema.withDecodingDefault(Effect.succeed([])),
+  confirmThreadArchive: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
   ),
-  diffIgnoreWhitespace: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  confirmThreadDelete: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
+  dismissedProviderUpdateNotificationKeys: Schema.Array(
+    TrimmedNonEmptyString,
+  ).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  diffIgnoreWhitespace: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
   environmentIdentificationMode: EnvironmentIdentificationMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE)),
+    Schema.withDecodingDefault(
+      Effect.succeed(DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE),
+    ),
   ),
   glassOpacity: GlassOpacity.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_GLASS_OPACITY)),
@@ -136,13 +181,23 @@ export const ClientSettingsSchema = Schema.Struct({
   fontSizeTerminal: TerminalFontSize.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TERMINAL_FONT_SIZE)),
   ),
-  fontFamilyCode: FontFamilyPreference.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
-  fontFamilyComposer: FontFamilyPreference.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
-  fontFamilySans: FontFamilyPreference.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
-  fontFamilyTerminal: FontFamilyPreference.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  fontFamilyCode: FontFamilyPreference.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+  ),
+  fontFamilyComposer: FontFamilyPreference.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+  ),
+  fontFamilySans: FontFamilyPreference.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+  ),
+  fontFamilyTerminal: FontFamilyPreference.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+  ),
   // Grayscale `-webkit-font-smoothing: antialiased` (thinner strokes);
   // disabling restores the platform's heavier default. No effect off macOS.
-  fontSmoothing: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  fontSmoothing: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
   // Model favorites. Historically keyed by provider kind, now
   // widened to `ProviderInstanceId` so users can favorite a specific model
   // on a custom provider instance (e.g. "Codex Personal · gpt-5") without
@@ -165,45 +220,65 @@ export const ClientSettingsSchema = Schema.Struct({
       hiddenModels: Schema.Array(Schema.String).pipe(
         Schema.withDecodingDefault(Effect.succeed([])),
       ),
-      modelOrder: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+      modelOrder: Schema.Array(Schema.String).pipe(
+        Schema.withDecodingDefault(Effect.succeed([])),
+      ),
     }),
   ).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // Legacy plan mode. The composer's Build/Plan toggle was removed from the
   // default UI; this beta flag restores it (plus the /plan and /default slash
   // commands) for users who still rely on the old workflow.
-  planModeEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  planModeEnabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
+  ),
   // Legacy sidebar (the original per-project tree). Deliberately a fresh key
   // (was `sidebarV2Enabled` + `sidebarV2ConfiguredByUser`): decoding drops the
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
-  legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  legacySidebarEnabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
+  ),
   sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
+    Schema.withDecodingDefault(
+      Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS),
+    ),
   ),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
+    Schema.withDecodingDefault(
+      Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE),
+    ),
   ),
   sidebarProjectGroupingOverrides: Schema.Record(
     TrimmedNonEmptyString,
     SidebarProjectGroupingMode,
   ).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   sidebarProjectSortOrder: SidebarProjectSortOrder.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_SORT_ORDER)),
+    Schema.withDecodingDefault(
+      Effect.succeed(DEFAULT_SIDEBAR_PROJECT_SORT_ORDER),
+    ),
   ),
   sidebarThreadSortOrder: SidebarThreadSortOrder.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_SORT_ORDER)),
+    Schema.withDecodingDefault(
+      Effect.succeed(DEFAULT_SIDEBAR_THREAD_SORT_ORDER),
+    ),
   ),
   sidebarThreadPreviewCount: SidebarThreadPreviewCount.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
+    Schema.withDecodingDefault(
+      Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT),
+    ),
   ),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
   ),
-  wordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  wordWrap: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
 });
 export type ClientSettings = typeof ClientSettingsSchema.Type;
 
-export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientSettingsSchema)({});
+export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(
+  ClientSettingsSchema,
+)({});
 
 // ── Server Settings (server-authoritative) ────────────────────
 
@@ -223,7 +298,8 @@ const makeBinaryPathSetting = (fallback: string) =>
     Schema.withDecodingDefault(Effect.succeed(fallback)),
   );
 
-export type ProviderSettingsFormControl = "text" | "password" | "textarea" | "switch";
+export type ProviderSettingsFormControl =
+  "text" | "password" | "textarea" | "switch";
 
 export interface ProviderSettingsFormAnnotation {
   readonly control?: ProviderSettingsFormControl | undefined;
@@ -239,18 +315,20 @@ export interface ProviderSettingsFormSchemaAnnotation {
 declare module "effect/Schema" {
   namespace Annotations {
     interface Annotations {
-      readonly providerSettingsForm?: ProviderSettingsFormAnnotation | undefined;
-      readonly providerSettingsFormSchema?: ProviderSettingsFormSchemaAnnotation | undefined;
+      readonly providerSettingsForm?:
+        ProviderSettingsFormAnnotation | undefined;
+      readonly providerSettingsFormSchema?:
+        ProviderSettingsFormSchemaAnnotation | undefined;
     }
   }
 }
 
-export type ProviderSettingsOrder<Fields extends Schema.Struct.Fields> = readonly Extract<
-  keyof Fields,
-  string
->[];
+export type ProviderSettingsOrder<Fields extends Schema.Struct.Fields> =
+  readonly Extract<keyof Fields, string>[];
 
-export function makeProviderSettingsSchema<const Fields extends Schema.Struct.Fields>(
+export function makeProviderSettingsSchema<
+  const Fields extends Schema.Struct.Fields,
+>(
   fields: Fields,
   options?: {
     readonly order?: ProviderSettingsOrder<Fields> | undefined;
@@ -304,7 +382,8 @@ export const CodexSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed("")),
       Schema.annotateKey({
         title: "Launch arguments",
-        description: "Additional CLI arguments passed to codex app-server on session start.",
+        description:
+          "Additional CLI arguments passed to codex app-server on session start.",
       }),
     ),
     customModels: Schema.Array(Schema.String).pipe(
@@ -337,7 +416,10 @@ export const ClaudeSettings = makeProviderSettingsSchema(
         title: "CLAUDE_CONFIG_DIR path",
         description:
           "Custom Claude home and config directory. Keeps .claude.json and .claude separate.",
-        providerSettingsForm: { placeholder: "~/.claude", clearWhenEmpty: "omit" },
+        providerSettingsForm: {
+          placeholder: "~/.claude",
+          clearWhenEmpty: "omit",
+        },
       }),
     ),
     customModels: Schema.Array(Schema.String).pipe(
@@ -372,7 +454,10 @@ export const CursorSettings = makeProviderSettingsSchema(
       Schema.annotateKey({
         title: "Binary path",
         description: "Path to the Cursor agent binary.",
-        providerSettingsForm: { placeholder: "cursor-agent", clearWhenEmpty: "omit" },
+        providerSettingsForm: {
+          placeholder: "cursor-agent",
+          clearWhenEmpty: "omit",
+        },
       }),
     ),
     apiEndpoint: TrimmedString.pipe(
@@ -472,8 +557,12 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
 export const ObservabilitySettings = Schema.Struct({
-  otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
-  otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  otlpTracesUrl: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+  ),
+  otlpMetricsUrl: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+  ),
 });
 export type ObservabilitySettings = typeof ObservabilitySettings.Type;
 
@@ -482,18 +571,22 @@ export const SourceControlWritingStyleMode = Schema.Literals([
   "conventional_commits",
   "custom",
 ]);
-export type SourceControlWritingStyleMode = typeof SourceControlWritingStyleMode.Type;
+export type SourceControlWritingStyleMode =
+  typeof SourceControlWritingStyleMode.Type;
 
 export const SourceControlWritingStyleSettings = Schema.Struct({
   mode: SourceControlWritingStyleMode.pipe(
     Schema.withDecodingDefault(Effect.succeed("repo_conventions" as const)),
   ),
-  customInstructions: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  customInstructions: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+  ),
   followChangeRequestTemplates: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
 });
-export type SourceControlWritingStyleSettings = typeof SourceControlWritingStyleSettings.Type;
+export type SourceControlWritingStyleSettings =
+  typeof SourceControlWritingStyleSettings.Type;
 
 export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 export const DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL = Duration.minutes(5);
@@ -504,7 +597,8 @@ export const BackgroundActivityProfile = Schema.Literals([
   "battery-saver",
 ]);
 export type BackgroundActivityProfile = typeof BackgroundActivityProfile.Type;
-export const DEFAULT_BACKGROUND_ACTIVITY_PROFILE: BackgroundActivityProfile = "balanced";
+export const DEFAULT_BACKGROUND_ACTIVITY_PROFILE: BackgroundActivityProfile =
+  "balanced";
 
 export const BackgroundActivityProfileSelection = Schema.Literals([
   "balanced",
@@ -512,7 +606,8 @@ export const BackgroundActivityProfileSelection = Schema.Literals([
   "battery-saver",
   "custom",
 ]);
-export type BackgroundActivityProfileSelection = typeof BackgroundActivityProfileSelection.Type;
+export type BackgroundActivityProfileSelection =
+  typeof BackgroundActivityProfileSelection.Type;
 
 export const BackgroundActivityOverrides = Schema.Struct({
   automaticGitFetchInterval: Schema.optionalKey(Schema.DurationFromMillis),
@@ -525,15 +620,22 @@ export const BackgroundActivityOverrides = Schema.Struct({
   pauseWhenClientLowPower: Schema.optionalKey(Schema.Boolean),
   pauseWhenOnBattery: Schema.optionalKey(Schema.Boolean),
 });
-export type BackgroundActivityOverrides = typeof BackgroundActivityOverrides.Type;
+export type BackgroundActivityOverrides =
+  typeof BackgroundActivityOverrides.Type;
 
 export const BackgroundActivitySettings = Schema.Struct({
-  schemaVersion: Schema.Literal(1).pipe(Schema.withDecodingDefault(Effect.succeed(1 as const))),
+  schemaVersion: Schema.Literal(1).pipe(
+    Schema.withDecodingDefault(Effect.succeed(1 as const)),
+  ),
   profile: BackgroundActivityProfileSelection.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_BACKGROUND_ACTIVITY_PROFILE)),
+    Schema.withDecodingDefault(
+      Effect.succeed(DEFAULT_BACKGROUND_ACTIVITY_PROFILE),
+    ),
   ),
   baseProfile: Schema.optionalKey(BackgroundActivityProfile),
-  overrides: BackgroundActivityOverrides.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  overrides: BackgroundActivityOverrides.pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
 }).pipe(Schema.withDecodingDefault(Effect.succeed({})));
 export type BackgroundActivitySettings = typeof BackgroundActivitySettings.Type;
 
@@ -544,7 +646,9 @@ export const ServerSettings = Schema.Struct({
   enableLegacyTokenStreaming: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(false)),
   ),
-  enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  enableProviderUpdateChecks: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
   backgroundActivity: BackgroundActivitySettings,
   // Legacy flat fields retained for old settings files and old clients. New
   // consumers should resolve `backgroundActivity` instead.
@@ -555,19 +659,27 @@ export const ServerSettings = Schema.Struct({
   ),
   providerHealthRefreshInterval: Schema.DurationFromMillis.pipe(
     Schema.withDecodingDefault(
-      Effect.succeed(Duration.toMillis(DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL)),
+      Effect.succeed(
+        Duration.toMillis(DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL),
+      ),
     ),
   ),
   backgroundActivityProfile: BackgroundActivityProfile.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_BACKGROUND_ACTIVITY_PROFILE)),
+    Schema.withDecodingDefault(
+      Effect.succeed(DEFAULT_BACKGROUND_ACTIVITY_PROFILE),
+    ),
   ),
   defaultThreadEnvMode: ThreadEnvMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed("local" as const satisfies ThreadEnvMode)),
+    Schema.withDecodingDefault(
+      Effect.succeed("local" as const satisfies ThreadEnvMode),
+    ),
   ),
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
-  addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  addProjectBaseDirectory: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+  ),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
       Effect.succeed({
@@ -597,24 +709,36 @@ export const ServerSettings = Schema.Struct({
   // is removed entirely.
   providers: Schema.Struct({
     codex: CodexSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
-    claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    claudeAgent: ClaudeSettings.pipe(
+      Schema.withDecodingDefault(Effect.succeed({})),
+    ),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
-    opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    opencode: OpenCodeSettings.pipe(
+      Schema.withDecodingDefault(Effect.succeed({})),
+    ),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
   // is `Schema.Unknown` at this layer so envelopes with unknown drivers
   // (forks, downgrades, in-flight PR branches) round-trip without loss.
   // See providerInstance.ts for the forward/backward compatibility invariant.
-  providerInstances: Schema.Record(ProviderInstanceId, ProviderInstanceConfig).pipe(
+  providerInstances: Schema.Record(
+    ProviderInstanceId,
+    ProviderInstanceConfig,
+  ).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  observability: ObservabilitySettings.pipe(
     Schema.withDecodingDefault(Effect.succeed({})),
   ),
-  observability: ObservabilitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  windowsTerminalShell: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+  ),
 });
 export type ServerSettings = typeof ServerSettings.Type;
 
-export const DEFAULT_SERVER_SETTINGS: ServerSettings = Schema.decodeSync(ServerSettings)({});
+export const DEFAULT_SERVER_SETTINGS: ServerSettings = Schema.decodeSync(
+  ServerSettings,
+)({});
 
 export const ServerSettingsOperation = Schema.Literals([
   "normalize",
@@ -641,7 +765,9 @@ export class ServerSettingsError extends Schema.TaggedErrorClass<ServerSettingsE
 ) {
   override get message(): string {
     const provider =
-      this.providerInstanceId === undefined ? "" : ` for provider ${this.providerInstanceId}`;
+      this.providerInstanceId === undefined
+        ? ""
+        : ` for provider ${this.providerInstanceId}`;
     const variable =
       this.environmentVariable === undefined
         ? ""
@@ -730,7 +856,9 @@ export const ServerSettingsPatch = Schema.Struct({
       followChangeRequestTemplates: Schema.optionalKey(Schema.Boolean),
     }),
   ),
-  sourceControlWriterModelSelection: Schema.optionalKey(Schema.NullOr(ModelSelection)),
+  sourceControlWriterModelSelection: Schema.optionalKey(
+    Schema.NullOr(ModelSelection),
+  ),
   observability: Schema.optionalKey(
     Schema.Struct({
       otlpTracesUrl: Schema.optionalKey(TrimmedString),
@@ -750,7 +878,10 @@ export const ServerSettingsPatch = Schema.Struct({
   // entries is intentionally out of scope: the map is small, and partial
   // patches risk leaving driver-specific config in a half-merged state.
   // The web UI sends a fully-formed map every time it edits this field.
-  providerInstances: Schema.optionalKey(Schema.Record(ProviderInstanceId, ProviderInstanceConfig)),
+  providerInstances: Schema.optionalKey(
+    Schema.Record(ProviderInstanceId, ProviderInstanceConfig),
+  ),
+  windowsTerminalShell: Schema.optionalKey(TrimmedString),
 });
 export type ServerSettingsPatch = typeof ServerSettingsPatch.Type;
 
@@ -758,7 +889,9 @@ export const ClientSettingsPatch = Schema.Struct({
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
-  environmentIdentificationMode: Schema.optionalKey(EnvironmentIdentificationMode),
+  environmentIdentificationMode: Schema.optionalKey(
+    EnvironmentIdentificationMode,
+  ),
   glassOpacity: Schema.optionalKey(GlassOpacity),
   fontSizeInterface: Schema.optionalKey(InterfaceFontSize),
   fontSizePrompt: Schema.optionalKey(PromptFontSize),
@@ -792,7 +925,9 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
-  sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
+  sidebarAutoSettleAfterDays: Schema.optionalKey(
+    Schema.NullOr(SidebarAutoSettleAfterDays),
+  ),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),


### PR DESCRIPTION
Fixes issue #123. Adds a setting to select terminal shell on Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every terminal session picks its shell at spawn time; wrong resolution or incomplete settings wiring could break terminal startup on Windows.
> 
> **Overview**
> Prepares **terminal shell selection on Windows** by resolving the preferred shell asynchronously when a PTY session starts, instead of reading it synchronously at manager construction time.
> 
> **`shellResolver`** is now an `Effect` (tests can still inject `Effect.succeed(...)`). **`resolveShellCandidates`** takes a resolved `preferredShell` string; **`startSession`** runs `yield* shellResolver` on each spawn so a user-configured shell can be read from settings at launch. Existing Windows fallback order (custom choice → `pwsh.exe` → Windows PowerShell → `ComSpec` / `cmd`) is unchanged.
> 
> The diff also adds a **`ServerSettingsService`** import (not wired in this hunk) and is largely **formatting** across `Manager.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8150931cca8c69e9ef9eff16a7b4f28e181b4ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add terminal shell selector for Windows in General settings
> - Adds a `WindowsTerminalShellRow` component to the General settings panel, visible only on Windows, letting users pick their preferred terminal shell from a predefined list.
> - Persists the selection as `windowsTerminalShell` in `ServerSettings` (defaults to empty string) and supports reset to default.
> - Adds a "Terminal shell" entry to the settings search index.
> - The `TerminalManagerOptions.shellResolver` type changes from a synchronous function to an `Effect.Effect<string>`, evaluated at session start to resolve the preferred shell.
> - `stopProcess` no longer immediately marks a session as exited; cleanup is now deferred until the process exit event is observed via `drainProcessEvents`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8150931. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->