### PR TITLE
fix(server): capture complete OpenCode CLI inventory

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.fileCapture.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.fileCapture.test.ts
@@ -1,0 +1,52 @@
+// @effect-diagnostics nodeBuiltinImport:off - exercises the Node process/file boundary used by the capture helper.
+import * as NodeAssert from "node:assert/strict";
+
+import { describe, it } from "vite-plus/test";
+
+import { captureOpenCodeCommandWithFileStdout } from "./opencodeRuntime.ts";
+
+describe("captureOpenCodeCommandWithFileStdout", () => {
+  it("captures stdout larger than a pipe buffer without dropping the tail", async () => {
+    const size = 512 * 1024;
+    const marker = "PRO_MAX_AT_THE_END";
+    const result = await captureOpenCodeCommandWithFileStdout({
+      command: process.execPath,
+      args: ["-e", `process.stdout.write("x".repeat(${size}) + "${marker}")`],
+      platform: "darwin",
+      shell: false,
+    });
+
+    NodeAssert.equal(result.code, 0);
+    NodeAssert.equal(result.stdout.length, size + marker.length);
+    NodeAssert.ok(result.stdout.endsWith(marker));
+  });
+
+  it("captures stderr and a non-zero exit code", async () => {
+    const result = await captureOpenCodeCommandWithFileStdout({
+      command: process.execPath,
+      args: ["-e", 'process.stderr.write("failed"); process.exit(7)'],
+      platform: "darwin",
+      shell: false,
+    });
+
+    NodeAssert.equal(result.code, 7);
+    NodeAssert.equal(result.stdout, "");
+    NodeAssert.equal(result.stderr, "failed");
+  });
+
+  it("aborts a running command", async () => {
+    const controller = new AbortController();
+    const result = captureOpenCodeCommandWithFileStdout({
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1000)"],
+      platform: "darwin",
+      shell: false,
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    await NodeAssert.rejects(result, (cause: unknown) => {
+      return cause instanceof Error && cause.name === "AbortError";
+    });
+  });
+});

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -1,3 +1,8 @@
+// @effect-diagnostics nodeBuiltinImport:off - Effect ChildProcess cannot redirect stdout to a file descriptor.
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
 import * as NodeURL from "node:url";
 
 import type { ChatAttachment, ProviderApprovalDecision, RuntimeMode } from "@t3tools/contracts";
@@ -96,6 +101,117 @@ export interface OpenCodeCommandResult {
   readonly stdout: string;
   readonly stderr: string;
   readonly code: number;
+}
+
+interface OpenCodeFileCaptureInput {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly shell: boolean;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly signal?: AbortSignal;
+  readonly platform: NodeJS.Platform;
+}
+
+/** @internal */
+export function captureOpenCodeCommandWithFileStdout(
+  input: OpenCodeFileCaptureInput,
+): Promise<OpenCodeCommandResult> {
+  let tempDirectory: string | undefined;
+  let stdoutFd: number | undefined;
+  try {
+    tempDirectory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-opencode-"));
+    const stdoutPath = NodePath.join(tempDirectory, "stdout");
+    stdoutFd = NodeFS.openSync(stdoutPath, "w");
+    const ownedTempDirectory = tempDirectory;
+    const ownedStdoutFd = stdoutFd;
+
+    return new Promise((resolve, reject) => {
+      let stderr = "";
+      let settled = false;
+      let abortError: Error | undefined;
+      let child: NodeChildProcess.ChildProcess | undefined;
+      const cleanup = () => {
+        try {
+          NodeFS.rmSync(ownedTempDirectory, { recursive: true, force: true });
+        } catch {
+          // Temp-file cleanup must never prevent the command result from settling.
+        }
+      };
+      const fail = (cause: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(cause);
+      };
+      const abort = () => {
+        if (settled || child?.pid === undefined) return;
+        abortError = new Error("The operation was aborted", { cause: input.signal?.reason });
+        abortError.name = "AbortError";
+        if (input.platform === "win32") {
+          NodeChildProcess.spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+            windowsHide: true,
+          });
+        } else {
+          try {
+            process.kill(-child.pid, "SIGKILL");
+          } catch {
+            child.kill("SIGKILL");
+          }
+        }
+      };
+
+      try {
+        child = NodeChildProcess.spawn(input.command, [...input.args], {
+          detached: input.platform !== "win32",
+          env: input.environment ?? process.env,
+          shell: input.shell,
+          stdio: ["ignore", ownedStdoutFd, "pipe"],
+          windowsHide: true,
+        });
+        NodeFS.closeSync(ownedStdoutFd);
+        stdoutFd = undefined;
+      } catch (cause) {
+        try {
+          NodeFS.closeSync(ownedStdoutFd);
+        } catch {
+          // The descriptor may already be closed by a partial spawn.
+        }
+        stdoutFd = undefined;
+        fail(cause);
+        return;
+      }
+
+      child.stderr?.setEncoding("utf8");
+      child.stderr?.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.once("error", fail);
+      input.signal?.addEventListener("abort", abort, { once: true });
+      if (input.signal?.aborted) abort();
+      child.once("close", (code) => {
+        if (settled) return;
+        input.signal?.removeEventListener("abort", abort);
+        if (abortError !== undefined) {
+          fail(abortError);
+          return;
+        }
+        try {
+          const stdout = NodeFS.readFileSync(stdoutPath, "utf8");
+          settled = true;
+          cleanup();
+          resolve({ stdout, stderr, code: code ?? 1 });
+        } catch (cause) {
+          fail(cause);
+        }
+      });
+    });
+  } catch (cause) {
+    if (stdoutFd !== undefined) NodeFS.closeSync(stdoutFd);
+    if (tempDirectory !== undefined) {
+      NodeFS.rmSync(tempDirectory, { recursive: true, force: true });
+    }
+    return Promise.reject(cause);
+  }
 }
 
 export interface OpenCodeInventory {
@@ -436,6 +552,39 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       ),
     );
 
