### PR TITLE
test(swift-ios): use environment-scoped provider catalogs

### DIFF
--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 


### PR DESCRIPTION
## What Changed

- construct home-thread metadata fixtures with `providersByEnvironment`
- keep provider lookup assertions aligned with the environment-scoped production model

## Why

The SwiftUI base moved provider discovery away from the deprecated flat `providers` array, but two metadata tests still populated only that legacy field. They fail against the current production lookup even though the lookup is behaving as designed.

## Verification

- `HomeThreadMetadataTests`: 5 passed, 0 failed on iOS Simulator
- `git diff --check`: passed

## Scope

Tests only; no product behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture updates with no production code or runtime behavior changes.
> 
> **Overview**
> Updates **HomeThreadMetadataTests** so `FeatureSnapshot` fixtures use **`providersByEnvironment`** (keyed by environment id, e.g. `"device"`) instead of the flat **`providers`** array.
> 
> This keeps catalog fallback and row-context provider assertions aligned with production home-thread metadata lookup, which resolves providers per environment. **Tests only**; no app behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d185ff05361a3ee825455df6d4068ccd4c590cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update iOS Swift tests to use environment-scoped provider catalogs
> Replaces the flat `providers` array with a `providersByEnvironment` dictionary keyed by `"device"` in [HomeThreadMetadataTests.swift](https://github.com/pingdotgg/t3code/pull/6130/files#diff-6c011ef0ee9b0b0c743e78ef9b0e374f0c5f74afb579f04439127d8bab79a2aa). Both affected `@Test` methods are updated to match the new `FeatureSnapshot` initialization shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d185ff0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: none
Merge order: this PR only
Validation status: Mergeable; native/repository checks and current review are green. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
