### PR TITLE
fix(web): browse pull requests across remote servers

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
@@ -1,4 +1,4 @@
-import type { ProjectId } from "@t3tools/contracts";
+import { EnvironmentId, type ProjectId } from "@t3tools/contracts";
 import { CircleIcon } from "lucide-react";
 import { Children, isValidElement, type ReactElement, type ReactNode } from "react";
 import { describe, expect, it, vi } from "vite-plus/test";
@@ -28,6 +28,26 @@ function findValueChange(
   return undefined;
 }
 
+function findValueChangeForValue(
+  node: ReactNode,
+  value: string,
+): ReactElement<{ readonly onValueChange: (value: string) => void }> | undefined {
+  for (const child of Children.toArray(node)) {
+    if (!isValidElement(child)) continue;
+    const props = child.props as {
+      readonly children?: ReactNode;
+      readonly value?: string;
+      readonly onValueChange?: (value: string) => void;
+    };
+    if (props.value === value && props.onValueChange) {
+      return child as ReactElement<{ readonly onValueChange: (value: string) => void }>;
+    }
+    const nested = findValueChangeForValue(props.children, value);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
 /** The nested radio-group component element carrying this label, invoked so its group shows. */
 function findLabeledGroup(node: ReactNode, label: string): ReactNode {
   for (const child of Children.toArray(node)) {
@@ -43,6 +63,7 @@ function findLabeledGroup(node: ReactNode, label: string): ReactNode {
 }
 
 function menu(overrides: Partial<Parameters<typeof PullRequestFiltersMenu>[0]>) {
+  const environmentId = EnvironmentId.make("environment-1");
   return PullRequestFiltersMenu({
     state: "open",
     stateOptions: [
@@ -56,11 +77,11 @@ function menu(overrides: Partial<Parameters<typeof PullRequestFiltersMenu>[0]>) 
     host: undefined,
     hostOptions: [],
     onHost: () => undefined,
-    environmentId: null,
-    projects: [],
+    environmentId,
+    environments: [{ id: environmentId, label: "Local", isPrimary: true, projects: [] }],
     projectId: undefined,
     unavailable: new Map(),
-    onProject: () => undefined,
+    onProjectScope: () => undefined,
     ...overrides,
   });
 }
@@ -80,20 +101,67 @@ describe("pull request filters menu", () => {
   });
 
   it("does not emit a change when the selected project is chosen again", () => {
+    const environmentId = EnvironmentId.make("environment-1");
     const projectId = "project-1" as ProjectId;
-    const onProject = vi.fn();
+    const onProjectScope = vi.fn();
     const view = menu({
-      projects: [{ id: projectId, title: "T3 Code", workspaceRoot: "/work/t3code" }],
+      environmentId,
+      environments: [
+        {
+          id: environmentId,
+          label: "Local",
+          isPrimary: true,
+          projects: [{ id: projectId, title: "T3 Code", workspaceRoot: "/work/t3code" }],
+        },
+      ],
       projectId,
-      onProject,
+      onProjectScope,
     });
-    const radioGroup = findValueChange(view);
+    const radioGroup = findValueChangeForValue(view, JSON.stringify([environmentId, projectId]));
     expect(radioGroup).toBeDefined();
 
-    radioGroup?.props.onValueChange(projectId);
-    expect(onProject).not.toHaveBeenCalled();
+    radioGroup?.props.onValueChange(JSON.stringify([environmentId, projectId]));
+    expect(onProjectScope).not.toHaveBeenCalled();
 
-    radioGroup?.props.onValueChange("all");
-    expect(onProject).toHaveBeenCalledWith(undefined);
+    radioGroup?.props.onValueChange("all-projects");
+    expect(onProjectScope).toHaveBeenLastCalledWith(environmentId, undefined);
+  });
+
+  it("selects all servers independently from the project filter", () => {
+    const environmentId = EnvironmentId.make("environment-1");
+    const onProjectScope = vi.fn();
+    const view = menu({ environmentId, onProjectScope });
+    const serverGroup = findValueChangeForValue(view, environmentId);
+
+    serverGroup?.props.onValueChange("all-environments");
+
+    expect(onProjectScope).toHaveBeenCalledWith(null, undefined);
+  });
+
+  it("selects a project together with its remote server", () => {
+    const localEnvironmentId = EnvironmentId.make("environment-1");
+    const remoteEnvironmentId = EnvironmentId.make("environment-2");
+    const remoteProjectId = "project-2" as ProjectId;
+    const onProjectScope = vi.fn();
+    const view = menu({
+      environmentId: null,
+      environments: [
+        { id: localEnvironmentId, label: "Local", isPrimary: true, projects: [] },
+        {
+          id: remoteEnvironmentId,
+          label: "Remote",
+          isPrimary: false,
+          projects: [
+            { id: remoteProjectId, title: "Remote project", workspaceRoot: "/work/remote" },
+          ],
+        },
+      ],
+      onProjectScope,
+    });
+    const projectGroup = findValueChangeForValue(view, "all-projects");
+
+    projectGroup?.props.onValueChange(JSON.stringify([remoteEnvironmentId, remoteProjectId]));
+
+    expect(onProjectScope).toHaveBeenCalledWith(remoteEnvironmentId, remoteProjectId);
   });
 });

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -5,7 +5,15 @@ import type {
   PullRequestListState,
   SourceControlProviderKind,
 } from "@t3tools/contracts";
-import { FolderGit2Icon, LayersIcon, ListFilterIcon, LoaderIcon, SearchIcon } from "lucide-react";
+import {
+  FolderGit2Icon,
+  LayersIcon,
+  ListFilterIcon,
+  LoaderIcon,
+  MonitorIcon,
+  SearchIcon,
+  ServerIcon,
+} from "lucide-react";
 import type { ElementType } from "react";
 
 import { cn } from "~/lib/utils";
@@ -98,9 +106,117 @@ export function PullRequestSearchInput({
  * default, so a narrowed list is never a mystery. Same menu chrome as the detail panel's
  * actions, which also owns its own spacing.
  */
-const ALL_PROJECTS_VALUE = "all";
 /** MenuRadioGroup wants a string, so "every host" wears the one value no host can be. */
 const ALL_HOSTS_VALUE = "";
+const ALL_ENVIRONMENTS_VALUE = "all-environments";
+const ALL_PROJECTS_VALUE = "all-projects";
+
+interface PullRequestProjectOption {
+  readonly id: ProjectId;
+  readonly title: string;
+  readonly workspaceRoot: string;
+}
+
+export interface PullRequestProjectEnvironmentOption {
+  readonly id: EnvironmentId;
+  readonly label: string;
+  readonly isPrimary: boolean;
+  readonly projects: ReadonlyArray<PullRequestProjectOption>;
+}
+
+export function pullRequestProjectScopeValue(
+  environmentId: EnvironmentId,
+  projectId?: ProjectId,
+): string {
+  return JSON.stringify([environmentId, projectId ?? null]);
+}
+
+function EnvironmentIcon({ isPrimary }: { isPrimary: boolean }) {
+  const Icon = isPrimary ? MonitorIcon : ServerIcon;
+  return <Icon aria-hidden className="size-3.5 shrink-0" />;
+}
+
+function AllProjectsLabel({ label = "All projects" }: { label?: string }) {
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <LayersIcon aria-hidden className="size-3.5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+    </span>
+  );
+}
+
+function ProjectLabel({
+  environment,
+  project,
+  unavailable,
+  showEnvironment,
+}: {
+  environment: PullRequestProjectEnvironmentOption;
+  project: PullRequestProjectOption;
+  unavailable?: string;
+  showEnvironment?: boolean;
+}) {
+  return (
+    <span className="flex min-w-0 flex-1 items-center gap-2">
+      <ProjectFavicon
+        environmentId={environment.id}
+        cwd={project.workspaceRoot}
+        fallbackIcon={FolderGit2Icon}
+        className="size-3.5 shrink-0"
+      />
+      <span className="min-w-0 flex-1 truncate">{project.title}</span>
+      {showEnvironment ? (
+        <span className="max-w-28 shrink-0 truncate text-xs text-muted-foreground">
+          {environment.label}
+        </span>
+      ) : null}
+      {unavailable === undefined ? null : (
+        <span className="shrink-0 rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 py-px text-[10px] font-medium text-amber-600 dark:text-amber-400/90">
+          Unavailable
+        </span>
+      )}
+    </span>
+  );
+}
+
+function sortedProjects(
+  environment: PullRequestProjectEnvironmentOption,
+  unavailable: ReadonlyMap<string, string>,
+) {
+  return environment.projects.toSorted(
+    (left, right) =>
+      Number(unavailable.has(pullRequestProjectScopeValue(environment.id, left.id))) -
+      Number(unavailable.has(pullRequestProjectScopeValue(environment.id, right.id))),
+  );
+}
+
+function ProjectScopeItem({
+  environment,
+  project,
+  unavailable,
+  showEnvironment,
+}: {
+  environment: PullRequestProjectEnvironmentOption;
+  project: PullRequestProjectOption;
+  unavailable: ReadonlyMap<string, string>;
+  showEnvironment?: boolean;
+}) {
+  const reason = unavailable.get(pullRequestProjectScopeValue(environment.id, project.id));
+  return (
+    <MenuRadioItem
+      value={pullRequestProjectScopeValue(environment.id, project.id)}
+      disabled={reason !== undefined}
+      title={reason}
+    >
+      <ProjectLabel
+        environment={environment}
+        project={project}
+        {...(reason === undefined ? {} : { unavailable: reason })}
+        {...(showEnvironment === undefined ? {} : { showEnvironment })}
+      />
+    </MenuRadioItem>
+  );
+}
 
 function PullRequestFilterRadioGroup<Value extends string>({
   label,
@@ -151,10 +267,10 @@ export function PullRequestFiltersMenu({
   hostOptions,
   onHost,
   environmentId,
-  projects,
+  environments,
   projectId,
   unavailable,
-  onProject,
+  onProjectScope,
 }: {
   state: PullRequestListState;
   stateOptions: ReadonlyArray<PullRequestFilterOption<PullRequestListState>>;
@@ -169,24 +285,46 @@ export function PullRequestFiltersMenu({
    */
   hostOptions: ReadonlyArray<PullRequestFilterOption<string>>;
   onHost: (host: string | undefined) => void;
-  /** Where the projects' own favicons are read from; null before the environment is known. */
+  /** The environment whose projects and pull requests are currently in scope. */
   environmentId: EnvironmentId | null;
-  projects: ReadonlyArray<{
-    readonly id: ProjectId;
-    readonly title: string;
-    readonly workspaceRoot: string;
-  }>;
+  environments: ReadonlyArray<PullRequestProjectEnvironmentOption>;
   projectId: ProjectId | undefined;
   /**
    * Projects whose repository could not be read this time round. They are named here, where
    * the reader is already choosing between projects, rather than as a count above the list
    * that says something is missing without saying which.
    */
-  unavailable: ReadonlyMap<ProjectId, string>;
-  onProject: (projectId: ProjectId | undefined) => void;
+  unavailable: ReadonlyMap<string, string>;
+  onProjectScope: (environmentId: EnvironmentId | null, projectId: ProjectId | undefined) => void;
 }) {
+  const selectedEnvironment =
+    environments.find((environment) => environment.id === environmentId) ?? null;
+  const selectedScopeValue =
+    selectedEnvironment === null || projectId === undefined
+      ? ALL_PROJECTS_VALUE
+      : pullRequestProjectScopeValue(selectedEnvironment.id, projectId);
+  const selectScopeValue = (next: string) => {
+    if (next === selectedScopeValue) return;
+    if (next === ALL_PROJECTS_VALUE) {
+      onProjectScope(environmentId, undefined);
+      return;
+    }
+    for (const environment of environments) {
+      const project = environment.projects.find(
+        (candidate) => next === pullRequestProjectScopeValue(environment.id, candidate.id),
+      );
+      if (project !== undefined) {
+        onProjectScope(environment.id, project.id);
+        return;
+      }
+    }
+  };
   const filtered =
-    state !== "open" || involvement !== "all" || host !== undefined || projectId !== undefined;
+    state !== "open" ||
+    involvement !== "all" ||
+    host !== undefined ||
+    environmentId !== null ||
+    projectId !== undefined;
   return (
     <Menu>
       <MenuTrigger
@@ -232,55 +370,44 @@ export function PullRequestFiltersMenu({
         ) : null}
         <MenuSeparator />
         <MenuRadioGroup
-          value={projectId ?? ALL_PROJECTS_VALUE}
-          onValueChange={(next) => {
-            const nextProjectId = next === ALL_PROJECTS_VALUE ? undefined : (next as ProjectId);
-            if (nextProjectId !== projectId) onProject(nextProjectId);
-          }}
-        >
-          <MenuGroupLabel>Project</MenuGroupLabel>
-          <MenuRadioItem value={ALL_PROJECTS_VALUE}>
-            <span className="flex min-w-0 items-center gap-2">
-              <LayersIcon aria-hidden className="size-3.5" />
-              All projects
-            </span>
-          </MenuRadioItem>
-          {/* The ones that can be chosen first: a list that opens with three disabled rows reads
-              as a broken menu rather than as a workspace with three unreadable repositories. */}
-          {projects
-            .toSorted(
-              (left, right) => Number(unavailable.has(left.id)) - Number(unavailable.has(right.id)),
+          value={environmentId ?? ALL_ENVIRONMENTS_VALUE}
+          onValueChange={(next) =>
+            onProjectScope(
+              next === ALL_ENVIRONMENTS_VALUE ? null : (next as EnvironmentId),
+              undefined,
             )
-            .map((project) => {
-              const reason = unavailable.get(project.id);
-              return (
-                <MenuRadioItem
-                  key={project.id}
-                  value={project.id}
-                  disabled={reason !== undefined}
-                  title={reason}
-                >
-                  <span className="flex min-w-0 flex-1 items-center gap-2">
-                    {environmentId === null ? (
-                      <FolderGit2Icon aria-hidden className="size-3.5 shrink-0" />
-                    ) : (
-                      <ProjectFavicon
-                        environmentId={environmentId}
-                        cwd={project.workspaceRoot}
-                        fallbackIcon={FolderGit2Icon}
-                        className="size-3.5 shrink-0"
-                      />
-                    )}
-                    <span className="min-w-0 flex-1 truncate">{project.title}</span>
-                    {reason === undefined ? null : (
-                      <span className="shrink-0 rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 py-px text-[10px] font-medium text-amber-600 dark:text-amber-400/90">
-                        Unavailable
-                      </span>
-                    )}
-                  </span>
-                </MenuRadioItem>
-              );
-            })}
+          }
+        >
+          <MenuGroupLabel>Server</MenuGroupLabel>
+          <MenuRadioItem value={ALL_ENVIRONMENTS_VALUE} closeOnClick={false}>
+            <AllProjectsLabel label="All servers" />
+          </MenuRadioItem>
+          {environments.map((environment) => (
+            <MenuRadioItem key={environment.id} value={environment.id} closeOnClick={false}>
+              <span className="flex min-w-0 items-center gap-2">
+                <EnvironmentIcon isPrimary={environment.isPrimary} />
+                <span className="min-w-0 flex-1 truncate">{environment.label}</span>
+              </span>
+            </MenuRadioItem>
+          ))}
+        </MenuRadioGroup>
+        <MenuRadioGroup value={selectedScopeValue} onValueChange={selectScopeValue}>
+          <MenuGroupLabel className="pt-2">Project</MenuGroupLabel>
+          <MenuRadioItem value={ALL_PROJECTS_VALUE}>
+            <AllProjectsLabel />
+          </MenuRadioItem>
+          {(selectedEnvironment === null ? environments : [selectedEnvironment]).flatMap(
+            (environment) =>
+              sortedProjects(environment, unavailable).map((project) => (
+                <ProjectScopeItem
+                  key={pullRequestProjectScopeValue(environment.id, project.id)}
+                  environment={environment}
+                  project={project}
+                  unavailable={unavailable}
+                  showEnvironment={selectedEnvironment === null}
+                />
+              )),
+          )}
         </MenuRadioGroup>
       </MenuPopup>
     </Menu>

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -14,25 +14,28 @@ import {
   PullRequestStateGlyph,
 } from "./pullRequestPresentation";
 
-function PullRequestRowImpl({
+function PullRequestRowImpl<Entry extends PullRequestListEntry>({
   entry,
   selected,
   showProjectTitle,
   showProvider,
+  environmentLabel,
   matchedElsewhere,
   onSelect,
 }: {
-  entry: PullRequestListEntry;
+  entry: Entry;
   selected: boolean;
   showProjectTitle: boolean;
   /** Only when the list spans more than one host, where the repository alone is ambiguous. */
   showProvider: boolean;
+  /** Names the owning server when the list spans more than one environment. */
+  environmentLabel?: string;
   /**
    * A search found this, but in something the row does not show — a description, a comment, a
    * commit message. Saying so is the difference between a result and an apparently random row.
    */
   matchedElsewhere?: boolean;
-  onSelect: (entry: PullRequestListEntry) => void;
+  onSelect: (entry: Entry) => void;
 }) {
   const { Icon, providerName } = getSourceControlPresentationForKind(entry.provider);
   return (
@@ -70,6 +73,7 @@ function PullRequestRowImpl({
             #{entry.number}
           </span>
           {showProjectTitle ? <span className="truncate">{entry.repository}</span> : null}
+          {environmentLabel ? <span className="max-w-32 truncate">{environmentLabel}</span> : null}
           <PullRequestActorLabel actor={entry.author} className="max-w-40 shrink-0" />
           <span className="truncate" title={`${entry.headBranch} to ${entry.baseBranch}`}>
             {entry.headBranch}
@@ -94,4 +98,4 @@ function PullRequestRowImpl({
  * row whose entry, selection and match state are unchanged has nothing new to say. Effective
  * because the route hands it a stable `onSelect`.
  */
-export const PullRequestRow = memo(PullRequestRowImpl);
+export const PullRequestRow = memo(PullRequestRowImpl) as typeof PullRequestRowImpl;

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -8,6 +8,7 @@ import {
   mergePullRequestDiffStats,
   narrowPullRequestsToFilters,
   partitionPullRequestsWithPriority,
+  pullRequestEntryKey,
   readPullRequestListSnapshot,
   writePullRequestListSnapshot,
   rankPullRequestMatches,
@@ -101,6 +102,35 @@ describe("pull request involvement filtering", () => {
     expect(
       filterPullRequestsByInvolvement(mixed, VIEWERS, "authored").map((item) => item.number),
     ).toEqual([1]);
+  });
+
+  it("keeps viewers separate when two servers use the same host", () => {
+    const mixed = [
+      {
+        ...entry({ number: 1, author: { login: "Bilal", name: null, avatarUrl: null } }),
+        environmentId: "local",
+        viewerLogin: "Bilal",
+      },
+      {
+        ...entry({ number: 2, author: { login: "Bilal", name: null, avatarUrl: null } }),
+        environmentId: "remote",
+        viewerLogin: "Octocat",
+      },
+    ];
+
+    expect(
+      filterPullRequestsByInvolvement(mixed, VIEWERS, "authored").map((item) => item.number),
+    ).toEqual([1]);
+  });
+});
+
+describe("pull request identity across servers", () => {
+  it("keeps otherwise identical rows distinct", () => {
+    const row = entry({ number: 1 });
+
+    expect(pullRequestEntryKey({ ...row, environmentId: "local" })).not.toBe(
+      pullRequestEntryKey({ ...row, environmentId: "remote" }),
+    );
   });
 });
 
@@ -298,6 +328,13 @@ describe("line counts that arrive after the rows", () => {
   it("leaves a row whose counts have not arrived as it is", () => {
     const row = entry({ number: 9, additions: 0, deletions: 0 });
     expect(withDiffStat(row, stats)).toBe(row);
+  });
+
+  it("does not apply another server's count to the same project and number", () => {
+    const row = { ...entry({ number: 7, additions: 0, deletions: 0 }), environmentId: "remote" };
+    const scopedStats = new Map([["local:project-1 7", { additions: 42, deletions: 3 }]]);
+
+    expect(withDiffStat(row, scopedStats)).toBe(row);
   });
 });
 

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -5,11 +5,16 @@ import type { PullRequestInvolvement, PullRequestListState } from "@t3tools/cont
 
 export type PullRequestGroupKey = "reviewRequested" | "authored" | "others";
 
-export interface PullRequestGroup {
+export interface PullRequestGroup<Entry extends PullRequestListEntry = PullRequestListEntry> {
   readonly key: PullRequestGroupKey;
   readonly label: string;
-  readonly entries: ReadonlyArray<PullRequestListEntry>;
+  readonly entries: ReadonlyArray<Entry>;
 }
+
+type PullRequestListEntryScope = PullRequestListEntry & {
+  readonly environmentId?: string;
+  readonly viewerLogin?: string | null;
+};
 
 /** The signed-in account per host, as the listing reports it. */
 export type PullRequestViewers = PullRequestListResult["viewers"];
@@ -30,8 +35,13 @@ function normalize(value: string | null | undefined): string | null {
  * GitHub, GitLab and a GitHub Enterprise install, and the account that owns one says nothing
  * about the others.
  */
-function isAuthoredByViewer(entry: PullRequestListEntry, viewers: PullRequestViewers): boolean {
-  const viewer = normalize(viewers[entry.host]);
+function isAuthoredByViewer(
+  entry: PullRequestListEntryScope,
+  viewers: PullRequestViewers,
+): boolean {
+  const viewer = normalize(
+    entry.viewerLogin === undefined ? viewers[entry.host] : entry.viewerLogin,
+  );
   return viewer !== null && normalize(entry.author?.login) === viewer;
 }
 
@@ -48,11 +58,11 @@ export function matchesPullRequestQuery(entry: PullRequestListEntry, query: stri
  * The server returns the involvement superset for a state, so switching between the Reviewing
  * and Authored tabs never waits on the network.
  */
-export function filterPullRequestsByInvolvement(
-  entries: ReadonlyArray<PullRequestListEntry>,
+export function filterPullRequestsByInvolvement<Entry extends PullRequestListEntryScope>(
+  entries: ReadonlyArray<Entry>,
   viewers: PullRequestViewers,
   involvement: PullRequestInvolvement,
-): ReadonlyArray<PullRequestListEntry> {
+): ReadonlyArray<Entry> {
   if (involvement === "reviewing") {
     return entries.filter((entry) => entry.viewerReviewRequested);
   }
@@ -75,14 +85,14 @@ export function filterPullRequestsByInvolvement(
  * it needs to know who is signed in on each host, and the search text because searching is the
  * hosts' own answer; both are narrowed where that knowledge already lives.
  */
-export function narrowPullRequestsToFilters(
-  entries: ReadonlyArray<PullRequestListEntry>,
+export function narrowPullRequestsToFilters<Entry extends PullRequestListEntry>(
+  entries: ReadonlyArray<Entry>,
   filters: {
     readonly state: PullRequestListState;
     readonly projectId: string | undefined;
     readonly host: string | undefined;
   },
-): ReadonlyArray<PullRequestListEntry> {
+): ReadonlyArray<Entry> {
   return entries.filter(
     (entry) =>
       (filters.state === "all" || entry.state === filters.state) &&
@@ -95,11 +105,11 @@ export function narrowPullRequestsToFilters(
  * Only relationships the list data actually carries: no "previously reviewed" bucket is
  * inferred, because the listing has no review history.
  */
-export function groupPullRequestsByInvolvement(
-  entries: ReadonlyArray<PullRequestListEntry>,
+export function groupPullRequestsByInvolvement<Entry extends PullRequestListEntryScope>(
+  entries: ReadonlyArray<Entry>,
   viewers: PullRequestViewers,
-): ReadonlyArray<PullRequestGroup> {
-  const buckets: Record<PullRequestGroupKey, PullRequestListEntry[]> = {
+): ReadonlyArray<PullRequestGroup<Entry>> {
+  const buckets: Record<PullRequestGroupKey, Entry[]> = {
     reviewRequested: [],
     authored: [],
     others: [],
@@ -119,8 +129,8 @@ export function groupPullRequestsByInvolvement(
 }
 
 /** Repository plus number is unique on one host, so the host makes the key unique overall. */
-export function pullRequestEntryKey(entry: PullRequestListEntry): string {
-  return `${entry.host}:${entry.repository}#${entry.number}`;
+export function pullRequestEntryKey(entry: PullRequestListEntryScope): string {
+  return `${entry.environmentId ? `${entry.environmentId}:` : ""}${entry.host}:${entry.repository}#${entry.number}`;
 }
 
 /**
@@ -131,11 +141,11 @@ export function pullRequestEntryKey(entry: PullRequestListEntry): string {
  * server-filtered reads, the feed fills "Others" in its own order, and a continuation can only
  * append — a row it carries that a partition already holds is dropped rather than moved.
  */
-export function partitionPullRequestsWithPriority(
-  entries: ReadonlyArray<PullRequestListEntry>,
-  authored: ReadonlyArray<PullRequestListEntry>,
-  reviewRequested: ReadonlyArray<PullRequestListEntry>,
-): ReadonlyArray<PullRequestGroup> {
+export function partitionPullRequestsWithPriority<Entry extends PullRequestListEntryScope>(
+  entries: ReadonlyArray<Entry>,
+  authored: ReadonlyArray<Entry>,
+  reviewRequested: ReadonlyArray<Entry>,
+): ReadonlyArray<PullRequestGroup<Entry>> {
   const authoredByKey = new Map(authored.map((entry) => [pullRequestEntryKey(entry), entry]));
   // A row can be both authored and review-requested; authored wins, as the local grouping has it.
   const reviewByKey = new Map(
@@ -144,7 +154,7 @@ export function partitionPullRequestsWithPriority(
       return authoredByKey.has(key) ? [] : [[key, entry] as const];
     }),
   );
-  const others: PullRequestListEntry[] = [];
+  const others: Entry[] = [];
   for (const entry of entries) {
     const key = pullRequestEntryKey(entry);
     // The feed's copy of a partitioned row is at least as fresh — it replaces in place.
@@ -183,6 +193,7 @@ export type PullRequestDiffStats = ReadonlyMap<
 export function mergePullRequestDiffStats(
   previous: PullRequestDiffStats,
   stats: ReadonlyArray<{
+    readonly environmentId?: string;
     readonly projectId: string;
     readonly number: number;
     readonly additions: number;
@@ -192,10 +203,13 @@ export function mergePullRequestDiffStats(
   if (stats.length === 0) return previous;
   const next = new Map(previous);
   for (const stat of stats) {
-    next.set(`${stat.projectId} ${stat.number}`, {
-      additions: stat.additions,
-      deletions: stat.deletions,
-    });
+    next.set(
+      `${stat.environmentId ? `${stat.environmentId}:` : ""}${stat.projectId} ${stat.number}`,
+      {
+        additions: stat.additions,
+        deletions: stat.deletions,
+      },
+    );
   }
   return next;
 }
@@ -353,10 +367,10 @@ export function scorePullRequestMatch(entry: PullRequestListEntry, query: string
  * Search results in the order they answer the question, most convincing first, and by recency
  * among equals. Only for a search: without one, a listing is a timeline and recency is the order.
  */
-export function rankPullRequestMatches(
-  entries: ReadonlyArray<PullRequestListEntry>,
+export function rankPullRequestMatches<Entry extends PullRequestListEntry>(
+  entries: ReadonlyArray<Entry>,
   query: string,
-): ReadonlyArray<PullRequestListEntry> {
+): ReadonlyArray<Entry> {
   if (query.trim().length === 0) return entries;
   return entries.toSorted((left, right) => {
     const byScore = scorePullRequestMatch(right, query) - scorePullRequestMatch(left, query);
@@ -369,11 +383,13 @@ export function rankPullRequestMatches(
  * listing that carried them is not second-guessed — and only where they have arrived, since a row
  * draws perfectly well without them in the meantime.
  */
-export function withDiffStat(
-  entry: PullRequestListEntry,
+export function withDiffStat<Entry extends PullRequestListEntryScope>(
+  entry: Entry,
   statsByRow: ReadonlyMap<string, { readonly additions: number; readonly deletions: number }>,
-): PullRequestListEntry {
+): Entry {
   if (entry.additions !== 0 || entry.deletions !== 0) return entry;
-  const stat = statsByRow.get(`${entry.projectId} ${entry.number}`);
+  const stat = statsByRow.get(
+    `${entry.environmentId ? `${entry.environmentId}:` : ""}${entry.projectId} ${entry.number}`,
+  );
   return stat === undefined ? entry : { ...entry, ...stat };
 }

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate } from "@tanstack/react-router";
 
 import { useEnvironmentIdentificationMode } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
-import { usePrimaryEnvironment } from "../../state/environments";
+import { useEnvironments } from "../../state/environments";
 import {
   resolveEnvironmentIdentificationPillLabel,
   resolveSidebarStageBackdropVariant,
@@ -112,9 +112,10 @@ function T3Wordmark() {
 export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
   const navigate = useNavigate();
   const { isMobile, setOpenMobile } = useSidebar();
-  const primaryEnvironment = usePrimaryEnvironment();
-  const pullRequestsSupported =
-    primaryEnvironment?.serverConfig?.environment.capabilities.pullRequests === true;
+  const { environments } = useEnvironments();
+  const pullRequestsSupported = environments.some(
+    (environment) => environment.serverConfig?.environment.capabilities.pullRequests === true,
+  );
   const closeMobileSidebar = useCallback(() => {
     if (isMobile) {
       setOpenMobile(false);

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -187,20 +187,31 @@ export function useOpenChangeRequestLink(
   return useCallback(
     (event, targetUrl, targetThreadRef) => {
       const resolvedThreadRef = targetThreadRef ?? threadRef;
-      const environmentId = resolvedThreadRef?.environmentId ?? primaryEnvironmentId;
-      if (
-        environmentId === null ||
-        serverConfigs.get(environmentId)?.environment.capabilities.pullRequests !== true
-      ) {
-        return false;
-      }
+      const parsed = parseChangeRequestUrl(targetUrl);
+      if (parsed === null) return false;
       // Beside a thread the panel reads on that thread's environment, so a project from another
       // one could not be read there whatever its remote says: two environments can hold the same
       // repository, and handing the panel the wrong one's id opens a surface that never loads.
-      const projects = allProjects.filter((project) => project.environmentId === environmentId);
-      const parsed = parseChangeRequestUrl(targetUrl);
-      const project = parsed === null ? undefined : findProjectForChangeRequest(projects, parsed);
-      if (parsed === null || project === undefined) return false;
+      const projects = resolvedThreadRef
+        ? allProjects.filter((project) => project.environmentId === resolvedThreadRef.environmentId)
+        : allProjects
+            .filter(
+              (project) =>
+                serverConfigs.get(project.environmentId)?.environment.capabilities.pullRequests ===
+                true,
+            )
+            .toSorted(
+              (left, right) =>
+                Number(right.environmentId === primaryEnvironmentId) -
+                Number(left.environmentId === primaryEnvironmentId),
+            );
+      const project = findProjectForChangeRequest(projects, parsed);
+      if (
+        project === undefined ||
+        serverConfigs.get(project.environmentId)?.environment.capabilities.pullRequests !== true
+      ) {
+        return false;
+      }
       event.preventDefault();
       event.stopPropagation();
       if (resolvedThreadRef) {
@@ -220,8 +231,10 @@ export function useOpenChangeRequestLink(
           // Every state, so the pull request being opened is also in the list behind it whether
           // it is open, merged or closed.
           state: "all",
+          environmentId: project.environmentId,
           repository: parsed.repository,
           number: parsed.number,
+          selectedEnvironmentId: project.environmentId,
           selectedProjectId: project.id,
         },
       });

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -419,6 +419,25 @@ describe("rightPanelStore", () => {
     expect(state.activeSurfaceId).toBe(pullRequestSurfaceId(first));
   });
 
+  it("keeps the same pull request on two servers as separate tabs", () => {
+    const local = {
+      environmentId: "local",
+      projectId: "project-a",
+      repository: "pingdotgg/t3code",
+      number: 4909,
+    };
+    const remote = { ...local, environmentId: "remote" };
+
+    useRightPanelStore.getState().openPullRequest(refA, local);
+    useRightPanelStore.getState().openPullRequest(refA, remote);
+
+    const state = selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA);
+    expect(state.surfaces.map((surface) => surface.id)).toEqual([
+      pullRequestSurfaceId(local),
+      pullRequestSurfaceId(remote),
+    ]);
+  });
+
   it("tracks one surface per terminal session", () => {
     useRightPanelStore.getState().openTerminal(refA, "term-1");
     useRightPanelStore.getState().openTerminal(refA, "term-2");

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -52,6 +52,8 @@ export type RightPanelSurface =
        */
       id: `pull-request:${string}`;
       kind: "pull-request";
+      /** Needed by the all-server pull-request list; thread panels inherit this from their ref. */
+      environmentId?: string;
       projectId: string;
       repository: string;
       number: number;
@@ -86,7 +88,7 @@ interface RightPanelStoreState {
   openFile: (ref: ScopedThreadRef, relativePath: string, line?: number) => void;
   openPullRequest: (
     ref: ScopedThreadRef,
-    target: { projectId: string; repository: string; number: number },
+    target: { environmentId?: string; projectId: string; repository: string; number: number },
   ) => void;
   openTerminal: (ref: ScopedThreadRef, terminalId: string) => void;
   splitTerminal: (
@@ -161,14 +163,16 @@ const terminalSurface = (terminalId: string): RightPanelSurface => ({
 export type PullRequestSurface = Extract<RightPanelSurface, { kind: "pull-request" }>;
 
 export function pullRequestSurfaceId(target: {
+  environmentId?: string;
   projectId: string;
   repository: string;
   number: number;
 }): PullRequestSurface["id"] {
-  return `pull-request:${encodeURIComponent(target.projectId)}:${encodeURIComponent(target.repository)}:${target.number}`;
+  return `pull-request:${target.environmentId ? `${encodeURIComponent(target.environmentId)}:` : ""}${encodeURIComponent(target.projectId)}:${encodeURIComponent(target.repository)}:${target.number}`;
 }
 
 export function pullRequestSurface(target: {
+  environmentId?: string;
   projectId: string;
   repository: string;
   number: number;
@@ -176,6 +180,7 @@ export function pullRequestSurface(target: {
   return {
     id: pullRequestSurfaceId(target),
     kind: "pull-request",
+    ...(target.environmentId === undefined ? {} : { environmentId: target.environmentId }),
     projectId: target.projectId,
     repository: target.repository,
     number: target.number,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -4,7 +4,6 @@ import type {
   EnvironmentId,
   ProjectId,
   PullRequestInvolvement,
-  PullRequestListEntry,
   PullRequestListResult,
   PullRequestListState,
   SourceControlProviderKind,
@@ -39,15 +38,16 @@ import {
   writePullRequestListSnapshot,
   scorePullRequestMatch,
   type PullRequestDiffStats,
-  type PullRequestPartitionsSnapshot,
 } from "../components/pullRequest/pullRequestList.logic";
 import { PullRequestDetailPanel } from "../components/pullRequest/PullRequestDetailPanel";
 import {
   PullRequestFiltersMenu,
   PullRequestSearchInput,
   pullRequestHostLabel,
+  pullRequestProjectScopeValue,
   type PullRequestExpectedHost,
   type PullRequestFilterOption,
+  type PullRequestProjectEnvironmentOption,
 } from "../components/pullRequest/PullRequestListFilters";
 import { PullRequestListEmptyState } from "../components/pullRequest/PullRequestListEmptyState";
 import { PullRequestListGhost } from "../components/pullRequest/PullRequestGhosts";
@@ -74,8 +74,14 @@ import {
 } from "../rightPanelStore";
 import { useDebouncedValue } from "../state/queries";
 import { useAllEnvironmentShellsBootstrapped, useProjects } from "../state/entities";
-import { usePrimaryEnvironment } from "../state/environments";
-import { pullRequestEnvironment } from "../state/pullRequests";
+import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import {
+  pullRequestEnvironment,
+  pullRequestsAcrossEnvironments,
+  scopePullRequestListResult,
+  type ScopedPullRequestListEntry,
+  type ScopedPullRequestListResult,
+} from "../state/pullRequests";
 import { useEnvironmentQuery } from "../state/query";
 import { useAtomCommand } from "../state/use-atom-command";
 import { cn } from "~/lib/utils";
@@ -85,6 +91,8 @@ import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 export interface PullRequestsSearch {
   readonly involvement: PullRequestInvolvement;
   readonly state: PullRequestListState;
+  /** The server whose projects and pull requests this page is browsing. */
+  readonly environmentId?: EnvironmentId;
   /** Scopes the list. Separate from the selection so one cannot silently change the other. */
   readonly projectId?: ProjectId;
   /**
@@ -94,6 +102,8 @@ export interface PullRequestsSearch {
   readonly host?: string;
   readonly repository?: string;
   readonly number?: number;
+  /** The server that owns the selected pull request while the list itself spans all servers. */
+  readonly selectedEnvironmentId?: EnvironmentId;
   readonly selectedProjectId?: ProjectId;
   readonly q?: string;
 }
@@ -126,7 +136,7 @@ const PAGE_SIZE = 99;
 const MAX_PAGE_SIZE = 500;
 /** Stable empty map so the memos below do not see a new object on every render. */
 const EMPTY_VIEWERS: PullRequestListResult["viewers"] = {};
-/** The list owns one environment-scoped right panel rather than borrowing a real thread's. */
+/** The list owns a shared right panel rather than borrowing a real thread's. */
 const PULL_REQUESTS_PANEL_ID = ThreadId.make("pull-requests-panel");
 const EMPTY_PREVIEW_SESSIONS = {};
 const EMPTY_TERMINAL_LABELS = new Map<string, string>();
@@ -147,9 +157,15 @@ export const Route = createFileRoute("/_chat/pull-requests")({
     ...(typeof raw.projectId === "string" && raw.projectId
       ? { projectId: raw.projectId as ProjectId }
       : {}),
+    ...(typeof raw.environmentId === "string" && raw.environmentId
+      ? { environmentId: raw.environmentId as EnvironmentId }
+      : {}),
     ...(typeof raw.host === "string" && raw.host ? { host: raw.host.slice(0, 200) } : {}),
     ...(typeof raw.selectedProjectId === "string" && raw.selectedProjectId
       ? { selectedProjectId: raw.selectedProjectId as ProjectId }
+      : {}),
+    ...(typeof raw.selectedEnvironmentId === "string" && raw.selectedEnvironmentId
+      ? { selectedEnvironmentId: raw.selectedEnvironmentId as EnvironmentId }
       : {}),
     ...(typeof raw.q === "string" && raw.q ? { q: raw.q.slice(0, 200) } : {}),
   }),
@@ -159,44 +175,99 @@ export const Route = createFileRoute("/_chat/pull-requests")({
 function PullRequestsRouteView() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
-  const primaryEnvironment = usePrimaryEnvironment();
-  const environmentId = primaryEnvironment?.environmentId ?? null;
-  const capabilityKnown = primaryEnvironment !== null && primaryEnvironment.serverConfig !== null;
-  const pullRequestsSupported =
-    primaryEnvironment?.serverConfig?.environment.capabilities.pullRequests === true;
-  // The primary environment may still be connecting, or may predate this feature. In either
-  // case every query remains idle until the server has explicitly advertised these APIs.
-  const pullRequestEnvironmentId = pullRequestsSupported ? environmentId : null;
+  const { isReady: environmentsKnown, environments: allEnvironments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  // A connecting environment stays selectable until it advertises its capabilities. An
+  // environment known to predate this feature is omitted rather than offered as a dead scope.
+  const pullRequestEnvironments = useMemo(
+    () =>
+      allEnvironments.filter(
+        (environment) =>
+          environment.serverConfig === null ||
+          environment.serverConfig.environment.capabilities.pullRequests === true,
+      ),
+    [allEnvironments],
+  );
+  const selectedEnvironment = useMemo(
+    () =>
+      search.environmentId === undefined
+        ? null
+        : (allEnvironments.find(
+            (environment) => environment.environmentId === search.environmentId,
+          ) ?? null),
+    [allEnvironments, search.environmentId],
+  );
+  const environmentId = selectedEnvironment?.environmentId ?? null;
+  const pullRequestEnvironmentIds = useMemo(
+    () =>
+      (selectedEnvironment === null ? pullRequestEnvironments : [selectedEnvironment])
+        .filter(
+          (environment) => environment.serverConfig?.environment.capabilities.pullRequests === true,
+        )
+        .map((environment) => environment.environmentId),
+    [pullRequestEnvironments, selectedEnvironment],
+  );
+  const capabilityKnown =
+    environmentsKnown &&
+    (pullRequestEnvironmentIds.length > 0 ||
+      (selectedEnvironment === null
+        ? pullRequestEnvironments.every((environment) => environment.serverConfig !== null)
+        : selectedEnvironment.serverConfig !== null));
+  const pullRequestsSupported = pullRequestEnvironmentIds.length > 0;
   const allProjects = useProjects();
   // Whether the workspace has said what it holds yet. Until it has, an empty project list is
   // "not loaded" rather than "none", and telling a reader to add a project they already have is
   // the one wrong answer the empty state can give.
   const projectsKnown = useAllEnvironmentShellsBootstrapped();
-  // The page reads one environment, so a project from another one could neither be listed
-  // nor acted on: scoping here keeps the filter and the selection honest.
-  const projects = useMemo(
-    () => allProjects.filter((project) => project.environmentId === environmentId),
-    [allProjects, environmentId],
+  const pullRequestEnvironmentIdSet = useMemo(
+    () => new Set(pullRequestEnvironmentIds),
+    [pullRequestEnvironmentIds],
   );
-  const scopedProjects = useMemo(
+  const environmentScopeKey = JSON.stringify(pullRequestEnvironmentIds);
+  const projects = useMemo(
+    () => allProjects.filter((project) => pullRequestEnvironmentIdSet.has(project.environmentId)),
+    [allProjects, pullRequestEnvironmentIdSet],
+  );
+  const projectEnvironments = useMemo<ReadonlyArray<PullRequestProjectEnvironmentOption>>(
     () =>
-      projects
-        .map((project) => ({
-          id: project.id,
-          title: project.title,
-          workspaceRoot: project.workspaceRoot,
-        }))
-        .toSorted((left, right) => left.title.localeCompare(right.title)),
-    [projects],
+      pullRequestEnvironments.map((environment) => ({
+        id: environment.environmentId,
+        label: environment.label,
+        isPrimary: environment.entry.target._tag === "PrimaryConnectionTarget",
+        projects: allProjects
+          .filter((project) => project.environmentId === environment.environmentId)
+          .map((project) => ({
+            id: project.id,
+            title: project.title,
+            workspaceRoot: project.workspaceRoot,
+          }))
+          .toSorted((left, right) => left.title.localeCompare(right.title)),
+      })),
+    [allProjects, pullRequestEnvironments],
+  );
+  const environmentLabelById = useMemo(
+    () => new Map(projectEnvironments.map((environment) => [environment.id, environment.label])),
+    [projectEnvironments],
   );
   // The scope the URL asks for, once the environment has had its say about whether it exists.
   const scopedProjectId = useMemo(
-    () => resolveProjectScope(search.projectId, projects, projectsKnown),
-    [projects, projectsKnown, search.projectId],
+    () =>
+      environmentId === null
+        ? undefined
+        : resolveProjectScope(search.projectId, projects, projectsKnown),
+    [environmentId, projects, projectsKnown, search.projectId],
   );
+  const panelEnvironmentId =
+    environmentId ??
+    (primaryEnvironmentId !== null && pullRequestEnvironmentIdSet.has(primaryEnvironmentId)
+      ? primaryEnvironmentId
+      : (pullRequestEnvironmentIds[0] ?? null));
   const rightPanelRef = useMemo(
-    () => (environmentId === null ? null : scopeThreadRef(environmentId, PULL_REQUESTS_PANEL_ID)),
-    [environmentId],
+    () =>
+      panelEnvironmentId === null
+        ? null
+        : scopeThreadRef(panelEnvironmentId, PULL_REQUESTS_PANEL_ID),
+    [panelEnvironmentId],
   );
   const rightPanelState = useRightPanelStore((state) =>
     selectThreadRightPanelState(state.byThreadKey, rightPanelRef),
@@ -207,17 +278,30 @@ function PullRequestsRouteView() {
   const selectedPullRequestSurface =
     selectedRightPanelSurface?.kind === "pull-request" ? selectedRightPanelSurface : null;
   const activePullRequestSurface = rightPanelState.isOpen ? selectedPullRequestSurface : null;
+  const activePullRequestEnvironmentId =
+    (activePullRequestSurface?.environmentId as EnvironmentId | undefined) ?? environmentId;
   const [pullRequestTabStatuses, setPullRequestTabStatuses] = useState<
     Record<string, PullRequestTabStatus>
   >({});
-  const handlePullRequestTabStatusChange = useCallback((status: PullRequestTabStatus) => {
-    const id = pullRequestSurfaceId(status);
-    setPullRequestTabStatuses((current) =>
-      current[id]?.state === status.state && current[id]?.isDraft === status.isDraft
-        ? current
-        : { ...current, [id]: status },
-    );
-  }, []);
+  useEffect(() => {
+    setPullRequestTabStatuses({});
+  }, [environmentScopeKey]);
+  const handlePullRequestTabStatusChange = useCallback(
+    (status: PullRequestTabStatus) => {
+      const id = pullRequestSurfaceId({
+        ...status,
+        ...(activePullRequestSurface?.environmentId === undefined
+          ? {}
+          : { environmentId: activePullRequestSurface.environmentId }),
+      });
+      setPullRequestTabStatuses((current) =>
+        current[id]?.state === status.state && current[id]?.isDraft === status.isDraft
+          ? current
+          : { ...current, [id]: status },
+      );
+    },
+    [activePullRequestSurface?.environmentId],
+  );
 
   const updateSearch = useCallback(
     (patch: {
@@ -231,10 +315,14 @@ function PullRequestsRouteView() {
           return {
             involvement: next.involvement ?? previous.involvement,
             state: next.state ?? previous.state,
+            ...(next.environmentId ? { environmentId: next.environmentId } : {}),
             ...(next.repository ? { repository: next.repository } : {}),
             ...(next.number ? { number: next.number } : {}),
             ...(next.projectId ? { projectId: next.projectId } : {}),
             ...(next.host ? { host: next.host } : {}),
+            ...(next.selectedEnvironmentId
+              ? { selectedEnvironmentId: next.selectedEnvironmentId }
+              : {}),
             ...(next.selectedProjectId ? { selectedProjectId: next.selectedProjectId } : {}),
             ...(next.q ? { q: next.q } : {}),
           };
@@ -250,6 +338,7 @@ function PullRequestsRouteView() {
     repository: undefined,
     number: undefined,
     selectedProjectId: undefined,
+    selectedEnvironmentId: undefined,
   };
   const updateListScope = (patch: {
     [Key in keyof PullRequestsSearch]?: PullRequestsSearch[Key] | undefined;
@@ -260,6 +349,17 @@ function PullRequestsRouteView() {
     }
     updateSearch({ ...patch, ...clearedSelection });
   };
+  const updateProjectScope = (
+    nextEnvironmentId: EnvironmentId | null,
+    nextProjectId: ProjectId | undefined,
+  ) => {
+    const environmentChanged = nextEnvironmentId !== environmentId;
+    updateListScope({
+      environmentId: nextEnvironmentId ?? undefined,
+      projectId: nextProjectId,
+      ...(environmentChanged ? { host: undefined } : {}),
+    });
+  };
 
   // Searching asks the hosts, which takes a round trip, so the text is held for a moment before
   // it is sent. Until it lands, the rows already on screen are narrowed locally: the answer is
@@ -269,7 +369,7 @@ function PullRequestsRouteView() {
   const querySettled = typedQuery === sentQuery;
 
   // Page size is view state, not a URL concern: a shared link should open the first page.
-  const scopeKey = `${environmentId ?? ""}:${search.state}:${search.involvement}:${scopedProjectId ?? ""}:${search.host ?? ""}`;
+  const scopeKey = `${environmentScopeKey}:${search.state}:${search.involvement}:${scopedProjectId ?? ""}:${search.host ?? ""}`;
   const filterKey = `${scopeKey}:${sentQuery}`;
   // Where the next slice carries on from, per repository, as the server handed it back. Sending
   // it is what makes a second page cost a second page rather than the whole list again — and a
@@ -290,23 +390,21 @@ function PullRequestsRouteView() {
   }, [filterKey]);
 
   const listQuery = useEnvironmentQuery(
-    pullRequestEnvironmentId === null
-      ? null
-      : pullRequestEnvironment.list({
-          environmentId: pullRequestEnvironmentId,
-          input: {
-            state: search.state,
-            // The hosts narrow by involvement themselves — GitHub by author and review request,
-            // and so on — so asking them is the difference between a page of results and a page
-            // of everything with the answer somewhere further down it.
-            involvement: search.involvement,
-            limit: pageSize,
-            ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
-            ...(search.host ? { host: search.host } : {}),
-            ...(sentQuery ? { query: sentQuery } : {}),
-            ...(sentCursors ? { cursors: sentCursors } : {}),
-          },
-        }),
+    pullRequestsAcrossEnvironments.list({
+      environmentIds: pullRequestEnvironmentIds,
+      input: {
+        state: search.state,
+        // The hosts narrow by involvement themselves — GitHub by author and review request,
+        // and so on — so asking them is the difference between a page of results and a page
+        // of everything with the answer somewhere further down it.
+        involvement: search.involvement,
+        limit: pageSize,
+        ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
+        ...(search.host ? { host: search.host } : {}),
+        ...(sentQuery ? { query: sentQuery } : {}),
+        ...(sentCursors ? { cursors: sentCursors } : {}),
+      },
+    }),
   );
 
   /**
@@ -320,18 +418,16 @@ function PullRequestsRouteView() {
    * not, and a search's answer would file itself under the workspace.
    */
   const baselineQuery = useEnvironmentQuery(
-    pullRequestEnvironmentId === null
-      ? null
-      : pullRequestEnvironment.list({
-          environmentId: pullRequestEnvironmentId,
-          input: {
-            state: search.state,
-            involvement: search.involvement,
-            limit: PAGE_SIZE,
-            ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
-            ...(search.host ? { host: search.host } : {}),
-          },
-        }),
+    pullRequestsAcrossEnvironments.list({
+      environmentIds: pullRequestEnvironmentIds,
+      input: {
+        state: search.state,
+        involvement: search.involvement,
+        limit: PAGE_SIZE,
+        ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
+        ...(search.host ? { host: search.host } : {}),
+      },
+    }),
   );
   // The priority groups' own reads. The feed below is paginated by recency, so an older authored
   // or review-requested row can be missing from its first page; partitioned from these
@@ -341,10 +437,10 @@ function PullRequestsRouteView() {
   // ask for, so switching to either is answered from cache.
   const partitionsWanted = search.involvement === "all" && typedQuery.length === 0;
   const authoredQuery = useEnvironmentQuery(
-    pullRequestEnvironmentId === null || !partitionsWanted
+    !partitionsWanted
       ? null
-      : pullRequestEnvironment.list({
-          environmentId: pullRequestEnvironmentId,
+      : pullRequestsAcrossEnvironments.list({
+          environmentIds: pullRequestEnvironmentIds,
           input: {
             state: search.state,
             involvement: "authored",
@@ -355,10 +451,10 @@ function PullRequestsRouteView() {
         }),
   );
   const reviewingQuery = useEnvironmentQuery(
-    pullRequestEnvironmentId === null || !partitionsWanted
+    !partitionsWanted
       ? null
-      : pullRequestEnvironment.list({
-          environmentId: pullRequestEnvironmentId,
+      : pullRequestsAcrossEnvironments.list({
+          environmentIds: pullRequestEnvironmentIds,
           input: {
             state: search.state,
             involvement: "reviewing",
@@ -382,9 +478,9 @@ function PullRequestsRouteView() {
   const refreshFromHost = async () => {
     setInvalidating(true);
     try {
-      if (pullRequestEnvironmentId !== null) {
-        await invalidate({ environmentId: pullRequestEnvironmentId, input: {} });
-      }
+      await Promise.all(
+        pullRequestEnvironmentIds.map((environmentId) => invalidate({ environmentId, input: {} })),
+      );
     } finally {
       setInvalidating(false);
     }
@@ -402,38 +498,59 @@ function PullRequestsRouteView() {
   // out: a longer page reads as growth, and a search shows the rows it already has, narrowed
   // here, until the hosts answer for themselves.
   const [loaded, setLoaded] = useState<{
-    environmentId: EnvironmentId | null;
+    environmentScopeKey: string;
     scope: string;
     query: string;
-    data: PullRequestListResult;
+    data: ScopedPullRequestListResult;
     /** The priority groups' own answers, carried so a cold start has whole groups too. */
-    partitions?: PullRequestPartitionsSnapshot;
+    partitions?: {
+      readonly authored: ReadonlyArray<ScopedPullRequestListEntry>;
+      readonly reviewing: ReadonlyArray<ScopedPullRequestListEntry>;
+    };
   } | null>(null);
   // A reload recreates the registry the queries live in, so with nothing held the page would
   // cold-start into skeletons even though almost every row is unchanged. The last answer for
-  // this environment is kept across reloads and hydrated here as the carried rows: they render
-  // at once — narrowed to the current filters like any carried answer — and the live read
+  // a single selected environment is kept across reloads and hydrated here as carried rows. They
+  // render at once — narrowed to the current filters like any carried answer — and the live read
   // reconciles them in place by key rather than replacing them with ghosts.
   useEffect(() => {
-    if (environmentId === null) return;
+    if (environmentId === null) {
+      setLoaded((current) =>
+        current?.environmentScopeKey === environmentScopeKey ? current : null,
+      );
+      return;
+    }
     setLoaded((current) => {
-      // Another environment's rows could not even be narrowed — nothing on a row says which
-      // environment read it — so its snapshot beats holding them.
-      if (current !== null && current.environmentId === environmentId) return current;
+      // Another server scope's rows are not a useful stand-in, so its snapshot beats holding them.
+      if (current !== null && current.environmentScopeKey === environmentScopeKey) return current;
       const snapshot = readPullRequestListSnapshot(
         typeof window === "undefined" ? undefined : window.localStorage,
         environmentId,
       );
       if (snapshot === null) return null;
+      const data = scopePullRequestListResult(environmentId, snapshot.data);
+      const partitions =
+        snapshot.partitions === undefined
+          ? undefined
+          : {
+              authored: scopePullRequestListResult(environmentId, {
+                ...snapshot.data,
+                entries: snapshot.partitions.authored,
+              }).entries,
+              reviewing: scopePullRequestListResult(environmentId, {
+                ...snapshot.data,
+                entries: snapshot.partitions.reviewing,
+              }).entries,
+            };
       return {
-        environmentId,
+        environmentScopeKey,
         scope: snapshot.scope,
         query: "",
-        data: snapshot.data,
-        ...(snapshot.partitions === undefined ? {} : { partitions: snapshot.partitions }),
+        data,
+        ...(partitions === undefined ? {} : { partitions }),
       };
     });
-  }, [environmentId]);
+  }, [environmentId, environmentScopeKey]);
   useEffect(() => {
     // Only once this query has settled. While a search is being swapped in or out the text has
     // already changed and the data has not, so recording them together would file the previous
@@ -450,7 +567,7 @@ function PullRequestsRouteView() {
         partitionsWanted && authoredQuery.data !== null && reviewingQuery.data !== null
           ? { authored: authoredQuery.data.entries, reviewing: reviewingQuery.data.entries }
           : current !== null &&
-              current.environmentId === environmentId &&
+              current.environmentScopeKey === environmentScopeKey &&
               current.scope === scopeKey
             ? current.partitions
             : undefined;
@@ -465,7 +582,7 @@ function PullRequestsRouteView() {
         );
       }
       return {
-        environmentId,
+        environmentScopeKey,
         scope: scopeKey,
         query: sentQuery,
         data,
@@ -474,6 +591,7 @@ function PullRequestsRouteView() {
     });
   }, [
     environmentId,
+    environmentScopeKey,
     scopeKey,
     sentQuery,
     listQuery.data,
@@ -486,10 +604,13 @@ function PullRequestsRouteView() {
   // perfectly good rows for the last one. Rather than blank out for the round trip, those rows
   // are narrowed to the new filters and stay until the answer lands — a subset of it, never a
   // row it excludes. Narrowed to nothing there is nothing to carry, and the skeletons below are
-  // right after all. Another environment's rows are dropped rather than narrowed: nothing on a
-  // row says which environment read it.
+  // right after all. Another server scope's rows are dropped rather than narrowed.
   const narrowed = useMemo(() => {
-    if (loaded === null || loaded.environmentId !== environmentId || loaded.scope === scopeKey) {
+    if (
+      loaded === null ||
+      loaded.environmentScopeKey !== environmentScopeKey ||
+      loaded.scope === scopeKey
+    ) {
       return null;
     }
     const entries = narrowPullRequestsToFilters(loaded.data.entries, {
@@ -498,7 +619,7 @@ function PullRequestsRouteView() {
       host: search.host,
     });
     return entries.length === 0 ? null : { ...loaded.data, entries };
-  }, [environmentId, loaded, scopeKey, scopedProjectId, search.host, search.state]);
+  }, [environmentScopeKey, loaded, scopeKey, scopedProjectId, search.host, search.state]);
   // With nothing typed and nothing to carry on from, the answer is taken from the read that is
   // keyed to exactly that question. Otherwise a search's answer lingers for a render after the
   // text has gone — the data cannot say which question it belongs to, but the read it came from
@@ -530,7 +651,7 @@ function PullRequestsRouteView() {
   // the order again.
   const [ordered, setOrdered] = useState<{
     key: string;
-    entries: ReadonlyArray<PullRequestListEntry>;
+    entries: ReadonlyArray<ScopedPullRequestListEntry>;
   } | null>(null);
   useEffect(() => {
     if (!answered) return;
@@ -611,7 +732,7 @@ function PullRequestsRouteView() {
       authoredQuery.refresh();
       reviewingQuery.refresh();
     },
-    { enabled: pullRequestEnvironmentId !== null },
+    { enabled: pullRequestEnvironmentIds.length > 0 },
   );
 
   const viewers = baselineQuery.data?.viewers ?? listData?.viewers ?? EMPTY_VIEWERS;
@@ -717,7 +838,9 @@ function PullRequestsRouteView() {
     // authored row older than it. Once the live reads land they take over; with neither,
     // the local grouping is still better than nothing.
     const held =
-      loaded !== null && loaded.environmentId === environmentId && loaded.scope === scopeKey
+      loaded !== null &&
+      loaded.environmentScopeKey === environmentScopeKey &&
+      loaded.scope === scopeKey
         ? loaded.partitions
         : undefined;
     const authored = partitionsWanted ? (authoredQuery.data?.entries ?? held?.authored) : undefined;
@@ -731,7 +854,7 @@ function PullRequestsRouteView() {
   }, [
     authoredQuery.data?.entries,
     entries,
-    environmentId,
+    environmentScopeKey,
     loaded,
     partitionsWanted,
     reviewingQuery.data?.entries,
@@ -747,6 +870,7 @@ function PullRequestsRouteView() {
       refs: groups
         .flatMap((group) => group.entries)
         .map((entry) => ({
+          environmentId: entry.environmentId,
           projectId: entry.projectId,
           repository: entry.repository,
           number: entry.number,
@@ -755,17 +879,18 @@ function PullRequestsRouteView() {
     [groups],
   );
   const statsQuery = useEnvironmentQuery(
-    pullRequestEnvironmentId === null || statsInput.refs.length === 0
-      ? null
-      : pullRequestEnvironment.listStats({
-          environmentId: pullRequestEnvironmentId,
-          input: statsInput,
-        }),
+    pullRequestsAcrossEnvironments.listStats({
+      environmentIds: pullRequestEnvironmentIds,
+      refs: statsInput.refs,
+    }),
   );
   // Adding or removing one row keys a fresh stats query with nothing in it yet, so the counts
   // are merged into what is already held rather than rebuilt: every count on screen stays until
   // its replacement arrives.
   const [statsByRow, setStatsByRow] = useState<PullRequestDiffStats>(() => new Map());
+  useEffect(() => {
+    setStatsByRow(new Map());
+  }, [environmentScopeKey]);
   useEffect(() => {
     const stats = statsQuery.data?.stats;
     if (stats === undefined) return;
@@ -774,10 +899,17 @@ function PullRequestsRouteView() {
 
   // A link from a thread or the sidebar only knows the repository, so the owning project is
   // resolved here; an explicit `projectId` in the URL still wins.
-  const projectIdForRepository = useMemo(() => {
+  const selectionProjects = useMemo(
+    () =>
+      search.selectedEnvironmentId === undefined
+        ? projects
+        : projects.filter((project) => project.environmentId === search.selectedEnvironmentId),
+    [projects, search.selectedEnvironmentId],
+  );
+  const projectForRepository = useMemo(() => {
     const repository = search.repository?.toLowerCase();
     if (repository === undefined) return undefined;
-    const identity = projects.find(
+    return selectionProjects.find(
       (project) =>
         project.repositoryIdentity?.owner &&
         project.repositoryIdentity.name &&
@@ -791,25 +923,37 @@ function PullRequestsRouteView() {
             project.repositoryIdentity.provider as SourceControlProviderKind,
           ) === search.host.toLowerCase()),
     );
-    return identity?.id;
-  }, [projects, search.host, search.repository]);
+  }, [search.host, search.repository, selectionProjects]);
 
   // The selection is resolved the same way the scope is: an id from another environment can
   // never be read here, and one that arrived before the projects did is not yet wrong.
-  const linkedProjectId = useMemo(
-    () => resolveProjectScope(search.selectedProjectId, projects, projectsKnown),
-    [projects, projectsKnown, search.selectedProjectId],
+  const linkedProject = useMemo(
+    () =>
+      search.selectedProjectId === undefined
+        ? undefined
+        : selectionProjects.find((project) => project.id === search.selectedProjectId),
+    [search.selectedProjectId, selectionProjects],
   );
   // The scope filter stands in as a last resort: a link can carry `projectId` with a repository
   // whose identity the inference above cannot match, and refusing to open it because of the
   // weaker signal would ignore the stronger one the URL spelled out.
-  const selectedProjectId = linkedProjectId ?? projectIdForRepository ?? scopedProjectId;
+  const selectedProject =
+    linkedProject ??
+    projectForRepository ??
+    (scopedProjectId === undefined
+      ? undefined
+      : projects.find((project) => project.id === scopedProjectId));
   const linkedSelection = useMemo(
     () =>
-      search.repository && search.number && selectedProjectId
-        ? { repository: search.repository, number: search.number, projectId: selectedProjectId }
+      search.repository && search.number && selectedProject
+        ? {
+            environmentId: selectedProject.environmentId,
+            repository: search.repository,
+            number: search.number,
+            projectId: selectedProject.id,
+          }
         : null,
-    [search.number, search.repository, selectedProjectId],
+    [search.number, search.repository, selectedProject],
   );
   useEffect(() => {
     if (!pullRequestsSupported || rightPanelRef === null || linkedSelection === null) return;
@@ -821,6 +965,7 @@ function PullRequestsRouteView() {
       ? {
           repository: activePullRequestSurface.repository,
           number: activePullRequestSurface.number,
+          environmentId: activePullRequestSurface.environmentId,
           projectId: activePullRequestSurface.projectId as ProjectId,
         }
       : null;
@@ -832,6 +977,7 @@ function PullRequestsRouteView() {
         : {
             repository: surface.repository,
             number: surface.number,
+            selectedEnvironmentId: surface.environmentId as EnvironmentId | undefined,
             selectedProjectId: surface.projectId as ProjectId,
           },
     );
@@ -851,6 +997,9 @@ function PullRequestsRouteView() {
   // The provider list is the workspace's hosts, not the filtered ones, so switching to a host
   // cannot make the switcher that got you there disappear.
   const [hosts, setHosts] = useState<PullRequestListResult["providers"]>([]);
+  useEffect(() => {
+    setHosts([]);
+  }, [environmentScopeKey]);
   useEffect(() => {
     // Only from an answer to these filters. Rows carried over from the previous ones bring the
     // host summaries of the question they answered, and coming back from one host to all of them
@@ -878,18 +1027,28 @@ function PullRequestsRouteView() {
 
   /** Reported per project rather than as a count, so the reader can see which one it was. */
   const unavailableProjects = useMemo(
-    () => new Map(listErrors.map((error) => [error.projectId, error.message] as const)),
+    () =>
+      new Map(
+        listErrors.map(
+          (error) =>
+            [
+              pullRequestProjectScopeValue(error.environmentId, error.projectId),
+              error.message,
+            ] as const,
+        ),
+      ),
     [listErrors],
   );
 
   // Stable so the memoized rows can skip re-rendering when the list around them changes.
   const selectEntry = useCallback(
-    (entry: PullRequestListEntry) => {
+    (entry: ScopedPullRequestListEntry) => {
       if (rightPanelRef === null) return;
       useRightPanelStore.getState().openPullRequest(rightPanelRef, entry);
       updateSearch({
         repository: entry.repository,
         number: entry.number,
+        selectedEnvironmentId: entry.environmentId,
         selectedProjectId: entry.projectId,
       });
     },
@@ -936,7 +1095,11 @@ function PullRequestsRouteView() {
       ) : !pullRequestsSupported ? (
         <PullRequestsUnavailableState
           title="Pull requests unavailable"
-          error="Update this environment's T3 Code server to browse pull requests."
+          error={
+            environmentId === null
+              ? "Update at least one connected T3 Code server to browse pull requests."
+              : "Update this environment's T3 Code server to browse pull requests."
+          }
         />
       ) : firstLoad ? (
         <PullRequestListGhost rows={7} />
@@ -980,6 +1143,12 @@ function PullRequestsRouteView() {
                   entry={withDiffStat(entry, statsByRow)}
                   showProjectTitle
                   showProvider={showProvider}
+                  {...(environmentId === null && projectEnvironments.length > 1
+                    ? {
+                        environmentLabel:
+                          environmentLabelById.get(entry.environmentId) ?? "Unknown server",
+                      }
+                    : {})}
                   // Ten is the floor the ranking gives a row whose own fields say nothing
                   // about the search: the host matched something this row cannot show.
                   matchedElsewhere={
@@ -987,7 +1156,9 @@ function PullRequestsRouteView() {
                     scorePullRequestMatch(entry, typedQuery) <= MATCHED_ELSEWHERE_SCORE
                   }
                   selected={
-                    selected?.repository === entry.repository && selected.number === entry.number
+                    selected?.repository === entry.repository &&
+                    selected.number === entry.number &&
+                    selected.environmentId === entry.environmentId
                   }
                   onSelect={selectEntry}
                 />
@@ -1049,10 +1220,10 @@ function PullRequestsRouteView() {
       hostOptions={hostMenuOptions}
       onHost={(host) => updateListScope({ host })}
       environmentId={environmentId}
-      projects={scopedProjects}
+      environments={projectEnvironments}
       projectId={scopedProjectId}
       unavailable={unavailableProjects}
-      onProject={(projectId) => updateListScope({ projectId })}
+      onProjectScope={updateProjectScope}
     />
   );
   const columnProps = {
@@ -1114,7 +1285,9 @@ function PullRequestsRouteView() {
         {pullRequestsSupported && rightPanelState.isOpen ? openPanelControls : null}
         <PullRequestsColumn {...columnProps} />
 
-        {rightPanelState.isOpen && activePullRequestSurface && pullRequestEnvironmentId !== null ? (
+        {rightPanelState.isOpen &&
+        activePullRequestSurface &&
+        activePullRequestEnvironmentId !== null ? (
           <RightPanelTabs
             mode="inline"
             widthStorageKey="t3code:pull-request-panel-width"
@@ -1158,7 +1331,7 @@ function PullRequestsRouteView() {
           >
             <PullRequestDetailPanel
               key={activePullRequestSurface.id}
-              environmentId={pullRequestEnvironmentId}
+              environmentId={activePullRequestEnvironmentId}
               reference={{
                 projectId: activePullRequestSurface.projectId as ProjectId,
                 repository: activePullRequestSurface.repository,

--- a/apps/web/src/state/pullRequests.test.ts
+++ b/apps/web/src/state/pullRequests.test.ts
@@ -1,0 +1,80 @@
+import type { EnvironmentId, ProjectId, PullRequestListResult } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { mergePullRequestLists, pullRequestCursorsForEnvironment } from "./pullRequests";
+
+const localEnvironmentId = "local" as EnvironmentId;
+const remoteEnvironmentId = "remote" as EnvironmentId;
+
+function result(title: string, cursor: string): PullRequestListResult {
+  return {
+    viewers: { "github.com": "octocat" },
+    providers: [
+      {
+        host: "github.com",
+        kind: "github",
+        searchesOnHost: true,
+        projectCount: 1,
+        configured: true,
+        detail: null,
+      },
+    ],
+    entries: [
+      {
+        provider: "github",
+        host: "github.com",
+        projectId: "project-1" as ProjectId,
+        projectTitle: title,
+        repository: "acme/project",
+        number: 1,
+        title: "A pull request",
+        url: "https://github.com/acme/project/pull/1",
+        author: { login: "octocat", name: null, avatarUrl: null },
+        headBranch: "feature",
+        baseBranch: "main",
+        state: "open",
+        isDraft: false,
+        mergeability: "mergeable",
+        additions: 0,
+        deletions: 0,
+        createdAt: "2026-08-01T00:00:00Z",
+        updatedAt: "2026-08-02T00:00:00Z",
+        viewerReviewRequested: false,
+        labels: [],
+      },
+    ],
+    errors: [],
+    truncated: true,
+    nextCursors: { "github.com acme/project": cursor },
+  } satisfies PullRequestListResult;
+}
+
+describe("pull request aggregation across environments", () => {
+  it("keeps rows and cursors scoped to their owning server", () => {
+    const merged = mergePullRequestLists([
+      { environmentId: localEnvironmentId, value: result("Local", "local-cursor") },
+      { environmentId: remoteEnvironmentId, value: result("Remote", "remote-cursor") },
+    ]);
+
+    expect(merged.entries.map((entry) => entry.environmentId)).toEqual([
+      localEnvironmentId,
+      remoteEnvironmentId,
+    ]);
+    expect(Object.keys(merged.nextCursors)).toEqual([
+      JSON.stringify([localEnvironmentId, "github.com acme/project"]),
+      JSON.stringify([remoteEnvironmentId, "github.com acme/project"]),
+    ]);
+  });
+
+  it("returns only the continuation that belongs to one server", () => {
+    const cursors = {
+      [JSON.stringify([localEnvironmentId, "github.com acme/project"])]: "local-cursor",
+      [JSON.stringify([remoteEnvironmentId, "github.com acme/project"])]: "remote-cursor",
+    };
+
+    expect(pullRequestCursorsForEnvironment(remoteEnvironmentId, cursors)).toEqual({
+      "github.com acme/project": "remote-cursor",
+    });
+    expect(pullRequestCursorsForEnvironment("other" as EnvironmentId, cursors)).toBeUndefined();
+  });
+});

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -1,5 +1,253 @@
 import { createPullRequestEnvironmentAtoms } from "@t3tools/client-runtime/state/pull-requests";
+import type {
+  EnvironmentId,
+  PullRequestDiffStat,
+  PullRequestListEntry,
+  PullRequestListInput,
+  PullRequestListProjectError,
+  PullRequestListResult,
+  PullRequestListStatsResult,
+} from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import { connectionAtomRuntime } from "../connection/runtime";
 
 export const pullRequestEnvironment = createPullRequestEnvironmentAtoms(connectionAtomRuntime);
+
+export interface ScopedPullRequestListEntry extends PullRequestListEntry {
+  readonly environmentId: EnvironmentId;
+  /** Captured per environment so two servers using the same host can have different accounts. */
+  readonly viewerLogin: string | null;
+}
+
+export interface ScopedPullRequestListProjectError extends PullRequestListProjectError {
+  readonly environmentId: EnvironmentId;
+}
+
+export interface ScopedPullRequestListResult extends Omit<
+  PullRequestListResult,
+  "entries" | "errors"
+> {
+  readonly entries: ReadonlyArray<ScopedPullRequestListEntry>;
+  readonly errors: ReadonlyArray<ScopedPullRequestListProjectError>;
+}
+
+export interface ScopedPullRequestDiffStat extends PullRequestDiffStat {
+  readonly environmentId: EnvironmentId;
+}
+
+export interface ScopedPullRequestListStatsResult extends Omit<
+  PullRequestListStatsResult,
+  "stats"
+> {
+  readonly stats: ReadonlyArray<ScopedPullRequestDiffStat>;
+}
+
+interface MultiEnvironmentListKey {
+  readonly environmentIds: ReadonlyArray<EnvironmentId>;
+  readonly input: PullRequestListInput;
+}
+
+interface MultiEnvironmentStatsKey {
+  readonly environmentIds: ReadonlyArray<EnvironmentId>;
+  readonly refs: ReadonlyArray<{
+    readonly environmentId: EnvironmentId;
+    readonly projectId: PullRequestDiffStat["projectId"];
+    readonly repository: string;
+    readonly number: number;
+  }>;
+}
+
+function scopedCursorKey(environmentId: EnvironmentId, key: string): string {
+  try {
+    const parsed: unknown = JSON.parse(key);
+    if (Array.isArray(parsed) && parsed[0] === environmentId && typeof parsed[1] === "string") {
+      return key;
+    }
+  } catch {
+    // An ordinary server cursor key is not JSON and is scoped below.
+  }
+  return JSON.stringify([environmentId, key]);
+}
+
+export function pullRequestCursorsForEnvironment(
+  environmentId: EnvironmentId,
+  cursors: PullRequestListInput["cursors"],
+): PullRequestListInput["cursors"] {
+  if (cursors === undefined) return undefined;
+  const scoped = Object.fromEntries(
+    Object.entries(cursors).flatMap(([key, cursor]) => {
+      try {
+        const parsed: unknown = JSON.parse(key);
+        return Array.isArray(parsed) && parsed[0] === environmentId && typeof parsed[1] === "string"
+          ? [[parsed[1], cursor] as const]
+          : [];
+      } catch {
+        return [];
+      }
+    }),
+  );
+  return Object.keys(scoped).length === 0 ? undefined : scoped;
+}
+
+function combineResults<A, B, E>(
+  results: ReadonlyArray<{
+    readonly environmentId: EnvironmentId;
+    readonly result: AsyncResult.AsyncResult<A, E>;
+  }>,
+  merge: (values: ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly value: A }>) => B,
+): AsyncResult.AsyncResult<B, E> {
+  const values = results.flatMap(({ environmentId, result }) =>
+    Option.match(AsyncResult.value(result), {
+      onNone: () => [],
+      onSome: (value) => [{ environmentId, value }],
+    }),
+  );
+  const waiting = results.some(({ result }) => result.waiting);
+  const failure = results.find(({ result }) => result._tag === "Failure")?.result;
+  if (values.length === 0) {
+    return failure?._tag === "Failure"
+      ? AsyncResult.failure(failure.cause, { waiting })
+      : AsyncResult.initial(waiting);
+  }
+  const success = AsyncResult.success(merge(values), { waiting });
+  return failure?._tag === "Failure"
+    ? AsyncResult.failure(failure.cause, { previousSuccess: Option.some(success), waiting })
+    : success;
+}
+
+function mergeProviders(values: ReadonlyArray<PullRequestListResult>) {
+  const providers = new Map<string, PullRequestListResult["providers"][number]>();
+  for (const provider of values.flatMap((value) => value.providers)) {
+    const previous = providers.get(provider.host);
+    providers.set(
+      provider.host,
+      previous === undefined
+        ? provider
+        : {
+            ...previous,
+            projectCount: previous.projectCount + provider.projectCount,
+            searchesOnHost: previous.searchesOnHost && provider.searchesOnHost,
+            configured: previous.configured && provider.configured,
+            detail: previous.detail ?? provider.detail,
+          },
+    );
+  }
+  return [...providers.values()];
+}
+
+export function scopePullRequestListResult(
+  environmentId: EnvironmentId,
+  value: PullRequestListResult,
+): ScopedPullRequestListResult {
+  return {
+    ...value,
+    entries: value.entries.map((entry) => ({
+      ...entry,
+      environmentId,
+      viewerLogin: value.viewers[entry.host] ?? null,
+    })),
+    errors: value.errors.map((error) => ({ ...error, environmentId })),
+    nextCursors: Object.fromEntries(
+      Object.entries(value.nextCursors).map(([key, cursor]) => [
+        scopedCursorKey(environmentId, key),
+        cursor,
+      ]),
+    ),
+  };
+}
+
+export function mergePullRequestLists(
+  values: ReadonlyArray<{
+    readonly environmentId: EnvironmentId;
+    readonly value: PullRequestListResult;
+  }>,
+): ScopedPullRequestListResult {
+  const scopedValues = values.map(({ environmentId, value }) => ({
+    raw: value,
+    scoped: scopePullRequestListResult(environmentId, value),
+  }));
+  return {
+    viewers: Object.assign({}, ...values.map(({ value }) => value.viewers)),
+    providers: mergeProviders(values.map(({ value }) => value)),
+    entries: scopedValues
+      .flatMap(({ scoped }) => scoped.entries)
+      .toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
+    errors: scopedValues.flatMap(({ scoped }) => scoped.errors),
+    truncated: scopedValues.some(({ raw }) => raw.truncated),
+    nextCursors: Object.assign({}, ...scopedValues.map(({ scoped }) => scoped.nextCursors)),
+  };
+}
+
+const multiEnvironmentList = Atom.family((key: string) => {
+  const { environmentIds, input } = JSON.parse(key) as MultiEnvironmentListKey;
+  const atoms = environmentIds.flatMap((environmentId) => {
+    const cursors = pullRequestCursorsForEnvironment(environmentId, input.cursors);
+    // A continuation only asks environments named by a cursor. Re-reading an exhausted
+    // environment from the top would append its first page again beside another server's next.
+    if (input.cursors !== undefined && cursors === undefined) return [];
+    return [
+      {
+        environmentId,
+        atom: pullRequestEnvironment.list({
+          environmentId,
+          input: { ...input, ...(cursors === undefined ? {} : { cursors }) },
+        }),
+      },
+    ];
+  });
+  return Atom.readable(
+    (get) =>
+      combineResults(
+        atoms.map(({ environmentId, atom }) => ({ environmentId, result: get(atom) })),
+        mergePullRequestLists,
+      ),
+    (refresh) => {
+      for (const { atom } of atoms) refresh(atom);
+    },
+  ).pipe(Atom.withLabel(`web-pull-requests:multi-list:${key}`));
+});
+
+const multiEnvironmentStats = Atom.family((key: string) => {
+  const { environmentIds, refs } = JSON.parse(key) as MultiEnvironmentStatsKey;
+  const atoms = environmentIds.flatMap((environmentId) => {
+    const environmentRefs = refs
+      .filter((ref) => ref.environmentId === environmentId)
+      .map(({ environmentId: _environmentId, ...ref }) => ref);
+    return environmentRefs.length === 0
+      ? []
+      : [
+          {
+            environmentId,
+            atom: pullRequestEnvironment.listStats({
+              environmentId,
+              input: { refs: environmentRefs },
+            }),
+          },
+        ];
+  });
+  return Atom.readable(
+    (get) =>
+      combineResults(
+        atoms.map(({ environmentId, atom }) => ({ environmentId, result: get(atom) })),
+        (values): ScopedPullRequestListStatsResult => ({
+          stats: values.flatMap(({ environmentId, value }) =>
+            value.stats.map((stat) => ({ ...stat, environmentId })),
+          ),
+        }),
+      ),
+    (refresh) => {
+      for (const { atom } of atoms) refresh(atom);
+    },
+  ).pipe(Atom.withLabel(`web-pull-requests:multi-stats:${key}`));
+});
+
+export const pullRequestsAcrossEnvironments = {
+  list: (key: MultiEnvironmentListKey) =>
+    key.environmentIds.length === 0 ? null : multiEnvironmentList(JSON.stringify(key)),
+  listStats: (key: MultiEnvironmentStatsKey) =>
+    key.environmentIds.length === 0 || key.refs.length === 0
+      ? null
+      : multiEnvironmentStats(JSON.stringify(key)),
+};

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -38,6 +38,7 @@ T3 Code works with the platforms your team already uses:
 **Stay on top of open reviews**
 
 - See if your current branch already has an open PR/MR
+- Browse reviews across all connected T3 Code servers, or narrow the list to one server and project
 - Open several reviews from the **Pull requests** page as tabs in the right panel
 - While working in a thread, open linked reviews in the same compact right-panel tabs without
   leaving the conversation


### PR DESCRIPTION
## Problem

The Pull Requests page was permanently scoped to the primary environment, so projects and pull requests from connected remote T3 Code servers never appeared.

## Fix

- add a **Server** selector above the existing **Project** selector, including **All servers**
- keep the menu open after choosing a server so the project can be selected next
- aggregate list results, pagination, stats, and viewer identity without losing each pull request's owning environment
- route linked pull requests, right-panel details, refreshes, and project actions to the correct server
- show the page when any connected server advertises pull-request support

## Verification

- `vp lint` on the changed web files
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/web build`
- focused unit coverage added for server/project selection, cross-server list merging and pagination, viewer grouping, row/stat identity, and right-panel tabs

The local Vitest runner currently fails before collecting tests with the same runner/config error on both changed and untouched baseline tests. Static checks and the production build pass. Authenticated before/after UI evidence will be added to this draft.

Generated with GPT-5.6 Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support browsing pull requests across multiple remote servers
> - Adds multi-environment pull request listing by introducing `pullRequestsAcrossEnvironments` atoms that aggregate per-environment list and stats results, with environment-scoped cursor keys to avoid cross-server collisions.
> - Extends the pull requests route to accept `environmentId` and `selectedEnvironmentId` URL params, enabling users to scope the list to a single server or browse all connected servers.
> - Updates `PullRequestFiltersMenu` to include a 'Server' radio group for picking an environment independently of the project filter; project scope values are now JSON-encoded `[environmentId, projectId]` strings (previously plain project IDs).
> - Adds `environmentId` to `pullRequestEntryKey`, diff stat keys, and right panel surface IDs so identical repository/PR numbers on different servers don't collide.
> - Updates the sidebar footer to show the pull requests link if any connected environment supports pull requests, not just the primary.
> - Behavioral Change: the project filter sentinel value changed from `'all'` to `'all-projects'`; stored URLs or state relying on the old value will not match.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 97598ea. 9 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->