### PR TITLE
fix(swift-ios): make thread swipe actions safe

### DIFF
--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -317,9 +317,10 @@ public final class FeatureRootModel {
         }
     }
 
-    public func setSnoozed(_ id: String, until: Date?) async {
+    @discardableResult
+    public func setSnoozed(_ id: String, until: Date?) async -> Bool {
         let environment = currentEnvironmentIdentity
-        await perform {
+        return await perform {
             try await client.setThreadSnoozed(id: id, until: until)
             guard currentEnvironmentIdentity == environment else { return }
             let snoozedAt = until.map { _ in Date.now }
@@ -330,9 +331,10 @@ public final class FeatureRootModel {
         }
     }
 
-    public func setPinned(_ id: String, pinned: Bool) async {
+    @discardableResult
+    public func setPinned(_ id: String, pinned: Bool) async -> Bool {
         let environment = currentEnvironmentIdentity
-        await perform {
+        return await perform {
             try await client.setThreadPinned(id: id, pinned: pinned)
             guard currentEnvironmentIdentity == environment else { return }
             mutateThread(id: id) {

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -299,9 +299,10 @@ public final class FeatureRootModel {
         }
     }
 
-    public func setSettled(_ id: String, settled: Bool) async {
+    @discardableResult
+    public func setSettled(_ id: String, settled: Bool) async -> Bool {
         let environment = currentEnvironmentIdentity
-        await perform {
+        return await perform {
             try await client.setThreadSettled(id: id, settled: settled)
             guard currentEnvironmentIdentity == environment else { return }
             let settledAt = settled ? Date.now : nil

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -635,9 +635,12 @@ extension FeatureThread {
             .first(where: { $0.id == projectID })?
             .environmentID
         let resolvedEnvironmentID = environmentID ?? projectEnvironmentID
-        let providers = resolvedEnvironmentID.flatMap {
-            snapshot.providersByEnvironment?[$0]
-        } ?? snapshot.providers
+        let providers: [FeatureProvider]
+        if let providersByEnvironment = snapshot.providersByEnvironment {
+            providers = resolvedEnvironmentID.flatMap { providersByEnvironment[$0] } ?? []
+        } else {
+            providers = snapshot.providers
+        }
         return providers.first(where: { $0.id == providerID })?.name ?? providerID
     }
 

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -637,7 +637,7 @@ extension FeatureThread {
         let resolvedEnvironmentID = environmentID ?? projectEnvironmentID
         let providers = resolvedEnvironmentID.flatMap {
             snapshot.providersByEnvironment?[$0]
-        } ?? []
+        } ?? snapshot.providers
         return providers.first(where: { $0.id == providerID })?.name ?? providerID
     }
 

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -25,7 +25,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         } else if thread.pinnedAt != nil, thread.canTogglePin {
             primary = .unpin
         } else if thread.canToggleSettlement {
-            primary = thread.isSettled || thread.isEffectivelySettled(at: now)
+            primary = thread.isEffectivelySettled(at: now)
                 ? .reopen
                 : .settle
         } else {

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -195,7 +195,10 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
             let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
                 self?.parent.onDelete(thread)
-                finish(true)
+                // Deletion is deferred until the confirmation alert. Keep the
+                // row in place if the user cancels instead of letting UIKit
+                // animate an optimistic removal that never reached the model.
+                finish(false)
             }
             delete.image = UIImage(systemName: "trash")
 

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -25,9 +25,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         } else if thread.pinnedAt != nil, thread.canTogglePin {
             primary = .unpin
         } else if thread.canToggleSettlement {
-            primary = thread.isEffectivelySettled(at: now)
-                ? .reopen
-                : .settle
+            primary = settlementAction(for: thread, now: now)
         } else {
             primary = .archive
         }
@@ -35,6 +33,13 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
             actions: [primary, .delete],
             performsFirstActionWithFullSwipe: primary == .settle || primary == .reopen
         )
+    }
+
+    static func settlementAction(
+        for thread: FeatureThread,
+        now: Date
+    ) -> HomeThreadSwipeActionKind {
+        thread.isEffectivelySettled(at: now) ? .reopen : .settle
     }
 }
 
@@ -460,7 +465,11 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     )
                 }
                 if thread.canToggleSettlement {
-                    let wasSettled = thread.isSettled || thread.isEffectivelySettled(at: .now)
+                    let settlementAction = HomeThreadSwipeActionPlan.settlementAction(
+                        for: thread,
+                        now: .now
+                    )
+                    let wasSettled = settlementAction == .reopen
                     actions.append(
                         UIAction(
                             title: wasSettled ? "Reopen" : "Settle",

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -33,7 +33,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         }
         return HomeThreadSwipeActionPlan(
             actions: [primary, .delete],
-            performsFirstActionWithFullSwipe: true
+            performsFirstActionWithFullSwipe: primary == .settle || primary == .reopen
         )
     }
 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -1,6 +1,45 @@
 import SwiftUI
 import UIKit
 
+enum HomeThreadSwipeActionKind: Equatable, Sendable {
+    case restore
+    case unpin
+    case settle
+    case reopen
+    case archive
+    case delete
+}
+
+struct HomeThreadSwipeActionPlan: Equatable, Sendable {
+    let primary: HomeThreadSwipeActionKind
+    let secondary: HomeThreadSwipeActionKind = .delete
+    let performsPrimaryWithFullSwipe = true
+    let deleteFinishesOptimistically = false
+
+    var orderedActions: [HomeThreadSwipeActionKind] {
+        [primary, secondary]
+    }
+
+    static func make(
+        thread: FeatureThread,
+        isArchived: Bool,
+        now: Date
+    ) -> HomeThreadSwipeActionPlan {
+        if isArchived {
+            return HomeThreadSwipeActionPlan(primary: .restore)
+        }
+        if thread.pinnedAt != nil, thread.canTogglePin {
+            return HomeThreadSwipeActionPlan(primary: .unpin)
+        }
+        if thread.canToggleSettlement {
+            return HomeThreadSwipeActionPlan(
+                primary: thread.isEffectivelySettled(at: now) ? .reopen : .settle
+            )
+        }
+        return HomeThreadSwipeActionPlan(primary: .archive)
+    }
+}
+
 /// A recycled, diffable Home surface. SwiftUI still owns the surrounding shell,
 /// while UIKit keeps row creation and updates proportional to visible threads.
 struct HomeThreadCollectionView: UIViewRepresentable {
@@ -20,7 +59,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onShowMoreSettled: () -> Void
     let onRename: (FeatureThread) -> Void
     let onArchive: (FeatureThread, Bool) -> Void
-    let onSettle: (FeatureThread, Bool) -> Void
+    let onSettle: (FeatureThread, Bool, Bool) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
     let onPin: (FeatureThread, Bool) -> Void
     let onDelete: (FeatureThread) -> Void
@@ -193,17 +232,23 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 return nil
             }
 
+            let plan = HomeThreadSwipeActionPlan.make(
+                thread: thread,
+                isArchived: isArchived,
+                now: .now
+            )
             let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
                 self?.parent.onDelete(thread)
                 // Deletion is deferred until the confirmation alert. Keep the
                 // row in place if the user cancels instead of letting UIKit
                 // animate an optimistic removal that never reached the model.
-                finish(false)
+                finish(plan.deleteFinishesOptimistically)
             }
             delete.image = UIImage(systemName: "trash")
 
             let primaryAction: UIContextualAction
-            if isArchived {
+            switch plan.primary {
+            case .restore:
                 primaryAction = UIContextualAction(style: .normal, title: "Restore") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, false)
@@ -211,7 +256,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 primaryAction.image = UIImage(systemName: "arrow.uturn.backward")
                 primaryAction.backgroundColor = .systemBlue
-            } else if thread.pinnedAt != nil, thread.canTogglePin {
+            case .unpin:
                 primaryAction = UIContextualAction(style: .normal, title: "Unpin") {
                     [weak self] _, _, finish in
                     self?.parent.onPin(thread, false)
@@ -219,20 +264,24 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 primaryAction.image = UIImage(systemName: "pin.slash")
                 primaryAction.backgroundColor = .systemBlue
-            } else if thread.canToggleSettlement {
-                let isSettled = thread.isEffectivelySettled(at: .now)
+            case .settle, .reopen:
+                let wasEffectivelySettled = plan.primary == .reopen
                 primaryAction = UIContextualAction(
                     style: .normal,
-                    title: isSettled ? "Reopen" : "Settle"
+                    title: wasEffectivelySettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(thread, !isSettled)
+                    self?.parent.onSettle(
+                        thread,
+                        !wasEffectivelySettled,
+                        wasEffectivelySettled
+                    )
                     finish(true)
                 }
                 primaryAction.image = UIImage(
-                    systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
+                    systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
                 )
-                primaryAction.backgroundColor = isSettled ? .systemBlue : .systemGreen
-            } else {
+                primaryAction.backgroundColor = wasEffectivelySettled ? .systemBlue : .systemGreen
+            case .archive:
                 primaryAction = UIContextualAction(style: .normal, title: "Archive") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, true)
@@ -240,10 +289,12 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 primaryAction.image = UIImage(systemName: "archivebox")
                 primaryAction.backgroundColor = .systemGray
+            case .delete:
+                preconditionFailure("Delete cannot be the primary full-swipe action")
             }
 
             let configuration = UISwipeActionsConfiguration(actions: [primaryAction, delete])
-            configuration.performsFirstActionWithFullSwipe = true
+            configuration.performsFirstActionWithFullSwipe = plan.performsPrimaryWithFullSwipe
             return configuration
         }
 
@@ -407,15 +458,19 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     )
                 }
                 if thread.canToggleSettlement {
-                    let isSettled = thread.isEffectivelySettled(at: .now)
+                    let wasEffectivelySettled = thread.isEffectivelySettled(at: .now)
                     actions.append(
                         UIAction(
-                            title: isSettled ? "Reopen" : "Settle",
+                            title: wasEffectivelySettled ? "Reopen" : "Settle",
                             image: UIImage(
-                                systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
+                                systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
                             )
                         ) { [weak self] _ in
-                            self?.parent.onSettle(thread, !isSettled)
+                            self?.parent.onSettle(
+                                thread,
+                                !wasEffectivelySettled,
+                                wasEffectivelySettled
+                            )
                         }
                     )
                 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -57,7 +57,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onShowMoreSettled: () -> Void
     let onRename: (FeatureThread) -> Void
     let onArchive: (FeatureThread, Bool) -> Void
-    let onSettle: (FeatureThread, Bool, Bool) -> Void
+    let onSettle: (FeatureThread, Bool) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
     let onPin: (FeatureThread, Bool) -> Void
     let onDelete: (FeatureThread) -> Void
@@ -270,7 +270,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     style: .normal,
                     title: wasSettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(thread, !wasSettled, wasSettled)
+                    self?.parent.onSettle(thread, !wasSettled)
                     finish(true)
                 }
                 action.image = UIImage(
@@ -468,7 +468,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                                 systemName: wasSettled ? "arrow.counterclockwise" : "checkmark"
                             )
                         ) { [weak self] _ in
-                            self?.parent.onSettle(thread, !wasSettled, wasSettled)
+                            self?.parent.onSettle(thread, !wasSettled)
                         }
                     )
                 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -11,32 +11,32 @@ enum HomeThreadSwipeActionKind: Equatable, Sendable {
 }
 
 struct HomeThreadSwipeActionPlan: Equatable, Sendable {
-    let primary: HomeThreadSwipeActionKind
-    let secondary: HomeThreadSwipeActionKind = .delete
-    let performsPrimaryWithFullSwipe = true
-    let deleteFinishesOptimistically = false
-
-    var orderedActions: [HomeThreadSwipeActionKind] {
-        [primary, secondary]
-    }
+    let actions: [HomeThreadSwipeActionKind]
+    let performsFirstActionWithFullSwipe: Bool
+    let deleteFinishesOptimistically: Bool
 
     static func make(
         thread: FeatureThread,
         isArchived: Bool,
         now: Date
     ) -> HomeThreadSwipeActionPlan {
+        let primary: HomeThreadSwipeActionKind
         if isArchived {
-            return HomeThreadSwipeActionPlan(primary: .restore)
+            primary = .restore
+        } else if thread.pinnedAt != nil, thread.canTogglePin {
+            primary = .unpin
+        } else if thread.canToggleSettlement {
+            primary = thread.isSettled || thread.isEffectivelySettled(at: now)
+                ? .reopen
+                : .settle
+        } else {
+            primary = .archive
         }
-        if thread.pinnedAt != nil, thread.canTogglePin {
-            return HomeThreadSwipeActionPlan(primary: .unpin)
-        }
-        if thread.canToggleSettlement {
-            return HomeThreadSwipeActionPlan(
-                primary: thread.isEffectivelySettled(at: now) ? .reopen : .settle
-            )
-        }
-        return HomeThreadSwipeActionPlan(primary: .archive)
+        return HomeThreadSwipeActionPlan(
+            actions: [primary, .delete],
+            performsFirstActionWithFullSwipe: true,
+            deleteFinishesOptimistically: false
+        )
     }
 }
 
