### PR TITLE
fix(web): stop terminal scrollback from jumping to the live prompt

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -3,7 +3,10 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { type TerminalSessionState } from "@t3tools/client-runtime/state/terminal";
+import {
+  terminalBufferWritePlan,
+  type TerminalSessionState,
+} from "@t3tools/client-runtime/state/terminal";
 import {
   Plus,
   SquareSplitHorizontal,
@@ -806,13 +809,13 @@ export function TerminalViewport({
       return;
     }
 
-    if (
-      current.buffer.length >= previous.buffer.length &&
-      current.buffer.startsWith(previous.buffer)
-    ) {
-      terminal.write(current.buffer.slice(previous.buffer.length));
-    } else {
-      writeTerminalBuffer(terminal, current.buffer);
+    // Prefer append (including after head-trim of the history ring) so the
+    // Ghostty viewport is not resetAndWrite'd back to the live prompt (#6096).
+    const plan = terminalBufferWritePlan(previous.buffer, current.buffer);
+    if (plan.kind === "append") {
+      if (plan.data.length > 0) terminal.write(plan.data);
+    } else if (plan.kind === "replace") {
+      writeTerminalBuffer(terminal, plan.data);
     }
     terminal.clearSelection();
 

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -196,6 +196,28 @@ describe("vendored libghostty-vt WebAssembly", () => {
     expect(call("ghostty_terminal_get", terminal, 9, scrollbar)).toBe(0);
     expect(Number(scrollbarView.getBigUint64(8, true))).toBe(36);
 
+    // Scrolled into history → viewport is no longer pinned to the active prompt.
+    const viewportActive = alloc(1);
+    expect(call("ghostty_terminal_get", terminal, 32, viewportActive)).toBe(0);
+    expect(new Uint8Array(memory.buffer, viewportActive, 1)[0]).toBe(0);
+
+    // Further output must not steal the user's scroll place (regression for #6096).
+    const more = new TextEncoder().encode("more\r\n");
+    const morePointer = alloc(more.length);
+    new Uint8Array(memory.buffer, morePointer, more.length).set(more);
+    call("ghostty_terminal_vt_write", terminal, morePointer, more.length);
+    expect(call("ghostty_terminal_get", terminal, 32, viewportActive)).toBe(0);
+    expect(new Uint8Array(memory.buffer, viewportActive, 1)[0]).toBe(0);
+    expect(call("ghostty_terminal_get", terminal, 9, scrollbar)).toBe(0);
+    expect(Number(scrollbarView.getBigUint64(8, true))).toBe(36);
+
+    // Resize/reflow also must not re-pin when the user is in history.
+    expect(call("ghostty_terminal_resize", terminal, 80, 12, 8, 16)).toBe(0);
+    expect(call("ghostty_terminal_get", terminal, 32, viewportActive)).toBe(0);
+    expect(new Uint8Array(memory.buffer, viewportActive, 1)[0]).toBe(0);
+
+    call("ghostty_wasm_free_u8_array", morePointer, more.length);
+    call("ghostty_wasm_free_u8_array", viewportActive, 1);
     call("ghostty_wasm_free_u8_array", scroll, 24);
     call("ghostty_wasm_free_u8_array", scrollbar, 24);
     call("ghostty_wasm_free_u8_array", inputPointer, input.length);

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_TERMINAL_FONT_FAMILY,
   DEFAULT_TERMINAL_FONT_SIZE,
   advanceTerminalSelectionClickSequence,
+  captureTerminalScrollAnchor,
   ghosttyMouseButton,
   isTerminalAltGraphText,
   isTerminalCompositionCommitInput,
@@ -18,6 +19,7 @@ import {
   terminalGridCellAt,
   terminalScrollbarGeometry,
   terminalScrollbarOffsetAtPointer,
+  terminalScrollDeltaToRestore,
   terminalLinkAtColumn,
   terminalLinkAtPosition,
   terminalLinkAtPositionWithRange,
@@ -489,5 +491,60 @@ describe("terminal scrollbar", () => {
       maxOffset: 9_980,
     });
     expect(terminalScrollbarOffsetAtPointer(state, 200, 191, 9)).toBe(9_980);
+  });
+});
+
+describe("terminal scroll anchor restore", () => {
+  it("captures follow when the viewport is pinned to the live prompt", () => {
+    expect(captureTerminalScrollAnchor(true, { total: 100, offset: 80, len: 20 })).toEqual({
+      kind: "follow",
+    });
+  });
+
+  it("captures a clamped offset when the user is reading history", () => {
+    expect(captureTerminalScrollAnchor(false, { total: 100, offset: 40, len: 20 })).toEqual({
+      kind: "offset",
+      offset: 40,
+      total: 100,
+      len: 20,
+    });
+    expect(captureTerminalScrollAnchor(false, { total: 50, offset: 999, len: 20 })).toEqual({
+      kind: "offset",
+      offset: 30,
+      total: 50,
+      len: 20,
+    });
+  });
+
+  it("does not move when still following or when already at the anchor", () => {
+    expect(
+      terminalScrollDeltaToRestore({ kind: "follow" }, { total: 100, offset: 80, len: 20 }),
+    ).toBe(0);
+    expect(
+      terminalScrollDeltaToRestore(
+        { kind: "offset", offset: 36, total: 51, len: 10 },
+        { total: 51, offset: 36, len: 10 },
+      ),
+    ).toBe(0);
+  });
+
+  it("restores absolute offset after append when output re-pins to the bottom", () => {
+    // User was at offset 36; write re-pinned to bottom (offset 50 of 60 with len 10).
+    expect(
+      terminalScrollDeltaToRestore(
+        { kind: "offset", offset: 36, total: 51, len: 10 },
+        { total: 60, offset: 50, len: 10 },
+      ),
+    ).toBe(-14);
+  });
+
+  it("restores a proportional place after scrollback is trimmed shorter", () => {
+    // Mid-history (offset 40 of max 80) → after trim, mid of new max 40 → target 20.
+    expect(
+      terminalScrollDeltaToRestore(
+        { kind: "offset", offset: 40, total: 100, len: 20 },
+        { total: 60, offset: 40, len: 20 },
+      ),
+    ).toBe(-20);
   });
 });

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -208,6 +208,63 @@ export function terminalScrollbarOffsetAtPointer(
   return Math.round((thumbTop / travel) * geometry.maxOffset);
 }
 
+/**
+ * Snapshot of where the user is looking in scrollback.
+ *
+ * Terminal output, reflow, and full buffer replays can re-pin the Ghostty
+ * viewport to the live prompt. Capture/restore keeps the user's place when
+ * they have scrolled into history (see #6096).
+ */
+export type TerminalScrollAnchor =
+  | { readonly kind: "follow" }
+  | {
+      readonly kind: "offset";
+      readonly offset: number;
+      readonly total: number;
+      readonly len: number;
+    };
+
+export function captureTerminalScrollAnchor(
+  isFollowing: boolean,
+  state: GhosttyScrollbar | null,
+): TerminalScrollAnchor {
+  if (isFollowing || state === null) return { kind: "follow" };
+  const total = Math.max(0, state.total);
+  const len = Math.max(0, Math.min(state.len, total));
+  const maxOffset = Math.max(0, total - len);
+  return {
+    kind: "offset",
+    offset: Math.max(0, Math.min(state.offset, maxOffset)),
+    total,
+    len,
+  };
+}
+
+/** Rows to pass to a delta scroll so the viewport returns to `anchor`. */
+export function terminalScrollDeltaToRestore(
+  anchor: TerminalScrollAnchor,
+  state: GhosttyScrollbar | null,
+): number {
+  if (anchor.kind === "follow" || state === null) return 0;
+  const total = Math.max(0, state.total);
+  const len = Math.max(0, Math.min(state.len, total));
+  const maxOffset = Math.max(0, total - len);
+  if (maxOffset === 0) return 0;
+
+  let target: number;
+  const priorMax = Math.max(0, anchor.total - anchor.len);
+  if (priorMax > 0 && (total < anchor.total || anchor.offset > maxOffset)) {
+    // Scrollback was trimmed or rebuilt shorter — keep the same relative place.
+    const fraction = anchor.offset / priorMax;
+    target = Math.round(fraction * maxOffset);
+  } else {
+    // Normal append/reflow: absolute offset still points at the same history.
+    target = anchor.offset;
+  }
+  target = Math.max(0, Math.min(target, maxOffset));
+  return target - state.offset;
+}
+
 export function terminalGridCellAt(options: {
   bounds: { left: number; top: number };
   clientX: number;
@@ -647,7 +704,10 @@ export class GhosttyTerminalSurface {
 
   write(data: string): void {
     if (this.disposed) return;
+    // New PTY bytes can re-pin Ghostty to the live prompt; keep scrollback place.
+    const anchor = this.captureScrollAnchor();
     this.core.write(data);
+    this.restoreScrollAnchor(anchor);
     // Restart the blink cycle from the visible phase so the cursor never sits
     // invisible through a stream of output or a burst of typing echo.
     this.cursorOn = true;
@@ -657,7 +717,11 @@ export class GhosttyTerminalSurface {
 
   resetAndWrite(data: string): void {
     if (this.disposed) return;
+    // Full history replay rebuilds the screen; restore relative place when the
+    // user was reading scrollback (e.g. buffer trim forcing a non-prefix rewrite).
+    const anchor = this.captureScrollAnchor();
     this.core.resetAndWrite(data);
+    this.restoreScrollAnchor(anchor);
     // A replayed session starts from the visible phase like any other write:
     // reattaching mid-blink must not open on an invisible cursor.
     this.cursorOn = true;
@@ -741,6 +805,8 @@ export class GhosttyTerminalSurface {
     const width = this.mount.clientWidth;
     const height = this.mount.clientHeight;
     if (width <= 0 || height <= 0) return false;
+    // Reflow on resize can re-pin to the active prompt; remember scroll place first.
+    const anchor = this.captureScrollAnchor();
     const ratio = window.devicePixelRatio || 1;
     const pixelWidth = Math.max(1, Math.round(width * ratio));
     const pixelHeight = Math.max(1, Math.round(height * ratio));
@@ -774,6 +840,7 @@ export class GhosttyTerminalSurface {
       this.scrollbarDirty = true;
       shouldRender = true;
     }
+    this.restoreScrollAnchor(anchor);
     // Rendering synchronously keeps the repaint inside the same frame as the
     // layout change: ResizeObserver fires before paint, so the browser never
     // composites the old backing store stretched into the new element box.
@@ -854,6 +921,27 @@ export class GhosttyTerminalSurface {
 
   isAtBottom(): boolean {
     return this.core.isViewportActive();
+  }
+
+  private captureScrollAnchor(): TerminalScrollAnchor {
+    return captureTerminalScrollAnchor(this.core.isViewportActive(), this.core.scrollbarState());
+  }
+
+  private restoreScrollAnchor(anchor: TerminalScrollAnchor): void {
+    if (anchor.kind === "follow") {
+      // Resize/write can unpin the live prompt; re-stick when the user was following.
+      if (!this.core.isViewportActive()) {
+        this.core.scrollToBottom();
+        this.forceFullRender = true;
+        this.scrollbarDirty = true;
+      }
+      return;
+    }
+    const delta = terminalScrollDeltaToRestore(anchor, this.core.scrollbarState());
+    if (delta === 0) return;
+    this.core.scroll(delta);
+    this.forceFullRender = true;
+    this.scrollbarDirty = true;
   }
 
   dispose(): void {

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -8,6 +8,7 @@ import {
   combineTerminalSessionState,
   EMPTY_TERMINAL_BUFFER_STATE,
   selectRunningSubprocessTerminalIds,
+  terminalBufferWritePlan,
 } from "./terminalSession.ts";
 
 const TARGET = {
@@ -183,5 +184,32 @@ describe("terminal session reducers", () => {
     );
 
     expect(state.buffer).toBe("🙂");
+  });
+});
+
+describe("terminalBufferWritePlan", () => {
+  it("appends a pure suffix without rewriting history", () => {
+    expect(terminalBufferWritePlan("hello", "hello world")).toEqual({
+      kind: "append",
+      data: " world",
+    });
+    expect(terminalBufferWritePlan("same", "same")).toEqual({ kind: "noop" });
+  });
+
+  it("treats head-trim of the history ring as an append of the new tail", () => {
+    // Simulates DEFAULT_MAX_TERMINAL_BUFFER_BYTES ring: drop the head, keep overlap.
+    const previous = "AAAA" + "B".repeat(32);
+    const current = "B".repeat(32) + "CCCC";
+    expect(terminalBufferWritePlan(previous, current)).toEqual({
+      kind: "append",
+      data: "CCCC",
+    });
+  });
+
+  it("replaces when the buffers are unrelated", () => {
+    expect(terminalBufferWritePlan("old prompt\n", "brand new session\n")).toEqual({
+      kind: "replace",
+      data: "brand new session\n",
+    });
   });
 });

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -122,6 +122,46 @@ export function combineTerminalSessionState(
   };
 }
 
+/**
+ * How to feed a new buffer snapshot into an already-rendered terminal surface.
+ *
+ * Prefer append so Ghostty keeps the user's scrollback place. A full replace is
+ * only used when the buffers are unrelated (clear / restart / true rewrite).
+ * Head-trim of the client-side history ring is treated as append of the new tail
+ * so we do not resetAndWrite and jump the viewport to the live prompt (#6096).
+ */
+export type TerminalBufferWritePlan =
+  | { readonly kind: "noop" }
+  | { readonly kind: "append"; readonly data: string }
+  | { readonly kind: "replace"; readonly data: string };
+
+export function terminalBufferWritePlan(
+  previous: string,
+  current: string,
+): TerminalBufferWritePlan {
+  if (current === previous) return { kind: "noop" };
+  if (current.startsWith(previous)) {
+    return { kind: "append", data: current.slice(previous.length) };
+  }
+  if (previous.length === 0) {
+    return { kind: "replace", data: current };
+  }
+
+  // Head-trim of the history ring: longest suffix of `previous` that prefixes `current`.
+  // Only runs when the cheap startsWith path failed (near the byte cap), so a linear
+  // scan over the overlap is acceptable. Require a minimum overlap so unrelated
+  // rewrites (clear → new prompt) do not accidentally append on a short shared tail.
+  const maxOverlap = Math.min(previous.length, current.length);
+  const minOverlap = Math.min(16, maxOverlap);
+  for (let len = maxOverlap; len >= minOverlap; len -= 1) {
+    if (current.startsWith(previous.slice(previous.length - len))) {
+      return { kind: "append", data: current.slice(len) };
+    }
+  }
+
+  return { kind: "replace", data: current };
+}
+
 export function applyTerminalAttachStreamEvent(
   current: TerminalBufferState,
   event: TerminalAttachStreamEvent,


### PR DESCRIPTION
## Summary

Fixes #6096 — desktop integrated terminal (Cmd+J / `terminal.toggle`) could force the viewport back to the live prompt while the user was reading scrollback.

### What changed

1. **Scroll anchor capture/restore** on the Ghostty surface (`write`, `resetAndWrite`, `fit`) so mutations that re-pin or rewrite the screen put the user back where they were when they had scrolled into history.
2. **Smarter buffer feed plan** — head-trim of the client history ring is treated as an **append of the new tail** instead of `resetAndWrite` of the whole buffer (which always landed at the bottom).
3. **Tests** — unit coverage for anchors + write plans; Ghostty WASM ABI regression that scroll + write/resize keep `VIEWPORT_ACTIVE` false.

### Why this approach

Upstream Ghostty already keeps scroll place across pure VT writes/resizes when unpinned (covered by the ABI test). The jump came from the **web layer** replaying history via full resets and from fit/write paths not restoring a non-following viewport. Small, focused change — no product-scope expansion.

## Test plan

- [x] `vp run --filter @t3tools/client-runtime test` (includes new write-plan cases)
- [x] `vp test run --project unit src/terminal/ghostty/` (surface + runtimeAbi)
- [ ] Manual: open terminal (`mod+j`), generate scrollback (`seq 1 200`), scroll up, keep a shell producing output / resize drawer — viewport should stay put until you return to the bottom
- [ ] Manual: confirm following still works when staying at the bottom (new output remains visible)

Closes #6096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal rendering and buffer sync paths used on every PTY update; behavior change is localized but user-visible if anchor restore is wrong.
> 
> **Overview**
> Fixes **#6096** — the integrated terminal could **snap back to the live prompt** while you were reading scrollback.
> 
> **Ghostty surface** now **captures and restores scroll position** around `write`, `resetAndWrite`, and `fit` when the viewport is not pinned to the bottom, including proportional restore after scrollback is trimmed.
> 
> **Client buffer sync** uses **`terminalBufferWritePlan`** so updates prefer **`terminal.write` append** (including after the **history ring head-trim**) instead of a full **`resetAndWrite`**, which was re-pinning the viewport.
> 
> **Tests** cover write-plan cases, scroll-anchor math, and a WASM ABI check that output and resize keep the viewport unpinned after scrolling into history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca060ae3ccd5505cda12041722a908f21162a7f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal scrollback jumping to the live prompt on write, resize, or buffer replay
> - Introduces `TerminalScrollAnchor` in [`surface.ts`](https://github.com/pingdotgg/t3code/pull/6104/files#diff-036d64ffe3b3b3d167137e8ea29edae7af74a9e0323fc798c4f291992235d267) to snapshot the user's scroll position before terminal operations and restore it after, preventing writes, full buffer replays, and resizes from re-pinning the viewport to the bottom.
> - Adds `terminalBufferWritePlan` in [`terminalSession.ts`](https://github.com/pingdotgg/t3code/pull/6104/files#diff-c939205ce2272b9eb963a11eb634ba5d09e9525a249ac2c259ef8b5fda367828) to decide between appending a suffix or doing a full buffer replace when the terminal buffer updates, reducing unnecessary full rewrites.
> - Updates [`ThreadTerminalDrawer`](https://github.com/pingdotgg/t3code/pull/6104/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) to use the write plan instead of a `startsWith`-based comparison, so appends are correctly identified even after scrollback ring head-trims.
> - Behavioral Change: terminal writes and resizes no longer re-pin users who have scrolled into history; viewport re-pins to bottom only when the user was already following.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ca060ae. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->