### PR TITLE
feat(swift-ios): copy thread metadata from rows

### DIFF
--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -317,9 +317,10 @@ public final class FeatureRootModel {
         }
     }
 
-    public func setSnoozed(_ id: String, until: Date?) async {
+    @discardableResult
+    public func setSnoozed(_ id: String, until: Date?) async -> Bool {
         let environment = currentEnvironmentIdentity
-        await perform {
+        return await perform {
             try await client.setThreadSnoozed(id: id, until: until)
             guard currentEnvironmentIdentity == environment else { return }
             let snoozedAt = until.map { _ in Date.now }
@@ -330,9 +331,10 @@ public final class FeatureRootModel {
         }
     }
 
-    public func setPinned(_ id: String, pinned: Bool) async {
+    @discardableResult
+    public func setPinned(_ id: String, pinned: Bool) async -> Bool {
         let environment = currentEnvironmentIdentity
-        await perform {
+        return await perform {
             try await client.setThreadPinned(id: id, pinned: pinned)
             guard currentEnvironmentIdentity == environment else { return }
             mutateThread(id: id) {

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -299,9 +299,10 @@ public final class FeatureRootModel {
         }
     }
 
-    public func setSettled(_ id: String, settled: Bool) async {
+    @discardableResult
+    public func setSettled(_ id: String, settled: Bool) async -> Bool {
         let environment = currentEnvironmentIdentity
-        await perform {
+        return await perform {
             try await client.setThreadSettled(id: id, settled: settled)
             guard currentEnvironmentIdentity == environment else { return }
             let settledAt = settled ? Date.now : nil

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -25,7 +25,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         } else if thread.pinnedAt != nil, thread.canTogglePin {
             primary = .unpin
         } else if thread.canToggleSettlement {
-            primary = thread.isSettled || thread.isEffectivelySettled(at: now)
+            primary = thread.isEffectivelySettled(at: now)
                 ? .reopen
                 : .settle
         } else {

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -195,7 +195,10 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
             let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
                 self?.parent.onDelete(thread)
-                finish(true)
+                // Deletion is deferred until the confirmation alert. Keep the
+                // row in place if the user cancels instead of letting UIKit
+                // animate an optimistic removal that never reached the model.
+                finish(false)
             }
             delete.image = UIImage(systemName: "trash")
 

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -33,7 +33,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         }
         return HomeThreadSwipeActionPlan(
             actions: [primary, .delete],
-            performsFirstActionWithFullSwipe: true
+            performsFirstActionWithFullSwipe: primary == .settle || primary == .reopen
         )
     }
 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -1,6 +1,45 @@
 import SwiftUI
 import UIKit
 
+enum HomeThreadSwipeActionKind: Equatable, Sendable {
+    case restore
+    case unpin
+    case settle
+    case reopen
+    case archive
+    case delete
+}
+
+struct HomeThreadSwipeActionPlan: Equatable, Sendable {
+    let primary: HomeThreadSwipeActionKind
+    let secondary: HomeThreadSwipeActionKind = .delete
+    let performsPrimaryWithFullSwipe = true
+    let deleteFinishesOptimistically = false
+
+    var orderedActions: [HomeThreadSwipeActionKind] {
+        [primary, secondary]
+    }
+
+    static func make(
+        thread: FeatureThread,
+        isArchived: Bool,
+        now: Date
+    ) -> HomeThreadSwipeActionPlan {
+        if isArchived {
+            return HomeThreadSwipeActionPlan(primary: .restore)
+        }
+        if thread.pinnedAt != nil, thread.canTogglePin {
+            return HomeThreadSwipeActionPlan(primary: .unpin)
+        }
+        if thread.canToggleSettlement {
+            return HomeThreadSwipeActionPlan(
+                primary: thread.isEffectivelySettled(at: now) ? .reopen : .settle
+            )
+        }
+        return HomeThreadSwipeActionPlan(primary: .archive)
+    }
+}
+
 /// A recycled, diffable Home surface. SwiftUI still owns the surrounding shell,
 /// while UIKit keeps row creation and updates proportional to visible threads.
 struct HomeThreadCollectionView: UIViewRepresentable {
@@ -20,7 +59,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onShowMoreSettled: () -> Void
     let onRename: (FeatureThread) -> Void
     let onArchive: (FeatureThread, Bool) -> Void
-    let onSettle: (FeatureThread, Bool) -> Void
+    let onSettle: (FeatureThread, Bool, Bool) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
     let onPin: (FeatureThread, Bool) -> Void
     let onDelete: (FeatureThread) -> Void
@@ -193,17 +232,23 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 return nil
             }
 
+            let plan = HomeThreadSwipeActionPlan.make(
+                thread: thread,
+                isArchived: isArchived,
+                now: .now
+            )
             let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
                 self?.parent.onDelete(thread)
                 // Deletion is deferred until the confirmation alert. Keep the
                 // row in place if the user cancels instead of letting UIKit
                 // animate an optimistic removal that never reached the model.
-                finish(false)
+                finish(plan.deleteFinishesOptimistically)
             }
             delete.image = UIImage(systemName: "trash")
 
             let primaryAction: UIContextualAction
-            if isArchived {
+            switch plan.primary {
+            case .restore:
                 primaryAction = UIContextualAction(style: .normal, title: "Restore") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, false)
@@ -211,7 +256,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 primaryAction.image = UIImage(systemName: "arrow.uturn.backward")
                 primaryAction.backgroundColor = .systemBlue
-            } else if thread.pinnedAt != nil, thread.canTogglePin {
+            case .unpin:
                 primaryAction = UIContextualAction(style: .normal, title: "Unpin") {
                     [weak self] _, _, finish in
                     self?.parent.onPin(thread, false)
@@ -219,20 +264,24 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 primaryAction.image = UIImage(systemName: "pin.slash")
                 primaryAction.backgroundColor = .systemBlue
-            } else if thread.canToggleSettlement {
-                let isSettled = thread.isEffectivelySettled(at: .now)
+            case .settle, .reopen:
+                let wasEffectivelySettled = plan.primary == .reopen
                 primaryAction = UIContextualAction(
                     style: .normal,
-                    title: isSettled ? "Reopen" : "Settle"
+                    title: wasEffectivelySettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(thread, !isSettled)
+                    self?.parent.onSettle(
+                        thread,
+                        !wasEffectivelySettled,
+                        wasEffectivelySettled
+                    )
                     finish(true)
                 }
                 primaryAction.image = UIImage(
-                    systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
+                    systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
                 )
-                primaryAction.backgroundColor = isSettled ? .systemBlue : .systemGreen
-            } else {
+                primaryAction.backgroundColor = wasEffectivelySettled ? .systemBlue : .systemGreen
+            case .archive:
                 primaryAction = UIContextualAction(style: .normal, title: "Archive") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, true)
@@ -240,10 +289,12 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 primaryAction.image = UIImage(systemName: "archivebox")
                 primaryAction.backgroundColor = .systemGray
+            case .delete:
+                preconditionFailure("Delete cannot be the primary full-swipe action")
             }
 
             let configuration = UISwipeActionsConfiguration(actions: [primaryAction, delete])
-            configuration.performsFirstActionWithFullSwipe = true
+            configuration.performsFirstActionWithFullSwipe = plan.performsPrimaryWithFullSwipe
             return configuration
         }
 
@@ -407,15 +458,19 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     )
                 }
                 if thread.canToggleSettlement {
-                    let isSettled = thread.isEffectivelySettled(at: .now)
+                    let wasEffectivelySettled = thread.isEffectivelySettled(at: .now)
                     actions.append(
                         UIAction(
-                            title: isSettled ? "Reopen" : "Settle",
+                            title: wasEffectivelySettled ? "Reopen" : "Settle",
                             image: UIImage(
-                                systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
+                                systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
                             )
                         ) { [weak self] _ in
-                            self?.parent.onSettle(thread, !isSettled)
+                            self?.parent.onSettle(
+                                thread,
+                                !wasEffectivelySettled,
+                                wasEffectivelySettled
+                            )
                         }
                     )
                 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -57,7 +57,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onShowMoreSettled: () -> Void
     let onRename: (FeatureThread) -> Void
     let onArchive: (FeatureThread, Bool) -> Void
-    let onSettle: (FeatureThread, Bool, Bool) -> Void
+    let onSettle: (FeatureThread, Bool) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
     let onPin: (FeatureThread, Bool) -> Void
     let onDelete: (FeatureThread) -> Void
@@ -270,7 +270,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     style: .normal,
                     title: wasSettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(thread, !wasSettled, wasSettled)
+                    self?.parent.onSettle(thread, !wasSettled)
                     finish(true)
                 }
                 action.image = UIImage(
@@ -468,7 +468,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                                 systemName: wasSettled ? "arrow.counterclockwise" : "checkmark"
                             )
                         ) { [weak self] _ in
-                            self?.parent.onSettle(thread, !wasSettled, wasSettled)
+                            self?.parent.onSettle(thread, !wasSettled)
                         }
                     )
                 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -60,6 +60,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onSettle: (FeatureThread, Bool) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
     let onPin: (FeatureThread, Bool) -> Void
+    let projectPath: (FeatureThread) -> String?
     let onDelete: (FeatureThread) -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -492,6 +493,16 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     actions.append(snooze)
                 }
             }
