### PR TITLE
fix(grok): publish models after session start

### DIFF
--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -1,7 +1,15 @@
-import { GrokSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import {
+  GrokSettings,
+  ProviderDriverKind,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import type * as EffectAcpSchema from "effect-acp/schema";
+import * as Deferred from "effect/Deferred";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Ref from "effect/Ref";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
@@ -16,6 +24,7 @@ import { makeGrokAdapter } from "../Layers/GrokAdapter.ts";
 import {
   buildInitialGrokProviderSnapshot,
   checkGrokProviderStatus,
+  grokModelsFromSessionModelState,
   enrichGrokSnapshot,
 } from "../Layers/GrokProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
@@ -25,6 +34,7 @@ import {
   type ProviderDriver,
   type ProviderInstance,
 } from "../ProviderDriver.ts";
+import type { ServerProviderShape } from "../Services/ServerProvider.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
@@ -46,6 +56,21 @@ const UPDATE = makeStaticProviderMaintenanceResolver(
     packageName: null,
   }),
 );
+
+function sameModelCatalog(
+  left: ReadonlyArray<ServerProviderModel>,
+  right: ReadonlyArray<ServerProviderModel>,
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every(
+      (model, index) =>
+        model.slug === right[index]?.slug &&
+        model.name === right[index]?.name &&
+        model.isCustom === right[index]?.isCustom,
+    )
+  );
+}
 
 export type GrokDriverEnv =
   | BackgroundPolicy.BackgroundPolicy
@@ -106,15 +131,33 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
       });
+      const discoveredModelsRef = yield* Ref.make<ReadonlyArray<ServerProviderModel>>([]);
+      const snapshotReady = yield* Deferred.make<ServerProviderShape>();
+      const publishDiscoveredModels = Effect.fn("GrokDriver.publishDiscoveredModels")(function* (
+        modelState: EffectAcpSchema.SessionModelState,
+      ) {
+        const discoveredModels = grokModelsFromSessionModelState(modelState);
+        if (discoveredModels.length === 0) return;
+        const changed = yield* Ref.modify(discoveredModelsRef, (current) =>
+          sameModelCatalog(current, discoveredModels) ? [false, current] : [true, discoveredModels],
+        );
+        if (!changed) return;
+        const provider = yield* Deferred.await(snapshotReady);
+        yield* provider.refresh;
+      });
 
       const adapter = yield* makeGrokAdapter(effectiveConfig, {
         environment: processEnv,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
         instanceId,
+        onModelStateDiscovered: publishDiscoveredModels,
       });
       const textGeneration = yield* makeGrokTextGeneration(effectiveConfig, processEnv);
 
-      const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv).pipe(
+      const checkProvider = Ref.get(discoveredModelsRef).pipe(
+        Effect.flatMap((discoveredModels) =>
+          checkGrokProviderStatus(effectiveConfig, processEnv, discoveredModels),
+        ),
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(FileSystem.FileSystem, fileSystem),
@@ -149,6 +192,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
             }),
         ),
       );
+      yield* Deferred.succeed(snapshotReady, snapshot);
 
       return {
         instanceId,

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -85,7 +85,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
   create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
     Effect.gen(function* () {
       const crypto = yield* Crypto.Crypto;
-      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -116,7 +117,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
-        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
       );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -127,7 +127,13 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-mock-thread");
       const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
-      const adapter = yield* makeTestAdapter(wrapperPath);
+      const discoveredModelIds: string[][] = [];
+      const adapter = yield* makeTestAdapter(wrapperPath, {
+        onModelStateDiscovered: (modelState) =>
+          Effect.sync(() => {
+            discoveredModelIds.push(modelState.availableModels.map((model) => model.modelId));
+          }),
+      });
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
       const turnCompleted = yield* Deferred.make<void>();
@@ -157,6 +163,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         schemaVersion: 1,
         sessionId: "mock-session-1",
       });
