### PR TITLE
feat(swift-ios): regenerate thread titles

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -1309,6 +1309,21 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         try? await refresh(client: route.client)
     }
 
+    func regenerateThreadTitle(
+        id: String
+    ) async throws -> FeatureTitleRegenerationDispatchReceipt {
+        let route = try threadRoute(for: id)
+        _ = try await route.client.regenerateTitle(threadID: route.wireID)
+        do {
+            try await refresh(client: route.client)
+            return cachedThread(id: route.uiID)?.isRegeneratingTitle == true
+                ? .regenerating
+                : .completed
+        } catch {
+            return .refreshUnavailable
+        }
+    }
+
     func setThreadArchived(id: String, archived: Bool) async throws {
         let route = try threadRoute(for: id)
         let cached = cachedThread(id: route.uiID)
@@ -2301,6 +2316,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             snoozedUntil: thread.snoozedUntil,
             snoozedAt: thread.snoozedAt,
             pinnedAt: thread.pinnedAt,
+            titleRegeneration: thread.titleRegeneration,
             session: thread.session,
             latestUserMessageAt: thread.latestUserMessageAt,
             hasPendingApprovals: thread.hasPendingApprovals,
@@ -3886,6 +3902,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             supportsSnooze: environment.descriptor?.capabilities.threadSnooze,
             supportsPinning: environment.descriptor?.capabilities.threadPinning,
             supportsTitleRegeneration: environment.descriptor?.capabilities.threadTitleRegeneration,
+            isRegeneratingTitle: thread.titleRegeneration != nil,
             attentionAt: failureDate(
                 latestTurn: thread.latestTurn,
                 session: thread.session
@@ -3955,6 +3972,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             supportsSnooze: environment.descriptor?.capabilities.threadSnooze,
             supportsPinning: environment.descriptor?.capabilities.threadPinning,
             supportsTitleRegeneration: environment.descriptor?.capabilities.threadTitleRegeneration,
+            isRegeneratingTitle: thread.titleRegeneration != nil,
             attentionAt: failureDate(
                 latestTurn: thread.latestTurn,
                 session: thread.session
@@ -4220,6 +4238,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             snoozedUntil: loaded.snoozedUntil,
             snoozedAt: loaded.snoozedAt,
             pinnedAt: loaded.pinnedAt,
+            titleRegeneration: loaded.titleRegeneration,
             deletedAt: loaded.deletedAt,
             messages: prependByID(older.messages, loaded.messages),
             activities: prependByID(older.activities, loaded.activities),

--- a/apps/swift-ios/Core/Models.swift
+++ b/apps/swift-ios/Core/Models.swift
@@ -383,6 +383,11 @@ public enum OrchestrationBackgroundLiveness: String, Codable, Equatable, Sendabl
     case monitoring
 }
 
+public struct ThreadTitleRegeneration: Codable, Equatable, Sendable {
+    public let requestId: String
+    public let startedAt: String
+}
+
 public struct OrchestrationThreadShell: Codable, Identifiable, Equatable, Sendable {
     public let id: String
     public let projectId: String
@@ -401,6 +406,7 @@ public struct OrchestrationThreadShell: Codable, Identifiable, Equatable, Sendab
     public let snoozedUntil: String?
     public let snoozedAt: String?
     public let pinnedAt: String?
+    public var titleRegeneration: ThreadTitleRegeneration? = nil
     public let session: OrchestrationSession?
     public let latestUserMessageAt: String?
     public let hasPendingApprovals: Bool
@@ -474,6 +480,7 @@ public struct OrchestrationThread: Codable, Identifiable, Equatable, Sendable {
     public let snoozedUntil: String?
     public let snoozedAt: String?
     public let pinnedAt: String?
+    public var titleRegeneration: ThreadTitleRegeneration? = nil
     public let deletedAt: String?
     @ForwardCompatibleArray public var messages: [OrchestrationMessage]
     @ForwardCompatibleArray public var activities: [OrchestrationActivity]

--- a/apps/swift-ios/Core/T3Client.swift
+++ b/apps/swift-ios/Core/T3Client.swift
@@ -335,6 +335,11 @@ public actor T3Client {
     }
 
     @discardableResult
+    public func regenerateTitle(threadID: String) async throws -> DispatchResult {
+        try await dispatch(OrchestrationCommands.regenerateTitle(threadID: threadID))
+    }
+
+    @discardableResult
     public func interrupt(threadID: String, turnID: String? = nil) async throws -> DispatchResult {
         try await dispatch(
             OrchestrationCommands.interrupt(threadID: threadID, turnID: turnID)
@@ -1454,6 +1459,18 @@ public enum OrchestrationCommands {
             "commandId": .string(commandID),
             "threadId": .string(threadID),
             "title": .string(title),
+        ])
+    }
+
+    public static func regenerateTitle(
+        threadID: String,
+        commandID: String = UUID().uuidString
+    ) -> JSONValue {
+        .object([
+            "type": .string("thread.meta.update"),
+            "commandId": .string(commandID),
+            "threadId": .string(threadID),
+            "regenerateTitle": .bool(true),
         ])
     }
 

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -317,9 +317,10 @@ public final class FeatureRootModel {
         }
     }
 
-    public func setSnoozed(_ id: String, until: Date?) async {
+    @discardableResult
+    public func setSnoozed(_ id: String, until: Date?) async -> Bool {
         let environment = currentEnvironmentIdentity
-        await perform {
+        return await perform {
             try await client.setThreadSnoozed(id: id, until: until)
             guard currentEnvironmentIdentity == environment else { return }
             let snoozedAt = until.map { _ in Date.now }
@@ -330,9 +331,10 @@ public final class FeatureRootModel {
         }
     }
 
-    public func setPinned(_ id: String, pinned: Bool) async {
+    @discardableResult
+    public func setPinned(_ id: String, pinned: Bool) async -> Bool {
         let environment = currentEnvironmentIdentity
-        await perform {
+        return await perform {
             try await client.setThreadPinned(id: id, pinned: pinned)
             guard currentEnvironmentIdentity == environment else { return }
             mutateThread(id: id) {

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -18,6 +18,95 @@ struct FeatureDetailRenderUpdate: Equatable {
     let change: FeatureDetailRenderChange
 }
 
+enum FeatureTitleRegenerationResult: Equatable {
+    case started
+    case alreadyRunning
+    case unavailable
+    case threadMissing
+    case failed(String)
+}
+
+private struct FeatureTitleRegenerationTracker {
+    private struct Pending {
+        let projectID: String
+        let environmentID: String?
+        let originalTitle: String
+        var observedServerRequest: Bool
+        var awaitingAuthoritativeUpdate: Bool
+    }
+
+    private var pendingByThreadID: [String: Pending] = [:]
+
+    var isEmpty: Bool { pendingByThreadID.isEmpty }
+    var threadIDs: Set<String> { Set(pendingByThreadID.keys) }
+
+    mutating func begin(_ thread: FeatureThread) -> Bool {
+        guard pendingByThreadID[thread.id] == nil, thread.isRegeneratingTitle != true else {
+            return false
+        }
+        pendingByThreadID[thread.id] = Pending(
+            projectID: thread.projectID,
+            environmentID: thread.environmentID,
+            originalTitle: thread.title,
+            observedServerRequest: false,
+            awaitingAuthoritativeUpdate: false
+        )
+        return true
+    }
+
+    mutating func cancel(threadID: String) {
+        pendingByThreadID.removeValue(forKey: threadID)
+    }
+
+    mutating func finishDispatch(
+        threadID: String,
+        receipt: FeatureTitleRegenerationDispatchReceipt
+    ) {
+        guard var pending = pendingByThreadID[threadID] else { return }
+        switch receipt {
+        case .completed:
+            pendingByThreadID.removeValue(forKey: threadID)
+        case .regenerating:
+            pending.observedServerRequest = true
+            pendingByThreadID[threadID] = pending
+        case .refreshUnavailable:
+            pending.awaitingAuthoritativeUpdate = true
+            pendingByThreadID[threadID] = pending
+        }
+    }
+
+    mutating func reconcile(thread: FeatureThread) {
+        guard var pending = pendingByThreadID[thread.id] else { return }
+        guard thread.projectID == pending.projectID,
+              thread.environmentID == pending.environmentID,
+              thread.title == pending.originalTitle else {
+            pendingByThreadID.removeValue(forKey: thread.id)
+            return
+        }
+        if thread.isRegeneratingTitle == true {
+            pending.observedServerRequest = true
+            pendingByThreadID[thread.id] = pending
+        } else if pending.observedServerRequest || pending.awaitingAuthoritativeUpdate {
+            pendingByThreadID.removeValue(forKey: thread.id)
+        }
+    }
+
+    mutating func reconcile(with threads: [FeatureThread]) {
+        guard !pendingByThreadID.isEmpty else { return }
+        let threadsByID = Dictionary(
+            threads.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for threadID in Array(pendingByThreadID.keys) {
+            guard let thread = threadsByID[threadID] else {
+                pendingByThreadID.removeValue(forKey: threadID)
+                continue
+            }
+            reconcile(thread: thread)
+        }
+    }
+}
+
 @MainActor
 @Observable
 public final class FeatureRootModel {
@@ -39,6 +128,18 @@ public final class FeatureRootModel {
     public private(set) var isManagingConnections = false
     public var errorMessage: String?
 
+    var regeneratingTitleThreadIDs: Set<String> {
+        if titleRegenerationTracker.isEmpty,
+           !snapshot.threads.contains(where: { $0.isRegeneratingTitle == true }) {
+            return []
+        }
+        return snapshot.threads.reduce(into: titleRegenerationTracker.threadIDs) { ids, thread in
+            if thread.isRegeneratingTitle == true {
+                ids.insert(thread.id)
+            }
+        }
+    }
+
     let client: any FeatureClient
     private let outboxStore: FeatureOutboxStore
     private var pendingSubmissionsByID: [String: FeatureQueuedSubmission] = [:]
@@ -49,6 +150,7 @@ public final class FeatureRootModel {
     private var outboxDrainTask: Task<Void, Never>?
     private var outboxRetryAttempt = 0
     private var outboxGeneration: UInt64 = 0
+    private var titleRegenerationTracker = FeatureTitleRegenerationTracker()
 
     public init(
         client: any FeatureClient,
@@ -287,6 +389,28 @@ public final class FeatureRootModel {
             try await client.renameThread(id: id, title: title)
             guard currentEnvironmentIdentity == environment else { return }
             mutateThread(id: id) { $0.title = title }
+        }
+    }
+
+    @discardableResult
+    func regenerateThreadTitle(_ id: String) async -> FeatureTitleRegenerationResult {
+        guard let thread = snapshot.threads.first(where: { $0.id == id }) else {
+            return .threadMissing
+        }
+        guard !thread.isArchived, thread.supportsTitleRegeneration == true else {
+            return .unavailable
+        }
+        guard titleRegenerationTracker.begin(thread) else {
+            return .alreadyRunning
+        }
+
+        do {
+            let receipt = try await client.regenerateThreadTitle(id: id)
+            titleRegenerationTracker.finishDispatch(threadID: id, receipt: receipt)
+            return .started
+        } catch {
+            titleRegenerationTracker.cancel(threadID: id)
+            return .failed(error.localizedDescription)
         }
     }
 
@@ -662,6 +786,7 @@ public final class FeatureRootModel {
     }
 
     private func upsert(_ thread: FeatureThread) {
+        titleRegenerationTracker.reconcile(thread: thread)
         if let index = snapshot.threads.firstIndex(where: { $0.id == thread.id }) {
             let previous = snapshot.threads[index]
             guard previous != thread else { return }
@@ -685,6 +810,7 @@ public final class FeatureRootModel {
         adjustProjectCount(id: projectID, by: -1)
         threadCollectionRevision &+= 1
         homePresentationRevision &+= 1
+        titleRegenerationTracker.cancel(threadID: id)
     }
 
     private func adjustProjectCount(id: String, by delta: Int) {
@@ -718,6 +844,7 @@ public final class FeatureRootModel {
             threadCollectionRevision &+= 1
         }
         snapshot = value
+        titleRegenerationTracker.reconcile(with: value.threads)
         if value.connection.state == .connected
             || value.environments.contains(where: { $0.connectionState == .connected }) {
             scheduleOutboxDrain()

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -299,9 +299,10 @@ public final class FeatureRootModel {
         }
     }
 
-    public func setSettled(_ id: String, settled: Bool) async {
+    @discardableResult
+    public func setSettled(_ id: String, settled: Bool) async -> Bool {
         let environment = currentEnvironmentIdentity
-        await perform {
+        return await perform {
             try await client.setThreadSettled(id: id, settled: settled)
             guard currentEnvironmentIdentity == environment else { return }
             let settledAt = settled ? Date.now : nil

--- a/apps/swift-ios/Features/Shared/FeatureClient.swift
+++ b/apps/swift-ios/Features/Shared/FeatureClient.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+public enum FeatureTitleRegenerationDispatchReceipt: Equatable {
+    case regenerating
+    case completed
+    case refreshUnavailable
+}
+
 /// The app-owned adapter between the native feature layer and T3's WebSocket/Core runtime.
 /// Implementations are main-actor isolated so UI state never depends on locking.
 @MainActor
@@ -55,6 +61,7 @@ public protocol FeatureClient: AnyObject {
         refresh: Bool
     ) async throws -> [FeatureWorkspaceBranch]
     func renameThread(id: String, title: String) async throws
+    func regenerateThreadTitle(id: String) async throws -> FeatureTitleRegenerationDispatchReceipt
     func setThreadArchived(id: String, archived: Bool) async throws
     func setThreadSettled(id: String, settled: Bool) async throws
     func setThreadSnoozed(id: String, until: Date?) async throws
@@ -167,6 +174,9 @@ public extension FeatureClient {
     }
     func releaseThread(id: String) {}
     func resolveUserInput(id: String, answers: [String: FeatureInputAnswer]) async throws {}
+    func regenerateThreadTitle(id: String) async throws -> FeatureTitleRegenerationDispatchReceipt {
+        throw FeatureCapabilityUnavailable("Thread title regeneration")
+    }
 
     /// Keeps simple text-only callers source-compatible while the typed API
     /// preserves multi-select answers as arrays.

--- a/apps/swift-ios/Features/Shared/FeatureModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureModels.swift
@@ -217,6 +217,7 @@ public struct FeatureThread: Identifiable, Sendable, Equatable, Hashable, Codabl
     public var supportsSnooze: Bool?
     public var supportsPinning: Bool?
     public var supportsTitleRegeneration: Bool?
+    public var isRegeneratingTitle: Bool?
     public var attentionAt: Date?
     public var workingStartedAt: Date?
     public var latestTurnCompletedAt: Date?
@@ -252,6 +253,7 @@ public struct FeatureThread: Identifiable, Sendable, Equatable, Hashable, Codabl
         supportsSnooze: Bool? = nil,
         supportsPinning: Bool? = nil,
         supportsTitleRegeneration: Bool? = nil,
+        isRegeneratingTitle: Bool? = nil,
         attentionAt: Date? = nil,
         workingStartedAt: Date? = nil,
         latestTurnCompletedAt: Date? = nil,
@@ -286,6 +288,7 @@ public struct FeatureThread: Identifiable, Sendable, Equatable, Hashable, Codabl
         self.supportsSnooze = supportsSnooze
         self.supportsPinning = supportsPinning
         self.supportsTitleRegeneration = supportsTitleRegeneration
+        self.isRegeneratingTitle = isRegeneratingTitle
         self.attentionAt = attentionAt
         self.workingStartedAt = workingStartedAt
         self.latestTurnCompletedAt = latestTurnCompletedAt

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -25,7 +25,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         } else if thread.pinnedAt != nil, thread.canTogglePin {
             primary = .unpin
         } else if thread.canToggleSettlement {
-            primary = thread.isSettled || thread.isEffectivelySettled(at: now)
+            primary = thread.isEffectivelySettled(at: now)
                 ? .reopen
                 : .settle
         } else {

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -195,7 +195,10 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
             let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
                 self?.parent.onDelete(thread)
-                finish(true)
+                // Deletion is deferred until the confirmation alert. Keep the
+                // row in place if the user cancels instead of letting UIKit
+                // animate an optimistic removal that never reached the model.
+                finish(false)
             }
             delete.image = UIImage(systemName: "trash")
 

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -55,6 +55,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onToggleSettled: () -> Void
     let onToggleArchive: () -> Void
     let onShowMoreSettled: () -> Void
+    let newThreadAvailability: (FeatureThread) -> ThreadNewTaskAvailability
+    let onNewThreadOnSameBranch: (ThreadNewTaskSeedRequest) -> Void
     let onRename: (FeatureThread) -> Void
     let onArchive: (FeatureThread, Bool) -> Void
     let onSettle: (FeatureThread, Bool) -> Void
@@ -437,6 +439,17 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         }
 
         private func menuActions(for thread: FeatureThread, isArchived: Bool) -> [UIMenuElement] {
+            let newThreadAvailability = parent.newThreadAvailability(thread)
+            let newThread = UIAction(
+                title: newThreadAvailability.menuTitle,
+                image: UIImage(systemName: "plus.bubble")
+            ) { [weak self] _ in
+                guard case let .available(request) = newThreadAvailability else { return }
+                self?.parent.onNewThreadOnSameBranch(request)
+            }
+            if !newThreadAvailability.isEnabled {
+                newThread.attributes = .disabled
+            }
             let rename = UIAction(title: "Rename", image: UIImage(systemName: "pencil")) { [weak self] _ in
                 self?.parent.onRename(thread)
             }
@@ -447,7 +460,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 self?.parent.onArchive(thread, !isArchived)
             }
 
-            var actions: [UIMenuElement] = [rename, archive]
+            var actions: [UIMenuElement] = [newThread, rename, archive]
             if !isArchived {
                 if thread.canTogglePin {
                     let isPinned = thread.pinnedAt != nil

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -33,7 +33,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         }
         return HomeThreadSwipeActionPlan(
             actions: [primary, .delete],
-            performsFirstActionWithFullSwipe: true
+            performsFirstActionWithFullSwipe: primary == .settle || primary == .reopen
         )
     }
 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -1,6 +1,45 @@
 import SwiftUI
 import UIKit
 
+enum HomeThreadSwipeActionKind: Equatable, Sendable {
+    case restore
+    case unpin
+    case settle
+    case reopen
+    case archive
+    case delete
+}
+
+struct HomeThreadSwipeActionPlan: Equatable, Sendable {
+    let primary: HomeThreadSwipeActionKind
+    let secondary: HomeThreadSwipeActionKind = .delete
+    let performsPrimaryWithFullSwipe = true
+    let deleteFinishesOptimistically = false
+
+    var orderedActions: [HomeThreadSwipeActionKind] {
+        [primary, secondary]
+    }
+
+    static func make(
+        thread: FeatureThread,
+        isArchived: Bool,
+        now: Date
+    ) -> HomeThreadSwipeActionPlan {
+        if isArchived {
+            return HomeThreadSwipeActionPlan(primary: .restore)
+        }
+        if thread.pinnedAt != nil, thread.canTogglePin {
+            return HomeThreadSwipeActionPlan(primary: .unpin)
+        }
+        if thread.canToggleSettlement {
+            return HomeThreadSwipeActionPlan(
+                primary: thread.isEffectivelySettled(at: now) ? .reopen : .settle
+            )
+        }
+        return HomeThreadSwipeActionPlan(primary: .archive)
+    }
+}
+
 /// A recycled, diffable Home surface. SwiftUI still owns the surrounding shell,
 /// while UIKit keeps row creation and updates proportional to visible threads.
 struct HomeThreadCollectionView: UIViewRepresentable {
@@ -20,7 +59,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onShowMoreSettled: () -> Void
     let onRename: (FeatureThread) -> Void
     let onArchive: (FeatureThread, Bool) -> Void
-    let onSettle: (FeatureThread, Bool) -> Void
+    let onSettle: (FeatureThread, Bool, Bool) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
     let onPin: (FeatureThread, Bool) -> Void
     let onDelete: (FeatureThread) -> Void
@@ -193,17 +232,23 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 return nil
             }
 
+            let plan = HomeThreadSwipeActionPlan.make(
+                thread: thread,
+                isArchived: isArchived,
+                now: .now
+            )
             let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
                 self?.parent.onDelete(thread)
                 // Deletion is deferred until the confirmation alert. Keep the
                 // row in place if the user cancels instead of letting UIKit
                 // animate an optimistic removal that never reached the model.
-                finish(false)
+                finish(plan.deleteFinishesOptimistically)
             }
             delete.image = UIImage(systemName: "trash")
 
             let primaryAction: UIContextualAction
-            if isArchived {
+            switch plan.primary {
+            case .restore:
                 primaryAction = UIContextualAction(style: .normal, title: "Restore") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, false)
@@ -211,7 +256,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 primaryAction.image = UIImage(systemName: "arrow.uturn.backward")
                 primaryAction.backgroundColor = .systemBlue
-            } else if thread.pinnedAt != nil, thread.canTogglePin {
+            case .unpin:
                 primaryAction = UIContextualAction(style: .normal, title: "Unpin") {
                     [weak self] _, _, finish in
                     self?.parent.onPin(thread, false)
@@ -219,20 +264,24 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 primaryAction.image = UIImage(systemName: "pin.slash")
                 primaryAction.backgroundColor = .systemBlue
-            } else if thread.canToggleSettlement {
-                let isSettled = thread.isEffectivelySettled(at: .now)
+            case .settle, .reopen:
+                let wasEffectivelySettled = plan.primary == .reopen
                 primaryAction = UIContextualAction(
                     style: .normal,
-                    title: isSettled ? "Reopen" : "Settle"
+                    title: wasEffectivelySettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(thread, !isSettled)
+                    self?.parent.onSettle(
+                        thread,
+                        !wasEffectivelySettled,
+                        wasEffectivelySettled
+                    )
                     finish(true)
                 }
                 primaryAction.image = UIImage(
-                    systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
+                    systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
                 )
-                primaryAction.backgroundColor = isSettled ? .systemBlue : .systemGreen
-            } else {
+                primaryAction.backgroundColor = wasEffectivelySettled ? .systemBlue : .systemGreen
+            case .archive:
                 primaryAction = UIContextualAction(style: .normal, title: "Archive") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, true)
@@ -240,10 +289,12 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 primaryAction.image = UIImage(systemName: "archivebox")
                 primaryAction.backgroundColor = .systemGray
+            case .delete:
+                preconditionFailure("Delete cannot be the primary full-swipe action")
             }
 
             let configuration = UISwipeActionsConfiguration(actions: [primaryAction, delete])
-            configuration.performsFirstActionWithFullSwipe = true
+            configuration.performsFirstActionWithFullSwipe = plan.performsPrimaryWithFullSwipe
             return configuration
         }
 
@@ -407,15 +458,19 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     )
                 }
                 if thread.canToggleSettlement {
-                    let isSettled = thread.isEffectivelySettled(at: .now)
+                    let wasEffectivelySettled = thread.isEffectivelySettled(at: .now)
                     actions.append(
                         UIAction(
-                            title: isSettled ? "Reopen" : "Settle",
+                            title: wasEffectivelySettled ? "Reopen" : "Settle",
                             image: UIImage(
-                                systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
+                                systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
                             )
                         ) { [weak self] _ in
-                            self?.parent.onSettle(thread, !isSettled)
+                            self?.parent.onSettle(
+                                thread,
+                                !wasEffectivelySettled,
+                                wasEffectivelySettled
+                            )
                         }
                     )
                 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -474,23 +474,31 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     )
                 }
 
-                if thread.canToggleSnooze {
-                    let isSnoozed = thread.isEffectivelySnoozed(at: .now)
-                    let snooze = UIAction(
-                        title: isSnoozed ? "Unsnooze" : "Snooze 1 hour",
-                        image: UIImage(systemName: isSnoozed ? "bell" : "clock")
-                    ) { [weak self] _ in
-                        self?.parent.onSnooze(
-                            thread,
-                            isSnoozed ? nil : Date.now.addingTimeInterval(60 * 60)
+                switch ThreadSnoozeMenuModel.menu(for: thread, isArchived: isArchived) {
+                case .hidden:
+                    break
+                case .unsnooze:
+                    actions.append(
+                        UIAction(title: "Unsnooze", image: UIImage(systemName: "bell")) {
+                            [weak self] _ in
+                            self?.parent.onSnooze(thread, nil)
+                        }
+                    )
+                case let .presets(presets, enabled):
+                    let presetActions = presets.map { preset in
+                        let action = UIAction(title: preset.menuTitle) { [weak self] _ in
+                            self?.parent.onSnooze(thread, preset.until)
+                        }
+                        if !enabled { action.attributes = .disabled }
+                        return action
+                    }
+                    actions.append(
+                        UIMenu(
+                            title: "Snooze",
+                            image: UIImage(systemName: "clock"),
+                            children: presetActions
                         )
-                    }
-                    if thread.state == .queued
-                        || thread.state == .waitingForApproval
-                        || thread.state == .waitingForInput {
-                        snooze.attributes = .disabled
-                    }
-                    actions.append(snooze)
+                    )
                 }
             }
 

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -57,7 +57,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onShowMoreSettled: () -> Void
     let onRename: (FeatureThread) -> Void
     let onArchive: (FeatureThread, Bool) -> Void
-    let onSettle: (FeatureThread, Bool, Bool) -> Void
+    let onSettle: (FeatureThread, Bool) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
     let onPin: (FeatureThread, Bool) -> Void
     let onDelete: (FeatureThread) -> Void
@@ -270,7 +270,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     style: .normal,
                     title: wasSettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(thread, !wasSettled, wasSettled)
+                    self?.parent.onSettle(thread, !wasSettled)
                     finish(true)
                 }
                 action.image = UIImage(
@@ -468,7 +468,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                                 systemName: wasSettled ? "arrow.counterclockwise" : "checkmark"
                             )
                         ) { [weak self] _ in
-                            self?.parent.onSettle(thread, !wasSettled, wasSettled)
+                            self?.parent.onSettle(thread, !wasSettled)
                         }
                     )
                 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -60,6 +60,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onSettle: (FeatureThread, Bool) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
     let onPin: (FeatureThread, Bool) -> Void
+    let projectPath: (FeatureThread) -> String?
     let onDelete: (FeatureThread) -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -492,6 +493,16 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     actions.append(snooze)
                 }
             }
+
+            let copyItems = ThreadMetadataCopyModel.items(
+                for: thread,
+                projectPath: parent.projectPath(thread)
+            )
+            actions.append(contentsOf: copyItems.map { item in
+                UIAction(title: item.title, image: UIImage(systemName: item.systemImage)) { _ in
+                    ThreadMetadataClipboard.copy(item)
+                }
+            })
 
             actions.append(
                 UIAction(title: "Delete", image: UIImage(systemName: "trash"), attributes: .destructive) {

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -11,32 +11,32 @@ enum HomeThreadSwipeActionKind: Equatable, Sendable {
 }
 
 struct HomeThreadSwipeActionPlan: Equatable, Sendable {
-    let primary: HomeThreadSwipeActionKind
-    let secondary: HomeThreadSwipeActionKind = .delete
-    let performsPrimaryWithFullSwipe = true
-    let deleteFinishesOptimistically = false
-
-    var orderedActions: [HomeThreadSwipeActionKind] {
-        [primary, secondary]
-    }
+    let actions: [HomeThreadSwipeActionKind]
+    let performsFirstActionWithFullSwipe: Bool
+    let deleteFinishesOptimistically: Bool
 
     static func make(
         thread: FeatureThread,
         isArchived: Bool,
         now: Date
     ) -> HomeThreadSwipeActionPlan {
+        let primary: HomeThreadSwipeActionKind
         if isArchived {
-            return HomeThreadSwipeActionPlan(primary: .restore)
+            primary = .restore
+        } else if thread.pinnedAt != nil, thread.canTogglePin {
+            primary = .unpin
+        } else if thread.canToggleSettlement {
+            primary = thread.isSettled || thread.isEffectivelySettled(at: now)
+                ? .reopen
+                : .settle
+        } else {
+            primary = .archive
         }
-        if thread.pinnedAt != nil, thread.canTogglePin {
-            return HomeThreadSwipeActionPlan(primary: .unpin)
-        }
-        if thread.canToggleSettlement {
-            return HomeThreadSwipeActionPlan(
-                primary: thread.isEffectivelySettled(at: now) ? .reopen : .settle
-            )
-        }
-        return HomeThreadSwipeActionPlan(primary: .archive)
+        return HomeThreadSwipeActionPlan(
+            actions: [primary, .delete],
+            performsFirstActionWithFullSwipe: true,
+            deleteFinishesOptimistically: false
+        )
     }
 }
 
@@ -237,65 +237,71 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 isArchived: isArchived,
                 now: .now
             )
-            let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
-                self?.parent.onDelete(thread)
-                // Deletion is deferred until the confirmation alert. Keep the
-                // row in place if the user cancels instead of letting UIKit
-                // animate an optimistic removal that never reached the model.
-                finish(plan.deleteFinishesOptimistically)
+            let actions = plan.actions.map {
+                swipeAction($0, for: thread, plan: plan)
             }
-            delete.image = UIImage(systemName: "trash")
+            let configuration = UISwipeActionsConfiguration(actions: actions)
+            configuration.performsFirstActionWithFullSwipe =
+                plan.performsFirstActionWithFullSwipe
+            return configuration
+        }
 
-            let primaryAction: UIContextualAction
-            switch plan.primary {
+        private func swipeAction(
+            _ kind: HomeThreadSwipeActionKind,
+            for thread: FeatureThread,
+            plan: HomeThreadSwipeActionPlan
+        ) -> UIContextualAction {
+            let action: UIContextualAction
+            switch kind {
             case .restore:
-                primaryAction = UIContextualAction(style: .normal, title: "Restore") {
+                action = UIContextualAction(style: .normal, title: "Restore") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, false)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "arrow.uturn.backward")
-                primaryAction.backgroundColor = .systemBlue
+                action.image = UIImage(systemName: "arrow.uturn.backward")
+                action.backgroundColor = .systemBlue
             case .unpin:
-                primaryAction = UIContextualAction(style: .normal, title: "Unpin") {
+                action = UIContextualAction(style: .normal, title: "Unpin") {
                     [weak self] _, _, finish in
                     self?.parent.onPin(thread, false)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "pin.slash")
-                primaryAction.backgroundColor = .systemBlue
+                action.image = UIImage(systemName: "pin.slash")
+                action.backgroundColor = .systemBlue
             case .settle, .reopen:
-                let wasEffectivelySettled = plan.primary == .reopen
-                primaryAction = UIContextualAction(
+                let wasSettled = kind == .reopen
+                action = UIContextualAction(
                     style: .normal,
-                    title: wasEffectivelySettled ? "Reopen" : "Settle"
+                    title: wasSettled ? "Reopen" : "Settle"
                 ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(
-                        thread,
-                        !wasEffectivelySettled,
-                        wasEffectivelySettled
-                    )
+                    self?.parent.onSettle(thread, !wasSettled, wasSettled)
                     finish(true)
                 }
-                primaryAction.image = UIImage(
-                    systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
+                action.image = UIImage(
+                    systemName: wasSettled ? "arrow.counterclockwise" : "checkmark"
                 )
-                primaryAction.backgroundColor = wasEffectivelySettled ? .systemBlue : .systemGreen
+                action.backgroundColor = wasSettled ? .systemBlue : .systemGreen
             case .archive:
-                primaryAction = UIContextualAction(style: .normal, title: "Archive") {
+                action = UIContextualAction(style: .normal, title: "Archive") {
                     [weak self] _, _, finish in
                     self?.parent.onArchive(thread, true)
                     finish(true)
                 }
-                primaryAction.image = UIImage(systemName: "archivebox")
-                primaryAction.backgroundColor = .systemGray
+                action.image = UIImage(systemName: "archivebox")
+                action.backgroundColor = .systemGray
             case .delete:
-                preconditionFailure("Delete cannot be the primary full-swipe action")
+                action = UIContextualAction(style: .destructive, title: "Delete") {
+                    [weak self] _, _, finish in
+                    self?.parent.onDelete(thread)
+                    // Deletion is deferred until the confirmation alert. Keep
+                    // the row if the user cancels instead of letting UIKit
+                    // animate a removal that never reached the model.
+                    finish(plan.deleteFinishesOptimistically)
+                }
+                action.image = UIImage(systemName: "trash")
             }
-
-            let configuration = UISwipeActionsConfiguration(actions: [primaryAction, delete])
-            configuration.performsFirstActionWithFullSwipe = plan.performsPrimaryWithFullSwipe
-            return configuration
+            return action
         }
 
         private func configure(
@@ -458,19 +464,15 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     )
                 }
                 if thread.canToggleSettlement {
-                    let wasEffectivelySettled = thread.isEffectivelySettled(at: .now)
+                    let wasSettled = thread.isSettled || thread.isEffectivelySettled(at: .now)
                     actions.append(
                         UIAction(
-                            title: wasEffectivelySettled ? "Reopen" : "Settle",
+                            title: wasSettled ? "Reopen" : "Settle",
                             image: UIImage(
-                                systemName: wasEffectivelySettled ? "arrow.counterclockwise" : "checkmark"
+                                systemName: wasSettled ? "arrow.counterclockwise" : "checkmark"
                             )
                         ) { [weak self] _ in
-                            self?.parent.onSettle(
-                                thread,
-                                !wasEffectivelySettled,
-                                wasEffectivelySettled
-                            )
+                            self?.parent.onSettle(thread, !wasSettled, wasSettled)
                         }
                     )
                 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -38,6 +38,23 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
     }
 }
 
+enum ThreadTitleRegenerationMenuState: Equatable {
+    case hidden
+    case available
+    case regenerating
+
+    static func resolve(
+        thread: FeatureThread,
+        isArchived: Bool,
+        regeneratingThreadIDs: Set<String>
+    ) -> Self {
+        guard !isArchived, thread.supportsTitleRegeneration == true else { return .hidden }
+        return regeneratingThreadIDs.contains(thread.id) || thread.isRegeneratingTitle == true
+            ? .regenerating
+            : .available
+    }
+}
+
 /// A recycled, diffable Home surface. SwiftUI still owns the surrounding shell,
 /// while UIKit keeps row creation and updates proportional to visible threads.
 struct HomeThreadCollectionView: UIViewRepresentable {
@@ -58,6 +75,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let newThreadAvailability: (FeatureThread) -> ThreadNewTaskAvailability
     let onNewThreadOnSameBranch: (ThreadNewTaskSeedRequest) -> Void
     let onRename: (FeatureThread) -> Void
+    let regeneratingTitleThreadIDs: Set<String>
+    let onRegenerateTitle: (String) -> Void
     let onArchive: (FeatureThread, Bool) -> Void
     let onSettle: (FeatureThread, Bool) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
@@ -460,7 +479,27 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 self?.parent.onArchive(thread, !isArchived)
             }
 
-            var actions: [UIMenuElement] = [newThread, rename, archive]
+            var actions: [UIMenuElement] = [newThread, rename]
+            switch ThreadTitleRegenerationMenuState.resolve(
+                thread: thread,
+                isArchived: isArchived,
+                regeneratingThreadIDs: parent.regeneratingTitleThreadIDs
+            ) {
+            case .hidden:
+                break
+            case .available, .regenerating:
+                let isRegenerating = parent.regeneratingTitleThreadIDs.contains(thread.id)
+                    || thread.isRegeneratingTitle == true
+                let regenerate = UIAction(
+                    title: isRegenerating ? "Regenerating…" : "Regenerate title",
+                    image: UIImage(systemName: "arrow.clockwise")
+                ) { [weak self] _ in
+                    self?.parent.onRegenerateTitle(thread.id)
+                }
+                if isRegenerating { regenerate.attributes = .disabled }
+                actions.append(regenerate)
+            }
+            actions.append(archive)
             if !isArchived {
                 if thread.canTogglePin {
                     let isPinned = thread.pinnedAt != nil

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -13,7 +13,6 @@ enum HomeThreadSwipeActionKind: Equatable, Sendable {
 struct HomeThreadSwipeActionPlan: Equatable, Sendable {
     let actions: [HomeThreadSwipeActionKind]
     let performsFirstActionWithFullSwipe: Bool
-    let deleteFinishesOptimistically: Bool
 
     static func make(
         thread: FeatureThread,
@@ -34,8 +33,7 @@ struct HomeThreadSwipeActionPlan: Equatable, Sendable {
         }
         return HomeThreadSwipeActionPlan(
             actions: [primary, .delete],
-            performsFirstActionWithFullSwipe: true,
-            deleteFinishesOptimistically: false
+            performsFirstActionWithFullSwipe: true
         )
     }
 }
@@ -237,9 +235,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 isArchived: isArchived,
                 now: .now
             )
-            let actions = plan.actions.map {
-                swipeAction($0, for: thread, plan: plan)
-            }
+            let actions = plan.actions.map { swipeAction($0, for: thread) }
             let configuration = UISwipeActionsConfiguration(actions: actions)
             configuration.performsFirstActionWithFullSwipe =
                 plan.performsFirstActionWithFullSwipe
@@ -248,8 +244,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
         private func swipeAction(
             _ kind: HomeThreadSwipeActionKind,
-            for thread: FeatureThread,
-            plan: HomeThreadSwipeActionPlan
+            for thread: FeatureThread
         ) -> UIContextualAction {
             let action: UIContextualAction
             switch kind {
@@ -291,15 +286,16 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 action.image = UIImage(systemName: "archivebox")
                 action.backgroundColor = .systemGray
             case .delete:
-                action = UIContextualAction(style: .destructive, title: "Delete") {
+                action = UIContextualAction(style: .normal, title: "Delete") {
                     [weak self] _, _, finish in
                     self?.parent.onDelete(thread)
-                    // Deletion is deferred until the confirmation alert. Keep
-                    // the row if the user cancels instead of letting UIKit
-                    // animate a removal that never reached the model.
-                    finish(plan.deleteFinishesOptimistically)
+                    // The alert owns the destructive operation. Complete this
+                    // non-destructive contextual action so Cancel closes the
+                    // swipe without UIKit animating a row deletion.
+                    finish(true)
                 }
                 action.image = UIImage(systemName: "trash")
+                action.backgroundColor = .systemRed
             }
             return action
         }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -239,8 +239,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 primaryAction.backgroundColor = .systemGray
             }
 
-            let configuration = UISwipeActionsConfiguration(actions: [delete, primaryAction])
-            configuration.performsFirstActionWithFullSwipe = false
+            let configuration = UISwipeActionsConfiguration(actions: [primaryAction, delete])
+            configuration.performsFirstActionWithFullSwipe = true
             return configuration
         }
 

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -8,6 +8,7 @@ public struct NewThreadView: View {
     let onCreateProject: @MainActor () -> Void
     private let draftStore: FeatureComposerDraftStore
     private let initialProjectID: String?
+    private let initialThreadWorkspace: ThreadNewTaskResolvedSeed?
 
     @State private var projectID = ""
     @State private var prompt = ""
@@ -30,6 +31,8 @@ public struct NewThreadView: View {
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var immediateDraftSaveTasks: [String: Task<Void, Never>] = [:]
     @State private var submittedSuccessfully = false
+    @State private var initialThreadWorkspaceApplied = false
+    @State private var threadWorkspaceError: ThreadNewTaskUnavailableReason?
     @FocusState private var promptFocused: Bool
 
     public init(
@@ -40,11 +43,32 @@ public struct NewThreadView: View {
         initialProjectID: String? = nil,
         draftStore: FeatureComposerDraftStore = .shared
     ) {
+        self.init(
+            model: model,
+            submit: submit,
+            onCreated: onCreated,
+            onCreateProject: onCreateProject,
+            initialProjectID: initialProjectID,
+            initialThreadWorkspace: nil,
+            draftStore: draftStore
+        )
+    }
+
+    init(
+        model: FeatureRootModel,
+        submit: @escaping (NewTaskRequest) async -> FeatureThread?,
+        onCreated: @escaping (FeatureThread) -> Void,
+        onCreateProject: @escaping @MainActor () -> Void,
+        initialProjectID: String?,
+        initialThreadWorkspace: ThreadNewTaskResolvedSeed?,
+        draftStore: FeatureComposerDraftStore = .shared
+    ) {
         self.model = model
         self.submit = submit
         self.onCreated = onCreated
         self.onCreateProject = onCreateProject
         self.initialProjectID = initialProjectID
+        self.initialThreadWorkspace = initialThreadWorkspace
         self.draftStore = draftStore
     }
 
@@ -105,6 +129,13 @@ public struct NewThreadView: View {
         .onChange(of: projectID) { prepareProjectIfNeeded(projectID) }
         .onChange(of: creationProjectIDs) { _, ids in
             guard !ids.contains(projectID) else { return }
+            if let initialThreadWorkspace,
+               projectID == initialThreadWorkspace.request.projectID {
+                persistCurrentDraftImmediately()
+                restoredDraftProjectID = nil
+                threadWorkspaceError = .projectUnavailable
+                return
+            }
             persistCurrentDraftImmediately()
             let previousProject = model.snapshot.projects.first { $0.id == projectID }
             let previousGroupID = previousProject.map {
@@ -157,6 +188,17 @@ public struct NewThreadView: View {
             Button("OK") {}
         } message: {
             Text("Check your connection and try again.")
+        }
+        .alert(
+            "Couldn’t use this thread’s checkout",
+            isPresented: Binding(
+                get: { threadWorkspaceError != nil },
+                set: { if !$0 { threadWorkspaceError = nil } }
+            )
+        ) {
+            Button("Cancel") { dismiss() }
+        } message: {
+            Text(threadWorkspaceError?.feedbackMessage ?? "")
         }
         .interactiveDismissDisabled(isSubmitting)
         .presentationDetents([.large])
@@ -481,6 +523,8 @@ public struct NewThreadView: View {
             && (!trimmedPrompt.isEmpty || !attachments.isEmpty)
             && (attachments.isEmpty || imagesAllowed)
             && (workspaceMode != .worktree || selectedBranch != nil)
+            && (initialThreadWorkspace == nil || initialThreadWorkspaceApplied)
+            && threadWorkspaceError == nil
     }
 
     private var trimmedPrompt: String {
@@ -748,6 +792,40 @@ public struct NewThreadView: View {
             scheduleDraftSave()
         }
         await loadBranches()
+        applyInitialThreadWorkspaceIfNeeded()
+    }
+
+    private func applyInitialThreadWorkspaceIfNeeded() {
+        guard !initialThreadWorkspaceApplied,
+              threadWorkspaceError == nil,
+              let initialThreadWorkspace else {
+            return
+        }
+        guard initialThreadWorkspace.belongs(to: projectID) else {
+            initialThreadWorkspaceApplied = true
+            return
+        }
+        guard !branchLoadFailed else {
+            threadWorkspaceError = .branchesUnavailable
+            return
+        }
+        switch ThreadNewTaskSeedModel.revalidate(
+            initialThreadWorkspace,
+            projects: creationProjects,
+            branches: branches
+        ) {
+        case let .success(seed):
+            let seededDraft = seed.applying(to: composerDraft)
+            workspaceMode = seededDraft.workspace?.mode ?? .local
+            selectedBranch = seed.branch
+            startFromOrigin = seededDraft.workspace?.startFromOrigin ?? false
+            workspaceSelectionIsExplicit = true
+            initialThreadWorkspaceApplied = true
+            scheduleDraftSave()
+        case let .failure(reason):
+            selectedBranch = nil
+            threadWorkspaceError = reason
+        }
     }
 
     private var currentDraftKey: String? {

--- a/apps/swift-ios/Features/Workspace/ThreadMetadataCopy.swift
+++ b/apps/swift-ios/Features/Workspace/ThreadMetadataCopy.swift
@@ -1,0 +1,82 @@
+import Foundation
+import UIKit
+
+enum ThreadMetadataCopyKind: Equatable, Sendable {
+    case path
+    case branch
+    case threadID
+}
+
+struct ThreadMetadataCopyItem: Equatable, Sendable {
+    let kind: ThreadMetadataCopyKind
+    let value: String
+
+    var title: String {
+        switch kind {
+        case .path: "Copy path"
+        case .branch: "Copy branch"
+        case .threadID: "Copy thread ID"
+        }
+    }
+
+    var systemImage: String {
+        switch kind {
+        case .path: "folder"
+        case .branch: "arrow.triangle.branch"
+        case .threadID: "number"
+        }
+    }
+
+    var confirmation: String {
+        switch kind {
+        case .path: "Path copied"
+        case .branch: "Branch copied"
+        case .threadID: "Thread ID copied"
+        }
+    }
+}
+
+enum ThreadMetadataCopyModel {
+    static func items(
+        for thread: FeatureThread,
+        projectPath: String?
+    ) -> [ThreadMetadataCopyItem] {
+        var items: [ThreadMetadataCopyItem] = []
+
+        if let path = nonEmptyPath(thread.worktreePath) ?? nonEmptyPath(projectPath) {
+            items.append(ThreadMetadataCopyItem(kind: .path, value: path))
+        }
+        if let branch = nonEmpty(thread.branch) {
+            items.append(ThreadMetadataCopyItem(kind: .branch, value: branch))
+        }
+        if let threadID = nonEmpty(thread.wireID) ?? nonEmpty(thread.id) {
+            items.append(ThreadMetadataCopyItem(kind: .threadID, value: threadID))
+        }
+
+        return items
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func nonEmptyPath(_ value: String?) -> String? {
+        guard let value,
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return value
+    }
+}
+
+@MainActor
+enum ThreadMetadataClipboard {
+    static func copy(_ item: ThreadMetadataCopyItem) {
+        UIPasteboard.general.string = item.value
+        UIAccessibility.post(notification: .announcement, argument: item.confirmation)
+    }
+}

--- a/apps/swift-ios/Features/Workspace/ThreadNewTaskSeed.swift
+++ b/apps/swift-ios/Features/Workspace/ThreadNewTaskSeed.swift
@@ -1,0 +1,250 @@
+import Foundation
+
+struct ThreadNewTaskSeedRequest: Equatable, Sendable {
+    let sourceThreadID: String
+    let projectID: String
+    let environmentID: String
+    let branch: String
+    let worktreePath: String?
+    let projectRootPath: String?
+}
+
+enum ThreadNewTaskUnavailableReason: String, Identifiable, Equatable, Sendable, Error {
+    case missingBranch
+    case projectUnavailable
+    case environmentUnavailable
+    case branchUnavailable
+    case worktreeUnavailable
+    case threadChanged
+    case branchesUnavailable
+
+    var id: String { rawValue }
+
+    var menuTitle: String {
+        switch self {
+        case .missingBranch:
+            "New thread unavailable (branch missing)"
+        case .projectUnavailable, .environmentUnavailable:
+            "New thread unavailable (project offline)"
+        case .branchUnavailable:
+            "New thread unavailable (branch missing)"
+        case .worktreeUnavailable:
+            "New thread unavailable (checkout missing)"
+        case .threadChanged:
+            "New thread unavailable (thread changed)"
+        case .branchesUnavailable:
+            "New thread unavailable (branches offline)"
+        }
+    }
+
+    var feedbackMessage: String {
+        switch self {
+        case .missingBranch:
+            "This thread no longer reports a branch. Refresh the thread and try again."
+        case .projectUnavailable:
+            "The project for this thread is no longer available. Reconnect it and try again."
+        case .environmentUnavailable:
+            "The thread’s original environment is no longer available. Reconnect it and try again."
+        case .branchUnavailable:
+            "The thread’s recorded branch no longer exists in its original project."
+        case .worktreeUnavailable:
+            "The thread’s branch or worktree no longer exists at the recorded location."
+        case .threadChanged:
+            "The thread changed while its menu was open. Open the menu again to use its current checkout."
+        case .branchesUnavailable:
+            "The branch list could not be loaded. Check the connection and try again."
+        }
+    }
+}
+
+enum ThreadNewTaskAvailability: Equatable, Sendable {
+    case available(ThreadNewTaskSeedRequest)
+    case unavailable(ThreadNewTaskUnavailableReason)
+
+    var menuTitle: String {
+        switch self {
+        case let .available(request):
+            "New thread on \(request.branch)"
+        case let .unavailable(reason):
+            reason.menuTitle
+        }
+    }
+
+    var isEnabled: Bool {
+        if case .available = self { return true }
+        return false
+    }
+}
+
+struct ThreadNewTaskResolvedSeed: Equatable, Sendable {
+    let request: ThreadNewTaskSeedRequest
+    let branch: FeatureWorkspaceBranch
+
+    func belongs(to projectID: String) -> Bool {
+        request.projectID == projectID
+    }
+
+    var workspace: FeatureComposerWorkspaceDraft {
+        FeatureComposerWorkspaceDraft(
+            mode: .local,
+            branch: branch.name,
+            worktreePath: request.worktreePath,
+            startFromOrigin: false
+        )
+    }
+
+    func applying(to draft: FeatureComposerDraft) -> FeatureComposerDraft {
+        var seeded = draft
+        seeded.workspace = workspace
+        return seeded
+    }
+}
+
+struct ThreadNewTaskPresentation: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let initialProjectID: String?
+    let resolvedSeed: ThreadNewTaskResolvedSeed?
+
+    static func newTask(initialProjectID: String? = nil) -> Self {
+        Self(id: UUID(), initialProjectID: initialProjectID, resolvedSeed: nil)
+    }
+
+    static func sameBranch(_ seed: ThreadNewTaskResolvedSeed) -> Self {
+        Self(id: UUID(), initialProjectID: seed.request.projectID, resolvedSeed: seed)
+    }
+}
+
+enum ThreadNewTaskSeedModel {
+    static func availability(
+        for thread: FeatureThread,
+        projects: [FeatureProject]
+    ) -> ThreadNewTaskAvailability {
+        guard let branch = nonEmpty(thread.branch) else {
+            return .unavailable(.missingBranch)
+        }
+        guard let project = projects.first(where: { $0.id == thread.projectID }) else {
+            return .unavailable(.projectUnavailable)
+        }
+        if let threadEnvironmentID = nonEmpty(thread.environmentID),
+           threadEnvironmentID != project.environmentID {
+            return .unavailable(.environmentUnavailable)
+        }
+        let worktreePath: String?
+        if let path = thread.worktreePath {
+            guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .unavailable(.worktreeUnavailable)
+            }
+            worktreePath = standardized(path)
+        } else {
+            worktreePath = nil
+        }
+        return .available(ThreadNewTaskSeedRequest(
+            sourceThreadID: thread.id,
+            projectID: project.id,
+            environmentID: project.environmentID,
+            branch: branch,
+            worktreePath: worktreePath,
+            projectRootPath: worktreePath == nil ? standardized(project.path) : nil
+        ))
+    }
+
+    static func resolve(
+        _ request: ThreadNewTaskSeedRequest,
+        currentThread: FeatureThread?,
+        projects: [FeatureProject],
+        branches: [FeatureWorkspaceBranch]
+    ) -> Result<ThreadNewTaskResolvedSeed, ThreadNewTaskUnavailableReason> {
+        guard let currentThread, currentThread.id == request.sourceThreadID else {
+            return .failure(.threadChanged)
+        }
+        guard let project = projects.first(where: { $0.id == request.projectID }) else {
+            return .failure(.projectUnavailable)
+        }
+        guard project.environmentID == request.environmentID else {
+            return .failure(.environmentUnavailable)
+        }
+        if let projectRootPath = request.projectRootPath,
+           standardized(project.path) != projectRootPath {
+            return .failure(.threadChanged)
+        }
+        guard case let .available(currentRequest) = availability(
+            for: currentThread,
+            projects: projects
+        ), currentRequest == request else {
+            return .failure(.threadChanged)
+        }
+        let branchResolution = resolveBranch(
+            for: request,
+            branches: branches
+        )
+        guard case let .success(branch) = branchResolution else {
+            if case let .failure(reason) = branchResolution { return .failure(reason) }
+            return .failure(.worktreeUnavailable)
+        }
+        return .success(ThreadNewTaskResolvedSeed(request: request, branch: branch))
+    }
+
+    static func revalidate(
+        _ seed: ThreadNewTaskResolvedSeed,
+        projects: [FeatureProject],
+        branches: [FeatureWorkspaceBranch]
+    ) -> Result<ThreadNewTaskResolvedSeed, ThreadNewTaskUnavailableReason> {
+        guard let project = projects.first(where: { $0.id == seed.request.projectID }) else {
+            return .failure(.projectUnavailable)
+        }
+        guard project.environmentID == seed.request.environmentID else {
+            return .failure(.environmentUnavailable)
+        }
+        if let projectRootPath = seed.request.projectRootPath,
+           standardized(project.path) != projectRootPath {
+            return .failure(.threadChanged)
+        }
+        let branchResolution = resolveBranch(
+            for: seed.request,
+            branches: branches
+        )
+        guard case let .success(branch) = branchResolution else {
+            if case let .failure(reason) = branchResolution { return .failure(reason) }
+            return .failure(.worktreeUnavailable)
+        }
+        return .success(ThreadNewTaskResolvedSeed(request: seed.request, branch: branch))
+    }
+
+    private static func resolveBranch(
+        for request: ThreadNewTaskSeedRequest,
+        branches: [FeatureWorkspaceBranch]
+    ) -> Result<FeatureWorkspaceBranch, ThreadNewTaskUnavailableReason> {
+        let candidates = branches.filter { !$0.isRemote && $0.name == request.branch }
+        guard !candidates.isEmpty else { return .failure(.branchUnavailable) }
+        if let requestedPath = request.worktreePath {
+            guard let branch = candidates.first(where: {
+                $0.worktreePath.map(standardized) == requestedPath
+            }) else {
+                return .failure(.worktreeUnavailable)
+            }
+            return .success(branch)
+        }
+        guard let rootPath = request.projectRootPath else {
+            return .failure(.worktreeUnavailable)
+        }
+        guard let branch = candidates.first(where: {
+            $0.isCurrent
+                && ($0.worktreePath.map(standardized) ?? rootPath) == rootPath
+        }) else {
+            return .failure(.worktreeUnavailable)
+        }
+        return .success(branch)
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func standardized(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+}

--- a/apps/swift-ios/Features/Workspace/ThreadSnoozePresets.swift
+++ b/apps/swift-ios/Features/Workspace/ThreadSnoozePresets.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+struct ThreadSnoozePreset: Identifiable, Equatable, Sendable {
+    let id: String
+    let label: String
+    let whenLabel: String
+    let until: Date
+
+    var menuTitle: String {
+        "\(label) (\(whenLabel))"
+    }
+}
+
+enum ThreadSnoozeMenu: Equatable, Sendable {
+    case hidden
+    case unsnooze
+    case presets([ThreadSnoozePreset], enabled: Bool)
+}
+
+enum ThreadSnoozeMenuModel {
+    static func menu(
+        for thread: FeatureThread,
+        isArchived: Bool,
+        now: Date = .now,
+        calendar: Calendar = .current,
+        locale: Locale = .current
+    ) -> ThreadSnoozeMenu {
+        guard !isArchived, thread.canToggleSnooze else { return .hidden }
+        if thread.snoozedUntil.map({ $0 > now }) == true {
+            return .unsnooze
+        }
+        return .presets(
+            ThreadSnoozePresets.resolve(now: now, calendar: calendar, locale: locale),
+            enabled: thread.canStartSnooze(at: now)
+        )
+    }
+}
+
+enum ThreadSnoozePresets {
+    private static let eveningHour = 18
+    private static let morningHour = 9
+
+    static func resolve(
+        now: Date = .now,
+        calendar: Calendar = .current,
+        locale: Locale = .current
+    ) -> [ThreadSnoozePreset] {
+        let inAnHour = now.addingTimeInterval(60 * 60)
+        var presets = [preset(
+            id: "hour",
+            label: "In 1 hour",
+            until: inAnHour,
+            calendar: calendar,
+            locale: locale
+        )]
+
+        if let evening = localTime(eveningHour, on: now, calendar: calendar),
+           evening > inAnHour {
+            presets.append(preset(
+                id: "evening",
+                label: "This evening",
+                until: evening,
+                calendar: calendar,
+                locale: locale
+            ))
+        }
+
+        if let tomorrowDay = calendar.date(byAdding: .day, value: 1, to: now),
+           let tomorrow = localTime(morningHour, on: tomorrowDay, calendar: calendar),
+           tomorrow > now {
+            presets.append(preset(
+                id: "tomorrow",
+                label: "Tomorrow",
+                until: tomorrow,
+                calendar: calendar,
+                locale: locale
+            ))
+        }
+
+        let weekday = calendar.component(.weekday, from: now)
+        let daysUntilMonday = switch weekday {
+        case 1: 8
+        case 2: 7
+        default: (2 - weekday + 7) % 7
+        }
+        if let mondayDay = calendar.date(byAdding: .day, value: daysUntilMonday, to: now),
+           let nextWeek = localTime(morningHour, on: mondayDay, calendar: calendar),
+           nextWeek > now {
+            presets.append(preset(
+                id: "next-week",
+                label: "Next week",
+                until: nextWeek,
+                calendar: calendar,
+                locale: locale,
+                whenPrefix: weekdayLabel(nextWeek, calendar: calendar, locale: locale)
+            ))
+        }
+
+        return presets
+    }
+
+    private static func preset(
+        id: String,
+        label: String,
+        until: Date,
+        calendar: Calendar,
+        locale: Locale,
+        whenPrefix: String? = nil
+    ) -> ThreadSnoozePreset {
+        let time = timeLabel(until, calendar: calendar, locale: locale)
+        return ThreadSnoozePreset(
+            id: id,
+            label: label,
+            whenLabel: [whenPrefix, time].compactMap { $0 }.joined(separator: " "),
+            until: until
+        )
+    }
+
+    private static func localTime(_ hour: Int, on day: Date, calendar: Calendar) -> Date? {
+        calendar.date(bySettingHour: hour, minute: 0, second: 0, of: day)
+    }
+
+    private static func timeLabel(
+        _ date: Date,
+        calendar: Calendar,
+        locale: Locale
+    ) -> String {
+        var style = Date.FormatStyle(date: .omitted, time: .shortened)
+        style.locale = locale
+        style.calendar = calendar
+        style.timeZone = calendar.timeZone
+        return date.formatted(style)
+    }
+
+    private static func weekdayLabel(
+        _ date: Date,
+        calendar: Calendar,
+        locale: Locale
+    ) -> String {
+        var style = Date.FormatStyle().weekday(.abbreviated)
+        style.locale = locale
+        style.calendar = calendar
+        style.timeZone = calendar.timeZone
+        return date.formatted(style)
+    }
+}
+
+extension FeatureThread {
+    func canStartSnooze(at now: Date) -> Bool {
+        guard supportsSnooze != false,
+              state != .waitingForApproval,
+              state != .waitingForInput else {
+            return false
+        }
+        guard state == .queued, let lastActivityAt else { return true }
+        return now.timeIntervalSince(lastActivityAt) > 2 * 60
+    }
+}

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -88,15 +88,20 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
         return notice
     }
 
+    mutating func dismiss(threadID: String) {
+        guard notice?.threadID == threadID else { return }
+        notice = nil
+    }
+
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
-        previousWasEffectivelySettled: Bool,
+        previousWasSettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
-            && !previousWasEffectivelySettled
+            && !previousWasSettled
             && updatedThread?.isSettled == true
     }
 }
@@ -282,6 +287,7 @@ public struct WorkspaceView: View {
             Button("Delete", role: .destructive) {
                 guard let confirmed = deleteConfirmation.takeConfirmedRequest(),
                       confirmed == request else { return }
+                settleUndo.dismiss(threadID: confirmed.id)
                 Task { await model.deleteThread(confirmed.id) }
             }
         } message: { request in
@@ -295,6 +301,10 @@ public struct WorkspaceView: View {
         }
         .onChange(of: selectedProjectIsAvailable) { _, isAvailable in
             if !isAvailable { selectedProjectID = nil }
+        }
+        .onChange(of: settleUndoTargetIsValid) { _, isValid in
+            guard !isValid, let notice = settleUndo.notice else { return }
+            settleUndo.dismiss(threadID: notice.threadID)
         }
         .onChange(of: navigationRequest?.id, initial: true) { _, _ in
             consumeNavigationRequest()
@@ -385,9 +395,11 @@ public struct WorkspaceView: View {
                     renamingThread = thread
                 },
                 onArchive: { thread, archived in
+                    settleUndo.dismiss(threadID: thread.id)
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
-                onSettle: { thread, settled, wasEffectivelySettled in
+                onSettle: { thread, settled, wasSettled in
+                    if !settled { settleUndo.dismiss(threadID: thread.id) }
                     let requestID = settleUndo.beginSettleRequest(ifSettling: settled)
                     let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
                     Task {
@@ -398,7 +410,7 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
-                            previousWasEffectivelySettled: wasEffectivelySettled,
+                            previousWasSettled: wasSettled,
                             updatedThread: updatedThread
                         ), let requestID else { return }
                         let notice = withAnimation(
@@ -494,21 +506,16 @@ public struct WorkspaceView: View {
                 let didReopen = await model.setSettled(notice.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
                 guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
-                guard await model.setPinned(notice.threadID, pinned: true) else {
-                    model.errorMessage = "Thread reopened, but its pin could not be restored. Try pinning it again."
-                    return
-                }
+                guard await model.setPinned(notice.threadID, pinned: true) else { return }
                 if let snoozeUntil = notice.restoresSnoozeUntil {
-                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else {
-                        model.errorMessage = "Thread reopened and pinned, but its snooze could not be restored. Try snoozing it again."
-                        return
-                    }
+                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else { return }
                 }
             }
         }
         .font(T3Typography.supportingStrong)
         .buttonStyle(.bordered)
         .frame(minHeight: T3Metrics.minimumTapTarget)
+        .contentShape(Rectangle())
         .accessibilityLabel("Undo settle \(notice.title)")
     }
 
@@ -804,6 +811,13 @@ public struct WorkspaceView: View {
     private var selectedProjectIsAvailable: Bool {
         guard let selectedProjectID else { return true }
         return model.snapshot.projects.contains { $0.id == selectedProjectID }
+    }
+
+    private var settleUndoTargetIsValid: Bool {
+        guard let notice = settleUndo.notice else { return true }
+        return model.snapshot.threads.contains {
+            $0.id == notice.threadID && $0.isSettled && !$0.isArchived
+        }
     }
 
     private func openThread(_ id: String) {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -897,6 +897,7 @@ public struct WorkspaceView: View {
     }
 
     private func dismissTransientPresentations() {
+        deleteConfirmation.cancel()
         showingNewTask = false
         showingAddProject = false
         showingSettings = false

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -104,6 +104,15 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
             && !previousWasSettled
             && updatedThread?.isSettled == true
     }
+
+    static func targetIsValid(
+        notice: HomeThreadSettleUndoNotice,
+        in threads: [FeatureThread]
+    ) -> Bool {
+        threads.contains {
+            $0.id == notice.threadID && $0.isSettled && !$0.isArchived
+        }
+    }
 }
 
 struct HomeThreadDeleteRequest: Equatable, Sendable {
@@ -815,9 +824,10 @@ public struct WorkspaceView: View {
 
     private var settleUndoTargetIsValid: Bool {
         guard let notice = settleUndo.notice else { return true }
-        return model.snapshot.threads.contains {
-            $0.id == notice.threadID && $0.isSettled && !$0.isArchived
-        }
+        return HomeThreadSettleUndoState.targetIsValid(
+            notice: notice,
+            in: model.snapshot.threads
+        )
     }
 
     private func openThread(_ id: String) {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -25,6 +25,19 @@ struct HomeThreadSettleUndoNotice: Equatable, Identifiable, Sendable {
     let restoresSnoozeUntil: Date?
 }
 
+struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
+    let restoresPin: Bool
+    let restoresSnoozeUntil: Date?
+
+    static func capture(from thread: FeatureThread) -> Self {
+        let restoresPin = thread.pinnedAt != nil
+        return Self(
+            restoresPin: restoresPin,
+            restoresSnoozeUntil: restoresPin ? thread.snoozedUntil : nil
+        )
+    }
+}
+
 struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
     private(set) var latestSettleRequestID: UUID?
@@ -33,6 +46,14 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     mutating func beginSettleRequest(id: UUID = UUID()) -> UUID {
         latestSettleRequestID = id
         return id
+    }
+
+    mutating func beginSettleRequest(
+        ifSettling settled: Bool,
+        id: UUID = UUID()
+    ) -> UUID? {
+        guard settled else { return nil }
+        return beginSettleRequest(id: id)
     }
 
     @discardableResult
@@ -70,12 +91,12 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
-        previousThread: FeatureThread,
+        previousWasEffectivelySettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
-            && !previousThread.isSettled
+            && !previousWasEffectivelySettled
             && updatedThread?.isSettled == true
     }
 }
@@ -366,8 +387,9 @@ public struct WorkspaceView: View {
                 onArchive: { thread, archived in
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
-                onSettle: { thread, settled in
-                    let requestID = settleUndo.beginSettleRequest()
+                onSettle: { thread, settled, wasEffectivelySettled in
+                    let requestID = settleUndo.beginSettleRequest(ifSettling: settled)
+                    let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
                     Task {
                         let didSucceed = await model.setSettled(thread.id, settled: settled)
                         let updatedThread = model.snapshot.threads.first {
@@ -376,9 +398,9 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
-                            previousThread: thread,
+                            previousWasEffectivelySettled: wasEffectivelySettled,
                             updatedThread: updatedThread
-                        ) else { return }
+                        ), let requestID else { return }
                         let notice = withAnimation(
                             accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)
                         ) {
@@ -386,10 +408,8 @@ public struct WorkspaceView: View {
                                 requestID: requestID,
                                 threadID: thread.id,
                                 title: thread.title,
-                                restoresPin: thread.pinnedAt != nil,
-                                restoresSnoozeUntil: thread.pinnedAt == nil
-                                    ? nil
-                                    : thread.snoozedUntil
+                                restoresPin: restoration.restoresPin,
+                                restoresSnoozeUntil: restoration.restoresSnoozeUntil
                             )
                         }
                         guard notice != nil else { return }
@@ -474,14 +494,21 @@ public struct WorkspaceView: View {
                 let didReopen = await model.setSettled(notice.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
                 guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
-                await model.setPinned(notice.threadID, pinned: true)
+                guard await model.setPinned(notice.threadID, pinned: true) else {
+                    model.errorMessage = "Thread reopened, but its pin could not be restored. Try pinning it again."
+                    return
+                }
                 if let snoozeUntil = notice.restoresSnoozeUntil {
-                    await model.setSnoozed(notice.threadID, until: snoozeUntil)
+                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else {
+                        model.errorMessage = "Thread reopened and pinned, but its snooze could not be restored. Try snoozing it again."
+                        return
+                    }
                 }
             }
         }
         .font(T3Typography.supportingStrong)
         .buttonStyle(.bordered)
+        .frame(minHeight: T3Metrics.minimumTapTarget)
         .accessibilityLabel("Undo settle \(notice.title)")
     }
 

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -198,6 +198,7 @@ public struct WorkspaceView: View {
     @State private var renamingThread: FeatureThread?
     @State private var renameTitle = ""
     @State private var deleteConfirmation = HomeThreadDeleteConfirmation()
+    @State private var titleRegenerationError: String?
     @State private var sidebarBoundaryNow = Date.now
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
     @State private var homePresentationCache = HomePresentationCache()
@@ -356,6 +357,17 @@ public struct WorkspaceView: View {
         } message: { request in
             Text("“\(request.title)” will be permanently deleted.")
         }
+        .alert(
+            "Couldn’t regenerate title",
+            isPresented: Binding(
+                get: { titleRegenerationError != nil },
+                set: { if !$0 { titleRegenerationError = nil } }
+            )
+        ) {
+            Button("OK") {}
+        } message: {
+            Text(titleRegenerationError ?? "Please try again.")
+        }
     }
 
     private var workspaceLifecycle: some View {
@@ -467,6 +479,21 @@ public struct WorkspaceView: View {
                 onRename: { thread in
                     renameTitle = thread.title
                     renamingThread = thread
+                },
+                regeneratingTitleThreadIDs: model.regeneratingTitleThreadIDs,
+                onRegenerateTitle: { threadID in
+                    Task {
+                        switch await model.regenerateThreadTitle(threadID) {
+                        case .started, .alreadyRunning:
+                            break
+                        case .unavailable:
+                            titleRegenerationError = "Title regeneration is not available for this thread."
+                        case .threadMissing:
+                            titleRegenerationError = "This thread is no longer available."
+                        case let .failed(message):
+                            titleRegenerationError = message
+                        }
+                    }
                 },
                 onArchive: { thread, archived in
                     settleUndo.dismiss(threadID: thread.id)
@@ -1033,6 +1060,7 @@ public struct WorkspaceView: View {
         showingSettings = false
         renamingThread = nil
         threadNewTaskError = nil
+        titleRegenerationError = nil
     }
 
     private func projectMenuTitle(_ project: FeatureProject) -> String {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -22,23 +22,35 @@ struct HomeThreadSettleUndoNotice: Equatable, Identifiable, Sendable {
     let threadID: String
     let title: String
     let restoresPin: Bool
+    let restoresSnoozeUntil: Date?
 }
 
 struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
+    private(set) var latestSettleRequestID: UUID?
+
+    @discardableResult
+    mutating func beginSettleRequest(id: UUID = UUID()) -> UUID {
+        latestSettleRequestID = id
+        return id
+    }
 
     @discardableResult
     mutating func present(
+        requestID: UUID,
         threadID: String,
         title: String,
         restoresPin: Bool,
+        restoresSnoozeUntil: Date?,
         id: UUID = UUID()
-    ) -> HomeThreadSettleUndoNotice {
+    ) -> HomeThreadSettleUndoNotice? {
+        guard requestID == latestSettleRequestID else { return nil }
         let notice = HomeThreadSettleUndoNotice(
             id: id,
             threadID: threadID,
             title: title,
-            restoresPin: restoresPin
+            restoresPin: restoresPin,
+            restoresSnoozeUntil: restoresSnoozeUntil
         )
         self.notice = notice
         return notice
@@ -57,9 +69,14 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
 
     static func shouldPresent(
         afterRequesting settled: Bool,
+        didSucceed: Bool,
+        previousThread: FeatureThread,
         updatedThread: FeatureThread?
     ) -> Bool {
-        settled && updatedThread?.isSettled == true
+        settled
+            && didSucceed
+            && !previousThread.isSettled
+            && updatedThread?.isSettled == true
     }
 }
 
@@ -77,6 +94,11 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 
     mutating func cancel() {
         request = nil
+    }
+
+    mutating func takeConfirmedRequest() -> HomeThreadDeleteRequest? {
+        defer { request = nil }
+        return request
     }
 }
 
@@ -237,8 +259,9 @@ public struct WorkspaceView: View {
                 deleteConfirmation.cancel()
             }
             Button("Delete", role: .destructive) {
-                deleteConfirmation.cancel()
-                Task { await model.deleteThread(request.id) }
+                guard let confirmed = deleteConfirmation.takeConfirmedRequest(),
+                      confirmed == request else { return }
+                Task { await model.deleteThread(confirmed.id) }
             }
         } message: { request in
             Text("“\(request.title)” will be permanently deleted.")
@@ -344,22 +367,32 @@ public struct WorkspaceView: View {
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
                 onSettle: { thread, settled in
+                    let requestID = settleUndo.beginSettleRequest()
                     Task {
-                        await model.setSettled(thread.id, settled: settled)
+                        let didSucceed = await model.setSettled(thread.id, settled: settled)
                         let updatedThread = model.snapshot.threads.first {
                             $0.id == thread.id
                         }
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
+                            didSucceed: didSucceed,
+                            previousThread: thread,
                             updatedThread: updatedThread
                         ) else { return }
-                        _ = withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
+                        let notice = withAnimation(
+                            accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)
+                        ) {
                             settleUndo.present(
+                                requestID: requestID,
                                 threadID: thread.id,
                                 title: thread.title,
-                                restoresPin: thread.pinnedAt != nil
+                                restoresPin: thread.pinnedAt != nil,
+                                restoresSnoozeUntil: thread.pinnedAt == nil
+                                    ? nil
+                                    : thread.snoozedUntil
                             )
                         }
+                        guard notice != nil else { return }
                         UIAccessibility.post(
                             notification: .announcement,
                             argument: "\(thread.title) settled. Undo available."
@@ -409,6 +442,7 @@ public struct WorkspaceView: View {
             .shadow(color: T3Colors.shadow, radius: 14, y: 6)
             .transition(.move(edge: .bottom).combined(with: .opacity))
             .accessibilityElement(children: .contain)
+            .accessibilitySortPriority(1_000)
         }
     }
 
@@ -437,10 +471,13 @@ public struct WorkspaceView: View {
                 _ = settleUndo.takeUndo(id: notice.id)
             }
             Task {
-                await model.setSettled(notice.threadID, settled: false)
+                let didReopen = await model.setSettled(notice.threadID, settled: false)
                 let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
-                guard reopened?.isSettled == false, notice.restoresPin else { return }
+                guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
                 await model.setPinned(notice.threadID, pinned: true)
+                if let snoozeUntil = notice.restoresSnoozeUntil {
+                    await model.setSnoozed(notice.threadID, until: snoozeUntil)
+                }
             }
         }
         .font(T3Typography.supportingStrong)

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -191,8 +191,8 @@ public struct WorkspaceView: View {
     @State private var isSettledExpanded = true
     @State private var isArchiveExpanded = false
     @State private var settledLimit = 12
-    @State private var showingNewTask = false
-    @State private var newTaskInitialProjectID: String?
+    @State private var newTaskPresentation: ThreadNewTaskPresentation?
+    @State private var threadNewTaskError: ThreadNewTaskUnavailableReason?
     @State private var showingAddProject = false
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
@@ -272,6 +272,10 @@ public struct WorkspaceView: View {
     }
 
     public var body: some View {
+        workspaceLifecycle
+    }
+
+    private var workspaceRoot: some View {
         NavigationSplitView(preferredCompactColumn: $preferredCompactColumn) {
             sidebar
                 .navigationSplitViewColumnWidth(
@@ -283,16 +287,21 @@ public struct WorkspaceView: View {
             detail
         }
         .navigationSplitViewStyle(.balanced)
-        .sheet(isPresented: $showingNewTask) {
+    }
+
+    private var workspaceSheets: some View {
+        workspaceRoot
+        .sheet(item: $newTaskPresentation) { presentation in
             NewThreadView(
                 model: model,
                 submit: submitNewTask,
                 onCreated: { thread in
                     openThread(thread.id)
-                    showingNewTask = false
+                    newTaskPresentation = nil
                 },
                 onCreateProject: openProjectCreation,
-                initialProjectID: newTaskInitialProjectID
+                initialProjectID: presentation.initialProjectID,
+                initialThreadWorkspace: presentation.resolvedSeed
             )
         }
         .sheet(isPresented: $showingAddProject) {
@@ -300,6 +309,21 @@ public struct WorkspaceView: View {
         }
         .sheet(isPresented: $showingSettings) {
             SettingsView(model: model)
+        }
+    }
+
+    private var workspaceAlerts: some View {
+        workspaceSheets
+        .alert(
+            "Couldn’t use this thread’s checkout",
+            isPresented: Binding(
+                get: { threadNewTaskError != nil },
+                set: { if !$0 { threadNewTaskError = nil } }
+            )
+        ) {
+            Button("OK") {}
+        } message: {
+            Text(threadNewTaskError?.feedbackMessage ?? "")
         }
         .alert(
             "Rename thread",
@@ -310,13 +334,8 @@ public struct WorkspaceView: View {
         ) {
             TextField("Thread title", text: $renameTitle)
             Button("Cancel", role: .cancel) { renamingThread = nil }
-            Button("Save") {
-                guard let thread = renamingThread else { return }
-                let title = renameTitle
-                renamingThread = nil
-                Task { await model.renameThread(thread.id, title: title) }
-            }
-            .disabled(renameTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            Button("Save", action: saveRenamedThread)
+                .disabled(renameTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
         .alert(
             "Delete thread?",
@@ -337,6 +356,10 @@ public struct WorkspaceView: View {
         } message: { request in
             Text("“\(request.title)” will be permanently deleted.")
         }
+    }
+
+    private var workspaceLifecycle: some View {
+        workspaceAlerts
         .onChange(of: selectedThreadIsAvailable) { _, isAvailable in
             if !isAvailable { closeSelectedThread() }
         }
@@ -439,6 +462,8 @@ public struct WorkspaceView: View {
                 onToggleSettled: { isSettledExpanded.toggle() },
                 onToggleArchive: { isArchiveExpanded.toggle() },
                 onShowMoreSettled: { settledLimit += 25 },
+                newThreadAvailability: newThreadAvailability,
+                onNewThreadOnSameBranch: openNewThreadOnSameBranch,
                 onRename: { thread in
                     renameTitle = thread.title
                     renamingThread = thread
@@ -912,7 +937,7 @@ public struct WorkspaceView: View {
 
     @MainActor
     private func openProjectCreation() {
-        showingNewTask = false
+        newTaskPresentation = nil
         showingAddProject = true
     }
 
@@ -924,9 +949,54 @@ public struct WorkspaceView: View {
         if creationProjects.isEmpty {
             showingAddProject = true
         } else {
-            newTaskInitialProjectID = initialProjectID
-            showingNewTask = true
+            newTaskPresentation = .newTask(initialProjectID: initialProjectID)
         }
+    }
+
+    private func openNewThreadOnSameBranch(_ request: ThreadNewTaskSeedRequest) {
+        Task { @MainActor in
+            let branches: [FeatureWorkspaceBranch]
+            do {
+                branches = try await model.workspaceBranches(
+                    projectID: request.projectID,
+                    refresh: true
+                )
+            } catch {
+                threadNewTaskError = .branchesUnavailable
+                return
+            }
+            let currentThread = model.snapshot.threads.first {
+                $0.id == request.sourceThreadID
+            }
+            let projects = creationProjects
+            switch ThreadNewTaskSeedModel.resolve(
+                request,
+                currentThread: currentThread,
+                projects: projects,
+                branches: branches
+            ) {
+            case let .success(seed):
+                newTaskPresentation = .sameBranch(seed)
+            case let .failure(reason):
+                threadNewTaskError = reason
+            }
+        }
+    }
+
+    private func saveRenamedThread() {
+        guard let thread = renamingThread else { return }
+        let title = renameTitle
+        renamingThread = nil
+        Task { await model.renameThread(thread.id, title: title) }
+    }
+
+    private func newThreadAvailability(
+        for thread: FeatureThread
+    ) -> ThreadNewTaskAvailability {
+        ThreadNewTaskSeedModel.availability(
+            for: thread,
+            projects: creationProjects
+        )
     }
 
     private func consumeNavigationRequest() {
@@ -958,10 +1028,11 @@ public struct WorkspaceView: View {
     private func dismissTransientPresentations() {
         deleteConfirmation.cancel()
         settleUndo.dismissAll()
-        showingNewTask = false
+        newTaskPresentation = nil
         showingAddProject = false
         showingSettings = false
         renamingThread = nil
+        threadNewTaskError = nil
     }
 
     private func projectMenuTitle(_ project: FeatureProject) -> String {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -492,6 +492,9 @@ public struct WorkspaceView: View {
                 onPin: { thread, pinned in
                     Task { await model.setPinned(thread.id, pinned: pinned) }
                 },
+                projectPath: { thread in
+                    model.snapshot.projects.first { $0.id == thread.projectID }?.path
+                },
                 onDelete: { thread in
                     deleteConfirmation.present(threadID: thread.id, title: thread.title)
                 }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -317,6 +317,9 @@ public struct WorkspaceView: View {
         .onChange(of: selectedProjectIsAvailable) { _, isAvailable in
             if !isAvailable { selectedProjectID = nil }
         }
+        .onChange(of: deleteConfirmationTargetIsValid) { _, isValid in
+            if !isValid { deleteConfirmation.cancel() }
+        }
         .onChange(of: settleUndoTargetIsValid) { _, isValid in
             guard !isValid, let notice = settleUndo.notice else { return }
             withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
@@ -831,6 +834,11 @@ public struct WorkspaceView: View {
     private var selectedProjectIsAvailable: Bool {
         guard let selectedProjectID else { return true }
         return model.snapshot.projects.contains { $0.id == selectedProjectID }
+    }
+
+    private var deleteConfirmationTargetIsValid: Bool {
+        guard let request = deleteConfirmation.request else { return true }
+        return model.snapshot.threads.contains { $0.id == request.id }
     }
 
     private var settleUndoTargetIsValid: Bool {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -17,7 +17,54 @@ struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     }
 }
 
+struct HomeThreadSettleUndoNotice: Equatable, Identifiable, Sendable {
+    let id: UUID
+    let threadID: String
+    let title: String
+    let restoresPin: Bool
+}
+
+struct HomeThreadSettleUndoState: Equatable, Sendable {
+    private(set) var notice: HomeThreadSettleUndoNotice?
+
+    @discardableResult
+    mutating func present(
+        threadID: String,
+        title: String,
+        restoresPin: Bool,
+        id: UUID = UUID()
+    ) -> HomeThreadSettleUndoNotice {
+        let notice = HomeThreadSettleUndoNotice(
+            id: id,
+            threadID: threadID,
+            title: title,
+            restoresPin: restoresPin
+        )
+        self.notice = notice
+        return notice
+    }
+
+    mutating func expire(id: UUID) {
+        guard notice?.id == id else { return }
+        notice = nil
+    }
+
+    mutating func takeUndo(id: UUID) -> HomeThreadSettleUndoNotice? {
+        guard notice?.id == id else { return nil }
+        defer { notice = nil }
+        return notice
+    }
+
+    static func shouldPresent(
+        afterRequesting settled: Bool,
+        updatedThread: FeatureThread?
+    ) -> Bool {
+        settled && updatedThread?.isSettled == true
+    }
+}
+
 public struct WorkspaceView: View {
+    @SwiftUI.Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @Bindable var model: FeatureRootModel
@@ -43,6 +90,7 @@ public struct WorkspaceView: View {
     @State private var sidebarBoundaryNow = Date.now
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
     @State private var homePresentationCache = HomePresentationCache()
+    @State private var settleUndo = HomeThreadSettleUndoState()
     @FocusState private var isSearchFocused: Bool
 
     public init(
@@ -186,6 +234,17 @@ public struct WorkspaceView: View {
                 return
             }
         }
+        .task(id: settleUndo.notice?.id) {
+            guard let notice = settleUndo.notice else { return }
+            do {
+                try await Task.sleep(for: settleUndoLifetime)
+                withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                    settleUndo.expire(id: notice.id)
+                }
+            } catch {
+                return
+            }
+        }
     }
 
     private var sidebar: some View {
@@ -202,6 +261,11 @@ public struct WorkspaceView: View {
             composeButton
                 .padding(.trailing, 16)
                 .padding(.bottom, 14)
+
+            settleUndoToast
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 78)
         }
         .background(T3Colors.background)
         .toolbar(.hidden, for: .navigationBar)
@@ -244,7 +308,27 @@ public struct WorkspaceView: View {
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
                 onSettle: { thread, settled in
-                    Task { await model.setSettled(thread.id, settled: settled) }
+                    Task {
+                        await model.setSettled(thread.id, settled: settled)
+                        let updatedThread = model.snapshot.threads.first {
+                            $0.id == thread.id
+                        }
+                        guard HomeThreadSettleUndoState.shouldPresent(
+                            afterRequesting: settled,
+                            updatedThread: updatedThread
+                        ) else { return }
+                        _ = withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
+                            settleUndo.present(
+                                threadID: thread.id,
+                                title: thread.title,
+                                restoresPin: thread.pinnedAt != nil
+                            )
+                        }
+                        UIAccessibility.post(
+                            notification: .announcement,
+                            argument: "\(thread.title) settled. Undo available."
+                        )
+                    }
                 },
                 onSnooze: { thread, until in
                     Task { await model.setSnoozed(thread.id, until: until) }
@@ -258,6 +342,81 @@ public struct WorkspaceView: View {
             )
         }
         .background(T3Colors.background)
+    }
+
+    @ViewBuilder
+    private var settleUndoToast: some View {
+        if let notice = settleUndo.notice {
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 10) {
+                        settleUndoDescription(notice)
+                        settleUndoButton(notice)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                } else {
+                    HStack(spacing: 12) {
+                        settleUndoDescription(notice)
+                        Spacer(minLength: 8)
+                        settleUndoButton(notice)
+                    }
+                }
+            }
+            .padding(.leading, 14)
+            .padding(.trailing, 10)
+            .padding(.vertical, 10)
+            .background(T3Colors.surfaceRaised, in: RoundedRectangle(cornerRadius: 14))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(T3Colors.border, lineWidth: 1)
+            }
+            .shadow(color: T3Colors.shadow, radius: 14, y: 6)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    private func settleUndoDescription(_ notice: HomeThreadSettleUndoNotice) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(T3Colors.success)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Thread settled")
+                    .font(T3Typography.supportingStrong)
+                    .foregroundStyle(T3Colors.textPrimary)
+                Text(notice.title)
+                    .font(T3Typography.supporting)
+                    .foregroundStyle(T3Colors.textSecondary)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    private func settleUndoButton(_ notice: HomeThreadSettleUndoNotice) -> some View {
+        Button("Undo") {
+            guard settleUndo.notice?.id == notice.id else { return }
+            withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                _ = settleUndo.takeUndo(id: notice.id)
+            }
+            Task {
+                await model.setSettled(notice.threadID, settled: false)
+                let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
+                guard reopened?.isSettled == false, notice.restoresPin else { return }
+                await model.setPinned(notice.threadID, pinned: true)
+            }
+        }
+        .font(T3Typography.supportingStrong)
+        .buttonStyle(.bordered)
+        .accessibilityLabel("Undo settle \(notice.title)")
+    }
+
+    private var settleUndoLifetime: Duration {
+        if UIAccessibility.isVoiceOverRunning || UIAccessibility.isSwitchControlRunning {
+            return .seconds(15)
+        }
+        return .seconds(5)
     }
 
     @ViewBuilder

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -34,6 +34,8 @@ struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
         let restoresPin = thread.pinnedAt != nil
         return Self(
             restoresPin: restoresPin,
+            // Restoring a pin clears snooze state, so preserve snooze only
+            // when Undo will re-pin the thread.
             restoresSnoozeUntil: restoresPin ? thread.snoozedUntil : nil
         )
     }
@@ -43,6 +45,7 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
     private(set) var latestSettleRequestID: UUID?
     private(set) var latestSettleThreadID: String?
+    private(set) var undoInProgressID: UUID?
 
     @discardableResult
     mutating func beginSettleRequest(
@@ -88,14 +91,25 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     }
 
     mutating func expire(id: UUID) {
-        guard notice?.id == id else { return }
+        guard notice?.id == id, undoInProgressID != id else { return }
         notice = nil
     }
 
-    mutating func takeUndo(id: UUID) -> HomeThreadSettleUndoNotice? {
-        guard notice?.id == id else { return nil }
-        defer { notice = nil }
+    mutating func beginUndo(id: UUID) -> HomeThreadSettleUndoNotice? {
+        guard notice?.id == id, undoInProgressID == nil else { return nil }
+        undoInProgressID = id
         return notice
+    }
+
+    mutating func finishUndo(id: UUID) {
+        guard undoInProgressID == id else { return }
+        undoInProgressID = nil
+        if notice?.id == id { notice = nil }
+    }
+
+    func isUndoInProgress(threadID: String) -> Bool {
+        guard let notice else { return false }
+        return notice.threadID == threadID && undoInProgressID == notice.id
     }
 
     mutating func dismiss(threadID: String) {
@@ -104,7 +118,15 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
             latestSettleThreadID = nil
         }
         guard notice?.threadID == threadID else { return }
+        undoInProgressID = nil
         notice = nil
+    }
+
+    mutating func dismissAll() {
+        notice = nil
+        latestSettleRequestID = nil
+        latestSettleThreadID = nil
+        undoInProgressID = nil
     }
 
     static func shouldPresent(
@@ -141,6 +163,13 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 
     mutating func cancel() {
         request = nil
+    }
+
+    static func targetIsValid(
+        request: HomeThreadDeleteRequest,
+        in threads: [FeatureThread]
+    ) -> Bool {
+        threads.contains { $0.id == request.id }
     }
 }
 
@@ -419,6 +448,7 @@ public struct WorkspaceView: View {
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
                 onSettle: { thread, settled in
+                    guard !settleUndo.isUndoInProgress(threadID: thread.id) else { return }
                     if !settled { settleUndo.dismiss(threadID: thread.id) }
                     let requestID = settleUndo.beginSettleRequest(
                         ifSettling: settled,
@@ -441,17 +471,19 @@ public struct WorkspaceView: View {
                             settleUndo.present(
                                 requestID: requestID,
                                 threadID: thread.id,
-                                title: thread.title,
+                                title: updatedThread?.title ?? thread.title,
                                 restoresPin: restoration.restoresPin,
                                 restoresSnoozeUntil: restoration.restoresSnoozeUntil
                             )
                         }
                         guard notice != nil else { return }
-                        var announcement = AttributedString(
-                            "\(thread.title) settled. Undo available."
-                        )
-                        announcement.accessibilitySpeechAnnouncementPriority = .high
-                        AccessibilityNotification.Announcement(announcement).post()
+                        if preferredCompactColumn != .detail {
+                            var announcement = AttributedString(
+                                "\(updatedThread?.title ?? thread.title) settled. Undo available."
+                            )
+                            announcement.accessibilitySpeechAnnouncementPriority = .high
+                            AccessibilityNotification.Announcement(announcement).post()
+                        }
                     }
                 },
                 onSnooze: { thread, until in
@@ -520,21 +552,33 @@ public struct WorkspaceView: View {
     }
 
     private func settleUndoButton(_ notice: HomeThreadSettleUndoNotice) -> some View {
-        Button("Undo") {
-            guard settleUndo.notice?.id == notice.id else { return }
-            withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
-                _ = settleUndo.takeUndo(id: notice.id)
-            }
+        let isUndoing = settleUndo.undoInProgressID == notice.id
+        return Button {
+            guard let undo = settleUndo.beginUndo(id: notice.id) else { return }
             Task {
-                let didReopen = await model.setSettled(notice.threadID, settled: false)
-                let reopened = model.snapshot.threads.first { $0.id == notice.threadID }
-                guard didReopen, reopened?.isSettled == false, notice.restoresPin else { return }
-                guard await model.setPinned(notice.threadID, pinned: true) else { return }
-                if let snoozeUntil = notice.restoresSnoozeUntil {
-                    guard await model.setSnoozed(notice.threadID, until: snoozeUntil) else { return }
+                defer {
+                    withAnimation(accessibilityReduceMotion ? nil : .easeIn(duration: 0.16)) {
+                        settleUndo.finishUndo(id: undo.id)
+                    }
+                }
+                let didReopen = await model.setSettled(undo.threadID, settled: false)
+                let reopened = model.snapshot.threads.first { $0.id == undo.threadID }
+                guard didReopen, reopened?.isSettled == false, undo.restoresPin else { return }
+                guard await model.setPinned(undo.threadID, pinned: true) else { return }
+                if let snoozeUntil = undo.restoresSnoozeUntil {
+                    guard await model.setSnoozed(undo.threadID, until: snoozeUntil) else { return }
                 }
             }
+        } label: {
+            if isUndoing {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityHidden(true)
+            } else {
+                Text("Undo")
+            }
         }
+        .disabled(isUndoing)
         .font(T3Typography.supportingStrong)
         .buttonStyle(.bordered)
         .frame(minHeight: T3Metrics.minimumTapTarget)
@@ -838,11 +882,15 @@ public struct WorkspaceView: View {
 
     private var deleteConfirmationTargetIsValid: Bool {
         guard let request = deleteConfirmation.request else { return true }
-        return model.snapshot.threads.contains { $0.id == request.id }
+        return HomeThreadDeleteConfirmation.targetIsValid(
+            request: request,
+            in: model.snapshot.threads
+        )
     }
 
     private var settleUndoTargetIsValid: Bool {
         guard let notice = settleUndo.notice else { return true }
+        if settleUndo.isUndoInProgress(threadID: notice.threadID) { return true }
         return HomeThreadSettleUndoState.targetIsValid(
             notice: notice,
             in: model.snapshot.threads
@@ -906,6 +954,7 @@ public struct WorkspaceView: View {
 
     private func dismissTransientPresentations() {
         deleteConfirmation.cancel()
+        settleUndo.dismissAll()
         showingNewTask = false
         showingAddProject = false
         showingSettings = false

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -63,6 +63,23 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     }
 }
 
+struct HomeThreadDeleteRequest: Equatable, Sendable {
+    let id: String
+    let title: String
+}
+
+struct HomeThreadDeleteConfirmation: Equatable, Sendable {
+    private(set) var request: HomeThreadDeleteRequest?
+
+    mutating func present(threadID: String, title: String) {
+        request = HomeThreadDeleteRequest(id: threadID, title: title)
+    }
+
+    mutating func cancel() {
+        request = nil
+    }
+}
+
 public struct WorkspaceView: View {
     @SwiftUI.Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -87,6 +104,7 @@ public struct WorkspaceView: View {
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
     @State private var renameTitle = ""
+    @State private var deleteConfirmation = HomeThreadDeleteConfirmation()
     @State private var sidebarBoundaryNow = Date.now
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
     @State private var homePresentationCache = HomePresentationCache()
@@ -206,6 +224,24 @@ public struct WorkspaceView: View {
                 Task { await model.renameThread(thread.id, title: title) }
             }
             .disabled(renameTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .alert(
+            "Delete thread?",
+            isPresented: Binding(
+                get: { deleteConfirmation.request != nil },
+                set: { if !$0 { deleteConfirmation.cancel() } }
+            ),
+            presenting: deleteConfirmation.request
+        ) { request in
+            Button("Cancel", role: .cancel) {
+                deleteConfirmation.cancel()
+            }
+            Button("Delete", role: .destructive) {
+                deleteConfirmation.cancel()
+                Task { await model.deleteThread(request.id) }
+            }
+        } message: { request in
+            Text("“\(request.title)” will be permanently deleted.")
         }
         .onChange(of: selectedThreadIsAvailable) { _, isAvailable in
             if !isAvailable { closeSelectedThread() }
@@ -337,7 +373,7 @@ public struct WorkspaceView: View {
                     Task { await model.setPinned(thread.id, pinned: pinned) }
                 },
                 onDelete: { thread in
-                    Task { await model.deleteThread(thread.id) }
+                    deleteConfirmation.present(threadID: thread.id, title: thread.title)
                 }
             )
         }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -110,12 +110,10 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     static func shouldPresent(
         afterRequesting settled: Bool,
         didSucceed: Bool,
-        previousWasSettled: Bool,
         updatedThread: FeatureThread?
     ) -> Bool {
         settled
             && didSucceed
-            && !previousWasSettled
             && updatedThread?.isSettled == true
     }
 
@@ -321,7 +319,9 @@ public struct WorkspaceView: View {
         }
         .onChange(of: settleUndoTargetIsValid) { _, isValid in
             guard !isValid, let notice = settleUndo.notice else { return }
-            settleUndo.dismiss(threadID: notice.threadID)
+            withAnimation(accessibilityReduceMotion ? nil : .easeOut(duration: 0.18)) {
+                settleUndo.dismiss(threadID: notice.threadID)
+            }
         }
         .onChange(of: navigationRequest?.id, initial: true) { _, _ in
             consumeNavigationRequest()
@@ -415,7 +415,7 @@ public struct WorkspaceView: View {
                     settleUndo.dismiss(threadID: thread.id)
                     Task { await model.setArchived(thread.id, archived: archived) }
                 },
-                onSettle: { thread, settled, wasSettled in
+                onSettle: { thread, settled in
                     if !settled { settleUndo.dismiss(threadID: thread.id) }
                     let requestID = settleUndo.beginSettleRequest(
                         ifSettling: settled,
@@ -430,7 +430,6 @@ public struct WorkspaceView: View {
                         guard HomeThreadSettleUndoState.shouldPresent(
                             afterRequesting: settled,
                             didSucceed: didSucceed,
-                            previousWasSettled: wasSettled,
                             updatedThread: updatedThread
                         ), let requestID else { return }
                         let notice = withAnimation(

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -1,3 +1,4 @@
+import Accessibility
 import SwiftUI
 import UIKit
 
@@ -41,19 +42,25 @@ struct HomeThreadSettleUndoRestoration: Equatable, Sendable {
 struct HomeThreadSettleUndoState: Equatable, Sendable {
     private(set) var notice: HomeThreadSettleUndoNotice?
     private(set) var latestSettleRequestID: UUID?
+    private(set) var latestSettleThreadID: String?
 
     @discardableResult
-    mutating func beginSettleRequest(id: UUID = UUID()) -> UUID {
+    mutating func beginSettleRequest(
+        threadID: String? = nil,
+        id: UUID = UUID()
+    ) -> UUID {
         latestSettleRequestID = id
+        latestSettleThreadID = threadID
         return id
     }
 
     mutating func beginSettleRequest(
         ifSettling settled: Bool,
+        threadID: String? = nil,
         id: UUID = UUID()
     ) -> UUID? {
         guard settled else { return nil }
-        return beginSettleRequest(id: id)
+        return beginSettleRequest(threadID: threadID, id: id)
     }
 
     @discardableResult
@@ -66,6 +73,7 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
         id: UUID = UUID()
     ) -> HomeThreadSettleUndoNotice? {
         guard requestID == latestSettleRequestID else { return nil }
+        if let latestSettleThreadID, latestSettleThreadID != threadID { return nil }
         let notice = HomeThreadSettleUndoNotice(
             id: id,
             threadID: threadID,
@@ -74,6 +82,8 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
             restoresSnoozeUntil: restoresSnoozeUntil
         )
         self.notice = notice
+        latestSettleRequestID = nil
+        latestSettleThreadID = nil
         return notice
     }
 
@@ -89,6 +99,10 @@ struct HomeThreadSettleUndoState: Equatable, Sendable {
     }
 
     mutating func dismiss(threadID: String) {
+        if latestSettleThreadID == threadID {
+            latestSettleRequestID = nil
+            latestSettleThreadID = nil
+        }
         guard notice?.threadID == threadID else { return }
         notice = nil
     }
@@ -129,11 +143,6 @@ struct HomeThreadDeleteConfirmation: Equatable, Sendable {
 
     mutating func cancel() {
         request = nil
-    }
-
-    mutating func takeConfirmedRequest() -> HomeThreadDeleteRequest? {
-        defer { request = nil }
-        return request
     }
 }
 
@@ -294,10 +303,9 @@ public struct WorkspaceView: View {
                 deleteConfirmation.cancel()
             }
             Button("Delete", role: .destructive) {
-                guard let confirmed = deleteConfirmation.takeConfirmedRequest(),
-                      confirmed == request else { return }
-                settleUndo.dismiss(threadID: confirmed.id)
-                Task { await model.deleteThread(confirmed.id) }
+                deleteConfirmation.cancel()
+                settleUndo.dismiss(threadID: request.id)
+                Task { await model.deleteThread(request.id) }
             }
         } message: { request in
             Text("“\(request.title)” will be permanently deleted.")
@@ -409,7 +417,10 @@ public struct WorkspaceView: View {
                 },
                 onSettle: { thread, settled, wasSettled in
                     if !settled { settleUndo.dismiss(threadID: thread.id) }
-                    let requestID = settleUndo.beginSettleRequest(ifSettling: settled)
+                    let requestID = settleUndo.beginSettleRequest(
+                        ifSettling: settled,
+                        threadID: thread.id
+                    )
                     let restoration = HomeThreadSettleUndoRestoration.capture(from: thread)
                     Task {
                         let didSucceed = await model.setSettled(thread.id, settled: settled)
@@ -434,10 +445,11 @@ public struct WorkspaceView: View {
                             )
                         }
                         guard notice != nil else { return }
-                        UIAccessibility.post(
-                            notification: .announcement,
-                            argument: "\(thread.title) settled. Undo available."
+                        var announcement = AttributedString(
+                            "\(thread.title) settled. Undo available."
                         )
+                        announcement.accessibilitySpeechAnnouncementPriority = .high
+                        AccessibilityNotification.Announcement(announcement).post()
                     }
                 },
                 onSnooze: { thread, until in

--- a/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
@@ -114,6 +114,19 @@ final class CoreContractTests: XCTestCase {
         XCTAssertEqual(unpin["type"]?.stringValue, "thread.unpin")
     }
 
+    func testRegenerateTitleCommandMatchesExistingMetaUpdateContract() {
+        let command = OrchestrationCommands.regenerateTitle(
+            threadID: "thread-1",
+            commandID: "command-1"
+        )
+
+        XCTAssertEqual(command["type"]?.stringValue, "thread.meta.update")
+        XCTAssertEqual(command["commandId"]?.stringValue, "command-1")
+        XCTAssertEqual(command["threadId"]?.stringValue, "thread-1")
+        XCTAssertEqual(command["regenerateTitle"], .bool(true))
+        XCTAssertNil(command["title"])
+    }
+
     func testFirstSendCommandCarriesCanonicalBootstrapMetadata() throws {
         let model = ModelSelection(instanceId: "codex", model: "gpt-5.4")
         let command = try OrchestrationCommands.createThreadAndSend(

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -31,6 +31,93 @@ struct DailyUXSidebarTests {
     private let now = Date(timeIntervalSince1970: 2_000_000)
 
     @Test
+    func swipePlanKeepsDeleteOutOfTheFullSwipeSlot() {
+        let active = thread(id: "active", created: -20, updated: -10)
+        let settled = thread(
+            id: "settled",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let settledButWorking = thread(
+            id: "settled-working",
+            created: -20,
+            updated: -10,
+            state: .working,
+            isSettled: true
+        )
+
+        let activePlan = HomeThreadSwipeActionPlan.make(
+            thread: active,
+            isArchived: false,
+            now: now
+        )
+        let settledPlan = HomeThreadSwipeActionPlan.make(
+            thread: settled,
+            isArchived: false,
+            now: now
+        )
+        let settledButWorkingPlan = HomeThreadSwipeActionPlan.make(
+            thread: settledButWorking,
+            isArchived: false,
+            now: now
+        )
+
+        #expect(activePlan.orderedActions == [.settle, .delete])
+        #expect(settledPlan.orderedActions == [.reopen, .delete])
+        #expect(settledButWorkingPlan.orderedActions == [.settle, .delete])
+        #expect(activePlan.performsPrimaryWithFullSwipe)
+        #expect(!activePlan.deleteFinishesOptimistically)
+        #expect(activePlan.orderedActions.first != .delete)
+    }
+
+    @Test
+    func settleUndoCapturesOnlyStateThatSettlementClears() {
+        let snoozeUntil = now.addingTimeInterval(300)
+        let pinnedAndSnoozed = thread(
+            id: "pinned",
+            created: -20,
+            updated: -10,
+            pinned: -5,
+            snoozedUntil: snoozeUntil
+        )
+        let snoozedOnly = thread(
+            id: "snoozed",
+            created: -20,
+            updated: -10,
+            snoozedUntil: snoozeUntil
+        )
+
+        #expect(
+            HomeThreadSettleUndoRestoration.capture(from: pinnedAndSnoozed)
+                == HomeThreadSettleUndoRestoration(
+                    restoresPin: true,
+                    restoresSnoozeUntil: snoozeUntil
+                )
+        )
+        #expect(
+            HomeThreadSettleUndoRestoration.capture(from: snoozedOnly)
+                == HomeThreadSettleUndoRestoration(
+                    restoresPin: false,
+                    restoresSnoozeUntil: nil
+                )
+        )
+    }
+
+    @Test
+    func reopeningDoesNotSupersedeAnInFlightSettleNotice() {
+        let settleRequestID = UUID()
+        var state = HomeThreadSettleUndoState()
+
+        #expect(
+            state.beginSettleRequest(ifSettling: true, id: settleRequestID)
+                == settleRequestID
+        )
+        #expect(state.beginSettleRequest(ifSettling: false) == nil)
+        #expect(state.latestSettleRequestID == settleRequestID)
+    }
+
+    @Test
     func settleUndoTargetsOnlyTheLatestNoticeOnce() {
         let firstID = UUID()
         let secondID = UUID()
@@ -122,7 +209,7 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: settled
             )
         )
@@ -130,7 +217,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: settled
             )
         )
@@ -138,7 +225,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: settled
             )
         )
@@ -146,7 +233,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: settled,
+                previousWasEffectivelySettled: true,
                 updatedThread: settled
             )
         )
@@ -154,7 +241,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: active
             )
         )
@@ -162,7 +249,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousThread: active,
+                previousWasEffectivelySettled: false,
                 updatedThread: nil
             )
         )
@@ -622,7 +709,9 @@ struct DailyUXSidebarTests {
         created: TimeInterval,
         updated: TimeInterval,
         state: FeatureThreadState = .idle,
-        isSettled: Bool = false
+        isSettled: Bool = false,
+        pinned: TimeInterval? = nil,
+        snoozedUntil: Date? = nil
     ) -> FeatureThread {
         FeatureThread(
             id: id,
@@ -632,7 +721,10 @@ struct DailyUXSidebarTests {
             updatedAt: now.addingTimeInterval(updated),
             state: state,
             isSettled: isSettled,
-            lastActivityAt: now.addingTimeInterval(updated)
+            lastActivityAt: now.addingTimeInterval(updated),
+            snoozedUntil: snoozedUntil,
+            snoozedAt: snoozedUntil.map { _ in now.addingTimeInterval(updated) },
+            pinnedAt: pinned.map(now.addingTimeInterval)
         )
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -90,7 +90,7 @@ struct DailyUXSidebarTests {
 
         #expect(activePlan.actions == [.settle, .delete])
         #expect(settledPlan.actions == [.reopen, .delete])
-        #expect(settledButWorkingPlan.actions == [.reopen, .delete])
+        #expect(settledButWorkingPlan.actions == [.settle, .delete])
         #expect(archivedPlan.actions == [.restore, .delete])
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
@@ -103,7 +103,7 @@ struct DailyUXSidebarTests {
     }
 
     @Test
-    func settleUndoCapturesOnlyStateThatSettlementClears() {
+    func settleUndoPreservesStateThatRepinningWouldClear() {
         let snoozeUntil = now.addingTimeInterval(300)
         let pinnedAndSnoozed = thread(
             id: "pinned",
@@ -261,11 +261,16 @@ struct DailyUXSidebarTests {
 
         state.expire(id: firstID)
         #expect(state.notice?.threadID == "second")
-        #expect(state.takeUndo(id: firstID) == nil)
-        let undo = state.takeUndo(id: secondID)
+        #expect(state.beginUndo(id: firstID) == nil)
+        let undo = state.beginUndo(id: secondID)
         #expect(undo?.restoresPin == true)
         #expect(undo?.restoresSnoozeUntil == now.addingTimeInterval(300))
-        #expect(state.takeUndo(id: secondID) == nil)
+        #expect(state.beginUndo(id: secondID) == nil)
+        #expect(state.notice?.id == secondID)
+        #expect(state.isUndoInProgress(threadID: "second"))
+        state.finishUndo(id: secondID)
+        #expect(state.notice == nil)
+        #expect(!state.isUndoInProgress(threadID: "second"))
     }
 
     @Test
@@ -285,6 +290,47 @@ struct DailyUXSidebarTests {
         state.expire(id: noticeID)
 
         #expect(state.notice == nil)
+    }
+
+    @Test
+    func settleUndoDoesNotExpireWhileUndoIsRunning() {
+        let noticeID = UUID()
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "thread")
+        state.present(
+            requestID: requestID,
+            threadID: "thread",
+            title: "Thread",
+            restoresPin: false,
+            restoresSnoozeUntil: nil,
+            id: noticeID
+        )
+
+        #expect(state.beginUndo(id: noticeID) != nil)
+        state.expire(id: noticeID)
+        #expect(state.notice?.id == noticeID)
+        state.finishUndo(id: noticeID)
+        #expect(state.notice == nil)
+    }
+
+    @Test
+    func deleteConfirmationTargetMustRemainInTheSnapshot() {
+        let request = HomeThreadDeleteRequest(id: "target", title: "Target")
+        let target = thread(id: "target", created: -20, updated: -10)
+        let other = thread(id: "other", created: -20, updated: -10)
+
+        #expect(
+            HomeThreadDeleteConfirmation.targetIsValid(
+                request: request,
+                in: [target, other]
+            )
+        )
+        #expect(
+            !HomeThreadDeleteConfirmation.targetIsValid(
+                request: request,
+                in: [other]
+            )
+        )
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -7,6 +7,84 @@ struct DailyUXSidebarTests {
     private let now = Date(timeIntervalSince1970: 2_000_000)
 
     @Test
+    func settleUndoTargetsOnlyTheLatestNoticeOnce() {
+        let firstID = UUID()
+        let secondID = UUID()
+        var state = HomeThreadSettleUndoState()
+
+        state.present(
+            threadID: "first",
+            title: "First thread",
+            restoresPin: false,
+            id: firstID
+        )
+        state.present(
+            threadID: "second",
+            title: "Second thread",
+            restoresPin: true,
+            id: secondID
+        )
+
+        state.expire(id: firstID)
+        #expect(state.notice?.threadID == "second")
+        #expect(state.takeUndo(id: firstID) == nil)
+        #expect(state.takeUndo(id: secondID)?.restoresPin == true)
+        #expect(state.takeUndo(id: secondID) == nil)
+    }
+
+    @Test
+    func settleUndoExpiresOnlyItsCurrentNotice() {
+        let noticeID = UUID()
+        var state = HomeThreadSettleUndoState()
+
+        state.present(
+            threadID: "thread",
+            title: "Thread",
+            restoresPin: false,
+            id: noticeID
+        )
+        state.expire(id: noticeID)
+
+        #expect(state.notice == nil)
+    }
+
+    @Test
+    func settleUndoAppearsOnlyAfterAConfirmedSettlement() {
+        let settled = thread(
+            id: "settled",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let active = thread(id: "active", created: -20, updated: -10)
+
+        #expect(
+            HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: false,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                updatedThread: active
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                updatedThread: nil
+            )
+        )
+    }
+
+    @Test
     func activeOrderUsesCreationTimeAndDoesNotJumpWithActivity() {
         let olderCreationRecentActivity = thread(
             id: "old",

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -4,6 +4,28 @@ import Testing
 
 @Suite("Sidebar v2")
 struct DailyUXSidebarTests {
+    @Test
+    func threadDeletionConfirmationCanBeCancelledAndReplaced() {
+        var confirmation = HomeThreadDeleteConfirmation()
+
+        confirmation.present(threadID: "thread-1", title: "Investigate swipe behavior")
+        #expect(
+            confirmation.request
+                == HomeThreadDeleteRequest(
+                    id: "thread-1",
+                    title: "Investigate swipe behavior"
+                )
+        )
+
+        confirmation.present(threadID: "thread-2", title: "Keep me")
+        confirmation.cancel()
+        #expect(confirmation.request == nil)
+
+        confirmation.present(threadID: "thread-3", title: "Replace me")
+        confirmation.present(threadID: "thread-4", title: "Delete me")
+        #expect(confirmation.request?.id == "thread-4")
+    }
+
     private let now = Date(timeIntervalSince1970: 2_000_000)
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -20,12 +20,10 @@ struct DailyUXSidebarTests {
         confirmation.present(threadID: "thread-2", title: "Keep me")
         confirmation.cancel()
         #expect(confirmation.request == nil)
-        #expect(confirmation.takeConfirmedRequest() == nil)
 
         confirmation.present(threadID: "thread-3", title: "Replace me")
         confirmation.present(threadID: "thread-4", title: "Delete me")
-        #expect(confirmation.takeConfirmedRequest()?.id == "thread-4")
-        #expect(confirmation.takeConfirmedRequest() == nil)
+        #expect(confirmation.request?.id == "thread-4")
     }
 
     private let now = Date(timeIntervalSince1970: 2_000_000)
@@ -97,6 +95,11 @@ struct DailyUXSidebarTests {
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
         #expect(activePlan.performsFirstActionWithFullSwipe)
+        #expect(settledPlan.performsFirstActionWithFullSwipe)
+        #expect(settledButWorkingPlan.performsFirstActionWithFullSwipe)
+        #expect(!archivedPlan.performsFirstActionWithFullSwipe)
+        #expect(!pinnedPlan.performsFirstActionWithFullSwipe)
+        #expect(!archiveOnlyPlan.performsFirstActionWithFullSwipe)
     }
 
     @Test
@@ -164,22 +167,46 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func dismissingAThreadCancelsOnlyItsPendingSettleNotice() {
+        var state = HomeThreadSettleUndoState()
+        let targetRequestID = state.beginSettleRequest(threadID: "target")
+
+        state.dismiss(threadID: "other")
+        #expect(state.latestSettleRequestID == targetRequestID)
+        #expect(state.latestSettleThreadID == "target")
+
+        state.dismiss(threadID: "target")
+        #expect(state.latestSettleRequestID == nil)
+        #expect(state.latestSettleThreadID == nil)
+        #expect(
+            state.present(
+                requestID: targetRequestID,
+                threadID: "target",
+                title: "Target",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) == nil
+        )
+    }
+
+    @Test
     func settleUndoTargetsOnlyTheLatestNoticeOnce() {
         let firstID = UUID()
         let secondID = UUID()
         var state = HomeThreadSettleUndoState()
-        let requestID = state.beginSettleRequest()
+        let firstRequestID = state.beginSettleRequest()
 
         state.present(
-            requestID: requestID,
+            requestID: firstRequestID,
             threadID: "first",
             title: "First thread",
             restoresPin: false,
             restoresSnoozeUntil: nil,
             id: firstID
         )
+        let secondRequestID = state.beginSettleRequest()
         state.present(
-            requestID: requestID,
+            requestID: secondRequestID,
             threadID: "second",
             title: "Second thread",
             restoresPin: true,

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -46,6 +46,18 @@ struct DailyUXSidebarTests {
             state: .working,
             isSettled: true
         )
+        let pinned = thread(
+            id: "pinned",
+            created: -20,
+            updated: -10,
+            pinned: -5
+        )
+        let archiveOnly = thread(
+            id: "archive-only",
+            created: -20,
+            updated: -10,
+            supportsSettlement: false
+        )
 
         let activePlan = HomeThreadSwipeActionPlan.make(
             thread: active,
@@ -62,13 +74,30 @@ struct DailyUXSidebarTests {
             isArchived: false,
             now: now
         )
+        let archivedPlan = HomeThreadSwipeActionPlan.make(
+            thread: active,
+            isArchived: true,
+            now: now
+        )
+        let pinnedPlan = HomeThreadSwipeActionPlan.make(
+            thread: pinned,
+            isArchived: false,
+            now: now
+        )
+        let archiveOnlyPlan = HomeThreadSwipeActionPlan.make(
+            thread: archiveOnly,
+            isArchived: false,
+            now: now
+        )
 
-        #expect(activePlan.orderedActions == [.settle, .delete])
-        #expect(settledPlan.orderedActions == [.reopen, .delete])
-        #expect(settledButWorkingPlan.orderedActions == [.settle, .delete])
-        #expect(activePlan.performsPrimaryWithFullSwipe)
+        #expect(activePlan.actions == [.settle, .delete])
+        #expect(settledPlan.actions == [.reopen, .delete])
+        #expect(settledButWorkingPlan.actions == [.reopen, .delete])
+        #expect(archivedPlan.actions == [.restore, .delete])
+        #expect(pinnedPlan.actions == [.unpin, .delete])
+        #expect(archiveOnlyPlan.actions == [.archive, .delete])
+        #expect(activePlan.performsFirstActionWithFullSwipe)
         #expect(!activePlan.deleteFinishesOptimistically)
-        #expect(activePlan.orderedActions.first != .delete)
     }
 
     @Test
@@ -115,6 +144,24 @@ struct DailyUXSidebarTests {
         )
         #expect(state.beginSettleRequest(ifSettling: false) == nil)
         #expect(state.latestSettleRequestID == settleRequestID)
+    }
+
+    @Test
+    func settleUndoDismissesOnlyTheMatchingThread() {
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest()
+        state.present(
+            requestID: requestID,
+            threadID: "target",
+            title: "Target",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+
+        state.dismiss(threadID: "other")
+        #expect(state.notice?.threadID == "target")
+        state.dismiss(threadID: "target")
+        #expect(state.notice == nil)
     }
 
     @Test
@@ -209,7 +256,7 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -217,7 +264,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -225,7 +272,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -233,7 +280,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: true,
+                previousWasSettled: true,
                 updatedThread: settled
             )
         )
@@ -241,7 +288,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: active
             )
         )
@@ -249,7 +296,7 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasEffectivelySettled: false,
+                previousWasSettled: false,
                 updatedThread: nil
             )
         )
@@ -711,7 +758,8 @@ struct DailyUXSidebarTests {
         state: FeatureThreadState = .idle,
         isSettled: Bool = false,
         pinned: TimeInterval? = nil,
-        snoozedUntil: Date? = nil
+        snoozedUntil: Date? = nil,
+        supportsSettlement: Bool? = nil
     ) -> FeatureThread {
         FeatureThread(
             id: id,
@@ -724,7 +772,8 @@ struct DailyUXSidebarTests {
             lastActivityAt: now.addingTimeInterval(updated),
             snoozedUntil: snoozedUntil,
             snoozedAt: snoozedUntil.map { _ in now.addingTimeInterval(updated) },
-            pinnedAt: pinned.map(now.addingTimeInterval)
+            pinnedAt: pinned.map(now.addingTimeInterval),
+            supportsSettlement: supportsSettlement
         )
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -190,6 +190,51 @@ struct DailyUXSidebarTests {
     }
 
     @Test
+    func settleUndoRejectsAThreadThatDoesNotMatchTheRequest() {
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "target")
+
+        #expect(
+            state.present(
+                requestID: requestID,
+                threadID: "other",
+                title: "Other",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) == nil
+        )
+        #expect(state.notice == nil)
+        #expect(state.latestSettleRequestID == requestID)
+        #expect(state.latestSettleThreadID == "target")
+    }
+
+    @Test
+    func settleUndoRequestCanPresentOnlyOnce() {
+        var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest(threadID: "target")
+
+        #expect(
+            state.present(
+                requestID: requestID,
+                threadID: "target",
+                title: "Target",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) != nil
+        )
+        #expect(
+            state.present(
+                requestID: requestID,
+                threadID: "target",
+                title: "Target again",
+                restoresPin: false,
+                restoresSnoozeUntil: nil
+            ) == nil
+        )
+        #expect(state.notice?.title == "Target")
+    }
+
+    @Test
     func settleUndoTargetsOnlyTheLatestNoticeOnce() {
         let firstID = UUID()
         let secondID = UUID()
@@ -282,7 +327,6 @@ struct DailyUXSidebarTests {
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -290,7 +334,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
                 didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -298,7 +341,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: false,
-                previousWasSettled: false,
                 updatedThread: settled
             )
         )
@@ -306,15 +348,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasSettled: true,
-                updatedThread: settled
-            )
-        )
-        #expect(
-            !HomeThreadSettleUndoState.shouldPresent(
-                afterRequesting: true,
-                didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: active
             )
         )
@@ -322,7 +355,6 @@ struct DailyUXSidebarTests {
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
                 didSucceed: true,
-                previousWasSettled: false,
                 updatedThread: nil
             )
         )

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -97,7 +97,6 @@ struct DailyUXSidebarTests {
         #expect(pinnedPlan.actions == [.unpin, .delete])
         #expect(archiveOnlyPlan.actions == [.archive, .delete])
         #expect(activePlan.performsFirstActionWithFullSwipe)
-        #expect(!activePlan.deleteFinishesOptimistically)
     }
 
     @Test
@@ -300,6 +299,43 @@ struct DailyUXSidebarTests {
                 updatedThread: nil
             )
         )
+    }
+
+    @Test
+    func settleUndoTargetRequiresTheSameSettledUnarchivedThread() {
+        let notice = HomeThreadSettleUndoNotice(
+            id: UUID(),
+            threadID: "target",
+            title: "Target",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+        let settled = thread(
+            id: "target",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+        let active = thread(id: "target", created: -20, updated: -10)
+        let archived = thread(
+            id: "target",
+            created: -20,
+            updated: -10,
+            isArchived: true,
+            isSettled: true
+        )
+        let other = thread(
+            id: "other",
+            created: -20,
+            updated: -10,
+            isSettled: true
+        )
+
+        #expect(HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [settled]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [active]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [archived]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: [other]))
+        #expect(!HomeThreadSettleUndoState.targetIsValid(notice: notice, in: []))
     }
 
     @Test
@@ -756,6 +792,7 @@ struct DailyUXSidebarTests {
         created: TimeInterval,
         updated: TimeInterval,
         state: FeatureThreadState = .idle,
+        isArchived: Bool = false,
         isSettled: Bool = false,
         pinned: TimeInterval? = nil,
         snoozedUntil: Date? = nil,
@@ -768,6 +805,7 @@ struct DailyUXSidebarTests {
             createdAt: now.addingTimeInterval(created),
             updatedAt: now.addingTimeInterval(updated),
             state: state,
+            isArchived: isArchived,
             isSettled: isSettled,
             lastActivityAt: now.addingTimeInterval(updated),
             snoozedUntil: snoozedUntil,

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -20,10 +20,12 @@ struct DailyUXSidebarTests {
         confirmation.present(threadID: "thread-2", title: "Keep me")
         confirmation.cancel()
         #expect(confirmation.request == nil)
+        #expect(confirmation.takeConfirmedRequest() == nil)
 
         confirmation.present(threadID: "thread-3", title: "Replace me")
         confirmation.present(threadID: "thread-4", title: "Delete me")
-        #expect(confirmation.request?.id == "thread-4")
+        #expect(confirmation.takeConfirmedRequest()?.id == "thread-4")
+        #expect(confirmation.takeConfirmedRequest() == nil)
     }
 
     private let now = Date(timeIntervalSince1970: 2_000_000)
@@ -33,24 +35,31 @@ struct DailyUXSidebarTests {
         let firstID = UUID()
         let secondID = UUID()
         var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest()
 
         state.present(
+            requestID: requestID,
             threadID: "first",
             title: "First thread",
             restoresPin: false,
+            restoresSnoozeUntil: nil,
             id: firstID
         )
         state.present(
+            requestID: requestID,
             threadID: "second",
             title: "Second thread",
             restoresPin: true,
+            restoresSnoozeUntil: now.addingTimeInterval(300),
             id: secondID
         )
 
         state.expire(id: firstID)
         #expect(state.notice?.threadID == "second")
         #expect(state.takeUndo(id: firstID) == nil)
-        #expect(state.takeUndo(id: secondID)?.restoresPin == true)
+        let undo = state.takeUndo(id: secondID)
+        #expect(undo?.restoresPin == true)
+        #expect(undo?.restoresSnoozeUntil == now.addingTimeInterval(300))
         #expect(state.takeUndo(id: secondID) == nil)
     }
 
@@ -58,16 +67,45 @@ struct DailyUXSidebarTests {
     func settleUndoExpiresOnlyItsCurrentNotice() {
         let noticeID = UUID()
         var state = HomeThreadSettleUndoState()
+        let requestID = state.beginSettleRequest()
 
         state.present(
+            requestID: requestID,
             threadID: "thread",
             title: "Thread",
             restoresPin: false,
+            restoresSnoozeUntil: nil,
             id: noticeID
         )
         state.expire(id: noticeID)
 
         #expect(state.notice == nil)
+    }
+
+    @Test
+    func settleUndoRejectsAnOlderRequestThatFinishesLast() {
+        var state = HomeThreadSettleUndoState()
+        let firstRequestID = state.beginSettleRequest()
+        let secondRequestID = state.beginSettleRequest()
+
+        let stale = state.present(
+            requestID: firstRequestID,
+            threadID: "first",
+            title: "First",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+        let current = state.present(
+            requestID: secondRequestID,
+            threadID: "second",
+            title: "Second",
+            restoresPin: false,
+            restoresSnoozeUntil: nil
+        )
+
+        #expect(stale == nil)
+        #expect(current?.threadID == "second")
+        #expect(state.notice?.threadID == "second")
     }
 
     @Test
@@ -83,24 +121,48 @@ struct DailyUXSidebarTests {
         #expect(
             HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: settled
             )
         )
         #expect(
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: false,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: settled
             )
         )
         #expect(
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
+                didSucceed: false,
+                previousThread: active,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                didSucceed: true,
+                previousThread: settled,
+                updatedThread: settled
+            )
+        )
+        #expect(
+            !HomeThreadSettleUndoState.shouldPresent(
+                afterRequesting: true,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: active
             )
         )
         #expect(
             !HomeThreadSettleUndoState.shouldPresent(
                 afterRequesting: true,
+                didSucceed: true,
+                previousThread: active,
                 updatedThread: nil
             )
         )

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -35,6 +35,143 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func titleRegenerationAllowsOnlyOneRequestPerThreadAndUpdatesTheExactRow() async {
+        let client = FeatureClientStub()
+        let first = regeneratableThread(id: "first", title: "First")
+        let second = regeneratableThread(id: "second", title: "Second")
+        client.snapshot = FeatureSnapshot(threads: [first, second])
+        client.holdTitleRegeneration = true
+        let model = testRootModel(client: client)
+        await model.reload()
+
+        let request = Task { await model.regenerateThreadTitle(first.id) }
+        while client.regeneratedTitleThreadIDs.isEmpty { await Task.yield() }
+
+        #expect(model.regeneratingTitleThreadIDs == [first.id])
+        #expect(await model.regenerateThreadTitle(first.id) == .alreadyRunning)
+        #expect(client.regeneratedTitleThreadIDs == [first.id])
+
+        client.resumeTitleRegeneration()
+        #expect(await request.value == .started)
+        var renamed = first
+        renamed.title = "A generated title"
+        client.snapshot = FeatureSnapshot(threads: [renamed, second])
+        await model.reload()
+
+        #expect(model.snapshot.threads.first { $0.id == first.id }?.title == "A generated title")
+        #expect(model.snapshot.threads.first { $0.id == second.id }?.title == "Second")
+        #expect(model.regeneratingTitleThreadIDs.isEmpty)
+    }
+
+    @Test
+    func titleRegenerationFailureClearsStateAndCanRetry() async {
+        let client = FeatureClientStub()
+        let thread = regeneratableThread(id: "retry", title: "Retry me")
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        client.titleRegenerationError = FeatureClientStubError.failed
+        let model = testRootModel(client: client)
+        await model.reload()
+
+        #expect(await model.regenerateThreadTitle(thread.id) == .failed("Regeneration failed."))
+        #expect(model.regeneratingTitleThreadIDs.isEmpty)
+
+        client.titleRegenerationError = nil
+        #expect(await model.regenerateThreadTitle(thread.id) == .started)
+        #expect(client.regeneratedTitleThreadIDs == [thread.id, thread.id])
+        #expect(model.regeneratingTitleThreadIDs.isEmpty)
+    }
+
+    @Test
+    func titleRegenerationUsesTheAuthoritativeDispatchReceipt() async {
+        let client = FeatureClientStub()
+        let thread = regeneratableThread(id: "receipt", title: "Receipt")
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        client.titleRegenerationReceipt = .refreshUnavailable
+        let model = testRootModel(client: client)
+        let run = Task { await model.start() }
+        while model.isLoading { await Task.yield() }
+
+        #expect(await model.regenerateThreadTitle(thread.id) == .started)
+        #expect(model.regeneratingTitleThreadIDs == [thread.id])
+        #expect(await model.regenerateThreadTitle(thread.id) == .alreadyRunning)
+
+        client.emit(.thread(thread))
+        while !model.regeneratingTitleThreadIDs.isEmpty { await Task.yield() }
+        #expect(model.regeneratingTitleThreadIDs.isEmpty)
+
+        client.titleRegenerationReceipt = .regenerating
+        #expect(await model.regenerateThreadTitle(thread.id) == .started)
+        #expect(model.regeneratingTitleThreadIDs == [thread.id])
+        client.emit(.thread(thread))
+        while !model.regeneratingTitleThreadIDs.isEmpty { await Task.yield() }
+        #expect(model.regeneratingTitleThreadIDs.isEmpty)
+
+        client.finishEvents()
+        await run.value
+    }
+
+    @Test
+    func titleRegenerationRejectsMissingUnsupportedAndArchivedThreads() async {
+        let client = FeatureClientStub()
+        var archived = regeneratableThread(id: "archived", title: "Archived")
+        archived.isArchived = true
+        client.snapshot = FeatureSnapshot(threads: [
+            FeatureThread(id: "unsupported", projectID: "project", title: "Unsupported"),
+            archived,
+        ])
+        let model = testRootModel(client: client)
+        await model.reload()
+
+        #expect(await model.regenerateThreadTitle("missing") == .threadMissing)
+        #expect(await model.regenerateThreadTitle("unsupported") == .unavailable)
+        #expect(await model.regenerateThreadTitle("archived") == .unavailable)
+        #expect(client.regeneratedTitleThreadIDs.isEmpty)
+    }
+
+    @Test
+    func titleRegenerationDropsStateWhenRowDisappearsOrItsIdentityIsReused() async {
+        let client = FeatureClientStub()
+        let thread = regeneratableThread(id: "reused", title: "Original")
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        let model = testRootModel(client: client)
+        await model.reload()
+
+        #expect(await model.regenerateThreadTitle(thread.id) == .started)
+        var reused = thread
+        reused.projectID = "different-project"
+        client.snapshot = FeatureSnapshot(threads: [reused])
+        await model.reload()
+        #expect(model.regeneratingTitleThreadIDs.isEmpty)
+
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        await model.reload()
+        #expect(await model.regenerateThreadTitle(thread.id) == .started)
+        client.snapshot = FeatureSnapshot()
+        await model.reload()
+        #expect(model.regeneratingTitleThreadIDs.isEmpty)
+    }
+
+    @Test
+    func titleRegenerationToleratesDuplicateRowsWhileDispatchIsPending() async {
+        let client = FeatureClientStub()
+        let thread = regeneratableThread(id: "duplicate", title: "Duplicate")
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        client.holdTitleRegeneration = true
+        let model = testRootModel(client: client)
+        await model.reload()
+
+        let request = Task { await model.regenerateThreadTitle(thread.id) }
+        while client.regeneratedTitleThreadIDs.isEmpty { await Task.yield() }
+        client.snapshot = FeatureSnapshot(threads: [thread, thread])
+        await model.reload()
+
+        #expect(model.regeneratingTitleThreadIDs == [thread.id])
+        client.resumeTitleRegeneration()
+        #expect(await request.value == .started)
+        #expect(model.regeneratingTitleThreadIDs.isEmpty)
+    }
+
+    @Test
     func savedServersKeepWorkspaceNavigationAvailableWhileDisconnected() {
         let savedEnvironment = FeatureEnvironment(
             id: "offline-demo",
@@ -1173,6 +1310,22 @@ private func testRootModel(client: FeatureClientStub) -> FeatureRootModel {
     )
 }
 
+private func regeneratableThread(id: String, title: String) -> FeatureThread {
+    FeatureThread(
+        id: id,
+        projectID: "project",
+        environmentID: "environment",
+        title: title,
+        supportsTitleRegeneration: true
+    )
+}
+
+private enum FeatureClientStubError: LocalizedError {
+    case failed
+
+    var errorDescription: String? { "Regeneration failed." }
+}
+
 private func orchestrationEvent(
     type: String,
     sequence: Int,
@@ -1254,6 +1407,11 @@ private final class FeatureClientStub: FeatureClient {
     var resolvedInputID: String?
     var resolvedInputAnswers: [String: FeatureInputAnswer]?
     var savedSettings: [FeatureSettings] = []
+    var regeneratedTitleThreadIDs: [String] = []
+    var titleRegenerationError: (any Error)?
+    var titleRegenerationReceipt: FeatureTitleRegenerationDispatchReceipt = .completed
+    var holdTitleRegeneration = false
+    private var titleRegenerationContinuation: CheckedContinuation<Void, Never>?
 
     init() {
         let pair = AsyncStream<FeatureEvent>.makeStream()
@@ -1352,6 +1510,21 @@ private final class FeatureClientStub: FeatureClient {
     }
 
     func renameThread(id: String, title: String) async throws {}
+    func regenerateThreadTitle(
+        id: String
+    ) async throws -> FeatureTitleRegenerationDispatchReceipt {
+        regeneratedTitleThreadIDs.append(id)
+        if let titleRegenerationError { throw titleRegenerationError }
+        if holdTitleRegeneration {
+            await withCheckedContinuation { titleRegenerationContinuation = $0 }
+        }
+        return titleRegenerationReceipt
+    }
+    func resumeTitleRegeneration() {
+        holdTitleRegeneration = false
+        titleRegenerationContinuation?.resume()
+        titleRegenerationContinuation = nil
+    }
     func setThreadArchived(id: String, archived: Bool) async throws {}
     func setThreadSettled(id: String, settled: Bool) async throws {
         if let setThreadSettledError { throw setThreadSettledError }

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -657,6 +657,24 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func testSettleReportsWhetherTheMutationSucceeded() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
+        client.createdThread = thread
+        let model = testRootModel(client: client)
+        _ = await model.createThread(projectID: thread.projectID, title: nil, selection: nil)
+
+        let succeeded = await model.setSettled(thread.id, settled: true)
+        #expect(succeeded)
+        #expect(model.snapshot.threads[0].isSettled)
+
+        client.setThreadSettledError = URLError(.cannotConnectToHost)
+        let failed = await model.setSettled(thread.id, settled: false)
+        #expect(!failed)
+        #expect(model.snapshot.threads[0].isSettled)
+    }
+
+    @Test
     func testCancelledDetailRefreshKeepsCachedContentWithoutAlert() async {
         let client = FeatureClientStub()
         let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
@@ -1226,6 +1244,7 @@ private final class FeatureClientStub: FeatureClient {
     var sendMessageCallCount = 0
     var startTaskError: (any Error)?
     var sendMessageError: (any Error)?
+    var setThreadSettledError: (any Error)?
     var enabledEnvironmentID: String?
     var environmentEnabledValue: Bool?
     var removedEnvironmentID: String?
@@ -1334,6 +1353,9 @@ private final class FeatureClientStub: FeatureClient {
 
     func renameThread(id: String, title: String) async throws {}
     func setThreadArchived(id: String, archived: Bool) async throws {}
+    func setThreadSettled(id: String, settled: Bool) async throws {
+        if let setThreadSettledError { throw setThreadSettledError }
+    }
     func deleteThread(id: String) async throws {}
 
     func loadThread(id: String) async throws -> FeatureThreadDetail {

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 

--- a/apps/swift-ios/Tests/FeatureTests/ThreadMetadataCopyTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ThreadMetadataCopyTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import T3Code
+
+@Suite("Thread metadata copy")
+struct ThreadMetadataCopyTests {
+    @Test
+    func offersWorktreePathBranchAndWireIDInMenuOrder() {
+        let thread = FeatureThread(
+            id: "environment:one:thread:thread-1",
+            wireID: "thread-1",
+            projectID: "project-1",
+            title: "Metadata",
+            branch: " feature/copy ",
+            worktreePath: " /tmp/copy-worktree "
+        )
+
+        let items = ThreadMetadataCopyModel.items(
+            for: thread,
+            projectPath: "/tmp/project"
+        )
+
+        #expect(items.map(\.kind) == [.path, .branch, .threadID])
+        #expect(items.map(\.value) == [" /tmp/copy-worktree ", "feature/copy", "thread-1"])
+        #expect(items.map(\.title) == ["Copy path", "Copy branch", "Copy thread ID"])
+        #expect(items.map(\.confirmation) == ["Path copied", "Branch copied", "Thread ID copied"])
+    }
+
+    @Test
+    func fallsBackToProjectPathAndInternalThreadID() {
+        let thread = FeatureThread(
+            id: "environment:one:thread:thread-1",
+            wireID: "  ",
+            projectID: "project-1",
+            title: "Fallback"
+        )
+
+        let items = ThreadMetadataCopyModel.items(
+            for: thread,
+            projectPath: "/tmp/project"
+        )
+
+        #expect(items.map(\.kind) == [.path, .threadID])
+        #expect(items.map(\.value) == ["/tmp/project", "environment:one:thread:thread-1"])
+    }
+
+    @Test
+    func unavailableValuesDoNotCreateDeadMenuActions() {
+        let thread = FeatureThread(
+            id: "  ",
+            wireID: nil,
+            projectID: "project-1",
+            title: "Unavailable",
+            branch: "\n",
+            worktreePath: nil
+        )
+
+        #expect(ThreadMetadataCopyModel.items(for: thread, projectPath: "  ").isEmpty)
+    }
+
+    @Test
+    func eachMenuRequestUsesTheCurrentRowMetadata() {
+        let first = FeatureThread(
+            id: "first",
+            wireID: "wire-first",
+            projectID: "project-1",
+            title: "First",
+            branch: "feature/first",
+            worktreePath: "/tmp/first"
+        )
+        let reused = FeatureThread(
+            id: "second",
+            wireID: "wire-second",
+            projectID: "project-2",
+            title: "Second",
+            branch: "feature/second",
+            worktreePath: "/tmp/second"
+        )
+
+        let firstItems = ThreadMetadataCopyModel.items(for: first, projectPath: nil)
+        let reusedItems = ThreadMetadataCopyModel.items(for: reused, projectPath: nil)
+
+        #expect(firstItems.map(\.value) == ["/tmp/first", "feature/first", "wire-first"])
+        #expect(reusedItems.map(\.value) == ["/tmp/second", "feature/second", "wire-second"])
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/ThreadNewTaskSeedTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ThreadNewTaskSeedTests.swift
@@ -1,0 +1,316 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+@Suite("New thread on this checkout")
+struct ThreadNewTaskSeedTests {
+    @Test
+    func derivesTheExactProjectEnvironmentBranchAndWorktree() throws {
+        let thread = makeThread(
+            branch: " feature/menu ",
+            worktreePath: "/worktrees/menu/../menu"
+        )
+
+        let availability = ThreadNewTaskSeedModel.availability(
+            for: thread,
+            projects: [project]
+        )
+        guard case let .available(request) = availability else {
+            Issue.record("Expected a same-checkout request")
+            return
+        }
+
+        #expect(request.sourceThreadID == thread.id)
+        #expect(request.projectID == project.id)
+        #expect(request.environmentID == project.environmentID)
+        #expect(request.branch == "feature/menu")
+        #expect(request.worktreePath == "/worktrees/menu")
+        #expect(request.projectRootPath == nil)
+        #expect(availability.menuTitle == "New thread on feature/menu")
+    }
+
+    @Test
+    func missingMetadataAndUnavailableOwnershipStayExplicitlyDisabled() {
+        #expect(availability(branch: " ") == .unavailable(.missingBranch))
+        #expect(
+            ThreadNewTaskSeedModel.availability(
+                for: makeThread(),
+                projects: []
+            ) == .unavailable(.projectUnavailable)
+        )
+        #expect(
+            ThreadNewTaskSeedModel.availability(
+                for: makeThread(environmentID: "other-environment"),
+                projects: [project]
+            ) == .unavailable(.environmentUnavailable)
+        )
+        #expect(
+            availability(worktreePath: " ") == .unavailable(.worktreeUnavailable)
+        )
+        #expect(!ThreadNewTaskAvailability.unavailable(.missingBranch).isEnabled)
+    }
+
+    @Test
+    func resolvesOnlyTheExactLiveBranchAndWorktree() throws {
+        let request = try request(
+            for: makeThread(worktreePath: "/worktrees/menu")
+        )
+        let exact = FeatureWorkspaceBranch(
+            name: "feature/menu",
+            worktreePath: "/worktrees/menu"
+        )
+        let sameNameWrongCheckout = FeatureWorkspaceBranch(
+            name: "feature/menu",
+            worktreePath: "/worktrees/other"
+        )
+
+        let resolved = ThreadNewTaskSeedModel.resolve(
+            request,
+            currentThread: makeThread(worktreePath: "/worktrees/menu"),
+            projects: [project],
+            branches: [sameNameWrongCheckout, exact]
+        )
+        guard case let .success(seed) = resolved else {
+            Issue.record("Expected the exact worktree to resolve")
+            return
+        }
+        #expect(seed.branch == exact)
+
+        let missingBranch = ThreadNewTaskSeedModel.revalidate(
+            seed,
+            projects: [project],
+            branches: []
+        )
+        guard case let .failure(missingBranchReason) = missingBranch else {
+            Issue.record("A deleted branch must be reported explicitly")
+            return
+        }
+        #expect(missingBranchReason == .branchUnavailable)
+
+        let deleted = ThreadNewTaskSeedModel.revalidate(
+            seed,
+            projects: [project],
+            branches: [sameNameWrongCheckout]
+        )
+        guard case let .failure(reason) = deleted else {
+            Issue.record("A deleted worktree must not fall back by branch name")
+            return
+        }
+        #expect(reason == .worktreeUnavailable)
+    }
+
+    @Test
+    func preservesLegalWhitespaceInTheRecordedWorktreePath() throws {
+        let thread = makeThread(worktreePath: "/worktrees/topic ")
+        let request = try request(for: thread)
+        let exact = FeatureWorkspaceBranch(
+            name: "feature/menu",
+            worktreePath: "/worktrees/topic "
+        )
+
+        #expect(request.worktreePath == "/worktrees/topic ")
+        guard case let .success(seed) = ThreadNewTaskSeedModel.resolve(
+            request,
+            currentThread: thread,
+            projects: [project],
+            branches: [exact]
+        ) else {
+            Issue.record("A legal trailing space must remain part of the checkout path")
+            return
+        }
+        #expect(seed.branch == exact)
+    }
+
+    @Test
+    func currentCheckoutRequiresTheCurrentBranchAtTheProjectRoot() throws {
+        let request = try request(for: makeThread(worktreePath: nil))
+        #expect(request.projectRootPath == "/repo")
+        let detachedSameName = FeatureWorkspaceBranch(name: "feature/menu")
+        let current = FeatureWorkspaceBranch(
+            name: "feature/menu",
+            isCurrent: true,
+            worktreePath: "/repo/./"
+        )
+
+        let missingCurrent = ThreadNewTaskSeedModel.resolve(
+            request,
+            currentThread: makeThread(worktreePath: nil),
+            projects: [project],
+            branches: [detachedSameName]
+        )
+        guard case let .failure(reason) = missingCurrent else {
+            Issue.record("A non-current branch must not replace the source checkout")
+            return
+        }
+        #expect(reason == .worktreeUnavailable)
+
+        guard case let .success(seed) = ThreadNewTaskSeedModel.resolve(
+            request,
+            currentThread: makeThread(worktreePath: nil),
+            projects: [project],
+            branches: [current]
+        ) else {
+            Issue.record("Expected the current root checkout to resolve")
+            return
+        }
+        #expect(seed.branch == current)
+    }
+
+    @Test
+    func rootCheckoutRejectsAProjectPathThatChangedAfterTheMenuOpened() throws {
+        let thread = makeThread(worktreePath: nil)
+        let request = try request(for: thread)
+        let movedProject = FeatureProject(
+            id: project.id,
+            environmentID: project.environmentID,
+            name: project.name,
+            path: "/moved-repo"
+        )
+        let current = FeatureWorkspaceBranch(
+            name: "feature/menu",
+            isCurrent: true,
+            worktreePath: "/moved-repo"
+        )
+
+        let resolution = ThreadNewTaskSeedModel.resolve(
+            request,
+            currentThread: thread,
+            projects: [movedProject],
+            branches: [current]
+        )
+        guard case let .failure(resolveReason) = resolution else {
+            Issue.record("A stale root checkout request must be rejected")
+            return
+        }
+        #expect(resolveReason == .threadChanged)
+
+        let seed = ThreadNewTaskResolvedSeed(request: request, branch: current)
+        let revalidation = ThreadNewTaskSeedModel.revalidate(
+            seed,
+            projects: [movedProject],
+            branches: [current]
+        )
+        guard case let .failure(revalidateReason) = revalidation else {
+            Issue.record("A moved project root must not be applied to the composer")
+            return
+        }
+        #expect(revalidateReason == .threadChanged)
+    }
+
+    @Test
+    func staleRowRequestCannotReuseAChangedThreadIdentity() throws {
+        let original = makeThread(branch: "feature/menu")
+        let request = try request(for: original)
+        let reusedRow = makeThread(branch: "feature/replacement")
+
+        let resolution = ThreadNewTaskSeedModel.resolve(
+            request,
+            currentThread: reusedRow,
+            projects: [project],
+            branches: [
+                FeatureWorkspaceBranch(
+                    name: "feature/menu",
+                    isCurrent: true,
+                    worktreePath: "/repo"
+                ),
+            ]
+        )
+        guard case let .failure(reason) = resolution else {
+            Issue.record("A stale context-menu request must be rejected")
+            return
+        }
+        #expect(reason == .threadChanged)
+    }
+
+    @Test
+    func eachPresentationIsFreshAndWorkspaceSeedingPreservesTheDraft() throws {
+        let request = try request(
+            for: makeThread(worktreePath: "/worktrees/menu")
+        )
+        let seed = ThreadNewTaskResolvedSeed(
+            request: request,
+            branch: FeatureWorkspaceBranch(
+                name: request.branch,
+                worktreePath: request.worktreePath
+            )
+        )
+        let first = ThreadNewTaskPresentation.sameBranch(seed)
+        let second = ThreadNewTaskPresentation.sameBranch(seed)
+        let attachment = FeatureDraftAttachment(
+            data: Data([1, 2, 3]),
+            filename: "proof.png",
+            mimeType: "image/png"
+        )
+        let selection = FeatureSelection(providerID: "codex", modelID: "gpt-5")
+        let draft = FeatureComposerDraft(
+            text: "Keep my draft",
+            attachments: [attachment],
+            selection: selection,
+            workspace: FeatureComposerWorkspaceDraft(
+                mode: .worktree,
+                branch: "old",
+                worktreePath: nil,
+                startFromOrigin: true
+            )
+        )
+
+        #expect(first.id != second.id)
+        #expect(first.initialProjectID == project.id)
+        #expect(seed.belongs(to: project.id))
+        #expect(!seed.belongs(to: "another-project"))
+        let seeded = seed.applying(to: draft)
+        #expect(seeded.text == draft.text)
+        #expect(seeded.attachments == draft.attachments)
+        #expect(seeded.selection == draft.selection)
+        #expect(seeded.workspace == FeatureComposerWorkspaceDraft(
+            mode: .local,
+            branch: "feature/menu",
+            worktreePath: "/worktrees/menu",
+            startFromOrigin: false
+        ))
+    }
+
+    private var project: FeatureProject {
+        FeatureProject(
+            id: "project-1",
+            environmentID: "environment-1",
+            name: "Project",
+            path: "/repo"
+        )
+    }
+
+    private func makeThread(
+        environmentID: String? = "environment-1",
+        branch: String? = "feature/menu",
+        worktreePath: String? = nil
+    ) -> FeatureThread {
+        FeatureThread(
+            id: "thread-1",
+            projectID: "project-1",
+            environmentID: environmentID,
+            title: "Menu",
+            branch: branch,
+            worktreePath: worktreePath
+        )
+    }
+
+    private func availability(
+        branch: String? = "feature/menu",
+        worktreePath: String? = nil
+    ) -> ThreadNewTaskAvailability {
+        ThreadNewTaskSeedModel.availability(
+            for: makeThread(branch: branch, worktreePath: worktreePath),
+            projects: [project]
+        )
+    }
+
+    private func request(for thread: FeatureThread) throws -> ThreadNewTaskSeedRequest {
+        guard case let .available(request) = ThreadNewTaskSeedModel.availability(
+            for: thread,
+            projects: [project]
+        ) else {
+            throw ThreadNewTaskUnavailableReason.projectUnavailable
+        }
+        return request
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/ThreadSnoozePresetTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ThreadSnoozePresetTests.swift
@@ -1,0 +1,265 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+@Suite("Thread snooze presets")
+struct ThreadSnoozePresetTests {
+    private let locale = Locale(identifier: "en_US_POSIX")
+
+    @Test
+    func ordersTheUsefulCalendarPresetsAndOmitsDuplicateEveningBoundary() throws {
+        let calendar = calendar(timeZone: TimeZone(secondsFromGMT: 0)!)
+        let beforeBoundary = try date(
+            year: 2026,
+            month: 4,
+            day: 8,
+            hour: 16,
+            minute: 59,
+            calendar: calendar
+        )
+        let atBoundary = try date(
+            year: 2026,
+            month: 4,
+            day: 8,
+            hour: 17,
+            calendar: calendar
+        )
+
+        let before = ThreadSnoozePresets.resolve(
+            now: beforeBoundary,
+            calendar: calendar,
+            locale: locale
+        )
+        let at = ThreadSnoozePresets.resolve(
+            now: atBoundary,
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(before.map(\.id) == ["hour", "evening", "tomorrow", "next-week"])
+        #expect(at.map(\.id) == ["hour", "tomorrow", "next-week"])
+        #expect(before.allSatisfy { $0.until > beforeBoundary })
+    }
+
+    @Test
+    func tomorrowUsesLocalCalendarTimeAcrossSpringDST() throws {
+        let zone = try #require(TimeZone(identifier: "America/New_York"))
+        let calendar = calendar(timeZone: zone)
+        let now = try date(
+            year: 2026,
+            month: 3,
+            day: 7,
+            hour: 10,
+            calendar: calendar
+        )
+
+        let tomorrow = try #require(ThreadSnoozePresets.resolve(
+            now: now,
+            calendar: calendar,
+            locale: locale
+        ).first { $0.id == "tomorrow" })
+        let components = calendar.dateComponents([.year, .month, .day, .hour], from: tomorrow.until)
+
+        #expect(components.year == 2026)
+        #expect(components.month == 3)
+        #expect(components.day == 8)
+        #expect(components.hour == 9)
+        #expect(tomorrow.until.timeIntervalSince(now) == 22 * 60 * 60)
+    }
+
+    @Test
+    func nextWeekIsTheFollowingMondayEvenWhenTodayIsMonday() throws {
+        let calendar = calendar(timeZone: TimeZone(secondsFromGMT: 0)!)
+        let now = try date(
+            year: 2026,
+            month: 4,
+            day: 6,
+            hour: 10,
+            calendar: calendar
+        )
+
+        let nextWeek = try #require(ThreadSnoozePresets.resolve(
+            now: now,
+            calendar: calendar,
+            locale: locale
+        ).first { $0.id == "next-week" })
+        let components = calendar.dateComponents([.year, .month, .day, .hour], from: nextWeek.until)
+
+        #expect(components.year == 2026)
+        #expect(components.month == 4)
+        #expect(components.day == 13)
+        #expect(components.hour == 9)
+        #expect(nextWeek.whenLabel.hasPrefix("Mon "))
+    }
+
+    @Test
+    func nextWeekDoesNotDuplicateTomorrowOnSunday() throws {
+        let calendar = calendar(timeZone: TimeZone(secondsFromGMT: 0)!)
+        let now = try date(
+            year: 2026,
+            month: 4,
+            day: 5,
+            hour: 10,
+            calendar: calendar
+        )
+
+        let presets = ThreadSnoozePresets.resolve(
+            now: now,
+            calendar: calendar,
+            locale: locale
+        )
+        let tomorrow = try #require(presets.first { $0.id == "tomorrow" })
+        let nextWeek = try #require(presets.first { $0.id == "next-week" })
+        let components = calendar.dateComponents([.year, .month, .day, .hour], from: nextWeek.until)
+
+        #expect(nextWeek.until != tomorrow.until)
+        #expect(components.year == 2026)
+        #expect(components.month == 4)
+        #expect(components.day == 13)
+        #expect(components.hour == 9)
+    }
+
+    @Test
+    func settledThreadsKeepPresetsAndSnoozedThreadsKeepWake() throws {
+        let calendar = calendar(timeZone: TimeZone(secondsFromGMT: 0)!)
+        let now = try date(
+            year: 2026,
+            month: 4,
+            day: 8,
+            hour: 10,
+            calendar: calendar
+        )
+        var thread = FeatureThread(
+            id: "thread-1",
+            projectID: "project-1",
+            title: "Snooze",
+            isSettled: true,
+            supportsSnooze: true
+        )
+
+        let settled = ThreadSnoozeMenuModel.menu(
+            for: thread,
+            isArchived: false,
+            now: now,
+            calendar: calendar,
+            locale: locale
+        )
+        guard case let .presets(presets, enabled) = settled else {
+            Issue.record("Settled thread should offer snooze presets")
+            return
+        }
+        #expect(presets.map(\.id) == ["hour", "evening", "tomorrow", "next-week"])
+        #expect(enabled)
+
+        thread.snoozedUntil = now.addingTimeInterval(60 * 60)
+        #expect(ThreadSnoozeMenuModel.menu(
+            for: thread,
+            isArchived: false,
+            now: now,
+            calendar: calendar,
+            locale: locale
+        ) == .unsnooze)
+        #expect(ThreadSnoozeMenuModel.menu(
+            for: thread,
+            isArchived: true,
+            now: now,
+            calendar: calendar,
+            locale: locale
+        ) == .hidden)
+    }
+
+    @Test
+    func pendingThreadsKeepThePresetOrderButDisableEveryChoice() throws {
+        let calendar = calendar(timeZone: TimeZone(secondsFromGMT: 0)!)
+        let now = try date(
+            year: 2026,
+            month: 4,
+            day: 8,
+            hour: 10,
+            calendar: calendar
+        )
+        let thread = FeatureThread(
+            id: "thread-1",
+            projectID: "project-1",
+            title: "Pending",
+            state: .waitingForApproval,
+            supportsSnooze: true
+        )
+
+        let menu = ThreadSnoozeMenuModel.menu(
+            for: thread,
+            isArchived: false,
+            now: now,
+            calendar: calendar,
+            locale: locale
+        )
+        guard case let .presets(presets, enabled) = menu else {
+            Issue.record("Pending thread should keep a disabled Snooze menu")
+            return
+        }
+
+        #expect(presets.map(\.id) == ["hour", "evening", "tomorrow", "next-week"])
+        #expect(!enabled)
+    }
+
+    @Test
+    func capabilityAndQueuedGraceGateOnlyNewSnoozes() throws {
+        let calendar = calendar(timeZone: TimeZone(secondsFromGMT: 0)!)
+        let now = try date(
+            year: 2026,
+            month: 4,
+            day: 8,
+            hour: 10,
+            calendar: calendar
+        )
+        var thread = FeatureThread(
+            id: "thread-1",
+            projectID: "project-1",
+            title: "Capability",
+            state: .queued,
+            lastActivityAt: now.addingTimeInterval(-30),
+            supportsSnooze: false
+        )
+
+        #expect(!thread.canStartSnooze(at: now))
+        thread.supportsSnooze = true
+        #expect(!thread.canStartSnooze(at: now))
+        thread.lastActivityAt = now.addingTimeInterval(3 * 60)
+        #expect(!thread.canStartSnooze(at: now))
+        thread.lastActivityAt = now.addingTimeInterval(-3 * 60)
+        #expect(thread.canStartSnooze(at: now))
+
+        thread.state = .waitingForApproval
+        thread.snoozedUntil = now.addingTimeInterval(60 * 60)
+        #expect(ThreadSnoozeMenuModel.menu(
+            for: thread,
+            isArchived: false,
+            now: now,
+            calendar: calendar,
+            locale: locale
+        ) == .unsnooze)
+    }
+
+    private func calendar(timeZone: TimeZone) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
+    }
+
+    private func date(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int = 0,
+        calendar: Calendar
+    ) throws -> Date {
+        try #require(calendar.date(from: DateComponents(
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute
+        )))
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/ThreadTitleRegenerationMenuTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ThreadTitleRegenerationMenuTests.swift
@@ -1,0 +1,56 @@
+import Testing
+@testable import T3Code
+
+@Suite("Thread title regeneration menu")
+struct ThreadTitleRegenerationMenuTests {
+    @Test
+    func hidesWithoutCapabilityOrWhenArchived() {
+        let unsupported = FeatureThread(id: "thread", projectID: "project", title: "Title")
+        var archived = supportedThread()
+        archived.isArchived = true
+
+        #expect(ThreadTitleRegenerationMenuState.resolve(
+            thread: unsupported,
+            isArchived: false,
+            regeneratingThreadIDs: []
+        ) == .hidden)
+        #expect(ThreadTitleRegenerationMenuState.resolve(
+            thread: archived,
+            isArchived: true,
+            regeneratingThreadIDs: []
+        ) == .hidden)
+    }
+
+    @Test
+    func exposesAvailableAndRegeneratingStates() {
+        let thread = supportedThread()
+
+        #expect(ThreadTitleRegenerationMenuState.resolve(
+            thread: thread,
+            isArchived: false,
+            regeneratingThreadIDs: []
+        ) == .available)
+        #expect(ThreadTitleRegenerationMenuState.resolve(
+            thread: thread,
+            isArchived: false,
+            regeneratingThreadIDs: [thread.id]
+        ) == .regenerating)
+
+        var serverPending = thread
+        serverPending.isRegeneratingTitle = true
+        #expect(ThreadTitleRegenerationMenuState.resolve(
+            thread: serverPending,
+            isArchived: false,
+            regeneratingThreadIDs: []
+        ) == .regenerating)
+    }
+
+    private func supportedThread() -> FeatureThread {
+        FeatureThread(
+            id: "thread",
+            projectID: "project",
+            title: "Title",
+            supportsTitleRegeneration: true
+        )
+    }
+}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -8,6 +8,11 @@ On web and desktop, drag a pinned thread to change its position. On mobile, open
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.
 
+In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. A full
+swipe uses the lifecycle action, such as **Settle** or **Reopen**; it never deletes the thread.
+Deleting asks for confirmation. After settling a thread, use the temporary **Undo** message to
+return it to active work and restore its previous pin and snooze state.
+
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -9,7 +9,7 @@ and choose **Move up** or **Move down**. The order is stored by the server and a
 other connected devices.
 
 In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. A full
-swipe uses the lifecycle action, such as **Settle** or **Reopen**; it never deletes the thread.
+swipe settles or reopens a thread; it never deletes the thread.
 Deleting asks for confirmation. After settling a thread, use the temporary **Undo** message to
 return it to active work and restore its previous pin and snooze state.
 

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -8,8 +8,8 @@ On web and desktop, drag a pinned thread to change its position. On mobile, open
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.
 
-In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. A full
-swipe settles or reopens a thread; it never deletes the thread.
+In the native iPhone app, swipe a thread to reveal its lifecycle action and **Delete**. On rows
+that offer **Settle** or **Reopen**, a full swipe performs that action; it never deletes the thread.
 Deleting asks for confirmation. After settling a thread, use the temporary **Undo** message to
 return it to active work and restore its previous pin and snooze state.
 


### PR DESCRIPTION
## What changed

Adds capability-gated thread-title regeneration through the existing `thread.meta.update` contract. The row action is hidden for unsupported or archived threads, becomes a disabled `Regenerating…` state for the exact row while dispatch is active, rejects duplicate requests, refreshes native state, and surfaces dispatch failures.

This is the title-regeneration-only slice after #6136. It does not add Mark unread.

## Why

Native SwiftUI should expose the server's existing title-generation capability with truthful per-row progress and failure handling.

## Verification

- exact isolated commit: `340afc4b75518af9072d4a4029bc28d20fecd054`
- refreshed from `3cee91009ea394a524c44c72212c26c1b9606fdb` through repaired #6136; the isolated commit also incorporates reviewed correctness fixes
- successful unchanged/empty regeneration can no longer strand a row in `Regenerating…`; a failed follow-up refresh keeps duplicate dispatch gated until an authoritative row update; duplicate snapshot IDs no longer trap; the no-pending hot path avoids full-set/dictionary allocations
- older-history merging now preserves active `titleRegeneration` metadata
- stale title errors clear on deep-link navigation
- final focused copy/snooze/seed/title/root suites after the last Macroscope repair: 59 passed, 0 failed, 0 skipped
- `apps/swift-ios/Scripts/ci-test.sh`: 268 tests in 33 suites passed, 0 failed
- `node scripts/generate-swift-wire-fixtures.ts --check`: passed; `git diff --check`: passed
- direct read-only Claude Opus high review command (`claude --model opus --effort high --print ...`) exited 0 and produced nine candidates. Valid minimum-scope findings were applied and retested; the accepted disabled-preset submenu was preserved, and the inherited queued-turn model mismatch is documented rather than misrepresented.
- required fresh post-fix Opus retry exited 1 with `session limit · resets 3:50am`; no second review occurred and no second-review findings are claimed

## UI evidence

| Full menu | Per-row progress |
| --- | --- |
| ![Complete thread menu with capability- and state-gated actions](https://github.com/saphid/t3code/releases/download/pr-thread-menu-chain-evidence-20260812/after.jpg) | ![Regenerating title shown disabled on the exact row](https://github.com/saphid/t3code/releases/download/pr-thread-menu-chain-evidence-20260812/title-regenerating.jpg) |

| Snooze presets | State-specific reverse actions |
| --- | --- |
| ![Snooze preset submenu](https://github.com/saphid/t3code/releases/download/pr-thread-menu-chain-evidence-20260812/snooze-presets.jpg) | ![Snoozed menu exposing Unsnooze](https://github.com/saphid/t3code/releases/download/pr-thread-menu-chain-evidence-20260812/snoozed-actions.jpg) |

[Short interaction video](https://github.com/saphid/t3code/releases/download/pr-thread-menu-chain-evidence-20260812/interaction.mp4) · [all state images and provenance](https://github.com/saphid/t3code/releases/tag/pr-thread-menu-chain-evidence-20260812)

The exact-final Simulator build displayed New thread on branch, Rename, Regenerate title, Archive, Pin, Settle, Snooze/Unsnooze, all three copy actions, and destructive-styled Delete; Mark Unread was absent and Delete was not activated. The transient progress capture was timeboxed as requested: the immutable approved capture above remains the proof, and this exact-final run did not recapture that transient state.

## Review state

Keep this draft until the ordered parents land and the cumulative XL feature has maintainer alignment. Review this PR at the isolated commit above, then revalidate and simplify after each parent lands.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: chain
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: #6117, #6134, #6135, #6136
Merge order: #6117 → #6134 → #6135 → #6136 → #6137
Validation status: Exact-head relevant CI is green on `340afc4b75518af9072d4a4029bc28d20fecd054`, including Contract fixtures and native tests; Macroscope found no issues across 123 reviewed code objects. Revalidate after each parent lands. Vercel marketing is a fork-authorization failure, and CodeRabbit skipped automatic review.
<!-- swiftui-delivery:end -->

Implemented and verified by GPT-5.6 Sol in T3 Code using the Codex harness.
