### PR TITLE
fix(web): thread error banner dismiss survives reconnect and rerenders

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1511,6 +1511,12 @@ function ChatViewContent(props: ChatViewProps) {
   )
     ? threadError
     : null;
+  // Dismissing only mutates the session-scoped mask set, which does not
+  // trigger a render on its own; setThreadError(null) can also bail when the
+  // local shadow is already empty and the banner is driven purely by
+  // session.lastError. Bump a tick so the banner hides immediately. Mirrors
+  // the branch mismatch banner.
+  const [, setThreadErrorBannerDismissTick] = useState(0);
   const runtimeMode = composerRuntimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   // Plan mode is legacy (Settings → Beta). With the flag off the effective
   // mode is forced to "default" — even for threads with a stored plan mode —
@@ -6168,6 +6174,7 @@ function ChatViewContent(props: ChatViewProps) {
           onDismiss={() => {
             setThreadError(activeThread.id, null);
             dismissThreadErrorBannerForSession(threadErrorBannerKey);
+            setThreadErrorBannerDismissTick((tick) => tick + 1);
           }}
         />
         {/* Main content area with optional plan sidebar */}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -264,7 +264,11 @@ import {
   ProviderStatusBanner,
   shouldShowProviderStatusBanner,
 } from "./chat/ProviderStatusBanner";
-import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
+import {
+  getThreadErrorBannerKey,
+  shouldShowThreadErrorBanner,
+  ThreadErrorBanner,
+} from "./chat/ThreadErrorBanner";
 import { resolveThreadPr } from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
 import { ThreadSyncStatusPill } from "./chat/ThreadSyncStatusPill";
@@ -1493,6 +1497,26 @@ function ChatViewContent(props: ChatViewProps) {
   const threadError = isServerThread
     ? (localServerError ?? activeServerThread?.session?.lastError ?? null)
     : localDraftError;
+  // Dismissals can only mask the shown error, never clear it: a server thread
+  // keeps its error in session.lastError, so clearing the local shadow would
+  // just fall through to the persisted one. Mask the current error until a
+  // different error arrives, mirroring the provider status banner.
+  const threadErrorBannerKey = getThreadErrorBannerKey(routeThreadKey, threadError);
+  const [dismissedThreadErrorBannerKey, setDismissedThreadErrorBannerKey] = useState<string | null>(
+    null,
+  );
+  useEffect(() => {
+    if (threadError === null && dismissedThreadErrorBannerKey !== null) {
+      setDismissedThreadErrorBannerKey(null);
+    }
+  }, [dismissedThreadErrorBannerKey, threadError]);
+  const visibleThreadError = shouldShowThreadErrorBanner(
+    routeThreadKey,
+    threadError,
+    dismissedThreadErrorBannerKey,
+  )
+    ? threadError
+    : null;
   const runtimeMode = composerRuntimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   // Plan mode is legacy (Settings → Beta). With the flag off the effective
   // mode is forced to "default" — even for threads with a stored plan mode —
@@ -2618,7 +2642,7 @@ function ChatViewContent(props: ChatViewProps) {
   )
     ? activeProviderStatus
     : null;
-  const hasTimelineTopBanner = Boolean(threadError) || visibleProviderStatus !== null;
+  const hasTimelineTopBanner = Boolean(visibleThreadError) || visibleProviderStatus !== null;
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
@@ -6146,8 +6170,11 @@ function ChatViewContent(props: ChatViewProps) {
         </header>
 
         <ThreadErrorBanner
-          error={threadError}
-          onDismiss={() => setThreadError(activeThread.id, null)}
+          error={visibleThreadError}
+          onDismiss={() => {
+            setThreadError(activeThread.id, null);
+            setDismissedThreadErrorBannerKey(threadErrorBannerKey);
+          }}
         />
         {/* Main content area with optional plan sidebar */}
         <div className="flex min-h-0 min-w-0 flex-1">

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -265,7 +265,9 @@ import {
   shouldShowProviderStatusBanner,
 } from "./chat/ProviderStatusBanner";
 import {
+  dismissThreadErrorBannerForSession,
   getThreadErrorBannerKey,
+  isThreadErrorBannerDismissedForSession,
   shouldShowThreadErrorBanner,
   ThreadErrorBanner,
 } from "./chat/ThreadErrorBanner";
@@ -1502,18 +1504,10 @@ function ChatViewContent(props: ChatViewProps) {
   // just fall through to the persisted one. Mask the current error until a
   // different error arrives, mirroring the provider status banner.
   const threadErrorBannerKey = getThreadErrorBannerKey(routeThreadKey, threadError);
-  const [dismissedThreadErrorBannerKey, setDismissedThreadErrorBannerKey] = useState<string | null>(
-    null,
-  );
-  useEffect(() => {
-    if (threadError === null && dismissedThreadErrorBannerKey !== null) {
-      setDismissedThreadErrorBannerKey(null);
-    }
-  }, [dismissedThreadErrorBannerKey, threadError]);
   const visibleThreadError = shouldShowThreadErrorBanner(
     routeThreadKey,
     threadError,
-    dismissedThreadErrorBannerKey,
+    isThreadErrorBannerDismissedForSession(threadErrorBannerKey),
   )
     ? threadError
     : null;
@@ -6173,7 +6167,7 @@ function ChatViewContent(props: ChatViewProps) {
           error={visibleThreadError}
           onDismiss={() => {
             setThreadError(activeThread.id, null);
-            setDismissedThreadErrorBannerKey(threadErrorBannerKey);
+            dismissThreadErrorBannerForSession(threadErrorBannerKey);
           }}
         />
         {/* Main content area with optional plan sidebar */}

--- a/apps/web/src/components/chat/ThreadErrorBanner.test.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.test.tsx
@@ -1,9 +1,35 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
 
-import { ThreadErrorBanner } from "./ThreadErrorBanner";
+import {
+  getThreadErrorBannerKey,
+  shouldShowThreadErrorBanner,
+  ThreadErrorBanner,
+} from "./ThreadErrorBanner";
 
 describe("ThreadErrorBanner", () => {
+  it("stays hidden after its current error is dismissed", () => {
+    const dismissedKey = getThreadErrorBannerKey("env:thread", "Aborted");
+
+    expect(shouldShowThreadErrorBanner("env:thread", "Aborted", null)).toBe(true);
+    expect(shouldShowThreadErrorBanner("env:thread", "Aborted", dismissedKey)).toBe(false);
+  });
+
+  it("reappears when a new error arrives on the same thread", () => {
+    const dismissedKey = getThreadErrorBannerKey("env:thread", "Aborted");
+
+    expect(shouldShowThreadErrorBanner("env:thread", "Turn failed", dismissedKey)).toBe(true);
+  });
+
+  it("scopes dismissals to the thread that dismissed them", () => {
+    const dismissedKey = getThreadErrorBannerKey("env:thread", "Aborted");
+
+    expect(shouldShowThreadErrorBanner("env:other-thread", "Aborted", dismissedKey)).toBe(true);
+  });
+
+  it("never shows a null error", () => {
+    expect(shouldShowThreadErrorBanner("env:thread", null, null)).toBe(false);
+  });
   it("aligns the warning and dismiss icons with the first line of a multi-line error", () => {
     const markup = renderToStaticMarkup(
       <ThreadErrorBanner

--- a/apps/web/src/components/chat/ThreadErrorBanner.test.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.test.tsx
@@ -2,33 +2,72 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  dismissThreadErrorBannerForSession,
   getThreadErrorBannerKey,
+  isThreadErrorBannerDismissedForSession,
   shouldShowThreadErrorBanner,
   ThreadErrorBanner,
 } from "./ThreadErrorBanner";
 
 describe("ThreadErrorBanner", () => {
   it("stays hidden after its current error is dismissed", () => {
-    const dismissedKey = getThreadErrorBannerKey("env:thread", "Aborted");
+    const bannerKey = getThreadErrorBannerKey("env:thread-a", "Aborted");
+    dismissThreadErrorBannerForSession(bannerKey);
 
-    expect(shouldShowThreadErrorBanner("env:thread", "Aborted", null)).toBe(true);
-    expect(shouldShowThreadErrorBanner("env:thread", "Aborted", dismissedKey)).toBe(false);
+    expect(
+      shouldShowThreadErrorBanner(
+        "env:thread-a",
+        "Aborted",
+        isThreadErrorBannerDismissedForSession(bannerKey),
+      ),
+    ).toBe(false);
   });
 
   it("reappears when a new error arrives on the same thread", () => {
-    const dismissedKey = getThreadErrorBannerKey("env:thread", "Aborted");
+    dismissThreadErrorBannerForSession(getThreadErrorBannerKey("env:thread-b", "Turn failed"));
+    const newErrorKey = getThreadErrorBannerKey("env:thread-b", "Provider crashed");
 
-    expect(shouldShowThreadErrorBanner("env:thread", "Turn failed", dismissedKey)).toBe(true);
+    expect(isThreadErrorBannerDismissedForSession(newErrorKey)).toBe(false);
+    expect(
+      shouldShowThreadErrorBanner(
+        "env:thread-b",
+        "Provider crashed",
+        isThreadErrorBannerDismissedForSession(newErrorKey),
+      ),
+    ).toBe(true);
   });
 
   it("scopes dismissals to the thread that dismissed them", () => {
-    const dismissedKey = getThreadErrorBannerKey("env:thread", "Aborted");
+    dismissThreadErrorBannerForSession(getThreadErrorBannerKey("env:thread-c", "Aborted"));
+    const otherThreadKey = getThreadErrorBannerKey("env:other-thread", "Aborted");
 
-    expect(shouldShowThreadErrorBanner("env:other-thread", "Aborted", dismissedKey)).toBe(true);
+    expect(isThreadErrorBannerDismissedForSession(otherThreadKey)).toBe(false);
+    expect(
+      shouldShowThreadErrorBanner(
+        "env:other-thread",
+        "Aborted",
+        isThreadErrorBannerDismissedForSession(otherThreadKey),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a dismissal across visiting threads with no error", () => {
+    const bannerKey = getThreadErrorBannerKey("env:thread-d", "Aborted");
+    dismissThreadErrorBannerForSession(bannerKey);
+
+    expect(shouldShowThreadErrorBanner("env:thread-d", null, false)).toBe(false);
+    expect(isThreadErrorBannerDismissedForSession(bannerKey)).toBe(true);
+    expect(
+      shouldShowThreadErrorBanner(
+        "env:thread-d",
+        "Aborted",
+        isThreadErrorBannerDismissedForSession(bannerKey),
+      ),
+    ).toBe(false);
   });
 
   it("never shows a null error", () => {
-    expect(shouldShowThreadErrorBanner("env:thread", null, null)).toBe(false);
+    expect(shouldShowThreadErrorBanner("env:thread-e", null, false)).toBe(false);
   });
   it("aligns the warning and dismiss icons with the first line of a multi-line error", () => {
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -4,6 +4,19 @@ import { Button } from "../ui/button";
 import { CircleAlertIcon, XIcon } from "lucide-react";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
+export function getThreadErrorBannerKey(threadKey: string, error: string | null): string | null {
+  return error === null ? null : `${threadKey}\u0000${error}`;
+}
+
+export function shouldShowThreadErrorBanner(
+  threadKey: string,
+  error: string | null,
+  dismissedBannerKey: string | null,
+): boolean {
+  const bannerKey = getThreadErrorBannerKey(threadKey, error);
+  return bannerKey !== null && bannerKey !== dismissedBannerKey;
+}
+
 export const ThreadErrorBanner = memo(function ThreadErrorBanner({
   error,
   onDismiss,

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -11,10 +11,26 @@ export function getThreadErrorBannerKey(threadKey: string, error: string | null)
 export function shouldShowThreadErrorBanner(
   threadKey: string,
   error: string | null,
-  dismissedBannerKey: string | null,
+  isDismissed: boolean,
 ): boolean {
-  const bannerKey = getThreadErrorBannerKey(threadKey, error);
-  return bannerKey !== null && bannerKey !== dismissedBannerKey;
+  return getThreadErrorBannerKey(threadKey, error) !== null && !isDismissed;
+}
+
+// Session-scoped (module-level so it survives ChatView remounts, e.g. route
+// changes between threads). Mirrors the branch-mismatch banner: a dismissal
+// is remembered per thread key plus message, so navigating away to a thread
+// with no error cannot resurrect the banner, while a different error message
+// on the same thread still appears.
+const sessionDismissedThreadErrorBannerKeys = new Set<string>();
+
+export function dismissThreadErrorBannerForSession(bannerKey: string | null): void {
+  if (bannerKey !== null) {
+    sessionDismissedThreadErrorBannerKeys.add(bannerKey);
+  }
+}
+
+export function isThreadErrorBannerDismissedForSession(bannerKey: string | null): boolean {
+  return bannerKey !== null && sessionDismissedThreadErrorBannerKeys.has(bannerKey);
 }
 
 export const ThreadErrorBanner = memo(function ThreadErrorBanner({


### PR DESCRIPTION
The ThreadErrorBanner dismiss did not survive reconnects or rerenders. Because it was keyed only by thread id, switching model or provider reopened it, a component remount restored it, and navigating to another thread wiped the dismissal for the original thread.

Dismissal is now remembered per thread key plus error message in a session-scoped set, mirroring the branch-mismatch banner. It stays masked until a different error message shows on that thread, and it survives route changes, remounts, and navigating between threads. Dismiss also clears the local error shadow for the thread. A genuinely new error on the current thread still appears.

Verified with the ThreadErrorBanner test suite (6 tests passing) plus targeted lint and typecheck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only banner visibility and session-local dismissal state; underlying thread errors are unchanged.
> 
> **Overview**
> **Thread error dismiss** now follows the same session-scoped pattern as the branch-mismatch banner: dismissals are stored in a module-level `Set` keyed by **thread route key + error message**, so the banner stays hidden after reconnects, `ChatView` remounts, and switching threads—without clearing `session.lastError`.
> 
> `ChatView` derives `visibleThreadError` via `shouldShowThreadErrorBanner` instead of always showing `threadError`, and dismiss still clears the local error shadow while recording the session dismissal and bumping a dismiss tick so the UI hides immediately when the banner is driven only by persisted session error. Timeline top spacing uses the visible error, not the raw one.
> 
> New unit tests cover per-thread scoping, persistence across navigation with no error, re-show on a new message, and null-error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eddd66eb4ad16b7fe357914e10ae7a3dba7f5ad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread error banner dismiss to persist across reconnects and rerenders
> - Introduces a module-level `Set` in [ThreadErrorBanner.tsx](https://github.com/pingdotgg/t3code/pull/6123/files#diff-3fa9e223d4ae557ff232900844d971974d42e09f07a6d6e005538eab923867f0) to track dismissed error banners per thread+message for the duration of the session, surviving `ChatView` remounts and reconnects.
> - Adds `getThreadErrorBannerKey`, `shouldShowThreadErrorBanner`, `dismissThreadErrorBannerForSession`, and `isThreadErrorBannerDismissedForSession` utilities to manage visibility state.
> - Updates `ChatViewContent` to gate banner visibility via `shouldShowThreadErrorBanner` and use a local `tick` state to force a rerender on dismiss, so the banner hides immediately.
> - Different errors on the same thread still show a new banner; only the specific dismissed thread+message combination is suppressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eddd66e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->