+
+            let copyItems = ThreadMetadataCopyModel.items(
+                for: thread,
+                projectPath: parent.projectPath(thread)
+            )
+            actions.append(contentsOf: copyItems.map { item in
+                UIAction(title: item.title, image: UIImage(systemName: item.systemImage)) { _ in
+                    ThreadMetadataClipboard.copy(item)
+                }
+            })
 
             actions.append(
                 UIAction(title: "Delete", image: UIImage(systemName: "trash"), attributes: .destructive) {

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -11,32 +11,32 @@ enum HomeThreadSwipeActionKind: Equatable, Sendable {
 }
 
 struct HomeThreadSwipeActionPlan: Equatable, Sendable {
-    let primary: HomeThreadSwipeActionKind
-    let secondary: HomeThreadSwipeActionKind = .delete
-    let performsPrimaryWithFullSwipe = true
-    let deleteFinishesOptimistically = false
-
-    var orderedActions: [HomeThreadSwipeActionKind] {
-        [primary, secondary]
-    }
+    let actions: [HomeThreadSwipeActionKind]
+    let performsFirstActionWithFullSwipe: Bool
+    let deleteFinishesOptimistically: Bool
 
     static func make(
         thread: FeatureThread,
         isArchived: Bool,
         now: Date
     ) -> HomeThreadSwipeActionPlan {
+        let primary: HomeThreadSwipeActionKind
         if isArchived {
-            return HomeThreadSwipeActionPlan(primary: .restore)
+            primary = .restore
+        } else if thread.pinnedAt != nil, thread.canTogglePin {
+            primary = .unpin
+        } else if thread.canToggleSettlement {
+            primary = thread.isSettled || thread.isEffectivelySettled(at: now)
+                ? .reopen
+                : .settle
+        } else {
+            primary = .archive
         }
-        if thread.pinnedAt != nil, thread.canTogglePin {
-            return HomeThreadSwipeActionPlan(primary: .unpin)
-        }
-        if thread.canToggleSettlement {
-            return HomeThreadSwipeActionPlan(
-                primary: thread.isEffectivelySettled(at: now) ? .reopen : .settle
-            )
-        }
-        return HomeThreadSwipeActionPlan(primary: .archive)
+        return HomeThreadSwipeActionPlan(
+            actions: [primary, .delete],
+            performsFirstActionWithFullSwipe: true,
+            deleteFinishesOptimistically: false
+        )
     }
 }
 
@@ -237,65 +237,71 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 isArchived: isArchived,
                 now: .now
             )
-            let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
-                self?.parent.onDelete(thread)
-                // Deletion is deferred until the confirmation alert. Keep the
-                // row in place if the user cancels instead of letting UIKit
-                // animate an optimistic removal that never reached the model.
-                finish(plan.deleteFinishesOptimistically)
+            let actions = plan.actions.map {
+                swipeAction($0, for: thread, plan: plan)
             }
-            delete.image = UIImage(systemName: "trash")
+            let configuration = UISwipeActionsConfiguration(actions: actions)
+            configuration.performsFirstActionWithFullSwipe =
+                plan.performsFirstActionWithFullSwipe
+            return configuration
+        }
 
-            let primaryAction: UIContextualAction
-            switch plan.primary {
+        private func swipeAction(
+            _ kind: HomeThreadSwipeActionKind,
+            for thread: FeatureThread,
+            plan: HomeThreadSwipeActionPlan
+        ) -> UIContextualAction {
+            let action: UIContextualAction
+            switch kind {
             case .restore:
-                primaryAction = UIContextualAction(style: .normal, title: "Restore") {
+                action = UIContextualAction(style: .normal, title: "Restore") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, false)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "arrow.uturn.backward")
-                primaryAction.backgroundColor = .systemBlue
+                action.image = UIImage(systemName: "arrow.uturn.backward")
+                action.backgroundColor = .systemBlue
             case .unpin:
-                primaryAction = UIContextualAction(style: .normal, title: "Unpin") {
+                action = UIContextualAction(style: .normal, title: "Unpin") {
                     [weak self] _, _, finish in
                     self?.parent.onPin(thread, false)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "pin.slash")
-                primaryAction.backgroundColor = .systemBlue
+                action.image = UIImage(systemName: "pin.slash")
+                action.backgroundColor = .systemBlue
             case .settle, .reopen:
-                let wasEffectivelySettled = plan.primary == .reopen
-                primaryAction = UIContextualAction(
+                let wasSettled = kind == .reopen
+                action = UIContextualAction(
                     style: .normal,
-                    title: wasEffectivelySettled ? "Reopen" : "Settle"
+                    title: wasSettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(
-                        thread,
-                        !wasEffectivelySettled,
-                        wasEffectivelySettled
-                    )
+                    self?.parent.onSettle(thread, !wasSettled, wasSettled)
                     finish(true)
                 }
-                primaryAction.image = UIImage(
-                    systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
+                action.image = UIImage(
+                    systemName: wasSettled ? "arrow.counterclockwise" : "checkmark"
                 )
-                primaryAction.backgroundColor = wasEffectivelySettled ? .systemBlue : .systemGreen
+                action.backgroundColor = wasSettled ? .systemBlue : .systemGreen
             case .archive:
-                primaryAction = UIContextualAction(style: .normal, title: "Archive") {
+                action = UIContextualAction(style: .normal, title: "Archive") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, true)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "archivebox")
-                primaryAction.backgroundColor = .systemGray
+                action.image = UIImage(systemName: "archivebox")
+                action.backgroundColor = .systemGray
             case .delete:
-                preconditionFailure("Delete cannot be the primary full-swipe action")
+                action = UIContextualAction(style: .destructive, title: "Delete") {
+                    [weak self] _, _, finish in
+                    self?.parent.onDelete(thread)
+                    // Deletion is deferred until the confirmation alert. Keep
+                    // the row if the user cancels instead of letting UIKit
+                    // animate a removal that never reached the model.
+                    finish(plan.deleteFinishesOptimistically)
+                }
+                action.image = UIImage(systemName: "trash")
             }
-
-            let configuration = UISwipeActionsConfiguration(actions: [primaryAction, delete])
-            configuration.performsFirstActionWithFullSwipe = plan.performsPrimaryWithFullSwipe
-            return configuration
+            return action
         }
 
         private func configure(
@@ -458,19 +464,15 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     )
                 }
                 if thread.canToggleSettlement {
-                    let wasEffectivelySettled = thread.isEffectivelySettled(at: .now)
+                    let wasSettled = thread.isSettled || thread.isEffectivelySettled(at: .now)
                     actions.append(
                         UIAction(
-                            title: wasEffectivelySettled ? "Reopen" : "Settle",
+                            title: wasSettled ? "Reopen" : "Settle",
                             image: UIImage(
-                                systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
+                                systemName: wasSettled ? "arrow.counterclockwise" : "checkmark"
                             )
                         ) { [weak self] _ in
-                            self?.parent.onSettle(
-                                thread,
-                                !wasEffectivelySettled,
-                                wasEffectivelySettled
-                            )
+                            self?.parent.onSettle(thread, !wasSettled, wasSettled)
                         }
                     )
                 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -13,7 +13,6 @@ enum HomeThreadSwipeActionKind: Equatable, Sendable {
 struct HomeThreadSwipeActionPlan: Equatable, Sendable {
     let actions: [HomeThreadSwipeActionKind]
     let performsFirstActionWithFullSwipe: Bool
-    let deleteFinishesOptimistically: Bool
 
     static func make(
         thread: FeatureThread,
@@ -34,8 +33,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         }
         return HomeThreadSwipeActionPlan(
             actions: [primary, .delete],
-            performsFirstActionWithFullSwipe: true,
-            deleteFinishesOptimistically: false
+            performsFirstActionWithFullSwipe: true
         )
     }
 }
@@ -237,9 +235,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 isArchived: isArchived,
                 now: .now
             )
-            let actions = plan.actions.map {
-                swipeAction($0, for: thread, plan: plan)
-            }
+            let actions = plan.actions.map { swipeAction($0, for: thread) }
             let configuration = UISwipeActionsConfiguration(actions: actions)
             configuration.performsFirstActionWithFullSwipe =
                 plan.performsFirstActionWithFullSwipe
@@ -248,8 +244,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
         private func swipeAction(
             _ kind: HomeThreadSwipeActionKind,
-            for thread: FeatureThread,
-            plan: HomeThreadSwipeActionPlan
+            for thread: FeatureThread
         ) -> UIContextualAction {
             let action: UIContextualAction
             switch kind {
@@ -291,15 +286,16 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 action.image = UIImage(systemName: "archivebox")
                 action.backgroundColor = .systemGray
             case .delete:
-                action = UIContextualAction(style: .destructive, title: "Delete") {
+                action = UIContextualAction(style: .normal, title: "Delete") {
                     [weak self] _, _, finish in
                     self?.parent.onDelete(thread)
-                    // Deletion is deferred until the confirmation alert. Keep
-                    // the row if the user cancels instead of letting UIKit
-                    // animate a removal that never reached the model.
-                    finish(plan.deleteFinishesOptimistically)
+                    // The alert owns the destructive operation. Complete this
+                    // non-destructive contextual action so Cancel closes the
+                    // swipe without UIKit animating a row deletion.
+                    finish(true)
                 }
                 action.image = UIImage(systemName: "trash")
+                action.backgroundColor = .systemRed
             }
             return action
         }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -239,8 +239,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 primaryAction.backgroundColor = .systemGray
             }
 
-            let configuration = UISwipeActionsConfiguration(actions: [delete, primaryAction])
-            configuration.performsFirstActionWithFullSwipe = false
+            let configuration = UISwipeActionsConfiguration(actions: [primaryAction, delete])
+            configuration.performsFirstActionWithFullSwipe = true
             return configuration
         }
 

--- a/apps/swift-ios/Features/Workspace/ThreadMetadataCopy.swift
+++ b/apps/swift-ios/Features/Workspace/ThreadMetadataCopy.swift
@@ -1,0 +1,82 @@
+import Foundation
+import UIKit
+
+enum ThreadMetadataCopyKind: Equatable, Sendable {
+    case path
+    case branch
+    case threadID
+}
+
+struct ThreadMetadataCopyItem: Equatable, Sendable {
+    let kind: ThreadMetadataCopyKind
+    let value: String
+
+    var title: String {
+        switch kind {
+        case .path: "Copy path"
+        case .branch: "Copy branch"
+        case .threadID: "Copy thread ID"
+        }
+    }
+
+    var systemImage: String {
+        switch kind {
+        case .path: "folder"
+        case .branch: "arrow.triangle.branch"
+        case .threadID: "number"
+        }
+    }
+
+    var confirmation: String {
+        switch kind {
+        case .path: "Path copied"
+        case .branch: "Branch copied"
+        case .threadID: "Thread ID copied"
+        }
+    }
+}
+
+enum ThreadMetadataCopyModel {
+    static func items(
+        for thread: FeatureThread,
+        projectPath: String?
+    ) -> [ThreadMetadataCopyItem] {
+        var items: [ThreadMetadataCopyItem] = []
+
+        if let path = nonEmptyPath(thread.worktreePath) ?? nonEmptyPath(projectPath) {
+            items.append(ThreadMetadataCopyItem(kind: .path, value: path))
+        }
+        if let branch = nonEmpty(thread.branch) {
+            items.append(ThreadMetadataCopyItem(kind: .branch, value: branch))
+        }
+        if let threadID = nonEmpty(thread.wireID) ?? nonEmpty(thread.id) {
+            items.append(ThreadMetadataCopyItem(kind: .threadID, value: threadID))
+        }
+
+        return items
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func nonEmptyPath(_ value: String?) -> String? {
+        guard let value,
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return value
+    }
+}
+
+@MainActor
+enum ThreadMetadataClipboard {
+    static func copy(_ item: ThreadMetadataCopyItem) {
+        UIPasteboard.general.string = item.value
+        UIAccessibility.post(notification: .announcement, argument: item.confirmation)
+    }
+}

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -88,15 +88,20 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
         return notice
     }
 