@@ -237,65 +237,71 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 isArchived: isArchived,
                 now: .now
             )
-            let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
-                self?.parent.onDelete(thread)
-                // Deletion is deferred until the confirmation alert. Keep the
-                // row in place if the user cancels instead of letting UIKit
-                // animate an optimistic removal that never reached the model.
-                finish(plan.deleteFinishesOptimistically)
+            let actions = plan.actions.map {
+                swipeAction($0, for: thread, plan: plan)
             }
-            delete.image = UIImage(systemName: "trash")
+            let configuration = UISwipeActionsConfiguration(actions: actions)
+            configuration.performsFirstActionWithFullSwipe =
+                plan.performsFirstActionWithFullSwipe
+            return configuration
+        }
 
-            let primaryAction: UIContextualAction
-            switch plan.primary {
+        private func swipeAction(
+            _ kind: HomeThreadSwipeActionKind,
+            for thread: FeatureThread,
+            plan: HomeThreadSwipeActionPlan
+        ) -> UIContextualAction {
+            let action: UIContextualAction
+            switch kind {
             case .restore:
-                primaryAction = UIContextualAction(style: .normal, title: "Restore") {
+                action = UIContextualAction(style: .normal, title: "Restore") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, false)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "arrow.uturn.backward")
-                primaryAction.backgroundColor = .systemBlue
+                action.image = UIImage(systemName: "arrow.uturn.backward")
+                action.backgroundColor = .systemBlue
             case .unpin:
-                primaryAction = UIContextualAction(style: .normal, title: "Unpin") {
+                action = UIContextualAction(style: .normal, title: "Unpin") {
                     [weak self] _, _, finish in
                     self?.parent.onPin(thread, false)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "pin.slash")
-                primaryAction.backgroundColor = .systemBlue
+                action.image = UIImage(systemName: "pin.slash")
+                action.backgroundColor = .systemBlue
             case .settle, .reopen:
-                let wasEffectivelySettled = plan.primary == .reopen
-                primaryAction = UIContextualAction(
+                let wasSettled = kind == .reopen
+                action = UIContextualAction(
                     style: .normal,
-                    title: wasEffectivelySettled ? "Reopen" : "Settle"
+                    title: wasSettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(
-                        thread,
-                        !wasEffectivelySettled,
-                        wasEffectivelySettled
-                    )
+                    self?.parent.onSettle(thread, !wasSettled, wasSettled)
                     finish(true)
                 }
-                primaryAction.image = UIImage(
-                    systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
+                action.image = UIImage(
+                    systemName: wasSettled ? "arrow.counterclockwise" : "checkmark"
                 )
-                primaryAction.backgroundColor = wasEffectivelySettled ? .systemBlue : .systemGreen
+                action.backgroundColor = wasSettled ? .systemBlue : .systemGreen
             case .archive:
-                primaryAction = UIContextualAction(style: .normal, title: "Archive") {
+                action = UIContextualAction(style: .normal, title: "Archive") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, true)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "archivebox")
-                primaryAction.backgroundColor = .systemGray
+                action.image = UIImage(systemName: "archivebox")
+                action.backgroundColor = .systemGray
             case .delete:
-                preconditionFailure("Delete cannot be the primary full-swipe action")
+                action = UIContextualAction(style: .destructive, title: "Delete") {
+                    [weak self] _, _, finish in
+                    self?.parent.onDelete(thread)
+                    // Deletion is deferred until the confirmation alert. Keep
+                    // the row if the user cancels instead of letting UIKit
+                    // animate a removal that never reached the model.
+                    finish(plan.deleteFinishesOptimistically)
+                }
+                action.image = UIImage(systemName: "trash")
             }
-
-            let configuration = UISwipeActionsConfiguration(actions: [primaryAction, delete])
-            configuration.performsFirstActionWithFullSwipe = plan.performsPrimaryWithFullSwipe
-            return configuration
+            return action
         }
 
         private func configure(
@@ -458,19 +464,15 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     )
                 }
                 if thread.canToggleSettlement {
-                    let wasEffectivelySettled = thread.isEffectivelySettled(at: .now)
+                    let wasSettled = thread.isSettled || thread.isEffectivelySettled(at: .now)
                     actions.append(
                         UIAction(
-                            title: wasEffectivelySettled ? "Reopen" : "Settle",
+                            title: wasSettled ? "Reopen" : "Settle",
                             image: UIImage(
-                                systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
+                                systemName: wasSettled ? "arrow.counterclockwise" : "checkmark"
                             )
                         ) { [weak self] _ in
-                            self?.parent.onSettle(
-                                thread,
-                                !wasEffectivelySettled,
-                                wasEffectivelySettled
-                            )
+                            self?.parent.onSettle(thread, !wasSettled, wasSettled)
                         }
                     )
                 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -24,8 +24,8 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
             primary = .restore
         } else if thread.pinnedAt != nil, thread.canTogglePin {
             primary = .unpin
-        } else if thread.canToggleSettlement {
-            primary = settlementAction(for: thread, now: now)
+        } else if let settlement = settlementAction(for: thread, now: now) {
+            primary = settlement
         } else {
             primary = .archive
         }
@@ -38,8 +38,11 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
     static func settlementAction(
         for thread: FeatureThread,
         now: Date
-    ) -> HomeThreadSwipeActionKind {
-        thread.isEffectivelySettled(at: now) ? .reopen : .settle
+    ) -> HomeThreadSwipeActionKind? {
+        guard thread.canToggleSettlement else { return nil }
+        if thread.isEffectivelySettled(at: now) { return .reopen }
+        if thread.isSettled { return nil }
+        return .settle
     }
 }
 
@@ -464,11 +467,10 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                         }
                     )
                 }
