### PR TITLE
feat(swift-ios): add file preview navigation and info

### DIFF
--- a/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
@@ -1,6 +1,17 @@
 import SwiftUI
 import UIKit
 
+private struct MarkdownTextSelectionEnabledKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+private extension EnvironmentValues {
+    var markdownTextSelectionEnabled: Bool {
+        get { self[MarkdownTextSelectionEnabledKey.self] }
+        set { self[MarkdownTextSelectionEnabledKey.self] = newValue }
+    }
+}
+
 /// Native chat Markdown with block-aware layout and Foundation inline parsing.
 struct MarkdownMessageView: View {
     private struct RenderRequest: Hashable {
@@ -11,13 +22,19 @@ struct MarkdownMessageView: View {
     private let source: String
     private let revision: MarkdownContentRevision
     private let isStreaming: Bool
+    private let onOpenURL: ((URL) -> Bool)?
     @State private var renderedDocument: MarkdownRenderedDocument?
     @State private var streamingRenderer = StreamingMarkdownRenderer()
     @State private var isSelectingText = false
 
-    init(_ source: String, isStreaming: Bool = false) {
+    init(
+        _ source: String,
+        isStreaming: Bool = false,
+        onOpenURL: ((URL) -> Bool)? = nil
+    ) {
         self.source = source
         self.isStreaming = isStreaming
+        self.onOpenURL = onOpenURL
         let revision = MarkdownContentRevision(source)
         self.revision = revision
         let initialDocument = if isStreaming {
@@ -44,6 +61,7 @@ struct MarkdownMessageView: View {
             }
         }
         .modifier(MarkdownTextSelectionModifier(isEnabled: isSelectingText))
+        .environment(\.markdownTextSelectionEnabled, isSelectingText)
         .contextMenu {
             Button {
                 isSelectingText.toggle()
@@ -62,6 +80,10 @@ struct MarkdownMessageView: View {
         .accessibilityAction(named: "Copy message") {
             UIPasteboard.general.string = source
         }
+        .environment(\.openURL, OpenURLAction { url in
+            if onOpenURL?(url) == true { return .handled }
+            return .systemAction
+        })
         .task(id: RenderRequest(revision: revision, isStreaming: isStreaming)) {
             if !isStreaming {
                 streamingRenderer.cancel()
@@ -216,7 +238,6 @@ private struct MarkdownBlockView: View, Equatable {
         switch block {
         case let .paragraph(inline):
             MarkdownInlineText(inline)
-                .lineSpacing(4)
 
         case let .heading(level, inline):
             MarkdownInlineText(inline)
@@ -290,7 +311,6 @@ private struct MarkdownTableView: View {
         GridRow(alignment: .top) {
             ForEach(cells.indices, id: \.self) { columnIndex in
                 MarkdownInlineText(cells[columnIndex])
-                    .lineSpacing(3)
                     .frame(
                         width: columnWidths[columnIndex],
                         alignment: alignment(for: columnIndex)
@@ -470,18 +490,199 @@ enum MarkdownCodeBlockWrapping {
 }
 
 private struct MarkdownInlineText: View {
+    @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @SwiftUI.Environment(\.legibilityWeight) private var legibilityWeight
+    @SwiftUI.Environment(\.markdownTextSelectionEnabled) private var isTextSelectionEnabled
+
     private let attributedText: AttributedString
     private let font: Font
+    private let style: MarkdownInlineStyle
+    private let hasLinks: Bool
 
     init(_ rendered: MarkdownRenderedInline) {
         attributedText = rendered.attributedText
         font = rendered.style.font
+        style = rendered.style
+        hasLinks = rendered.attributedText.runs.contains { $0.link != nil }
     }
 
     var body: some View {
         Text(attributedText)
             .font(font)
+            .lineSpacing(style.lineSpacing)
             .fixedSize(horizontal: false, vertical: true)
+            .overlay {
+                if hasLinks {
+                    MarkdownLinkInteractionOverlay(
+                        attributedText: attributedText,
+                        baseFont: style.uiFont(
+                            dynamicTypeSize: dynamicTypeSize,
+                            legibilityWeight: legibilityWeight
+                        ),
+                        lineSpacing: style.lineSpacing
+                    )
+                    .allowsHitTesting(!isTextSelectionEnabled)
+                }
+            }
+    }
+}
+
+@MainActor
+final class MarkdownLinkActionRelay {
+    var handler: (URL) -> Void = { _ in }
+
+    func open(_ url: URL) {
+        handler(url)
+    }
+}
+
+private struct MarkdownLinkInteractionOverlay: UIViewRepresentable {
+    @SwiftUI.Environment(\.openURL) private var openURL
+
+    let attributedText: AttributedString
+    let baseFont: UIFont
+    let lineSpacing: CGFloat
+
+    func makeCoordinator() -> MarkdownLinkActionRelay {
+        MarkdownLinkActionRelay()
+    }
+
+    func makeUIView(context: Context) -> MarkdownLinkInteractionView {
+        let relay = context.coordinator
+        let view = MarkdownLinkInteractionView()
+        view.onOpenURL = { relay.open($0) }
+        return view
+    }
+
+    func updateUIView(_ view: MarkdownLinkInteractionView, context: Context) {
+        // UIHostingConfiguration recycles transcript cells. Updating this relay
+        // keeps a reused link wired to the current SwiftUI environment.
+        context.coordinator.handler = { url in openURL(url) }
+        view.render(attributedText, baseFont: baseFont, lineSpacing: lineSpacing)
+    }
+}
+
+private final class MarkdownLinkInteractionView: UIView {
+    var onOpenURL: ((URL) -> Void)?
+
+    private let textStorage = NSTextStorage()
+    private let layoutManager = NSLayoutManager()
+    private let textContainer = NSTextContainer(size: .zero)
+    private var initialTouch: (point: CGPoint, url: URL, timestamp: TimeInterval)?
+    private var renderedText: AttributedString?
+    private var renderedFont: UIFont?
+    private var renderedLineSpacing: CGFloat?
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        isOpaque = false
+        isUserInteractionEnabled = true
+        isAccessibilityElement = false
+        accessibilityElementsHidden = true
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func render(_ text: AttributedString, baseFont: UIFont, lineSpacing: CGFloat) {
+        guard renderedText != text
+                || renderedFont?.isEqual(baseFont) != true
+                || renderedLineSpacing != lineSpacing else { return }
+        renderedText = text
+        renderedFont = baseFont
+        renderedLineSpacing = lineSpacing
+
+        let rendered = NSMutableAttributedString()
+        for run in text.runs {
+            let string = String(text[run.range].characters)
+            var attributes: [NSAttributedString.Key: Any] = [
+                .font: font(for: run.inlinePresentationIntent, baseFont: baseFont),
+                .foregroundColor: UIColor.clear,
+            ]
+            if let link = run.link { attributes[.link] = link }
+            rendered.append(NSAttributedString(string: string, attributes: attributes))
+        }
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = lineSpacing
+        rendered.addAttribute(
+            .paragraphStyle,
+            value: paragraph,
+            range: NSRange(location: 0, length: rendered.length)
+        )
+        textStorage.setAttributedString(rendered)
+        setNeedsLayout()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        textContainer.size = bounds.size
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        link(at: point) != nil
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first,
+              let url = link(at: touch.location(in: self)) else {
+            initialTouch = nil
+            super.touchesBegan(touches, with: event)
+            return
+        }
+        initialTouch = (touch.location(in: self), url, touch.timestamp)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first, let initialTouch,
+              initialTouch.url == link(at: touch.location(in: self)),
+              hypot(
+                  touch.location(in: self).x - initialTouch.point.x,
+                  touch.location(in: self).y - initialTouch.point.y
+              ) <= 10,
+              touch.timestamp - initialTouch.timestamp <= 0.5 else {
+            self.initialTouch = nil
+            super.touchesEnded(touches, with: event)
+            return
+        }
+        self.initialTouch = nil
+        onOpenURL?(initialTouch.url)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        initialTouch = nil
+        super.touchesCancelled(touches, with: event)
+    }
+
+    private func link(at point: CGPoint) -> URL? {
+        guard textStorage.length > 0, bounds.contains(point) else { return nil }
+        let glyph = layoutManager.glyphIndex(for: point, in: textContainer)
+        guard glyph < layoutManager.numberOfGlyphs else { return nil }
+        let glyphRect = layoutManager.boundingRect(
+            forGlyphRange: NSRange(location: glyph, length: 1),
+            in: textContainer
+        )
+        guard glyphRect.insetBy(dx: -6, dy: -4).contains(point) else { return nil }
+        let character = layoutManager.characterIndexForGlyph(at: glyph)
+        guard character < textStorage.length else { return nil }
+        return textStorage.attribute(.link, at: character, effectiveRange: nil) as? URL
+    }
+
+    private func font(for intent: InlinePresentationIntent?, baseFont: UIFont) -> UIFont {
+        var descriptor = baseFont.fontDescriptor
+        if intent?.contains(.code) == true {
+            descriptor = descriptor.withDesign(.monospaced) ?? descriptor
+        }
+        var traits = descriptor.symbolicTraits
+        if intent?.contains(.stronglyEmphasized) == true { traits.insert(.traitBold) }
+        if intent?.contains(.emphasized) == true { traits.insert(.traitItalic) }
+        guard let descriptor = descriptor.withSymbolicTraits(traits) else { return baseFont }
+        return UIFont(descriptor: descriptor, size: baseFont.pointSize)
     }
 }
 

--- a/apps/swift-ios/Features/Chat/MarkdownRenderCache.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownRenderCache.swift
@@ -54,6 +54,52 @@ enum MarkdownInlineStyle: String, Hashable, Sendable {
         }
     }
 
+    func uiFont(
+        dynamicTypeSize: DynamicTypeSize,
+        legibilityWeight: LegibilityWeight?
+    ) -> UIFont {
+        let textStyle: UIFont.TextStyle
+        let weight: UIFont.Weight
+        switch self {
+        case .body, .tableCell:
+            textStyle = .body
+            weight = .regular
+        case .heading1:
+            textStyle = .title2
+            weight = .bold
+        case .heading2:
+            textStyle = .title3
+            weight = .bold
+        case .heading3:
+            textStyle = .headline
+            weight = .bold
+        case .heading4, .tableHeader:
+            textStyle = .body
+            weight = .semibold
+        }
+        let traits = UITraitCollection(traitsFrom: [
+            UITraitCollection(
+                preferredContentSizeCategory: UIContentSizeCategory(dynamicTypeSize)
+            ),
+            UITraitCollection(
+                legibilityWeight: legibilityWeight == .bold ? .bold : .unspecified
+            ),
+        ])
+        let preferred = UIFont.preferredFont(forTextStyle: textStyle, compatibleWith: traits)
+        let effectiveWeight: UIFont.Weight = legibilityWeight == .bold
+            ? max(weight, .semibold)
+            : weight
+        return UIFont.systemFont(ofSize: preferred.pointSize, weight: effectiveWeight)
+    }
+
+    var lineSpacing: CGFloat {
+        switch self {
+        case .body: 4
+        case .tableHeader, .tableCell: 3
+        case .heading1, .heading2, .heading3, .heading4: 0
+        }
+    }
+
     static func heading(level: Int) -> Self {
         switch level {
         case 1: .heading1

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -21,6 +21,8 @@ public struct ThreadDetailView: View {
     @State private var didRestoreDraft = false
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var toolSurface: FeatureThreadToolSurface?
+    @State private var linkedFile: FeatureWorkspaceFileLink?
+    @State private var fileLinkFailureMessage: String?
     @FocusState private var composerFocused: Bool
 
     public init(
@@ -101,10 +103,37 @@ public struct ThreadDetailView: View {
             .presentationDetents([.large])
             .presentationDragIndicator(.visible)
         }
+        .sheet(item: $linkedFile) { link in
+            NavigationStack {
+                FeatureFilePreviewView(
+                    client: model.client,
+                    threadID: thread.id,
+                    entry: link.entry
+                )
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { linkedFile = nil }
+                    }
+                }
+            }
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+        }
         .alert("Message not sent", isPresented: $sendFailed) {
             Button("OK") {}
         } message: {
             Text("Your draft is still here. Check your connection and try again.")
+        }
+        .alert(
+            "File link unavailable",
+            isPresented: Binding(
+                get: { fileLinkFailureMessage != nil },
+                set: { if !$0 { fileLinkFailureMessage = nil } }
+            )
+        ) {
+            Button("OK") { fileLinkFailureMessage = nil }
+        } message: {
+            Text(fileLinkFailureMessage ?? "This file is not inside the active workspace.")
         }
         .simultaneousGesture(edgeBackGesture)
     }
@@ -128,6 +157,11 @@ public struct ThreadDetailView: View {
 
     private var currentThread: FeatureThread {
         detail?.thread ?? thread
+    }
+
+    private var workspaceRoot: String? {
+        currentThread.worktreePath
+            ?? model.snapshot.projects.first { $0.id == currentThread.projectID }?.path
     }
 
     private var currentSelection: FeatureSelection? {
@@ -334,6 +368,7 @@ public struct ThreadDetailView: View {
                     onLoadEarlier: {
                         Task { await model.loadEarlierTurns(for: thread.id) }
                     },
+                    onOpenURL: openURL,
                     onDismissKeyboard: dismissKeyboard
                 )
             }
@@ -366,6 +401,18 @@ public struct ThreadDetailView: View {
             )
             .simultaneousGesture(composerKeyboardDismissGesture)
         }
+    }
+
+    private func openURL(_ url: URL) -> Bool {
+        guard let link = FeatureWorkspaceFileLink(url: url, workspaceRoot: workspaceRoot) else {
+            guard FeatureWorkspaceFileLink.isWorkspaceDestination(url) else { return false }
+            fileLinkFailureMessage = workspaceRoot == nil
+                ? "The active workspace is not available for this thread."
+                : "This file is not inside the active workspace."
+            return true
+        }
+        linkedFile = link
+        return true
     }
 
     private var composerKeyboardDismissGesture: some Gesture {
@@ -644,6 +691,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
     let canLoadEarlier: Bool
     let isLoadingEarlier: Bool
     let onLoadEarlier: () -> Void
+    let onOpenURL: (URL) -> Bool
     let onDismissKeyboard: () -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -679,6 +727,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             canLoadEarlier: canLoadEarlier,
             isLoadingEarlier: isLoadingEarlier,
             onLoadEarlier: onLoadEarlier,
+            onOpenURL: onOpenURL,
             onDismissKeyboard: onDismissKeyboard,
             in: collectionView
         )
@@ -730,6 +779,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         private var currentIsLoadingEarlier = false
         private var markdownPrefetches: [String: MarkdownPrefetch] = [:]
         private var onLoadEarlier: (() -> Void)?
+        private var onOpenURL: ((URL) -> Bool)?
         private var onDismissKeyboard: (() -> Void)?
 
         deinit {
@@ -770,7 +820,10 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 }
 
                 cell.contentConfiguration = UIHostingConfiguration {
-                    FeatureMessageView(message: message)
+                    FeatureMessageView(
+                        message: message,
+                        onOpenURL: { [weak self] url in self?.onOpenURL?(url) == true }
+                    )
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .margins(.all, 0)
@@ -803,11 +856,13 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             canLoadEarlier: Bool,
             isLoadingEarlier: Bool,
             onLoadEarlier: @escaping () -> Void,
+            onOpenURL: @escaping (URL) -> Bool,
             onDismissKeyboard: @escaping () -> Void,
             in collectionView: UICollectionView
         ) {
             guard let dataSource else { return }
             self.onLoadEarlier = onLoadEarlier
+            self.onOpenURL = onOpenURL
             self.onDismissKeyboard = onDismissKeyboard
 
             let threadChanged = currentThreadID != threadID
@@ -1501,6 +1556,7 @@ private enum FeatureAttachmentThumbnailError: Error {
 
 struct FeatureMessageView: View {
     let message: FeatureMessage
+    let onOpenURL: (URL) -> Bool
 
     var body: some View {
         switch message.role {
@@ -1512,7 +1568,8 @@ struct FeatureMessageView: View {
                     if !message.text.isEmpty {
                         MarkdownMessageView(
                             message.text,
-                            isStreaming: message.state == .streaming
+                            isStreaming: message.state == .streaming,
+                            onOpenURL: onOpenURL
                         )
                     }
                 }
@@ -1546,7 +1603,8 @@ struct FeatureMessageView: View {
                 if !message.text.isEmpty {
                     MarkdownMessageView(
                         message.text,
-                        isStreaming: message.state == .streaming
+                        isStreaming: message.state == .streaming,
+                        onOpenURL: onOpenURL
                     )
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -84,7 +84,11 @@ public struct ThreadDetailView: View {
             NavigationStack {
                 switch surface {
                 case .files:
-                    FeatureFilesView(client: model.client, threadID: thread.id)
+                    FeatureFilesView(
+                        client: model.client,
+                        threadID: thread.id,
+                        workspaceRoot: workspaceRoot
+                    )
                 case .review:
                     FeatureReviewView(client: model.client, threadID: thread.id)
                 case .sourceControl:
@@ -104,18 +108,13 @@ public struct ThreadDetailView: View {
             .presentationDragIndicator(.visible)
         }
         .sheet(item: $linkedFile) { link in
-            NavigationStack {
-                FeatureFilePreviewView(
-                    client: model.client,
-                    threadID: thread.id,
-                    entry: link.entry
-                )
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Done") { linkedFile = nil }
-                    }
-                }
-            }
+            FeatureLinkedFileSheet(
+                client: model.client,
+                threadID: thread.id,
+                workspaceRoot: workspaceRoot,
+                entry: link.entry,
+                onDone: { linkedFile = nil }
+            )
             .presentationDetents([.large])
             .presentationDragIndicator(.visible)
         }
@@ -588,6 +587,44 @@ public struct ThreadDetailView: View {
         )
     }
 
+}
+
+private struct FeatureLinkedFileSheet: View {
+    let client: any FeatureClient
+    let threadID: String
+    let workspaceRoot: String?
+    let entry: FeatureFileEntry
+    let onDone: () -> Void
+
+    @State private var showsContainingDirectory = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if showsContainingDirectory {
+                    FeatureFilesView(
+                        client: client,
+                        threadID: threadID,
+                        workspaceRoot: workspaceRoot,
+                        initialPath: entry.containingDirectoryPath
+                    )
+                } else {
+                    FeatureFilePreviewView(
+                        client: client,
+                        threadID: threadID,
+                        workspaceRoot: workspaceRoot,
+                        entry: entry,
+                        onShowInFiles: { showsContainingDirectory = true }
+                    )
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done", action: onDone)
+                }
+            }
+        }
+    }
 }
 
 private struct FeatureThreadOpeningView: View {

--- a/apps/swift-ios/Features/Files/FeatureFilesView.swift
+++ b/apps/swift-ios/Features/Files/FeatureFilesView.swift
@@ -308,7 +308,11 @@ struct FeatureFilePreviewView: View {
     }
 
     private func openURL(_ url: URL) -> Bool {
-        guard let link = FeatureWorkspaceFileLink(url: url, workspaceRoot: workspaceRoot) else {
+        guard let link = FeatureWorkspaceFileLink(
+            url: url,
+            workspaceRoot: workspaceRoot,
+            relativeTo: entry.containingDirectoryPath
+        ) else {
             guard FeatureWorkspaceFileLink.isWorkspaceDestination(url) else { return false }
             linkFailureMessage = workspaceRoot == nil
                 ? "The active workspace is not available for this thread."

--- a/apps/swift-ios/Features/Files/FeatureFilesView.swift
+++ b/apps/swift-ios/Features/Files/FeatureFilesView.swift
@@ -149,7 +149,7 @@ private struct FeatureFileRow: View {
     }
 }
 
-private struct FeatureFilePreviewView: View {
+struct FeatureFilePreviewView: View {
     let client: any FeatureClient
     let threadID: String
     let entry: FeatureFileEntry
@@ -211,6 +211,7 @@ private struct FeatureFilePreviewView: View {
         .background(T3Colors.background)
         .navigationTitle(entry.name)
         .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("workspace-file-preview")
         .toolbar {
             if let assetURL {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/apps/swift-ios/Features/Files/FeatureFilesView.swift
+++ b/apps/swift-ios/Features/Files/FeatureFilesView.swift
@@ -5,14 +5,29 @@ import UIKit
 public struct FeatureFilesView: View {
     let client: any FeatureClient
     let threadID: String
+    let workspaceRoot: String?
+    let initialPath: String?
 
-    public init(client: any FeatureClient, threadID: String) {
+    public init(
+        client: any FeatureClient,
+        threadID: String,
+        workspaceRoot: String? = nil,
+        initialPath: String? = nil
+    ) {
         self.client = client
         self.threadID = threadID
+        self.workspaceRoot = workspaceRoot
+        self.initialPath = initialPath
     }
 
     public var body: some View {
-        FeatureFileDirectoryView(client: client, threadID: threadID, path: nil, title: "Files")
+        FeatureFileDirectoryView(
+            client: client,
+            threadID: threadID,
+            workspaceRoot: workspaceRoot,
+            path: initialPath,
+            title: initialPath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "Files"
+        )
             .background(T3Colors.background)
     }
 }
@@ -20,6 +35,7 @@ public struct FeatureFilesView: View {
 private struct FeatureFileDirectoryView: View {
     let client: any FeatureClient
     let threadID: String
+    let workspaceRoot: String?
     let path: String?
     let title: String
 
@@ -87,11 +103,17 @@ private struct FeatureFileDirectoryView: View {
             FeatureFileDirectoryView(
                 client: client,
                 threadID: threadID,
+                workspaceRoot: workspaceRoot,
                 path: entry.path,
                 title: entry.name
             )
         } else {
-            FeatureFilePreviewView(client: client, threadID: threadID, entry: entry)
+            FeatureFilePreviewView(
+                client: client,
+                threadID: threadID,
+                workspaceRoot: workspaceRoot,
+                entry: entry
+            )
         }
     }
 
@@ -152,7 +174,9 @@ private struct FeatureFileRow: View {
 struct FeatureFilePreviewView: View {
     let client: any FeatureClient
     let threadID: String
+    let workspaceRoot: String?
     let entry: FeatureFileEntry
+    var onShowInFiles: (() -> Void)? = nil
 
     @State private var content: FeatureFileContent?
     @State private var sourceLines: [FeatureSourceLine] = []
@@ -160,6 +184,9 @@ struct FeatureFilePreviewView: View {
     @State private var assetURL: URL?
     @State private var errorMessage: String?
     @State private var isLoading = true
+    @State private var linkedFile: FeatureWorkspaceFileLink?
+    @State private var linkFailureMessage: String?
+    @State private var showsInfo = false
 
     private var previewKind: FeatureFilePreviewKind {
         FeatureFilePreviewKind.infer(path: entry.path, language: content?.language)
@@ -187,7 +214,7 @@ struct FeatureFilePreviewView: View {
                     switch previewKind {
                     case .markdown:
                         ScrollView {
-                            MarkdownMessageView(content.text)
+                            MarkdownMessageView(content.text, onOpenURL: openURL)
                                 .frame(maxWidth: T3Metrics.readingWidth, alignment: .leading)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, 18)
@@ -212,7 +239,32 @@ struct FeatureFilePreviewView: View {
         .navigationTitle(entry.name)
         .navigationBarTitleDisplayMode(.inline)
         .accessibilityIdentifier("workspace-file-preview")
+        .navigationDestination(item: $linkedFile) { link in
+            FeatureFilePreviewView(
+                client: client,
+                threadID: threadID,
+                workspaceRoot: workspaceRoot,
+                entry: link.entry
+            )
+        }
         .toolbar {
+            if let onShowInFiles {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: onShowInFiles) {
+                        Label("Files", systemImage: "chevron.backward")
+                    }
+                    .accessibilityIdentifier("workspace-file-show-in-files")
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showsInfo = true
+                } label: {
+                    Image(systemName: "info.circle")
+                }
+                .accessibilityLabel("File info")
+                .accessibilityIdentifier("workspace-file-info")
+            }
             if let assetURL {
                 ToolbarItem(placement: .topBarTrailing) {
                     ShareLink(item: assetURL) {
@@ -229,7 +281,42 @@ struct FeatureFilePreviewView: View {
                 }
             }
         }
+        .sheet(isPresented: $showsInfo) {
+            NavigationStack {
+                FeatureFileInfoView(entry: entry, content: content)
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") { showsInfo = false }
+                        }
+                    }
+            }
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+        }
+        .alert(
+            "File link unavailable",
+            isPresented: Binding(
+                get: { linkFailureMessage != nil },
+                set: { if !$0 { linkFailureMessage = nil } }
+            )
+        ) {
+            Button("OK") { linkFailureMessage = nil }
+        } message: {
+            Text(linkFailureMessage ?? "This file is not inside the active workspace.")
+        }
         .task { await load() }
+    }
+
+    private func openURL(_ url: URL) -> Bool {
+        guard let link = FeatureWorkspaceFileLink(url: url, workspaceRoot: workspaceRoot) else {
+            guard FeatureWorkspaceFileLink.isWorkspaceDestination(url) else { return false }
+            linkFailureMessage = workspaceRoot == nil
+                ? "The active workspace is not available for this thread."
+                : "This file is not inside the active workspace."
+            return true
+        }
+        linkedFile = link
+        return true
     }
 
     private func load() async {
@@ -299,6 +386,48 @@ struct FeatureFilePreviewView: View {
         } catch {
             guard !Task.isCancelled else { return }
             errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct FeatureFileInfoView: View {
+    let entry: FeatureFileEntry
+    let content: FeatureFileContent?
+
+    var body: some View {
+        List {
+            LabeledContent("Name", value: entry.name)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Path")
+                    .foregroundStyle(T3Colors.textSecondary)
+                Text(entry.path)
+                    .font(T3Typography.code)
+                    .textSelection(.enabled)
+            }
+            LabeledContent("Kind", value: kindLabel)
+            if let byteCount = content?.totalBytes ?? entry.sizeBytes {
+                LabeledContent(
+                    "Size",
+                    value: ByteCountFormatter.string(fromByteCount: Int64(byteCount), countStyle: .file)
+                )
+            }
+            if let language = content?.language, !language.isEmpty {
+                LabeledContent("Language", value: language)
+            }
+            if content?.isTruncated == true {
+                LabeledContent("Preview", value: "Partial")
+            }
+        }
+        .navigationTitle("File Info")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("workspace-file-info-view")
+    }
+
+    private var kindLabel: String {
+        switch entry.kind {
+        case .file: "File"
+        case .directory: "Folder"
+        case .symbolicLink: "Symbolic Link"
         }
     }
 }

--- a/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
+++ b/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Resolves transcript destinations to paths accepted by the workspace file APIs.
+/// The server expects workspace-relative paths, so absolute destinations must remain
+/// inside the active workspace and relative destinations must not escape it.
+public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hashable {
+    private static let conventionalFileNames: Set<String> = [
+        "AUTHORS", "Brewfile", "BUILD", "Caddyfile", "CHANGELOG", "CODEOWNERS",
+        "Containerfile", "CONTRIBUTORS", "COPYING", "Dockerfile", "Fastfile",
+        "Gemfile", "GNUmakefile", "Jenkinsfile", "Justfile", "LICENSE", "LICENCE",
+        "Makefile", "NOTICE", "Podfile", "Procfile", "README", "Rakefile",
+        "Vagrantfile", "WORKSPACE", "justfile", "makefile",
+    ]
+
+    private static let positionedPathExtensions: Set<String> = [
+        "c", "cc", "conf", "cpp", "cs", "css", "csv", "env", "go", "h", "hpp",
+        "html", "ini", "java", "js", "json", "jsx", "kt", "kts", "m", "md",
+        "mdx", "mm", "php", "plist", "py", "rb", "rs", "scss", "sh", "sql",
+        "swift", "text", "toml", "ts", "tsx", "txt", "vue", "xml", "yaml",
+        "yml", "zsh",
+    ]
+
+    public let path: String
+    public var id: String { path }
+
+    public var entry: FeatureFileEntry {
+        FeatureFileEntry(
+            path: path,
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            kind: .file
+        )
+    }
+
+    public init?(url: URL, workspaceRoot: String?) {
+        guard let workspaceRoot, !workspaceRoot.isEmpty,
+              url.host == nil, url.user == nil, url.password == nil, url.port == nil else {
+            return nil
+        }
+
+        let destination: ParsedDestination
+        switch url.scheme?.lowercased() {
+        case nil:
+            destination = Self.parsePosition(from: url.path)
+        case "file":
+            destination = Self.parsePosition(from: url.path)
+        default:
+            guard let positioned = Self.positionedRelativeDestination(from: url) else {
+                return nil
+            }
+            destination = positioned
+        }
+
+        guard !destination.path.isEmpty,
+              !destination.path.contains(":"),
+              !destination.path.unicodeScalars.contains(where: { $0.value == 0 }) else {
+            return nil
+        }
+
+        if !destination.path.hasPrefix("/"), !destination.path.contains("/"),
+           !Self.isRecognizableFilePath(destination.path) {
+            return nil
+        }
+
+        let root = (workspaceRoot as NSString).standardizingPath
+        let absolute: String
+        if destination.path.hasPrefix("/") {
+            absolute = (destination.path as NSString).standardizingPath
+        } else {
+            absolute = ((root as NSString).appendingPathComponent(destination.path) as NSString)
+                .standardizingPath
+        }
+
+        guard let relative = Self.relativePath(for: absolute, in: root) else { return nil }
+        path = relative
+    }
+
+    public static func isWorkspaceDestination(_ url: URL) -> Bool {
+        guard url.host == nil, url.user == nil, url.password == nil, url.port == nil else {
+            return false
+        }
+        if url.scheme?.lowercased() == "file" { return true }
+        if url.scheme == nil {
+            return url.path.hasPrefix("/")
+                || url.path.contains("/")
+                || isRecognizableFilePath(parsePosition(from: url.path).path)
+        }
+        return positionedRelativeDestination(from: url) != nil
+    }
+
+    private struct ParsedDestination {
+        var path: String
+        var line: Int?
+        var column: Int?
+    }
+
+    private static func positionedRelativeDestination(from url: URL) -> ParsedDestination? {
+        let raw = url.absoluteString
+            .split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+            .split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)[0]
+        let decoded = String(raw).removingPercentEncoding ?? String(raw)
+        let destination = parsePosition(from: decoded)
+        guard destination.line != nil, isRecognizableFilePath(destination.path) else { return nil }
+        return destination
+    }
+
+    private static func parsePosition(from rawPath: String) -> ParsedDestination {
+        var path = rawPath
+        var trailingNumbers: [Int] = []
+        while trailingNumbers.count < 2, let separator = path.lastIndex(of: ":") {
+            let suffix = path[path.index(after: separator)...]
+            guard !suffix.isEmpty, suffix.allSatisfy(\.isNumber), let value = Int(suffix) else {
+                break
+            }
+            trailingNumbers.append(value)
+            path.removeSubrange(separator...)
+        }
+        return ParsedDestination(
+            path: path,
+            line: trailingNumbers.last,
+            column: trailingNumbers.count == 2 ? trailingNumbers.first : nil
+        )
+    }
+
+    private static func isRecognizableFilePath(_ path: String) -> Bool {
+        let name = (path as NSString).lastPathComponent
+        if conventionalFileNames.contains(name) { return true }
+        let fileExtension = (name as NSString).pathExtension.lowercased()
+        return positionedPathExtensions.contains(fileExtension)
+    }
+
+    private static func relativePath(for absolutePath: String, in root: String) -> String? {
+        guard absolutePath != root else { return nil }
+        let prefix = root == "/" ? root : root + "/"
+        guard absolutePath.hasPrefix(prefix) else { return nil }
+        let relative = String(absolutePath.dropFirst(prefix.count))
+        guard !relative.isEmpty, relative != ".", !relative.hasPrefix("../") else { return nil }
+        return relative
+    }
+}

--- a/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
+++ b/apps/swift-ios/Features/Files/FeatureWorkspacePathResolver.swift
@@ -31,7 +31,7 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         )
     }
 
-    public init?(url: URL, workspaceRoot: String?) {
+    public init?(url: URL, workspaceRoot: String?, relativeTo basePath: String? = nil) {
         guard let workspaceRoot, !workspaceRoot.isEmpty,
               url.host == nil, url.user == nil, url.password == nil, url.port == nil else {
             return nil
@@ -56,17 +56,24 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
             return nil
         }
 
-        if !destination.path.hasPrefix("/"), !destination.path.contains("/"),
-           !Self.isRecognizableFilePath(destination.path) {
+        if !destination.path.hasPrefix("/"), !Self.isRecognizableFilePath(destination.path) {
             return nil
         }
 
         let root = (workspaceRoot as NSString).standardizingPath
+        let base: String
+        if let basePath, !basePath.isEmpty {
+            base = ((root as NSString).appendingPathComponent(basePath) as NSString)
+                .standardizingPath
+            guard Self.contains(base, in: root) else { return nil }
+        } else {
+            base = root
+        }
         let absolute: String
         if destination.path.hasPrefix("/") {
             absolute = (destination.path as NSString).standardizingPath
         } else {
-            absolute = ((root as NSString).appendingPathComponent(destination.path) as NSString)
+            absolute = ((base as NSString).appendingPathComponent(destination.path) as NSString)
                 .standardizingPath
         }
 
@@ -81,7 +88,6 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         if url.scheme?.lowercased() == "file" { return true }
         if url.scheme == nil {
             return url.path.hasPrefix("/")
-                || url.path.contains("/")
                 || isRecognizableFilePath(parsePosition(from: url.path).path)
         }
         return positionedRelativeDestination(from: url) != nil
@@ -135,5 +141,9 @@ public struct FeatureWorkspaceFileLink: Identifiable, Sendable, Equatable, Hasha
         let relative = String(absolutePath.dropFirst(prefix.count))
         guard !relative.isEmpty, relative != ".", !relative.hasPrefix("../") else { return nil }
         return relative
+    }
+
+    private static func contains(_ absolutePath: String, in root: String) -> Bool {
+        absolutePath == root || absolutePath.hasPrefix(root == "/" ? root : root + "/")
     }
 }

--- a/apps/swift-ios/Features/Shared/FeatureToolModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureToolModels.swift
@@ -48,6 +48,14 @@ public struct FeatureFileEntry: Identifiable, Sendable, Equatable, Hashable, Cod
     }
 }
 
+public extension FeatureFileEntry {
+    var containingDirectoryPath: String? {
+        guard let separator = path.lastIndex(of: "/") else { return nil }
+        let directory = path[..<separator]
+        return directory.isEmpty ? nil : String(directory)
+    }
+}
+
 public extension Array where Element == FeatureFileEntry {
     func featureFiltered(by query: String, includesHidden: Bool) -> [FeatureFileEntry] {
         let visible = includesHidden ? self : filter { !$0.isHidden }

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -639,7 +639,9 @@ extension FeatureThread {
             snapshot.providersByEnvironment?[$0]
         }
         let configuredProvider = environmentProviders?.first(where: { $0.id == providerID })
-            ?? snapshot.providers.first(where: { $0.id == providerID })
+            ?? (snapshot.providersByEnvironment == nil
+                ? snapshot.providers.first(where: { $0.id == providerID })
+                : nil)
         return configuredProvider?.name ?? providerID
     }
 

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -635,10 +635,12 @@ extension FeatureThread {
             .first(where: { $0.id == projectID })?
             .environmentID
         let resolvedEnvironmentID = environmentID ?? projectEnvironmentID
-        let providers = resolvedEnvironmentID.flatMap {
+        let environmentProviders = resolvedEnvironmentID.flatMap {
             snapshot.providersByEnvironment?[$0]
-        } ?? []
-        return providers.first(where: { $0.id == providerID })?.name ?? providerID
+        }
+        let configuredProvider = environmentProviders?.first(where: { $0.id == providerID })
+            ?? snapshot.providers.first(where: { $0.id == providerID })
+        return configuredProvider?.name ?? providerID
     }
 
     var needsAttention: Bool {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -780,9 +780,11 @@ struct HomeThreadRowContext: Equatable {
             let explicitProvider = thread.providerName?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let configuredProvider = thread.providerID.flatMap { providerID in
-                environmentID.flatMap {
+                let environmentProvider = environmentID.flatMap {
                     snapshot.providersByEnvironment?[$0]?.first(where: { $0.id == providerID })
                 }
+                return environmentProvider
+                    ?? snapshot.providers.first(where: { $0.id == providerID })
             }
             let providerName = (explicitProvider?.isEmpty == false ? explicitProvider : nil)
                 ?? configuredProvider?.name

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -784,7 +784,9 @@ struct HomeThreadRowContext: Equatable {
                     snapshot.providersByEnvironment?[$0]?.first(where: { $0.id == providerID })
                 }
                 return environmentProvider
-                    ?? snapshot.providers.first(where: { $0.id == providerID })
+                    ?? (snapshot.providersByEnvironment == nil
+                        ? snapshot.providers.first(where: { $0.id == providerID })
+                        : nil)
             }
             let providerName = (explicitProvider?.isEmpty == false ? explicitProvider : nil)
                 ?? configuredProvider?.name

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import T3Code
 
@@ -25,6 +26,64 @@ struct FeatureToolStateTests {
         #expect(FeatureFilePreviewKind.infer(path: "Package.swift") == .source)
         #expect(FeatureFilePreviewKind.infer(path: "LICENSE") == .plainText)
         #expect(FeatureFilePreviewKind.infer(path: "template", language: "html") == .source)
+    }
+
+    @Test
+    func workspaceFileLinksResolveRelativeAndContainedAbsolutePaths() throws {
+        let relative = try #require(URL(string: "docs/My%20Notes.txt#L12"))
+        #expect(
+            FeatureWorkspaceFileLink(url: relative, workspaceRoot: "/repo")?.path
+                == "docs/My Notes.txt"
+        )
+
+        let absolute = URL(fileURLWithPath: "/repo/Sources/App.swift")
+        #expect(
+            FeatureWorkspaceFileLink(url: absolute, workspaceRoot: "/repo")?.path
+                == "Sources/App.swift"
+        )
+    }
+
+    @Test
+    func workspaceFileLinksStripLineAndColumnPositions() throws {
+        let relative = try #require(URL(string: "Sources/App.swift:42:7"))
+        let link = try #require(FeatureWorkspaceFileLink(url: relative, workspaceRoot: "/repo"))
+        #expect(link.path == "Sources/App.swift")
+
+        let readme = try #require(URL(string: "README.md:12"))
+        #expect(FeatureWorkspaceFileLink(url: readme, workspaceRoot: "/repo")?.path == "README.md")
+    }
+
+    @Test
+    func workspaceFileLinksRejectEscapesAuthoritiesSchemesAndOutsidePaths() throws {
+        let rejected = [
+            try #require(URL(string: "../../secret.txt")),
+            try #require(URL(string: "sub/../../secret.txt")),
+            try #require(URL(string: "%2E%2E/secret.txt")),
+            try #require(URL(string: "//example.com/repo/README.md")),
+            try #require(URL(string: "tel:123")),
+            try #require(URL(string: "org.example:123")),
+            URL(fileURLWithPath: "/other/secret.txt"),
+        ]
+        for url in rejected {
+            #expect(FeatureWorkspaceFileLink(url: url, workspaceRoot: "/repo") == nil)
+        }
+
+        let trailingRoot = URL(fileURLWithPath: "/repo/Sources/App.swift")
+        #expect(
+            FeatureWorkspaceFileLink(url: trailingRoot, workspaceRoot: "/repo/")?.path
+                == "Sources/App.swift"
+        )
+
+        let rootFile = URL(fileURLWithPath: "/README.md")
+        #expect(FeatureWorkspaceFileLink(url: rootFile, workspaceRoot: "/")?.path == "README.md")
+    }
+
+    @Test
+    func remoteLinksRemainOutsideWorkspaceRouting() throws {
+        let remote = try #require(URL(string: "https://example.com/readme.txt"))
+        #expect(FeatureWorkspaceFileLink(url: remote, workspaceRoot: "/repo") == nil)
+        let bareDomain = try #require(URL(string: "www.example.com"))
+        #expect(FeatureWorkspaceFileLink(url: bareDomain, workspaceRoot: "/repo") == nil)
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -73,6 +73,35 @@ struct FeatureToolStateTests {
     }
 
     @Test
+    func workspaceFileLinksResolveFromTheContainingFileDirectory() throws {
+        let sibling = try #require(URL(string: "next.md"))
+        #expect(
+            FeatureWorkspaceFileLink(
+                url: sibling,
+                workspaceRoot: "/repo",
+                relativeTo: "docs/guides"
+            )?.path == "docs/guides/next.md"
+        )
+
+        let parent = try #require(URL(string: "../README.md"))
+        #expect(
+            FeatureWorkspaceFileLink(
+                url: parent,
+                workspaceRoot: "/repo",
+                relativeTo: "docs/guides"
+            )?.path == "docs/README.md"
+        )
+
+        #expect(
+            FeatureWorkspaceFileLink(
+                url: sibling,
+                workspaceRoot: "/repo",
+                relativeTo: "../../outside"
+            ) == nil
+        )
+    }
+
+    @Test
     func workspaceFileLinksRejectEscapesAuthoritiesSchemesAndOutsidePaths() throws {
         let rejected = [
             try #require(URL(string: "../../secret.txt")),
@@ -103,6 +132,11 @@ struct FeatureToolStateTests {
         #expect(FeatureWorkspaceFileLink(url: remote, workspaceRoot: "/repo") == nil)
         let bareDomain = try #require(URL(string: "www.example.com"))
         #expect(FeatureWorkspaceFileLink(url: bareDomain, workspaceRoot: "/repo") == nil)
+        let bareDomainWithPath = try #require(URL(string: "www.example.com/docs"))
+        #expect(
+            FeatureWorkspaceFileLink(url: bareDomainWithPath, workspaceRoot: "/repo") == nil
+        )
+        #expect(!FeatureWorkspaceFileLink.isWorkspaceDestination(bareDomainWithPath))
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -29,6 +29,25 @@ struct FeatureToolStateTests {
     }
 
     @Test
+    func fileEntryFindsItsContainingDirectory() {
+        #expect(
+            FeatureFileEntry(
+                path: "Sources/App/RootView.swift",
+                name: "RootView.swift",
+                kind: .file
+            ).containingDirectoryPath == "Sources/App"
+        )
+        #expect(
+            FeatureFileEntry(path: "README.md", name: "README.md", kind: .file)
+                .containingDirectoryPath == nil
+        )
+        #expect(
+            FeatureFileEntry(path: "/README.md", name: "README.md", kind: .file)
+                .containingDirectoryPath == nil
+        )
+    }
+
+    @Test
     func workspaceFileLinksResolveRelativeAndContainedAbsolutePaths() throws {
         let relative = try #require(URL(string: "docs/My%20Notes.txt#L12"))
         #expect(

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -195,4 +195,39 @@ struct HomeThreadMetadataTests {
             ) == nil
         )
     }
+
+    @Test
+    func environmentCatalogDoesNotFallBackToAnActiveEnvironmentProvider() throws {
+        let thread = FeatureThread(
+            id: "remote-thread",
+            projectID: "remote-project",
+            environmentID: "remote",
+            title: "Remote task",
+            providerID: "shared-provider"
+        )
+        let snapshot = FeatureSnapshot(
+            projects: [
+                FeatureProject(
+                    id: "remote-project",
+                    environmentID: "remote",
+                    name: "remote",
+                    path: "/remote/workspace"
+                ),
+            ],
+            threads: [thread],
+            providers: [
+                FeatureProvider(
+                    id: "shared-provider",
+                    name: "Active Environment Provider",
+                    driver: "active-driver"
+                ),
+            ],
+            providersByEnvironment: ["remote": []]
+        )
+
+        #expect(thread.homeProviderLabel(in: snapshot) == "shared-provider")
+        let context = try #require(HomeThreadRowContext.index(snapshot: snapshot)[thread.id])
+        #expect(context.providerName == "shared-provider")
+        #expect(context.providerDriver == "shared-provider")
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
@@ -263,4 +263,19 @@ struct MarkdownDocumentTests {
         #expect(runs.contains { $0.inlinePresentationIntent?.contains(.code) == true })
         #expect(runs.contains { $0.link == URL(string: "https://example.com") })
     }
+
+    @Test @MainActor
+    func recycledMarkdownLinkRelayUsesItsLatestHandler() throws {
+        let relay = MarkdownLinkActionRelay()
+        let url = try #require(URL(string: "Sources/App.swift"))
+        var firstHandlerCount = 0
+        var currentHandlerCount = 0
+
+        relay.handler = { _ in firstHandlerCount += 1 }
+        relay.handler = { _ in currentHandlerCount += 1 }
+        relay.open(url)
+
+        #expect(firstHandlerCount == 0)
+        #expect(currentHandlerCount == 1)
+    }
 }


### PR DESCRIPTION
## What Changed

- open workspace-file links in a native preview
- navigate between files without returning to the transcript
- resolve relative links in nested Markdown from the containing file directory
- expose file path and metadata in an info surface
- preserve legacy provider metadata only when environment-scoped catalogs are absent

## Dependency

Chain order: **#5803 → #6132**. Review the final navigation commit and current-head integration/review repair until #5803 lands.

## Current-head repair

Macroscope found three valid issues in the refreshed chain. Head `b19aab5339f851323b706ad7360fb810d35fd034` now:

- prevents a thread from another environment inheriting active-environment provider branding when provider IDs overlap
- resolves `[next](next.md)` in `docs/guide.md` as `docs/next.md`, while preserving workspace containment
- leaves scheme-less external paths such as `www.example.com/docs` on the system URL path instead of treating them as workspace files

Approved file-preview navigation behavior is otherwise unchanged.

## Verification

- Theo target: `f98cab553546558e28d6e22f3dbe9807ecc3325f`
- affected exact-head Simulator tests: **28 passed, 0 failed, 0 skipped**
- generated Swift wire fixtures: matched in the integrated child validation
- `git diff --check`: passed
- direct Claude Opus 5 high review remains unavailable at the current Anthropic session limit; no Opus result is claimed
- current-head GitHub CI, Macroscope, and CodeRabbit passed; no unresolved review threads remain

<!-- swiftui-delivery:start -->
Delivery: chain
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: #5803
Merge order: #5803 → #6132
Validation status: Current head b19aab5339f851323b706ad7360fb810d35fd034 is mergeable, has 28 affected tests green, and every actionable current-head CI/review check is green. Revalidate after #5803 lands. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->

Built with GPT-5.6 Sol in the Codex harness.
