### PR TITLE
feat(terminal): let users choose their default shell

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -330,6 +330,7 @@ const PortScannerLayerLive = PortScanner.layer.pipe(Layer.provide(ProcessRunner.
 const TerminalLayerLive = TerminalManager.layer.pipe(
   Layer.provide(PtyAdapterLive),
   Layer.provide(PortScannerLayerLive),
+  Layer.provide(ServerSettingsLayerLive),
 );
 
 const PreviewLayerLive = Layer.empty.pipe(

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1533,6 +1533,35 @@ it.layer(
     }),
   );
 
+  it.effect("resolves a quoted configured Windows shell path", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code quoted terminal shell ",
+      });
+      const shellPath = path.join(binDir, "bash.EXE");
+      yield* fileSystem.writeFileString(shellPath, "MZ");
+
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => `"${shellPath}"`,
+        env: {
+          PATH: "",
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+          SystemRoot: "C:\\Windows",
+        },
+      }).pipe(Effect.provide(withHostPlatform("win32")));
+
+      yield* manager.open(openInput());
+
+      expect(ptyAdapter.spawnInputs[0]).toEqual(
+        expect.objectContaining({
+          shell: shellPath,
+        }),
+      );
+    }),
+  );
+
   it.effect("resolves a configured Windows shell against the terminal runtime PATH", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1,3 +1,5 @@
+import * as NodeOS from "node:os";
+
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import {
@@ -1484,6 +1486,21 @@ it.layer(
         yield* manager.open(openInput({ terminalId: "quoted-shell" }));
         expect(ptyAdapter.spawnInputs.at(-1)?.shell).toBe("/definitely/missing shell");
       }
+    }),
+  );
+
+  it.effect("expands home-relative configured shell paths before spawning", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => "~/bin/test-shell",
+      }).pipe(Effect.provide(withHostPlatform("linux")));
+
+      yield* manager.open(openInput());
+
+      expect(ptyAdapter.spawnInputs[0]?.shell).toBe(
+        path.join(NodeOS.homedir(), "bin", "test-shell"),
+      );
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1,6 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import {
+  DEFAULT_SERVER_SETTINGS,
   DEFAULT_TERMINAL_ID,
   type TerminalAttachStreamEvent,
   type TerminalEvent,
@@ -20,14 +21,19 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { expect } from "vite-plus/test";
 
+import * as ServerConfig from "../config.ts";
+import * as PortScanner from "../preview/PortScanner.ts";
 import * as ProcessRunner from "../processRunner.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as TerminalManager from "./Manager.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
@@ -280,6 +286,48 @@ it.layer(
   Layer.merge(NodeServices.layer, ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer))),
   { excludeTestServices: true },
 )("TerminalManager", (it) => {
+  it.effect("subscribes to settings changes before reading the initial shell setting", () =>
+    Effect.gen(function* () {
+      const callOrder: string[] = [];
+      const settingsChanges = yield* PubSub.unbounded<typeof DEFAULT_SERVER_SETTINGS>();
+      const serverSettings = ServerSettings.ServerSettingsService.of({
+        start: Effect.void,
+        ready: Effect.void,
+        getSettings: Effect.sync(() => {
+          callOrder.push("getSettings");
+          return DEFAULT_SERVER_SETTINGS;
+        }),
+        updateSettings: () => Effect.die(new Error("unused in this test")),
+        streamChanges: Stream.empty,
+        subscribeChanges: PubSub.subscribe(settingsChanges).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              callOrder.push("subscribeChanges");
+            }),
+          ),
+          Effect.map((subscription) => Stream.fromSubscription(subscription)),
+        ),
+      });
+      const ptyAdapter = new FakePtyAdapter();
+      const portDiscovery = PortScanner.PortDiscovery.of({
+        scan: () => Effect.succeed([]),
+        subscribe: () => Effect.void,
+        retain: Effect.void,
+        registerTerminalProcesses: () => Effect.void,
+        unregisterTerminal: () => Effect.void,
+      });
+
+      yield* TerminalManager.make().pipe(
+        Effect.provideService(PtyAdapter.PtyAdapter, ptyAdapter),
+        Effect.provideService(PortScanner.PortDiscovery, portDiscovery),
+        Effect.provideService(ServerSettings.ServerSettingsService, serverSettings),
+        Effect.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-terminal-settings-" })),
+      );
+
+      expect(callOrder).toEqual(["subscribeChanges", "getSettings"]);
+    }),
+  );
+
   it.effect("spawns lazily and reuses running terminal per thread", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
@@ -1401,10 +1449,10 @@ it.layer(
   it.effect("retries with fallback shells when preferred shell spawn fails", () =>
     Effect.gen(function* () {
       const platform = yield* HostProcessPlatform;
-      const missingShell =
+      let configuredShell =
         platform === "win32" ? "C:\\definitely\\missing-shell.exe" : "/definitely/missing-shell -l";
       const { manager, ptyAdapter } = yield* createManager(5, {
-        shellResolver: () => missingShell,
+        shellResolver: () => configuredShell,
       });
       ptyAdapter.spawnFailures.push(new Error("posix_spawnp failed."));
 
@@ -1413,7 +1461,7 @@ it.layer(
       assert.equal(snapshot.status, "running");
       expect(ptyAdapter.spawnInputs.length).toBeGreaterThanOrEqual(2);
       expect(ptyAdapter.spawnInputs[0]?.shell).toBe(
-        platform === "win32" ? missingShell : "/definitely/missing-shell",
+        platform === "win32" ? configuredShell : "/definitely/missing-shell",
       );
 
       if (platform === "win32") {
@@ -1431,6 +1479,10 @@ it.layer(
             .slice(1)
             .some((input) => input.shell !== "/definitely/missing-shell"),
         ).toBe(true);
+
+        configuredShell = '"/definitely/missing shell" -l';
+        yield* manager.open(openInput({ terminalId: "quoted-shell" }));
+        expect(ptyAdapter.spawnInputs.at(-1)?.shell).toBe("/definitely/missing shell");
       }
     }),
   );
@@ -1466,12 +1518,12 @@ it.layer(
       const runtimeBinDir = yield* fileSystem.makeTempDirectoryScoped({
         prefix: "t3code-terminal-runtime-shell-",
       });
-      const baseShellPath = path.join(baseBinDir, "jz.EXE");
-      const runtimeShellPath = path.join(runtimeBinDir, "jz.EXE");
+      const baseShellPath = path.join(baseBinDir, "test-shell.EXE");
+      const runtimeShellPath = path.join(runtimeBinDir, "test-shell.EXE");
       yield* fileSystem.writeFileString(baseShellPath, "MZ");
       yield* fileSystem.writeFileString(runtimeShellPath, "MZ");
 
-      let configuredShell = "jz";
+      let configuredShell = "test-shell";
       const { manager, ptyAdapter } = yield* createManager(5, {
         shellResolver: () => configuredShell,
         env: {
@@ -1482,12 +1534,15 @@ it.layer(
       }).pipe(Effect.provide(withHostPlatform("win32")));
 
       yield* manager.open(openInput());
+      configuredShell = baseShellPath;
+      yield* manager.open(openInput({ terminalId: "unquoted-shell" }));
       configuredShell = `"${baseShellPath}"`;
       yield* manager.open(openInput({ terminalId: "quoted-shell" }));
-      configuredShell = "jz";
+      configuredShell = "test-shell";
       yield* manager.open(openInput({ terminalId: "runtime-shell", env: { PATH: runtimeBinDir } }));
 
       expect(ptyAdapter.spawnInputs.map(({ shell }) => shell)).toEqual([
+        baseShellPath,
         baseShellPath,
         baseShellPath,
         runtimeShellPath,

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1525,6 +1525,24 @@ it.layer(
     }),
   );
 
+  it.effect("adds no-logo when a configured Windows PowerShell alias is unresolved", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => "pwsh",
+        env: { SystemRoot: "C:\\Windows" },
+      }).pipe(Effect.provide(withHostPlatform("win32")));
+
+      yield* manager.open(openInput());
+
+      expect(ptyAdapter.spawnInputs[0]).toEqual(
+        expect.objectContaining({
+          shell: "pwsh",
+          args: ["-NoLogo"],
+        }),
+      );
+    }),
+  );
+
   it.effect("resolves configured Windows shells against the effective environment", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1,6 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import {
+  DEFAULT_SERVER_SETTINGS,
   DEFAULT_TERMINAL_ID,
   type TerminalAttachStreamEvent,
   type TerminalEvent,
@@ -20,14 +21,19 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { expect } from "vite-plus/test";
 
+import * as ServerConfig from "../config.ts";
+import * as PortScanner from "../preview/PortScanner.ts";
 import * as ProcessRunner from "../processRunner.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as TerminalManager from "./Manager.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
@@ -280,6 +286,48 @@ it.layer(
   Layer.merge(NodeServices.layer, ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer))),
   { excludeTestServices: true },
 )("TerminalManager", (it) => {
+  it.effect("subscribes to settings changes before reading the initial shell setting", () =>
+    Effect.gen(function* () {
+      const callOrder: string[] = [];
+      const settingsChanges = yield* PubSub.unbounded<typeof DEFAULT_SERVER_SETTINGS>();
+      const serverSettings = ServerSettings.ServerSettingsService.of({
+        start: Effect.void,
+        ready: Effect.void,
+        getSettings: Effect.sync(() => {
+          callOrder.push("getSettings");
+          return DEFAULT_SERVER_SETTINGS;
+        }),
+        updateSettings: () => Effect.die(new Error("unused in this test")),
+        streamChanges: Stream.empty,
+        subscribeChanges: PubSub.subscribe(settingsChanges).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              callOrder.push("subscribeChanges");
+            }),
+          ),
+          Effect.map((subscription) => Stream.fromSubscription(subscription)),
+        ),
+      });
+      const ptyAdapter = new FakePtyAdapter();
+      const portDiscovery = PortScanner.PortDiscovery.of({
+        scan: () => Effect.succeed([]),
+        subscribe: () => Effect.void,
+        retain: Effect.void,
+        registerTerminalProcesses: () => Effect.void,
+        unregisterTerminal: () => Effect.void,
+      });
+
+      yield* TerminalManager.make().pipe(
+        Effect.provideService(PtyAdapter.PtyAdapter, ptyAdapter),
+        Effect.provideService(PortScanner.PortDiscovery, portDiscovery),
+        Effect.provideService(ServerSettings.ServerSettingsService, serverSettings),
+        Effect.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-terminal-settings-" })),
+      );
+
+      expect(callOrder).toEqual(["subscribeChanges", "getSettings"]);
+    }),
+  );
+
   it.effect("spawns lazily and reuses running terminal per thread", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
@@ -1480,6 +1528,40 @@ it.layer(
       expect(ptyAdapter.spawnInputs[0]).toEqual(
         expect.objectContaining({
           shell: shellPath,
+        }),
+      );
+    }),
+  );
+
+  it.effect("resolves a configured Windows shell against the terminal runtime PATH", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseBinDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-terminal-base-shell-",
+      });
+      const runtimeBinDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-terminal-runtime-shell-",
+      });
+      yield* fileSystem.writeFileString(path.join(baseBinDir, "jz.EXE"), "MZ");
+      const runtimeShellPath = path.join(runtimeBinDir, "jz.EXE");
+      yield* fileSystem.writeFileString(runtimeShellPath, "MZ");
+
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => "jz",
+        env: {
+          PATH: baseBinDir,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+          SystemRoot: "C:\\Windows",
+        },
+      }).pipe(Effect.provide(withHostPlatform("win32")));
+
+      yield* manager.open(openInput({ env: { PATH: runtimeBinDir } }));
+
+      expect(ptyAdapter.spawnInputs[0]).toEqual(
+        expect.objectContaining({
+          shell: runtimeShellPath,
+          env: expect.objectContaining({ PATH: runtimeBinDir }),
         }),
       );
     }),

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1,7 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import {
-  DEFAULT_SERVER_SETTINGS,
   DEFAULT_TERMINAL_ID,
   type TerminalAttachStreamEvent,
   type TerminalEvent,
@@ -21,19 +20,14 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Path from "effect/Path";
-import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
-import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { expect } from "vite-plus/test";
 
-import * as ServerConfig from "../config.ts";
-import * as PortScanner from "../preview/PortScanner.ts";
 import * as ProcessRunner from "../processRunner.ts";
-import * as ServerSettings from "../serverSettings.ts";
 import * as TerminalManager from "./Manager.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
@@ -286,48 +280,6 @@ it.layer(
   Layer.merge(NodeServices.layer, ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer))),
   { excludeTestServices: true },
 )("TerminalManager", (it) => {
-  it.effect("subscribes to settings changes before reading the initial shell setting", () =>
-    Effect.gen(function* () {
-      const callOrder: string[] = [];
-      const settingsChanges = yield* PubSub.unbounded<typeof DEFAULT_SERVER_SETTINGS>();
-      const serverSettings = ServerSettings.ServerSettingsService.of({
-        start: Effect.void,
-        ready: Effect.void,
-        getSettings: Effect.sync(() => {
-          callOrder.push("getSettings");
-          return DEFAULT_SERVER_SETTINGS;
-        }),
-        updateSettings: () => Effect.die(new Error("unused in this test")),
-        streamChanges: Stream.empty,
-        subscribeChanges: PubSub.subscribe(settingsChanges).pipe(
-          Effect.tap(() =>
-            Effect.sync(() => {
-              callOrder.push("subscribeChanges");
-            }),
-          ),
-          Effect.map((subscription) => Stream.fromSubscription(subscription)),
-        ),
-      });
-      const ptyAdapter = new FakePtyAdapter();
-      const portDiscovery = PortScanner.PortDiscovery.of({
-        scan: () => Effect.succeed([]),
-        subscribe: () => Effect.void,
-        retain: Effect.void,
-        registerTerminalProcesses: () => Effect.void,
-        unregisterTerminal: () => Effect.void,
-      });
-
-      yield* TerminalManager.make().pipe(
-        Effect.provideService(PtyAdapter.PtyAdapter, ptyAdapter),
-        Effect.provideService(PortScanner.PortDiscovery, portDiscovery),
-        Effect.provideService(ServerSettings.ServerSettingsService, serverSettings),
-        Effect.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-terminal-settings-" })),
-      );
-
-      expect(callOrder).toEqual(["subscribeChanges", "getSettings"]);
-    }),
-  );
-
   it.effect("spawns lazily and reuses running terminal per thread", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
@@ -1504,80 +1456,24 @@ it.layer(
     }),
   );
 
-  it.effect("resolves a configured Windows shell through PATH before spawning", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const binDir = yield* fileSystem.makeTempDirectoryScoped({
-        prefix: "t3code-terminal-shell-",
-      });
-      const shellPath = path.join(binDir, "jz.EXE");
-      yield* fileSystem.writeFileString(shellPath, "MZ");
-
-      const { manager, ptyAdapter } = yield* createManager(5, {
-        shellResolver: () => "jz",
-        env: {
-          PATH: binDir,
-          PATHEXT: ".COM;.EXE;.BAT;.CMD",
-          SystemRoot: "C:\\Windows",
-        },
-      }).pipe(Effect.provide(withHostPlatform("win32")));
-
-      yield* manager.open(openInput());
-
-      expect(ptyAdapter.spawnInputs[0]).toEqual(
-        expect.objectContaining({
-          shell: shellPath,
-        }),
-      );
-    }),
-  );
-
-  it.effect("resolves a quoted configured Windows shell path", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const binDir = yield* fileSystem.makeTempDirectoryScoped({
-        prefix: "t3code quoted terminal shell ",
-      });
-      const shellPath = path.join(binDir, "bash.EXE");
-      yield* fileSystem.writeFileString(shellPath, "MZ");
-
-      const { manager, ptyAdapter } = yield* createManager(5, {
-        shellResolver: () => `"${shellPath}"`,
-        env: {
-          PATH: "",
-          PATHEXT: ".COM;.EXE;.BAT;.CMD",
-          SystemRoot: "C:\\Windows",
-        },
-      }).pipe(Effect.provide(withHostPlatform("win32")));
-
-      yield* manager.open(openInput());
-
-      expect(ptyAdapter.spawnInputs[0]).toEqual(
-        expect.objectContaining({
-          shell: shellPath,
-        }),
-      );
-    }),
-  );
-
-  it.effect("resolves a configured Windows shell against the terminal runtime PATH", () =>
+  it.effect("resolves configured Windows shells against the effective environment", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const baseBinDir = yield* fileSystem.makeTempDirectoryScoped({
-        prefix: "t3code-terminal-base-shell-",
+        prefix: "t3code terminal base shell ",
       });
       const runtimeBinDir = yield* fileSystem.makeTempDirectoryScoped({
         prefix: "t3code-terminal-runtime-shell-",
       });
-      yield* fileSystem.writeFileString(path.join(baseBinDir, "jz.EXE"), "MZ");
+      const baseShellPath = path.join(baseBinDir, "jz.EXE");
       const runtimeShellPath = path.join(runtimeBinDir, "jz.EXE");
+      yield* fileSystem.writeFileString(baseShellPath, "MZ");
       yield* fileSystem.writeFileString(runtimeShellPath, "MZ");
 
+      let configuredShell = "jz";
       const { manager, ptyAdapter } = yield* createManager(5, {
-        shellResolver: () => "jz",
+        shellResolver: () => configuredShell,
         env: {
           PATH: baseBinDir,
           PATHEXT: ".COM;.EXE;.BAT;.CMD",
@@ -1585,14 +1481,17 @@ it.layer(
         },
       }).pipe(Effect.provide(withHostPlatform("win32")));
 
-      yield* manager.open(openInput({ env: { PATH: runtimeBinDir } }));
+      yield* manager.open(openInput());
+      configuredShell = `"${baseShellPath}"`;
+      yield* manager.open(openInput({ terminalId: "quoted-shell" }));
+      configuredShell = "jz";
+      yield* manager.open(openInput({ terminalId: "runtime-shell", env: { PATH: runtimeBinDir } }));
 
-      expect(ptyAdapter.spawnInputs[0]).toEqual(
-        expect.objectContaining({
-          shell: runtimeShellPath,
-          env: expect.objectContaining({ PATH: runtimeBinDir }),
-        }),
-      );
+      expect(ptyAdapter.spawnInputs.map(({ shell }) => shell)).toEqual([
+        baseShellPath,
+        baseShellPath,
+        runtimeShellPath,
+      ]);
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1456,6 +1456,35 @@ it.layer(
     }),
   );
 
+  it.effect("resolves a configured Windows shell through PATH before spawning", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-terminal-shell-",
+      });
+      const shellPath = path.join(binDir, "jz.EXE");
+      yield* fileSystem.writeFileString(shellPath, "MZ");
+
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => "jz",
+        env: {
+          PATH: binDir,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+          SystemRoot: "C:\\Windows",
+        },
+      }).pipe(Effect.provide(withHostPlatform("win32")));
+
+      yield* manager.open(openInput());
+
+      expect(ptyAdapter.spawnInputs[0]).toEqual(
+        expect.objectContaining({
+          shell: shellPath,
+        }),
+      );
+    }),
+  );
+
   it.effect("falls back to built-in PowerShell by absolute path on Windows", () =>
     Effect.gen(function* () {
       const ptyAdapter = new FakePtyAdapter();

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1144,8 +1144,9 @@ export const make = Effect.fn("TerminalManager.make")(function* () {
   const ptyAdapter = yield* PtyAdapter.PtyAdapter;
   const portDiscovery = yield* PortScanner.PortDiscovery;
   const settingsService = yield* ServerSettings.ServerSettingsService;
+  const settingsChanges = yield* settingsService.subscribeChanges;
   let configuredShell = (yield* settingsService.getSettings).defaultTerminalShell;
-  yield* settingsService.streamChanges.pipe(
+  yield* settingsChanges.pipe(
     Stream.runForEach((settings) =>
       Effect.sync(() => {
         configuredShell = settings.defaultTerminalShell;
@@ -1888,15 +1889,15 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
         Effect.andThen(
           Effect.gen(function* () {
+            const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const shellCandidates = yield* resolveShellCandidates(
               shellResolver,
               platform,
-              baseEnv,
+              terminalEnv,
             ).pipe(
               Effect.provideService(FileSystem.FileSystem, fileSystem),
               Effect.provideService(Path.Path, path),
             );
-            const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;
             startedShell = spawnResult.shellLabel;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -464,7 +464,7 @@ function normalizeShellCommand(
   if (trimmed.length === 0) return null;
 
   if (platform === "win32") {
-    return trimmed;
+    return trimmed.replace(/^(["'])(.*)\1$/u, "$2");
   }
 
   const firstToken = trimmed.split(/\s+/g)[0]?.trim();

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -34,6 +34,7 @@ import {
 } from "@t3tools/contracts";
 import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { resolveCommandPath } from "@t3tools/shared/shell";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
@@ -49,6 +50,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import * as ServerConfig from "../config.ts";
@@ -59,6 +61,7 @@ import {
 } from "../observability/Metrics.ts";
 import * as ProcessRunner from "../processRunner.ts";
 import * as PortScanner from "../preview/PortScanner.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
 export {
@@ -539,15 +542,20 @@ function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellC
   return ordered;
 }
 
-function resolveShellCandidates(
+const resolveShellCandidates = Effect.fn("terminal.resolveShellCandidates")(function* (
   shellResolver: () => string,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
-): ShellCandidate[] {
-  const requested = shellCandidateFromCommand(
-    normalizeShellCommand(shellResolver(), platform),
-    platform,
-  );
+): Effect.fn.Return<ShellCandidate[], never, FileSystem.FileSystem | Path.Path> {
+  const requestedCommand = normalizeShellCommand(shellResolver(), platform);
+  const resolvedRequestedCommand =
+    platform === "win32" && requestedCommand !== null
+      ? yield* resolveCommandPath(requestedCommand, { env }).pipe(
+          Effect.provideService(HostProcessPlatform, platform),
+          Effect.catchTag("CommandResolutionError", () => Effect.succeed(requestedCommand)),
+        )
+      : requestedCommand;
+  const requested = shellCandidateFromCommand(resolvedRequestedCommand, platform);
 
   if (platform === "win32") {
     return uniqueShellCandidates([
@@ -571,7 +579,7 @@ function resolveShellCandidates(
     shellCandidateFromCommand("bash", platform),
     shellCandidateFromCommand("sh", platform),
   ]);
-}
+});
 
 function isRetryableShellSpawnError(error: PtyAdapter.PtySpawnError): boolean {
   const queue: unknown[] = [error];
@@ -1133,9 +1141,20 @@ export const make = Effect.fn("TerminalManager.make")(function* () {
   const { terminalLogsDir } = yield* ServerConfig.ServerConfig;
   const ptyAdapter = yield* PtyAdapter.PtyAdapter;
   const portDiscovery = yield* PortScanner.PortDiscovery;
+  const settingsService = yield* ServerSettings.ServerSettingsService;
+  let configuredShell = (yield* settingsService.getSettings).defaultTerminalShell;
+  yield* settingsService.streamChanges.pipe(
+    Stream.runForEach((settings) =>
+      Effect.sync(() => {
+        configuredShell = settings.defaultTerminalShell;
+      }),
+    ),
+    Effect.forkScoped,
+  );
   return yield* makeWithOptions({
     logsDir: terminalLogsDir,
     ptyAdapter,
+    shellResolver: () => configuredShell,
     registerTerminalProcesses: portDiscovery.registerTerminalProcesses,
     unregisterTerminal: portDiscovery.unregisterTerminal,
   });
@@ -1867,7 +1886,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
         Effect.andThen(
           Effect.gen(function* () {
-            const shellCandidates = resolveShellCandidates(shellResolver, platform, baseEnv);
+            const shellCandidates = yield* resolveShellCandidates(
+              shellResolver,
+              platform,
+              baseEnv,
+            ).pipe(
+              Effect.provideService(FileSystem.FileSystem, fileSystem),
+              Effect.provideService(Path.Path, path),
+            );
             const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1170,7 +1170,7 @@ export const make = Effect.fn("TerminalManager.make")(function* () {
         configuredShell = settings.defaultTerminalShell;
       }),
     ),
-    Effect.forkScoped,
+    Effect.forkScoped({ startImmediately: true }),
   );
   return yield* makeWithOptions({
     logsDir: terminalLogsDir,

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -499,7 +499,13 @@ function shellCandidateFromCommand(
 ): ShellCandidate | null {
   if (!command || command.length === 0) return null;
   const shellName = basenameForPlatform(command, platform).toLowerCase();
-  if (platform === "win32" && (shellName === "pwsh.exe" || shellName === "powershell.exe")) {
+  if (
+    platform === "win32" &&
+    (shellName === "pwsh" ||
+      shellName === "pwsh.exe" ||
+      shellName === "powershell" ||
+      shellName === "powershell.exe")
+  ) {
     return { shell: command, args: ["-NoLogo"] };
   }
   if (platform !== "win32" && shellName === "zsh") {
@@ -550,15 +556,25 @@ const resolveShellCandidates = Effect.fn("terminal.resolveShellCandidates")(func
   env: NodeJS.ProcessEnv,
 ): Effect.fn.Return<ShellCandidate[], never, FileSystem.FileSystem | Path.Path> {
   const requestedCommand = normalizeShellCommand(shellResolver(), platform);
-  const resolvedRequestedCommand =
-    platform === "win32" && requestedCommand !== null
-      ? yield* resolveCommandPath(requestedCommand, { env }).pipe(
-          Effect.provideService(HostProcessPlatform, platform),
-          Effect.catchTags({
-            CommandResolutionError: () => Effect.succeed(requestedCommand),
-          }),
-        )
-      : requestedCommand;
+  // `resolveCommandPath` checks explicit paths relative to the server process,
+  // while PTY spawns resolve them relative to the session cwd. Only resolve
+  // bare command names through PATH so a relative configured path keeps its
+  // normal PTY semantics.
+  const isPathLikeCommand =
+    requestedCommand?.includes("/") === true ||
+    requestedCommand?.includes("\\") === true ||
+    requestedCommand?.includes(":") === true ||
+    /\s/u.test(requestedCommand ?? "");
+  const canResolveFromPath =
+    platform === "win32" && requestedCommand !== null && !isPathLikeCommand;
+  const resolvedRequestedCommand = canResolveFromPath
+    ? yield* resolveCommandPath(requestedCommand, { env }).pipe(
+        Effect.provideService(HostProcessPlatform, platform),
+        Effect.catchTags({
+          CommandResolutionError: () => Effect.succeed(requestedCommand),
+        }),
+      )
+    : requestedCommand;
   const requested = shellCandidateFromCommand(resolvedRequestedCommand, platform);
 
   if (platform === "win32") {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -552,7 +552,9 @@ const resolveShellCandidates = Effect.fn("terminal.resolveShellCandidates")(func
     platform === "win32" && requestedCommand !== null
       ? yield* resolveCommandPath(requestedCommand, { env }).pipe(
           Effect.provideService(HostProcessPlatform, platform),
-          Effect.catchTag("CommandResolutionError", () => Effect.succeed(requestedCommand)),
+          Effect.catchTags({
+            CommandResolutionError: () => Effect.succeed(requestedCommand),
+          }),
         )
       : requestedCommand;
   const requested = shellCandidateFromCommand(resolvedRequestedCommand, platform);

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -54,6 +54,7 @@ import * as Stream from "effect/Stream";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import * as ServerConfig from "../config.ts";
+import { expandHomePath } from "../pathExpansion.ts";
 import {
   increment,
   terminalRestartsTotal,
@@ -464,13 +465,13 @@ function normalizeShellCommand(
   if (trimmed.length === 0) return null;
 
   const quotedExecutable = trimmed.match(/^(["'])(.*?)\1(?:\s|$)/u)?.[2];
-  if (quotedExecutable) return quotedExecutable;
+  if (quotedExecutable) return expandHomePath(quotedExecutable);
 
-  if (platform === "win32") return trimmed;
+  if (platform === "win32") return expandHomePath(trimmed);
 
   const firstToken = trimmed.split(/\s+/g)[0]?.trim();
   if (!firstToken) return null;
-  return firstToken.replace(/^['"]|['"]$/g, "");
+  return expandHomePath(firstToken.replace(/^['"]|['"]$/g, ""));
 }
 
 function basenameForPlatform(command: string, platform: NodeJS.Platform): string {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -463,9 +463,10 @@ function normalizeShellCommand(
   const trimmed = value.trim();
   if (trimmed.length === 0) return null;
 
-  if (platform === "win32") {
-    return trimmed.replace(/^(["'])(.*)\1$/u, "$2");
-  }
+  const quotedExecutable = trimmed.match(/^(["'])(.*?)\1(?:\s|$)/u)?.[2];
+  if (quotedExecutable) return quotedExecutable;
+
+  if (platform === "win32") return trimmed;
 
   const firstToken = trimmed.split(/\s+/g)[0]?.trim();
   if (!firstToken) return null;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2345,7 +2345,7 @@ export function GeneralSettingsPanel() {
               className="w-full sm:w-72"
               value={settings.defaultTerminalShell}
               onCommit={(next) => updateSettings({ defaultTerminalShell: next })}
-              placeholder={isElectron ? "pwsh.exe" : "Platform default"}
+              placeholder="Platform default"
               spellCheck={false}
               aria-label="Default terminal shell"
             />

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -529,6 +529,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
+      ...(settings.defaultTerminalShell !== DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell
+        ? ["Default terminal shell"]
+        : []),
       ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
         ? ["Archive confirmation"]
         : []),
@@ -557,6 +560,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
+      settings.defaultTerminalShell,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
@@ -668,6 +672,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+      defaultTerminalShell: DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
       confirmQuit: DEFAULT_UNIFIED_SETTINGS.confirmQuit,
@@ -2316,6 +2321,33 @@ export function GeneralSettingsPanel() {
               placeholder="~/"
               spellCheck={false}
               aria-label="Add project base directory"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("default-terminal-shell")}
+          description="Executable used for new terminals in this environment. Leave empty for the platform default; paths such as Git Bash are supported."
+          resetAction={
+            settings.defaultTerminalShell !== DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell ? (
+              <SettingResetButton
+                label="default terminal shell"
+                onClick={() =>
+                  updateSettings({
+                    defaultTerminalShell: DEFAULT_UNIFIED_SETTINGS.defaultTerminalShell,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <DraftInput
+              className="w-full sm:w-72"
+              value={settings.defaultTerminalShell}
+              onCommit={(next) => updateSettings({ defaultTerminalShell: next })}
+              placeholder={isElectron ? "pwsh.exe" : "Platform default"}
+              spellCheck={false}
+              aria-label="Default terminal shell"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -158,6 +158,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "default-terminal-shell",
+    title: "Default terminal shell",
+    to: "/settings/general",
+  },
+  {
     id: "archive-confirmation",
     title: "Archive confirmation",
     to: "/settings/general",

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -320,22 +320,6 @@ describe("ServerSettings.sourceControlWritingStyle", () => {
   });
 });
 
-describe("ServerSettings terminal shell", () => {
-  it("defaults to automatic shell selection and trims configured commands", () => {
-    expect(decodeServerSettings({}).defaultTerminalShell).toBe("");
-    expect(
-      decodeServerSettings({ defaultTerminalShell: "  C:\\Program Files\\Git\\bin\\bash.exe  " })
-        .defaultTerminalShell,
-    ).toBe("C:\\Program Files\\Git\\bin\\bash.exe");
-  });
-
-  it("accepts a terminal shell settings patch", () => {
-    expect(decodeServerSettingsPatch({ defaultTerminalShell: "pwsh.exe" })).toEqual({
-      defaultTerminalShell: "pwsh.exe",
-    });
-  });
-});
-
 describe("ServerSettingsPatch.providerInstances", () => {
   it("treats providerInstances as an optional whole-map replacement", () => {
     const patch = decodeServerSettingsPatch({});
@@ -370,6 +354,7 @@ describe("ServerSettingsPatch string normalization", () => {
   it("trims string settings while decoding patches", () => {
     const patch = decodeServerSettingsPatch({
       addProjectBaseDirectory: "  ~/Development  ",
+      defaultTerminalShell: "  C:\\Program Files\\Git\\bin\\bash.exe  ",
       textGenerationModelSelection: { model: "  gpt-5.4-mini  " },
       observability: {
         otlpTracesUrl: "  http://localhost:4318/v1/traces  ",
@@ -391,6 +376,7 @@ describe("ServerSettingsPatch string normalization", () => {
     });
 
     expect(patch.addProjectBaseDirectory).toBe("~/Development");
+    expect(patch.defaultTerminalShell).toBe("C:\\Program Files\\Git\\bin\\bash.exe");
     expect(patch.textGenerationModelSelection?.model).toBe("gpt-5.4-mini");
     expect(patch.observability?.otlpTracesUrl).toBe("http://localhost:4318/v1/traces");
     expect(patch.providers?.codex?.binaryPath).toBe("/opt/homebrew/bin/codex");

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -320,6 +320,22 @@ describe("ServerSettings.sourceControlWritingStyle", () => {
   });
 });
 
+describe("ServerSettings terminal shell", () => {
+  it("defaults to automatic shell selection and trims configured commands", () => {
+    expect(decodeServerSettings({}).defaultTerminalShell).toBe("");
+    expect(
+      decodeServerSettings({ defaultTerminalShell: "  C:\\Program Files\\Git\\bin\\bash.exe  " })
+        .defaultTerminalShell,
+    ).toBe("C:\\Program Files\\Git\\bin\\bash.exe");
+  });
+
+  it("accepts a terminal shell settings patch", () => {
+    expect(decodeServerSettingsPatch({ defaultTerminalShell: "pwsh.exe" })).toEqual({
+      defaultTerminalShell: "pwsh.exe",
+    });
+  });
+});
+
 describe("ServerSettingsPatch.providerInstances", () => {
   it("treats providerInstances as an optional whole-map replacement", () => {
     const patch = decodeServerSettingsPatch({});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -659,6 +659,7 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  defaultTerminalShell: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
       Effect.succeed({
@@ -864,6 +865,7 @@ export const ServerSettingsPatch = Schema.Struct({
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
+  defaultTerminalShell: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(
     Schema.Struct({


### PR DESCRIPTION
## What Changed

Terminal sessions always chose their shell implicitly, so users who preferred PowerShell, Git Bash, WSL, or another shell could not make it the default.

Settings now includes a Default terminal shell field. New terminal sessions read the current setting, preserve Windows executable paths whether quoted or unquoted, extract executable tokens from POSIX shell command lines, resolve bare Windows commands against the session environment, and retain the existing fallback candidates when the configured command cannot be started.

## Why

A coding environment's terminal should open the shell the user actually works in. Making the choice explicit removes platform-dependent surprises while preserving safe fallback behavior and applying setting changes without restarting the server.

## Verification

- Focused terminal and settings suites passed: 88/88 tests.
- Targeted lint passed for the changed server files.
- Typechecking passed for `t3`; prior checks also passed for `@t3tools/web` and `@t3tools/contracts`.

## UI Changes

Settings gains a Default terminal shell field. Before/after screenshots are not available from this environment.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for the Settings change
- [x] Animation or interaction changes are not applicable

model: gpt-5.6-sol
harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which executable starts PTY sessions and adds Windows PATH resolution per session env; misconfiguration or PATH overrides could pick unexpected shells, though fallbacks remain.
> 
> **Overview**
> Adds a **Default terminal shell** setting (`defaultTerminalShell`, empty = platform default) in server settings and General settings UI, with search/reset support.
> 
> **TerminalManager** now wires in `ServerSettingsService`, subscribes to settings changes before reading the initial value, and uses the live value when spawning new sessions (no server restart). Shell resolution is tightened: `~` expansion, quoted executable extraction on POSIX, `-NoLogo` for Windows `pwsh`/`powershell` (including bare aliases), and PATH/PATHEXT lookup for bare Windows command names against each session’s spawn environment—while keeping existing fallback candidates when spawn fails. The terminal layer is provided `ServerSettingsLayerLive` in `server.ts`.
> 
> Contracts decode patches with trimmed strings; tests cover subscription ordering and the new resolution paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb5d7d5441add6d412004ec829aca422239625a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable default terminal shell setting with live updates
> - Introduces `defaultTerminalShell` (`TrimmedString`, defaults to `""`) in `ServerSettings` and `ServerSettingsPatch` in [settings.ts](https://github.com/pingdotgg/t3code/pull/6125/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c)
> - `TerminalManager` now subscribes to `ServerSettingsService`, reads the initial configured shell, and spawns a scoped fiber to keep the local `configuredShell` in sync as settings change; shell resolution runs against each session's effective environment instead of the base env
> - `normalizeShellCommand` expands home-relative paths and handles quoted executables; on Windows, `shellCandidateFromCommand` appends `-NoLogo` to `pwsh`/`powershell`, and `resolveShellCandidates` resolves bare command names against effective PATH (with PATHEXT) via `resolveCommandPath`
> - Frontend adds a `DraftInput` for the setting in `GeneralSettingsPanel`, includes it in `useSettingsRestore` reset logic, and registers a search entry in `settingsSearch.ts`
> - Risk: `resolveShellCandidates` now requires `FileSystem` and `Path` services and performs PATH lookups on Windows before spawning; misconfigured PATH per-session env can change which executable is selected, and bare names previously spawned without PATH resolution
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bb5d7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->