-                if thread.canToggleSettlement {
-                    let settlementAction = HomeThreadSwipeActionPlan.settlementAction(
+                if let settlementAction = HomeThreadSwipeActionPlan.settlementAction(
                         for: thread,
                         now: .now
-                    )
+                    ) {
                     let wasSettled = settlementAction == .reopen
                     actions.append(
                         UIAction(

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -13,7 +13,6 @@ enum HomeThreadSwipeActionKind: Equatable, Sendable {
 struct HomeThreadSwipeActionPlan: Equatable, Sendable {
     let actions: [HomeThreadSwipeActionKind]
     let performsFirstActionWithFullSwipe: Bool
-    let deleteFinishesOptimistically: Bool
 
     static func make(
         thread: FeatureThread,
@@ -34,8 +33,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         }
         return HomeThreadSwipeActionPlan(
             actions: [primary, .delete],
-            performsFirstActionWithFullSwipe: true,
-            deleteFinishesOptimistically: false
+            performsFirstActionWithFullSwipe: true
         )
     }
 }
@@ -237,9 +235,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 isArchived: isArchived,
                 now: .now
             )
-            let actions = plan.actions.map {
-                swipeAction($0, for: thread, plan: plan)
-            }
+            let actions = plan.actions.map { swipeAction($0, for: thread) }
             let configuration = UISwipeActionsConfiguration(actions: actions)
             configuration.performsFirstActionWithFullSwipe =
                 plan.performsFirstActionWithFullSwipe
@@ -248,8 +244,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
         private func swipeAction(
             _ kind: HomeThreadSwipeActionKind,
-            for thread: FeatureThread,
-            plan: HomeThreadSwipeActionPlan
+            for thread: FeatureThread
         ) -> UIContextualAction {
             let action: UIContextualAction
             switch kind {
@@ -291,15 +286,16 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 action.image = UIImage(systemName: "archivebox")
                 action.backgroundColor = .systemGray
             case .delete:
-                action = UIContextualAction(style: .destructive, title: "Delete") {
+                action = UIContextualAction(style: .normal, title: "Delete") {
                     [weak self] _, _, finish in
                     self?.parent.onDelete(thread)
-                    // Deletion is deferred until the confirmation alert. Keep
-                    // the row if the user cancels instead of letting UIKit
-                    // animate a removal that never reached the model.
-                    finish(plan.deleteFinishesOptimistically)
+                    // The alert owns the destructive operation. Complete this
+                    // non-destructive contextual action so Cancel closes the
+                    // swipe without UIKit animating a row deletion.
+                    finish(true)
                 }
                 action.image = UIImage(systemName: "trash")
+                action.backgroundColor = .systemRed
             }
             return action
         }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -239,8 +239,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 primaryAction.backgroundColor = .systemGray
             }
 
-            let configuration = UISwipeActionsConfiguration(actions: [delete, primaryAction])
-            configuration.performsFirstActionWithFullSwipe = false
+            let configuration = UISwipeActionsConfiguration(actions: [primaryAction, delete])
+            configuration.performsFirstActionWithFullSwipe = true
             return configuration
         }
 

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -132,11 +132,20 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
+        previousWasSettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
+            && !previousWasSettled
             && updatedThread?.isSettled == true
+    }
+
+    static func shouldAnnounce(
+        isRegularWidth: Bool,
+        isDetailPreferred: Bool
+    ) -> Bool {
+        isRegularWidth || !isDetailPreferred
     }
 
     static func targetIsValid(
@@ -176,6 +185,7 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 public struct WorkspaceView: View {
     @SwiftUI.Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @SwiftUI.Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @Bindable var model: FeatureRootModel
     private let navigationRequest: FeatureWorkspaceNavigationRequest?
@@ -463,6 +473,7 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
+                            previousWasSettled: thread.isSettled,
                             updatedThread: updatedThread
                         ), let requestID else { return }
                         let notice = withAnimation(
@@ -477,7 +488,10 @@ public struct WorkspaceView: View {
                             )
                         }
                         guard notice != nil else { return }
-                        if preferredCompactColumn != .detail {
+                        if HomeThreadSettleUndoState.shouldAnnounce(
+                            isRegularWidth: horizontalSizeClass == .regular,
+                            isDetailPreferred: preferredCompactColumn == .detail
+                        ) {
                             var announcement = AttributedString(
                                 "\(updatedThread?.title ?? thread.title) settled. Undo available."
                             )

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -88,15 +88,20 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
         return notice
     }
 
+    mutating func dismiss(threadID: String) {
+        guard notice?.threadID == threadID else { return }
+        notice = nil
+    }
+
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
-        previousWasEffectivelySettled: Bool,
+        previousWasSettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
-            && !previousWasEffectivelySettled
+            && !previousWasSettled
             && updatedThread?.isSettled == true
     }
 }
@@ -282,6 +287,7 @@ public struct WorkspaceView: View {
             Button("Delete", role: .destructive) {
                 guard let confirmed = deleteConfirmation.takeConfirmedRequest(),
                       confirmed == request else { return }
+                settleUndo.dismiss(threadID: confirmed.id)
                 Task { await model.deleteThread(confirmed.id) }
             }
         } message: { request in
@@ -295,6 +301,10 @@ public struct WorkspaceView: View {
         }
         .onChange(of: selectedProjectIsAvailable) { _, isAvailable in
             if !isAvailable { selectedProjectID = nil }
+        }
+        .onChange(of: settleUndoTargetIsValid) { _, isValid in
+            guard !isValid, let notice = settleUndo.notice else { return }
+            settleUndo.dismiss(threadID: notice.threadID)
         }
         .onChange(of: navigationRequest?.id, initial: true) { _, _ in
             consumeNavigationRequest()
@@ -385,9 +395,11 @@ public struct WorkspaceView: View {
                     renamingThread = thread
                 },
                 onArchive: { thread, archived in
+                    settleUndo.dismiss(threadID: thread.id)
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
-                onSettle: { thread, settled, wasEffectivelySettled in
+                onSettle: { thread, settled, wasSettled in
+                    if !settled { settleUndo.dismiss(threadID: thread.id) }
                     let requestID = settleUndo.beginSettleRequest(ifSettling: settled)
                     let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
                     Task {
@@ -398,7 +410,7 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
-                            previousWasEffectivelySettled: wasEffectivelySettled,
+                            previousWasSettled: wasSettled,
                             updatedThread: updatedThread
                         ), let requestID else { return }
                         let notice = withAnimation(
@@ -494,21 +506,16 @@ public struct WorkspaceView: View {
                 let didReopen = await model.setSettled(notice.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
                 guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
-                guard await model.setPinned(notice.threadID, pinned: true) else {
-                    model.errorMessage = "Thread reopened, but its pin could not be restored. Try pinning it again."
-                    return
-                }
+                guard await model.setPinned(notice.threadID, pinned: true) else { return }
                 if let snoozeUntil = notice.restoresSnoozeUntil {
-                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else {
-                        model.errorMessage = "Thread reopened and pinned, but its snooze could not be restored. Try snoozing it again."
-                        return
-                    }
+                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else { return }
                 }
             }
         }
         .font(T3Typography.supportingStrong)
         .buttonStyle(.bordered)
         .frame(minHeight: T3Metrics.minimumTapTarget)
+        .contentShape(Rectangle())
         .accessibilityLabel("Undo settle \(notice.title)")
     }
 
@@ -804,6 +811,13 @@ public struct WorkspaceView: View {
     private var selectedProjectIsAvailable: Bool {
         guard let selectedProjectID else { return true }
         return model.snapshot.projects.contains { $0.id == selectedProjectID }
+    }
+
+    private var settleUndoTargetIsValid: Bool {
+        guard let notice = settleUndo.notice else { return true }
+        return model.snapshot.threads.contains {
+            $0.id == notice.threadID && $0.isSettled && !$0.isArchived
+        }
     }
 
     private func openThread(_ id: String) {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -897,6 +897,7 @@ public struct WorkspaceView: View {
     }
 
     private func dismissTransientPresentations() {
+        deleteConfirmation.cancel()
         showingNewTask = false
         showingAddProject = false
         showingSettings = false

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -104,6 +104,15 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
             && !previousWasSettled
             && updatedThread?.isSettled == true
     }
+
+    static func targetIsValid(
+        notice: HomeThreadSettleUndoNotice,
+        in threads: [FeatureThread]
+    ) -> Bool {
+        threads.contains {
+            $0.id == notice.threadID && $0.isSettled && !$0.isArchived
+        }
+    }
 }
 
 struct HomeThreadDeleteRequest: Equatable, Sendable {
@@ -815,9 +824,10 @@ public struct WorkspaceView: View {
 
     private var settleUndoTargetIsValid: Bool {
         guard let notice = settleUndo.notice else { return true }
-        return model.snapshot.threads.contains {
-            $0.id == notice.threadID && $0.isSettled && !$0.isArchived
-        }
+        return HomeThreadSettleUndoState.targetIsValid(
+            notice: notice,
+            in: model.snapshot.threads
+        )
     }
 
     private func openThread(_ id: String) {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -25,6 +25,19 @@ struct HomeThreadSettleUndoNotice: Equatable, Identifiable, Sendable {
     let restoresSnoozeUntil: Date?
 }
 
+struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
+    let restoresPin: Bool
+    let restoresSnoozeUntil: Date?
+
+    static func capture(from thread: FeatureThread) -> Self {
+        let restoresPin = thread.pinnedAt != nil
+        return Self(
+            restoresPin: restoresPin,
+            restoresSnoozeUntil: restoresPin ? thread.snoozedUntil : nil
+        )
+    }
+}
+
 struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
     private(set) var latestSettleRequestID: UUID?
@@ -33,6 +46,14 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     mutating func beginSettleRequest(id: UUID = UUID()) -> UUID {
         latestSettleRequestID = id
         return id
+    }
+
+    mutating func beginSettleRequest(
+        ifSettling settled: Bool,
+        id: UUID = UUID()
+    ) -> UUID? {
+        guard settled else { return nil }
+        return beginSettleRequest(id: id)
     }
 
     @discardableResult
@@ -70,12 +91,12 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
-        previousThread: FeatureThread,
+        previousWasEffectivelySettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
-            && !previousThread.isSettled
+            && !previousWasEffectivelySettled
             && updatedThread?.isSettled == true
     }
 }
@@ -366,8 +387,9 @@ public struct WorkspaceView: View {
                 onArchive: { thread, archived in
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
-                onSettle: { thread, settled in
-                    let requestID = settleUndo.beginSettleRequest()
+                onSettle: { thread, settled, wasEffectivelySettled in
+                    let requestID = settleUndo.beginSettleRequest(ifSettling: settled)
+                    let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
                     Task {
                         let didSucceed = await model.setSettled(thread.id, settled: settled)
                         let updatedThread = model.snapshot.threads.first {
@@ -376,9 +398,9 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
-                            previousThread: thread,
+                            previousWasEffectivelySettled: wasEffectivelySettled,
                             updatedThread: updatedThread
-                        ) else { return }
+                        ), let requestID else { return }
                         let notice = withAnimation(
                             accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)
                         ) {
@@ -386,10 +408,8 @@ public struct WorkspaceView: View {
                                 requestID: requestID,
                                 threadID: thread.id,
                                 title: thread.title,
-                                restoresPin: thread.pinnedAt != nil,
-                                restoresSnoozeUntil: thread.pinnedAt == nil
-                                    ? nil
-                                    : thread.snoozedUntil
+                                restoresPin: restoration.restoresPin,
+                                restoresSnoozeUntil: restoration.restoresSnoozeUntil
                             )
                         }
                         guard notice != nil else { return }
@@ -474,14 +494,21 @@ public struct WorkspaceView: View {
                 let didReopen = await model.setSettled(notice.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
                 guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
-                await model.setPinned(notice.threadID, pinned: true)
+                guard await model.setPinned(notice.threadID, pinned: true) else {
+                    model.errorMessage = "Thread reopened, but its pin could not be restored. Try pinning it again."
+                    return
+                }
                 if let snoozeUntil = notice.restoresSnoozeUntil {
-                    await model.setSnoozed(notice.threadID, until: snoozeUntil)
+                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else {
+                        model.errorMessage = "Thread reopened and pinned, but its snooze could not be restored. Try snoozing it again."
+                        return
+                    }
                 }
             }
         }
         .font(T3Typography.supportingStrong)
         .buttonStyle(.bordered)
+        .frame(minHeight: T3Metrics.minimumTapTarget)
         .accessibilityLabel("Undo settle \(notice.title)")
     }
 

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -22,23 +22,35 @@ struct HomeThreadSettleUndoNotice: Equatable, Identifiable, Sendable {
     let threadID: String
     let title: String
     let restoresPin: Bool
+    let restoresSnoozeUntil: Date?
 }
 
 struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
+    private(set) var latestSettleRequestID: UUID?
+
+    @discardableResult
+    mutating func beginSettleRequest(id: UUID = UUID()) -> UUID {
+        latestSettleRequestID = id
+        return id
+    }
 
     @discardableResult
     mutating func present(
+        requestID: UUID,
         threadID: String,
         title: String,
         restoresPin: Bool,
+        restoresSnoozeUntil: Date?,
         id: UUID = UUID()
-    ) -> HomeThreadSettleUndoNotice {
+    ) -> HomeThreadSettleUndoNotice? {
+        guard requestID == latestSettleRequestID else { return nil }
         let notice = HomeThreadSettleUndoNotice(
             id: id,
             threadID: threadID,
             title: title,
-            restoresPin: restoresPin
+            restoresPin: restoresPin,
+            restoresSnoozeUntil: restoresSnoozeUntil
         )
         self.notice = notice
         return notice
@@ -57,9 +69,14 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
 
     static func shouldPresent(
         afterRequesting settled: Bool,
+        didSucceed: Bool,
+        previousThread: FeatureThread,
         updatedThread: FeatureThread?
     ) -> Bool {
-        settled && updatedThread?.isSettled == true
+        settled
+            && didSucceed
+            && !previousThread.isSettled
+            && updatedThread?.isSettled == true
     }
 }
 
@@ -77,6 +94,11 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 
     mutating func cancel() {
         request = nil
+    }
+
+    mutating func takeConfirmedRequest() -> HomeThreadDeleteRequest? {
+        defer { request = nil }
+        return request
     }
 }
 
@@ -237,8 +259,9 @@ public struct WorkspaceView: View {
                 deleteConfirmation.cancel()
             }
             Button("Delete", role: .destructive) {
-                deleteConfirmation.cancel()
-                Task { await model.deleteThread(request.id) }
+                guard let confirmed = deleteConfirmation.takeConfirmedRequest(),
+                      confirmed == request else { return }
+                Task { await model.deleteThread(confirmed.id) }
             }
         } message: { request in
             Text("“\(request.title)” will be permanently deleted.")
@@ -344,22 +367,32 @@ public struct WorkspaceView: View {
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
                 onSettle: { thread, settled in
+                    let requestID = settleUndo.beginSettleRequest()
                     Task {
-                        await model.setSettled(thread.id, settled: settled)
+                        let didSucceed = await model.setSettled(thread.id, settled: settled)
                         let updatedThread = model.snapshot.threads.first {
                             $0.id == thread.id
                         }
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
+                            didSucceed: didSucceed,
+                            previousThread: thread,
                             updatedThread: updatedThread
                         ) else { return }
-                        _ = withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
+                        let notice = withAnimation(
+                            accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)
+                        ) {
                             settleUndo.present(
+                                requestID: requestID,
                                 threadID: thread.id,
                                 title: thread.title,
-                                restoresPin: thread.pinnedAt != nil
+                                restoresPin: thread.pinnedAt != nil,
+                                restoresSnoozeUntil: thread.pinnedAt == nil
+                                    ? nil
+                                    : thread.snoozedUntil
                             )
                         }
+                        guard notice != nil else { return }
                         UIAccessibility.post(
                             notification: .announcement,
                             argument: "\(thread.title) settled. Undo available."
@@ -409,6 +442,7 @@ public struct WorkspaceView: View {
             .shadow(color: T3Colors.shadow, radius: 14, y: 6)
             .transition(.move(edge: .bottom).combined(with: .opacity))
             .accessibilityElement(children: .contain)
+            .accessibilitySortPriority(1_000)
         }
     }
 
@@ -437,10 +471,13 @@ public struct WorkspaceView: View {
                 _ = settleUndo.takeUndo(id: notice.id)
             }
             Task {
-                await model.setSettled(notice.threadID, settled: false)
+                let didReopen = await model.setSettled(notice.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
-                guard reopened?.isSettled == false, notice.restoresPin else { return }
+                guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
                 await model.setPinned(notice.threadID, pinned: true)
+                if let snoozeUntil = notice.restoresSnoozeUntil {
+                    await model.setSnoozed(notice.threadID, until: snoozeUntil)
+                }
             }
         }
         .font(T3Typography.supportingStrong)

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -30,11 +30,13 @@ struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
     let restoresPin: Bool
     let restoresSnoozeUntil: Date?
 
-    static func capture(from thread: FeatureThread) -> Self {
+    static func capture(from thread: FeatureThread, now: Date) -> Self {
         let restoresPin = thread.pinnedAt != nil
         return Self(
             restoresPin: restoresPin,
-            restoresSnoozeUntil: thread.snoozedUntil
+            restoresSnoozeUntil: thread.isEffectivelySnoozed(at: now)
+                ? thread.snoozedUntil
+                : nil
         )
     }
 }
@@ -103,6 +105,11 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
         guard undoInProgressID == id else { return }
         undoInProgressID = nil
         if notice?.id == id { notice = nil }
+    }
+
+    mutating func failUndo(id: UUID) {
+        guard undoInProgressID == id else { return }
+        undoInProgressID = nil
     }
 
     func isUndoInProgress(threadID: String) -> Bool {
@@ -462,7 +469,10 @@ public struct WorkspaceView: View {
                         ifSettling: settled,
                         threadID: thread.id
                     )
-                    let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
+                    let restoration = HomeThreadSettleUndoRestoration.capture(
+                        from: thread,
+                        now: .now
+                    )
                     Task {
                         let didSucceed = await model.setSettled(thread.id, settled: settled)
                         let updatedThread = model.snapshot.threads.first {
@@ -568,19 +578,26 @@ public struct WorkspaceView: View {
         return Button {
             guard let undo = settleUndo.beginUndo(id: notice.id) else { return }
             Task {
-                defer {
-                    withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
-                        settleUndo.finishUndo(id: undo.id)
-                    }
-                }
                 let didReopen = await model.setSettled(undo.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == undo.threadID }
-                guard didReopen, reopened?.isSettled == false else { return }
+                guard didReopen, reopened?.isSettled == false else {
+                    settleUndo.failUndo(id: undo.id)
+                    return
+                }
                 if undo.restoresPin {
-                    guard await model.setPinned(undo.threadID, pinned: true) else { return }
+                    guard await model.setPinned(undo.threadID, pinned: true) else {
+                        settleUndo.failUndo(id: undo.id)
+                        return
+                    }
                 }
                 if let snoozeUntil = undo.restoresSnoozeUntil {
-                    guard await model.setSnoozed(undo.threadID, until: snoozeUntil) else { return }
+                    guard await model.setSnoozed(undo.threadID, until: snoozeUntil) else {
+                        settleUndo.failUndo(id: undo.id)
+                        return
+                    }
+                }
+                withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                    settleUndo.finishUndo(id: undo.id)
                 }
             }
         } label: {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -317,6 +317,9 @@ public struct WorkspaceView: View {
         .onChange(of: selectedProjectIsAvailable) { _, isAvailable in
             if !isAvailable { selectedProjectID = nil }
         }
+        .onChange(of: deleteConfirmationTargetIsValid) { _, isValid in
+            if !isValid { deleteConfirmation.cancel() }
+        }
         .onChange(of: settleUndoTargetIsValid) { _, isValid in
             guard !isValid, let notice = settleUndo.notice else { return }
             withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
@@ -831,6 +834,11 @@ public struct WorkspaceView: View {
     private var selectedProjectIsAvailable: Bool {
         guard let selectedProjectID else { return true }
         return model.snapshot.projects.contains { $0.id == selectedProjectID }
+    }
+
+    private var deleteConfirmationTargetIsValid: Bool {
+        guard let request = deleteConfirmation.request else { return true }
+        return model.snapshot.threads.contains { $0.id == request.id }
     }
 
     private var settleUndoTargetIsValid: Bool {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -17,7 +17,54 @@ struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     }
 }
 
+struct HomeThreadSettleUndoNotice: Equatable, Identifiable, Sendable {
+    let id: UUID
+    let threadID: String
+    let title: String
+    let restoresPin: Bool
+}
+
+struct HomeThreadSettleUndoState: Equatable, Sendable {
+    private(set) var notice: HomeThreadSettleUndoNotice?
+
+    @discardableResult
+    mutating func present(
+        threadID: String,
+        title: String,
+        restoresPin: Bool,
+        id: UUID = UUID()
+    ) -> HomeThreadSettleUndoNotice {
+        let notice = HomeThreadSettleUndoNotice(
+            id: id,
+            threadID: threadID,
+            title: title,
+            restoresPin: restoresPin
+        )
+        self.notice = notice
+        return notice
+    }
+
+    mutating func expire(id: UUID) {
+        guard notice?.id == id else { return }
+        notice = nil
+    }
+
+    mutating func takeUndo(id: UUID) -> HomeThreadSettleUndoNotice? {
+        guard notice?.id == id else { return nil }
+        defer { notice = nil }
+        return notice
+    }
+
+    static func shouldPresent(
+        afterRequesting settled: Bool,
+        updatedThread: FeatureThread?
+    ) -> Bool {
+        settled && updatedThread?.isSettled == true
+    }
+}
+
 public struct WorkspaceView: View {
+    @SwiftUI.Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @Bindable var model: FeatureRootModel
@@ -43,6 +90,7 @@ public struct WorkspaceView: View {
     @State private var sidebarBoundaryNow = Date.now
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
     @State private var homePresentationCache = HomePresentationCache()
+    @State private var settleUndo = HomeThreadSettleUndoState()
     @FocusState private var isSearchFocused: Bool
 
     public init(
@@ -186,6 +234,17 @@ public struct WorkspaceView: View {
                 return
             }
         }
+        .task(id: settleUndo.notice?.id) {
+            guard let notice = settleUndo.notice else { return }
+            do {
+                try await Task.sleep(for: settleUndoLifetime)
+                withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                    settleUndo.expire(id: notice.id)
+                }
+            } catch {
+                return
+            }
+        }
     }
 
     private var sidebar: some View {
@@ -202,6 +261,11 @@ public struct WorkspaceView: View {
             composeButton
                 .padding(.trailing, 16)
                 .padding(.bottom, 14)
+
+            settleUndoToast
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 78)
         }
         .background(T3Colors.background)
         .toolbar(.hidden, for: .navigationBar)
@@ -244,7 +308,27 @@ public struct WorkspaceView: View {
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
                 onSettle: { thread, settled in
-                    Task { await model.setSettled(thread.id, settled: settled) }
+                    Task {
+                        await model.setSettled(thread.id, settled: settled)
+                        let updatedThread = model.snapshot.threads.first {
+                            $0.id == thread.id
+                        }
+                        guard HomeThreadSettleUndoState.shouldPresent(
+                            afterRequesting: settled,
+                            updatedThread: updatedThread
+                        ) else { return }
+                        _ = withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
+                            settleUndo.present(
+                                threadID: thread.id,
+                                title: thread.title,
+                                restoresPin: thread.pinnedAt != nil
+                            )
+                        }
+                        UIAccessibility.post(
+                            notification: .announcement,
+                            argument: "\(thread.title) settled. Undo available."
+                        )
+                    }
                 },
                 onSnooze: { thread, until in
                     Task { await model.setSnoozed(thread.id, until: until) }
@@ -258,6 +342,81 @@ public struct WorkspaceView: View {
             )
         }
         .background(T3Colors.background)
+    }
+
+    @ViewBuilder
+    private var settleUndoToast: some View {
+        if let notice = settleUndo.notice {
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 10) {
+                        settleUndoDescription(notice)
+                        settleUndoButton(notice)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                } else {
+                    HStack(spacing: 12) {
+                        settleUndoDescription(notice)
+                        Spacer(minLength: 8)
+                        settleUndoButton(notice)
+                    }
+                }
+            }
+            .padding(.leading, 14)
+            .padding(.trailing, 10)
+            .padding(.vertical, 10)
+            .background(T3Colors.surfaceRaised, in: RoundedRectangle(cornerRadius: 14))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(T3Colors.border, lineWidth: 1)
+            }
+            .shadow(color: T3Colors.shadow, radius: 14, y: 6)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    private func settleUndoDescription(_ notice: HomeThreadSettleUndoNotice) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(T3Colors.success)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Thread settled")
+                    .font(T3Typography.supportingStrong)
+                    .foregroundStyle(T3Colors.textPrimary)
+                Text(notice.title)
+                    .font(T3Typography.supporting)
+                    .foregroundStyle(T3Colors.textSecondary)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    private func settleUndoButton(_ notice: HomeThreadSettleUndoNotice) -> some View {
+        Button("Undo") {
+            guard settleUndo.notice?.id == notice.id else { return }
+            withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                _ = settleUndo.takeUndo(id: notice.id)
+            }
+            Task {
+                await model.setSettled(notice.threadID, settled: false)
+                let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
+                guard reopened?.isSettled == false, notice.restoresPin else { return }
+                await model.setPinned(notice.threadID, pinned: true)
+            }
+        }
+        .font(T3Typography.supportingStrong)
+        .buttonStyle(.bordered)
+        .accessibilityLabel("Undo settle \(notice.title)")
+    }
+
+    private var settleUndoLifetime: Duration {
+        if UIAccessibility.isVoiceOverRunning || UIAccessibility.isSwitchControlRunning {
+            return .seconds(15)
+        }
+        return .seconds(5)
     }
 
     @ViewBuilder

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -34,6 +34,8 @@ struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
         let restoresPin = thread.pinnedAt != nil
         return Self(
             restoresPin: restoresPin,
+            // Restoring a pin clears snooze state, so preserve snooze only
+            // when Undo will re-pin the thread.
             restoresSnoozeUntil: restoresPin ? thread.snoozedUntil : nil
         )
     }
@@ -43,6 +45,7 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
     private(set) var latestSettleRequestID: UUID?
     private(set) var latestSettleThreadID: String?
+    private(set) var undoInProgressID: UUID?
 
     @discardableResult
     mutating func beginSettleRequest(
@@ -88,14 +91,25 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     }
 
     mutating func expire(id: UUID) {
-        guard notice?.id == id else { return }
+        guard notice?.id == id, undoInProgressID != id else { return }
         notice = nil
     }
 
-    mutating func takeUndo(id: UUID) -> HomeThreadSettleUndoNotice? {
-        guard notice?.id == id else { return nil }
-        defer { notice = nil }
+    mutating func beginUndo(id: UUID) -> HomeThreadSettleUndoNotice? {
+        guard notice?.id == id, undoInProgressID == nil else { return nil }
+        undoInProgressID = id
         return notice
+    }
+
+    mutating func finishUndo(id: UUID) {
+        guard undoInProgressID == id else { return }
+        undoInProgressID = nil
+        if notice?.id == id { notice = nil }
+    }
+
+    func isUndoInProgress(threadID: String) -> Bool {
+        guard let notice else { return false }
+        return notice.threadID == threadID && undoInProgressID == notice.id
     }
 
     mutating func dismiss(threadID: String) {
@@ -104,7 +118,15 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
             latestSettleThreadID = nil
         }
         guard notice?.threadID == threadID else { return }
+        undoInProgressID = nil
         notice = nil
+    }
+
+    mutating func dismissAll() {
+        notice = nil
+        latestSettleRequestID = nil
+        latestSettleThreadID = nil
+        undoInProgressID = nil
     }
 
     static func shouldPresent(
@@ -141,6 +163,13 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 
     mutating func cancel() {
         request = nil
+    }
+
+    static func targetIsValid(
+        request: HomeThreadDeleteRequest,
+        in threads: [FeatureThread]
+    ) -> Bool {
+        threads.contains { $0.id == request.id }
     }
 }
 
@@ -419,6 +448,7 @@ public struct WorkspaceView: View {
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
                 onSettle: { thread, settled in
+                    guard !settleUndo.isUndoInProgress(threadID: thread.id) else { return }
                     if !settled { settleUndo.dismiss(threadID: thread.id) }
                     let requestID = settleUndo.beginSettleRequest(
                         ifSettling: settled,
@@ -441,17 +471,19 @@ public struct WorkspaceView: View {
                             settleUndo.present(
                                 requestID: requestID,
                                 threadID: thread.id,
-                                title: thread.title,
+                                title: updatedThread?.title ?? thread.title,
                                 restoresPin: restoration.restoresPin,
                                 restoresSnoozeUntil: restoration.restoresSnoozeUntil
                             )
                         }
                         guard notice != nil else { return }
-                        var announcement = AttributedString(
-                            "\(thread.title) settled. Undo available."
-                        )
-                        announcement.accessibilitySpeechAnnouncementPriority = .high
-                        AccessibilityNotification.Announcement(announcement).post()
+                        if preferredCompactColumn != .detail {
+                            var announcement = AttributedString(
+                                "\(updatedThread?.title ?? thread.title) settled. Undo available."
+                            )
+                            announcement.accessibilitySpeechAnnouncementPriority = .high
+                            AccessibilityNotification.Announcement(announcement).post()
+                        }
                     }
                 },
                 onSnooze: { thread, until in
@@ -520,21 +552,33 @@ public struct WorkspaceView: View {
     }
 
     private func settleUndoButton(_ notice: HomeThreadSettleUndoNotice) -> some View {
-        Button("Undo") {
-            guard settleUndo.notice?.id == notice.id else { return }
-            withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
-                _ = settleUndo.takeUndo(id: notice.id)
-            }
+        let isUndoing = settleUndo.undoInProgressID == notice.id
+        return Button {
+            guard let undo = settleUndo.beginUndo(id: notice.id) else { return }
             Task {
-                let didReopen = await model.setSettled(notice.threadID, settled: false)
-                let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
-                guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
-                guard await model.setPinned(notice.threadID, pinned: true) else { return }
-                if let snoozeUntil = notice.restoresSnoozeUntil {
-                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else { return }
+                defer {
+                    withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                        settleUndo.finishUndo(id: undo.id)
+                    }
+                }
+                let didReopen = await model.setSettled(undo.threadID, settled: false)
+                let reopened = model.snapshot.threads.first { $0.id == undo.threadID }
+                guard didReopen, reopened?.isSettled == false, undo.restoresPin else { return }
+                guard await model.setPinned(undo.threadID, pinned: true) else { return }
+                if let snoozeUntil = undo.restoresSnoozeUntil {
+                    guard await model.setSnoozed(undo.threadID, until: snoozeUntil) else { return }
                 }
             }
+        } label: {
+            if isUndoing {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityHidden(true)
+            } else {
+                Text("Undo")
+            }
         }
+        .disabled(isUndoing)
         .font(T3Typography.supportingStrong)
         .buttonStyle(.bordered)
         .frame(minHeight: T3Metrics.minimumTapTarget)
@@ -838,11 +882,15 @@ public struct WorkspaceView: View {
 
     private var deleteConfirmationTargetIsValid: Bool {
         guard let request = deleteConfirmation.request else { return true }
-        return model.snapshot.threads.contains { $0.id == request.id }
+        return HomeThreadDeleteConfirmation.targetIsValid(
+            request: request,
+            in: model.snapshot.threads
+        )
     }
 
     private var settleUndoTargetIsValid: Bool {
         guard let notice = settleUndo.notice else { return true }
+        if settleUndo.isUndoInProgress(threadID: notice.threadID) { return true }
         return HomeThreadSettleUndoState.targetIsValid(
             notice: notice,
             in: model.snapshot.threads
@@ -906,6 +954,7 @@ public struct WorkspaceView: View {
 
     private func dismissTransientPresentations() {
         deleteConfirmation.cancel()
+        settleUndo.dismissAll()
         showingNewTask = false
         showingAddProject = false
         showingSettings = false

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -63,6 +63,23 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     }
 }
 
+struct HomeThreadDeleteRequest: Equatable, Sendable {
+    let id: String
+    let title: String
+}
+
+struct HomeThreadDeleteConfirmation: Equatable, Sendable {
+    private(set) var request: HomeThreadDeleteRequest?
+
+    mutating func present(threadID: String, title: String) {
+        request = HomeThreadDeleteRequest(id: threadID, title: title)
+    }
+
+    mutating func cancel() {
+        request = nil
+    }
+}
+
 public struct WorkspaceView: View {
     @SwiftUI.Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -87,6 +104,7 @@ public struct WorkspaceView: View {
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
     @State private var renameTitle = ""
+    @State private var deleteConfirmation = HomeThreadDeleteConfirmation()
     @State private var sidebarBoundaryNow = Date.now
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
     @State private var homePresentationCache = HomePresentationCache()
@@ -206,6 +224,24 @@ public struct WorkspaceView: View {
                 Task { await model.renameThread(thread.id, title: title) }
             }
             .disabled(renameTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .alert(
+            "Delete thread?",
+            isPresented: Binding(
+                get: { deleteConfirmation.request != nil },
+                set: { if !$0 { deleteConfirmation.cancel() } }
+            ),
+            presenting: deleteConfirmation.request
+        ) { request in
+            Button("Cancel", role: .cancel) {
+                deleteConfirmation.cancel()
+            }
+            Button("Delete", role: .destructive) {
+                deleteConfirmation.cancel()
+                Task { await model.deleteThread(request.id) }
+            }
+        } message: { request in
+            Text("“\(request.title)” will be permanently deleted.")
         }
         .onChange(of: selectedThreadIsAvailable) { _, isAvailable in
             if !isAvailable { closeSelectedThread() }
@@ -337,7 +373,7 @@ public struct WorkspaceView: View {
                     Task { await model.setPinned(thread.id, pinned: pinned) }
                 },
                 onDelete: { thread in
-                    Task { await model.deleteThread(thread.id) }
+                    deleteConfirmation.present(threadID: thread.id, title: thread.title)
                 }
             )
         }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -110,12 +110,10 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
-        previousWasSettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
-            && !previousWasSettled
             && updatedThread?.isSettled == true
     }
 
@@ -321,7 +319,9 @@ public struct WorkspaceView: View {
         }
         .onChange(of: settleUndoTargetIsValid) { _, isValid in
             guard !isValid, let notice = settleUndo.notice else { return }
-            settleUndo.dismiss(threadID: notice.threadID)
+            withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
+                settleUndo.dismiss(threadID: notice.threadID)
+            }
         }
         .onChange(of: navigationRequest?.id, initial: true) { _, _ in
             consumeNavigationRequest()
@@ -415,7 +415,7 @@ public struct WorkspaceView: View {
                     settleUndo.dismiss(threadID: thread.id)
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
-                onSettle: { thread, settled, wasSettled in
+                onSettle: { thread, settled in
                     if !settled { settleUndo.dismiss(threadID: thread.id) }
                     let requestID = settleUndo.beginSettleRequest(
                         ifSettling: settled,
@@ -430,7 +430,6 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
-                            previousWasSettled: wasSettled,
                             updatedThread: updatedThread
                         ), let requestID else { return }
                         let notice = withAnimation(

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -1,3 +1,4 @@
+import Accessibility
 import SwiftUI
 import UIKit
 
@@ -41,19 +42,25 @@ struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
 struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
     private(set) var latestSettleRequestID: UUID?
+    private(set) var latestSettleThreadID: String?
 
     @discardableResult
-    mutating func beginSettleRequest(id: UUID = UUID()) -> UUID {
+    mutating func beginSettleRequest(
+        threadID: String? = nil,
+        id: UUID = UUID()
+    ) -> UUID {
         latestSettleRequestID = id
+        latestSettleThreadID = threadID
         return id
     }
 
     mutating func beginSettleRequest(
         ifSettling settled: Bool,
+        threadID: String? = nil,
         id: UUID = UUID()
     ) -> UUID? {
         guard settled else { return nil }
-        return beginSettleRequest(id: id)
+        return beginSettleRequest(threadID: threadID, id: id)
     }
 
     @discardableResult
@@ -66,6 +73,7 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
         id: UUID = UUID()
     ) -> HomeThreadSettleUndoNotice? {
         guard requestID == latestSettleRequestID else { return nil }
+        if let latestSettleThreadID, latestSettleThreadID != threadID { return nil }
         let notice = HomeThreadSettleUndoNotice(
             id: id,
             threadID: threadID,
@@ -74,6 +82,8 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
             restoresSnoozeUntil: restoresSnoozeUntil
         )
         self.notice = notice
+        latestSettleRequestID = nil
+        latestSettleThreadID = nil
         return notice
     }
 
@@ -89,6 +99,10 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     }
 
     mutating func dismiss(threadID: String) {
+        if latestSettleThreadID == threadID {
+            latestSettleRequestID = nil
+            latestSettleThreadID = nil
+        }
         guard notice?.threadID == threadID else { return }
         notice = nil
     }
@@ -129,11 +143,6 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 
     mutating func cancel() {
         request = nil
-    }
-
-    mutating func takeConfirmedRequest() -> HomeThreadDeleteRequest? {
-        defer { request = nil }
-        return request
     }
 }
 
@@ -294,10 +303,9 @@ public struct WorkspaceView: View {
                 deleteConfirmation.cancel()
             }
             Button("Delete", role: .destructive) {
-                guard let confirmed = deleteConfirmation.takeConfirmedRequest(),
-                      confirmed == request else { return }
-                settleUndo.dismiss(threadID: confirmed.id)
-                Task { await model.deleteThread(confirmed.id) }
+                deleteConfirmation.cancel()
+                settleUndo.dismiss(threadID: request.id)
+                Task { await model.deleteThread(request.id) }
             }
         } message: { request in
             Text("“\(request.title)” will be permanently deleted.")
@@ -409,7 +417,10 @@ public struct WorkspaceView: View {
                 },
                 onSettle: { thread, settled, wasSettled in
                     if !settled { settleUndo.dismiss(threadID: thread.id) }
-                    let requestID = settleUndo.beginSettleRequest(ifSettling: settled)
+                    let requestID = settleUndo.beginSettleRequest(
+                        ifSettling: settled,
+                        threadID: thread.id
+                    )
                     let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
                     Task {
                         let didSucceed = await model.setSettled(thread.id, settled: settled)
@@ -434,10 +445,11 @@ public struct WorkspaceView: View {
                             )
                         }
                         guard notice != nil else { return }
-                        UIAccessibility.post(
-                            notification: .announcement,
-                            argument: "\(thread.title) settled. Undo available."
+                        var announcement = AttributedString(
+                            "\(thread.title) settled. Undo available."
                         )
+                        announcement.accessibilitySpeechAnnouncementPriority = .high
+                        AccessibilityNotification.Announcement(announcement).post()
                     }
                 },
                 onSnooze: { thread, until in

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -34,9 +34,7 @@ struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
         let restoresPin = thread.pinnedAt != nil
         return Self(
             restoresPin: restoresPin,
-            // Restoring a pin clears snooze state, so preserve snooze only
-            // when Undo will re-pin the thread.
-            restoresSnoozeUntil: restoresPin ? thread.snoozedUntil : nil
+            restoresSnoozeUntil: thread.snoozedUntil
         )
     }
 }
@@ -577,8 +575,10 @@ public struct WorkspaceView: View {
                 }
                 let didReopen = await model.setSettled(undo.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == undo.threadID }
-                guard didReopen, reopened?.isSettled == false, undo.restoresPin else { return }
-                guard await model.setPinned(undo.threadID, pinned: true) else { return }
+                guard didReopen, reopened?.isSettled == false else { return }
+                if undo.restoresPin {
+                    guard await model.setPinned(undo.threadID, pinned: true) else { return }
+                }
                 if let snoozeUntil = undo.restoresSnoozeUntil {
                     guard await model.setSnoozed(undo.threadID, until: snoozeUntil) else { return }
                 }
@@ -1146,9 +1146,12 @@ struct HomeThreadRowContext: Equatable {
             let explicitProvider = thread.providerName?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let configuredProvider = thread.providerID.flatMap { providerID in
-                environmentID.flatMap {
-                    snapshot.providersByEnvironment?[$0]?.first(where: { $0.id == providerID })
-                } ?? snapshot.providers.first(where: { $0.id == providerID })
+                if let providersByEnvironment = snapshot.providersByEnvironment {
+                    return environmentID.flatMap {
+                        providersByEnvironment[$0]?.first(where: { $0.id == providerID })
+                    }
+                }
+                return snapshot.providers.first(where: { $0.id == providerID })
             }
             let providerName = (explicitProvider?.isEmpty == false ? explicitProvider : nil)
                 ?? configuredProvider?.name

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -1148,7 +1148,7 @@ struct HomeThreadRowContext: Equatable {
             let configuredProvider = thread.providerID.flatMap { providerID in
                 environmentID.flatMap {
                     snapshot.providersByEnvironment?[$0]?.first(where: { $0.id == providerID })
-                }
+                } ?? snapshot.providers.first(where: { $0.id == providerID })
             }
             let providerName = (explicitProvider?.isEmpty == false ? explicitProvider : nil)
                 ?? configuredProvider?.name

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -103,6 +103,29 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func settlementActionUsesEffectiveStateAcrossAllEntryPoints() {
+        let settled = thread(
+            id: "settled",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let settledButWorking = thread(
+            id: "settled-working",
+            created: -20,
+            updated: -10,
+            state: .working,
+            isSettled: true
+        )
+
+        #expect(HomeThreadSwipeActionPlan.settlementAction(for: settled, now: now) == .reopen)
+        #expect(
+            HomeThreadSwipeActionPlan.settlementAction(for: settledButWorking, now: now)
+                == .settle
+        )
+    }
+
+    @Test
     func settleUndoPreservesStateThatRepinningWouldClear() {
         let snoozeUntil = now.addingTimeInterval(300)
         let pinnedAndSnoozed = thread(
@@ -373,6 +396,7 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -380,6 +404,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -387,6 +412,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -394,6 +420,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
+                previousWasSettled: false,
                 updatedThread: active
             )
         )
@@ -401,7 +428,38 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
+                previousWasSettled: false,
                 updatedThread: nil
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                didSucceed: true,
+                previousWasSettled: true,
+                updatedThread: settled
+            )
+        )
+    }
+
+    @Test
+    func settleUndoAnnouncementFollowsSidebarVisibility() {
+        #expect(
+            HomeThreadSettleUndoState.shouldAnnounce(
+                isRegularWidth: true,
+                isDetailPreferred: true
+            )
+        )
+        #expect(
+            HomeThreadSettleUndoState.shouldAnnounce(
+                isRegularWidth: false,
+                isDetailPreferred: false
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldAnnounce(
+                isRegularWidth: false,
+                isDetailPreferred: true
             )
         )
     }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -31,6 +31,93 @@ struct DailyUXSidebarTests {
     private let now = Date(timeIntervalSince1970: 2_000_000)
 
     @Test
+    func swipePlanKeepsDeleteOutOfTheFullSwipeSlot() {
+        let active = thread(id: "active", created: -20, updated: -10)
+        let settled = thread(
+            id: "settled",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let settledButWorking = thread(
+            id: "settled-working",
+            created: -20,
+            updated: -10,
+            state: .working,
+            isSettled: true
+        )
+
+        let activePlan = HomeThreadSwipeActionPlan.make(
+            thread: active,
+            isArchived: false,
+            now: now
+        )
+        let settledPlan = HomeThreadSwipeActionPlan.make(
+            thread: settled,
+            isArchived: false,
+            now: now
+        )
+        let settledButWorkingPlan = HomeThreadSwipeActionPlan.make(
+            thread: settledButWorking,
+            isArchived: false,
+            now: now
+        )
+
+        #expect(activePlan.orderedActions == [.settle, .delete])
+        #expect(settledPlan.orderedActions == [.reopen, .delete])
+        #expect(settledButWorkingPlan.orderedActions == [.settle, .delete])
+        #expect(activePlan.performsPrimaryWithFullSwipe)
+        #expect(!activePlan.deleteFinishesOptimistically)
+        #expect(activePlan.orderedActions.first != .delete)
+    }
+
+    @Test
+    func settleUndoCapturesOnlyStateThatSettlementClears() {
+        let snoozeUntil = now.addingTimeInterval(300)
+        let pinnedAndSnoozed = thread(
+            id: "pinned",
+            created: -20,
+            updated: -10,
+            pinned: -5,
+            snoozedUntil: snoozeUntil
+        )
+        let snoozedOnly = thread(
+            id: "snoozed",
+            created: -20,
+            updated: -10,
+            snoozedUntil: snoozeUntil
+        )
+
+        #expect(
+            HomeThreadSettleUndoRestoration.capture(from: pinnedAndSnoozed)
+                == HomeThreadSettleUndoRestoration(
+                    restoresPin: true,
+                    restoresSnoozeUntil: snoozeUntil
+                )
+        )
+        #expect(
+            HomeThreadSettleUndoRestoration.capture(from: snoozedOnly)
+                == HomeThreadSettleUndoRestoration(
+                    restoresPin: false,
+                    restoresSnoozeUntil: nil
+                )
+        )
+    }
+
+    @Test
+    func reopeningDoesNotSupersedeAnInFlightSettleNotice() {
+        let settleRequestID = UUID()
+        var state = HomeThreadSettleUndoState()
+
+        #expect(
+            state.beginSettleRequest(ifSettling: true, id: settleRequestID)
+                == settleRequestID
+        )
+        #expect(state.beginSettleRequest(ifSettling: false) == nil)
+        #expect(state.latestSettleRequestID == settleRequestID)
+    }
+
+    @Test
     func settleUndoTargetsOnlyTheLatestNoticeOnce() {
         let firstID = UUID()
         let secondID = UUID()
@@ -122,7 +209,7 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: settled
             )
         )
@@ -130,7 +217,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: settled
             )
         )
@@ -138,7 +225,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: settled
             )
         )
@@ -146,7 +233,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: settled,
+                previousWasEffectivelySettled: true,
                 updatedThread: settled
             )
         )
@@ -154,7 +241,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: active
             )
         )
@@ -162,7 +249,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: nil
             )
         )
@@ -622,7 +709,9 @@ struct DailyUXSidebarTests {
         created: TimeInterval,
         updated: TimeInterval,
         state: FeatureThreadState = .idle,
-        isSettled: Bool = false
+        isSettled: Bool = false,
+        pinned: TimeInterval? = nil,
+        snoozedUntil: Date? = nil
     ) -> FeatureThread {
         FeatureThread(
             id: id,
@@ -632,7 +721,10 @@ struct DailyUXSidebarTests {
             updatedAt: now.addingTimeInterval(updated),
             state: state,
             isSettled: isSettled,
-            lastActivityAt: now.addingTimeInterval(updated)
+            lastActivityAt: now.addingTimeInterval(updated),
+            snoozedUntil: snoozedUntil,
+            snoozedAt: snoozedUntil.map { _ in now.addingTimeInterval(updated) },
+            pinnedAt: pinned.map(now.addingTimeInterval)
         )
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -90,7 +90,7 @@ struct DailyUXSidebarTests {
 
         #expect(activePlan.actions == [.settle, .delete])
         #expect(settledPlan.actions == [.reopen, .delete])
-        #expect(settledButWorkingPlan.actions == [.reopen, .delete])
+        #expect(settledButWorkingPlan.actions == [.settle, .delete])
         #expect(archivedPlan.actions == [.restore, .delete])
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
@@ -103,7 +103,7 @@ struct DailyUXSidebarTests {
     }
 
     @Test
-    func settleUndoCapturesOnlyStateThatSettlementClears() {
+    func settleUndoPreservesStateThatRepinningWouldClear() {
         let snoozeUntil = now.addingTimeInterval(300)
         let pinnedAndSnoozed = thread(
             id: "pinned",
@@ -261,11 +261,16 @@ struct DailyUXSidebarTests {
 
         state.expire(id: firstID)
         #expect(state.notice?.threadID == "second")
-        #expect(state.takeUndo(id: firstID) == nil)
-        let undo = state.takeUndo(id: secondID)
+        #expect(state.beginUndo(id: firstID) == nil)
+        let undo = state.beginUndo(id: secondID)
         #expect(undo?.restoresPin == true)
         #expect(undo?.restoresSnoozeUntil == now.addingTimeInterval(300))
-        #expect(state.takeUndo(id: secondID) == nil)
+        #expect(state.beginUndo(id: secondID) == nil)
+        #expect(state.notice?.id == secondID)
+        #expect(state.isUndoInProgress(threadID: "second"))
+        state.finishUndo(id: secondID)
+        #expect(state.notice == nil)
+        #expect(!state.isUndoInProgress(threadID: "second"))
     }
 
     @Test
@@ -285,6 +290,47 @@ struct DailyUXSidebarTests {
         state.expire(id: noticeID)
 
         #expect(state.notice == nil)
+    }
+
+    @Test
+    func settleUndoDoesNotExpireWhileUndoIsRunning() {
+        let noticeID = UUID()
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "thread")
+        state.present(
+            requestID: requestID,
+            threadID: "thread",
+            title: "Thread",
+            restoresPin: false,
+            restoresSnoozeUntil: nil,
+            id: noticeID
+        )
+
+        #expect(state.beginUndo(id: noticeID) != nil)
+        state.expire(id: noticeID)
+        #expect(state.notice?.id == noticeID)
+        state.finishUndo(id: noticeID)
+        #expect(state.notice == nil)
+    }
+
+    @Test
+    func deleteConfirmationTargetMustRemainInTheSnapshot() {
+        let request = HomeThreadDeleteRequest(id: "target", title: "Target")
+        let target = thread(id: "target", created: -20, updated: -10)
+        let other = thread(id: "other", created: -20, updated: -10)
+
+        #expect(
+            HomeThreadDeleteConfirmation.targetIsValid(
+                request: request,
+                in: [target, other]
+            )
+        )
+        #expect(
+            !HomeThreadDeleteConfirmation.targetIsValid(
+                request: request,
+                in: [other]
+            )
+        )
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -7,6 +7,84 @@ struct DailyUXSidebarTests {
     private let now = Date(timeIntervalSince1970: 2_000_000)
 
     @Test
+    func settleUndoTargetsOnlyTheLatestNoticeOnce() {
+        let firstID = UUID()
+        let secondID = UUID()
+        var state = HomeThreadSettleUndoState()
+
+        state.present(
+            threadID: "first",
+            title: "First thread",
+            restoresPin: false,
+            id: firstID
+        )
+        state.present(
+            threadID: "second",
+            title: "Second thread",
+            restoresPin: true,
+            id: secondID
+        )
+
+        state.expire(id: firstID)
+        #expect(state.notice?.threadID == "second")
+        #expect(state.takeUndo(id: firstID) == nil)
+        #expect(state.takeUndo(id: secondID)?.restoresPin == true)
+        #expect(state.takeUndo(id: secondID) == nil)
+    }
+
+    @Test
+    func settleUndoExpiresOnlyItsCurrentNotice() {
+        let noticeID = UUID()
+        var state = HomeThreadSettleUndoState()
+
+        state.present(
+            threadID: "thread",
+            title: "Thread",
+            restoresPin: false,
+            id: noticeID
+        )
+        state.expire(id: noticeID)
+
+        #expect(state.notice == nil)
+    }
+
+    @Test
+    func settleUndoAppearsOnlyAfterAConfirmedSettlement() {
+        let settled = thread(
+            id: "settled",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let active = thread(id: "active", created: -20, updated: -10)
+
+        #expect(
+            HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: false,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                updatedThread: active
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                updatedThread: nil
+            )
+        )
+    }
+
+    @Test
     func activeOrderUsesCreationTimeAndDoesNotJumpWithActivity() {
         let olderCreationRecentActivity = thread(
             id: "old",

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -143,17 +143,27 @@ struct DailyUXSidebarTests {
         )
 
         #expect(
-            HomeThreadSettleUndoRestoration.capture(from: pinnedAndSnoozed)
+            HomeThreadSettleUndoRestoration.capture(from: pinnedAndSnoozed, now: now)
                 == HomeThreadSettleUndoRestoration(
                     restoresPin: true,
                     restoresSnoozeUntil: snoozeUntil
                 )
         )
         #expect(
-            HomeThreadSettleUndoRestoration.capture(from: snoozedOnly)
+            HomeThreadSettleUndoRestoration.capture(from: snoozedOnly, now: now)
                 == HomeThreadSettleUndoRestoration(
                     restoresPin: false,
                     restoresSnoozeUntil: snoozeUntil
+                )
+        )
+
+        var invalidatedSnooze = snoozedOnly
+        invalidatedSnooze.latestTurnCompletedAt = now
+        #expect(
+            HomeThreadSettleUndoRestoration.capture(from: invalidatedSnooze, now: now)
+                == HomeThreadSettleUndoRestoration(
+                    restoresPin: false,
+                    restoresSnoozeUntil: nil
                 )
         )
     }
@@ -334,6 +344,26 @@ struct DailyUXSidebarTests {
         #expect(state.notice?.id == noticeID)
         state.finishUndo(id: noticeID)
         #expect(state.notice == nil)
+    }
+
+    @Test
+    func failedSettleUndoKeepsTheNoticeRetryable() {
+        let noticeID = UUID()
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "thread")
+        state.present(
+            requestID: requestID,
+            threadID: "thread",
+            title: "Thread",
+            restoresPin: false,
+            restoresSnoozeUntil: nil,
+            id: noticeID
+        )
+
+        #expect(state.beginUndo(id: noticeID) != nil)
+        state.failUndo(id: noticeID)
+        #expect(state.notice?.id == noticeID)
+        #expect(state.beginUndo(id: noticeID) != nil)
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -4,6 +4,28 @@ import Testing
 
 @Suite("Sidebar v2")
 struct DailyUXSidebarTests {
+    @Test
+    func threadDeletionConfirmationCanBeCancelledAndReplaced() {
+        var confirmation = HomeThreadDeleteConfirmation()
+
+        confirmation.present(threadID: "thread-1", title: "Investigate swipe behavior")
+        #expect(
+            confirmation.request
+                == HomeThreadDeleteRequest(
+                    id: "thread-1",
+                    title: "Investigate swipe behavior"
+                )
+        )
+
+        confirmation.present(threadID: "thread-2", title: "Keep me")
+        confirmation.cancel()
+        #expect(confirmation.request == nil)
+
+        confirmation.present(threadID: "thread-3", title: "Replace me")
+        confirmation.present(threadID: "thread-4", title: "Delete me")
+        #expect(confirmation.request?.id == "thread-4")
+    }
+
     private let now = Date(timeIntervalSince1970: 2_000_000)
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -20,12 +20,10 @@ struct DailyUXSidebarTests {
         confirmation.present(threadID: "thread-2", title: "Keep me")
         confirmation.cancel()
         #expect(confirmation.request == nil)
-        #expect(confirmation.takeConfirmedRequest() == nil)
 
         confirmation.present(threadID: "thread-3", title: "Replace me")
         confirmation.present(threadID: "thread-4", title: "Delete me")
-        #expect(confirmation.takeConfirmedRequest()?.id == "thread-4")
-        #expect(confirmation.takeConfirmedRequest() == nil)
+        #expect(confirmation.request?.id == "thread-4")
     }
 
     private let now = Date(timeIntervalSince1970: 2_000_000)
@@ -97,6 +95,11 @@ struct DailyUXSidebarTests {
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
         #expect(activePlan.performsFirstActionWithFullSwipe)
+        #expect(settledPlan.performsFirstActionWithFullSwipe)
+        #expect(settledButWorkingPlan.performsFirstActionWithFullSwipe)
+        #expect(!archivedPlan.performsFirstActionWithFullSwipe)
+        #expect(!pinnedPlan.performsFirstActionWithFullSwipe)
+        #expect(!archiveOnlyPlan.performsFirstActionWithFullSwipe)
     }
 
     @Test
@@ -164,22 +167,46 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func dismissingAThreadCancelsOnlyItsPendingSettleNotice() {
+        var state = HomeThreadSettleUndoState()
+        let targetRequestID = state.beginSettleRequest(threadID: "target")
+
+        state.dismiss(threadID: "other")
+        #expect(state.latestSettleRequestID == targetRequestID)
+        #expect(state.latestSettleThreadID == "target")
+
+        state.dismiss(threadID: "target")
+        #expect(state.latestSettleRequestID == nil)
+        #expect(state.latestSettleThreadID == nil)
+        #expect(
+            state.present(
+                requestID: targetRequestID,
+                threadID: "target",
+                title: "Target",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) == nil
+        )
+    }
+
+    @Test
     func settleUndoTargetsOnlyTheLatestNoticeOnce() {
         let firstID = UUID()
         let secondID = UUID()
         var state = HomeThreadSettleUndoState()
-        let requestID = state.beginSettleRequest()
+        let firstRequestID = state.beginSettleRequest()
 
         state.present(
-            requestID: requestID,
+            requestID: firstRequestID,
             threadID: "first",
             title: "First thread",
             restoresPin: false,
             restoresSnoozeUntil: nil,
             id: firstID
         )
+        let secondRequestID = state.beginSettleRequest()
         state.present(
-            requestID: requestID,
+            requestID: secondRequestID,
             threadID: "second",
             title: "Second thread",
             restoresPin: true,

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -46,6 +46,18 @@ struct DailyUXSidebarTests {
             state: .working,
             isSettled: true
         )
+        let pinned = thread(
+            id: "pinned",
+            created: -20,
+            updated: -10,
+            pinned: -5
+        )
+        let archiveOnly = thread(
+            id: "archive-only",
+            created: -20,
+            updated: -10,
+            supportsSettlement: false
+        )
 
         let activePlan = HomeThreadSwipeActionPlan.make(
             thread: active,
@@ -62,13 +74,30 @@ struct DailyUXSidebarTests {
             isArchived: false,
             now: now
         )
+        let archivedPlan = HomeThreadSwipeActionPlan.make(
+            thread: active,
+            isArchived: true,
+            now: now
+        )
+        let pinnedPlan = HomeThreadSwipeActionPlan.make(
+            thread: pinned,
+            isArchived: false,
+            now: now
+        )
+        let archiveOnlyPlan = HomeThreadSwipeActionPlan.make(
+            thread: archiveOnly,
+            isArchived: false,
+            now: now
+        )
 
-        #expect(activePlan.orderedActions == [.settle, .delete])
-        #expect(settledPlan.orderedActions == [.reopen, .delete])
-        #expect(settledButWorkingPlan.orderedActions == [.settle, .delete])
-        #expect(activePlan.performsPrimaryWithFullSwipe)
+        #expect(activePlan.actions == [.settle, .delete])
+        #expect(settledPlan.actions == [.reopen, .delete])
+        #expect(settledButWorkingPlan.actions == [.reopen, .delete])
+        #expect(archivedPlan.actions == [.restore, .delete])
+        #expect(pinnedPlan.actions == [.unpin, .delete])
+        #expect(archiveOnlyPlan.actions == [.archive, .delete])
+        #expect(activePlan.performsFirstActionWithFullSwipe)
         #expect(!activePlan.deleteFinishesOptimistically)
-        #expect(activePlan.orderedActions.first != .delete)
     }
 
     @Test
@@ -115,6 +144,24 @@ struct DailyUXSidebarTests {
         )
         #expect(state.beginSettleRequest(ifSettling: false) == nil)
         #expect(state.latestSettleRequestID == settleRequestID)
+    }
+
+    @Test
+    func settleUndoDismissesOnlyTheMatchingThread() {
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest()
+        state.present(
+            requestID: requestID,
+            threadID: "target",
+            title: "Target",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+
+        state.dismiss(threadID: "other")
+        #expect(state.notice?.threadID == "target")
+        state.dismiss(threadID: "target")
+        #expect(state.notice == nil)
     }
 
     @Test
@@ -209,7 +256,7 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -217,7 +264,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -225,7 +272,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -233,7 +280,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: true,
+                previousWasSettled: true,
                 updatedThread: settled
             )
         )
@@ -241,7 +288,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: active
             )
         )
@@ -249,7 +296,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: nil
             )
         )
