### PR TITLE
fix(swift-ios): restore thread scrolling and back swipe

### DIFF
--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -1318,10 +1318,14 @@ enum ThreadBackSwipeGesture {
     static func shouldReceiveTouch(in view: UIView?, host: UIView) -> Bool {
         var currentView = view
         while let current = currentView {
-            // Text fields and selectable transcript text need to own horizontal
-            // drags for caret movement and selection. The back pan can still
-            // begin from the surrounding thread surface.
-            if current is UITextField || current is UITextView {
+            // Editable text and an active transcript selection need to own
+            // horizontal drags for caret and selection-handle movement. Plain
+            // rendered message text still participates in the full-surface pan.
+            if current is UITextField {
+                return false
+            }
+            if let textView = current as? UITextView,
+               textView.isEditable || textView.isFirstResponder {
                 return false
             }
             if let scrollView = current as? UIScrollView,

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -106,20 +106,13 @@ public struct ThreadDetailView: View {
         } message: {
             Text("Your draft is still here. Check your connection and try again.")
         }
-        .simultaneousGesture(edgeBackGesture)
-    }
-
-    private var edgeBackGesture: some Gesture {
-        DragGesture(minimumDistance: 18, coordinateSpace: .local)
-            .onEnded { value in
-                guard horizontalSizeClass == .compact,
-                      value.startLocation.x <= 24,
-                      value.translation.width >= 72,
-                      abs(value.translation.height) <= abs(value.translation.width) * 0.7 else {
-                    return
-                }
-                onNavigateBack()
-            }
+        .background {
+            ThreadBackSwipeGestureView(
+                isEnabled: horizontalSizeClass == .compact,
+                onNavigateBack: onNavigateBack
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
     }
 
     private var detail: FeatureThreadDetail? {
@@ -1279,6 +1272,234 @@ struct TranscriptViewportGeometry: Equatable {
         guard contentChanged || viewportChanged else { return nil }
 
         return bottomOffset
+    }
+}
+
+/// The detail surface uses a native pan recognizer instead of a SwiftUI
+/// `DragGesture`. SwiftUI's broad drag recognizer can begin before it knows
+/// whether a gesture is vertical, which competes with the transcript's native
+/// collection-view scrolling. This recognizer fails for vertical motion at
+/// gesture-begin time and remains simultaneous with the collection view for
+/// horizontal motion.
+enum ThreadBackSwipeGesture {
+    static let minimumTranslation: CGFloat = 72
+    static let horizontalToVerticalRatio: CGFloat = 1.4
+    private static let scrollExtentEpsilon: CGFloat = 1
+
+    static func shouldBegin(with velocity: CGPoint) -> Bool {
+        shouldBegin(with: velocity, translation: .zero)
+    }
+
+    static func shouldBegin(with velocity: CGPoint, translation: CGPoint) -> Bool {
+        let direction = hypot(translation.x, translation.y) >= 8 ? translation : velocity
+        return direction.x > 0
+            && direction.x >= abs(direction.y) * horizontalToVerticalRatio
+    }
+
+    static func shouldNavigateBack(with translation: CGPoint) -> Bool {
+        translation.x >= minimumTranslation
+            && translation.x >= abs(translation.y) * horizontalToVerticalRatio
+    }
+
+    @MainActor
+    static func shouldAllowSimultaneousRecognition(with scrollView: UIScrollView) -> Bool {
+        let hasHorizontalContent = scrollView.alwaysBounceHorizontal
+            || scrollView.contentSize.width
+                > scrollView.bounds.width + scrollExtentEpsilon
+        guard hasHorizontalContent else {
+            return scrollView.alwaysBounceVertical
+                || scrollView.contentSize.height
+                    > scrollView.bounds.height + scrollExtentEpsilon
+        }
+        return isAtLeadingEdge(scrollView)
+    }
+
+    @MainActor
+    static func shouldReceiveTouch(in view: UIView?, host: UIView) -> Bool {
+        var currentView = view
+        while let current = currentView {
+            if let scrollView = current as? UIScrollView,
+               scrollView.alwaysBounceHorizontal
+                || scrollView.contentSize.width
+                    > scrollView.bounds.width + scrollExtentEpsilon {
+                guard isAtLeadingEdge(scrollView) else { return false }
+            }
+            if current === host { return true }
+            currentView = current.superview
+        }
+        return false
+    }
+
+    @MainActor
+    private static func isAtLeadingEdge(_ scrollView: UIScrollView) -> Bool {
+        scrollView.contentOffset.x
+            <= -scrollView.adjustedContentInset.left + scrollExtentEpsilon
+    }
+
+    @MainActor
+    static func shouldReceiveTouch(
+        _ touch: UITouch,
+        surface: UIView,
+        host: UIView
+    ) -> Bool {
+        guard surface.window === host.window,
+              surface.bounds.contains(touch.location(in: surface)),
+              shouldReceiveTouch(in: touch.view, host: host),
+              surface.window?.rootViewController?.presentedViewController == nil else {
+            return false
+        }
+        return true
+    }
+}
+
+private struct ThreadBackSwipeGestureView: UIViewRepresentable {
+    let isEnabled: Bool
+    let onNavigateBack: () -> Void
+
+    func makeUIView(context: Context) -> InstallerView {
+        let view = InstallerView()
+        view.update(isEnabled: isEnabled, onNavigateBack: onNavigateBack)
+        return view
+    }
+
+    func updateUIView(_ view: InstallerView, context: Context) {
+        view.update(isEnabled: isEnabled, onNavigateBack: onNavigateBack)
+    }
+
+    static func dismantleUIView(_ view: InstallerView, coordinator: ()) {
+        view.uninstallGesture()
+    }
+
+    final class InstallerView: UIView {
+        private var isEnabled = false
+        private var onNavigateBack: (() -> Void)?
+        private weak var gestureHost: UIView?
+        private var panGesture: UIPanGestureRecognizer?
+        private var gestureDelegate: GestureDelegate?
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            isUserInteractionEnabled = false
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        deinit {
+            uninstallGesture()
+        }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            if window == nil {
+                uninstallGesture()
+            } else {
+                installGestureIfPossible()
+            }
+        }
+
+        func update(isEnabled: Bool, onNavigateBack: @escaping () -> Void) {
+            self.isEnabled = isEnabled
+            self.onNavigateBack = onNavigateBack
+            installGestureIfPossible()
+        }
+
+        func uninstallGesture() {
+            if let panGesture, let gestureHost {
+                gestureHost.removeGestureRecognizer(panGesture)
+            }
+            panGesture = nil
+            gestureDelegate = nil
+            gestureHost = nil
+        }
+
+        private func installGestureIfPossible() {
+            // SwiftUI hosts a background UIViewRepresentable beside, rather than
+            // above, the transcript and composer. Install on their shared root
+            // view and use the representable's frame to scope received touches.
+            guard isEnabled, let window, let host = window.rootViewController?.view else {
+                if !isEnabled { uninstallGesture() }
+                return
+            }
+            guard gestureHost !== host else { return }
+
+            uninstallGesture()
+            let panGesture = UIPanGestureRecognizer(
+                target: self,
+                action: #selector(handlePan(_:))
+            )
+            let gestureDelegate = GestureDelegate(owner: self)
+            panGesture.delegate = gestureDelegate
+            panGesture.cancelsTouchesInView = false
+            panGesture.delaysTouchesBegan = false
+            panGesture.maximumNumberOfTouches = 1
+            host.addGestureRecognizer(panGesture)
+            gestureHost = host
+            self.panGesture = panGesture
+            self.gestureDelegate = gestureDelegate
+        }
+
+        @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+            guard isEnabled,
+                  gesture.state == .ended,
+                  ThreadBackSwipeGesture.shouldNavigateBack(
+                      with: gesture.translation(in: gesture.view)
+                  ) else {
+                return
+            }
+            onNavigateBack?()
+        }
+
+        private final class GestureDelegate: NSObject, UIGestureRecognizerDelegate {
+            weak var owner: InstallerView?
+
+            init(owner: InstallerView) {
+                self.owner = owner
+            }
+
+            func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+                guard let owner,
+                      owner.isEnabled,
+                      let panGesture = gestureRecognizer as? UIPanGestureRecognizer else {
+                    return false
+                }
+                return ThreadBackSwipeGesture.shouldBegin(
+                    with: panGesture.velocity(in: panGesture.view),
+                    translation: panGesture.translation(in: panGesture.view)
+                )
+            }
+
+            func gestureRecognizer(
+                _ gestureRecognizer: UIGestureRecognizer,
+                shouldReceive touch: UITouch
+            ) -> Bool {
+                guard let owner,
+                      let gestureHost = owner.gestureHost,
+                      ThreadBackSwipeGesture.shouldReceiveTouch(
+                          touch,
+                          surface: owner,
+                          host: gestureHost
+                      )
+                else { return false }
+                return true
+            }
+
+            func gestureRecognizer(
+                _ gestureRecognizer: UIGestureRecognizer,
+                shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+            ) -> Bool {
+                if otherGestureRecognizer is UIScreenEdgePanGestureRecognizer {
+                    return true
+                }
+                guard let scrollView = otherGestureRecognizer.view as? UIScrollView else {
+                    return false
+                }
+                return ThreadBackSwipeGesture.shouldAllowSimultaneousRecognition(
+                    with: scrollView
+                )
+            }
+        }
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -1318,6 +1318,12 @@ enum ThreadBackSwipeGesture {
     static func shouldReceiveTouch(in view: UIView?, host: UIView) -> Bool {
         var currentView = view
         while let current = currentView {
+            // Text fields and selectable transcript text need to own horizontal
+            // drags for caret movement and selection. The back pan can still
+            // begin from the surrounding thread surface.
+            if current is UITextField || current is UITextView {
+                return false
+            }
             if let scrollView = current as? UIScrollView,
                scrollView.alwaysBounceHorizontal
                 || scrollView.contentSize.width

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 

--- a/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
@@ -188,18 +188,40 @@ struct TranscriptViewportGeometryTests {
 
     @Test
     @MainActor
-    func textInteractionSurfacesKeepHorizontalDrags() {
+    func activeTextInteractionsKeepHorizontalDrags() {
         let host = UIView(frame: CGRect(x: 0, y: 0, width: 240, height: 240))
         let textField = UITextField(frame: .zero)
         let textView = UITextView(frame: .zero)
+        textView.text = "Selectable transcript text"
         let textViewContent = UIView(frame: .zero)
         textView.addSubview(textViewContent)
         host.addSubview(textField)
         host.addSubview(textView)
 
         #expect(!ThreadBackSwipeGesture.shouldReceiveTouch(in: textField, host: host))
+        textView.isEditable = false
+        #expect(ThreadBackSwipeGesture.shouldReceiveTouch(in: textView, host: host))
+        #expect(ThreadBackSwipeGesture.shouldReceiveTouch(in: textViewContent, host: host))
+
+        textView.selectedRange = NSRange(location: 0, length: 1)
+        #expect(ThreadBackSwipeGesture.shouldReceiveTouch(in: textView, host: host))
+        #expect(ThreadBackSwipeGesture.shouldReceiveTouch(in: textViewContent, host: host))
+
+        textView.selectedRange = NSRange(location: 0, length: 0)
+        textView.isEditable = true
         #expect(!ThreadBackSwipeGesture.shouldReceiveTouch(in: textView, host: host))
+
+        let window = UIWindow(frame: host.bounds)
+        let rootViewController = UIViewController()
+        window.rootViewController = rootViewController
+        rootViewController.view.addSubview(host)
+        window.makeKeyAndVisible()
+        textView.isEditable = false
+        #expect(textView.becomeFirstResponder())
         #expect(!ThreadBackSwipeGesture.shouldReceiveTouch(in: textViewContent, host: host))
+        textView.resignFirstResponder()
+        window.isHidden = true
+
         #expect(ThreadBackSwipeGesture.shouldReceiveTouch(in: host, host: host))
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
@@ -1,4 +1,6 @@
+import CoreGraphics
 import Testing
+import UIKit
 @testable import T3Code
 
 @Suite("Transcript viewport anchoring")
@@ -97,5 +99,90 @@ struct TranscriptViewportGeometryTests {
                 isInteracting: true
             ) == nil
         )
+    }
+
+    @Test
+    func verticalPanFailsBeforeItCanCompeteWithTranscriptScrolling() {
+        #expect(!ThreadBackSwipeGesture.shouldBegin(with: CGPoint(x: 40, y: 120)))
+        #expect(!ThreadBackSwipeGesture.shouldBegin(with: CGPoint(x: -120, y: 0)))
+    }
+
+    @Test
+    func horizontalPanCanLeaveTheThreadFromAnywhereOnTheSurface() {
+        #expect(ThreadBackSwipeGesture.shouldBegin(with: CGPoint(x: 120, y: 20)))
+        #expect(
+            ThreadBackSwipeGesture.shouldNavigateBack(
+                with: CGPoint(x: 96, y: 16)
+            )
+        )
+    }
+
+    @Test
+    func slowHorizontalPanUsesTranslationWhenVelocityIsUnavailable() {
+        #expect(
+            ThreadBackSwipeGesture.shouldBegin(
+                with: .zero,
+                translation: CGPoint(x: 16, y: 2)
+            )
+        )
+        #expect(
+            !ThreadBackSwipeGesture.shouldBegin(
+                with: .zero,
+                translation: CGPoint(x: 4, y: 16)
+            )
+        )
+    }
+
+    @Test
+    func shortOrDiagonalPanDoesNotLeaveTheThread() {
+        #expect(
+            !ThreadBackSwipeGesture.shouldNavigateBack(
+                with: CGPoint(x: 71, y: 0)
+            )
+        )
+        #expect(
+            !ThreadBackSwipeGesture.shouldNavigateBack(
+                with: CGPoint(x: 96, y: 80)
+            )
+        )
+    }
+
+    @Test
+    @MainActor
+    func horizontalScrollContentSharesOnlyAtItsLeadingEdge() {
+        let transcript = UIScrollView(frame: CGRect(x: 0, y: 0, width: 120, height: 120))
+        transcript.contentSize = CGSize(width: 120, height: 480)
+        #expect(ThreadBackSwipeGesture.shouldAllowSimultaneousRecognition(with: transcript))
+
+        let codeBlock = UIScrollView(frame: CGRect(x: 0, y: 0, width: 120, height: 120))
+        codeBlock.contentSize = CGSize(width: 480, height: 120)
+        codeBlock.alwaysBounceVertical = true
+        #expect(ThreadBackSwipeGesture.shouldAllowSimultaneousRecognition(with: codeBlock))
+        codeBlock.contentOffset = CGPoint(x: 100, y: 0)
+        #expect(!ThreadBackSwipeGesture.shouldAllowSimultaneousRecognition(with: codeBlock))
+    }
+
+    @Test
+    @MainActor
+    func horizontalScrollAncestorsCanReceiveBackPanAtLeadingEdge() {
+        let host = UIView(frame: CGRect(x: 0, y: 0, width: 240, height: 240))
+        let codeBlock = UIScrollView(frame: host.bounds)
+        codeBlock.contentSize = CGSize(width: 480, height: 240)
+        let label = UILabel(frame: .zero)
+        codeBlock.addSubview(label)
+        host.addSubview(codeBlock)
+
+        #expect(ThreadBackSwipeGesture.shouldReceiveTouch(in: label, host: host))
+        codeBlock.contentOffset = CGPoint(x: 100, y: 0)
+        #expect(!ThreadBackSwipeGesture.shouldReceiveTouch(in: label, host: host))
+        #expect(ThreadBackSwipeGesture.shouldReceiveTouch(in: host, host: host))
+
+        let detachedHost = UIView(frame: host.bounds)
+        let detachedCodeBlock = UIScrollView(frame: detachedHost.bounds)
+        detachedCodeBlock.contentSize = CGSize(width: 480, height: 240)
+        let detachedLabel = UILabel(frame: .zero)
+        detachedCodeBlock.addSubview(detachedLabel)
+        detachedHost.addSubview(detachedCodeBlock)
+        #expect(!ThreadBackSwipeGesture.shouldReceiveTouch(in: detachedLabel, host: host))
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
@@ -185,4 +185,21 @@ struct TranscriptViewportGeometryTests {
         detachedHost.addSubview(detachedCodeBlock)
         #expect(!ThreadBackSwipeGesture.shouldReceiveTouch(in: detachedLabel, host: host))
     }
+
+    @Test
+    @MainActor
+    func textInteractionSurfacesKeepHorizontalDrags() {
+        let host = UIView(frame: CGRect(x: 0, y: 0, width: 240, height: 240))
+        let textField = UITextField(frame: .zero)
+        let textView = UITextView(frame: .zero)
+        let textViewContent = UIView(frame: .zero)
+        textView.addSubview(textViewContent)
+        host.addSubview(textField)
+        host.addSubview(textView)
+
+        #expect(!ThreadBackSwipeGesture.shouldReceiveTouch(in: textField, host: host))
+        #expect(!ThreadBackSwipeGesture.shouldReceiveTouch(in: textView, host: host))
+        #expect(!ThreadBackSwipeGesture.shouldReceiveTouch(in: textViewContent, host: host))
+        #expect(ThreadBackSwipeGesture.shouldReceiveTouch(in: host, host: host))
+    }
 }


### PR DESCRIPTION
## What Changed

- replace the thread-level SwiftUI `DragGesture` with a native UIKit `UIPanGestureRecognizer`
- fail the back recognizer as soon as motion is vertical so transcript scrolling keeps ownership anywhere on screen
- allow rightward back swipes across the full thread surface, while preserving nested horizontal scrollers away from their leading edge
- scope and remove the window-hosted recognizer with the thread view lifecycle
- add focused coverage for vertical, horizontal, diagonal, slow, and nested-scroll gesture policy

## Why

The broad SwiftUI gesture attached to `ThreadDetailView` competed with the transcript collection view. In practice, vertical scrolling was only reliable when the gesture began near the top of the window, while the native navigation gesture only worked from the screen edge.

UIKit gesture-recognizer arbitration lets the back gesture reject vertical pans before recognition and cooperate with child scroll views explicitly. That restores native scrolling ownership and makes the requested full-surface back swipe reliable without stealing horizontal child scrolling.

This is a focused child PR for #5178 and targets its owner branch.

## UI Changes

There is no visual appearance change; this changes touch interaction only.

Verified on a physical iPhone with the final implementation: transcript scrolling works from the full thread surface and a rightward swipe returns to the thread list from anywhere on screen. The reporter completed the device acceptance pass.

## Verification

- `TranscriptViewportGeometryTests`: 10/10 passed on iPhone 17 Pro Simulator
- `apps/swift-ios/Scripts/ci-test.sh`: the changed gesture suite passed; the script exits 65 because five `HomeThreadMetadataTests` assertions already fail identically on the owner branch at `f98cab553`
- fresh read-only Claude Opus 5 high review of rebased commit `4863570f3`: exit 0, no blocking defects
- `git diff --check upstream/t3code/rebuild-mobile-app-swift...HEAD`: passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable because appearance is unchanged
- [ ] I included a video for animation/interaction changes

Implemented with GPT-5.6 Sol in T3 Code/Codex. Independently reviewed by Claude Opus 5 high.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core navigation and scroll gesture arbitration by installing a window-level pan recognizer, which can regress scrolling, text selection, or nested horizontal pans if heuristics are wrong.
> 
> **Overview**
> Replaces the thread detail SwiftUI `DragGesture` back-swipe with a native UIKit `UIPanGestureRecognizer`, so transcript scrolling no longer fights the navigation gesture.
> 
> The new `ThreadBackSwipeGesture` / `ThreadBackSwipeGestureView` installs on the window root, fails vertical pans immediately, and allows full-surface rightward back swipes while still deferring to editable text and nested horizontal scrollers away from their leading edge. Compact size class only.
> 
> Adds focused unit coverage for vertical, horizontal, diagonal, slow, and nested-scroll gesture policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6ac86ee85b137aca53ad6d57c90dd78195fb39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread scrolling and back swipe in iOS by replacing SwiftUI gesture with native UIPanGestureRecognizer
> - Removes the SwiftUI `DragGesture`-based back navigation from [`ThreadDetailView`](https://github.com/pingdotgg/t3code/pull/6090/files#diff-c987f84bf3746c99e23dc49057c113592bca2c0bce299b9dd80fe73c9495af30) and replaces it with a `ThreadBackSwipeGestureView` that installs a native `UIPanGestureRecognizer` on the window's root view.
> - The new gesture logic (in `ThreadBackSwipeGesture`) cooperates with vertical and horizontal scroll views, only triggering navigation on rightward, predominantly-horizontal pans that exceed a minimum translation of 72pt.
> - Touch receipt is scoped to exclude editable text fields and horizontal scrollers not at the leading edge, fixing conflicts that broke thread scrolling.
> - Adds unit tests in [`TranscriptViewportGeometryTests`](https://github.com/pingdotgg/t3code/pull/6090/files#diff-177ccdc39e6a056ecd668ebe5e714fe8cff83788612b00fd1d0cbbcf3d9c2829) covering begin, end, simultaneous recognition, and touch-receipt rules for the new gesture.
> - Behavioral Change: back swipe is now only enabled in compact width (`horizontalSizeClass == .compact`) and fires via a host-level recognizer rather than a SwiftUI gesture overlay.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd6ac86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable; native/repository checks and current review are green. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
