### PR TITLE
feat(preview): agents can set cookies in the collaborative browser

### DIFF
--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -53,6 +53,7 @@ export const PREVIEW_HARD_RELOAD_CHANNEL = "desktop:preview-hard-reload";
 export const PREVIEW_SET_COLOR_SCHEME_CHANNEL = "desktop:preview-set-color-scheme";
 export const PREVIEW_OPEN_DEVTOOLS_CHANNEL = "desktop:preview-open-devtools";
 export const PREVIEW_CLEAR_COOKIES_CHANNEL = "desktop:preview-clear-cookies";
+export const PREVIEW_SET_COOKIE_CHANNEL = "desktop:preview-set-cookie";
 export const PREVIEW_CLEAR_CACHE_CHANNEL = "desktop:preview-clear-cache";
 export const PREVIEW_GET_CONFIG_CHANNEL = "desktop:preview-get-config";
 export const PREVIEW_SET_ANNOTATION_THEME_CHANNEL = "desktop:preview-set-annotation-theme";

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -8,6 +8,7 @@ import {
   DesktopPreviewAutomationTypeInputSchema,
   DesktopPreviewAutomationWaitForInputSchema,
   DesktopPreviewConfigInputSchema,
+  DesktopPreviewSetCookieInputSchema,
   DesktopPreviewNavigateInputSchema,
   DesktopPreviewRecordingArtifactSchema,
   DesktopPreviewRecordingSaveInputSchema,
@@ -186,6 +187,16 @@ export const clearCookies = DesktopIpc.makeIpcMethod({
   handler: Effect.fn("desktop.ipc.preview.clearCookies")(function* () {
     const manager = yield* PreviewManager.PreviewManager;
     yield* manager.clearCookies();
+  }),
+});
+
+export const setCookie = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PREVIEW_SET_COOKIE_CHANNEL,
+  payload: DesktopPreviewSetCookieInputSchema,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.preview.setCookie")(function* ({ environmentId, cookie }) {
+    const manager = yield* PreviewManager.PreviewManager;
+    yield* manager.setCookie(environmentId, cookie);
   }),
 });
 
@@ -369,6 +380,7 @@ export const methods = [
   setColorScheme,
   openDevTools,
   clearCookies,
+  setCookie,
   clearCache,
   getPreviewConfig,
   setAnnotationTheme,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -165,6 +165,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     openDevTools: (tabId) =>
       ipcRenderer.invoke(IpcChannels.PREVIEW_OPEN_DEVTOOLS_CHANNEL, { tabId }),
     clearCookies: () => ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_COOKIES_CHANNEL),
+    setCookie: (environmentId, cookie) =>
+      ipcRenderer.invoke(IpcChannels.PREVIEW_SET_COOKIE_CHANNEL, { environmentId, cookie }),
     clearCache: () => ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_CACHE_CHANNEL),
     getPreviewConfig: (environmentId) =>
       ipcRenderer.invoke(IpcChannels.PREVIEW_GET_CONFIG_CHANNEL, { environmentId }),