@@ -711,7 +758,8 @@ struct DailyUXSidebarTests {
         state: FeatureThreadState = .idle,
         isSettled: Bool = false,
         pinned: TimeInterval? = nil,
-        snoozedUntil: Date? = nil
+        snoozedUntil: Date? = nil,
+        supportsSettlement: Bool? = nil
     ) -> FeatureThread {
         FeatureThread(
             id: id,
@@ -724,7 +772,8 @@ struct DailyUXSidebarTests {
             lastActivityAt: now.addingTimeInterval(updated),
             snoozedUntil: snoozedUntil,
             snoozedAt: snoozedUntil.map { _ in now.addingTimeInterval(updated) },
-            pinnedAt: pinned.map(now.addingTimeInterval)
+            pinnedAt: pinned.map(now.addingTimeInterval),
+            supportsSettlement: supportsSettlement
         )
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -190,6 +190,51 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func settleUndoRejectsAThreadThatDoesNotMatchTheRequest() {
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "target")
+
+        #expect(
+            state.present(
+                requestID: requestID,
+                threadID: "other",
+                title: "Other",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) == nil
+        )
+        #expect(state.notice == nil)
+        #expect(state.latestSettleRequestID == requestID)
+        #expect(state.latestSettleThreadID == "target")
+    }
+
+    @Test
+    func settleUndoRequestCanPresentOnlyOnce() {
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "target")
+
+        #expect(
+            state.present(
+                requestID: requestID,
+                threadID: "target",
+                title: "Target",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) != nil
+        )
+        #expect(
+            state.present(
+                requestID: requestID,
+                threadID: "target",
+                title: "Target again",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) == nil
+        )
+        #expect(state.notice?.title == "Target")
+    }
+
+    @Test
     func settleUndoTargetsOnlyTheLatestNoticeOnce() {
         let firstID = UUID()
         let secondID = UUID()
@@ -282,7 +327,6 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -290,7 +334,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -298,7 +341,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
-                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -306,15 +348,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasSettled: true,
-                updatedThread: settled
-            )
-        )
-        #expect(
-            !HomeThreadSettleUndoState.shouldPresent(
-                afterRequesting: true,
-                didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: active
             )
         )
