### PR TITLE
feat(mobile): filter threads by multiple hosts

### DIFF
--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -29,6 +29,7 @@ import {
 } from "./home-list-filter-menu";
 import {
   hasCustomHomeListOptions,
+  isEnvironmentInHomeScope,
   PROJECT_SORT_OPTIONS,
   THREAD_SORT_OPTIONS,
 } from "./home-list-options";
@@ -39,7 +40,7 @@ export function HomeHeader(props: {
   readonly environments: ReadonlyArray<HomeHeaderEnvironment>;
   readonly projects: ReadonlyArray<HomeListFilterMenuProject>;
   readonly searchQuery: string;
-  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly selectedEnvironmentIds: ReadonlySet<EnvironmentId>;
   readonly selectedProjectKey: string | null;
   readonly projectSortOrder: HomeProjectSortOrder;
   readonly threadSortOrder: SidebarThreadSortOrder;
@@ -75,7 +76,7 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
   // key the "customized" icon state off the environment filter alone.
   const threadListV2Enabled = useThreadListV2Enabled();
   const hasCustomListOptions = threadListV2Enabled
-    ? props.selectedEnvironmentId !== null || props.selectedProjectKey !== null
+    ? props.selectedEnvironmentIds.size > 0 || props.selectedProjectKey !== null
     : hasCustomHomeListOptions(props);
   const menuActions = useMemo<MenuAction[]>(
     () => [
@@ -86,12 +87,15 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
           {
             id: "environment:all",
             title: "All environments",
-            state: checkedMenuState(props.selectedEnvironmentId === null),
+            state: checkedMenuState(props.selectedEnvironmentIds.size === 0),
           },
           ...props.environments.map((environment) => ({
             id: `environment:${environment.environmentId}`,
             title: environment.label,
-            state: checkedMenuState(props.selectedEnvironmentId === environment.environmentId),
+            state: checkedMenuState(
+              props.selectedEnvironmentIds.size > 0 &&
+                isEnvironmentInHomeScope(props.selectedEnvironmentIds, environment.environmentId),
+            ),
           })),
         ],
       },
@@ -142,7 +146,7 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
       props.environments,
       props.projectSortOrder,
       props.projects,
-      props.selectedEnvironmentId,
+      props.selectedEnvironmentIds,
       props.selectedProjectKey,
       props.threadSortOrder,
       threadListV2Enabled,
@@ -306,7 +310,7 @@ function IosHomeHeader(props: HomeHeaderProps) {
   // key the "customized" icon state off the environment filter alone.
   const threadListV2Enabled = useThreadListV2Enabled();
   const hasCustomListOptions = threadListV2Enabled
-    ? props.selectedEnvironmentId !== null || props.selectedProjectKey !== null
+    ? props.selectedEnvironmentIds.size > 0 || props.selectedProjectKey !== null
     : hasCustomHomeListOptions(props);
   const focusSearch = useCallback(() => {
     searchBarRef.current?.focus();
@@ -393,7 +397,7 @@ function IosHomeHeader(props: HomeHeaderProps) {
             <NativeHeaderToolbar.Menu title="Environment">
               <NativeHeaderToolbar.Label>Environment</NativeHeaderToolbar.Label>
               <NativeHeaderToolbar.MenuAction
-                isOn={props.selectedEnvironmentId === null}
+                isOn={props.selectedEnvironmentIds.size === 0}
                 onPress={() => props.onEnvironmentChange(null)}
                 subtitle="Show threads from every environment"
               >
@@ -402,7 +406,13 @@ function IosHomeHeader(props: HomeHeaderProps) {
               {props.environments.map((environment) => (
                 <NativeHeaderToolbar.MenuAction
                   key={environment.environmentId}
-                  isOn={props.selectedEnvironmentId === environment.environmentId}
+                  isOn={
+                    props.selectedEnvironmentIds.size > 0 &&
+                    isEnvironmentInHomeScope(
+                      props.selectedEnvironmentIds,
+                      environment.environmentId,
+                    )
+                  }
                   onPress={() => props.onEnvironmentChange(environment.environmentId)}
                 >
                   <NativeHeaderToolbar.Label>{environment.label}</NativeHeaderToolbar.Label>

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -15,7 +15,7 @@ import { checkForAppUpdateOnLaunch } from "../updates/app-updates";
 import { AndroidHomeFabLayout } from "./AndroidHomeFab";
 import { HomeScreen } from "./HomeScreen";
 import { HomeHeader } from "./HomeHeader";
-import { useHomeListOptions } from "./home-list-options";
+import { isEnvironmentInHomeScope, useHomeListOptions } from "./home-list-options";
 import { buildHomeProjectScopes } from "./homeThreadList";
 import { usePendingTaskListActions } from "./usePendingTaskListActions";
 import { useThreadListActions } from "./useThreadListActions";
@@ -75,19 +75,26 @@ export function HomeRouteScreen() {
     setProjectSortOrder,
     setThreadSortOrder,
   } = useHomeListOptions(availableEnvironmentIds);
-  const selectedEnvironmentId = listOptions.selectedEnvironmentId;
+  const selectedEnvironmentIds = listOptions.selectedEnvironmentIds;
+  const environmentScopedProjects = useMemo(
+    () =>
+      projects.filter((project) =>
+        isEnvironmentInHomeScope(selectedEnvironmentIds, project.environmentId),
+      ),
+    [projects, selectedEnvironmentIds],
+  );
   const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(null);
   const projectFilterOptions = useMemo(
     () =>
       buildHomeProjectScopes({
-        projects,
-        environmentId: selectedEnvironmentId,
+        projects: environmentScopedProjects,
+        environmentId: null,
         projectGroupingMode: listOptions.projectGroupingMode,
       }).map((scope) => ({
         key: scope.key,
         label: scope.title,
       })),
-    [listOptions.projectGroupingMode, projects, selectedEnvironmentId],
+    [environmentScopedProjects, listOptions.projectGroupingMode],
   );
   useEffect(() => {
     if (
@@ -141,7 +148,7 @@ export function HomeRouteScreen() {
           environments={environments}
           projects={projectFilterOptions}
           searchQuery={searchQuery}
-          selectedEnvironmentId={selectedEnvironmentId}
+          selectedEnvironmentIds={selectedEnvironmentIds}
           selectedProjectKey={selectedProjectKey}
           projectSortOrder={listOptions.projectSortOrder}
           threadSortOrder={listOptions.threadSortOrder}
@@ -205,7 +212,7 @@ export function HomeRouteScreen() {
           projectSortOrder={listOptions.projectSortOrder}
           savedConnectionsById={savedConnectionsById}
           searchQuery={searchQuery}
-          selectedEnvironmentId={selectedEnvironmentId}
+          selectedEnvironmentIds={selectedEnvironmentIds}
           selectedProjectKey={selectedProjectKey}
           threads={threads}
           threadSortOrder={listOptions.threadSortOrder}

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -71,6 +71,7 @@ import {
   sortHomeProjectScopes,
   type HomeProjectSortOrder,
 } from "./homeThreadList";
+import { homeEnvironmentScopeKey, isEnvironmentInHomeScope } from "./home-list-options";
 import { SwipeableScrollGateProvider, useSwipeableScrollGate } from "./thread-swipe-actions";
 
 /* ─── Types ──────────────────────────────────────────────────────────── */
@@ -85,7 +86,7 @@ interface HomeScreenProps {
     HomeListFilterMenuEnvironment & Pick<WorkspaceEnvironment, "connectionState">
   >;
   readonly searchQuery: string;
-  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly selectedEnvironmentIds: ReadonlySet<EnvironmentId>;
   readonly selectedProjectKey: string | null;
   readonly projectSortOrder: HomeProjectSortOrder;
   readonly threadSortOrder: SidebarThreadSortOrder;
@@ -215,20 +216,37 @@ export function HomeScreen(props: HomeScreenProps) {
     Platform.OS === "ios" && !NATIVE_LIQUID_GLASS_SUPPORTED
       ? PRE_LIQUID_GLASS_BOTTOM_TOOLBAR_HEIGHT
       : 0;
+  const environmentScopedProjects = useMemo(
+    () =>
+      props.projects.filter((project) =>
+        isEnvironmentInHomeScope(props.selectedEnvironmentIds, project.environmentId),
+      ),
+    [props.projects, props.selectedEnvironmentIds],
+  );
+  const environmentScopedThreads = useMemo(
+    () =>
+      props.threads.filter((thread) =>
+        isEnvironmentInHomeScope(props.selectedEnvironmentIds, thread.environmentId),
+      ),
+    [props.selectedEnvironmentIds, props.threads],
+  );
+  const environmentScopedPendingTasks = useMemo(
+    () =>
+      props.pendingTasks.filter((pendingTask) =>
+        isEnvironmentInHomeScope(props.selectedEnvironmentIds, pendingTask.message.environmentId),
+      ),
+    [props.pendingTasks, props.selectedEnvironmentIds],
+  );
   const searchEnvironmentIds = useMemo(
     () =>
-      props.selectedEnvironmentId === null
-        ? props.environments
-            .filter((environment) => environment.connectionState === "connected")
-            .map((environment) => environment.environmentId)
-        : props.environments.some(
-              (environment) =>
-                environment.environmentId === props.selectedEnvironmentId &&
-                environment.connectionState === "connected",
-            )
-          ? [props.selectedEnvironmentId]
-          : [],
-    [props.environments, props.selectedEnvironmentId],
+      props.environments
+        .filter(
+          (environment) =>
+            environment.connectionState === "connected" &&
+            isEnvironmentInHomeScope(props.selectedEnvironmentIds, environment.environmentId),
+        )
+        .map((environment) => environment.environmentId),
+    [props.environments, props.selectedEnvironmentIds],
   );
   const threadSearch = useThreadSearch(searchEnvironmentIds, props.searchQuery);
   const threadSearchMatchByKey = useMemo(() => {
@@ -303,11 +321,11 @@ export function HomeScreen(props: HomeScreenProps) {
   const projectScopes = useMemo(
     () =>
       buildHomeProjectScopes({
-        projects: props.projects,
-        environmentId: props.selectedEnvironmentId,
+        projects: environmentScopedProjects,
+        environmentId: null,
         projectGroupingMode: props.projectGroupingMode,
       }),
-    [props.projectGroupingMode, props.projects, props.selectedEnvironmentId],
+    [environmentScopedProjects, props.projectGroupingMode],
   );
   const selectedProjectScope = useMemo(
     () =>
@@ -338,31 +356,31 @@ export function HomeScreen(props: HomeScreenProps) {
   const scopedProjects = useMemo(
     () =>
       selectedProjectRefKeys === null
-        ? props.projects
-        : props.projects.filter((project) =>
+        ? environmentScopedProjects
+        : environmentScopedProjects.filter((project) =>
             selectedProjectRefKeys.has(scopedProjectKey(project.environmentId, project.id)),
           ),
-    [props.projects, selectedProjectRefKeys],
+    [environmentScopedProjects, selectedProjectRefKeys],
   );
   const scopedThreads = useMemo(
     () =>
       selectedProjectRefKeys === null
-        ? props.threads
-        : props.threads.filter((thread) =>
+        ? environmentScopedThreads
+        : environmentScopedThreads.filter((thread) =>
             selectedProjectRefKeys.has(scopedProjectKey(thread.environmentId, thread.projectId)),
           ),
-    [props.threads, selectedProjectRefKeys],
+    [environmentScopedThreads, selectedProjectRefKeys],
   );
   const scopedPendingTasks = useMemo(
     () =>
       selectedProjectRefKeys === null
-        ? props.pendingTasks
-        : props.pendingTasks.filter((pendingTask) =>
+        ? environmentScopedPendingTasks
+        : environmentScopedPendingTasks.filter((pendingTask) =>
             selectedProjectRefKeys.has(
               scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
             ),
           ),
-    [props.pendingTasks, selectedProjectRefKeys],
+    [environmentScopedPendingTasks, selectedProjectRefKeys],
   );
 
   const projectGroups = useMemo(
@@ -371,7 +389,7 @@ export function HomeScreen(props: HomeScreenProps) {
         projects: scopedProjects,
         threads: scopedThreads,
         pendingTasks: scopedPendingTasks,
-        environmentId: props.selectedEnvironmentId,
+        environmentId: null,
         searchQuery: props.searchQuery,
         matchedThreadKeys,
         projectSortOrder: props.projectSortOrder,
@@ -382,7 +400,7 @@ export function HomeScreen(props: HomeScreenProps) {
       props.projectGroupingMode,
       props.projectSortOrder,
       props.searchQuery,
-      props.selectedEnvironmentId,
+      props.selectedEnvironmentIds,
       props.threadSortOrder,
       matchedThreadKeys,
       scopedPendingTasks,
@@ -423,16 +441,14 @@ export function HomeScreen(props: HomeScreenProps) {
     () =>
       sortHomeProjectScopes({
         scopes: projectScopes,
-        threads: props.threads,
-        pendingTasks: props.pendingTasks,
+        threads: environmentScopedThreads,
+        pendingTasks: environmentScopedPendingTasks,
         projectSortOrder: props.projectSortOrder,
       }),
     [
-      props.pendingTasks,
-      props.projects,
+      environmentScopedPendingTasks,
+      environmentScopedThreads,
       props.projectSortOrder,
-      props.selectedEnvironmentId,
-      props.threads,
       projectScopes,
     ],
   );
@@ -545,7 +561,7 @@ export function HomeScreen(props: HomeScreenProps) {
   const [settledVisibleCount, setSettledVisibleCount] = useState(
     THREAD_LIST_V2_SETTLED_INITIAL_COUNT,
   );
-  const settledResetKey = `${props.selectedEnvironmentId ?? "all"}:${v2ProjectScopeKey ?? "all"}:${props.searchQuery.trim()}`;
+  const settledResetKey = `${homeEnvironmentScopeKey(props.selectedEnvironmentIds)}:${v2ProjectScopeKey ?? "all"}:${props.searchQuery.trim()}`;
   const lastSettledResetKeyRef = useRef(settledResetKey);
   if (lastSettledResetKeyRef.current !== settledResetKey) {
     lastSettledResetKeyRef.current = settledResetKey;
@@ -643,8 +659,8 @@ export function HomeScreen(props: HomeScreenProps) {
     // Settled threads are live shells; archived threads keep their original
     // "hidden from lists" meaning.
     return buildThreadListV2Items({
-      threads: props.threads.filter((thread) => thread.archivedAt === null),
-      environmentId: props.selectedEnvironmentId,
+      threads: environmentScopedThreads.filter((thread) => thread.archivedAt === null),
+      environmentId: null,
       projectRefs: v2ScopedProjectGroup === null ? null : v2ScopedProjectGroup.projectRefs,
       searchQuery: props.searchQuery,
       matchedThreadKeys,
@@ -668,8 +684,7 @@ export function HomeScreen(props: HomeScreenProps) {
     settlementEnvironmentIds,
     snoozeEnvironmentIds,
     props.searchQuery,
-    props.selectedEnvironmentId,
-    props.threads,
+    environmentScopedThreads,
     matchedThreadKeys,
     threadListV2Enabled,
     v2ScopedProjectGroup,
@@ -695,10 +710,8 @@ export function HomeScreen(props: HomeScreenProps) {
   const v2SearchQuery = props.searchQuery.trim().toLocaleLowerCase();
   const v2PendingTasks = useMemo(
     () =>
-      props.pendingTasks.filter(
+      environmentScopedPendingTasks.filter(
         (pendingTask) =>
-          (props.selectedEnvironmentId === null ||
-            pendingTask.message.environmentId === props.selectedEnvironmentId) &&
           (v2ScopedProjectKeys === null ||
             v2ScopedProjectKeys.has(
               scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
@@ -706,7 +719,7 @@ export function HomeScreen(props: HomeScreenProps) {
           (v2SearchQuery.length === 0 ||
             pendingTask.title.toLocaleLowerCase().includes(v2SearchQuery)),
       ),
-    [props.pendingTasks, props.selectedEnvironmentId, v2ScopedProjectKeys, v2SearchQuery],
+    [environmentScopedPendingTasks, v2ScopedProjectKeys, v2SearchQuery],
   );
   const threadListV2Items = useMemo(
     () =>
@@ -1013,10 +1026,12 @@ export function HomeScreen(props: HomeScreenProps) {
     props.threads.some((thread) => thread.archivedAt === null) || props.pendingTasks.length > 0;
   const hasResults = projectGroups.length > 0;
   const selectedEnvironmentLabel =
-    props.selectedEnvironmentId === null
-      ? null
-      : (props.savedConnectionsById[props.selectedEnvironmentId]?.environmentLabel ??
-        "this environment");
+    props.selectedEnvironmentIds.size === 1
+      ? (props.savedConnectionsById[[...props.selectedEnvironmentIds][0]!]?.environmentLabel ??
+        "this environment")
+      : props.selectedEnvironmentIds.size > 1
+        ? `${props.selectedEnvironmentIds.size} environments`
+        : null;
   // Connection state surfaces in the header title slot
   // (WorkspaceConnectionTitle) — nothing renders inside the list, so
   // reconnects never shift the rows.

--- a/apps/mobile/src/features/home/home-list-filter-menu.test.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.test.ts
@@ -11,7 +11,7 @@ describe("buildHomeListFilterMenu", () => {
         { key: "environment-1:project-1", label: "Codething" },
         { key: "environment-1:project-2", label: "Website" },
       ],
-      selectedEnvironmentId: null,
+      selectedEnvironmentIds: new Set(),
       selectedProjectKey: "environment-1:project-1",
       projectSortOrder: "updated_at",
       threadSortOrder: "updated_at",
@@ -39,5 +39,34 @@ describe("buildHomeListFilterMenu", () => {
     projectMenu.items[2]?.onPress();
     expect(onProjectChange).toHaveBeenNthCalledWith(1, null);
     expect(onProjectChange).toHaveBeenNthCalledWith(2, "environment-1:project-2");
+  });
+
+  it("keeps multiple selected environments checked", () => {
+    const menu = buildHomeListFilterMenu({
+      environments: [
+        { environmentId: "environment-1" as never, label: "Primary" },
+        { environmentId: "environment-2" as never, label: "Remote" },
+        { environmentId: "environment-3" as never, label: "Other" },
+      ],
+      projects: [],
+      selectedEnvironmentIds: new Set(["environment-1" as never, "environment-2" as never]),
+      selectedProjectKey: null,
+      projectSortOrder: "updated_at",
+      threadSortOrder: "updated_at",
+      onEnvironmentChange: vi.fn(),
+      onProjectChange: vi.fn(),
+      onProjectSortOrderChange: vi.fn(),
+      onThreadSortOrderChange: vi.fn(),
+    });
+
+    expect(menu.items[0]).toMatchObject({
+      type: "submenu",
+      items: [
+        { title: "All environments", state: "off" },
+        { title: "Primary", state: "on" },
+        { title: "Remote", state: "on" },
+        { title: "Other", state: "off" },
+      ],
+    });
   });
 });

--- a/apps/mobile/src/features/home/home-list-filter-menu.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.ts
@@ -2,6 +2,7 @@ import type { EnvironmentId, SidebarThreadSortOrder } from "@t3tools/contracts";
 
 import type { HomeProjectSortOrder } from "./homeThreadList";
 import { PROJECT_SORT_OPTIONS, THREAD_SORT_OPTIONS } from "./home-list-options";
+import { isEnvironmentInHomeScope } from "./home-list-options";
 
 export interface HomeListFilterMenuEnvironment {
   readonly environmentId: EnvironmentId;
@@ -35,7 +36,7 @@ export interface HomeListFilterMenu {
 export function buildHomeListFilterMenu(props: {
   readonly environments: ReadonlyArray<HomeListFilterMenuEnvironment>;
   readonly projects: ReadonlyArray<HomeListFilterMenuProject>;
-  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly selectedEnvironmentIds: ReadonlySet<EnvironmentId>;
   readonly selectedProjectKey: string | null;
   readonly projectSortOrder: HomeProjectSortOrder;
   readonly threadSortOrder: SidebarThreadSortOrder;
@@ -58,14 +59,15 @@ export function buildHomeListFilterMenu(props: {
         type: "action",
         title: "All environments",
         subtitle: "Show threads from every environment",
-        state: props.selectedEnvironmentId === null ? "on" : "off",
+        state: props.selectedEnvironmentIds.size === 0 ? "on" : "off",
         onPress: () => props.onEnvironmentChange(null),
       },
       ...props.environments.map((environment) => ({
         type: "action" as const,
         title: environment.label,
         state:
-          props.selectedEnvironmentId === environment.environmentId
+          isEnvironmentInHomeScope(props.selectedEnvironmentIds, environment.environmentId) &&
+          props.selectedEnvironmentIds.size > 0
             ? ("on" as const)
             : ("off" as const),
         onPress: () => props.onEnvironmentChange(environment.environmentId),

--- a/apps/mobile/src/features/home/home-list-options.test.ts
+++ b/apps/mobile/src/features/home/home-list-options.test.ts
@@ -4,10 +4,14 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { hasCustomHomeListOptions, type HomeListOptions } from "./home-list-options";
+import {
+  hasCustomHomeListOptions,
+  isEnvironmentInHomeScope,
+  type HomeListOptions,
+} from "./home-list-options";
 
 const defaults: HomeListOptions = {
-  selectedEnvironmentId: null,
+  selectedEnvironmentIds: new Set(),
   projectSortOrder:
     DEFAULT_SIDEBAR_PROJECT_SORT_ORDER === "manual"
       ? "updated_at"
@@ -22,10 +26,20 @@ describe("home list options", () => {
 
   it("marks environment filters as customized", () => {
     expect(
-      hasCustomHomeListOptions({ ...defaults, selectedEnvironmentId: "environment-1" as never }),
+      hasCustomHomeListOptions({
+        ...defaults,
+        selectedEnvironmentIds: new Set(["environment-1" as never]),
+      }),
     ).toBe(true);
     expect(
       hasCustomHomeListOptions({ ...defaults, selectedProjectKey: "environment-1:project-1" }),
     ).toBe(true);
+  });
+
+  it("treats an empty environment selection as all and supports multiple hosts", () => {
+    expect(isEnvironmentInHomeScope(new Set(), "environment-1" as never)).toBe(true);
+    const selected = new Set(["environment-1", "environment-2"] as never[]);
+    expect(isEnvironmentInHomeScope(selected, "environment-1" as never)).toBe(true);
+    expect(isEnvironmentInHomeScope(selected, "environment-3" as never)).toBe(false);
   });
 });

--- a/apps/mobile/src/features/home/home-list-options.ts
+++ b/apps/mobile/src/features/home/home-list-options.ts
@@ -22,7 +22,7 @@ import {
 import type { HomeProjectSortOrder } from "./homeThreadList";
 
 export interface HomeListOptions {
-  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly selectedEnvironmentIds: ReadonlySet<EnvironmentId>;
   readonly projectSortOrder: HomeProjectSortOrder;
   readonly threadSortOrder: SidebarThreadSortOrder;
 }
@@ -49,13 +49,26 @@ export const THREAD_SORT_OPTIONS: ReadonlyArray<{
 
 function defaultHomeListOptions(): HomeListOptions {
   return {
-    selectedEnvironmentId: null,
+    selectedEnvironmentIds: new Set(),
     projectSortOrder:
       DEFAULT_SIDEBAR_PROJECT_SORT_ORDER === "manual"
         ? "updated_at"
         : DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
     threadSortOrder: DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
   };
+}
+
+export function isEnvironmentInHomeScope(
+  selectedEnvironmentIds: ReadonlySet<EnvironmentId>,
+  environmentId: EnvironmentId,
+): boolean {
+  return selectedEnvironmentIds.size === 0 || selectedEnvironmentIds.has(environmentId);
+}
+
+export function homeEnvironmentScopeKey(
+  selectedEnvironmentIds: ReadonlySet<EnvironmentId>,
+): string {
+  return selectedEnvironmentIds.size === 0 ? "all" : [...selectedEnvironmentIds].sort().join(",");
 }
 
 interface HomeListOptionsContextValue {
@@ -91,7 +104,7 @@ export function hasCustomHomeListOptions(
       ? "updated_at"
       : DEFAULT_SIDEBAR_PROJECT_SORT_ORDER;
   return (
-    options.selectedEnvironmentId !== null ||
+    options.selectedEnvironmentIds.size > 0 ||
     (options.selectedProjectKey !== null && options.selectedProjectKey !== undefined) ||
     options.projectSortOrder !== defaultProjectSortOrder ||
     options.threadSortOrder !== DEFAULT_SIDEBAR_THREAD_SORT_ORDER
@@ -103,22 +116,34 @@ export function useHomeListOptions(availableEnvironmentIds: ReadonlySet<Environm
   const [localOptions, setLocalOptions] = useState<HomeListOptions>(defaultHomeListOptions);
   const options = shared?.options ?? localOptions;
   const setOptions = shared?.setOptions ?? setLocalOptions;
-  const selectedEnvironmentId =
-    options.selectedEnvironmentId !== null &&
-    availableEnvironmentIds.has(options.selectedEnvironmentId)
-      ? options.selectedEnvironmentId
-      : null;
+  const selectedEnvironmentIds =
+    options.selectedEnvironmentIds.size === 0
+      ? options.selectedEnvironmentIds
+      : new Set(
+          [...options.selectedEnvironmentIds].filter((environmentId) =>
+            availableEnvironmentIds.has(environmentId),
+          ),
+        );
   const availableOptions =
-    selectedEnvironmentId === options.selectedEnvironmentId
+    selectedEnvironmentIds.size === options.selectedEnvironmentIds.size
       ? options
-      : { ...options, selectedEnvironmentId };
+      : { ...options, selectedEnvironmentIds };
   const resolvedOptions: ResolvedHomeListOptions = {
     ...availableOptions,
     projectGroupingMode: shared?.projectGroupingMode ?? "repository",
   };
 
   const setSelectedEnvironmentId = useCallback((value: EnvironmentId | null) => {
-    setOptions((current) => ({ ...current, selectedEnvironmentId: value }));
+    setOptions((current) => {
+      if (value === null) return { ...current, selectedEnvironmentIds: new Set() };
+      const selectedEnvironmentIds = new Set(current.selectedEnvironmentIds);
+      if (selectedEnvironmentIds.has(value)) {
+        selectedEnvironmentIds.delete(value);
+      } else {
+        selectedEnvironmentIds.add(value);
+      }
+      return { ...current, selectedEnvironmentIds };
+    });
   }, []);
   const setProjectSortOrder = useCallback((value: HomeProjectSortOrder) => {
     setOptions((current) => ({ ...current, projectSortOrder: value }));

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -38,6 +38,8 @@ import { useSavedRemoteConnections } from "../../state/use-remote-environment-re
 import { useHardwareKeyboardCommand } from "../keyboard/hardwareKeyboardCommands";
 import {
   hasCustomHomeListOptions,
+  homeEnvironmentScopeKey,
+  isEnvironmentInHomeScope,
   PROJECT_SORT_OPTIONS,
   THREAD_SORT_OPTIONS,
   useHomeListOptions,
@@ -231,20 +233,37 @@ function ThreadNavigationSidebarPane(
   );
   const { options, setSelectedEnvironmentId, setProjectSortOrder, setThreadSortOrder } =
     useHomeListOptions(availableEnvironmentIds);
+  const environmentScopedProjects = useMemo(
+    () =>
+      projects.filter((project) =>
+        isEnvironmentInHomeScope(options.selectedEnvironmentIds, project.environmentId),
+      ),
+    [options.selectedEnvironmentIds, projects],
+  );
+  const environmentScopedThreads = useMemo(
+    () =>
+      threads.filter((thread) =>
+        isEnvironmentInHomeScope(options.selectedEnvironmentIds, thread.environmentId),
+      ),
+    [options.selectedEnvironmentIds, threads],
+  );
+  const environmentScopedPendingTasks = useMemo(
+    () =>
+      pendingTasks.filter((pendingTask) =>
+        isEnvironmentInHomeScope(options.selectedEnvironmentIds, pendingTask.message.environmentId),
+      ),
+    [options.selectedEnvironmentIds, pendingTasks],
+  );
   const searchEnvironmentIds = useMemo(
     () =>
-      options.selectedEnvironmentId === null
-        ? workspaceEnvironments
-            .filter((environment) => environment.connectionState === "connected")
-            .map((environment) => environment.environmentId)
-        : workspaceEnvironments.some(
-              (environment) =>
-                environment.environmentId === options.selectedEnvironmentId &&
-                environment.connectionState === "connected",
-            )
-          ? [options.selectedEnvironmentId]
-          : [],
-    [options.selectedEnvironmentId, workspaceEnvironments],
+      workspaceEnvironments
+        .filter(
+          (environment) =>
+            environment.connectionState === "connected" &&
+            isEnvironmentInHomeScope(options.selectedEnvironmentIds, environment.environmentId),
+        )
+        .map((environment) => environment.environmentId),
+    [options.selectedEnvironmentIds, workspaceEnvironments],
   );
   const threadSearch = useThreadSearch(searchEnvironmentIds, props.searchQuery);
   const threadSearchMatchByKey = useMemo(() => {
@@ -264,11 +283,11 @@ function ThreadNavigationSidebarPane(
   const projectScopes = useMemo(
     () =>
       buildHomeProjectScopes({
-        projects,
-        environmentId: options.selectedEnvironmentId,
+        projects: environmentScopedProjects,
+        environmentId: null,
         projectGroupingMode: options.projectGroupingMode,
       }),
-    [options.projectGroupingMode, options.selectedEnvironmentId, projects],
+    [environmentScopedProjects, options.projectGroupingMode],
   );
   const projectFilterOptions = useMemo(
     () =>
@@ -322,31 +341,31 @@ function ThreadNavigationSidebarPane(
   const scopedProjects = useMemo(
     () =>
       selectedProjectRefs === null
-        ? projects
-        : projects.filter((project) =>
+        ? environmentScopedProjects
+        : environmentScopedProjects.filter((project) =>
             selectedProjectRefs.has(scopedProjectKey(project.environmentId, project.id)),
           ),
-    [projects, selectedProjectRefs],
+    [environmentScopedProjects, selectedProjectRefs],
   );
   const scopedThreads = useMemo(
     () =>
       selectedProjectRefs === null
-        ? threads
-        : threads.filter((thread) =>
+        ? environmentScopedThreads
+        : environmentScopedThreads.filter((thread) =>
             selectedProjectRefs.has(scopedProjectKey(thread.environmentId, thread.projectId)),
           ),
-    [selectedProjectRefs, threads],
+    [environmentScopedThreads, selectedProjectRefs],
   );
   const scopedPendingTasks = useMemo(
     () =>
       selectedProjectRefs === null
-        ? pendingTasks
-        : pendingTasks.filter((pendingTask) =>
+        ? environmentScopedPendingTasks
+        : environmentScopedPendingTasks.filter((pendingTask) =>
             selectedProjectRefs.has(
               scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
             ),
           ),
-    [pendingTasks, selectedProjectRefs],
+    [environmentScopedPendingTasks, selectedProjectRefs],
   );
   const groups = useMemo(
     () =>
@@ -354,7 +373,7 @@ function ThreadNavigationSidebarPane(
         projects: scopedProjects,
         threads: scopedThreads,
         pendingTasks: scopedPendingTasks,
-        environmentId: options.selectedEnvironmentId,
+        environmentId: null,
         searchQuery: props.searchQuery,
         matchedThreadKeys,
         projectSortOrder: options.projectSortOrder,
@@ -435,7 +454,7 @@ function ThreadNavigationSidebarPane(
   const [settledVisibleCount, setSettledVisibleCount] = useState(
     THREAD_LIST_V2_SETTLED_INITIAL_COUNT,
   );
-  const settledResetKey = `${options.selectedEnvironmentId ?? "all"}:${selectedProjectKey ?? "all"}:${props.searchQuery.trim()}`;
+  const settledResetKey = `${homeEnvironmentScopeKey(options.selectedEnvironmentIds)}:${selectedProjectKey ?? "all"}:${props.searchQuery.trim()}`;
   const lastSettledResetKeyRef = useRef(settledResetKey);
   if (lastSettledResetKeyRef.current !== settledResetKey) {
     lastSettledResetKeyRef.current = settledResetKey;
@@ -530,8 +549,8 @@ function ThreadNavigationSidebarPane(
         nextSnoozeWakeAt: null,
       };
     return buildThreadListV2Items({
-      threads: threads.filter((thread) => thread.archivedAt === null),
-      environmentId: options.selectedEnvironmentId,
+      threads: environmentScopedThreads.filter((thread) => thread.archivedAt === null),
+      environmentId: null,
       projectRefs: selectedProjectScope === null ? null : selectedProjectScope.projectRefs,
       searchQuery: props.searchQuery,
       matchedThreadKeys,
@@ -552,7 +571,7 @@ function ThreadNavigationSidebarPane(
     snoozedShelfExpanded,
     settledShelfExpanded,
     props.selectedThreadKey,
-    options.selectedEnvironmentId,
+    environmentScopedThreads,
     props.searchQuery,
     matchedThreadKeys,
     settledVisibleCount,
@@ -584,10 +603,8 @@ function ThreadNavigationSidebarPane(
     // deletable while their environment is offline. Same environment scope
     // and search filter as the list.
     const v2SearchQuery = props.searchQuery.trim().toLocaleLowerCase();
-    const v2PendingTasks = pendingTasks.filter(
+    const v2PendingTasks = environmentScopedPendingTasks.filter(
       (pendingTask) =>
-        (options.selectedEnvironmentId === null ||
-          pendingTask.message.environmentId === options.selectedEnvironmentId) &&
         (selectedProjectRefs === null ||
           selectedProjectRefs.has(
             scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
@@ -617,8 +634,7 @@ function ThreadNavigationSidebarPane(
   }, [
     listLayout.items,
     nowMinute,
-    options.selectedEnvironmentId,
-    pendingTasks,
+    environmentScopedPendingTasks,
     props.searchQuery,
     selectedProjectRefs,
     settledShelfExpanded,
@@ -636,15 +652,14 @@ function ThreadNavigationSidebarPane(
             id: "environment:all",
             title: "All environments",
             subtitle: "Show threads from every environment",
-            state: options.selectedEnvironmentId === null ? "on" : "off",
+            state: options.selectedEnvironmentIds.size === 0 ? "on" : "off",
           },
           ...environments.map((environment) => ({
             id: `environment:${environment.environmentId}`,
             title: environment.label,
-            state:
-              options.selectedEnvironmentId === environment.environmentId
-                ? ("on" as const)
-                : ("off" as const),
+            state: options.selectedEnvironmentIds.has(environment.environmentId)
+              ? ("on" as const)
+              : ("off" as const),
           })),
         ],
       },
@@ -1128,7 +1143,7 @@ function ThreadNavigationSidebarPane(
   // v2 ignores the sort/group options, so only the environment filter can
   // light the "customized" state while the beta is on.
   const filterCustomized = threadListV2Enabled
-    ? options.selectedEnvironmentId !== null || selectedProjectKey !== null
+    ? options.selectedEnvironmentIds.size > 0 || selectedProjectKey !== null
     : hasCustomHomeListOptions({ ...options, selectedProjectKey });
   const filterIcon = filterCustomized
     ? "line.3.horizontal.decrease.circle.fill"
@@ -1138,7 +1153,7 @@ function ThreadNavigationSidebarPane(
       buildHomeListFilterMenu({
         environments,
         projects: projectFilterOptions,
-        selectedEnvironmentId: options.selectedEnvironmentId,
+        selectedEnvironmentIds: options.selectedEnvironmentIds,
         selectedProjectKey,
         projectSortOrder: options.projectSortOrder,
         threadSortOrder: options.threadSortOrder,


### PR DESCRIPTION
The mobile thread list only allowed one environment at a time, while multi-host users often need a subset of connected environments.

Make the environment menu additive: an empty selection still means all hosts, individual hosts toggle independently, and the same scope filters search, projects, threads, pending tasks, and both list layouts in compact and split navigation.

Verification:
- `vp test run apps/mobile/src/features/home/home-list-options.test.ts apps/mobile/src/features/home/home-list-filter-menu.test.ts` (5 tests)
- `vp run --filter @t3tools/mobile typecheck`

Implemented with OpenAI Codex GPT-5.6 in Oh My Pi.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad but localized changes to how the home and sidebar thread lists are filtered and searched; behavior is covered by new unit tests and does not touch persistence or server APIs.
> 
> **Overview**
> Replaces the home thread list’s **single-environment** filter with a **multi-host** selection: an empty set still means all environments, and tapping a host **toggles** it in or out instead of replacing the previous choice.
> 
> **`home-list-options`** now stores `selectedEnvironmentIds` as a `Set`, exposes `isEnvironmentInHomeScope` and `homeEnvironmentScopeKey`, and updates “custom filter” detection and settled-list reset keys for multi-select scopes. **Home** (`HomeRouteScreen`, `HomeScreen`, `HomeHeader`) and **split sidebar** (`ThreadNavigationSidebar`) pre-filter projects, threads, pending tasks, and search targets through that scope before project grouping, including Thread List v2. Filter menus show multiple environments checked; empty states can describe “N environments” when more than one is selected.
> 
> Tests cover scope helpers and multi-checked environment menu items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d1ebd3f2f29f9e26216b2172bf4b3dfa3080d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter home and sidebar thread lists by multiple environments
> - Replaces single environment selection with a `ReadonlySet<EnvironmentId>` throughout the home and sidebar thread views; an empty set means "all environments".
> - Adds `isEnvironmentInHomeScope`, `homeEnvironmentScopeKey`, and toggle-based `setSelectedEnvironmentId` in [home-list-options.ts](https://github.com/pingdotgg/t3code/pull/6077/files#diff-9c8d937dff6c056fa183e790cac4efc40bda9492809565dd83fd2fc799b152e8) to support multi-select with stable reset keys.
> - Environment filter menus in [HomeHeader](https://github.com/pingdotgg/t3code/pull/6077/files#diff-1ba9649b1bf1262669a23a80f40994038467f6ae019d2ce77f1bbc7e0f65e198), [home-list-filter-menu.ts](https://github.com/pingdotgg/t3code/pull/6077/files#diff-cf160a75aadc6f93da0243be0557afd7eedbd5868ae2aa80e06698957fa6357e), and [ThreadNavigationSidebar](https://github.com/pingdotgg/t3code/pull/6077/files#diff-4431208d7dda139d19919302f332d6a63788b9d114b4b7a410d89a727b9ed455) now show multiple checked items and an "All environments" option when nothing is selected.
> - Project scoping, thread grouping, pending tasks, and search environment sets are all derived by filtering through the selected environment set before being passed downstream.
> - Behavioral Change: environment selection is now toggle-based multi-select; previously selected single IDs are not automatically migrated and unavailable IDs are pruned on load.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 89d1ebd. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->