+  const runOpenCodeCommandWithFileStdout = (input: {
+    readonly binaryPath: string;
+    readonly args: ReadonlyArray<string>;
+    readonly environment?: NodeJS.ProcessEnv;
+  }) =>
+    Effect.gen(function* () {
+      const spawnCommand = yield* resolveCommand(input.binaryPath, input.args, input.environment);
+      const result = yield* Effect.tryPromise({
+        try: (signal) =>
+          captureOpenCodeCommandWithFileStdout({
+            command: spawnCommand.command,
+            args: spawnCommand.args,
+            shell: spawnCommand.shell,
+            signal,
+            platform: hostPlatform,
+            ...(input.environment ? { environment: input.environment } : {}),
+          }),
+        catch: (cause) =>
+          ensureRuntimeError(
+            "runOpenCodeCommandWithFileStdout",
+            `Failed to execute '${input.binaryPath} ${input.args.join(" ")}': ${openCodeRuntimeErrorDetail(cause)}`,
+            cause,
+          ),
+      });
+      if (yield* isWindowsCommandNotFound(result.code, result.stderr)) {
+        return yield* new OpenCodeRuntimeError({
+          operation: "runOpenCodeCommandWithFileStdout",
+          detail: `spawn ${input.binaryPath} ENOENT`,
+        });
+      }
+      return result;
+    });
+
   const startOpenCodeServerProcess: OpenCodeRuntimeShape["startOpenCodeServerProcess"] = (input) =>
     Effect.gen(function* () {
       // Bind this server's lifetime to the caller's scope. When the caller's
@@ -665,15 +814,17 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       const env = input.environment !== undefined ? { environment: input.environment } : ({} as {});
 
       const runModelsCli = () =>
-        runOpenCodeCommand({
+        runOpenCodeCommandWithFileStdout({
           binaryPath: input.binaryPath,
           args: ["models", "--verbose"],
           ...env,
         }).pipe(Effect.exit);
       const runAgentsCli = () =>
-        runOpenCodeCommand({ binaryPath: input.binaryPath, args: ["agent", "list"], ...env }).pipe(
-          Effect.exit,
-        );
+        runOpenCodeCommandWithFileStdout({
+          binaryPath: input.binaryPath,
+          args: ["agent", "list"],
+          ...env,
+        }).pipe(Effect.exit);
 
       // First attempt — run both in parallel
       let [modelsResult, agentsResult] = yield* Effect.all([runModelsCli(), runAgentsCli()], {


### PR DESCRIPTION
Fixes #6118

## Problem

Large `opencode agent list` and `opencode models --verbose` responses can lose their tail when captured through a pipe, silently omitting valid agents from the picker.

## Fix

Capture only those two large CLI outputs through a temporary file descriptor, then feed the complete text into the existing parsers. This preserves the existing provider health, version gate, model discovery, agent filtering, and local-server lifecycle.

The capture is interruptible, cleans up temporary resources, preserves Windows shell command resolution and missing-command classification, and terminates the spawned process tree on cancellation.

## Verification

- Real OpenCode agent capture: 7.58 MB, 61 agent headers, `Pro Max` present
- `pnpm --filter t3 typecheck`
- Targeted lint/format
- 24 focused tests across file capture, CLI parsing, and provider status
- `git diff --check`
- Manual T3 Code verification: `Pro Max` appears in the agent picker

Generated with OpenAI GPT-5.6 Luna via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process spawning, cancellation, and temp-file I/O on the OpenCode provider path; scope is limited to two inventory CLI commands with tests, but incorrect capture could still break model/agent discovery.
> 
> **Overview**
> Fixes truncated **`opencode models --verbose`** and **`opencode agent list`** output when responses exceed pipe buffer size, which could silently drop agents (e.g. missing from the picker).
> 
> Adds **`captureOpenCodeCommandWithFileStdout`**, which redirects child **stdout** to a temp file via Node **`child_process`**, still pipes **stderr**, reads the full file on exit, and cleans up. It supports **`AbortSignal`** (process-tree kill on Unix, **`taskkill`** on Windows) and is wired through **`runOpenCodeCommandWithFileStdout`** with the same command resolution and Windows ENOENT handling as the existing pipe-based runner.
> 
> **`loadInventoryFromCli`** now uses the file-capture path for those two commands only; other CLI usage stays on **`runOpenCodeCommand`**. New unit tests cover large stdout, stderr/exit codes, and abort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2687cd44dccabb555b9f658b3574ceaf1d71a3e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Capture OpenCode CLI inventory stdout via a temp file instead of a pipe buffer
> - Adds `captureOpenCodeCommandWithFileStdout` in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/6121/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8), which redirects child process stdout to a temp file to avoid pipe buffer limits that could truncate large `models --verbose` or `agent list` output.
> - Adds a corresponding `runOpenCodeCommandWithFileStdout` Effect handler and switches `loadInventoryFromCli` to use it for both CLI calls.
> - Implements cross-platform process termination: uses `taskkill /T /F` on Windows and negative-pid `kill` (with fallback) on POSIX; temp directory is cleaned up in all code paths.
> - Adds three tests covering large stdout capture, non-zero exit with stderr, and `AbortSignal`-driven cancellation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2687cd4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->