@@ -322,7 +355,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: nil
             )
         )

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -97,7 +97,6 @@ struct DailyUXSidebarTests {
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
         #expect(activePlan.performsFirstActionWithFullSwipe)
-        #expect(!activePlan.deleteFinishesOptimistically)
     }
 
     @Test
@@ -300,6 +299,43 @@ struct DailyUXSidebarTests {
                 updatedThread: nil
             )
         )
+    }
+
+    @Test
+    func settleUndoTargetRequiresTheSameSettledUnarchivedThread() {
+        let notice = HomeThreadSettleUndoNotice(
+            id: UUID(),
+            threadID: "target",
+            title: "Target",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+        let settled = thread(
+            id: "target",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let active = thread(id: "target", created: -20, updated: -10)
+        let archived = thread(
+            id: "target",
+            created: -20,
+            updated: -10,
+            isArchived: true,
+            isSettled: true
+        )
+        let other = thread(
+            id: "other",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+
+        #expect(HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [settled]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [active]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [archived]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [other]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: []))
     }
 
     @Test
@@ -756,6 +792,7 @@ struct DailyUXSidebarTests {
         created: TimeInterval,
         updated: TimeInterval,
         state: FeatureThreadState = .idle,
+        isArchived: Bool = false,
         isSettled: Bool = false,
         pinned: TimeInterval? = nil,
         snoozedUntil: Date? = nil,
@@ -768,6 +805,7 @@ struct DailyUXSidebarTests {
             createdAt: now.addingTimeInterval(created),
             updatedAt: now.addingTimeInterval(updated),
             state: state,
+            isArchived: isArchived,
             isSettled: isSettled,
             lastActivityAt: now.addingTimeInterval(updated),
             snoozedUntil: snoozedUntil,

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -20,10 +20,12 @@ struct DailyUXSidebarTests {
         confirmation.present(threadID: "thread-2", title: "Keep me")
         confirmation.cancel()
         #expect(confirmation.request == nil)
+        #expect(confirmation.takeConfirmedRequest() == nil)
 
         confirmation.present(threadID: "thread-3", title: "Replace me")
         confirmation.present(threadID: "thread-4", title: "Delete me")
-        #expect(confirmation.request?.id == "thread-4")
+        #expect(confirmation.takeConfirmedRequest()?.id == "thread-4")
+        #expect(confirmation.takeConfirmedRequest() == nil)
     }
 
     private let now = Date(timeIntervalSince1970: 2_000_000)
@@ -33,24 +35,31 @@ struct DailyUXSidebarTests {
         let firstID = UUID()
         let secondID = UUID()
         var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest()
 
         state.present(
+            requestID: requestID,
             threadID: "first",
             title: "First thread",
             restoresPin: false,
+            restoresSnoozeUntil: nil,
             id: firstID
         )
         state.present(
+            requestID: requestID,
             threadID: "second",
             title: "Second thread",
             restoresPin: true,
+            restoresSnoozeUntil: now.addingTimeInterval(300),
             id: secondID
         )
 
         state.expire(id: firstID)
         #expect(state.notice?.threadID == "second")
         #expect(state.takeUndo(id: firstID) == nil)
-        #expect(state.takeUndo(id: secondID)?.restoresPin == true)
+        let undo = state.takeUndo(id: secondID)
+        #expect(undo?.restoresPin == true)
+        #expect(undo?.restoresSnoozeUntil == now.addingTimeInterval(300))
         #expect(state.takeUndo(id: secondID) == nil)
     }
 
@@ -58,16 +67,45 @@ struct DailyUXSidebarTests {
     func settleUndoExpiresOnlyItsCurrentNotice() {
         let noticeID = UUID()
         var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest()
 
         state.present(
+            requestID: requestID,
             threadID: "thread",
             title: "Thread",
             restoresPin: false,
+            restoresSnoozeUntil: nil,
             id: noticeID
         )
         state.expire(id: noticeID)
 
         #expect(state.notice == nil)
+    }
+
+    @Test
+    func settleUndoRejectsAnOlderRequestThatFinishesLast() {
+        var state = HomeThreadSettleUndoState()
+        let firstRequestID = state.beginSettleRequest()
+        let secondRequestID = state.beginSettleRequest()
+
+        let stale = state.present(
+            requestID: firstRequestID,
+            threadID: "first",
+            title: "First",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+        let current = state.present(
+            requestID: secondRequestID,
+            threadID: "second",
+            title: "Second",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+
+        #expect(stale == nil)
+        #expect(current?.threadID == "second")
+        #expect(state.notice?.threadID == "second")
     }
 
     @Test
@@ -83,24 +121,48 @@ struct DailyUXSidebarTests {
         #expect(
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: settled
             )
         )
         #expect(
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: settled
             )
         )
         #expect(
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
+                didSucceed: false,
+                previousThread: active,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                didSucceed: true,
+                previousThread: settled,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: active
             )
         )
         #expect(
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: nil
             )
         )

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -90,13 +90,13 @@ struct DailyUXSidebarTests {
 
         #expect(activePlan.actions == [.settle, .delete])
         #expect(settledPlan.actions == [.reopen, .delete])
-        #expect(settledButWorkingPlan.actions == [.settle, .delete])
+        #expect(settledButWorkingPlan.actions == [.archive, .delete])
         #expect(archivedPlan.actions == [.restore, .delete])
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
         #expect(activePlan.performsFirstActionWithFullSwipe)
         #expect(settledPlan.performsFirstActionWithFullSwipe)
-        #expect(settledButWorkingPlan.performsFirstActionWithFullSwipe)
+        #expect(!settledButWorkingPlan.performsFirstActionWithFullSwipe)
         #expect(!archivedPlan.performsFirstActionWithFullSwipe)
         #expect(!pinnedPlan.performsFirstActionWithFullSwipe)
         #expect(!archiveOnlyPlan.performsFirstActionWithFullSwipe)
@@ -121,7 +121,7 @@ struct DailyUXSidebarTests {
         #expect(HomeThreadSwipeActionPlan.settlementAction(for: settled, now: now) == .reopen)
         #expect(
             HomeThreadSwipeActionPlan.settlementAction(for: settledButWorking, now: now)
-                == .settle
+                == nil
         )
     }
 
@@ -153,7 +153,7 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoRestoration.capture(from: snoozedOnly)
                 == HomeThreadSettleUndoRestoration(
                     restoresPin: false,
-                    restoresSnoozeUntil: nil
+                    restoresSnoozeUntil: snoozeUntil
                 )
         )
     }

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -657,6 +657,24 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func testSettleReportsWhetherTheMutationSucceeded() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
+        client.createdThread = thread
+        let model = testRootModel(client: client)
+        _ = await model.createThread(projectID: thread.projectID, title: nil, selection: nil)
+
+        let succeeded = await model.setSettled(thread.id, settled: true)
+        #expect(succeeded)
+        #expect(model.snapshot.threads[0].isSettled)
+
+        client.setThreadSettledError = URLError(.cannotConnectToHost)
+        let failed = await model.setSettled(thread.id, settled: false)
+        #expect(!failed)
+        #expect(model.snapshot.threads[0].isSettled)
+    }
+
+    @Test
     func testCancelledDetailRefreshKeepsCachedContentWithoutAlert() async {
         let client = FeatureClientStub()
         let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
@@ -1226,6 +1244,7 @@ private final class FeatureClientStub: FeatureClient {
     var sendMessageCallCount = 0
     var startTaskError: (any Error)?
     var sendMessageError: (any Error)?
+    var setThreadSettledError: (any Error)?
     var enabledEnvironmentID: String?
     var environmentEnabledValue: Bool?
     var removedEnvironmentID: String?
@@ -1334,6 +1353,9 @@ private final class FeatureClientStub: FeatureClient {
 
     func renameThread(id: String, title: String) async throws {}
     func setThreadArchived(id: String, archived: Bool) async throws {}
+    func setThreadSettled(id: String, settled: Bool) async throws {
+        if let setThreadSettledError { throw setThreadSettledError }
+    }
     func deleteThread(id: String) async throws {}
 
     func loadThread(id: String) async throws -> FeatureThreadDetail {

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -199,4 +199,36 @@ struct HomeThreadMetadataTests {
             ) == nil
         )
     }
+
+    @Test
+    func environmentCatalogMissDoesNotUseLegacyProviders() throws {
+        let thread = FeatureThread(
+            id: "thread",
+            projectID: "project",
+            title: "Use provider",
+            providerID: "shared-id"
+        )
+        let snapshot = FeatureSnapshot(
+            projects: [
+                FeatureProject(
+                    id: "project",
+                    environmentID: "remote",
+                    name: "Remote",
+                    path: "/remote"
+                ),
+            ],
+            threads: [thread],
+            providers: [
+                FeatureProvider(id: "shared-id", name: "Wrong environment", driver: "codex"),
+            ],
+            providersByEnvironment: ["local": [
+                FeatureProvider(id: "shared-id", name: "Local only", driver: "codex"),
+            ]]
+        )
+
+        #expect(thread.homeProviderLabel(in: snapshot) == "shared-id")
+        let context = try #require(HomeThreadRowContext.index(snapshot: snapshot)[thread.id])
+        #expect(context.providerName == "shared-id")
+        #expect(context.providerDriver == "shared-id")
+    }
 }

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -8,6 +8,11 @@ On web and desktop, drag a pinned thread to change its position. On mobile, open
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.
 
+In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. A full
+swipe uses the lifecycle action, such as **Settle** or **Reopen**; it never deletes the thread.
+Deleting asks for confirmation. After settling a thread, use the temporary **Undo** message to
+return it to active work and restore its previous pin and snooze state.
+
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -9,7 +9,7 @@ and choose **Move up** or **Move down**. The order is stored by the server and a
 other connected devices.
 
 In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. A full
-swipe uses the lifecycle action, such as **Settle** or **Reopen**; it never deletes the thread.
+swipe settles or reopens a thread; it never deletes the thread.
 Deleting asks for confirmation. After settling a thread, use the temporary **Undo** message to
 return it to active work and restore its previous pin and snooze state.
 

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -8,8 +8,8 @@ On web and desktop, drag a pinned thread to change its position. On mobile, open
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.
 
-In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. A full
-swipe settles or reopens a thread; it never deletes the thread.
+In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. On rows
+that offer **Settle** or **Reopen**, a full swipe performs that action; it never deletes the thread.
 Deleting asks for confirmation. After settling a thread, use the temporary **Undo** message to
 return it to active work and restore its previous pin and snooze state.
 


### PR DESCRIPTION
## Problem

The native iPhone thread list made a destructive swipe too easy: the primary full-swipe path could resolve to Delete, deletion had no confirmation, and settling had no immediate recovery path.

## Fix

- **Settle**, **Reopen**, **Restore**, **Unpin**, or **Archive** is always the primary full-swipe action; **Delete** is never first.
- Delete keeps the row in place and presents a destructive confirmation that names the thread.
- A successful active-to-settled transition shows a five-second **Undo** message.
- Undo reopens the thread and restores prior pin and snooze state, with a contextual error if a partial restore fails.
- VoiceOver and Switch Control get a 15-second recovery window, a 44-point Undo target, and prioritized accessibility order.

Fixes #6106.
Fixes #6107.

## Visual evidence

| Partial swipe | Delete confirmation | Settle recovery |
| --- | --- | --- |
| ![Delete and Settle actions](https://raw.githubusercontent.com/saphid/t3code/3d3a7e41ed6d5d0028431bcc0017ddd58b51ede9/partial-swipe-actions.png) | ![Delete confirmation](https://raw.githubusercontent.com/saphid/t3code/3d3a7e41ed6d5d0028431bcc0017ddd58b51ede9/delete-confirmation.png) | ![Thread settled message with Undo](https://raw.githubusercontent.com/saphid/t3code/3d3a7e41ed6d5d0028431bcc0017ddd58b51ede9/settle-undo.png) |

[Watch the 28-second interaction video](https://github.com/saphid/t3code/blob/3d3a7e41ed6d5d0028431bcc0017ddd58b51ede9/swipe-safety-demo.mp4?raw=1).

Before this change, Delete completed immediately and Settle had no recovery message. The screenshots and video above show the replacement interaction on the signed final-head simulator build.

## Verification

- Focused `DailyUXSidebarTests`: 24/24 passed
- Focused `FeatureRootModelTests`: 32/32 passed
- Combined focused run: 56 tests in 2 suites passed
- Signed current-head build installed and launched on iPhone 17 Pro simulator (iOS 26.5)
- Full-width swipe produced the Settle flow; the video proves Undo returns the thread to the active list
- Delete confirmation Cancel preserved both seeded threads
- `git diff --check`: passed

## Scope decision

This is intentionally one native SwiftUI thread-swipe safety concern. Confirmation, primary-action ordering, and recovery touch the same coordinator/view state; splitting them would create overlapping conflicting PRs and unsafe intermediate combinations. The React Native client, providers, and wire contracts are unchanged because the reported behavior is specific to the separate native SwiftUI iPhone client.

## Review

- Direct Claude Opus 5 high review of `f98cab553..4ecd6697c`: exit 0; six code findings were addressed.
- Fresh direct review of the amended frozen range `f98cab553..3f90545f9` is running; any actionable finding will be resolved before merge.

Built with GPT-5.6 Sol high in Codex through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only SwiftUI UX and local state; thread lifecycle still goes through existing APIs, with broader test coverage for swipe plans and undo edge cases.
> 
> **Overview**
> Makes the native iPhone home thread list safer by changing swipe behavior, gating delete, and adding settle recovery.
> 
> **Swipe actions** are centralized in `HomeThreadSwipeActionPlan`: the **first** trailing action is always restore, unpin, settle/reopen, or archive; **Delete** is second and never gets full swipe. Settle/reopen can use full swipe where appropriate. Delete swipe completes without removing the row so a confirmation alert can run.
> 
> **Delete** flows through `HomeThreadDeleteConfirmation` and a named destructive alert; confirming delete clears any settle-undo state for that thread.
> 
> **Settle undo** adds `HomeThreadSettleUndoState` and a sidebar toast after a successful active→settled transition. **Undo** reopens the thread and restores prior pin/snooze (captured before settle). `setSettled`, `setPinned`, and `setSnoozed` on `FeatureRootModel` now return **`Bool`** so undo and toasts only run when mutations succeed.
> 
> **Provider labels** prefer `providersByEnvironment` for the resolved environment and only fall back to the global `providers` list when that map is absent—avoiding wrong-environment names when IDs collide.
> 
> User docs for the iPhone app describe the new swipe, confirmation, and undo behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c68326640b4b528d0d5956124d595861e8f8931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make thread swipe actions safe with delete confirmation and settle Undo toast
> - Replaces ad-hoc swipe action construction in [`HomeThreadCollectionView`](https://github.com/pingdotgg/t3code/pull/6117/files#diff-71b51c44b9cda4172685b500cb742a05438cef1aff0cbb3ae51526305da7fbb7) with a plan-driven approach (`HomeThreadSwipeActionPlan`) that prevents full-swipe from triggering Delete; full-swipe now only performs Settle or Reopen.
> - Adds a delete confirmation alert and a temporary Undo toast in [`WorkspaceView`](https://github.com/pingdotgg/t3code/pull/6117/files#diff-06a43c1b27d1a4bc0456aef6f149417250cdee6930e57b06458c76f9c606b644); Undo reopens the thread and restores its previous pin and snooze state.
> - Posts accessibility announcements for settle/undo actions and auto-expires notices, with validity checks that cancel stale confirmations when the target thread leaves the snapshot.
> - Fixes provider resolution in [`DailyUXModels`](https://github.com/pingdotgg/t3code/pull/6117/files#diff-2bae36acfcaa822eaaa43aea2e36dd5ded98f236fd6c38e524e50fbd0c85331e) to fall back to the global providers list when no per-environment catalog is present.
> - Behavioral Change: Delete no longer animates row removal immediately; it waits for confirmation. Full-swipe behavior changes from Delete to Settle/Reopen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c68326.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable with runnable checks green; requested review changes remain. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
