### PR TITLE
fix(web): resolve z-index stacking for select dropdowns inside keybindings popover

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -877,7 +877,7 @@ function KeybindingTableRow({
         <Popover>
           <PopoverTrigger
             className={cn(
-              "inline-flex h-7 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+              "inline-flex h-7 w-full cursor-pointer items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
               !whenDraftExpression && "text-muted-foreground",
             )}
             aria-label={`Edit when clause for ${commandLabel(row.command)}`}
@@ -1039,7 +1039,7 @@ function NewKeybindingTableRow({
         <Popover>
           <PopoverTrigger
             className={cn(
-              "inline-flex h-7 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+              "inline-flex h-7 w-full cursor-pointer items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
               !whenDraftExpression && "text-muted-foreground",
             )}
             aria-label={`Edit when clause for ${commandLabelText}`}

--- a/apps/web/src/components/ui/autocomplete.tsx
+++ b/apps/web/src/components/ui/autocomplete.tsx
@@ -77,6 +77,7 @@ function AutocompleteInput({
 
 function AutocompletePopup({
   className,
+  positionerClassName,
   children,
   side = "bottom",
   sideOffset = 4,
@@ -85,6 +86,7 @@ function AutocompletePopup({
   anchor,
   ...props
 }: AutocompletePrimitive.Popup.Props & {
+  positionerClassName?: string;
   align?: AutocompletePrimitive.Positioner.Props["align"];
   sideOffset?: AutocompletePrimitive.Positioner.Props["sideOffset"];
   alignOffset?: AutocompletePrimitive.Positioner.Props["alignOffset"];
@@ -97,7 +99,7 @@ function AutocompletePopup({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="z-50 select-none"
+        className={cn("z-70 select-none", positionerClassName)}
         data-slot="autocomplete-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -140,6 +140,7 @@ function ComboboxTrigger({ className, children, ...props }: ComboboxPrimitive.Tr
 
 function ComboboxPopup({
   className,
+  positionerClassName,
   children,
   side = "bottom",
   sideOffset = 4,
@@ -148,6 +149,7 @@ function ComboboxPopup({
   anchor: anchorProp,
   ...props
 }: ComboboxPrimitive.Popup.Props & {
+  positionerClassName?: string;
   align?: ComboboxPrimitive.Positioner.Props["align"];
   sideOffset?: ComboboxPrimitive.Positioner.Props["sideOffset"];
   alignOffset?: ComboboxPrimitive.Positioner.Props["alignOffset"];
@@ -163,7 +165,7 @@ function ComboboxPopup({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="z-50 select-none"
+        className={cn("z-70 select-none", positionerClassName)}
         data-slot="combobox-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -106,6 +106,7 @@ function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
 function SelectPopup({
   className,
   popupClassName,
+  positionerClassName,
   children,
   side = "bottom",
   sideOffset = 4,
@@ -117,6 +118,7 @@ function SelectPopup({
   ...props
 }: SelectPrimitive.Popup.Props & {
   popupClassName?: string;
+  positionerClassName?: string;
   side?: SelectPrimitive.Positioner.Props["side"];
   sideOffset?: SelectPrimitive.Positioner.Props["sideOffset"];
   align?: SelectPrimitive.Positioner.Props["align"];
@@ -132,7 +134,7 @@ function SelectPopup({
         alignItemWithTrigger={alignItemWithTrigger}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="z-50 select-none"
+        className={cn("z-70 select-none", positionerClassName)}
         data-slot="select-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -33,7 +33,7 @@ function TooltipPopup({
       <TooltipPrimitive.Positioner
         align={align}
         anchor={anchor}
-        className="pointer-events-none z-70 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none"
+        className="pointer-events-none z-80 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none"
         data-slot="tooltip-positioner"
         side={side}
         sideOffset={sideOffset}


### PR DESCRIPTION
## What Changed

- Raised positioner `z-index` from `z-50` to `z-70` for `Select`, `Combobox`, and `Autocomplete` UI primitives, and added an optional `positionerClassName` prop to `SelectPopup`, `ComboboxPopup`, and `AutocompletePopup`.
- Updated `Tooltip` positioner `z-index` from `z-70` to `z-80` so tooltips remain properly layered above select dropdowns.
- Added `cursor-pointer` class to `PopoverTrigger` in `KeybindingsSettings.tsx` for keybinding "When" clause triggers.

## Why

When editing keybinding "When" expressions (`Settings -> Keybindings`), the "When" popover container (`PopoverPositioner`) uses `z-[60]`. Because `Select` dropdown positioners previously used `z-50`, options inside the popover's dropdowns rendered behind the main popover window, making them unselectable.

Updating the stacking order ensures all floating picker dropdowns (`z-70`) render clearly on top of popover windows (`z-[60]`) and dialogs (`z-50`), while keeping tooltips (`z-80`) and toasts (`z-100`) on top.

## UI Changes

Before:
<img width="399" height="175" alt="before" src="https://github.com/user-attachments/assets/1d67242e-c906-4aed-b82b-861648f68ab4" />

After:
<img width="318" height="176" alt="after" src="https://github.com/user-attachments/assets/2909f187-abce-40fb-9309-72acf9b78890" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS stacking and small UI primitive API additions only; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes **select/combobox/autocomplete dropdowns rendering behind the keybindings “When” popover** by raising their positioner stacking from `z-50` to **`z-70`**, above popovers at **`z-[60]`**. **`Tooltip`** positioners move to **`z-80`** so hints still sit above those lists.
> 
> Shared popup components (`SelectPopup`, `ComboboxPopup`, `AutocompletePopup`) now accept an optional **`positionerClassName`** for per-use overrides. Keybindings **When** popover triggers get **`cursor-pointer`** for clearer affordance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71f60fb95e48ccc49b1d963c6151d9e9fe45a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix z-index stacking for select dropdowns inside the keybindings popover
> - Raises the positioner z-index from `z-50` to `z-70` in [`autocomplete.tsx`](https://github.com/pingdotgg/t3code/pull/6114/files#diff-97edfff0276fda8a5e3f20147b67956bb253dec7cd81bdd32537c2a92ea94dde), [`combobox.tsx`](https://github.com/pingdotgg/t3code/pull/6114/files#diff-10ddf105a1e88483c98dd15827574c77c53320d7ae56a262c90bfad67e790ef9), and [`select.tsx`](https://github.com/pingdotgg/t3code/pull/6114/files#diff-f8dc315356af4a3938a8bfea44f5cb369e197db435ab6b932a79253ad2844789) so dropdowns render above the keybindings popover.
> - Raises tooltip positioner z-index from `z-70` to `z-80` in [`tooltip.tsx`](https://github.com/pingdotgg/t3code/pull/6114/files#diff-97acc7c97f91957af019082b41210bb280e2dd2af1a011328a1549f5647431d9) to preserve tooltip stacking above the updated dropdowns.
> - Adds an optional `positionerClassName` prop to `AutocompletePopup`, `ComboboxPopup`, and `SelectPopup` for per-consumer positioner overrides.
> - Adds `cursor-pointer` to the when-clause `PopoverTrigger` in [`KeybindingsSettings.tsx`](https://github.com/pingdotgg/t3code/pull/6114/files#diff-12068495a79a13f54503fa3061aafb91f05537621626906b290ed059e660d4d4).
> - Behavioral Change: global z-index baseline for all select, combobox, and autocomplete dropdowns increases site-wide, not just inside the keybindings popover.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d71f60f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->