### PR TITLE
feat(swift-ios): add recent projects picker

### DIFF
--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -114,14 +114,14 @@ enum DailyUXCreationContext {
 
     static func recentProjects(in snapshot: FeatureSnapshot) -> [DailyUXRecentProject] {
         let groups = projectGroups(in: snapshot)
+        let availableProjectByID = projects(in: snapshot).reduce(
+            into: [String: FeatureProject]()
+        ) { $0[$1.id] = $1 }
         let groupByProjectID = groups.reduce(into: [String: DailyUXProjectGroup]()) {
             result, group in
             for projectID in group.memberProjectIDs {
                 result[projectID] = group
             }
-        }
-        let projectEnvironmentByID = snapshot.projects.reduce(into: [String: String]()) {
-            $0[$1.id] = $1.environmentID
         }
         var seenGroupIDs = Set<String>()
 
@@ -130,10 +130,7 @@ enum DailyUXCreationContext {
             .compactMap { thread in
                 guard let group = groupByProjectID[thread.projectID],
                       seenGroupIDs.insert(group.id).inserted,
-                      let project = group.preferredProject(
-                          environmentID: thread.environmentID
-                              ?? projectEnvironmentByID[thread.projectID]
-                      ) else {
+                      let project = availableProjectByID[thread.projectID] else {
                     return nil
                 }
                 return DailyUXRecentProject(group: group, project: project)
@@ -144,20 +141,14 @@ enum DailyUXCreationContext {
         in snapshot: FeatureSnapshot,
         requestedProjectID: String?
     ) -> FeatureProject? {
-        let groups = projectGroups(in: snapshot)
-
+        let availableProjects = projects(in: snapshot)
         if let requestedProjectID,
-           let requestedGroup = DailyUXProjectGrouping.group(
-               containing: requestedProjectID,
-               in: groups
-           ) {
-            let requestedEnvironmentID = snapshot.projects
-                .first(where: { $0.id == requestedProjectID })?
-                .environmentID
-            return requestedGroup.preferredProject(environmentID: requestedEnvironmentID)
+           let requestedProject = availableProjects.first(where: { $0.id == requestedProjectID }) {
+            return requestedProject
         }
 
-        return recentProjects(in: snapshot).first?.project ?? groups.first?.projects.first
+        return recentProjects(in: snapshot).first?.project
+            ?? projectGroups(in: snapshot).first?.projects.first
     }
 
     static func logicalProjectID(
@@ -184,6 +175,29 @@ enum DailyUXCreationContext {
         if lhsDate != rhsDate { return lhsDate > rhsDate }
         return lhs.id < rhs.id
     }
+
+    static func shouldAdoptAutomaticProject(
+        currentProjectID: String,
+        nextRecentProjectID: String?,
+        isAwaitingRecentActivity: Bool,
+        projectSelectionIsExplicit: Bool,
+        modelSelectionIsExplicit: Bool,
+        workspaceSelectionIsExplicit: Bool,
+        hasDraftContent: Bool,
+        draftRestoreIsComplete: Bool
+    ) -> Bool {
+        guard isAwaitingRecentActivity,
+              let nextRecentProjectID,
+              nextRecentProjectID != currentProjectID else {
+            return false
+        }
+        return !projectSelectionIsExplicit
+            && !modelSelectionIsExplicit
+            && !workspaceSelectionIsExplicit
+            && !hasDraftContent
+            && draftRestoreIsComplete
+    }
+
     static func providers(
         for project: FeatureProject?,
         in snapshot: FeatureSnapshot

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -129,8 +129,12 @@ enum DailyUXCreationContext {
             .sorted(by: recentUseOrder)
             .compactMap { thread in
                 guard let group = groupByProjectID[thread.projectID],
-                      seenGroupIDs.insert(group.id).inserted,
-                      let project = availableProjectByID[thread.projectID] else {
+                      let sourceProject = availableProjectByID[thread.projectID],
+                      let project = DailyUXProjectGrouping.physicalRepresentative(
+                          for: sourceProject,
+                          in: group
+                      ),
+                      seenGroupIDs.insert(group.id).inserted else {
                     return nil
                 }
                 return DailyUXRecentProject(group: group, project: project)
@@ -143,8 +147,16 @@ enum DailyUXCreationContext {
     ) -> FeatureProject? {
         let availableProjects = projects(in: snapshot)
         if let requestedProjectID,
-           let requestedProject = availableProjects.first(where: { $0.id == requestedProjectID }) {
-            return requestedProject
+           let requestedProject = availableProjects.first(where: { $0.id == requestedProjectID }),
+           let group = DailyUXProjectGrouping.group(
+               containing: requestedProjectID,
+               in: projectGroups(in: snapshot)
+           ),
+           let representative = DailyUXProjectGrouping.physicalRepresentative(
+               for: requestedProject,
+               in: group
+           ) {
+            return representative
         }
 
         return recentProjects(in: snapshot).first?.project
@@ -335,6 +347,17 @@ enum DailyUXProjectGrouping {
     ) -> FeatureProject? {
         groups.first { $0.id == groupID }?
             .preferredProject(environmentID: preferredEnvironmentID)
+    }
+
+    static func physicalRepresentative(
+        for project: FeatureProject,
+        in group: DailyUXProjectGroup
+    ) -> FeatureProject? {
+        let path = normalizedPath(project.path)
+        return group.projects.first {
+            $0.environmentID == project.environmentID
+                && normalizedPath($0.path) == path
+        }
     }
 
     private static func physicalKey(_ project: FeatureProject) -> String {

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -112,6 +112,54 @@ enum DailyUXCreationContext {
         )
     }
 
+    static func recentProjects(in snapshot: FeatureSnapshot) -> [DailyUXRecentProject] {
+        let groups = projectGroups(in: snapshot)
+        let groupByProjectID = groups.reduce(into: [String: DailyUXProjectGroup]()) {
+            result, group in
+            for projectID in group.memberProjectIDs {
+                result[projectID] = group
+            }
+        }
+        let projectEnvironmentByID = snapshot.projects.reduce(into: [String: String]()) {
+            $0[$1.id] = $1.environmentID
+        }
+        var seenGroupIDs = Set<String>()
+
+        return snapshot.threads
+            .sorted(by: recentUseOrder)
+            .compactMap { thread in
+                guard let group = groupByProjectID[thread.projectID],
+                      seenGroupIDs.insert(group.id).inserted,
+                      let project = group.preferredProject(
+                          environmentID: thread.environmentID
+                              ?? projectEnvironmentByID[thread.projectID]
+                      ) else {
+                    return nil
+                }
+                return DailyUXRecentProject(group: group, project: project)
+            }
+    }
+
+    static func initialProject(
+        in snapshot: FeatureSnapshot,
+        requestedProjectID: String?
+    ) -> FeatureProject? {
+        let groups = projectGroups(in: snapshot)
+
+        if let requestedProjectID,
+           let requestedGroup = DailyUXProjectGrouping.group(
+               containing: requestedProjectID,
+               in: groups
+           ) {
+            let requestedEnvironmentID = snapshot.projects
+                .first(where: { $0.id == requestedProjectID })?
+                .environmentID
+            return requestedGroup.preferredProject(environmentID: requestedEnvironmentID)
+        }
+
+        return recentProjects(in: snapshot).first?.project ?? groups.first?.projects.first
+    }
+
     static func logicalProjectID(
         for project: FeatureProject,
         in snapshot: FeatureSnapshot
@@ -130,6 +178,12 @@ enum DailyUXCreationContext {
             )
     }
 
+    private static func recentUseOrder(_ lhs: FeatureThread, _ rhs: FeatureThread) -> Bool {
+        let lhsDate = lhs.lastActivityAt ?? lhs.updatedAt
+        let rhsDate = rhs.lastActivityAt ?? rhs.updatedAt
+        if lhsDate != rhsDate { return lhsDate > rhsDate }
+        return lhs.id < rhs.id
+    }
     static func providers(
         for project: FeatureProject?,
         in snapshot: FeatureSnapshot
@@ -185,6 +239,11 @@ enum DailyUXCreationContext {
         return snapshot.preferencesByEnvironment?[environmentID]
             ?? FeatureEnvironmentPreferences()
     }
+}
+
+struct DailyUXRecentProject: Equatable {
+    let group: DailyUXProjectGroup
+    let project: FeatureProject
 }
 
 struct DailyUXProjectGroup: Identifiable, Equatable {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -11,6 +11,7 @@ public struct NewThreadView: View {
 
     @State private var projectID = ""
     @State private var projectSelectionIsExplicit = false
+    @State private var isAwaitingRecentProject = false
     @State private var prompt = ""
     @State private var selection: FeatureSelection?
     @State private var selectionIsExplicit = false
@@ -90,10 +91,14 @@ public struct NewThreadView: View {
         }
         .onAppear {
             if projectID.isEmpty {
+                let recentProject = DailyUXCreationContext.recentProjects(
+                    in: model.snapshot
+                ).first?.project
                 let initialID = DailyUXCreationContext.initialProject(
                     in: model.snapshot,
                     requestedProjectID: initialProjectID
                 )?.id ?? ""
+                isAwaitingRecentProject = initialProjectID == nil && recentProject == nil
                 selectInitialProject(initialID)
             }
         }
@@ -101,10 +106,14 @@ public struct NewThreadView: View {
         .onChange(of: creationProjectIDs) { _, ids in
             guard !ids.contains(projectID) else { return }
             if projectID.isEmpty {
+                let recentProject = DailyUXCreationContext.recentProjects(
+                    in: model.snapshot
+                ).first?.project
                 let initialID = DailyUXCreationContext.initialProject(
                     in: model.snapshot,
                     requestedProjectID: initialProjectID
                 )?.id ?? ""
+                isAwaitingRecentProject = initialProjectID == nil && recentProject == nil
                 selectInitialProject(initialID)
                 return
             }
@@ -567,6 +576,7 @@ public struct NewThreadView: View {
     private func selectProject(_ id: String) -> Bool {
         guard creationProjects.contains(where: { $0.id == id }) else { return false }
         projectSelectionIsExplicit = true
+        isAwaitingRecentProject = false
         guard id != projectID else { return true }
         persistCurrentDraftImmediately()
         projectID = id
@@ -599,17 +609,24 @@ public struct NewThreadView: View {
     }
 
     private func refreshAutomaticProjectIfNeeded() {
-        guard initialProjectID == nil,
-              !projectSelectionIsExplicit,
-              prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              attachments.isEmpty,
-              let nextProjectID = DailyUXCreationContext.initialProject(
-                  in: model.snapshot,
-                  requestedProjectID: nil
-              )?.id,
-              nextProjectID != projectID else {
+        let nextProjectID = DailyUXCreationContext.recentProjects(
+            in: model.snapshot
+        ).first?.project.id
+        guard DailyUXCreationContext.shouldAdoptAutomaticProject(
+            currentProjectID: projectID,
+            nextRecentProjectID: nextProjectID,
+            isAwaitingRecentActivity: isAwaitingRecentProject,
+            projectSelectionIsExplicit: projectSelectionIsExplicit,
+            modelSelectionIsExplicit: selectionIsExplicit,
+            workspaceSelectionIsExplicit: workspaceSelectionIsExplicit,
+            hasDraftContent: !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || !attachments.isEmpty,
+            draftRestoreIsComplete: restoredDraftProjectID == projectID
+        ) else {
             return
         }
+        isAwaitingRecentProject = false
+        guard let nextProjectID else { return }
         selectInitialProject(nextProjectID)
     }
 
@@ -771,6 +788,7 @@ public struct NewThreadView: View {
             scheduleDraftSave()
         }
         await loadBranches()
+        refreshAutomaticProjectIfNeeded()
     }
 
     private var currentDraftKey: String? {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -10,6 +10,7 @@ public struct NewThreadView: View {
     private let initialProjectID: String?
 
     @State private var projectID = ""
+    @State private var projectSelectionIsExplicit = false
     @State private var prompt = ""
     @State private var selection: FeatureSelection?
     @State private var selectionIsExplicit = false
@@ -116,6 +117,9 @@ public struct NewThreadView: View {
                 .preferredProject(environmentID: previousProject?.environmentID)
                 ?? creationProjectGroups.first?.projects.first
             selectInitialProject(replacement?.id ?? "")
+        }
+        .onChange(of: model.homePresentationRevision) { _, _ in
+            refreshAutomaticProjectIfNeeded()
         }
         .onChange(of: prompt) { scheduleDraftSave() }
         .onChange(of: selection) { scheduleDraftSave() }
@@ -561,8 +565,9 @@ public struct NewThreadView: View {
 
     @discardableResult
     private func selectProject(_ id: String) -> Bool {
-        guard id != projectID else { return true }
         guard creationProjects.contains(where: { $0.id == id }) else { return false }
+        projectSelectionIsExplicit = true
+        guard id != projectID else { return true }
         persistCurrentDraftImmediately()
         projectID = id
         prepareProjectIfNeeded(id)
@@ -576,6 +581,7 @@ public struct NewThreadView: View {
             preferredEnvironmentID: selectedProject?.environmentID,
             in: creationProjectGroups
         ) else { return false }
+        projectSelectionIsExplicit = true
         guard group.id != selectedProjectGroup?.id else { return true }
         return selectProject(target.id)
     }
@@ -590,6 +596,21 @@ public struct NewThreadView: View {
     private func selectInitialProject(_ id: String) {
         projectID = id
         prepareProjectIfNeeded(id)
+    }
+
+    private func refreshAutomaticProjectIfNeeded() {
+        guard initialProjectID == nil,
+              !projectSelectionIsExplicit,
+              prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              attachments.isEmpty,
+              let nextProjectID = DailyUXCreationContext.initialProject(
+                  in: model.snapshot,
+                  requestedProjectID: nil
+              )?.id,
+              nextProjectID != projectID else {
+            return
+        }
+        selectInitialProject(nextProjectID)
     }
 
     private func prepareProjectIfNeeded(_ id: String) {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -609,9 +609,16 @@ public struct NewThreadView: View {
     }
 
     private func refreshAutomaticProjectIfNeeded() {
+        guard isAwaitingRecentProject else { return }
         let nextProjectID = DailyUXCreationContext.recentProjects(
             in: model.snapshot
         ).first?.project.id
+        guard let nextProjectID else { return }
+        if nextProjectID == projectID {
+            isAwaitingRecentProject = false
+            return
+        }
+        let draftRestoreIsComplete = restoredDraftProjectID == projectID
         guard DailyUXCreationContext.shouldAdoptAutomaticProject(
             currentProjectID: projectID,
             nextRecentProjectID: nextProjectID,
@@ -621,12 +628,14 @@ public struct NewThreadView: View {
             workspaceSelectionIsExplicit: workspaceSelectionIsExplicit,
             hasDraftContent: !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 || !attachments.isEmpty,
-            draftRestoreIsComplete: restoredDraftProjectID == projectID
+            draftRestoreIsComplete: draftRestoreIsComplete
         ) else {
+            if draftRestoreIsComplete {
+                isAwaitingRecentProject = false
+            }
             return
         }
         isAwaitingRecentProject = false
-        guard let nextProjectID else { return }
         selectInitialProject(nextProjectID)
     }
 
@@ -787,8 +796,9 @@ public struct NewThreadView: View {
         if liveDraft != context.baseline {
             scheduleDraftSave()
         }
-        await loadBranches()
         refreshAutomaticProjectIfNeeded()
+        guard projectID == requestedProjectID else { return }
+        await loadBranches()
     }
 
     private var currentDraftKey: String? {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -89,22 +89,24 @@ public struct NewThreadView: View {
         }
         .onAppear {
             if projectID.isEmpty {
-                let initialProject = creationProjects.first { $0.id == initialProjectID }
-                let initialGroup = initialProject.flatMap {
-                    DailyUXProjectGrouping.group(
-                        containing: $0.id,
-                        in: creationProjectGroups
-                    )
-                }
-                let initialID = initialGroup?.preferredProject(
-                    environmentID: initialProject?.environmentID
-                )?.id ?? creationProjectGroups.first?.projects.first?.id ?? ""
+                let initialID = DailyUXCreationContext.initialProject(
+                    in: model.snapshot,
+                    requestedProjectID: initialProjectID
+                )?.id ?? ""
                 selectInitialProject(initialID)
             }
         }
         .onChange(of: projectID) { prepareProjectIfNeeded(projectID) }
         .onChange(of: creationProjectIDs) { _, ids in
             guard !ids.contains(projectID) else { return }
+            if projectID.isEmpty {
+                let initialID = DailyUXCreationContext.initialProject(
+                    in: model.snapshot,
+                    requestedProjectID: initialProjectID
+                )?.id ?? ""
+                selectInitialProject(initialID)
+                return
+            }
             persistCurrentDraftImmediately()
             let previousProject = model.snapshot.projects.first { $0.id == projectID }
             let previousGroupID = previousProject.map {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -146,6 +146,7 @@ public struct NewThreadView: View {
             case .project:
                 NewTaskProjectPicker(
                     groups: creationProjectGroups,
+                    recentProjects: DailyUXCreationContext.recentProjects(in: model.snapshot),
                     selectionID: selectedProjectGroup?.id,
                     onSelect: { group in
                         if selectProjectGroup(group) {
@@ -956,13 +957,71 @@ private enum NewTaskPicker: String, Identifiable {
     var id: String { rawValue }
 }
 
+enum NewTaskProjectListSections {
+    static let recentLimit = 3
+
+    static func split(
+        groups: [DailyUXProjectGroup],
+        recentProjects: [DailyUXRecentProject],
+        query: String = "",
+        limit: Int = recentLimit
+    ) -> (recent: [DailyUXProjectGroup], remaining: [DailyUXProjectGroup]) {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        var seenGroupIDs = Set<String>()
+        let matchingGroups = groups
+            .filter { seenGroupIDs.insert($0.id).inserted }
+            .filter { group in
+                guard !normalizedQuery.isEmpty else { return true }
+                let searchableValues = [group.name]
+                    + group.projects.flatMap { [$0.name, $0.path] }
+                return searchableValues.contains {
+                    $0.localizedCaseInsensitiveContains(normalizedQuery)
+                }
+            }
+            .sorted(by: projectOrder)
+
+        let groupsByID = matchingGroups.reduce(into: [String: DailyUXProjectGroup]()) { groupsByID, group in
+            groupsByID[group.id] = groupsByID[group.id] ?? group
+        }
+        var seenRecentIDs = Set<String>()
+        let recent = recentProjects
+            .prefix(max(0, limit))
+            .compactMap { groupsByID[$0.group.id] }
+            .filter { seenRecentIDs.insert($0.id).inserted }
+        let recentIDs = Set(recent.map(\.id))
+        return (recent, matchingGroups.filter { !recentIDs.contains($0.id) })
+    }
+
+    private static func projectOrder(
+        _ lhs: DailyUXProjectGroup,
+        _ rhs: DailyUXProjectGroup
+    ) -> Bool {
+        let comparison = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+        if comparison != .orderedSame { return comparison == .orderedAscending }
+        return lhs.id < rhs.id
+    }
+}
+
 private struct NewTaskProjectPicker: View {
     @SwiftUI.Environment(\.dismiss) private var dismiss
     let groups: [DailyUXProjectGroup]
+    let recentProjects: [DailyUXRecentProject]
     let selectionID: String?
     let onSelect: (DailyUXProjectGroup) -> Void
 
+    @State private var query = ""
+
+    private var sections: (recent: [DailyUXProjectGroup], remaining: [DailyUXProjectGroup]) {
+        NewTaskProjectListSections.split(
+            groups: groups,
+            recentProjects: recentProjects,
+            query: query
+        )
+    }
+
     var body: some View {
+        let visibleSections = sections
+
         NavigationStack {
             Group {
                 if groups.isEmpty {
@@ -971,31 +1030,30 @@ private struct NewTaskProjectPicker: View {
                         systemImage: "folder",
                         description: Text("Reconnect an environment or add a project to continue.")
                     )
+                } else if visibleSections.recent.isEmpty, visibleSections.remaining.isEmpty {
+                    ContentUnavailableView(
+                        "No projects found",
+                        systemImage: "magnifyingglass",
+                        description: Text("Try a different search.")
+                    )
                 } else {
-                    List(groups) { group in
-                        Button {
-                            onSelect(group)
-                        } label: {
-                            HStack(spacing: 12) {
-                                Text(group.name)
-                                    .foregroundStyle(T3Colors.textPrimary)
-
-                                Spacer(minLength: 10)
-
-                                if group.id == selectionID {
-                                    Image(systemName: "checkmark")
-                                        .font(.system(size: 13, weight: .semibold))
-                                        .foregroundStyle(T3Colors.accent)
+                    List {
+                        if visibleSections.recent.isEmpty {
+                            ForEach(visibleSections.remaining, content: row)
+                        } else {
+                            Section {
+                                ForEach(visibleSections.recent, content: row)
+                            } header: {
+                                sectionHeader("Recent")
+                            }
+                            if !visibleSections.remaining.isEmpty {
+                                Section {
+                                    ForEach(visibleSections.remaining, content: row)
+                                } header: {
+                                    sectionHeader("Other projects")
                                 }
                             }
-                            .frame(minHeight: 34)
-                            .contentShape(Rectangle())
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityAddTraits(
-                            group.id == selectionID ? .isSelected : []
-                        )
-                        .listRowBackground(T3Colors.background)
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
@@ -1004,6 +1062,7 @@ private struct NewTaskProjectPicker: View {
             .background(T3Colors.background)
             .navigationTitle("Project")
             .navigationBarTitleDisplayMode(.inline)
+            .searchable(text: $query, prompt: "Search projects")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -1012,6 +1071,37 @@ private struct NewTaskProjectPicker: View {
         }
         .presentationDetents([.medium, .large])
         .presentationBackground(T3Colors.background)
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(T3Typography.supporting)
+            .foregroundStyle(T3Colors.textTertiary)
+            .textCase(nil)
+    }
+
+    private func row(_ group: DailyUXProjectGroup) -> some View {
+        Button {
+            onSelect(group)
+        } label: {
+            HStack(spacing: 12) {
+                Text(group.name)
+                    .foregroundStyle(T3Colors.textPrimary)
+
+                Spacer(minLength: 10)
+
+                if group.id == selectionID {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(T3Colors.accent)
+                }
+            }
+            .frame(minHeight: 34)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(group.id == selectionID ? .isSelected : [])
+        .listRowBackground(T3Colors.background)
     }
 }
 

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -564,7 +564,7 @@ public struct WorkspaceView: View {
     }
 
     private func openNewTaskOrProjectCreation() {
-        openNewTaskOrProjectCreation(initialProjectID: nil)
+        openNewTaskOrProjectCreation(initialProjectID: selectedProjectID)
     }
 
     private func openNewTaskOrProjectCreation(initialProjectID: String?) {

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -269,6 +269,42 @@ struct DailyUXNewTaskTests {
                 draftRestoreIsComplete: false
             )
         )
+        #expect(
+            !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: "recent",
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: true,
+                draftRestoreIsComplete: true
+            )
+        )
+        #expect(
+            !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: "fallback",
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: false,
+                draftRestoreIsComplete: true
+            )
+        )
+        #expect(
+            !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: nil,
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: false,
+                draftRestoreIsComplete: true
+            )
+        )
     }
 
     @Test
@@ -664,6 +700,21 @@ struct DailyUXNewTaskTests {
 
         #expect(group.projects.map(\.id) == ["remote", "current"])
         #expect(group.memberProjectIDs == ["stale", "current", "remote"])
+
+        let snapshot = rankedSnapshot(
+            projects: [stale, current, remote],
+            threads: [rankedThread("recent", projectID: stale.id, activity: 20)]
+        )
+        #expect(
+            DailyUXCreationContext.recentProjects(in: snapshot).first?.project.id
+                == current.id
+        )
+        #expect(
+            DailyUXCreationContext.initialProject(
+                in: snapshot,
+                requestedProjectID: stale.id
+            )?.id == current.id
+        )
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -6,6 +6,123 @@ import UIKit
 @Suite("Message-first task creation")
 struct DailyUXNewTaskTests {
     @Test
+    func recentProjectRankingDrivesTheDefaultAndKeepsUnusedProjectsOut() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let unused = rankedProject("unused", name: "Unused")
+        let value = rankedSnapshot(
+            projects: [unused, beta, alpha],
+            threads: [
+                rankedThread("older", projectID: alpha.id, activity: 10),
+                rankedThread("newer", projectID: beta.id, activity: 20),
+            ]
+        )
+
+        let ranking = DailyUXCreationContext.recentProjects(in: value)
+
+        #expect(ranking.map(\.project.id) == [beta.id, alpha.id])
+        #expect(
+            DailyUXCreationContext.initialProject(in: value, requestedProjectID: nil)?.id
+                == ranking.first?.project.id
+        )
+    }
+
+    @Test
+    func recentProjectRankingIsStableForTiesAndIgnoresMissingProjects() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let value = rankedSnapshot(
+            projects: [alpha, beta],
+            threads: [
+                rankedThread("z-thread", projectID: alpha.id, activity: 20),
+                rankedThread("missing", projectID: "missing", activity: 30),
+                rankedThread("a-thread", projectID: beta.id, activity: 20),
+            ]
+        )
+
+        #expect(
+            DailyUXCreationContext.recentProjects(in: value)
+                .map(\.project.id) == [beta.id, alpha.id]
+        )
+    }
+
+    @Test
+    func recentProjectRankingUsesActivityInsteadOfMetadataChanges() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let value = rankedSnapshot(
+            projects: [alpha, beta],
+            threads: [
+                rankedThread(
+                    "metadata-change",
+                    projectID: alpha.id,
+                    updatedAt: 100,
+                    lastActivityAt: 10
+                ),
+                rankedThread("actual-use", projectID: beta.id, activity: 20),
+            ]
+        )
+
+        #expect(
+            DailyUXCreationContext.recentProjects(in: value)
+                .map(\.project.id) == [beta.id, alpha.id]
+        )
+    }
+
+    @Test
+    func archivedAndSettledThreadsStillRepresentProjectUse() {
+        let archived = rankedProject("archived", name: "Archived")
+        let settled = rankedProject("settled", name: "Settled")
+        let value = rankedSnapshot(
+            projects: [archived, settled],
+            threads: [
+                rankedThread(
+                    "archived-thread",
+                    projectID: archived.id,
+                    activity: 30,
+                    isArchived: true
+                ),
+                rankedThread(
+                    "settled-thread",
+                    projectID: settled.id,
+                    activity: 20,
+                    isSettled: true
+                ),
+            ]
+        )
+
+        #expect(
+            DailyUXCreationContext.recentProjects(in: value)
+                .map(\.project.id) == [archived.id, settled.id]
+        )
+    }
+
+    @Test
+    func explicitProjectWinsAndNoActivityFallsBackAlphabetically() {
+        let zulu = rankedProject("zulu", name: "Zulu")
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let withActivity = rankedSnapshot(
+            projects: [zulu, alpha],
+            threads: [rankedThread("recent", projectID: zulu.id, activity: 20)]
+        )
+        let withoutActivity = rankedSnapshot(projects: [zulu, alpha], threads: [])
+
+        #expect(
+            DailyUXCreationContext.initialProject(
+                in: withActivity,
+                requestedProjectID: alpha.id
+            )?.id == alpha.id
+        )
+        #expect(DailyUXCreationContext.recentProjects(in: withoutActivity).isEmpty)
+        #expect(
+            DailyUXCreationContext.initialProject(
+                in: withoutActivity,
+                requestedProjectID: nil
+            )?.id == alpha.id
+        )
+    }
+
+    @Test
     func requestNormalizesLegacyModesAndKeepsImageBytes() {
         let image = FeatureDraftAttachment(
             data: Data([1, 2, 3]),
@@ -520,5 +637,37 @@ struct DailyUXNewTaskTests {
         #expect(max(prepared.size.width, prepared.size.height) <= 2_048)
         #expect(max(thumbnail.size.width, thumbnail.size.height) <= 160)
         #expect(attachment.mimeType == "image/jpeg")
+    }
+
+    private func rankedProject(_ id: String, name: String) -> FeatureProject {
+        FeatureProject(id: id, environmentID: "environment", name: name, path: "/\(id)")
+    }
+
+    private func rankedThread(
+        _ id: String,
+        projectID: String,
+        activity: TimeInterval? = nil,
+        updatedAt: TimeInterval? = nil,
+        lastActivityAt: TimeInterval? = nil,
+        isArchived: Bool = false,
+        isSettled: Bool = false
+    ) -> FeatureThread {
+        let updatedAt = updatedAt ?? activity ?? 0
+        return FeatureThread(
+            id: id,
+            projectID: projectID,
+            title: id,
+            updatedAt: Date(timeIntervalSince1970: updatedAt),
+            isArchived: isArchived,
+            isSettled: isSettled,
+            lastActivityAt: lastActivityAt.map(Date.init(timeIntervalSince1970:))
+        )
+    }
+
+    private func rankedSnapshot(
+        projects: [FeatureProject],
+        threads: [FeatureThread]
+    ) -> FeatureSnapshot {
+        FeatureSnapshot(projects: projects, threads: threads)
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -203,6 +203,75 @@ struct DailyUXNewTaskTests {
     }
 
     @Test
+    func recentProjectRankingKeepsTheExactWorktreeUsedByTheThread() {
+        let root = rankedProject(
+            "root",
+            name: "Project",
+            repositoryKey: "github.com/example/project"
+        )
+        let worktree = rankedProject(
+            "worktree",
+            name: "Project",
+            repositoryKey: "github.com/example/project"
+        )
+        let value = rankedSnapshot(
+            projects: [root, worktree],
+            threads: [rankedThread("recent", projectID: worktree.id, activity: 20)]
+        )
+
+        #expect(DailyUXCreationContext.recentProjects(in: value).first?.project.id == worktree.id)
+        #expect(
+            DailyUXCreationContext.initialProject(
+                in: value,
+                requestedProjectID: worktree.id
+            )?.id == worktree.id
+        )
+    }
+
+    @Test
+    func automaticProjectAdoptionWaitsForRestoreAndStopsAfterExplicitChoices() {
+        #expect(
+            DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: "recent",
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: false,
+                draftRestoreIsComplete: true
+            )
+        )
+
+        for explicitChoice in 0..<3 {
+            #expect(
+                !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                    currentProjectID: "fallback",
+                    nextRecentProjectID: "recent",
+                    isAwaitingRecentActivity: true,
+                    projectSelectionIsExplicit: explicitChoice == 0,
+                    modelSelectionIsExplicit: explicitChoice == 1,
+                    workspaceSelectionIsExplicit: explicitChoice == 2,
+                    hasDraftContent: false,
+                    draftRestoreIsComplete: true
+                )
+            )
+        }
+        #expect(
+            !DailyUXCreationContext.shouldAdoptAutomaticProject(
+                currentProjectID: "fallback",
+                nextRecentProjectID: "recent",
+                isAwaitingRecentActivity: true,
+                projectSelectionIsExplicit: false,
+                modelSelectionIsExplicit: false,
+                workspaceSelectionIsExplicit: false,
+                hasDraftContent: false,
+                draftRestoreIsComplete: false
+            )
+        )
+    }
+
+    @Test
     func requestNormalizesLegacyModesAndKeepsImageBytes() {
         let image = FeatureDraftAttachment(
             data: Data([1, 2, 3]),

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -123,6 +123,86 @@ struct DailyUXNewTaskTests {
     }
 
     @Test
+    func recentProjectRankingExcludesDisabledEnvironments() {
+        let enabled = rankedProject("enabled", name: "Enabled", environmentID: "enabled-env")
+        let disabled = rankedProject("disabled", name: "Disabled", environmentID: "disabled-env")
+        let value = rankedSnapshot(
+            environments: [
+                FeatureEnvironment(
+                    id: "enabled-env",
+                    name: "Enabled",
+                    endpoint: "http://enabled",
+                    isEnabled: true
+                ),
+                FeatureEnvironment(
+                    id: "disabled-env",
+                    name: "Disabled",
+                    endpoint: "http://disabled",
+                    isEnabled: false
+                ),
+            ],
+            projects: [enabled, disabled],
+            threads: [
+                rankedThread("enabled-thread", projectID: enabled.id, activity: 10),
+                rankedThread("disabled-thread", projectID: disabled.id, activity: 20),
+            ]
+        )
+
+        #expect(
+            DailyUXCreationContext.recentProjects(in: value).map(\.project.id) == [enabled.id]
+        )
+    }
+
+    @Test
+    func recentProjectRankingDeduplicatesARepositoryAcrossEnvironments() {
+        let local = rankedProject(
+            "local",
+            name: "Project",
+            environmentID: "local-env",
+            repositoryKey: "github.com/example/project"
+        )
+        let remote = rankedProject(
+            "remote",
+            name: "Project",
+            environmentID: "remote-env",
+            repositoryKey: "github.com/example/project"
+        )
+        let value = rankedSnapshot(
+            environments: [
+                FeatureEnvironment(
+                    id: "local-env",
+                    name: "Local",
+                    endpoint: "http://local"
+                ),
+                FeatureEnvironment(
+                    id: "remote-env",
+                    name: "Remote",
+                    endpoint: "http://remote"
+                ),
+            ],
+            projects: [local, remote],
+            threads: [
+                rankedThread(
+                    "local-thread",
+                    projectID: local.id,
+                    environmentID: "local-env",
+                    activity: 10
+                ),
+                rankedThread(
+                    "remote-thread",
+                    projectID: remote.id,
+                    environmentID: "remote-env",
+                    activity: 20
+                ),
+            ]
+        )
+
+        let ranking = DailyUXCreationContext.recentProjects(in: value)
+        #expect(ranking.count == 1)
+        #expect(ranking.first?.project.id == remote.id)
+    }
+
+    @Test
     func requestNormalizesLegacyModesAndKeepsImageBytes() {
         let image = FeatureDraftAttachment(
             data: Data([1, 2, 3]),
@@ -639,13 +719,27 @@ struct DailyUXNewTaskTests {
         #expect(attachment.mimeType == "image/jpeg")
     }
 
-    private func rankedProject(_ id: String, name: String) -> FeatureProject {
-        FeatureProject(id: id, environmentID: "environment", name: name, path: "/\(id)")
+    private func rankedProject(
+        _ id: String,
+        name: String,
+        environmentID: String = "environment",
+        repositoryKey: String? = nil
+    ) -> FeatureProject {
+        FeatureProject(
+            id: id,
+            environmentID: environmentID,
+            name: name,
+            path: "/\(id)",
+            repositoryIdentity: repositoryKey.map {
+                FeatureRepositoryIdentity(canonicalKey: $0)
+            }
+        )
     }
 
     private func rankedThread(
         _ id: String,
         projectID: String,
+        environmentID: String? = nil,
         activity: TimeInterval? = nil,
         updatedAt: TimeInterval? = nil,
         lastActivityAt: TimeInterval? = nil,
@@ -656,6 +750,7 @@ struct DailyUXNewTaskTests {
         return FeatureThread(
             id: id,
             projectID: projectID,
+            environmentID: environmentID,
             title: id,
             updatedAt: Date(timeIntervalSince1970: updatedAt),
             isArchived: isArchived,
@@ -665,9 +760,10 @@ struct DailyUXNewTaskTests {
     }
 
     private func rankedSnapshot(
+        environments: [FeatureEnvironment] = [],
         projects: [FeatureProject],
         threads: [FeatureThread]
     ) -> FeatureSnapshot {
-        FeatureSnapshot(projects: projects, threads: threads)
+        FeatureSnapshot(environments: environments, projects: projects, threads: threads)
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -6,6 +6,102 @@ import UIKit
 @Suite("Message-first task creation")
 struct DailyUXNewTaskTests {
     @Test
+    func projectPickerSharesTheDefaultRankingAndLimitsUniqueRecentGroups() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let bravo = rankedProject("bravo", name: "Bravo")
+        let charlie = rankedProject("charlie", name: "Charlie")
+        let delta = rankedProject("delta", name: "Delta")
+        let echo = rankedProject("echo", name: "Echo")
+        let value = rankedSnapshot(
+            projects: [echo, delta, charlie, bravo, alpha],
+            threads: [
+                rankedThread("echo-new", projectID: echo.id, activity: 50),
+                rankedThread("echo-old", projectID: echo.id, activity: 10),
+                rankedThread("z-delta", projectID: delta.id, activity: 40),
+                rankedThread("a-charlie", projectID: charlie.id, activity: 40),
+                rankedThread("bravo", projectID: bravo.id, activity: 30),
+            ]
+        )
+        let ranking = DailyUXCreationContext.recentProjects(in: value)
+        let sections = NewTaskProjectListSections.split(
+            groups: DailyUXCreationContext.projectGroups(in: value),
+            recentProjects: ranking
+        )
+
+        #expect(ranking.map(\.project.id) == [echo.id, charlie.id, delta.id, bravo.id])
+        #expect(
+            DailyUXCreationContext.initialProject(in: value, requestedProjectID: nil)?.id
+                == ranking.first?.project.id
+        )
+        #expect(sections.recent.map(\.id) == ranking.prefix(3).map(\.group.id))
+        #expect(sections.remaining.map(\.name) == [alpha.name, bravo.name])
+        #expect(Set(sections.recent.map(\.id)).count == sections.recent.count)
+    }
+
+    @Test
+    func projectPickerSearchesEveryProjectAndReportsNoMatches() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let bravo = rankedProject("bravo", name: "Bravo")
+        let aliasedCheckout = FeatureProject(
+            id: "aliased-checkout",
+            environmentID: "environment",
+            name: "Physical Checkout Alias",
+            path: "/aliased-checkout",
+            repositoryIdentity: FeatureRepositoryIdentity(
+                canonicalKey: "repository:aliased",
+                displayName: "Canonical Repository"
+            )
+        )
+        let value = rankedSnapshot(
+            projects: [bravo, aliasedCheckout, alpha],
+            threads: [rankedThread("alpha", projectID: alpha.id, activity: 20)]
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+        let ranking = DailyUXCreationContext.recentProjects(in: value)
+
+        let recentMatch = NewTaskProjectListSections.split(
+            groups: groups,
+            recentProjects: ranking,
+            query: "ALPHA"
+        )
+        let otherMatch = NewTaskProjectListSections.split(
+            groups: groups,
+            recentProjects: ranking,
+            query: "/bravo"
+        )
+        let physicalProjectNameMatch = NewTaskProjectListSections.split(
+            groups: groups,
+            recentProjects: ranking,
+            query: "checkout alias"
+        )
+        let visibleGroupNameMatch = NewTaskProjectListSections.split(
+            groups: groups,
+            recentProjects: ranking,
+            query: "canonical repository"
+        )
+        let noMatch = NewTaskProjectListSections.split(
+            groups: groups,
+            recentProjects: ranking,
+            query: "missing"
+        )
+        let noProjects = NewTaskProjectListSections.split(
+            groups: [],
+            recentProjects: []
+        )
+
+        #expect(recentMatch.recent.map(\.name) == [alpha.name])
+        #expect(recentMatch.remaining.isEmpty)
+        #expect(otherMatch.recent.isEmpty)
+        #expect(otherMatch.remaining.map(\.name) == [bravo.name])
+        #expect(physicalProjectNameMatch.recent.isEmpty)
+        #expect(physicalProjectNameMatch.remaining.map(\.name) == ["Canonical Repository"])
+        #expect(visibleGroupNameMatch.recent.isEmpty)
+        #expect(visibleGroupNameMatch.remaining.map(\.name) == ["Canonical Repository"])
+        #expect(noMatch.recent.isEmpty && noMatch.remaining.isEmpty)
+        #expect(noProjects.recent.isEmpty && noProjects.remaining.isEmpty)
+    }
+
+    @Test
     func recentProjectRankingDrivesTheDefaultAndKeepsUnusedProjectsOut() {
         let alpha = rankedProject("alpha", name: "Alpha")
         let beta = rankedProject("beta", name: "Beta")

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 


### PR DESCRIPTION
## What Changed

- show a compact recent-projects section in the new-task project picker
- rank the section with the same activity model used by the default project
- keep search available across every project and report empty results clearly

## Dependency

Stacked on #5802. Review the final commit for this feature until that PR lands.

## Verification

- Current head `52237e65` is directly stacked on #5802 head `b6444b8`.
- Exact-current-head `DailyUXNewTaskTests`: 26 passed, 0 failed, including deleted/missing selection, stable fallback, physical project-name search, and visible group-label search.
- The rebased child before behavior-neutral review refinements passed the full native gate: 236 tests in 29 suites. Exact current head `52237e65` then passed GitHub `Contract fixtures and native tests` plus the general `Test` job.
- Integrated iOS Simulator: exact-current-head app built and launched successfully; the picker showed Thread Menu Proof under Recent with its checkmark and `saphid/t3code-personal` under Other projects.
- `git diff --check`: passed.
- Direct independent review: Claude Opus 5 high, exit 0; no actionable correctness, performance, or test findings remain after the accepted refinements.

## UI

Current child head — Recent and Other projects sections, with the default project selected:

![PR #6131 current-head project picker](https://github.com/saphid/t3code/releases/download/pr-evidence-20260809/pr6131-current-head-picker-52237e6.png)

[Playable current-head Simulator flow (MP4 wrapper)](https://alexs-macbook-pro-1.tail4e5636.ts.net:8767/pr5802-6131-exact-head-flow.html)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add recent projects picker to the new task composer in iOS
> - Adds a recent projects list to `NewTaskProjectPicker` with search support, splitting project groups into recent and remaining sections via `NewTaskProjectListSections`.
> - Introduces `DailyUXCreationContext.recentProjects` and `initialProject` to derive a de-duplicated, most-recently-used project list from thread activity and preselect the best matching project on open.
> - The new task view automatically switches to the most recent project after draft restoration if the user has made no explicit selections and there is no draft content.
> - Opening the new task view from `WorkspaceView` now preselects the currently active project.
> - `DailyUXProjectGrouping.physicalRepresentative` ensures the selected project matches the exact environment and worktree path within a group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ee5216. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: chain
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: #5802 at b6444b8ad3a2c9d1520c482c8b9171b970f57994
Merge order: #5802 → #6131
Validation status: Current head 52237e65 is locally and CI proven, Macroscope-correctness green, and mergeable. Keep this PR draft and revalidate after #5802 lands. The unrelated Vercel authorization failure remains a maintainer-side gate.
<!-- swiftui-delivery:end -->