--- a/apps/desktop/src/preview/BrowserSession.test.ts
+++ b/apps/desktop/src/preview/BrowserSession.test.ts
@@ -13,6 +13,7 @@ const { fromPartition, sessions } = vi.hoisted(() => ({
     {
       readonly clearCache: ReturnType<typeof vi.fn>;
       readonly clearStorageData: ReturnType<typeof vi.fn>;
+      readonly cookies: { readonly set: ReturnType<typeof vi.fn> };
       readonly getUserAgent: ReturnType<typeof vi.fn>;
       readonly setPermissionRequestHandler: ReturnType<typeof vi.fn>;
       readonly setPermissionCheckHandler: ReturnType<typeof vi.fn>;
@@ -39,6 +40,7 @@ describe("BrowserSession", () => {
       const browserSession = {
         clearCache: vi.fn(() => Promise.resolve()),
         clearStorageData: vi.fn(() => Promise.resolve()),
+        cookies: { set: vi.fn(() => Promise.resolve()) },
         getUserAgent: vi.fn(() => "Mozilla/5.0 Electron/41.5.0 t3code/0.0.27"),
         setPermissionRequestHandler: vi.fn(),
         setPermissionCheckHandler: vi.fn(),
@@ -189,6 +191,57 @@ describe("BrowserSession", () => {
         ]);
         assert.strictEqual(browserSession.clearCache.mock.calls.length, 1);
       }
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("sets a cookie in only the requested environment partition", () =>
+    Effect.gen(function* () {
+      const browserSessions = yield* BrowserSession.BrowserSession;
+      const cookie = {
+        url: "https://example.test/",
+        name: "preview_session",
+        value: "session-value",
+        domain: "example.test",
+        path: "/account",
+        secure: true,
+        httpOnly: true as const,
+        sameSite: "lax" as const,
+        expirationDate: 2_000_000_000,
+      };
+
+      yield* browserSessions.setCookie("environment-a", cookie);
+
+      const targetPartition = yield* browserSessions.getPartition("environment-a");
+      const targetSession = sessions.get(targetPartition);
+      assert.isDefined(targetSession);
+      assert.deepEqual(targetSession.cookies.set.mock.calls, [[cookie]]);
+      assert.strictEqual(sessions.size, 1);
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("does not expose a rejected cookie value in its error message", () =>
+    Effect.gen(function* () {
+      const browserSessions = yield* BrowserSession.BrowserSession;
+      const cookie = {
+        url: "https://example.test/",
+        name: "preview_session",
+        value: "cookie-value-must-stay-secret",
+        path: "/",
+        secure: true,
+        httpOnly: true as const,
+        sameSite: "lax" as const,
+        expirationDate: 2_000_000_000,
+      };
+      const partition = yield* browserSessions.getPartition("environment-a");
+      const browser = yield* browserSessions.getSession("environment-a");
+      vi.mocked(browser.cookies.set).mockRejectedValueOnce(new Error("cookie rejected"));
+
+      const error = yield* browserSessions.setCookie("environment-a", cookie).pipe(Effect.flip);
+
+      assert.instanceOf(error, BrowserSession.BrowserSessionCookieSetError);
+      assert.equal(error.partition, partition);
+      assert.notInclude(error.message, cookie.value);
+      assert.notInclude(error.message, cookie.name);
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/desktop/src/preview/BrowserSession.ts
+++ b/apps/desktop/src/preview/BrowserSession.ts
@@ -1,4 +1,5 @@
-import type { Session } from "electron";
+import type { PreviewAutomationCookie } from "@t3tools/contracts";
+import type { CookiesSetDetails, Session } from "electron";
 import { session } from "electron";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
@@ -78,6 +79,18 @@ export class BrowserSessionCacheClearError extends Schema.TaggedErrorClass<Brows
   }
 }
 
+export class BrowserSessionCookieSetError extends Schema.TaggedErrorClass<BrowserSessionCookieSetError>()(
+  "BrowserSessionCookieSetError",
+  {
+    partition: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to set a cookie in desktop preview partition ${this.partition}.`;
+  }
+}
+
 export const BrowserSessionGetSessionError = Schema.Union([
   BrowserSessionPartitionDerivationError,
   BrowserSessionCreationError,
@@ -90,6 +103,7 @@ export const BrowserSessionError = Schema.Union([
   BrowserSessionCreationError,
   BrowserSessionStorageClearError,
   BrowserSessionCacheClearError,
+  BrowserSessionCookieSetError,
 ]);
 export type BrowserSessionError = typeof BrowserSessionError.Type;
 export const isBrowserSessionError = Schema.is(BrowserSessionError);
@@ -102,6 +116,10 @@ export class BrowserSession extends Context.Service<
     ) => Effect.Effect<string, BrowserSessionPartitionDerivationError>;
     readonly isPartition: (partition: string) => boolean;
     readonly getSession: (scope?: string) => Effect.Effect<Session, BrowserSessionGetSessionError>;
+    readonly setCookie: (
+      scope: string,
+      cookie: PreviewAutomationCookie,
+    ) => Effect.Effect<void, BrowserSessionGetSessionError | BrowserSessionCookieSetError>;
     readonly clearCookies: () => Effect.Effect<void, BrowserSessionStorageClearError>;
     readonly clearCache: () => Effect.Effect<void, BrowserSessionCacheClearError>;
   }
@@ -161,6 +179,25 @@ export const make = Effect.gen(function* BrowserSessionMake() {
     getPartition,
     isPartition: (partition) => partition.startsWith(PREVIEW_PARTITION_PREFIX),
     getSession,
+    setCookie: Effect.fn("BrowserSession.setCookie")(function* (scope, cookie) {
+      const partition = yield* getPartition(scope);
+      const browserSession = yield* getSession(scope);
+      const details: CookiesSetDetails = {
+        url: cookie.url,
+        name: cookie.name,
+        value: cookie.value,
+        ...(cookie.domain === undefined ? {} : { domain: cookie.domain }),
+        ...(cookie.path === undefined ? {} : { path: cookie.path }),
+        ...(cookie.secure === undefined ? {} : { secure: cookie.secure }),
+        ...(cookie.httpOnly === undefined ? {} : { httpOnly: cookie.httpOnly }),
+        ...(cookie.sameSite === undefined ? {} : { sameSite: cookie.sameSite }),
+        ...(cookie.expirationDate === undefined ? {} : { expirationDate: cookie.expirationDate }),
+      };
+      yield* Effect.tryPromise({
+        try: () => browserSession.cookies.set(details),
+        catch: (cause) => new BrowserSessionCookieSetError({ partition, cause }),
+      });
+    }),
     clearCookies: Effect.fn("BrowserSession.clearCookies")(function* () {
       const sessions = yield* SynchronizedRef.get(sessionsRef);
       yield* Effect.all(

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -106,6 +106,7 @@ const browserSessionLayer = Layer.succeed(
     getPartition: () => Effect.succeed("persist:t3code-preview-test"),
     isPartition: (partition) => partition.startsWith("persist:t3code-preview-"),
     getSession: () => Effect.die("unexpected getSession"),
+    setCookie: () => Effect.void,
     clearCookies: () => Effect.void,
     clearCache: () => Effect.void,
   }),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -18,6 +18,7 @@ import type {
   PreviewAutomationClickInput,
   PreviewAutomationActionEvent,
   PreviewAutomationConsoleEntry,
+  PreviewAutomationCookie,
   PreviewAutomationEvaluateInput,
   PreviewAutomationPressInput,
   PreviewAutomationNetworkEntry,
@@ -3598,6 +3599,10 @@ export class PreviewManager extends Context.Service<
     ) => Effect.Effect<void, PreviewManagerError>;
     readonly openDevTools: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly clearCookies: () => Effect.Effect<void, PreviewManagerError>;
+    readonly setCookie: (
+      scope: string,
+      cookie: PreviewAutomationCookie,
+    ) => Effect.Effect<void, PreviewManagerError>;
     readonly clearCache: () => Effect.Effect<void, PreviewManagerError>;
     readonly getBrowserPartition: (scope?: string) => Effect.Effect<string, PreviewManagerError>;
     readonly setAnnotationTheme: (
@@ -3701,6 +3706,13 @@ export const make = Effect.gen(function* PreviewManagerMake() {
           Effect.mapError(
             (cause) => new PreviewOperationError({ operation: "clearCookies", cause }),
           ),
+        );
+    }),
+    setCookie: Effect.fn("PreviewManager.setCookie")(function* (scope, cookie) {
+      yield* browserSession
+        .setCookie(scope, cookie)
+        .pipe(
+          Effect.mapError((cause) => new PreviewOperationError({ operation: "setCookie", cause })),
         );
     }),
     clearCache: Effect.fn("PreviewManager.clearCache")(function* () {

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -1,7 +1,13 @@
 import { expect, it } from "@effect/vitest";
 import { NodeHttpServer } from "@effect/platform-node";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { EnvironmentId, PreviewTabId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  PREVIEW_AUTOMATION_OPERATIONS,
+  PreviewTabId,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
@@ -159,10 +165,12 @@ it.effect("registers annotated tools and preserves authenticated request context
       const routedRequests: Array<{
         readonly operation: string;
         readonly tabId?: string | undefined;
+        readonly input?: unknown;
       }> = [];
       const events = yield* broker.connect({
         clientId: "mcp-test-client",
         environmentId,
+        supportedOperations: [...PREVIEW_AUTOMATION_OPERATIONS],
       });
       yield* Stream.runForEach(events, (event) => {
         if (event.type === "connected") return Effect.void;
@@ -224,6 +232,10 @@ it.effect("registers annotated tools and preserves authenticated request context
       expect(navigateTool?.tool.annotations?.destructiveHint).toBe(false);
       expect(navigateTool?.tool.annotations?.openWorldHint).toBe(true);
 
+      const setCookieTool = server.tools.find(({ tool }) => tool.name === "preview_set_cookie");
+      expect(setCookieTool?.tool.annotations?.destructiveHint).toBe(true);
+      expect(setCookieTool?.tool.annotations?.openWorldHint).toBe(true);
+
       const status = yield* server
         .callTool({ name: "preview_status", arguments: {} })
         .pipe(
@@ -269,6 +281,42 @@ it.effect("registers annotated tools and preserves authenticated request context
       expect(press.isError).toBe(false);
       expect(press.structuredContent).toBeNull();
       expect(press.content).toEqual([{ type: "text", text: "null" }]);
+
+      const cookieSet = yield* server
+        .callTool({
+          name: "preview_set_cookie",
+          arguments: {
+            url: "https://example.test/account",
+            name: "preview_session",
+            value: "session-value",
+            domain: "example.test",
+            path: "/account",
+            secure: true,
+            httpOnly: true,
+            sameSite: "strict",
+            expirationDate: 4_000_000_000,
+          },
+        })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+      expect(cookieSet.isError).toBe(false);
+      expect(cookieSet.structuredContent).toBeNull();
+      expect(cookieSet.content).toEqual([{ type: "text", text: "null" }]);
+      expect(routedRequests.find(({ operation }) => operation === "setCookie")?.input).toEqual({
+        cookie: {
+          url: "https://example.test/account",
+          name: "preview_session",
+          value: "session-value",
+          domain: "example.test",
+          path: "/account",
+          secure: true,
+          httpOnly: true,
+          sameSite: "strict",
+          expirationDate: 4_000_000_000,
+        },
+      });
     }),
   ).pipe(Effect.provide(TestLayer)),
 );

--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -6,6 +6,8 @@ import type {
   PreviewAutomationRecordingStatus,
   PreviewAutomationResizeResult,
   PreviewAutomationSetColorSchemeResult,
+  PreviewAutomationSetCookieInput,
+  PreviewAutomationSetCookiePayload,
   PreviewAutomationSnapshot,
   PreviewAutomationStatus,
   PreviewTabId,
@@ -60,6 +62,12 @@ const invokeTargeted = <A>(
   return invoke<A>(operation, operationInput, timeoutMs, tabId);
 };
 
+const setCookie = (input: PreviewAutomationSetCookieInput) => {
+  const { tabId, ...cookie } = input;
+  const payload: PreviewAutomationSetCookiePayload = { cookie };
+  return invoke<void>("setCookie", payload, undefined, tabId);
+};
+
 const handlers = {
   preview_status: (input) => invokeTargeted<PreviewAutomationStatus>("status", input ?? {}),
   preview_open: (input) =>
@@ -79,6 +87,7 @@ const handlers = {
   preview_scroll: (input) => invokeTargeted<void>("scroll", input).pipe(Effect.as(null)),
   preview_evaluate: (input) =>
     invokeTargeted<unknown>("evaluate", input).pipe(Effect.map((result) => result ?? null)),
+  preview_set_cookie: (input) => setCookie(input).pipe(Effect.as(null)),
   preview_wait_for: (input) =>
     invokeTargeted<void>("waitFor", input, input.timeoutMs).pipe(Effect.as(null)),
   preview_recording_start: (input) =>

--- a/apps/server/src/mcp/toolkits/preview/tools.test.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.test.ts
@@ -3,6 +3,10 @@ import { Tool } from "effect/unstable/ai";
 
 import { PreviewToolkit } from "./tools.ts";
 
+it("exposes generic cookie setting", () => {
+  expect(Object.keys(PreviewToolkit.tools)).toContain("preview_set_cookie");
+});
+
 const schemaHasDescription = (schema: unknown): boolean => {
   if (!schema || typeof schema !== "object") return false;
   const record = schema as Record<string, unknown>;

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -12,6 +12,7 @@ import {
   PreviewAutomationScrollInput,
   PreviewAutomationSetColorSchemeInput,
   PreviewAutomationSetColorSchemeResult,
+  PreviewAutomationSetCookieInput,
   PreviewAutomationSnapshot,
   PreviewAutomationStatus,
   PreviewAutomationTabTargetInput,
@@ -167,6 +168,17 @@ export const PreviewEvaluateTool = browserTool(
   }).annotate(Tool.Title, "Evaluate JavaScript in preview"),
 );
 
+export const PreviewSetCookieTool = browserTool(
+  Tool.make("preview_set_cookie", {
+    description:
+      "Set one cookie in this environment's isolated collaborative browser partition. Supply the cookie URL, name, value, and any optional domain, path, security, SameSite, or expiry attributes.",
+    parameters: PreviewAutomationSetCookieInput,
+    success: Schema.Null,
+    failure: PreviewAutomationError,
+    dependencies,
+  }).annotate(Tool.Title, "Set preview cookie"),
+);
+
 export const PreviewWaitForTool = readonlyBrowserTool(
   Tool.make("preview_wait_for", {
     description:
@@ -212,6 +224,7 @@ export const PreviewToolkit = Toolkit.make(
   PreviewPressTool,
   PreviewScrollTool,
   PreviewEvaluateTool,
+  PreviewSetCookieTool,
   PreviewWaitForTool,
   PreviewRecordingStartTool,
   PreviewRecordingStopTool,
@@ -228,6 +241,7 @@ export const PreviewStandardToolkit = Toolkit.make(
   PreviewPressTool,
   PreviewScrollTool,
   PreviewEvaluateTool,
+  PreviewSetCookieTool,
   PreviewWaitForTool,
   PreviewRecordingStartTool,
   PreviewRecordingStopTool,

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -309,7 +309,11 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
       let tabId = request.tabId ?? null;
       try {
         let state = readThreadPreviewState(threadRef);
-        const needsSessionSync = needsPreviewAutomationSessionSync(state, request.tabId);
+        const needsSessionSync = needsPreviewAutomationSessionSync(
+          state,
+          request.tabId,
+          request.operation,
+        );
         if (needsSessionSync) {
           const listTarget = {
             environmentId,

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -12,6 +12,7 @@ import {
   type PreviewAutomationResizeResult,
   type PreviewAutomationSetColorSchemeInput,
   type PreviewAutomationSetColorSchemeResult,
+  type PreviewAutomationSetCookiePayload,
   type PreviewAutomationHost as PreviewAutomationHostState,
   type PreviewAutomationRequest,
   type PreviewAutomationStatus,
@@ -613,6 +614,14 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               ready.runtimeTabId,
               request.input as Parameters<typeof ready.bridge.automation.evaluate>[1],
             );
+          }
+          case "setCookie": {
+            if (!previewBridge) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            const input = request.input as PreviewAutomationSetCookiePayload;
+            await previewBridge.setCookie(environmentId, input.cookie);
+            return null;
           }
           case "waitFor": {
             const ready = await requireReadyTab();

--- a/apps/web/src/components/preview/previewAutomationTarget.test.ts
+++ b/apps/web/src/components/preview/previewAutomationTarget.test.ts
@@ -23,15 +23,22 @@ describe("preview automation target selection", () => {
       needsPreviewAutomationSessionSync(
         { snapshot: active, sessions: { [active.tabId]: active } },
         undefined,
+        "snapshot",
       ),
     ).toBe(true);
+  });
+
+  it("does not sync sessions for environment-scoped cookie writes", () => {
+    expect(
+      needsPreviewAutomationSessionSync({ snapshot: null, sessions: {} }, undefined, "setCookie"),
+    ).toBe(false);
   });
 
   it("refreshes an explicit tab only when it is absent locally", () => {
     const active = snapshot("tab-active");
     const state = { snapshot: active, sessions: { [active.tabId]: active } };
-    expect(needsPreviewAutomationSessionSync(state, active.tabId)).toBe(false);
-    expect(needsPreviewAutomationSessionSync(state, "tab-missing")).toBe(true);
+    expect(needsPreviewAutomationSessionSync(state, active.tabId, "snapshot")).toBe(false);
+    expect(needsPreviewAutomationSessionSync(state, "tab-missing", "snapshot")).toBe(true);
   });
 
   it("does not report the active tab under an unknown requested tab id", () => {

--- a/apps/web/src/components/preview/previewAutomationTarget.ts
+++ b/apps/web/src/components/preview/previewAutomationTarget.ts
@@ -1,4 +1,4 @@
-import type { PreviewSessionSnapshot } from "@t3tools/contracts";
+import type { PreviewAutomationOperation, PreviewSessionSnapshot } from "@t3tools/contracts";
 
 interface PreviewAutomationSessionIndex {
   readonly snapshot: PreviewSessionSnapshot | null;
@@ -8,7 +8,9 @@ interface PreviewAutomationSessionIndex {
 export function needsPreviewAutomationSessionSync(
   state: PreviewAutomationSessionIndex,
   requestedTabId: string | undefined,
+  operation: PreviewAutomationOperation,
 ): boolean {
+  if (operation === "setCookie") return false;
   return (
     Object.keys(state.sessions).length === 0 ||
     requestedTabId === undefined ||

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -67,6 +67,7 @@ import {
   PreviewAutomationEvaluateInput,
   PreviewAutomationHost,
   PreviewAutomationHostFocus,
+  PreviewAutomationCookie,
   PreviewAutomationPressInput,
   PreviewAutomationResponse,
   PreviewAutomationScrollInput,
@@ -950,6 +951,11 @@ export const DesktopPreviewSetColorSchemeInputSchema = Schema.Struct({
   colorScheme: DesktopPreviewColorSchemeSchema,
 });
 
+export const DesktopPreviewSetCookieInputSchema = Schema.Struct({
+  environmentId: EnvironmentId,
+  cookie: PreviewAutomationCookie,
+});
+
 export const DesktopPreviewAnnotationThemeInputSchema = Schema.Struct({
   theme: DesktopPreviewAnnotationThemeSchema,
 });
@@ -1086,6 +1092,8 @@ export interface DesktopPreviewBridge {
   openDevTools: (tabId: string) => Promise<void>;
   /** Drop cookies + storage data for the preview partition (all tabs). */
   clearCookies: () => Promise<void>;
+  /** Set one cookie in an environment-scoped preview partition. */
+  setCookie: (environmentId: EnvironmentId, cookie: PreviewAutomationCookie) => Promise<void>;
   /** Drop the HTTP cache for the preview partition (all tabs). */
   clearCache: () => Promise<void>;
   /**

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -43,6 +43,7 @@ export const PREVIEW_AUTOMATION_OPERATIONS = [
   ...PREVIEW_AUTOMATION_V1_OPERATIONS,
   "resize",
   "setColorScheme",
+  "setCookie",
 ] as const;
 
 export const PreviewAutomationOperation = Schema.Literals(PREVIEW_AUTOMATION_OPERATIONS);
@@ -443,6 +444,62 @@ export const PreviewAutomationEvaluateInput = Schema.Struct({
     "Evaluates JavaScript in the page. Prefer snapshot and semantic actions; use evaluate for inspection or unsupported interactions.",
 });
 export type PreviewAutomationEvaluateInput = typeof PreviewAutomationEvaluateInput.Type;
+
+export const PreviewAutomationCookie = Schema.Struct({
+  url: BoundedUrl.annotate({
+    description: "HTTP(S) URL whose origin receives the cookie.",
+  }),
+  name: Schema.String.check(Schema.isTrimmed())
+    .check(Schema.isNonEmpty({ description: "Cookie name." }))
+    .check(Schema.isMaxLength(256))
+    .annotateKey({ description: "Cookie name." }),
+  value: Schema.String.check(Schema.isMaxLength(16_384)).annotate({
+    description: "Cookie value, including an empty value when required.",
+  }),
+  domain: Schema.optional(
+    TrimmedNonEmptyString.check(Schema.isMaxLength(253)).annotate({
+      description: "Optional cookie domain; omit to scope the cookie to the URL host.",
+    }),
+  ).annotate({
+    description: "Optional cookie domain; omit to scope the cookie to the URL host.",
+  }),
+  path: Schema.optional(
+    Schema.String.check(Schema.isTrimmed())
+      .check(Schema.isNonEmpty())
+      .check(Schema.isMaxLength(1_024))
+      .annotate({ description: "Optional cookie path, for example /." }),
+  ).annotate({ description: "Optional cookie path, for example /." }),
+  secure: Schema.optional(
+    Schema.Boolean.annotate({ description: "Whether to mark the cookie Secure." }),
+  ).annotate({ description: "Whether to mark the cookie Secure." }),
+  httpOnly: Schema.optional(
+    Schema.Boolean.annotate({ description: "Whether to mark the cookie HTTP-only." }),
+  ).annotate({ description: "Whether to mark the cookie HTTP-only." }),
+  sameSite: Schema.optional(
+    Schema.Literals(["unspecified", "no_restriction", "lax", "strict"]).annotate({
+      description: "Optional SameSite policy.",
+    }),
+  ).annotate({ description: "Optional SameSite policy." }),
+  expirationDate: Schema.optional(
+    Schema.Number.check(Schema.isFinite()).check(Schema.isGreaterThan(0)).annotate({
+      description: "Optional expiry as Unix epoch seconds; omit for a session cookie.",
+    }),
+  ).annotate({ description: "Optional expiry as Unix epoch seconds; omit for a session cookie." }),
+});
+export type PreviewAutomationCookie = typeof PreviewAutomationCookie.Type;
+
+export const PreviewAutomationSetCookieInput = Schema.Struct({
+  ...PreviewAutomationTabTargetFields,
+  ...PreviewAutomationCookie.fields,
+}).annotate({
+  description: "Sets one cookie in this environment's isolated preview browser partition.",
+});
+export type PreviewAutomationSetCookieInput = typeof PreviewAutomationSetCookieInput.Type;
+
+export const PreviewAutomationSetCookiePayload = Schema.Struct({
+  cookie: PreviewAutomationCookie,
+});
+export type PreviewAutomationSetCookiePayload = typeof PreviewAutomationSetCookiePayload.Type;
 
 export const PreviewAutomationWaitForInput = Schema.Struct({
   ...PreviewAutomationTabTargetFields,


### PR DESCRIPTION
## Problem

Preview automation could not set cookies in its environment-scoped Electron browser partition. That forced authenticated QA into a separate browser and made the collaborative preview diverge from the session being tested.

Closes #6111.

## Fix

- Add a generic `preview_set_cookie` MCP tool with standard cookie attributes.
- Route cookie writes through the preview automation host and desktop IPC bridge.
- Store cookies in the selected environment isolated Electron session partition.
- Return typed failures without including cookie values.
- Cover the contracts, server routing, desktop manager, and browser session behavior with focused tests.

## Verification

- 7 focused test files: 76 tests passed.
- Contracts, server, desktop, and web package typechecks passed.
- Targeted lint, format, and `git diff --check` passed.
- Live Electron QA with `agent-browser`: 100 concurrent writes, 100 sequential overwrites, and 500 set/clear churn writes passed with zero failures.
- Verified HTTP-only, path, expiry, SameSite, empty-value, environment-isolation, clear-cookie, and invalid-input behavior.

Model: OpenAI GPT-5.6-sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes session cookies into isolated preview partitions (auth-relevant), but scoped per environment with sanitized errors and contract validation; no change to server-side auth.
> 
> **Overview**
> Adds **`preview_set_cookie`** so agents can seed auth and other state in the **environment-isolated** Electron preview partition, without opening a separate browser.
> 
> The change introduces a shared **`PreviewAutomationCookie`** contract and **`setCookie`** automation operation, exposes an MCP tool that routes through the preview broker, and implements desktop **`BrowserSession.setCookie`** (Electron `session.cookies.set`) behind new IPC/preload APIs. Failures use **`BrowserSessionCookieSetError`** messages that **omit cookie names and values**.
> 
> On the web automation host, **`setCookie`** skips the usual preview session sync (no open tab required) and calls **`previewBridge.setCookie(environmentId, cookie)`** directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f4dcc07439c3b2ce8374076cbd88bd6c6c42933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `preview_set_cookie` tool to set cookies in the collaborative browser
> - Adds a `setCookie` automation operation end-to-end: MCP tool (`preview_set_cookie`), server handler, IPC channel, desktop `BrowserSession` implementation, and web automation host case.
> - Defines `PreviewAutomationCookie` schema in [previewAutomation.ts](https://github.com/pingdotgg/t3code/pull/6112/files#diff-2ef56f22cedaed8aa5c26215295ac5661980479b1dced68072d9ca5bc81a9602) with fields for url, name, value, domain, path, secure, httpOnly, sameSite, and expirationDate.
> - Cookies are written into the environment-scoped Electron session partition; errors surface as `BrowserSessionCookieSetError` with sanitized messages that omit cookie name and value.
> - Cookie-setting requests skip preview session synchronization and do not require a tab to be ready.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f4dcc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->