### PR TITLE
fix(web): scope source control settings by environment

### DIFF
--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -22,22 +22,12 @@ import * as Arr from "effect/Array";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
 import * as Result from "effect/Result";
-import {
-  CloudIcon,
-  LaptopIcon,
-  LoaderIcon,
-  MonitorIcon,
-  PlusIcon,
-  RefreshCwIcon,
-  TerminalIcon,
-} from "lucide-react";
+import { LoaderIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 
-import { isDesktopLocalConnectionTarget } from "../../connection/desktopLocal";
 import { isElectron } from "../../env";
 import { usePrimarySessionState } from "../../environments/primary";
 import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
-import { cn } from "../../lib/utils";
 import { resolveAppModelSelectionState } from "../../modelSelection";
 import {
   useEnvironments,
@@ -48,11 +38,6 @@ import { EMPTY_SERVER_PROVIDERS, serverEnvironment } from "../../state/server";
 import { useEnvironmentSessionState } from "../../state/session";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { getRelativeTimeState } from "../../timestampFormat";
-import {
-  ConnectionStatusDot,
-  connectionPhaseDotClassName,
-  connectionPhasePingClassName,
-} from "../ConnectionStatusDot";
 import {
   canOneClickUpdateProviderCandidate,
   collectProviderUpdateCandidates,
@@ -89,6 +74,7 @@ import {
   SettingsSection,
   useRelativeTimeTick,
 } from "./settingsLayout";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import {
   buildProviderEnvironmentOptions,
   classifyProviderEnvironmentAccess,
@@ -145,22 +131,6 @@ function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }
   );
 }
 
-function providerEnvironmentIcon(environment: EnvironmentPresentation) {
-  if (environment.entry.target._tag === "PrimaryConnectionTarget") return MonitorIcon;
-  if (environment.entry.target._tag === "RelayConnectionTarget") return CloudIcon;
-  if (environment.entry.target._tag === "SshConnectionTarget") return TerminalIcon;
-  if (isDesktopLocalConnectionTarget(environment.entry.target)) return LaptopIcon;
-  return CloudIcon;
-}
-
-function providerEnvironmentDetail(environment: EnvironmentPresentation): string {
-  if (environment.entry.target._tag === "PrimaryConnectionTarget") return "Primary device";
-  if (environment.relayManaged) return "T3 Connect";
-  if (environment.entry.target._tag === "SshConnectionTarget") return "SSH";
-  if (isDesktopLocalConnectionTarget(environment.entry.target)) return "Local device";
-  return environment.displayUrl ?? "Remote device";
-}
-
 function EnvironmentUnavailableRow({
   environment,
   access,
@@ -208,68 +178,16 @@ export function ProviderSettingsPanel() {
   );
   const selectedEnvironment =
     options.find((environment) => environment.environmentId === effectiveEnvironmentId) ?? null;
-  const onlyPrimaryDevice =
-    options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
 
   return (
     <SettingsPageContainer>
-      {!onlyPrimaryDevice ? (
-        <SettingsSection title="Devices">
-          {options.length === 0 ? (
-            // The catalog hydrates asynchronously, so an empty list before it is
-            // ready means "not loaded yet", not "nothing is connected".
-            <SettingsRow
-              title={isReady ? "No connected devices" : "Loading devices"}
-              description={
-                isReady
-                  ? "Connect an execution environment before configuring providers."
-                  : "Reading connected execution environments."
-              }
-            />
-          ) : (
-            <div className="grid gap-1 sm:grid-cols-2">
-              {options.map((environment) => {
-                const Icon = providerEnvironmentIcon(environment);
-                const selected = environment.environmentId === effectiveEnvironmentId;
-                const statusText = connectionStatusText(environment.connection);
-                return (
-                  <button
-                    key={environment.environmentId}
-                    type="button"
-                    aria-pressed={selected}
-                    className={cn(
-                      "flex min-w-0 items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors sm:px-4",
-                      selected
-                        ? "bg-primary/8 ring-1 ring-primary/25 dark:bg-primary/12"
-                        : "hover:bg-muted/40",
-                    )}
-                    onClick={() => setSelectedEnvironmentId(environment.environmentId)}
-                  >
-                    <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-background text-muted-foreground">
-                      <Icon className="size-4" aria-hidden />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="flex items-center gap-1.5">
-                        <ConnectionStatusDot
-                          tooltipText={statusText}
-                          dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
-                          pingClassName={connectionPhasePingClassName(environment.connection.phase)}
-                        />
-                        <span className="truncate text-sm font-medium text-foreground">
-                          {environment.label}
-                        </span>
-                      </span>
-                      <span className="block truncate pl-[18px] text-xs text-muted-foreground">
-                        {providerEnvironmentDetail(environment)} · {statusText}
-                      </span>
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </SettingsSection>
-      ) : null}
+      <SettingsEnvironmentSelector
+        environments={options}
+        isReady={isReady}
+        selectedEnvironmentId={effectiveEnvironmentId}
+        emptyDescription="Connect an execution environment before configuring providers."
+        onSelect={setSelectedEnvironmentId}
+      />
 
       {selectedEnvironment ? (
         <SelectedEnvironmentProviderSettings

--- a/apps/web/src/components/settings/SettingsEnvironmentSelector.test.tsx
+++ b/apps/web/src/components/settings/SettingsEnvironmentSelector.test.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from "react";
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { visitElements } from "../../test/reactElementTree";
+import { ConnectionStatusDot } from "../ConnectionStatusDot";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
+
+describe("SettingsEnvironmentSelector", () => {
+  it("renders a non-interactive status dot inside each environment button", () => {
+    const environmentId = EnvironmentId.make("remote-device");
+    const selector = SettingsEnvironmentSelector({
+      environments: [
+        {
+          environmentId,
+          label: "Remote device",
+          displayUrl: null,
+          relayManaged: true,
+          entry: { target: { _tag: "RelayConnectionTarget" } },
+          connection: { phase: "connected", error: null, traceId: null },
+          serverConfig: null,
+        },
+      ] as unknown as Parameters<typeof SettingsEnvironmentSelector>[0]["environments"],
+      isReady: true,
+      selectedEnvironmentId: environmentId,
+      emptyDescription: "Connect an environment.",
+      onSelect: () => undefined,
+    }) as ReactElement<Record<string, unknown>>;
+
+    const statusDot = visitElements(selector, (element) => element.type === ConnectionStatusDot);
+    expect(statusDot?.props.tooltipText).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
+++ b/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
@@ -77,7 +77,6 @@ export function SettingsEnvironmentSelector({
                 <span className="min-w-0 flex-1">
                   <span className="flex items-center gap-1.5">
                     <ConnectionStatusDot
-                      tooltipText={statusText}
                       dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
                       pingClassName={connectionPhasePingClassName(environment.connection.phase)}
                     />

--- a/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
+++ b/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
@@ -1,0 +1,99 @@
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
+import type { EnvironmentId } from "@t3tools/contracts";
+import { CloudIcon, LaptopIcon, MonitorIcon, TerminalIcon } from "lucide-react";
+
+import { isDesktopLocalConnectionTarget } from "../../connection/desktopLocal";
+import { cn } from "../../lib/utils";
+import type { EnvironmentPresentation } from "../../state/environments";
+import {
+  ConnectionStatusDot,
+  connectionPhaseDotClassName,
+  connectionPhasePingClassName,
+} from "../ConnectionStatusDot";
+import { SettingsRow, SettingsSection } from "./settingsLayout";
+
+function environmentIcon(environment: EnvironmentPresentation) {
+  if (environment.entry.target._tag === "PrimaryConnectionTarget") return MonitorIcon;
+  if (environment.entry.target._tag === "RelayConnectionTarget") return CloudIcon;
+  if (environment.entry.target._tag === "SshConnectionTarget") return TerminalIcon;
+  if (isDesktopLocalConnectionTarget(environment.entry.target)) return LaptopIcon;
+  return CloudIcon;
+}
+
+function environmentDetail(environment: EnvironmentPresentation): string {
+  if (environment.entry.target._tag === "PrimaryConnectionTarget") return "Primary device";
+  if (environment.relayManaged) return "T3 Connect";
+  if (environment.entry.target._tag === "SshConnectionTarget") return "SSH";
+  if (isDesktopLocalConnectionTarget(environment.entry.target)) return "Local device";
+  return environment.displayUrl ?? "Remote device";
+}
+
+export function SettingsEnvironmentSelector({
+  environments,
+  isReady,
+  selectedEnvironmentId,
+  emptyDescription,
+  onSelect,
+}: {
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly isReady: boolean;
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly emptyDescription: string;
+  readonly onSelect: (environmentId: EnvironmentId) => void;
+}) {
+  const onlyPrimaryDevice =
+    environments.length === 1 && environments[0]?.entry.target._tag === "PrimaryConnectionTarget";
+  if (onlyPrimaryDevice) return null;
+
+  return (
+    <SettingsSection title="Devices">
+      {environments.length === 0 ? (
+        <SettingsRow
+          title={isReady ? "No connected devices" : "Loading devices"}
+          description={isReady ? emptyDescription : "Reading connected execution environments."}
+        />
+      ) : (
+        <div className="grid gap-1 sm:grid-cols-2">
+          {environments.map((environment) => {
+            const Icon = environmentIcon(environment);
+            const selected = environment.environmentId === selectedEnvironmentId;
+            const statusText = connectionStatusText(environment.connection);
+            return (
+              <button
+                key={environment.environmentId}
+                type="button"
+                aria-pressed={selected}
+                className={cn(
+                  "flex min-w-0 items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors sm:px-4",
+                  selected
+                    ? "bg-primary/8 ring-1 ring-primary/25 dark:bg-primary/12"
+                    : "hover:bg-muted/40",
+                )}
+                onClick={() => onSelect(environment.environmentId)}
+              >
+                <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-background text-muted-foreground">
+                  <Icon className="size-4" aria-hidden />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center gap-1.5">
+                    <ConnectionStatusDot
+                      tooltipText={statusText}
+                      dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
+                      pingClassName={connectionPhasePingClassName(environment.connection.phase)}
+                    />
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {environment.label}
+                    </span>
+                  </span>
+                  <span className="block truncate pl-[18px] text-xs text-muted-foreground">
+                    {environmentDetail(environment)} · {statusText}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </SettingsSection>
+  );
+}

--- a/apps/web/src/components/settings/SourceControlSettings.environment.test.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.environment.test.tsx
@@ -1,0 +1,139 @@
+import type { ReactElement } from "react";
+import { DEFAULT_UNIFIED_SETTINGS, EnvironmentId } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { visitElements } from "../../test/reactElementTree";
+import { reactHookHarness as hooks } from "../../test/reactHookHarness";
+
+const environmentId = EnvironmentId.make("remote-device");
+const primaryEnvironmentId = EnvironmentId.make("primary-device");
+
+const routing = vi.hoisted(() => ({
+  discoveryTargets: [] as Array<{ readonly environmentId: EnvironmentId; readonly input: {} }>,
+  settingsReads: [] as EnvironmentId[],
+  settingsUpdates: [] as EnvironmentId[],
+}));
+
+const environmentState = vi.hoisted(() => ({
+  environments: [] as ReadonlyArray<{
+    readonly environmentId: EnvironmentId;
+    readonly label: string;
+  }>,
+  primaryEnvironmentId: null as EnvironmentId | null,
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return {
+    ...actual,
+    useMemo: reactHookHarness.useMemo,
+    useState: reactHookHarness.useState,
+  };
+});
+
+vi.mock("react/compiler-runtime", async () => {
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return { c: reactHookHarness.useMemoCache };
+});
+
+vi.mock("../../hooks/useSettings", () => ({
+  useEnvironmentSettings: (targetEnvironmentId: EnvironmentId) => {
+    routing.settingsReads.push(targetEnvironmentId);
+    return DEFAULT_UNIFIED_SETTINGS;
+  },
+  useUpdateEnvironmentSettings: (targetEnvironmentId: EnvironmentId) => {
+    routing.settingsUpdates.push(targetEnvironmentId);
+    return vi.fn();
+  },
+}));
+
+vi.mock("../../state/query", () => ({
+  useEnvironmentQuery: () => ({
+    data: { versionControlSystems: [], sourceControlProviders: [] },
+    error: null,
+    isPending: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("../../state/environments", () => ({
+  useEnvironments: () => ({
+    environments: environmentState.environments,
+    isReady: true,
+  }),
+  usePrimaryEnvironmentId: () => environmentState.primaryEnvironmentId,
+}));
+
+vi.mock("../../state/sourceControl", () => ({
+  sourceControlEnvironment: {
+    discovery: (target: { readonly environmentId: EnvironmentId; readonly input: {} }) => {
+      routing.discoveryTargets.push(target);
+      return Symbol("source-control-discovery");
+    },
+  },
+}));
+
+vi.mock("./SourceControlWritingSettings", () => ({
+  SourceControlWritingSettingsSection: (props: { readonly environmentId: EnvironmentId }) => (
+    <div data-writing-environment={props.environmentId} />
+  ),
+}));
+
+import {
+  EnvironmentSourceControlSettings,
+  GitFetchIntervalSettings,
+  SourceControlSettingsPanel,
+} from "./SourceControlSettings";
+
+describe("Source Control environment routing", () => {
+  beforeEach(() => {
+    hooks.reset();
+    environmentState.environments = [
+      { environmentId: primaryEnvironmentId, label: "This device" },
+      { environmentId, label: "Remote device" },
+    ];
+    environmentState.primaryEnvironmentId = primaryEnvironmentId;
+    routing.discoveryTargets = [];
+    routing.settingsReads = [];
+    routing.settingsUpdates = [];
+  });
+
+  it("retargets the panel when another environment is selected", () => {
+    hooks.beginRender();
+    let panel = SourceControlSettingsPanel() as ReactElement<Record<string, unknown>>;
+    const selector = visitElements(
+      panel,
+      (element) => element.props.selectedEnvironmentId === primaryEnvironmentId,
+    );
+    expect(selector).not.toBeNull();
+
+    (selector?.props.onSelect as ((environmentId: EnvironmentId) => void) | undefined)?.(
+      environmentId,
+    );
+
+    hooks.beginRender();
+    panel = SourceControlSettingsPanel() as ReactElement<Record<string, unknown>>;
+    expect(
+      visitElements(panel, (element) => element.props.environmentId === environmentId),
+    ).not.toBeNull();
+  });
+
+  it("routes discovery and writing settings to the selected environment", () => {
+    const panel = EnvironmentSourceControlSettings({ environmentId }) as ReactElement<
+      Record<string, unknown>
+    >;
+
+    expect(routing.discoveryTargets).toEqual([{ environmentId, input: {} }]);
+    expect(
+      visitElements(panel, (element) => element.props.environmentId === environmentId),
+    ).not.toBeNull();
+  });
+
+  it("routes Git fetch policy reads and writes to the selected environment", () => {
+    GitFetchIntervalSettings({ environmentId });
+
+    expect(routing.settingsReads).toEqual([environmentId]);
+    expect(routing.settingsUpdates).toEqual([environmentId]);
+  });
+});

--- a/apps/web/src/components/settings/SourceControlSettings.environment.test.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.environment.test.tsx
@@ -75,9 +75,10 @@ vi.mock("../../state/sourceControl", () => ({
 }));
 
 vi.mock("./SourceControlWritingSettings", () => ({
-  SourceControlWritingSettingsSection: (props: { readonly environmentId: EnvironmentId }) => (
-    <div data-writing-environment={props.environmentId} />
-  ),
+  SourceControlWritingSettingsSection: (props: {
+    readonly environmentId: EnvironmentId;
+    readonly readOnly?: boolean;
+  }) => <div data-writing-environment={props.environmentId} data-read-only={props.readOnly} />,
 }));
 
 import {
@@ -115,18 +116,43 @@ describe("Source Control environment routing", () => {
     hooks.beginRender();
     panel = SourceControlSettingsPanel() as ReactElement<Record<string, unknown>>;
     expect(
-      visitElements(panel, (element) => element.props.environmentId === environmentId),
+      visitElements(
+        panel,
+        (element) =>
+          (element.props.environment as { readonly environmentId?: EnvironmentId } | undefined)
+            ?.environmentId === environmentId,
+      ),
     ).not.toBeNull();
   });
 
   it("routes discovery and writing settings to the selected environment", () => {
-    const panel = EnvironmentSourceControlSettings({ environmentId }) as ReactElement<
-      Record<string, unknown>
-    >;
+    const panel = EnvironmentSourceControlSettings({
+      environmentId,
+      environmentLabel: "Remote device",
+    }) as ReactElement<Record<string, unknown>>;
 
     expect(routing.discoveryTargets).toEqual([{ environmentId, input: {} }]);
     expect(
       visitElements(panel, (element) => element.props.environmentId === environmentId),
+    ).not.toBeNull();
+  });
+
+  it("renders environment-owned write controls read only when access is limited", () => {
+    const panel = EnvironmentSourceControlSettings({
+      environmentId,
+      environmentLabel: "Remote device",
+      readOnly: true,
+    }) as ReactElement<Record<string, unknown>>;
+
+    expect(
+      visitElements(panel, (element) => element.props.title === "Limited permissions"),
+    ).not.toBeNull();
+    expect(
+      visitElements(
+        panel,
+        (element) =>
+          element.props.environmentId === environmentId && element.props.readOnly === true,
+      ),
     ).not.toBeNull();
   });
 

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -1,4 +1,5 @@
 import { ChevronDownIcon, GitPullRequestIcon, InfoIcon, RefreshCwIcon } from "lucide-react";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import * as Duration from "effect/Duration";
 import * as Option from "effect/Option";
 import { useMemo, useState, type ReactNode } from "react";
@@ -18,10 +19,17 @@ import {
   resolveServerBackgroundActivitySettings,
 } from "@t3tools/shared/backgroundActivitySettings";
 
+import { isElectron } from "../../env";
+import { usePrimarySessionState } from "../../environments/primary";
 import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
-import { useEnvironments, usePrimaryEnvironmentId } from "../../state/environments";
+import {
+  useEnvironments,
+  usePrimaryEnvironmentId,
+  type EnvironmentPresentation,
+} from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
+import { useEnvironmentSessionState } from "../../state/session";
 import { sourceControlEnvironment } from "../../state/sourceControl";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -56,10 +64,20 @@ import {
 import { RedactedSensitiveText } from "./RedactedSensitiveText";
 import { SourceControlWritingSettingsSection } from "./SourceControlWritingSettings";
 import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
-import { SettingResetButton, SettingsPageContainer, SettingsSection } from "./settingsLayout";
+import {
+  SettingResetButton,
+  SettingsPageContainer,
+  SettingsRow,
+  SettingsSection,
+} from "./settingsLayout";
 import { searchableSetting } from "./settingsSearch";
 import {
   buildProviderEnvironmentOptions,
+  classifyProviderEnvironmentAccess,
+  type ProviderEnvironmentAccess,
+  type ProviderOperateAccess,
+  resolvePrimaryOperateAccess,
+  resolveRemoteOperateAccess,
   resolveSelectedProviderEnvironmentId,
 } from "./ProviderSettingsPanel.logic";
 
@@ -354,8 +372,10 @@ function DiscoveryItemRow({
 
 export function GitFetchIntervalSettings({
   environmentId,
+  readOnly = false,
 }: {
   readonly environmentId: EnvironmentId;
+  readonly readOnly?: boolean;
 }) {
   const settings = useEnvironmentSettings(environmentId);
   const updateSettings = useUpdateEnvironmentSettings(environmentId);
@@ -372,7 +392,11 @@ export function GitFetchIntervalSettings({
     automaticGitFetchIntervalSeconds !== defaultAutomaticGitFetchIntervalSeconds;
 
   return (
-    <div className="grid gap-3">
+    <div
+      inert={readOnly}
+      aria-disabled={readOnly || undefined}
+      className={cn("grid gap-3", readOnly && "opacity-50 select-none")}
+    >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 space-y-1">
           <div className="flex min-w-0 items-center gap-1">
@@ -532,6 +556,8 @@ export function SourceControlSettingsPanel() {
     selectedEnvironmentId,
     primaryEnvironmentId,
   );
+  const selectedEnvironment =
+    options.find((environment) => environment.environmentId === effectiveEnvironmentId) ?? null;
 
   return (
     <SettingsPageContainer>
@@ -542,20 +568,123 @@ export function SourceControlSettingsPanel() {
         emptyDescription="Connect an execution environment before configuring source control."
         onSelect={setSelectedEnvironmentId}
       />
-      {effectiveEnvironmentId !== null ? (
-        <EnvironmentSourceControlSettings
-          key={effectiveEnvironmentId}
-          environmentId={effectiveEnvironmentId}
+      {selectedEnvironment ? (
+        <SelectedEnvironmentSourceControlSettings
+          key={selectedEnvironment.environmentId}
+          environment={selectedEnvironment}
         />
       ) : null}
     </SettingsPageContainer>
   );
 }
 
+function SourceControlEnvironmentUnavailableRow({
+  environment,
+  access,
+}: {
+  readonly environment: EnvironmentPresentation;
+  readonly access: Exclude<ProviderEnvironmentAccess, { kind: "editable" | "read-only" }>;
+}) {
+  const isLoading = access.kind === "loading";
+  const title = isLoading
+    ? "Loading source control settings"
+    : access.kind === "error"
+      ? "Could not connect to this device"
+      : "Source control settings are unavailable";
+  const description = isLoading
+    ? access.reason === "permissions"
+      ? "Checking what this session is allowed to change."
+      : `Waiting for ${environment.label}'s configuration.`
+    : connectionStatusText(environment.connection);
+
+  return (
+    <SettingsSection title="Source Control">
+      <SettingsRow title={title} description={description} />
+    </SettingsSection>
+  );
+}
+
+function SelectedEnvironmentSourceControlSettings({
+  environment,
+}: {
+  readonly environment: EnvironmentPresentation;
+}) {
+  const isPrimary = environment.entry.target._tag === "PrimaryConnectionTarget";
+  if (isPrimary) {
+    if (isElectron) {
+      return <AccessGatedSourceControlSettings environment={environment} operateAccess="granted" />;
+    }
+    return <PrimarySessionGatedSourceControlSettings environment={environment} />;
+  }
+  return <RemoteSessionGatedSourceControlSettings environment={environment} />;
+}
+
+function PrimarySessionGatedSourceControlSettings({
+  environment,
+}: {
+  readonly environment: EnvironmentPresentation;
+}) {
+  const primarySessionState = usePrimarySessionState();
+  const operateAccess = resolvePrimaryOperateAccess({
+    isPrimary: true,
+    hasDesktopBridge: false,
+    session: primarySessionState.data,
+    isPending: primarySessionState.isPending,
+    hasError: primarySessionState.error !== null,
+  });
+  return (
+    <AccessGatedSourceControlSettings environment={environment} operateAccess={operateAccess} />
+  );
+}
+
+function RemoteSessionGatedSourceControlSettings({
+  environment,
+}: {
+  readonly environment: EnvironmentPresentation;
+}) {
+  const sessionState = useEnvironmentSessionState(environment.environmentId);
+  const operateAccess = resolveRemoteOperateAccess({
+    session: sessionState.data,
+    isPending: sessionState.isPending,
+    hasError: sessionState.hasError,
+  });
+  return (
+    <AccessGatedSourceControlSettings environment={environment} operateAccess={operateAccess} />
+  );
+}
+
+function AccessGatedSourceControlSettings({
+  environment,
+  operateAccess,
+}: {
+  readonly environment: EnvironmentPresentation;
+  readonly operateAccess: ProviderOperateAccess;
+}) {
+  const access = classifyProviderEnvironmentAccess({
+    connectionPhase: environment.connection.phase,
+    hasServerConfig: environment.serverConfig !== null,
+    operateAccess,
+  });
+  if (access.kind !== "editable" && access.kind !== "read-only") {
+    return <SourceControlEnvironmentUnavailableRow environment={environment} access={access} />;
+  }
+  return (
+    <EnvironmentSourceControlSettings
+      environmentId={environment.environmentId}
+      environmentLabel={environment.label}
+      readOnly={access.kind === "read-only"}
+    />
+  );
+}
+
 export function EnvironmentSourceControlSettings({
   environmentId,
+  environmentLabel,
+  readOnly = false,
 }: {
   readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+  readonly readOnly?: boolean;
 }) {
   const discovery = useEnvironmentQuery(
     sourceControlEnvironment.discovery({
@@ -592,6 +721,14 @@ export function EnvironmentSourceControlSettings({
 
   return (
     <>
+      {readOnly ? (
+        <SettingsSection title="Source Control">
+          <SettingsRow
+            title="Limited permissions"
+            description={`This session can view ${environmentLabel}'s source control configuration, but its credential does not allow changing it.`}
+          />
+        </SettingsSection>
+      ) : null}
       {isInitialScanPending ? (
         <>
           <SourceControlSectionSkeleton title="Version Control" headerAction={scanButton} />
@@ -608,7 +745,7 @@ export function EnvironmentSourceControlSettings({
               {result.versionControlSystems.map((item) => (
                 <DiscoveryItemRow key={`vcs:${item.kind}`} item={item}>
                   {item.kind === "git" ? (
-                    <GitFetchIntervalSettings environmentId={environmentId} />
+                    <GitFetchIntervalSettings environmentId={environmentId} readOnly={readOnly} />
                   ) : undefined}
                 </DiscoveryItemRow>
               ))}
@@ -635,7 +772,7 @@ export function EnvironmentSourceControlSettings({
         />
       )}
 
-      <SourceControlWritingSettingsSection environmentId={environmentId} />
+      <SourceControlWritingSettingsSection environmentId={environmentId} readOnly={readOnly} />
     </>
   );
 }

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -1,9 +1,10 @@
 import { ChevronDownIcon, GitPullRequestIcon, InfoIcon, RefreshCwIcon } from "lucide-react";
 import * as Duration from "effect/Duration";
 import * as Option from "effect/Option";
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import type {
   BackgroundActivitySettings,
+  EnvironmentId,
   SourceControlProviderKind,
   SourceControlDiscoveryResult,
   SourceControlProviderAuth,
@@ -17,9 +18,9 @@ import {
   resolveServerBackgroundActivitySettings,
 } from "@t3tools/shared/backgroundActivitySettings";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
-import { usePrimaryEnvironment } from "../../state/environments";
+import { useEnvironments, usePrimaryEnvironmentId } from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
 import { sourceControlEnvironment } from "../../state/sourceControl";
 import { Badge } from "../ui/badge";
@@ -54,8 +55,13 @@ import {
 } from "../Icons";
 import { RedactedSensitiveText } from "./RedactedSensitiveText";
 import { SourceControlWritingSettingsSection } from "./SourceControlWritingSettings";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import { SettingResetButton, SettingsPageContainer, SettingsSection } from "./settingsLayout";
 import { searchableSetting } from "./settingsSearch";
+import {
+  buildProviderEnvironmentOptions,
+  resolveSelectedProviderEnvironmentId,
+} from "./ProviderSettingsPanel.logic";
 
 const EMPTY_DISCOVERY_RESULT: SourceControlDiscoveryResult = {
   versionControlSystems: [],
@@ -346,9 +352,13 @@ function DiscoveryItemRow({
   );
 }
 
-function GitFetchIntervalSettings() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+export function GitFetchIntervalSettings({
+  environmentId,
+}: {
+  readonly environmentId: EnvironmentId;
+}) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
   const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
   const automaticGitFetchIntervalSeconds = durationToSeconds(
     resolvedBackgroundActivity.automaticGitFetchInterval,
@@ -508,14 +518,50 @@ function EmptySourceControlDiscovery({
 }
 
 export function SourceControlSettingsPanel() {
-  const environmentId = usePrimaryEnvironment()?.environmentId ?? null;
+  const { environments, isReady } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const options = useMemo(
+    () => buildProviderEnvironmentOptions(environments, primaryEnvironmentId),
+    [environments, primaryEnvironmentId],
+  );
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(
+    primaryEnvironmentId,
+  );
+  const effectiveEnvironmentId = resolveSelectedProviderEnvironmentId(
+    options,
+    selectedEnvironmentId,
+    primaryEnvironmentId,
+  );
+
+  return (
+    <SettingsPageContainer>
+      <SettingsEnvironmentSelector
+        environments={options}
+        isReady={isReady}
+        selectedEnvironmentId={effectiveEnvironmentId}
+        emptyDescription="Connect an execution environment before configuring source control."
+        onSelect={setSelectedEnvironmentId}
+      />
+      {effectiveEnvironmentId !== null ? (
+        <EnvironmentSourceControlSettings
+          key={effectiveEnvironmentId}
+          environmentId={effectiveEnvironmentId}
+        />
+      ) : null}
+    </SettingsPageContainer>
+  );
+}
+
+export function EnvironmentSourceControlSettings({
+  environmentId,
+}: {
+  readonly environmentId: EnvironmentId;
+}) {
   const discovery = useEnvironmentQuery(
-    environmentId === null
-      ? null
-      : sourceControlEnvironment.discovery({
-          environmentId,
-          input: {},
-        }),
+    sourceControlEnvironment.discovery({
+      environmentId,
+      input: {},
+    }),
   );
   const result = discovery.data ?? EMPTY_DISCOVERY_RESULT;
   const hasVersionControlSystems = result.versionControlSystems.length > 0;
@@ -545,7 +591,7 @@ export function SourceControlSettingsPanel() {
   );
 
   return (
-    <SettingsPageContainer>
+    <>
       {isInitialScanPending ? (
         <>
           <SourceControlSectionSkeleton title="Version Control" headerAction={scanButton} />
@@ -561,7 +607,9 @@ export function SourceControlSettingsPanel() {
             >
               {result.versionControlSystems.map((item) => (
                 <DiscoveryItemRow key={`vcs:${item.kind}`} item={item}>
-                  {item.kind === "git" ? <GitFetchIntervalSettings /> : undefined}
+                  {item.kind === "git" ? (
+                    <GitFetchIntervalSettings environmentId={environmentId} />
+                  ) : undefined}
                 </DiscoveryItemRow>
               ))}
             </SettingsSection>
@@ -587,7 +635,7 @@ export function SourceControlSettingsPanel() {
         />
       )}
 
-      {environmentId !== null ? <SourceControlWritingSettingsSection /> : null}
-    </SettingsPageContainer>
+      <SourceControlWritingSettingsSection environmentId={environmentId} />
+    </>
   );
 }

--- a/apps/web/src/components/settings/SourceControlWritingSettings.environment.test.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.environment.test.tsx
@@ -1,0 +1,65 @@
+import { DEFAULT_UNIFIED_SETTINGS, EnvironmentId } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const environmentId = EnvironmentId.make("remote-device");
+
+const routing = vi.hoisted(() => ({
+  providerReads: [] as EnvironmentId[],
+  settingsReads: [] as EnvironmentId[],
+  settingsUpdates: [] as EnvironmentId[],
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useRef: () => ({ current: null }),
+  };
+});
+
+vi.mock("react/compiler-runtime", () => ({
+  c: () => [],
+}));
+
+vi.mock("@effect/atom-react", () => ({
+  useAtomValue: () => [],
+}));
+
+vi.mock("../../hooks/useSettings", () => ({
+  useEnvironmentSettings: (targetEnvironmentId: EnvironmentId) => {
+    routing.settingsReads.push(targetEnvironmentId);
+    return DEFAULT_UNIFIED_SETTINGS;
+  },
+  useUpdateEnvironmentSettings: (targetEnvironmentId: EnvironmentId) => {
+    routing.settingsUpdates.push(targetEnvironmentId);
+    return vi.fn();
+  },
+}));
+
+vi.mock("../../state/server", () => ({
+  EMPTY_SERVER_PROVIDERS: [],
+  serverEnvironment: {
+    providersValueAtom: (targetEnvironmentId: EnvironmentId) => {
+      routing.providerReads.push(targetEnvironmentId);
+      return Symbol("providers");
+    },
+  },
+}));
+
+import { SourceControlWritingSettingsSection } from "./SourceControlWritingSettings";
+
+describe("Source Control writing settings environment routing", () => {
+  beforeEach(() => {
+    routing.providerReads = [];
+    routing.settingsReads = [];
+    routing.settingsUpdates = [];
+  });
+
+  it("reads and updates settings and provider models for the selected environment", () => {
+    SourceControlWritingSettingsSection({ environmentId });
+
+    expect(routing.settingsReads).toEqual([environmentId]);
+    expect(routing.settingsUpdates).toEqual([environmentId]);
+    expect(routing.providerReads).toEqual([environmentId]);
+  });
+});

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -1,11 +1,11 @@
 import { useAtomValue } from "@effect/atom-react";
 import { useRef } from "react";
-import type { SourceControlWritingStyleMode } from "@t3tools/contracts";
+import type { EnvironmentId, SourceControlWritingStyleMode } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import { createModelSelection } from "@t3tools/shared/model";
 import { resolveSourceControlWriterModelSelection } from "@t3tools/shared/serverSettings";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -15,7 +15,7 @@ import {
   getCustomModelOptionsByInstance,
   resolveAppModelSelectionState,
 } from "../../modelSelection";
-import { primaryServerProvidersAtom } from "../../state/server";
+import { EMPTY_SERVER_PROVIDERS, serverEnvironment } from "../../state/server";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
@@ -40,10 +40,15 @@ const MODE_OPTIONS: Record<SourceControlWritingStyleMode, { label: string; descr
     },
   };
 
-export function SourceControlWritingSettingsSection() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+export function SourceControlWritingSettingsSection({
+  environmentId,
+}: {
+  readonly environmentId: EnvironmentId;
+}) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const serverProviders =
+    useAtomValue(serverEnvironment.providersValueAtom(environmentId)) ?? EMPTY_SERVER_PROVIDERS;
   const customInstructionsRef = useRef<HTMLTextAreaElement>(null);
   const style = settings.sourceControlWritingStyle;
   const defaults = DEFAULT_UNIFIED_SETTINGS.sourceControlWritingStyle;

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -42,8 +42,10 @@ const MODE_OPTIONS: Record<SourceControlWritingStyleMode, { label: string; descr
 
 export function SourceControlWritingSettingsSection({
   environmentId,
+  readOnly = false,
 }: {
   readonly environmentId: EnvironmentId;
+  readonly readOnly?: boolean;
 }) {
   const settings = useEnvironmentSettings(environmentId);
   const updateSettings = useUpdateEnvironmentSettings(environmentId);
@@ -76,7 +78,12 @@ export function SourceControlWritingSettingsSection({
   );
 
   return (
-    <SettingsSection title="Text generation">
+    <SettingsSection
+      title="Text generation"
+      inert={readOnly}
+      aria-disabled={readOnly || undefined}
+      className={readOnly ? "opacity-50 select-none" : undefined}
+    >
       <SettingsRow
         title="Source control writing style"
         description={MODE_OPTIONS[style.mode].description}

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -53,6 +53,8 @@ The **Source Control settings** page shows you exactly what's connected:
 - 👤 Which account is signed in (when available)
 
 Run a quick **Rescan** after setting up a new machine or changing credentials.
+If you have multiple environments connected, select a device at the top of the page to view and
+configure its source control tools and settings.
 
 ## Getting Started
 


### PR DESCRIPTION
## What Changed

This adds the same device selection used by Provider settings to Source Control Settings, and routes discovery, Git fetch policy, writing preferences, and writer-model data through the selected environment.
The backend APIs were already environment-scoped, so no wire-contract or server changes were required.
Both settings panels now use a shared SettingsEnvironmentSelector component (componented out from SettingsEnvironmentSelector), hence the slightly larger diff churn.

## Why

Both Source Control and Provider features use the connected environment's tools, but Source Control Settings only reflected the current local environment. This brings them both into line, and allows changing of Source Control settings between local environments.

## UI Changes

Before:
<img width="1920" height="1032" alt="Screenshot 2026-08-11 041747" src="https://github.com/user-attachments/assets/39255548-3aa2-4796-a4f8-6b42e4cf3cbb" />

After (Video):

https://github.com/user-attachments/assets/02f97656-e479-4156-8788-beffb6402bd3

Tested on desktop + web builds on Windows 11, connected to Windows + Linux remote environments.

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where persisted settings are read and written per environment; mistakes could target the wrong device, though the pattern mirrors the existing provider panel and adds read-only gating.
> 
> **Overview**
> **Source Control settings** now follow the same per-device model as Provider settings: a shared **`SettingsEnvironmentSelector`** (extracted from the provider panel) lets you pick which connected environment to configure, and hides itself when only the primary device exists.
> 
> Discovery, Git fetch interval, writing style, and writer model reads/writes all go through **`environmentId`**-scoped hooks and queries instead of primary-only settings. Session and connection access reuse **`ProviderSettingsPanel.logic`** so remote or limited sessions see read-only or unavailable states instead of editing the wrong host.
> 
> Provider settings only swap in the shared selector; status dots in device buttons no longer use tooltips (status still appears in the subtitle). Tests cover environment routing and the selector behavior; user docs note device selection for multi-environment setups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd9b8d1e116f141a83b15d95f04b0476b103fb34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope source control settings by environment with per-device selector
> - Adds a device selector to the Source Control settings panel that routes all settings, discovery, and provider controls to the selected environment.
> - Introduces a reusable `SettingsEnvironmentSelector` component used by both the source control and provider settings panels.
> - Access is gated per environment: settings render read-only with a 'Limited permissions' banner when operate access is restricted, and show a status row when the environment is loading, errored, or unavailable.
> - Git fetch interval and text generation settings now read/write via environment-scoped hooks using the selected `environmentId`.
> - Behavioral Change: the connection status dot inside environment selector buttons no longer shows a tooltip.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd9b8d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->