### PR TITLE
fix(desktop): prevent shared database ownership

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -15,6 +15,7 @@ import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
 import * as DesktopApplicationMenu from "../window/DesktopApplicationMenu.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
+import * as DesktopBackendDatabaseOwner from "../backend/DesktopBackendDatabaseOwner.ts";
 import * as DesktopBackendPool from "../backend/DesktopBackendPool.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./DesktopLifecycle.ts";
@@ -153,6 +154,11 @@ const bootstrap = Effect.gen(function* () {
   if (environment.isDevelopment && Option.isNone(environment.configuredBackendPort)) {
     return yield* new DesktopDevelopmentBackendPortRequiredError();
   }
+
+  yield* DesktopBackendDatabaseOwner.ensureDesktopBackendDatabaseAvailable({
+    stateDir: environment.stateDir,
+    joinPath: environment.path.join,
+  });
 
   const backendPortSelection = yield* resolveDesktopBackendPort(environment.configuredBackendPort);
   const backendPort = backendPortSelection.port;

--- a/apps/desktop/src/backend/DesktopBackendDatabaseOwner.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendDatabaseOwner.test.ts
@@ -1,0 +1,127 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+import {
+  DesktopBackendDatabaseOwnedError,
+  ensureDesktopBackendDatabaseAvailable,
+} from "./DesktopBackendDatabaseOwner.ts";
+
+const descriptor = {
+  environmentId: "local-environment",
+  label: "Local environment",
+  platform: { os: "linux", arch: "x64" },
+  serverVersion: "0.0.34",
+  capabilities: {},
+};
+
+const runtimeState = '{"version":1,"pid":12345,"origin":"http://127.0.0.1:3773"}';
+
+const withStateDir = <A, E, R>(
+  effect: (input: {
+    readonly stateDir: string;
+    readonly statePath: string;
+    readonly requestCount: Ref.Ref<number>;
+  }) => Effect.Effect<A, E, R>,
+  responseStatus = 200,
+) =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+      prefix: "t3-desktop-database-owner-test-",
+    });
+    const statePath = `${stateDir}/server-runtime.json`;
+    const requestCount = yield* Ref.make(0);
+    const httpClientLayer = Layer.succeed(
+      HttpClient.HttpClient,
+      HttpClient.make((request) =>
+        Ref.update(requestCount, (count) => count + 1).pipe(
+          Effect.as(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(JSON.stringify(descriptor), {
+                status: responseStatus,
+                headers: { "content-type": "application/json" },
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+    return yield* effect({ stateDir, statePath, requestCount }).pipe(
+      Effect.provide(httpClientLayer),
+    );
+  }).pipe(Effect.provide(NodeServices.layer), Effect.scoped);
+
+const ensureAvailable = (input: {
+  readonly stateDir: string;
+  readonly isProcessAlive: (pid: number) => boolean;
+}) =>
+  ensureDesktopBackendDatabaseAvailable({
+    stateDir: input.stateDir,
+    joinPath: (...parts) => parts.join("/"),
+    isProcessAlive: input.isProcessAlive,
+  });
+
+describe("DesktopBackendDatabaseOwner", () => {
+  it.effect("allows startup when no runtime state exists", () =>
+    withStateDir(({ stateDir, requestCount }) =>
+      Effect.gen(function* () {
+        yield* ensureAvailable({ stateDir, isProcessAlive: () => true });
+        assert.equal(yield* Ref.get(requestCount), 0);
+      }),
+    ),
+  );
+
+  it.effect("allows startup when the recorded process is gone", () =>
+    withStateDir(({ stateDir, statePath, requestCount }) =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        yield* fileSystem.writeFileString(statePath, runtimeState);
+
+        yield* ensureAvailable({ stateDir, isProcessAlive: () => false });
+        assert.equal(yield* Ref.get(requestCount), 0);
+      }),
+    ),
+  );
+
+  it.effect("allows startup when the recorded endpoint is not a live T3 server", () =>
+    withStateDir(
+      ({ stateDir, statePath, requestCount }) =>
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          yield* fileSystem.writeFileString(statePath, runtimeState);
+
+          yield* ensureAvailable({ stateDir, isProcessAlive: () => true });
+          assert.equal(yield* Ref.get(requestCount), 1);
+        }),
+      404,
+    ),
+  );
+
+  it.effect("blocks startup when a live T3 server owns the database", () =>
+    withStateDir(({ stateDir, statePath, requestCount }) =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        yield* fileSystem.writeFileString(statePath, runtimeState);
+
+        const error = yield* ensureAvailable({
+          stateDir,
+          isProcessAlive: () => true,
+        }).pipe(Effect.flip);
+
+        assert.instanceOf(error, DesktopBackendDatabaseOwnedError);
+        assert.equal(error.stateDir, stateDir);
+        assert.equal(error.origin, "http://127.0.0.1:3773");
+        assert.equal(error.pid, 12_345);
+        assert.include(error.message, "Starting another backend with the same database is unsafe.");
+        assert.equal(yield* Ref.get(requestCount), 1);
+      }),
+    ),
+  );
+});