+    mutating func dismiss(threadID: String) {
+        guard notice?.threadID == threadID else { return }
+        notice = nil
+    }
+
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
-        previousWasEffectivelySettled: Bool,
+        previousWasSettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
-            && !previousWasEffectivelySettled
+            && !previousWasSettled
             && updatedThread?.isSettled == true
     }
 }
@@ -282,6 +287,7 @@ public struct WorkspaceView: View {
             Button("Delete", role: .destructive) {
                 guard let confirmed = deleteConfirmation.takeConfirmedRequest(),
                       confirmed == request else { return }
+                settleUndo.dismiss(threadID: confirmed.id)
                 Task { await model.deleteThread(confirmed.id) }
             }
         } message: { request in
@@ -295,6 +301,10 @@ public struct WorkspaceView: View {
         }
         .onChange(of: selectedProjectIsAvailable) { _, isAvailable in
             if !isAvailable { selectedProjectID = nil }
+        }
+        .onChange(of: settleUndoTargetIsValid) { _, isValid in
+            guard !isValid, let notice = settleUndo.notice else { return }
+            settleUndo.dismiss(threadID: notice.threadID)
         }
         .onChange(of: navigationRequest?.id, initial: true) { _, _ in
             consumeNavigationRequest()
@@ -385,9 +395,11 @@ public struct WorkspaceView: View {
                     renamingThread = thread
                 },
                 onArchive: { thread, archived in
+                    settleUndo.dismiss(threadID: thread.id)
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
-                onSettle: { thread, settled, wasEffectivelySettled in
+                onSettle: { thread, settled, wasSettled in
+                    if !settled { settleUndo.dismiss(threadID: thread.id) }
                     let requestID = settleUndo.beginSettleRequest(ifSettling: settled)
                     let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
                     Task {
@@ -398,7 +410,7 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
-                            previousWasEffectivelySettled: wasEffectivelySettled,
+                            previousWasSettled: wasSettled,
                             updatedThread: updatedThread
                         ), let requestID else { return }
                         let notice = withAnimation(
@@ -494,21 +506,16 @@ public struct WorkspaceView: View {
                 let didReopen = await model.setSettled(notice.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
                 guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
-                guard await model.setPinned(notice.threadID, pinned: true) else {
-                    model.errorMessage = "Thread reopened, but its pin could not be restored. Try pinning it again."
-                    return
-                }
+                guard await model.setPinned(notice.threadID, pinned: true) else { return }
                 if let snoozeUntil = notice.restoresSnoozeUntil {
-                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else {
-                        model.errorMessage = "Thread reopened and pinned, but its snooze could not be restored. Try snoozing it again."
-                        return
-                    }
+                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else { return }
                 }
             }
         }
         .font(T3Typography.supportingStrong)
         .buttonStyle(.bordered)
         .frame(minHeight: T3Metrics.minimumTapTarget)
+        .contentShape(Rectangle())
         .accessibilityLabel("Undo settle \(notice.title)")
     }
 
@@ -804,6 +811,13 @@ public struct WorkspaceView: View {
     private var selectedProjectIsAvailable: Bool {
         guard let selectedProjectID else { return true }
         return model.snapshot.projects.contains { $0.id == selectedProjectID }
+    }
+
+    private var settleUndoTargetIsValid: Bool {
+        guard let notice = settleUndo.notice else { return true }
+        return model.snapshot.threads.contains {
+            $0.id == notice.threadID && $0.isSettled && !$0.isArchived
+        }
     }
 
     private func openThread(_ id: String) {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -897,6 +897,7 @@ public struct WorkspaceView: View {
     }
 
     private func dismissTransientPresentations() {
+        deleteConfirmation.cancel()
         showingNewTask = false
         showingAddProject = false
         showingSettings = false

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -104,6 +104,15 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
             && !previousWasSettled
             && updatedThread?.isSettled == true
     }
+
+    static func targetIsValid(
+        notice: HomeThreadSettleUndoNotice,
+        in threads: [FeatureThread]
+    ) -> Bool {
+        threads.contains {
+            $0.id == notice.threadID && $0.isSettled && !$0.isArchived
+        }
+    }
 }
 
 struct HomeThreadDeleteRequest: Equatable, Sendable {
@@ -815,9 +824,10 @@ public struct WorkspaceView: View {
 
     private var settleUndoTargetIsValid: Bool {
         guard let notice = settleUndo.notice else { return true }
-        return model.snapshot.threads.contains {
-            $0.id == notice.threadID && $0.isSettled && !$0.isArchived
-        }
+        return HomeThreadSettleUndoState.targetIsValid(
+            notice: notice,
+            in: model.snapshot.threads
+        )
     }
 
     private func openThread(_ id: String) {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -25,6 +25,19 @@ struct HomeThreadSettleUndoNotice: Equatable, Identifiable, Sendable {
     let restoresSnoozeUntil: Date?
 }
 
+struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
+    let restoresPin: Bool
+    let restoresSnoozeUntil: Date?
+
+    static func capture(from thread: FeatureThread) -> Self {
+        let restoresPin = thread.pinnedAt != nil
+        return Self(
+            restoresPin: restoresPin,
+            restoresSnoozeUntil: restoresPin ? thread.snoozedUntil : nil
+        )
+    }
+}
+
 struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
     private(set) var latestSettleRequestID: UUID?
@@ -33,6 +46,14 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     mutating func beginSettleRequest(id: UUID = UUID()) -> UUID {
         latestSettleRequestID = id
         return id
+    }
+
+    mutating func beginSettleRequest(
+        ifSettling settled: Bool,
+        id: UUID = UUID()
+    ) -> UUID? {
+        guard settled else { return nil }
+        return beginSettleRequest(id: id)
     }
 
     @discardableResult
@@ -70,12 +91,12 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
-        previousThread: FeatureThread,
+        previousWasEffectivelySettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
-            && !previousThread.isSettled
+            && !previousWasEffectivelySettled
             && updatedThread?.isSettled == true
     }
 }
@@ -366,8 +387,9 @@ public struct WorkspaceView: View {
                 onArchive: { thread, archived in
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
-                onSettle: { thread, settled in
-                    let requestID = settleUndo.beginSettleRequest()
+                onSettle: { thread, settled, wasEffectivelySettled in
+                    let requestID = settleUndo.beginSettleRequest(ifSettling: settled)
+                    let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
                     Task {
                         let didSucceed = await model.setSettled(thread.id, settled: settled)
                         let updatedThread = model.snapshot.threads.first {
@@ -376,9 +398,9 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
-                            previousThread: thread,
+                            previousWasEffectivelySettled: wasEffectivelySettled,
                             updatedThread: updatedThread
-                        ) else { return }
+                        ), let requestID else { return }
                         let notice = withAnimation(
                             accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)
                         ) {
@@ -386,10 +408,8 @@ public struct WorkspaceView: View {
                                 requestID: requestID,
                                 threadID: thread.id,
                                 title: thread.title,
-                                restoresPin: thread.pinnedAt != nil,
-                                restoresSnoozeUntil: thread.pinnedAt == nil
-                                    ? nil
-                                    : thread.snoozedUntil
+                                restoresPin: restoration.restoresPin,
+                                restoresSnoozeUntil: restoration.restoresSnoozeUntil
                             )
                         }
                         guard notice != nil else { return }
@@ -474,14 +494,21 @@ public struct WorkspaceView: View {
                 let didReopen = await model.setSettled(notice.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
                 guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
-                await model.setPinned(notice.threadID, pinned: true)
+                guard await model.setPinned(notice.threadID, pinned: true) else {
+                    model.errorMessage = "Thread reopened, but its pin could not be restored. Try pinning it again."
+                    return
+                }
                 if let snoozeUntil = notice.restoresSnoozeUntil {
-                    await model.setSnoozed(notice.threadID, until: snoozeUntil)
+                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else {
+                        model.errorMessage = "Thread reopened and pinned, but its snooze could not be restored. Try snoozing it again."
+                        return
+                    }
                 }
             }
         }
         .font(T3Typography.supportingStrong)
         .buttonStyle(.bordered)
+        .frame(minHeight: T3Metrics.minimumTapTarget)
         .accessibilityLabel("Undo settle \(notice.title)")
     }
 

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -22,23 +22,35 @@ struct HomeThreadSettleUndoNotice: Equatable, Identifiable, Sendable {
     let threadID: String
     let title: String
     let restoresPin: Bool
+    let restoresSnoozeUntil: Date?
 }
 
 struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
+    private(set) var latestSettleRequestID: UUID?
+
+    @discardableResult
+    mutating func beginSettleRequest(id: UUID = UUID()) -> UUID {
+        latestSettleRequestID = id
+        return id
+    }
 
     @discardableResult
     mutating func present(
+        requestID: UUID,
         threadID: String,
         title: String,
         restoresPin: Bool,
+        restoresSnoozeUntil: Date?,
         id: UUID = UUID()
-    ) -> HomeThreadSettleUndoNotice {
+    ) -> HomeThreadSettleUndoNotice? {
+        guard requestID == latestSettleRequestID else { return nil }
         let notice = HomeThreadSettleUndoNotice(
             id: id,
             threadID: threadID,
             title: title,
-            restoresPin: restoresPin
+            restoresPin: restoresPin,
+            restoresSnoozeUntil: restoresSnoozeUntil
         )
         self.notice = notice
         return notice
@@ -57,9 +69,14 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
 
     static func shouldPresent(
         afterRequesting settled: Bool,
+        didSucceed: Bool,
+        previousThread: FeatureThread,
         updatedThread: FeatureThread?
     ) -> Bool {
-        settled && updatedThread?.isSettled == true
+        settled
+            && didSucceed
+            && !previousThread.isSettled
+            && updatedThread?.isSettled == true
     }
 }
 
@@ -77,6 +94,11 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 
     mutating func cancel() {
         request = nil
+    }
+
+    mutating func takeConfirmedRequest() -> HomeThreadDeleteRequest? {
+        defer { request = nil }
+        return request
     }
 }
 
@@ -237,8 +259,9 @@ public struct WorkspaceView: View {
                 deleteConfirmation.cancel()
             }
             Button("Delete", role: .destructive) {
-                deleteConfirmation.cancel()
-                Task { await model.deleteThread(request.id) }
+                guard let confirmed = deleteConfirmation.takeConfirmedRequest(),
+                      confirmed == request else { return }
+                Task { await model.deleteThread(confirmed.id) }
             }
         } message: { request in
             Text("“\(request.title)” will be permanently deleted.")
@@ -344,22 +367,32 @@ public struct WorkspaceView: View {
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
                 onSettle: { thread, settled in
+                    let requestID = settleUndo.beginSettleRequest()
                     Task {
-                        await model.setSettled(thread.id, settled: settled)
+                        let didSucceed = await model.setSettled(thread.id, settled: settled)
                         let updatedThread = model.snapshot.threads.first {
                             $0.id == thread.id
                         }
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
+                            didSucceed: didSucceed,
+                            previousThread: thread,
                             updatedThread: updatedThread
                         ) else { return }
-                        _ = withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
+                        let notice = withAnimation(
+                            accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)
+                        ) {
                             settleUndo.present(
+                                requestID: requestID,
                                 threadID: thread.id,
                                 title: thread.title,
-                                restoresPin: thread.pinnedAt != nil
+                                restoresPin: thread.pinnedAt != nil,
+                                restoresSnoozeUntil: thread.pinnedAt == nil
+                                    ? nil
+                                    : thread.snoozedUntil
                             )
                         }
+                        guard notice != nil else { return }
                         UIAccessibility.post(
                             notification: .announcement,
                             argument: "\(thread.title) settled. Undo available."
@@ -409,6 +442,7 @@ public struct WorkspaceView: View {
             .shadow(color: T3Colors.shadow, radius: 14, y: 6)
             .transition(.move(edge: .bottom).combined(with: .opacity))
             .accessibilityElement(children: .contain)
+            .accessibilitySortPriority(1_000)
         }
     }
 
@@ -437,10 +471,13 @@ public struct WorkspaceView: View {
                 _ = settleUndo.takeUndo(id: notice.id)
             }
             Task {
-                await model.setSettled(notice.threadID, settled: false)
+                let didReopen = await model.setSettled(notice.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
-                guard reopened?.isSettled == false, notice.restoresPin else { return }
+                guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
                 await model.setPinned(notice.threadID, pinned: true)
+                if let snoozeUntil = notice.restoresSnoozeUntil {
+                    await model.setSnoozed(notice.threadID, until: snoozeUntil)
+                }
             }
         }
         .font(T3Typography.supportingStrong)

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -492,6 +492,9 @@ public struct WorkspaceView: View {
                 onPin: { thread, pinned in
                     Task { await model.setPinned(thread.id, pinned: pinned) }
                 },
+                projectPath: { thread in
+                    model.snapshot.projects.first { $0.id == thread.projectID }?.path
+                },
                 onDelete: { thread in
                     deleteConfirmation.present(threadID: thread.id, title: thread.title)
                 }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -317,6 +317,9 @@ public struct WorkspaceView: View {
         .onChange(of: selectedProjectIsAvailable) { _, isAvailable in
             if !isAvailable { selectedProjectID = nil }
         }
+        .onChange(of: deleteConfirmationTargetIsValid) { _, isValid in
+            if !isValid { deleteConfirmation.cancel() }
+        }
         .onChange(of: settleUndoTargetIsValid) { _, isValid in
             guard !isValid, let notice = settleUndo.notice else { return }
             withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
@@ -831,6 +834,11 @@ public struct WorkspaceView: View {
     private var selectedProjectIsAvailable: Bool {
         guard let selectedProjectID else { return true }
         return model.snapshot.projects.contains { $0.id == selectedProjectID }
+    }
+
+    private var deleteConfirmationTargetIsValid: Bool {
+        guard let request = deleteConfirmation.request else { return true }
+        return model.snapshot.threads.contains { $0.id == request.id }
     }
 
     private var settleUndoTargetIsValid: Bool {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -17,7 +17,54 @@ struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     }
 }
 
+struct HomeThreadSettleUndoNotice: Equatable, Identifiable, Sendable {
+    let id: UUID
+    let threadID: String
+    let title: String
+    let restoresPin: Bool
+}
+
+struct HomeThreadSettleUndoState: Equatable, Sendable {
+    private(set) var notice: HomeThreadSettleUndoNotice?
+
+    @discardableResult
+    mutating func present(
+        threadID: String,
+        title: String,
+        restoresPin: Bool,
+        id: UUID = UUID()
+    ) -> HomeThreadSettleUndoNotice {
+        let notice = HomeThreadSettleUndoNotice(
+            id: id,
+            threadID: threadID,
+            title: title,
+            restoresPin: restoresPin
+        )
+        self.notice = notice
+        return notice
+    }
+
+    mutating func expire(id: UUID) {
+        guard notice?.id == id else { return }
+        notice = nil
+    }
+
+    mutating func takeUndo(id: UUID) -> HomeThreadSettleUndoNotice? {
+        guard notice?.id == id else { return nil }
+        defer { notice = nil }
+        return notice
+    }
+
+    static func shouldPresent(
+        afterRequesting settled: Bool,
+        updatedThread: FeatureThread?
+    ) -> Bool {
+        settled && updatedThread?.isSettled == true
+    }
+}
+
 public struct WorkspaceView: View {
+    @SwiftUI.Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @Bindable var model: FeatureRootModel
@@ -43,6 +90,7 @@ public struct WorkspaceView: View {
     @State private var sidebarBoundaryNow = Date.now
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
     @State private var homePresentationCache = HomePresentationCache()
+    @State private var settleUndo = HomeThreadSettleUndoState()
     @FocusState private var isSearchFocused: Bool
 
     public init(
@@ -186,6 +234,17 @@ public struct WorkspaceView: View {
                 return
             }
         }
+        .task(id: settleUndo.notice?.id) {
+            guard let notice = settleUndo.notice else { return }
+            do {
+                try await Task.sleep(for: settleUndoLifetime)
+                withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                    settleUndo.expire(id: notice.id)
+                }
+            } catch {
+                return
+            }
+        }
     }
 
     private var sidebar: some View {
@@ -202,6 +261,11 @@ public struct WorkspaceView: View {
             composeButton
                 .padding(.trailing, 16)
                 .padding(.bottom, 14)
+
+            settleUndoToast
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 78)
         }
         .background(T3Colors.background)
         .toolbar(.hidden, for: .navigationBar)
@@ -244,7 +308,27 @@ public struct WorkspaceView: View {
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
                 onSettle: { thread, settled in
-                    Task { await model.setSettled(thread.id, settled: settled) }
+                    Task {
+                        await model.setSettled(thread.id, settled: settled)
+                        let updatedThread = model.snapshot.threads.first {
+                            $0.id == thread.id
+                        }
+                        guard HomeThreadSettleUndoState.shouldPresent(
+                            afterRequesting: settled,
+                            updatedThread: updatedThread
+                        ) else { return }
+                        _ = withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
+                            settleUndo.present(
+                                threadID: thread.id,
+                                title: thread.title,
+                                restoresPin: thread.pinnedAt != nil
+                            )
+                        }
+                        UIAccessibility.post(
+                            notification: .announcement,
+                            argument: "\(thread.title) settled. Undo available."
+                        )
+                    }
                 },
                 onSnooze: { thread, until in
                     Task { await model.setSnoozed(thread.id, until: until) }
@@ -258,6 +342,81 @@ public struct WorkspaceView: View {
             )
         }
         .background(T3Colors.background)
+    }
+
+    @ViewBuilder
+    private var settleUndoToast: some View {
+        if let notice = settleUndo.notice {
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 10) {
+                        settleUndoDescription(notice)
+                        settleUndoButton(notice)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                } else {
+                    HStack(spacing: 12) {
+                        settleUndoDescription(notice)
+                        Spacer(minLength: 8)
+                        settleUndoButton(notice)
+                    }
+                }
+            }
+            .padding(.leading, 14)
+            .padding(.trailing, 10)
+            .padding(.vertical, 10)
+            .background(T3Colors.surfaceRaised, in: RoundedRectangle(cornerRadius: 14))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(T3Colors.border, lineWidth: 1)
+            }
+            .shadow(color: T3Colors.shadow, radius: 14, y: 6)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    private func settleUndoDescription(_ notice: HomeThreadSettleUndoNotice) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(T3Colors.success)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Thread settled")
+                    .font(T3Typography.supportingStrong)
+                    .foregroundStyle(T3Colors.textPrimary)
+                Text(notice.title)
+                    .font(T3Typography.supporting)
+                    .foregroundStyle(T3Colors.textSecondary)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    private func settleUndoButton(_ notice: HomeThreadSettleUndoNotice) -> some View {
+        Button("Undo") {
+            guard settleUndo.notice?.id == notice.id else { return }
+            withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                _ = settleUndo.takeUndo(id: notice.id)
+            }
+            Task {
+                await model.setSettled(notice.threadID, settled: false)
+                let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
+                guard reopened?.isSettled == false, notice.restoresPin else { return }
+                await model.setPinned(notice.threadID, pinned: true)
+            }
+        }
+        .font(T3Typography.supportingStrong)
+        .buttonStyle(.bordered)
+        .accessibilityLabel("Undo settle \(notice.title)")
+    }
+
+    private var settleUndoLifetime: Duration {
+        if UIAccessibility.isVoiceOverRunning || UIAccessibility.isSwitchControlRunning {
+            return .seconds(15)
+        }
+        return .seconds(5)
     }
 
     @ViewBuilder

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -34,6 +34,8 @@ struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
         let restoresPin = thread.pinnedAt != nil
         return Self(
             restoresPin: restoresPin,
+            // Restoring a pin clears snooze state, so preserve snooze only
+            // when Undo will re-pin the thread.
             restoresSnoozeUntil: restoresPin ? thread.snoozedUntil : nil
         )
     }
@@ -43,6 +45,7 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
     private(set) var latestSettleRequestID: UUID?
     private(set) var latestSettleThreadID: String?
+    private(set) var undoInProgressID: UUID?
 
     @discardableResult
     mutating func beginSettleRequest(
@@ -88,14 +91,25 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     }
 
     mutating func expire(id: UUID) {
-        guard notice?.id == id else { return }
+        guard notice?.id == id, undoInProgressID != id else { return }
         notice = nil
     }
 
-    mutating func takeUndo(id: UUID) -> HomeThreadSettleUndoNotice? {
-        guard notice?.id == id else { return nil }
-        defer { notice = nil }
+    mutating func beginUndo(id: UUID) -> HomeThreadSettleUndoNotice? {
+        guard notice?.id == id, undoInProgressID == nil else { return nil }
+        undoInProgressID = id
         return notice
+    }
+
+    mutating func finishUndo(id: UUID) {
+        guard undoInProgressID == id else { return }
+        undoInProgressID = nil
+        if notice?.id == id { notice = nil }
+    }
+
+    func isUndoInProgress(threadID: String) -> Bool {
+        guard let notice else { return false }
+        return notice.threadID == threadID && undoInProgressID == notice.id
     }
 
     mutating func dismiss(threadID: String) {
@@ -104,7 +118,15 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
             latestSettleThreadID = nil
         }
         guard notice?.threadID == threadID else { return }
+        undoInProgressID = nil
         notice = nil
+    }
+
+    mutating func dismissAll() {
+        notice = nil
+        latestSettleRequestID = nil
+        latestSettleThreadID = nil
+        undoInProgressID = nil
     }
 
     static func shouldPresent(
@@ -141,6 +163,13 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 
     mutating func cancel() {
         request = nil
+    }
+
+    static func targetIsValid(
+        request: HomeThreadDeleteRequest,
+        in threads: [FeatureThread]
+    ) -> Bool {
+        threads.contains { $0.id == request.id }
     }
 }
 
@@ -419,6 +448,7 @@ public struct WorkspaceView: View {
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
                 onSettle: { thread, settled in
+                    guard !settleUndo.isUndoInProgress(threadID: thread.id) else { return }
                     if !settled { settleUndo.dismiss(threadID: thread.id) }
                     let requestID = settleUndo.beginSettleRequest(
                         ifSettling: settled,
@@ -441,17 +471,19 @@ public struct WorkspaceView: View {
                             settleUndo.present(
                                 requestID: requestID,
                                 threadID: thread.id,
-                                title: thread.title,
+                                title: updatedThread?.title ?? thread.title,
                                 restoresPin: restoration.restoresPin,
                                 restoresSnoozeUntil: restoration.restoresSnoozeUntil
                             )
                         }
                         guard notice != nil else { return }
-                        var announcement = AttributedString(
-                            "\(thread.title) settled. Undo available."
-                        )
-                        announcement.accessibilitySpeechAnnouncementPriority = .high
-                        AccessibilityNotification.Announcement(announcement).post()
+                        if preferredCompactColumn != .detail {
+                            var announcement = AttributedString(
+                                "\(updatedThread?.title ?? thread.title) settled. Undo available."
+                            )
+                            announcement.accessibilitySpeechAnnouncementPriority = .high
+                            AccessibilityNotification.Announcement(announcement).post()
+                        }
                     }
                 },
                 onSnooze: { thread, until in
@@ -520,21 +552,33 @@ public struct WorkspaceView: View {
     }
 
     private func settleUndoButton(_ notice: HomeThreadSettleUndoNotice) -> some View {
-        Button("Undo") {
-            guard settleUndo.notice?.id == notice.id else { return }
-            withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
-                _ = settleUndo.takeUndo(id: notice.id)
-            }
+        let isUndoing = settleUndo.undoInProgressID == notice.id
+        return Button {
+            guard let undo = settleUndo.beginUndo(id: notice.id) else { return }
             Task {
-                let didReopen = await model.setSettled(notice.threadID, settled: false)
-                let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
-                guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
-                guard await model.setPinned(notice.threadID, pinned: true) else { return }
-                if let snoozeUntil = notice.restoresSnoozeUntil {
-                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else { return }
+                defer {
+                    withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                        settleUndo.finishUndo(id: undo.id)
+                    }
+                }
+                let didReopen = await model.setSettled(undo.threadID, settled: false)
+                let reopened = model.snapshot.threads.first { $0.id == undo.threadID }
+                guard didReopen, reopened?.isSettled == false, undo.restoresPin else { return }
+                guard await model.setPinned(undo.threadID, pinned: true) else { return }
+                if let snoozeUntil = undo.restoresSnoozeUntil {
+                    guard await model.setSnoozed(undo.threadID, until: snoozeUntil) else { return }
                 }
             }
+        } label: {
+            if isUndoing {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityHidden(true)
+            } else {
+                Text("Undo")
+            }
         }
+        .disabled(isUndoing)
         .font(T3Typography.supportingStrong)
         .buttonStyle(.bordered)
         .frame(minHeight: T3Metrics.minimumTapTarget)
@@ -838,11 +882,15 @@ public struct WorkspaceView: View {
 
     private var deleteConfirmationTargetIsValid: Bool {
         guard let request = deleteConfirmation.request else { return true }
-        return model.snapshot.threads.contains { $0.id == request.id }
+        return HomeThreadDeleteConfirmation.targetIsValid(
+            request: request,
+            in: model.snapshot.threads
+        )
     }
 
     private var settleUndoTargetIsValid: Bool {
         guard let notice = settleUndo.notice else { return true }
+        if settleUndo.isUndoInProgress(threadID: notice.threadID) { return true }
         return HomeThreadSettleUndoState.targetIsValid(
             notice: notice,
             in: model.snapshot.threads
@@ -906,6 +954,7 @@ public struct WorkspaceView: View {
 
     private func dismissTransientPresentations() {
         deleteConfirmation.cancel()
+        settleUndo.dismissAll()
         showingNewTask = false
         showingAddProject = false
         showingSettings = false

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -63,6 +63,23 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     }
 }
 
+struct HomeThreadDeleteRequest: Equatable, Sendable {
+    let id: String
+    let title: String
+}
+
+struct HomeThreadDeleteConfirmation: Equatable, Sendable {
+    private(set) var request: HomeThreadDeleteRequest?
+
+    mutating func present(threadID: String, title: String) {
+        request = HomeThreadDeleteRequest(id: threadID, title: title)
+    }
+
+    mutating func cancel() {
+        request = nil
+    }
+}
+
 public struct WorkspaceView: View {
     @SwiftUI.Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -87,6 +104,7 @@ public struct WorkspaceView: View {
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
     @State private var renameTitle = ""
+    @State private var deleteConfirmation = HomeThreadDeleteConfirmation()
     @State private var sidebarBoundaryNow = Date.now
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
     @State private var homePresentationCache = HomePresentationCache()
@@ -206,6 +224,24 @@ public struct WorkspaceView: View {
                 Task { await model.renameThread(thread.id, title: title) }
             }
             .disabled(renameTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .alert(
+            "Delete thread?",
+            isPresented: Binding(
+                get: { deleteConfirmation.request != nil },
+                set: { if !$0 { deleteConfirmation.cancel() } }
+            ),
+            presenting: deleteConfirmation.request
+        ) { request in
+            Button("Cancel", role: .cancel) {
+                deleteConfirmation.cancel()
+            }
+            Button("Delete", role: .destructive) {
+                deleteConfirmation.cancel()
+                Task { await model.deleteThread(request.id) }
+            }
+        } message: { request in
+            Text("“\(request.title)” will be permanently deleted.")
         }
         .onChange(of: selectedThreadIsAvailable) { _, isAvailable in
             if !isAvailable { closeSelectedThread() }
@@ -337,7 +373,7 @@ public struct WorkspaceView: View {
                     Task { await model.setPinned(thread.id, pinned: pinned) }
                 },
                 onDelete: { thread in
-                    Task { await model.deleteThread(thread.id) }
+                    deleteConfirmation.present(threadID: thread.id, title: thread.title)
                 }
             )
         }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -110,12 +110,10 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
-        previousWasSettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
-            && !previousWasSettled
             && updatedThread?.isSettled == true
     }
 
@@ -321,7 +319,9 @@ public struct WorkspaceView: View {
         }
         .onChange(of: settleUndoTargetIsValid) { _, isValid in
             guard !isValid, let notice = settleUndo.notice else { return }
-            settleUndo.dismiss(threadID: notice.threadID)
+            withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
+                settleUndo.dismiss(threadID: notice.threadID)
+            }
         }
         .onChange(of: navigationRequest?.id, initial: true) { _, _ in
             consumeNavigationRequest()
@@ -415,7 +415,7 @@ public struct WorkspaceView: View {
                     settleUndo.dismiss(threadID: thread.id)
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
-                onSettle: { thread, settled, wasSettled in
+                onSettle: { thread, settled in
                     if !settled { settleUndo.dismiss(threadID: thread.id) }
                     let requestID = settleUndo.beginSettleRequest(
                         ifSettling: settled,
@@ -430,7 +430,6 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
-                            previousWasSettled: wasSettled,
                             updatedThread: updatedThread
                         ), let requestID else { return }
                         let notice = withAnimation(

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -1,3 +1,4 @@
+import Accessibility
 import SwiftUI
 import UIKit
 
@@ -41,19 +42,25 @@ struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
 struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
     private(set) var latestSettleRequestID: UUID?
+    private(set) var latestSettleThreadID: String?
 
     @discardableResult
-    mutating func beginSettleRequest(id: UUID = UUID()) -> UUID {
+    mutating func beginSettleRequest(
+        threadID: String? = nil,
+        id: UUID = UUID()
+    ) -> UUID {
         latestSettleRequestID = id
+        latestSettleThreadID = threadID
         return id
     }
 
     mutating func beginSettleRequest(
         ifSettling settled: Bool,
+        threadID: String? = nil,
         id: UUID = UUID()
     ) -> UUID? {
         guard settled else { return nil }
-        return beginSettleRequest(id: id)
+        return beginSettleRequest(threadID: threadID, id: id)
     }
 
     @discardableResult
@@ -66,6 +73,7 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
         id: UUID = UUID()
     ) -> HomeThreadSettleUndoNotice? {
         guard requestID == latestSettleRequestID else { return nil }
+        if let latestSettleThreadID, latestSettleThreadID != threadID { return nil }
         let notice = HomeThreadSettleUndoNotice(
             id: id,
             threadID: threadID,
@@ -74,6 +82,8 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
             restoresSnoozeUntil: restoresSnoozeUntil
         )
         self.notice = notice
+        latestSettleRequestID = nil
+        latestSettleThreadID = nil
         return notice
     }
 
@@ -89,6 +99,10 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     }
 
     mutating func dismiss(threadID: String) {
+        if latestSettleThreadID == threadID {
+            latestSettleRequestID = nil
+            latestSettleThreadID = nil
+        }
         guard notice?.threadID == threadID else { return }
         notice = nil
     }
@@ -129,11 +143,6 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 
     mutating func cancel() {
         request = nil
-    }
-
-    mutating func takeConfirmedRequest() -> HomeThreadDeleteRequest? {
-        defer { request = nil }
-        return request
     }
 }
 
@@ -294,10 +303,9 @@ public struct WorkspaceView: View {
                 deleteConfirmation.cancel()
             }
             Button("Delete", role: .destructive) {
-                guard let confirmed = deleteConfirmation.takeConfirmedRequest(),
-                      confirmed == request else { return }
-                settleUndo.dismiss(threadID: confirmed.id)
-                Task { await model.deleteThread(confirmed.id) }
+                deleteConfirmation.cancel()
+                settleUndo.dismiss(threadID: request.id)
+                Task { await model.deleteThread(request.id) }
             }
         } message: { request in
             Text("“\(request.title)” will be permanently deleted.")
@@ -409,7 +417,10 @@ public struct WorkspaceView: View {
                 },
                 onSettle: { thread, settled, wasSettled in
                     if !settled { settleUndo.dismiss(threadID: thread.id) }
-                    let requestID = settleUndo.beginSettleRequest(ifSettling: settled)
+                    let requestID = settleUndo.beginSettleRequest(
+                        ifSettling: settled,
+                        threadID: thread.id
+                    )
                     let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
                     Task {
                         let didSucceed = await model.setSettled(thread.id, settled: settled)
@@ -434,10 +445,11 @@ public struct WorkspaceView: View {
                             )
                         }
                         guard notice != nil else { return }
-                        UIAccessibility.post(
-                            notification: .announcement,
-                            argument: "\(thread.title) settled. Undo available."
+                        var announcement = AttributedString(
+                            "\(thread.title) settled. Undo available."
                         )
+                        announcement.accessibilitySpeechAnnouncementPriority = .high
+                        AccessibilityNotification.Announcement(announcement).post()
                     }
                 },
                 onSnooze: { thread, until in

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -31,6 +31,93 @@ struct DailyUXSidebarTests {
     private let now = Date(timeIntervalSince1970: 2_000_000)
 
     @Test
+    func swipePlanKeepsDeleteOutOfTheFullSwipeSlot() {
+        let active = thread(id: "active", created: -20, updated: -10)
+        let settled = thread(
+            id: "settled",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let settledButWorking = thread(
+            id: "settled-working",
+            created: -20,
+            updated: -10,
+            state: .working,
+            isSettled: true
+        )
+
+        let activePlan = HomeThreadSwipeActionPlan.make(
+            thread: active,
+            isArchived: false,
+            now: now
+        )
+        let settledPlan = HomeThreadSwipeActionPlan.make(
+            thread: settled,
+            isArchived: false,
+            now: now
+        )
+        let settledButWorkingPlan = HomeThreadSwipeActionPlan.make(
+            thread: settledButWorking,
+            isArchived: false,
+            now: now
+        )
+
+        #expect(activePlan.orderedActions == [.settle, .delete])
+        #expect(settledPlan.orderedActions == [.reopen, .delete])
+        #expect(settledButWorkingPlan.orderedActions == [.settle, .delete])
+        #expect(activePlan.performsPrimaryWithFullSwipe)
+        #expect(!activePlan.deleteFinishesOptimistically)
+        #expect(activePlan.orderedActions.first != .delete)
+    }
+
+    @Test
+    func settleUndoCapturesOnlyStateThatSettlementClears() {
+        let snoozeUntil = now.addingTimeInterval(300)
+        let pinnedAndSnoozed = thread(
+            id: "pinned",
+            created: -20,
+            updated: -10,
+            pinned: -5,
+            snoozedUntil: snoozeUntil
+        )
+        let snoozedOnly = thread(
+            id: "snoozed",
+            created: -20,
+            updated: -10,
+            snoozedUntil: snoozeUntil
+        )
+
+        #expect(
+            HomeThreadSettleUndoRestoration.capture(from: pinnedAndSnoozed)
+                == HomeThreadSettleUndoRestoration(
+                    restoresPin: true,
+                    restoresSnoozeUntil: snoozeUntil
+                )
+        )
+        #expect(
+            HomeThreadSettleUndoRestoration.capture(from: snoozedOnly)
+                == HomeThreadSettleUndoRestoration(
+                    restoresPin: false,
+                    restoresSnoozeUntil: nil
+                )
+        )
+    }
+
+    @Test
+    func reopeningDoesNotSupersedeAnInFlightSettleNotice() {
+        let settleRequestID = UUID()
+        var state = HomeThreadSettleUndoState()
+
+        #expect(
+            state.beginSettleRequest(ifSettling: true, id: settleRequestID)
+                == settleRequestID
+        )
+        #expect(state.beginSettleRequest(ifSettling: false) == nil)
+        #expect(state.latestSettleRequestID == settleRequestID)
+    }
+
+    @Test
     func settleUndoTargetsOnlyTheLatestNoticeOnce() {
         let firstID = UUID()
         let secondID = UUID()
@@ -122,7 +209,7 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: settled
             )
         )
@@ -130,7 +217,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: settled
             )
         )
@@ -138,7 +225,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: settled
             )
         )
@@ -146,7 +233,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: settled,
+                previousWasEffectivelySettled: true,
                 updatedThread: settled
             )
         )
@@ -154,7 +241,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: active
             )
         )
@@ -162,7 +249,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: nil
             )
         )
@@ -622,7 +709,9 @@ struct DailyUXSidebarTests {
         created: TimeInterval,
         updated: TimeInterval,
         state: FeatureThreadState = .idle,
-        isSettled: Bool = false
+        isSettled: Bool = false,
+        pinned: TimeInterval? = nil,
+        snoozedUntil: Date? = nil
     ) -> FeatureThread {
         FeatureThread(
             id: id,
@@ -632,7 +721,10 @@ struct DailyUXSidebarTests {
             updatedAt: now.addingTimeInterval(updated),
             state: state,
             isSettled: isSettled,
-            lastActivityAt: now.addingTimeInterval(updated)
+            lastActivityAt: now.addingTimeInterval(updated),
+            snoozedUntil: snoozedUntil,
+            snoozedAt: snoozedUntil.map { _ in now.addingTimeInterval(updated) },
+            pinnedAt: pinned.map(now.addingTimeInterval)
         )
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -90,7 +90,7 @@ struct DailyUXSidebarTests {
 
         #expect(activePlan.actions == [.settle, .delete])
         #expect(settledPlan.actions == [.reopen, .delete])
-        #expect(settledButWorkingPlan.actions == [.reopen, .delete])
+        #expect(settledButWorkingPlan.actions == [.settle, .delete])
         #expect(archivedPlan.actions == [.restore, .delete])
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
@@ -103,7 +103,7 @@ struct DailyUXSidebarTests {
     }
 
     @Test
-    func settleUndoCapturesOnlyStateThatSettlementClears() {
+    func settleUndoPreservesStateThatRepinningWouldClear() {
         let snoozeUntil = now.addingTimeInterval(300)
         let pinnedAndSnoozed = thread(
             id: "pinned",
@@ -261,11 +261,16 @@ struct DailyUXSidebarTests {
 
         state.expire(id: firstID)
         #expect(state.notice?.threadID == "second")
-        #expect(state.takeUndo(id: firstID) == nil)
-        let undo = state.takeUndo(id: secondID)
+        #expect(state.beginUndo(id: firstID) == nil)
+        let undo = state.beginUndo(id: secondID)
         #expect(undo?.restoresPin == true)
         #expect(undo?.restoresSnoozeUntil == now.addingTimeInterval(300))
-        #expect(state.takeUndo(id: secondID) == nil)
+        #expect(state.beginUndo(id: secondID) == nil)
+        #expect(state.notice?.id == secondID)
+        #expect(state.isUndoInProgress(threadID: "second"))
+        state.finishUndo(id: secondID)
+        #expect(state.notice == nil)
+        #expect(!state.isUndoInProgress(threadID: "second"))
     }
 
     @Test
@@ -285,6 +290,47 @@ struct DailyUXSidebarTests {
         state.expire(id: noticeID)
 
         #expect(state.notice == nil)
+    }
+
+    @Test
+    func settleUndoDoesNotExpireWhileUndoIsRunning() {
+        let noticeID = UUID()
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "thread")
+        state.present(
+            requestID: requestID,
+            threadID: "thread",
+            title: "Thread",
+            restoresPin: false,
+            restoresSnoozeUntil: nil,
+            id: noticeID
+        )
+
+        #expect(state.beginUndo(id: noticeID) != nil)
+        state.expire(id: noticeID)
+        #expect(state.notice?.id == noticeID)
+        state.finishUndo(id: noticeID)
+        #expect(state.notice == nil)
+    }
+
+    @Test
+    func deleteConfirmationTargetMustRemainInTheSnapshot() {
+        let request = HomeThreadDeleteRequest(id: "target", title: "Target")
+        let target = thread(id: "target", created: -20, updated: -10)
+        let other = thread(id: "other", created: -20, updated: -10)
+
+        #expect(
+            HomeThreadDeleteConfirmation.targetIsValid(
+                request: request,
+                in: [target, other]
+            )
+        )
+        #expect(
+            !HomeThreadDeleteConfirmation.targetIsValid(
+                request: request,
+                in: [other]
+            )
+        )
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -7,6 +7,84 @@ struct DailyUXSidebarTests {
     private let now = Date(timeIntervalSince1970: 2_000_000)
 
     @Test
+    func settleUndoTargetsOnlyTheLatestNoticeOnce() {
+        let firstID = UUID()
+        let secondID = UUID()
+        var state = HomeThreadSettleUndoState()
+
+        state.present(
+            threadID: "first",
+            title: "First thread",
+            restoresPin: false,
+            id: firstID
+        )
+        state.present(
+            threadID: "second",
+            title: "Second thread",
+            restoresPin: true,
+            id: secondID
+        )
+
+        state.expire(id: firstID)
+        #expect(state.notice?.threadID == "second")
+        #expect(state.takeUndo(id: firstID) == nil)
+        #expect(state.takeUndo(id: secondID)?.restoresPin == true)
+        #expect(state.takeUndo(id: secondID) == nil)
+    }
+
+    @Test
+    func settleUndoExpiresOnlyItsCurrentNotice() {
+        let noticeID = UUID()
+        var state = HomeThreadSettleUndoState()
+
+        state.present(
+            threadID: "thread",
+            title: "Thread",
+            restoresPin: false,
+            id: noticeID
+        )
+        state.expire(id: noticeID)
+
+        #expect(state.notice == nil)
+    }
+
+    @Test
+    func settleUndoAppearsOnlyAfterAConfirmedSettlement() {
+        let settled = thread(
+            id: "settled",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let active = thread(id: "active", created: -20, updated: -10)
+
+        #expect(
+            HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: false,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                updatedThread: active
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                updatedThread: nil
+            )
+        )
+    }
+
+    @Test
     func activeOrderUsesCreationTimeAndDoesNotJumpWithActivity() {
         let olderCreationRecentActivity = thread(
             id: "old",

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -4,6 +4,28 @@ import Testing
 
 @Suite("Sidebar v2")
 struct DailyUXSidebarTests {
+    @Test
+    func threadDeletionConfirmationCanBeCancelledAndReplaced() {
+        var confirmation = HomeThreadDeleteConfirmation()
+
+        confirmation.present(threadID: "thread-1", title: "Investigate swipe behavior")
+        #expect(
+            confirmation.request
+                == HomeThreadDeleteRequest(
+                    id: "thread-1",
+                    title: "Investigate swipe behavior"
+                )
+        )
+
+        confirmation.present(threadID: "thread-2", title: "Keep me")
+        confirmation.cancel()
+        #expect(confirmation.request == nil)
+
+        confirmation.present(threadID: "thread-3", title: "Replace me")
+        confirmation.present(threadID: "thread-4", title: "Delete me")
+        #expect(confirmation.request?.id == "thread-4")
+    }
+
     private let now = Date(timeIntervalSince1970: 2_000_000)
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -20,12 +20,10 @@ struct DailyUXSidebarTests {
         confirmation.present(threadID: "thread-2", title: "Keep me")
         confirmation.cancel()
         #expect(confirmation.request == nil)
-        #expect(confirmation.takeConfirmedRequest() == nil)
 
         confirmation.present(threadID: "thread-3", title: "Replace me")
         confirmation.present(threadID: "thread-4", title: "Delete me")
-        #expect(confirmation.takeConfirmedRequest()?.id == "thread-4")
-        #expect(confirmation.takeConfirmedRequest() == nil)
+        #expect(confirmation.request?.id == "thread-4")
     }
 
     private let now = Date(timeIntervalSince1970: 2_000_000)
@@ -97,6 +95,11 @@ struct DailyUXSidebarTests {
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
         #expect(activePlan.performsFirstActionWithFullSwipe)
+        #expect(settledPlan.performsFirstActionWithFullSwipe)
+        #expect(settledButWorkingPlan.performsFirstActionWithFullSwipe)
+        #expect(!archivedPlan.performsFirstActionWithFullSwipe)
+        #expect(!pinnedPlan.performsFirstActionWithFullSwipe)
+        #expect(!archiveOnlyPlan.performsFirstActionWithFullSwipe)
     }
 
     @Test
@@ -164,22 +167,46 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func dismissingAThreadCancelsOnlyItsPendingSettleNotice() {
+        var state = HomeThreadSettleUndoState()
+        let targetRequestID = state.beginSettleRequest(threadID: "target")
+
+        state.dismiss(threadID: "other")
+        #expect(state.latestSettleRequestID == targetRequestID)
+        #expect(state.latestSettleThreadID == "target")
+
+        state.dismiss(threadID: "target")
+        #expect(state.latestSettleRequestID == nil)
+        #expect(state.latestSettleThreadID == nil)
+        #expect(
+            state.present(
+                requestID: targetRequestID,
+                threadID: "target",
+                title: "Target",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) == nil
+        )
+    }
+
+    @Test
     func settleUndoTargetsOnlyTheLatestNoticeOnce() {
         let firstID = UUID()
         let secondID = UUID()
         var state = HomeThreadSettleUndoState()
-        let requestID = state.beginSettleRequest()
+        let firstRequestID = state.beginSettleRequest()
 
         state.present(
-            requestID: requestID,
+            requestID: firstRequestID,
             threadID: "first",
             title: "First thread",
             restoresPin: false,
             restoresSnoozeUntil: nil,
             id: firstID
         )
+        let secondRequestID = state.beginSettleRequest()
         state.present(
-            requestID: requestID,
+            requestID: secondRequestID,
             threadID: "second",
             title: "Second thread",
             restoresPin: true,

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -46,6 +46,18 @@ struct DailyUXSidebarTests {
             state: .working,
             isSettled: true
         )
+        let pinned = thread(
+            id: "pinned",
+            created: -20,
+            updated: -10,
+            pinned: -5
+        )
+        let archiveOnly = thread(
+            id: "archive-only",
+            created: -20,
+            updated: -10,
+            supportsSettlement: false
+        )
 
         let activePlan = HomeThreadSwipeActionPlan.make(
             thread: active,
@@ -62,13 +74,30 @@ struct DailyUXSidebarTests {
             isArchived: false,
             now: now
         )
+        let archivedPlan = HomeThreadSwipeActionPlan.make(
+            thread: active,
+            isArchived: true,
+            now: now
+        )
+        let pinnedPlan = HomeThreadSwipeActionPlan.make(
+            thread: pinned,
+            isArchived: false,
+            now: now
+        )
+        let archiveOnlyPlan = HomeThreadSwipeActionPlan.make(
+            thread: archiveOnly,
+            isArchived: false,
+            now: now
+        )
 
-        #expect(activePlan.orderedActions == [.settle, .delete])
-        #expect(settledPlan.orderedActions == [.reopen, .delete])
-        #expect(settledButWorkingPlan.orderedActions == [.settle, .delete])
-        #expect(activePlan.performsPrimaryWithFullSwipe)
+        #expect(activePlan.actions == [.settle, .delete])
+        #expect(settledPlan.actions == [.reopen, .delete])
+        #expect(settledButWorkingPlan.actions == [.reopen, .delete])
+        #expect(archivedPlan.actions == [.restore, .delete])
+        #expect(pinnedPlan.actions == [.unpin, .delete])
+        #expect(archiveOnlyPlan.actions == [.archive, .delete])
+        #expect(activePlan.performsFirstActionWithFullSwipe)
         #expect(!activePlan.deleteFinishesOptimistically)
-        #expect(activePlan.orderedActions.first != .delete)
     }
 
     @Test
@@ -115,6 +144,24 @@ struct DailyUXSidebarTests {
         )
         #expect(state.beginSettleRequest(ifSettling: false) == nil)
         #expect(state.latestSettleRequestID == settleRequestID)
+    }
+
+    @Test
+    func settleUndoDismissesOnlyTheMatchingThread() {
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest()
+        state.present(
+            requestID: requestID,
+            threadID: "target",
+            title: "Target",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+
+        state.dismiss(threadID: "other")
+        #expect(state.notice?.threadID == "target")
+        state.dismiss(threadID: "target")
+        #expect(state.notice == nil)
     }
 
     @Test
@@ -209,7 +256,7 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -217,7 +264,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -225,7 +272,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -233,7 +280,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: true,
+                previousWasSettled: true,
                 updatedThread: settled
             )
         )
@@ -241,7 +288,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: active
             )
         )
@@ -249,7 +296,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: nil
             )
         )
@@ -711,7 +758,8 @@ struct DailyUXSidebarTests {
         state: FeatureThreadState = .idle,
         isSettled: Bool = false,
         pinned: TimeInterval? = nil,
-        snoozedUntil: Date? = nil
+        snoozedUntil: Date? = nil,
+        supportsSettlement: Bool? = nil
     ) -> FeatureThread {
         FeatureThread(
             id: id,
@@ -724,7 +772,8 @@ struct DailyUXSidebarTests {
             lastActivityAt: now.addingTimeInterval(updated),
             snoozedUntil: snoozedUntil,
             snoozedAt: snoozedUntil.map { _ in now.addingTimeInterval(updated) },
-            pinnedAt: pinned.map(now.addingTimeInterval)
+            pinnedAt: pinned.map(now.addingTimeInterval),
+            supportsSettlement: supportsSettlement
         )
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -190,6 +190,51 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func settleUndoRejectsAThreadThatDoesNotMatchTheRequest() {
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "target")
+
+        #expect(
+            state.present(
+                requestID: requestID,
+                threadID: "other",
+                title: "Other",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) == nil
+        )
+        #expect(state.notice == nil)
+        #expect(state.latestSettleRequestID == requestID)
+        #expect(state.latestSettleThreadID == "target")
+    }
+
+    @Test
+    func settleUndoRequestCanPresentOnlyOnce() {
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "target")
+
+        #expect(
+            state.present(
+                requestID: requestID,
+                threadID: "target",
+                title: "Target",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) != nil
+        )
+        #expect(
+            state.present(
+                requestID: requestID,
+                threadID: "target",
+                title: "Target again",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) == nil
+        )
+        #expect(state.notice?.title == "Target")
+    }
+
+    @Test
     func settleUndoTargetsOnlyTheLatestNoticeOnce() {
         let firstID = UUID()
         let secondID = UUID()
@@ -282,7 +327,6 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -290,7 +334,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -298,7 +341,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
-                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -306,15 +348,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasSettled: true,
-                updatedThread: settled
-            )
-        )
-        #expect(
-            !HomeThreadSettleUndoState.shouldPresent(
-                afterRequesting: true,
-                didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: active
             )
         )
@@ -322,7 +355,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: nil
             )
         )

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -97,7 +97,6 @@ struct DailyUXSidebarTests {
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
         #expect(activePlan.performsFirstActionWithFullSwipe)
-        #expect(!activePlan.deleteFinishesOptimistically)
     }
 
     @Test
