### PR TITLE
fix(web): align sidebar wordmark label

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -90,7 +90,7 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
       <T3Wordmark />
       <span
         className={cn(
-          "truncate text-sm font-medium tracking-tight",
+          "-translate-y-px truncate text-sm font-medium tracking-tight",
           onBackdrop ? "text-white/70" : "text-muted-foreground",
         )}
       >


### PR DESCRIPTION
## What Changed

Moved the sidebar “Code” label up by one pixel. 

## Why

The T3 and Code labels in the sidebar weren't aligned in Chrome.

## UI Changes

Before:

<img width="468" height="132" alt="image" src="https://github.com/user-attachments/assets/f9dca400-e6c7-4e2e-b689-17b4f4aa810b" />

After: 

<img width="480" height="155" alt="image" src="https://github.com/user-attachments/assets/f061e391-81d9-46bc-87e1-69bf6c89f069" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic one-pixel CSS tweak in the sidebar brand; no functional or security impact.
> 
> **Overview**
> Nudges the sidebar **“Code”** label up by 1px with `-translate-y-px` so it aligns with the T3 wordmark in Chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf9a674d8c2e5f12bf2c43d66ecd802fa3f554a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix vertical alignment of wordmark label in sidebar
> Adds `-translate-y-px` to the label span in `SidebarBrand`, shifting the 'Code' text up by 1px to correct its visual alignment in [SidebarChrome.tsx](https://github.com/pingdotgg/t3code/pull/6086/files#diff-cbdc7d544762cec67fb7c23f9e66e80e1ca2158f0d100a878363a7ae01f77c11).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cf9a67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->