--- a/apps/desktop/src/backend/DesktopBackendDatabaseOwner.ts
+++ b/apps/desktop/src/backend/DesktopBackendDatabaseOwner.ts
@@ -1,0 +1,106 @@
+import { ExecutionEnvironmentDescriptor } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+const SERVER_RUNTIME_STATE_FILE_NAME = "server-runtime.json";
+const SERVER_PROBE_TIMEOUT = Duration.seconds(2);
+const WELL_KNOWN_ENVIRONMENT_PATH = "/.well-known/t3/environment";
+
+const PersistedServerRuntimeOwner = Schema.Struct({
+  version: Schema.Literal(1),
+  pid: Schema.Int,
+  origin: Schema.String,
+});
+type PersistedServerRuntimeOwner = typeof PersistedServerRuntimeOwner.Type;
+
+const decodePersistedServerRuntimeOwner = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(PersistedServerRuntimeOwner),
+);
+
+export class DesktopBackendDatabaseOwnedError extends Schema.TaggedErrorClass<DesktopBackendDatabaseOwnedError>()(
+  "DesktopBackendDatabaseOwnedError",
+  {
+    stateDir: Schema.String,
+    origin: Schema.String,
+    pid: Schema.Int,
+  },
+) {
+  override get message(): string {
+    return [
+      `A running T3 Code server at ${this.origin} (PID ${String(this.pid)}) already uses ${this.stateDir}.`,
+      "Starting another backend with the same database is unsafe.",
+      "Stop the background service before opening the desktop app, or start the desktop app with a separate T3CODE_HOME and connect to the running environment.",
+    ].join("\n");
+  }
+}
+
+const readRuntimeOwner = (
+  statePath: string,
+): Effect.Effect<Option.Option<PersistedServerRuntimeOwner>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const raw = yield* fileSystem.readFileString(statePath).pipe(Effect.option);
+    if (Option.isNone(raw) || raw.value.trim().length === 0) {
+      return Option.none();
+    }
+    return yield* decodePersistedServerRuntimeOwner(raw.value.trim()).pipe(Effect.option);
+  });
+
+const defaultIsProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error instanceof Error && "code" in error && error.code === "EPERM";
+  }
+};
+
+const probeT3Server = (origin: string): Effect.Effect<boolean, never, HttpClient.HttpClient> =>
+  Effect.gen(function* () {
+    const httpClient = yield* HttpClient.HttpClient;
+    const endpoint = yield* Effect.try(() =>
+      new URL(WELL_KNOWN_ENVIRONMENT_PATH, origin).toString(),
+    );
+    const request = HttpClientRequest.get(endpoint);
+    yield* httpClient
+      .execute(request)
+      .pipe(
+        Effect.flatMap(HttpClientResponse.filterStatusOk),
+        Effect.flatMap(HttpClientResponse.schemaBodyJson(ExecutionEnvironmentDescriptor)),
+        Effect.timeout(SERVER_PROBE_TIMEOUT),
+      );
+    return true;
+  }).pipe(Effect.orElseSucceed(() => false));
+
+export const ensureDesktopBackendDatabaseAvailable = Effect.fn(
+  "desktop.backendDatabaseOwner.ensureAvailable",
+)(function* (input: {
+  readonly stateDir: string;
+  readonly joinPath: (...parts: ReadonlyArray<string>) => string;
+  readonly isProcessAlive?: (pid: number) => boolean;
+}) {
+  const statePath = input.joinPath(input.stateDir, SERVER_RUNTIME_STATE_FILE_NAME);
+  const runtimeOwner = yield* readRuntimeOwner(statePath);
+  if (Option.isNone(runtimeOwner)) {
+    return;
+  }
+
+  const owner = runtimeOwner.value;
+  if (!(input.isProcessAlive ?? defaultIsProcessAlive)(owner.pid)) {
+    return;
+  }
+
+  if (!(yield* probeT3Server(owner.origin))) {
+    return;
+  }
+
+  return yield* new DesktopBackendDatabaseOwnedError({
+    stateDir: input.stateDir,
+    origin: owner.origin,
+    pid: owner.pid,
+  });
+});