@@ -300,6 +299,43 @@ struct DailyUXSidebarTests {
                 updatedThread: nil
             )
         )
+    }
+
+    @Test
+    func settleUndoTargetRequiresTheSameSettledUnarchivedThread() {
+        let notice = HomeThreadSettleUndoNotice(
+            id: UUID(),
+            threadID: "target",
+            title: "Target",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+        let settled = thread(
+            id: "target",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let active = thread(id: "target", created: -20, updated: -10)
+        let archived = thread(
+            id: "target",
+            created: -20,
+            updated: -10,
+            isArchived: true,
+            isSettled: true
+        )
+        let other = thread(
+            id: "other",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+
+        #expect(HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [settled]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [active]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [archived]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [other]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: []))
     }
 
     @Test
@@ -756,6 +792,7 @@ struct DailyUXSidebarTests {
         created: TimeInterval,
         updated: TimeInterval,
         state: FeatureThreadState = .idle,
+        isArchived: Bool = false,
         isSettled: Bool = false,
         pinned: TimeInterval? = nil,
         snoozedUntil: Date? = nil,
@@ -768,6 +805,7 @@ struct DailyUXSidebarTests {
             createdAt: now.addingTimeInterval(created),
             updatedAt: now.addingTimeInterval(updated),
             state: state,
+            isArchived: isArchived,
             isSettled: isSettled,
             lastActivityAt: now.addingTimeInterval(updated),
             snoozedUntil: snoozedUntil,

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -20,10 +20,12 @@ struct DailyUXSidebarTests {
         confirmation.present(threadID: "thread-2", title: "Keep me")
         confirmation.cancel()
         #expect(confirmation.request == nil)
+        #expect(confirmation.takeConfirmedRequest() == nil)
 
         confirmation.present(threadID: "thread-3", title: "Replace me")
         confirmation.present(threadID: "thread-4", title: "Delete me")
-        #expect(confirmation.request?.id == "thread-4")
+        #expect(confirmation.takeConfirmedRequest()?.id == "thread-4")
+        #expect(confirmation.takeConfirmedRequest() == nil)
     }
 
     private let now = Date(timeIntervalSince1970: 2_000_000)
@@ -33,24 +35,31 @@ struct DailyUXSidebarTests {
         let firstID = UUID()
         let secondID = UUID()
         var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest()
 
         state.present(
+            requestID: requestID,
             threadID: "first",
             title: "First thread",
             restoresPin: false,
+            restoresSnoozeUntil: nil,
             id: firstID
         )
         state.present(
+            requestID: requestID,
             threadID: "second",
             title: "Second thread",
             restoresPin: true,
+            restoresSnoozeUntil: now.addingTimeInterval(300),
             id: secondID
         )
 
         state.expire(id: firstID)
         #expect(state.notice?.threadID == "second")
         #expect(state.takeUndo(id: firstID) == nil)
-        #expect(state.takeUndo(id: secondID)?.restoresPin == true)
+        let undo = state.takeUndo(id: secondID)
+        #expect(undo?.restoresPin == true)
+        #expect(undo?.restoresSnoozeUntil == now.addingTimeInterval(300))
         #expect(state.takeUndo(id: secondID) == nil)
     }
 
@@ -58,16 +67,45 @@ struct DailyUXSidebarTests {
     func settleUndoExpiresOnlyItsCurrentNotice() {
         let noticeID = UUID()
         var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest()
 
         state.present(
+            requestID: requestID,
             threadID: "thread",
             title: "Thread",
             restoresPin: false,
+            restoresSnoozeUntil: nil,
             id: noticeID
         )
         state.expire(id: noticeID)
 
         #expect(state.notice == nil)
+    }
+
+    @Test
+    func settleUndoRejectsAnOlderRequestThatFinishesLast() {
+        var state = HomeThreadSettleUndoState()
+        let firstRequestID = state.beginSettleRequest()
+        let secondRequestID = state.beginSettleRequest()
+
+        let stale = state.present(
+            requestID: firstRequestID,
+            threadID: "first",
+            title: "First",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+        let current = state.present(
+            requestID: secondRequestID,
+            threadID: "second",
+            title: "Second",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+
+        #expect(stale == nil)
+        #expect(current?.threadID == "second")
+        #expect(state.notice?.threadID == "second")
     }
 
     @Test
@@ -83,24 +121,48 @@ struct DailyUXSidebarTests {
         #expect(
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: settled
             )
         )
         #expect(
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: settled
             )
         )
         #expect(
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
+                didSucceed: false,
+                previousThread: active,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                didSucceed: true,
+                previousThread: settled,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: active
             )
         )
         #expect(
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: nil
             )
         )

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -657,6 +657,24 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func testSettleReportsWhetherTheMutationSucceeded() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
+        client.createdThread = thread
+        let model = testRootModel(client: client)
+        _ = await model.createThread(projectID: thread.projectID, title: nil, selection: nil)
+
+        let succeeded = await model.setSettled(thread.id, settled: true)
+        #expect(succeeded)
+        #expect(model.snapshot.threads[0].isSettled)
+
+        client.setThreadSettledError = URLError(.cannotConnectToHost)
+        let failed = await model.setSettled(thread.id, settled: false)
+        #expect(!failed)
+        #expect(model.snapshot.threads[0].isSettled)
+    }
+
+    @Test
     func testCancelledDetailRefreshKeepsCachedContentWithoutAlert() async {
         let client = FeatureClientStub()
         let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
@@ -1226,6 +1244,7 @@ private final class FeatureClientStub: FeatureClient {
     var sendMessageCallCount = 0
     var startTaskError: (any Error)?
     var sendMessageError: (any Error)?
+    var setThreadSettledError: (any Error)?
     var enabledEnvironmentID: String?
     var environmentEnabledValue: Bool?
     var removedEnvironmentID: String?
@@ -1334,6 +1353,9 @@ private final class FeatureClientStub: FeatureClient {
 
     func renameThread(id: String, title: String) async throws {}
     func setThreadArchived(id: String, archived: Bool) async throws {}
+    func setThreadSettled(id: String, settled: Bool) async throws {
+        if let setThreadSettledError { throw setThreadSettledError }
+    }
     func deleteThread(id: String) async throws {}
 
     func loadThread(id: String) async throws -> FeatureThreadDetail {

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 

--- a/apps/swift-ios/Tests/FeatureTests/ThreadMetadataCopyTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ThreadMetadataCopyTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import T3Code
+
+@Suite("Thread metadata copy")
+struct ThreadMetadataCopyTests {
+    @Test
+    func offersWorktreePathBranchAndWireIDInMenuOrder() {
+        let thread = FeatureThread(
+            id: "environment:one:thread:thread-1",
+            wireID: "thread-1",
+            projectID: "project-1",
+            title: "Metadata",
+            branch: " feature/copy ",
+            worktreePath: " /tmp/copy-worktree "
+        )
+
+        let items = ThreadMetadataCopyModel.items(
+            for: thread,
+            projectPath: "/tmp/project"
+        )
+
+        #expect(items.map(\.kind) == [.path, .branch, .threadID])
+        #expect(items.map(\.value) == [" /tmp/copy-worktree ", "feature/copy", "thread-1"])
+        #expect(items.map(\.title) == ["Copy path", "Copy branch", "Copy thread ID"])
+        #expect(items.map(\.confirmation) == ["Path copied", "Branch copied", "Thread ID copied"])
+    }
+
+    @Test
+    func fallsBackToProjectPathAndInternalThreadID() {
+        let thread = FeatureThread(
+            id: "environment:one:thread:thread-1",
+            wireID: "  ",
+            projectID: "project-1",
+            title: "Fallback"
+        )
+
+        let items = ThreadMetadataCopyModel.items(
+            for: thread,
+            projectPath: "/tmp/project"
+        )
+
+        #expect(items.map(\.kind) == [.path, .threadID])
+        #expect(items.map(\.value) == ["/tmp/project", "environment:one:thread:thread-1"])
+    }
+
+    @Test
+    func unavailableValuesDoNotCreateDeadMenuActions() {
+        let thread = FeatureThread(
+            id: "  ",
+            wireID: nil,
+            projectID: "project-1",
+            title: "Unavailable",
+            branch: "\n",
+            worktreePath: nil
+        )
+
+        #expect(ThreadMetadataCopyModel.items(for: thread, projectPath: "  ").isEmpty)
+    }
+
+    @Test
+    func eachMenuRequestUsesTheCurrentRowMetadata() {
+        let first = FeatureThread(
+            id: "first",
+            wireID: "wire-first",
+            projectID: "project-1",
+            title: "First",
+            branch: "feature/first",
+            worktreePath: "/tmp/first"
+        )
+        let reused = FeatureThread(
+            id: "second",
+            wireID: "wire-second",
+            projectID: "project-2",
+            title: "Second",
+            branch: "feature/second",
+            worktreePath: "/tmp/second"
+        )
+
+        let firstItems = ThreadMetadataCopyModel.items(for: first, projectPath: nil)
+        let reusedItems = ThreadMetadataCopyModel.items(for: reused, projectPath: nil)
+
+        #expect(firstItems.map(\.value) == ["/tmp/first", "feature/first", "wire-first"])
+        #expect(reusedItems.map(\.value) == ["/tmp/second", "feature/second", "wire-second"])
+    }
+}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -8,6 +8,11 @@ On web and desktop, drag a pinned thread to change its position. On mobile, open
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.
 
+In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. A full
+swipe uses the lifecycle action, such as **Settle** or **Reopen**; it never deletes the thread.
+Deleting asks for confirmation. After settling a thread, use the temporary **Undo** message to
+return it to active work and restore its previous pin and snooze state.
+
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -9,7 +9,7 @@ and choose **Move up** or **Move down**. The order is stored by the server and a
 other connected devices.
 
 In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. A full
-swipe uses the lifecycle action, such as **Settle** or **Reopen**; it never deletes the thread.
+swipe settles or reopens a thread; it never deletes the thread.
 Deleting asks for confirmation. After settling a thread, use the temporary **Undo** message to
 return it to active work and restore its previous pin and snooze state.
 

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -8,8 +8,8 @@ On web and desktop, drag a pinned thread to change its position. On mobile, open
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.
 
-In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. A full
-swipe settles or reopens a thread; it never deletes the thread.
+In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. On rows
+that offer **Settle** or **Reopen**, a full swipe performs that action; it never deletes the thread.
 Deleting asks for confirmation. After settling a thread, use the temporary **Undo** message to
 return it to active work and restore its previous pin and snooze state.
 


### PR DESCRIPTION
## What changed

Adds three independent thread-row menu actions to copy the current checkout path, branch, and wire thread ID. Missing values do not produce dead actions; the checkout path falls back to the project root, and each successful copy announces the result for accessibility.

This is the first thread-menu slice after #6117. It does not add Mark unread.

## Why

Thread metadata is frequently needed outside the app. Copying the stable underlying values from the row menu avoids relying on truncated visible text.

## Verification

- exact isolated commit: `e11dbaac6`
- refreshed from `7280970f653d844d2f370caaa327a986390ab6d2` onto current #6117 (`3956fefd53358cbfdc05790711ac833afe0975b2`), then amended for reviewed path correctness
- legal leading/trailing whitespace in an actual checkout path is preserved in the copied value; emptiness checks do not mutate it
- final focused `ThreadMetadataCopyTests`: 4 passed, 0 failed; the prior combined copy/home run passed 9/9
- final-chain `apps/swift-ios/Scripts/ci-test.sh`: 268 tests in 33 suites passed
- final-chain fixture check and `git diff --check`: passed

## UI evidence

| Before | Copy actions and destructive presentation |
| --- | --- |
| ![Before: original compact row menu](https://github.com/saphid/t3code/releases/download/pr-thread-menu-chain-evidence-20260812/before.jpg) | ![After: path, branch, and thread ID copy actions above destructive Delete](https://github.com/saphid/t3code/releases/download/pr-thread-menu-chain-evidence-20260812/archived-actions.jpg) |

[Short interaction video](https://github.com/saphid/t3code/releases/download/pr-thread-menu-chain-evidence-20260812/interaction.mp4) · [evidence release and provenance](https://github.com/saphid/t3code/releases/tag/pr-thread-menu-chain-evidence-20260812)

## Review state

Keep this draft while #6117 remains unmerged and has requested changes. Macroscope's undo-restoration finding is inherited from #6117 and is not changed in this child. GitHub shows the cumulative stack as XL; this PR's intended review unit is the single commit above. Revalidate and simplify immediately after #6117 lands.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: chain
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: #6117
Merge order: #6117 → #6134
Validation status: Exact-head relevant CI is green on `e11dbaac6`, including Contract fixtures and native tests; Macroscope found no issues across 48 reviewed code objects. Draft is intentional until #6117 lands and its requested changes are resolved. Revalidate and simplify after the parent lands. Vercel marketing is a fork-authorization failure, and CodeRabbit skipped automatic review.
<!-- swiftui-delivery:end -->

Implemented and verified by GPT-5.6 Sol in T3 Code using the Codex harness.