+      assert.deepStrictEqual(discoveredModelIds, [["grok-build", "grok-mock-alt"]]);
 
       yield* adapter.sendTurn({
         threadId,

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -84,6 +84,9 @@ export interface GrokAdapterLiveOptions {
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
   readonly instanceId?: ProviderInstanceId;
+  readonly onModelStateDiscovered?: (
+    modelState: EffectAcpSchema.SessionModelState,
+  ) => Effect.Effect<void>;
 }
 
 interface PendingApproval {
@@ -734,6 +737,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
             ),
           );
+          if (started.sessionSetupResult.models && options?.onModelStateDiscovered) {
+            yield* options.onModelStateDiscovered(started.sessionSetupResult.models);
+          }
 
           const requestedStartModelId = grokModelSelection?.model
             ? resolveGrokAcpBaseModelId(grokModelSelection.model)

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -6,7 +6,11 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { GrokSettings } from "@t3tools/contracts";
 
-import { buildInitialGrokProviderSnapshot, checkGrokProviderStatus } from "./GrokProvider.ts";
+import {
+  buildInitialGrokProviderSnapshot,
+  checkGrokProviderStatus,
+  grokModelsFromSessionModelState,
+} from "./GrokProvider.ts";
 
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 
@@ -68,13 +72,22 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
 
         const snapshot = yield* checkGrokProviderStatus(
           decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+          process.env,
+          grokModelsFromSessionModelState({
+            currentModelId: "grok-build",
+            availableModels: [
+              { modelId: "grok-build", name: "Grok Build" },
+              { modelId: "grok-next", name: "Grok Next" },
+              { modelId: "grok-next", name: "Duplicate" },
+            ],
+          }),
         );
 
         expect(snapshot.enabled).toBe(true);
         expect(snapshot.installed).toBe(true);
         expect(snapshot.status).toBe("ready");
         expect(snapshot.version).toBeNull();
-        expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-build"]);
+        expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-build", "grok-next"]);
         expect(snapshot.message).toContain("checked when a Grok thread starts");
         expect(yield* fs.exists(executionMarker)).toBe(false);
       }),

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -52,59 +52,32 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
     }),
   );
 
-  it.effect("reports an installed CLI as unhealthy when --version exits non-zero", () =>
-    Effect.gen(function* () {
-      const secretStderr = "broken grok install: secret-token-value";
-      const snapshot = yield* Effect.scoped(
-        Effect.gen(function* () {
-          const fs = yield* FileSystem.FileSystem;
-          const path = yield* Path.Path;
-          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-version-" });
-          const grokPath = path.join(dir, "grok");
-          yield* fs.writeFileString(
-            grokPath,
-            ["#!/bin/sh", `printf "%s\\n" "${secretStderr}" >&2`, "exit 2", ""].join("\n"),
-          );
-          yield* fs.chmod(grokPath, 0o755);
+  it.effect("checks availability without executing the CLI", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-probe-" });
+        const grokPath = path.join(dir, "grok");
+        const executionMarker = `${grokPath}.executed`;
+        yield* fs.writeFileString(
+          grokPath,
+          ["#!/bin/sh", 'touch "$0.executed"', "exit 0", ""].join("\n"),
+        );
+        yield* fs.chmod(grokPath, 0o755);
 
-          return yield* checkGrokProviderStatus(
-            decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
-          );
-        }),
-      );
+        const snapshot = yield* checkGrokProviderStatus(
+          decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+        );
 
-      expect(snapshot.enabled).toBe(true);
-      expect(snapshot.installed).toBe(true);
-      expect(snapshot.status).toBe("error");
-      expect(snapshot.message).toBe("Grok CLI is installed but failed to run.");
-      expect(snapshot.message).not.toContain(secretStderr);
-    }),
-  );
-
-  it.effect("reports an error when ACP model discovery is unavailable", () =>
-    Effect.gen(function* () {
-      const snapshot = yield* Effect.scoped(
-        Effect.gen(function* () {
-          const fs = yield* FileSystem.FileSystem;
-          const path = yield* Path.Path;
-          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-success-" });
-          const grokPath = path.join(dir, "grok");
-          yield* fs.writeFileString(
-            grokPath,
-            ["#!/bin/sh", 'printf "grok-cli 0.0.99\\n"', "exit 0", ""].join("\n"),
-          );
-          yield* fs.chmod(grokPath, 0o755);
-
-          return yield* checkGrokProviderStatus(
-            decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
-          );
-        }),
-      );
-
-      expect(snapshot.status).toBe("error");
-      expect(snapshot.installed).toBe(true);
-      expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-build"]);
-      expect(snapshot.message).toContain("ACP startup failed");
-    }),
+        expect(snapshot.enabled).toBe(true);
+        expect(snapshot.installed).toBe(true);
+        expect(snapshot.status).toBe("ready");
+        expect(snapshot.version).toBeNull();
+        expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-build"]);
+        expect(snapshot.message).toContain("checked when a Grok thread starts");
+        expect(yield* fs.exists(executionMarker)).toBe(false);
+      }),
+    ),
   );
 });

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -4,6 +4,7 @@ import {
   type ServerProvider,
   type ServerProviderModel,
 } from "@t3tools/contracts";