### PR DESCRIPTION
## What

- add a desktop bootstrap preflight for the selected T3 state directory
- read the existing `server-runtime.json` owner record before scanning for another port
- confirm both the recorded PID and the T3 environment descriptor before blocking startup
- surface a specific recovery message instead of opening the shared SQLite database
- preserve normal startup for missing, malformed, dead, or non-T3 runtime records

## Why

When the background service already listens on port 3773, the desktop currently scans to 3774 but still launches its embedded backend with the same default T3 home. Both long-lived servers then open `userdata/state.sqlite`, causing `database is locked` HTTP 500s and duplicate resource usage.

This enforces a single live backend owner for a desktop state directory. A SQLite busy timeout can reduce transient contention, but it cannot make duplicate schedulers, command processors, and WebSocket streams safe.

## Impact

Users who launch the desktop while a background service owns the same T3 home now get a clear startup error with safe recovery instructions. They can stop the service or use a separate `T3CODE_HOME` and connect to the running environment.

## Checks

- `pnpm exec vp test run apps/desktop/src/backend/DesktopBackendDatabaseOwner.test.ts apps/desktop/src/app/DesktopAppErrors.test.ts` — 2 files, 6 tests passed
- `pnpm exec vp run --filter @t3tools/desktop typecheck` — passed
- targeted `vp fmt --check` — passed
- `git diff --cached --check` — passed

Fixes #6097

Model: GPT-5 Codex
Harness: Codex desktop app

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent desktop backend startup when another T3 server owns the database
> - Adds `DesktopBackendDatabaseOwner.ensureDesktopBackendDatabaseAvailable` in [DesktopBackendDatabaseOwner.ts](https://github.com/pingdotgg/t3code/pull/6098/files#diff-3bdcade13d6ef3b65a89a5404267c0a2a6d0e6d3215f7bd69c1c25c3844cae07), a pre-start guard that checks whether a previously recorded server process is still alive and serving a live T3 backend.
> - The guard reads a persisted runtime owner record from the state directory, checks PID liveness via `process.kill(pid, 0)`, and probes `/.well-known/t3/environment` on the recorded origin with a 2s timeout.
> - If all checks pass (process alive, endpoint responds 200), startup is aborted with a structured `DesktopBackendDatabaseOwnedError` containing the origin, PID, and state directory.
> - This guard is called in [DesktopApp.ts](https://github.com/pingdotgg/t3code/pull/6098/files#diff-267cf20af5c499f356b88a4bc3d3dec61aa6c7a3398f93f8836975b3bcf764e9) during bootstrap, before the backend starts.
> - Risk: if the liveness probe is slow or the state file is stale but not cleaned up, startup may be blocked unnecessarily.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 971ce3f. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->