+import type * as EffectAcpSchema from "effect-acp/schema";
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { isCommandAvailable } from "@t3tools/shared/shell";
 import { causeErrorTag } from "@t3tools/shared/observability";
@@ -20,6 +21,7 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
+import { resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -88,19 +90,44 @@ function grokModelsFromSettings(
   return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
 }
 
+export function grokModelsFromSessionModelState(
+  modelState: EffectAcpSchema.SessionModelState | null | undefined,
+): ReadonlyArray<ServerProviderModel> {
+  if (!modelState || modelState.availableModels.length === 0) return [];
+
+  const seen = new Set<string>();
+  return modelState.availableModels.flatMap((model) => {
+    const slug = resolveGrokAcpBaseModelId(model.modelId);
+    if (!slug || seen.has(slug)) return [];
+    seen.add(slug);
+    return [
+      {
+        slug,
+        name: model.name?.trim() || slug,
+        isCustom: false,
+        capabilities: EMPTY_CAPABILITIES,
+      },
+    ];
+  });
+}
+
 export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(function* (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
+  discoveredModels: ReadonlyArray<ServerProviderModel> = [],
 ) {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
-  const fallbackModels = grokModelsFromSettings(grokSettings.customModels);
+  const models = grokModelsFromSettings(
+    grokSettings.customModels,
+    discoveredModels.length > 0 ? discoveredModels : GROK_BUILT_IN_MODELS,
+  );
 
   if (!grokSettings.enabled) {
     return buildServerProvider({
       presentation: GROK_PRESENTATION,
       enabled: false,
       checkedAt,
-      models: fallbackModels,
+      models,
       probe: {
         installed: false,
         version: null,
@@ -121,7 +148,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       presentation: GROK_PRESENTATION,
       enabled: grokSettings.enabled,
       checkedAt,
-      models: fallbackModels,
+      models,
       probe: {
         installed: false,
         version: null,
@@ -136,7 +163,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     presentation: GROK_PRESENTATION,
     enabled: grokSettings.enabled,
     checkedAt,
-    models: fallbackModels,
+    models,
     probe: {
       installed: true,
       version: null,

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -4,32 +4,22 @@ import {
   type ServerProvider,
   type ServerProviderModel,
 } from "@t3tools/contracts";
-import type * as EffectAcpSchema from "effect-acp/schema";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { isCommandAvailable } from "@t3tools/shared/shell";
 import { causeErrorTag } from "@t3tools/shared/observability";
-import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
-import * as Option from "effect/Option";
-import * as Result from "effect/Result";
 import { HttpClient } from "effect/unstable/http";
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
-import { createModelCapabilities } from "@t3tools/shared/model";
-import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
 import {
   buildServerProvider,
-  isCommandMissingCause,
-  parseGenericCliVersion,
   providerModelsFromSettings,
-  spawnAndCollect,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
-import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -41,8 +31,7 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
 
-const VERSION_PROBE_TIMEOUT_MS = 4_000;
-const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+const GROK_BINARY_UNAVAILABLE_MESSAGE = "Grok CLI (`grok`) is not installed or not on PATH.";
 
 const GROK_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   {
@@ -99,73 +88,10 @@ function grokModelsFromSettings(
   return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
 }
 
-function buildGrokDiscoveredModelsFromSessionModelState(
-  modelState: EffectAcpSchema.SessionModelState | null | undefined,
-): ReadonlyArray<ServerProviderModel> {
-  if (!modelState || modelState.availableModels.length === 0) {
-    return [];
-  }
-  const seen = new Set<string>();
-  return modelState.availableModels
-    .map((model): ServerProviderModel | undefined => {
-      const slug = resolveGrokAcpBaseModelId(model.modelId);
-      if (!slug || seen.has(slug)) {
-        return undefined;
-      }
-      seen.add(slug);
-      return {
-        slug,
-        name: model.name.trim() || slug,
-        isCustom: false,
-        capabilities: EMPTY_CAPABILITIES,
-      };
-    })
-    .filter((model): model is ServerProviderModel => model !== undefined);
-}
-
-const discoverGrokModelsViaAcp = (
-  grokSettings: GrokSettings,
-  environment: NodeJS.ProcessEnv = process.env,
-) =>
-  Effect.gen(function* () {
-    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const acp = yield* makeGrokAcpRuntime({
-      grokSettings,
-      environment,
-      childProcessSpawner,
-      cwd: process.cwd(),
-      clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
-    });
-    const started = yield* acp.start();
-    return buildGrokDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models);
-  }).pipe(Effect.scoped);
-
-const runGrokVersionCommand = (
-  grokSettings: GrokSettings,
-  environment: NodeJS.ProcessEnv = process.env,
-) =>
-  Effect.gen(function* () {
-    const command = grokSettings.binaryPath || "grok";
-    const spawnCommand = yield* resolveSpawnCommand(command, ["--version"], {
-      env: environment,
-    });
-    return yield* spawnAndCollect(
-      command,
-      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
-        env: environment,
-        shell: spawnCommand.shell,
-      }),
-    );
-  });
-
 export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(function* (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
-): Effect.fn.Return<
-  ServerProviderDraft,
-  never,
-  ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
-> {
+) {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const fallbackModels = grokModelsFromSettings(grokSettings.customModels);
 
@@ -185,128 +111,38 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
-  const versionResult = yield* runGrokVersionCommand(grokSettings, environment).pipe(
-    Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
-    Effect.result,
-  );
-
-  if (Result.isFailure(versionResult)) {
-    const error = versionResult.failure;
-    yield* Effect.logWarning("Grok CLI health check failed.", {
-      errorTag: error._tag,
-    });
+  const command = grokSettings.binaryPath || "grok";
+  // Status refreshes are periodic and must stay passive: some unrelated `grok`
+  // executables launch an interactive app even for probe-like arguments.
+  // Starting a real Grok thread performs ACP authentication and model discovery.
+  const installed = yield* isCommandAvailable(command, { env: environment });
+  if (!installed) {
     return buildServerProvider({
       presentation: GROK_PRESENTATION,
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
       probe: {
-        installed: !isCommandMissingCause(error),
+        installed: false,
         version: null,
         status: "error",
         auth: { status: "unknown" },
-        message: isCommandMissingCause(error)
-          ? "Grok CLI (`grok`) is not installed or not on PATH."
-          : "Failed to execute Grok CLI health check.",
+        message: GROK_BINARY_UNAVAILABLE_MESSAGE,
       },
     });
   }
-
-  if (Option.isNone(versionResult.success)) {
-    return buildServerProvider({
-      presentation: GROK_PRESENTATION,
-      enabled: grokSettings.enabled,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Grok CLI is installed but timed out while running `grok --version`.",
-      },
-    });
-  }
-
-  const versionOutput = versionResult.success.value;
-  const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
-  if (versionOutput.code !== 0) {
-    yield* Effect.logWarning("Grok CLI version probe exited with a non-zero status.", {
-      exitCode: versionOutput.code,
-      stdoutLength: versionOutput.stdout.length,
-      stderrLength: versionOutput.stderr.length,
-    });
-    return buildServerProvider({
-      presentation: GROK_PRESENTATION,
-      enabled: grokSettings.enabled,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Grok CLI is installed but failed to run.",
-      },
-    });
-  }
-
-  const discoveryExit = yield* discoverGrokModelsViaAcp(grokSettings, environment).pipe(
-    Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
-    Effect.exit,
-  );
-  if (Exit.isFailure(discoveryExit)) {
-    yield* Effect.logWarning("Grok ACP model discovery failed", {
-      errorTag: causeErrorTag(discoveryExit.cause),
-    });
-    return buildServerProvider({
-      presentation: GROK_PRESENTATION,
-      enabled: grokSettings.enabled,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Grok CLI is installed but ACP startup failed. Check server logs for details.",
-      },
-    });
-  }
-  if (Option.isNone(discoveryExit.value)) {
-    yield* Effect.logWarning(
-      `Grok ACP model discovery timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
-    );
-    return buildServerProvider({
-      presentation: GROK_PRESENTATION,
-      enabled: grokSettings.enabled,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version,
-        status: "error",
-        auth: { status: "unknown" },
-        message: `Grok CLI is installed but ACP startup timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
-      },
-    });
-  }
-  const discoveredModels = discoveryExit.value.value;
-  const models =
-    discoveredModels.length > 0
-      ? grokModelsFromSettings(grokSettings.customModels, discoveredModels)
-      : fallbackModels;
 
   return buildServerProvider({
     presentation: GROK_PRESENTATION,
     enabled: grokSettings.enabled,
     checkedAt,
-    models,
+    models: fallbackModels,
     probe: {
       installed: true,
-      version,
+      version: null,
       status: "ready",
       auth: { status: "unknown" },
+      message: "Authentication is checked when a Grok thread starts.",
     },
   });
 });


### PR DESCRIPTION
Grok provider status refreshes were executing the CLI, which could open an interactive authentication flow during startup. Making probes fully passive removed the only path that discovered models.

Keep startup and periodic status checks executable-free. When a user explicitly starts an authenticated Grok session, publish the session model catalog back into the provider snapshot for subsequent model pickers.

Verification:
- `vp test run apps/server/src/provider/Layers/GrokProvider.test.ts apps/server/src/provider/Layers/GrokAdapter.test.ts` (24 tests)
- `vp run --filter t3 typecheck`

Implemented with OpenAI Codex GPT-5.6 in Oh My Pi.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Grok appears ready and which models are listed until the first thread; behavior is intentional but affects provider UX and snapshot timing.
> 
> **Overview**
> Grok **provider status refreshes** no longer run the CLI (`grok --version`) or spin up ACP for model discovery, avoiding interactive auth flows during startup and periodic checks. Availability is determined with a **passive PATH/binary check** only; auth is deferred until a thread starts.
> 
> **Model catalogs** are filled when a user starts a Grok session: the adapter reports ACP `SessionModelState` after `session/start`, the driver deduplicates and stores discovered models, and triggers a **provider snapshot refresh** so model pickers see the live list on later checks.
> 
> Tests were updated to assert non-execution of the CLI on probe and to verify the discovery callback on session start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72dd944432cceb91c6d4dd25df61b01bc80df3c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish Grok models after ACP session start and make status checks passive
> - `checkGrokProviderStatus` no longer executes the Grok CLI or starts an ACP session; it uses `isCommandAvailable` to detect binary presence and returns `status=ready` with `version=null` when found.
> - `GrokAdapter` gains an optional `onModelStateDiscovered` callback that fires with the ACP session's model state immediately after session startup.
> - `GrokDriver` wires this callback to update a tracked model catalog, trigger a provider snapshot refresh when the catalog changes, and pass discovered models into status checks.
> - Behavioral Change: Grok provider status is now always `ready` when the binary is present, with authentication deferred until a thread starts; version is always reported as `null`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72dd944.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->