### PR TITLE
fix(swift-ios): harden new task presentation lifecycle

### DIFF
--- a/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
+++ b/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
@@ -12,7 +12,6 @@ enum PlatformRoute: Codable, Hashable, Identifiable, Sendable {
     case project(environmentID: String?, projectID: String)
     case thread(environmentID: String?, threadID: String)
     case newTask(environmentID: String?, projectID: String?)
-    case incomingShare(id: String)
 
     var id: String {
         switch self {
@@ -26,8 +25,6 @@ enum PlatformRoute: Codable, Hashable, Identifiable, Sendable {
             "thread:\(environmentID ?? ""):\(threadID)"
         case let .newTask(environmentID, projectID):
             "new-task:\(environmentID ?? ""):\(projectID ?? "")"
-        case let .incomingShare(id):
-            "incoming-share:\(id)"
         }
     }
 
@@ -63,9 +60,6 @@ enum PlatformRoute: Codable, Hashable, Identifiable, Sendable {
                 environmentID.map { URLQueryItem(name: "environment", value: $0) },
                 projectID.map { URLQueryItem(name: "project", value: $0) },
             ].compactMap { $0 }
-        case let .incomingShare(id):
-            components.host = "share"
-            components.queryItems = [URLQueryItem(name: "id", value: id)]
         }
         return components.url
     }
@@ -180,15 +174,6 @@ enum PlatformDeepLinkParser {
                 environmentID: try queryEnvironment.map(validatedIdentifier),
                 projectID: try queryProject.map(validatedIdentifier)
             )
-        case "share", "incoming-share":
-            guard let rawID = tail.first ?? query["id"] else {
-                throw PlatformDeepLinkError.missingIdentifier
-            }
-            let id = try validatedIdentifier(rawID)
-            guard UUID(uuidString: id) != nil else {
-                throw PlatformDeepLinkError.invalidIdentifier
-            }
-            return .incomingShare(id: id.lowercased())
         default:
             if let queryThread {
                 return .thread(

--- a/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
+++ b/apps/swift-ios/App/Platform/PlatformDeepLinks.swift
@@ -12,6 +12,7 @@ enum PlatformRoute: Codable, Hashable, Identifiable, Sendable {
     case project(environmentID: String?, projectID: String)
     case thread(environmentID: String?, threadID: String)
     case newTask(environmentID: String?, projectID: String?)
+    case incomingShare(id: String)
 
     var id: String {
         switch self {
@@ -25,6 +26,8 @@ enum PlatformRoute: Codable, Hashable, Identifiable, Sendable {
             "thread:\(environmentID ?? ""):\(threadID)"
         case let .newTask(environmentID, projectID):
             "new-task:\(environmentID ?? ""):\(projectID ?? "")"
+        case let .incomingShare(id):
+            "incoming-share:\(id)"
         }
     }
 
@@ -60,6 +63,9 @@ enum PlatformRoute: Codable, Hashable, Identifiable, Sendable {
                 environmentID.map { URLQueryItem(name: "environment", value: $0) },
                 projectID.map { URLQueryItem(name: "project", value: $0) },
             ].compactMap { $0 }
+        case let .incomingShare(id):
+            components.host = "share"
+            components.queryItems = [URLQueryItem(name: "id", value: id)]
         }
         return components.url
     }
@@ -174,6 +180,15 @@ enum PlatformDeepLinkParser {
                 environmentID: try queryEnvironment.map(validatedIdentifier),
                 projectID: try queryProject.map(validatedIdentifier)
             )
+        case "share", "incoming-share":
+            guard let rawID = tail.first ?? query["id"] else {
+                throw PlatformDeepLinkError.missingIdentifier
+            }
+            let id = try validatedIdentifier(rawID)
+            guard UUID(uuidString: id) != nil else {
+                throw PlatformDeepLinkError.invalidIdentifier
+            }
+            return .incomingShare(id: id.lowercased())
         default:
             if let queryThread {
                 return .thread(

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -107,7 +107,7 @@ struct PlatformIncomingShareDraftImport: Sendable {
 
 struct PlatformIncomingShareImport: Sendable {
     let draft: FeatureComposerDraft
-    let sharedContent: FeatureComposerDraft?
+    let sharedContent: FeatureComposerIncomingShareDraft
 }
 
 struct PlatformIncomingShareDraftRepository: Sendable {
@@ -269,12 +269,12 @@ struct PlatformIncomingSharePipeline: Sendable {
         if removesEnvelope {
             try await source.remove(envelope.id)
         }
-        let sharedContent = imported.didImport
-            ? FeatureComposerDraft(text: sharedText, attachments: prepared)
-            : nil
         return PlatformIncomingShareImport(
             draft: imported.draft,
-            sharedContent: sharedContent
+            sharedContent: FeatureComposerIncomingShareDraft(
+                shareID: envelope.id,
+                draft: FeatureComposerDraft(text: sharedText, attachments: prepared)
+            )
         )
     }
 

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -107,7 +107,7 @@ struct PlatformIncomingShareDraftImport: Sendable {
 
 struct PlatformIncomingShareImport: Sendable {
     let draft: FeatureComposerDraft
-    let sharedContent: FeatureComposerIncomingShareDraft
+    let sharedContent: FeatureComposerIncomingShareDraft?
 }
 
 struct PlatformIncomingShareDraftRepository: Sendable {
@@ -271,10 +271,12 @@ struct PlatformIncomingSharePipeline: Sendable {
         }
         return PlatformIncomingShareImport(
             draft: imported.draft,
-            sharedContent: FeatureComposerIncomingShareDraft(
-                shareID: envelope.id,
-                draft: FeatureComposerDraft(text: sharedText, attachments: prepared)
-            )
+            sharedContent: imported.didImport
+                ? FeatureComposerIncomingShareDraft(
+                    shareID: envelope.id,
+                    draft: FeatureComposerDraft(text: sharedText, attachments: prepared)
+                )
+                : nil
         )
     }
 

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -434,6 +434,11 @@ final class PlatformIncomingShareCoordinator {
         pendingEnvelope = nil
     }
 
+    func requestAnotherDestination() {
+        guard !isImporting else { return }
+        pendingEnvelope?.destination = nil
+    }
+
     func importPending(into project: FeatureProject) async throws {
         guard let pendingEnvelope, !isImporting else { return }
         isImporting = true

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -437,6 +437,7 @@ final class PlatformIncomingShareCoordinator {
     private let pipeline: PlatformIncomingSharePipeline
     private var isRefreshing = false
     private var lastNoProjectNoticeID: String?
+    private var dismissedEnvelopeIDs: Set<String> = []
 
     init(pipeline: PlatformIncomingSharePipeline = PlatformIncomingSharePipeline()) {
         self.pipeline = pipeline
@@ -459,7 +460,9 @@ final class PlatformIncomingShareCoordinator {
                 $0.id.caseInsensitiveCompare(preferredID) == .orderedSame
             }
         } else {
-            pendingEnvelope = envelopes.first
+            pendingEnvelope = envelopes.first {
+                !dismissedEnvelopeIDs.contains($0.id.lowercased())
+            }
         }
         guard pendingEnvelope != nil,
               pendingEnvelope?.destination == nil,
@@ -469,6 +472,16 @@ final class PlatformIncomingShareCoordinator {
 
     func dismissDestination() {
         guard !isImporting else { return }
+        if let id = pendingEnvelope?.id {
+            dismissedEnvelopeIDs.insert(id.lowercased())
+        }
+        pendingEnvelope = nil
+    }
+
+    func dismissStagedNewThread(id: String) {
+        guard !isImporting,
+              pendingEnvelope?.id.caseInsensitiveCompare(id) == .orderedSame else { return }
+        dismissedEnvelopeIDs.insert(id.lowercased())
         pendingEnvelope = nil
     }
 

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -1,10 +1,17 @@
+import AVFoundation
+import CoreGraphics
 import Foundation
+import ImageIO
 import Observation
 import SwiftUI
+import UniformTypeIdentifiers
 
 enum PlatformIncomingShareError: LocalizedError, Equatable {
     case missingImage(String)
     case invalidImage(String)
+    case missingVideo(String)
+    case invalidVideo(String)
+    case unreadableVideo(String)
     case invalidEnvelope
 
     var errorDescription: String? {
@@ -13,6 +20,12 @@ enum PlatformIncomingShareError: LocalizedError, Equatable {
             "The shared image \(name) is no longer available. Share it again to retry."
         case let .invalidImage(name):
             "The shared image \(name) is incomplete or too large. Share it again to retry."
+        case let .missingVideo(name):
+            "The shared video \(name) is no longer available. Share it again to retry."
+        case let .invalidVideo(name):
+            "The shared video \(name) is incomplete or too large. Share it again to retry."
+        case let .unreadableVideo(name):
+            "T3 Code could not create representative frames from \(name)."
         case .invalidEnvelope:
             "This shared item is invalid. Share it again to retry."
         }
@@ -22,6 +35,9 @@ enum PlatformIncomingShareError: LocalizedError, Equatable {
 struct PlatformIncomingShareSource: Sendable {
     var loadAll: @Sendable () async -> [T3IncomingShareEnvelope]
     var data: @Sendable (T3IncomingShareImage) async throws -> Data
+    var videoURL: @Sendable (T3IncomingShareVideo) async throws -> URL = { video in
+        throw PlatformIncomingShareError.missingVideo(video.fileName)
+    }
     var remove: @Sendable (String) async throws -> Void
 
     static let live = PlatformIncomingShareSource(
@@ -48,6 +64,22 @@ struct PlatformIncomingShareSource: Sendable {
                 throw PlatformIncomingShareError.invalidImage(image.fileName)
             }
             return data
+        },
+        videoURL: { video in
+            guard let root = T3SharedContainer.rootURL?.standardizedFileURL,
+                  let url = T3IncomingShareStore.fileURL(for: video)?.standardizedFileURL,
+                  url.path.hasPrefix(root.path + "/") else {
+                throw PlatformIncomingShareError.missingVideo(video.fileName)
+            }
+            let values = try url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            guard values.isRegularFile == true,
+                  let byteCount = values.fileSize,
+                  byteCount > 0,
+                  byteCount <= T3IncomingShareStore.maximumVideoBytes,
+                  byteCount == video.byteCount else {
+                throw PlatformIncomingShareError.invalidVideo(video.fileName)
+            }
+            return url
         },
         remove: { id in
             guard UUID(uuidString: id) != nil else {
@@ -91,6 +123,11 @@ struct PlatformIncomingSharePipeline: Sendable {
     private let source: PlatformIncomingShareSource
     private let drafts: PlatformIncomingShareDraftRepository
     private let prepareImage: @Sendable (Data, Int) async throws -> FeatureDraftAttachment
+    private let prepareVideo: @Sendable (
+        URL,
+        T3IncomingShareVideo,
+        Int
+    ) async throws -> FeatureDraftAttachment
 
     init(
         source: PlatformIncomingShareSource = .live,
@@ -101,11 +138,23 @@ struct PlatformIncomingSharePipeline: Sendable {
             try await Task.detached(priority: .userInitiated) {
                 try FeatureImageProcessor.attachment(from: data, ordinal: ordinal)
             }.value
+        },
+        prepareVideo: @escaping @Sendable (
+            URL,
+            T3IncomingShareVideo,
+            Int
+        ) async throws -> FeatureDraftAttachment = { url, video, ordinal in
+            try await PlatformSharedVideoProcessor.contactSheetAttachment(
+                videoURL: url,
+                video: video,
+                ordinal: ordinal
+            )
         }
     ) {
         self.source = source
         self.drafts = drafts
         self.prepareImage = prepareImage
+        self.prepareVideo = prepareVideo
     }
 
     func pendingEnvelopes() async -> [T3IncomingShareEnvelope] {
@@ -116,12 +165,48 @@ struct PlatformIncomingSharePipeline: Sendable {
         _ envelope: T3IncomingShareEnvelope,
         into project: FeatureProject
     ) async throws -> FeatureComposerDraft {
+        try await importEnvelope(
+            envelope,
+            draftKey: FeatureComposerDraftStore.newTaskKey(project: project),
+            removesEnvelope: true
+        )
+    }
+
+    func importEnvelope(
+        _ envelope: T3IncomingShareEnvelope,
+        into thread: FeatureThread
+    ) async throws -> FeatureComposerDraft {
+        try await importEnvelope(
+            envelope,
+            draftKey: FeatureComposerDraftStore.threadKey(thread),
+            removesEnvelope: true
+        )
+    }
+
+    func stageEnvelopeForNewThread(
+        _ envelope: T3IncomingShareEnvelope
+    ) async throws -> FeatureComposerDraft {
+        try await importEnvelope(
+            envelope,
+            draftKey: FeatureComposerDraftStore.incomingShareKey(shareID: envelope.id),
+            removesEnvelope: false
+        )
+    }
+
+    func acknowledgeEnvelope(id: String) async throws {
+        try await source.remove(id)
+    }
+
+    private func importEnvelope(
+        _ envelope: T3IncomingShareEnvelope,
+        draftKey: String,
+        removesEnvelope: Bool
+    ) async throws -> FeatureComposerDraft {
         guard UUID(uuidString: envelope.id) != nil else {
             throw PlatformIncomingShareError.invalidEnvelope
         }
-        let key = FeatureComposerDraftStore.newTaskKey(project: project)
         var prepared: [FeatureDraftAttachment] = []
-        prepared.reserveCapacity(envelope.images.count)
+        prepared.reserveCapacity(envelope.images.count + envelope.videos.count)
         for (offset, image) in envelope.images.enumerated() {
             let data = try await source.data(image)
             let attachment = try await prepareImage(
@@ -131,18 +216,38 @@ struct PlatformIncomingSharePipeline: Sendable {
             prepared.append(Self.stableAttachment(attachment, for: image))
         }
 
+        for (offset, video) in envelope.videos.enumerated() {
+            let url = try await source.videoURL(video)
+            let attachment = try await prepareVideo(
+                url,
+                video,
+                envelope.images.count + offset + 1
+            )
+            prepared.append(Self.stableAttachment(attachment, for: video))
+        }
+
         let merged = try await drafts.importContent(
             envelope.id,
-            envelope.text,
+            Self.composerText(for: envelope),
             prepared,
-            key,
+            draftKey,
             Self.maximumAttachmentCount
         )
 
         // The repository's actor operation atomically merges the latest draft
         // and records the share ID. Never acknowledge the inbox before it ends.
-        try await source.remove(envelope.id)
+        if removesEnvelope {
+            try await source.remove(envelope.id)
+        }
         return merged
+    }
+
+    private static func composerText(for envelope: T3IncomingShareEnvelope) -> String {
+        var fragments = [envelope.text].filter { !$0.isEmpty }
+        fragments.append(contentsOf: envelope.videos.map { video in
+            "Shared video: \(video.fileName) (representative frames attached as a contact sheet)."
+        })
+        return fragments.joined(separator: "\n\n")
     }
 
     private static func stableAttachment(
@@ -156,6 +261,132 @@ struct PlatformIncomingSharePipeline: Sendable {
             filename: attachment.filename,
             mimeType: attachment.mimeType
         )
+    }
+
+    private static func stableAttachment(
+        _ attachment: FeatureDraftAttachment,
+        for video: T3IncomingShareVideo
+    ) -> FeatureDraftAttachment {
+        FeatureDraftAttachment(
+            id: UUID(uuidString: video.id) ?? attachment.id,
+            data: attachment.data,
+            thumbnailData: attachment.thumbnailData,
+            filename: attachment.filename,
+            mimeType: attachment.mimeType
+        )
+    }
+}
+
+enum PlatformSharedVideoProcessor {
+    private static let frameCount = 6
+    private static let cellSize = CGSize(width: 640, height: 360)
+
+    static func contactSheetAttachment(
+        videoURL: URL,
+        video: T3IncomingShareVideo,
+        ordinal: Int
+    ) async throws -> FeatureDraftAttachment {
+        let data = try await Task.detached(priority: .userInitiated) {
+            let asset = AVURLAsset(url: videoURL)
+            let duration = try await asset.load(.duration)
+            let seconds = duration.seconds
+            guard seconds.isFinite, seconds > 0 else {
+                throw PlatformIncomingShareError.unreadableVideo(video.fileName)
+            }
+
+            let generator = AVAssetImageGenerator(asset: asset)
+            generator.appliesPreferredTrackTransform = true
+            generator.maximumSize = cellSize
+            generator.requestedTimeToleranceBefore = CMTime(seconds: 0.25, preferredTimescale: 600)
+            generator.requestedTimeToleranceAfter = CMTime(seconds: 0.25, preferredTimescale: 600)
+
+            let fractions = (0..<frameCount).map {
+                (Double($0) + 0.5) / Double(frameCount)
+            }
+            var frames: [CGImage] = []
+            for fraction in fractions {
+                try Task.checkCancellation()
+                let time = CMTime(seconds: seconds * fraction, preferredTimescale: 600)
+                if let image = try? generator.copyCGImage(at: time, actualTime: nil) {
+                    frames.append(image)
+                }
+            }
+            guard !frames.isEmpty else {
+                throw PlatformIncomingShareError.unreadableVideo(video.fileName)
+            }
+            return try jpegContactSheet(frames: frames)
+        }.value
+
+        return try FeatureImageProcessor.attachment(from: data, ordinal: ordinal)
+    }
+
+    private static func jpegContactSheet(frames: [CGImage]) throws -> Data {
+        let columns = min(2, frames.count)
+        let rows = Int(ceil(Double(frames.count) / Double(columns)))
+        let width = Int(cellSize.width) * columns
+        let height = Int(cellSize.height) * rows
+        guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+              let context = CGContext(
+                  data: nil,
+                  width: width,
+                  height: height,
+                  bitsPerComponent: 8,
+                  bytesPerRow: 0,
+                  space: colorSpace,
+                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else {
+            throw PlatformIncomingShareError.invalidEnvelope
+        }
+
+        context.setFillColor(CGColor(gray: 0.04, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        for (index, frame) in frames.enumerated() {
+            let column = index % columns
+            let row = rows - 1 - (index / columns)
+            let cell = CGRect(
+                x: CGFloat(column) * cellSize.width,
+                y: CGFloat(row) * cellSize.height,
+                width: cellSize.width,
+                height: cellSize.height
+            )
+            let scale = min(
+                cell.width / CGFloat(frame.width),
+                cell.height / CGFloat(frame.height)
+            )
+            let size = CGSize(
+                width: CGFloat(frame.width) * scale,
+                height: CGFloat(frame.height) * scale
+            )
+            let frameRect = CGRect(
+                x: cell.midX - size.width / 2,
+                y: cell.midY - size.height / 2,
+                width: size.width,
+                height: size.height
+            )
+            context.draw(frame, in: frameRect)
+        }
+
+        guard let image = context.makeImage() else {
+            throw PlatformIncomingShareError.invalidEnvelope
+        }
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            throw PlatformIncomingShareError.invalidEnvelope
+        }
+        CGImageDestinationAddImage(
+            destination,
+            image,
+            [kCGImageDestinationLossyCompressionQuality: 0.82] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(destination) else {
+            throw PlatformIncomingShareError.invalidEnvelope
+        }
+        return data as Data
     }
 }
 
@@ -175,17 +406,26 @@ final class PlatformIncomingShareCoordinator {
 
     /// Returns true once per pending envelope when the app cannot offer a
     /// destination. The envelope remains in the shared container.
-    func refresh(hasProjects: Bool) async -> Bool {
+    func refresh(preferredID: String? = nil, hasProjects: Bool) async -> Bool {
         guard pendingEnvelope == nil, !isRefreshing, !isImporting else {
             return pendingEnvelope != nil
+                && pendingEnvelope?.destination == nil
                 && !hasProjects
                 && markNoProjectNoticeIfNeeded()
         }
         isRefreshing = true
         let envelopes = await pipeline.pendingEnvelopes()
         isRefreshing = false
-        pendingEnvelope = envelopes.first
-        guard pendingEnvelope != nil, !hasProjects else { return false }
+        if let preferredID {
+            pendingEnvelope = envelopes.first {
+                $0.id.caseInsensitiveCompare(preferredID) == .orderedSame
+            }
+        } else {
+            pendingEnvelope = envelopes.first
+        }
+        guard pendingEnvelope != nil,
+              pendingEnvelope?.destination == nil,
+              !hasProjects else { return false }
         return markNoProjectNoticeIfNeeded()
     }
 
@@ -206,6 +446,41 @@ final class PlatformIncomingShareCoordinator {
             isImporting = false
             throw error
         }
+    }
+
+    func importPending(into thread: FeatureThread) async throws {
+        guard let pendingEnvelope, !isImporting else { return }
+        isImporting = true
+        do {
+            _ = try await pipeline.importEnvelope(pendingEnvelope, into: thread)
+            self.pendingEnvelope = nil
+            lastNoProjectNoticeID = nil
+            isImporting = false
+        } catch {
+            isImporting = false
+            throw error
+        }
+    }
+
+    func stagePendingForNewThread() async throws -> String? {
+        guard let pendingEnvelope, !isImporting else { return nil }
+        isImporting = true
+        do {
+            _ = try await pipeline.stageEnvelopeForNewThread(pendingEnvelope)
+            isImporting = false
+            return pendingEnvelope.id
+        } catch {
+            isImporting = false
+            throw error
+        }
+    }
+
+    func acknowledgeStagedNewThread(id: String) async throws {
+        try await pipeline.acknowledgeEnvelope(id: id)
+        if pendingEnvelope?.id.caseInsensitiveCompare(id) == .orderedSame {
+            pendingEnvelope = nil
+        }
+        lastNoProjectNoticeID = nil
     }
 
     private func markNoProjectNoticeIfNeeded() -> Bool {
@@ -305,12 +580,18 @@ struct PlatformIncomingShareDestinationSheet: View {
     }
 
     private var summary: String {
-        if !envelope.text.isEmpty, !envelope.images.isEmpty {
-            return "\(envelope.text)\n\(envelope.images.count) image\(envelope.images.count == 1 ? "" : "s")"
+        var fragments = [envelope.text].filter { !$0.isEmpty }
+        if !envelope.images.isEmpty {
+            fragments.append(
+                "\(envelope.images.count) image\(envelope.images.count == 1 ? "" : "s")"
+            )
         }
-        if !envelope.text.isEmpty { return envelope.text }
-        guard !envelope.images.isEmpty else { return "" }
-        return "\(envelope.images.count) shared image\(envelope.images.count == 1 ? "" : "s")"
+        if !envelope.videos.isEmpty {
+            fragments.append(
+                "\(envelope.videos.count) video\(envelope.videos.count == 1 ? "" : "s")"
+            )
+        }
+        return fragments.joined(separator: "\n")
     }
 
     private func environmentName(for project: FeatureProject) -> String? {

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -39,6 +39,14 @@ struct PlatformIncomingShareSource: Sendable {
         throw PlatformIncomingShareError.missingVideo(video.fileName)
     }
     var remove: @Sendable (String) async throws -> Void
+    var updateDestination: @Sendable (
+        String,
+        T3IncomingShareDestination?
+    ) async throws -> Void = { id, destination in
+        try await Task.detached(priority: .utility) {
+            try T3IncomingShareStore.updateDestination(id: id, destination: destination)
+        }.value
+    }
 
     static let live = PlatformIncomingShareSource(
         loadAll: {
@@ -195,6 +203,13 @@ struct PlatformIncomingSharePipeline: Sendable {
 
     func acknowledgeEnvelope(id: String) async throws {
         try await source.remove(id)
+    }
+
+    func updateDestination(
+        id: String,
+        destination: T3IncomingShareDestination?
+    ) async throws {
+        try await source.updateDestination(id, destination)
     }
 
     private func importEnvelope(
@@ -434,8 +449,10 @@ final class PlatformIncomingShareCoordinator {
         pendingEnvelope = nil
     }
 
-    func requestAnotherDestination() {
+    func requestAnotherDestination() async throws {
         guard !isImporting else { return }
+        guard let id = pendingEnvelope?.id else { return }
+        try await pipeline.updateDestination(id: id, destination: nil)
         pendingEnvelope?.destination = nil
     }
 

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -329,13 +329,13 @@ enum PlatformSharedVideoProcessor {
             guard !frames.isEmpty else {
                 throw PlatformIncomingShareError.unreadableVideo(video.fileName)
             }
-            return try jpegContactSheet(frames: frames)
+            return try jpegContactSheet(frames: frames, videoName: video.fileName)
         }.value
 
         return try FeatureImageProcessor.attachment(from: data, ordinal: ordinal)
     }
 
-    private static func jpegContactSheet(frames: [CGImage]) throws -> Data {
+    private static func jpegContactSheet(frames: [CGImage], videoName: String) throws -> Data {
         let columns = min(2, frames.count)
         let rows = Int(ceil(Double(frames.count) / Double(columns)))
         let width = Int(cellSize.width) * columns
@@ -350,7 +350,7 @@ enum PlatformSharedVideoProcessor {
                   space: colorSpace,
                   bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
               ) else {
-            throw PlatformIncomingShareError.invalidEnvelope
+            throw PlatformIncomingShareError.unreadableVideo(videoName)
         }
 
         context.setFillColor(CGColor(gray: 0.04, alpha: 1))
@@ -382,7 +382,7 @@ enum PlatformSharedVideoProcessor {
         }
 
         guard let image = context.makeImage() else {
-            throw PlatformIncomingShareError.invalidEnvelope
+            throw PlatformIncomingShareError.unreadableVideo(videoName)
         }
         let data = NSMutableData()
         guard let destination = CGImageDestinationCreateWithData(
@@ -391,7 +391,7 @@ enum PlatformSharedVideoProcessor {
             1,
             nil
         ) else {
-            throw PlatformIncomingShareError.invalidEnvelope
+            throw PlatformIncomingShareError.unreadableVideo(videoName)
         }
         CGImageDestinationAddImage(
             destination,
@@ -399,7 +399,7 @@ enum PlatformSharedVideoProcessor {
             [kCGImageDestinationLossyCompressionQuality: 0.82] as CFDictionary
         )
         guard CGImageDestinationFinalize(destination) else {
-            throw PlatformIncomingShareError.invalidEnvelope
+            throw PlatformIncomingShareError.unreadableVideo(videoName)
         }
         return data as Data
     }

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -100,6 +100,16 @@ struct PlatformIncomingShareSource: Sendable {
     )
 }
 
+struct PlatformIncomingShareDraftImport: Sendable {
+    let draft: FeatureComposerDraft
+    let didImport: Bool
+}
+
+struct PlatformIncomingShareImport: Sendable {
+    let draft: FeatureComposerDraft
+    let sharedContent: FeatureComposerDraft?
+}
+
 struct PlatformIncomingShareDraftRepository: Sendable {
     var importContent: @Sendable (
         _ shareID: String,
@@ -107,16 +117,20 @@ struct PlatformIncomingShareDraftRepository: Sendable {
         _ attachments: [FeatureDraftAttachment],
         _ key: String,
         _ maximumAttachmentCount: Int
-    ) async throws -> FeatureComposerDraft
+    ) async throws -> PlatformIncomingShareDraftImport
 
     static let live = PlatformIncomingShareDraftRepository(
         importContent: { shareID, text, attachments, key, maximumAttachmentCount in
-            try await FeatureComposerDraftStore.shared.importSharedContent(
+            let result = try await FeatureComposerDraftStore.shared.importSharedContentResult(
                 shareID: shareID,
                 text: text,
                 attachments: attachments,
                 for: key,
                 maximumAttachmentCount: maximumAttachmentCount
+            )
+            return PlatformIncomingShareDraftImport(
+                draft: result.draft,
+                didImport: result.didImport
             )
         }
     )
@@ -177,13 +191,13 @@ struct PlatformIncomingSharePipeline: Sendable {
             envelope,
             draftKey: FeatureComposerDraftStore.newTaskKey(project: project),
             removesEnvelope: true
-        )
+        ).draft
     }
 
     func importEnvelope(
         _ envelope: T3IncomingShareEnvelope,
         into thread: FeatureThread
-    ) async throws -> FeatureComposerDraft {
+    ) async throws -> PlatformIncomingShareImport {
         try await importEnvelope(
             envelope,
             draftKey: FeatureComposerDraftStore.threadKey(thread),
@@ -198,7 +212,7 @@ struct PlatformIncomingSharePipeline: Sendable {
             envelope,
             draftKey: FeatureComposerDraftStore.incomingShareKey(shareID: envelope.id),
             removesEnvelope: false
-        )
+        ).draft
     }
 
     func acknowledgeEnvelope(id: String) async throws {
@@ -216,7 +230,7 @@ struct PlatformIncomingSharePipeline: Sendable {
         _ envelope: T3IncomingShareEnvelope,
         draftKey: String,
         removesEnvelope: Bool
-    ) async throws -> FeatureComposerDraft {
+    ) async throws -> PlatformIncomingShareImport {
         guard UUID(uuidString: envelope.id) != nil else {
             throw PlatformIncomingShareError.invalidEnvelope
         }
@@ -241,9 +255,10 @@ struct PlatformIncomingSharePipeline: Sendable {
             prepared.append(Self.stableAttachment(attachment, for: video))
         }
 
-        let merged = try await drafts.importContent(
+        let sharedText = Self.composerText(for: envelope)
+        let imported = try await drafts.importContent(
             envelope.id,
-            Self.composerText(for: envelope),
+            sharedText,
             prepared,
             draftKey,
             Self.maximumAttachmentCount
@@ -254,7 +269,13 @@ struct PlatformIncomingSharePipeline: Sendable {
         if removesEnvelope {
             try await source.remove(envelope.id)
         }
-        return merged
+        let sharedContent = imported.didImport
+            ? FeatureComposerDraft(text: sharedText, attachments: prepared)
+            : nil
+        return PlatformIncomingShareImport(
+            draft: imported.draft,
+            sharedContent: sharedContent
+        )
     }
 
     private static func composerText(for envelope: T3IncomingShareEnvelope) -> String {
@@ -470,15 +491,15 @@ final class PlatformIncomingShareCoordinator {
         }
     }
 
-    func importPending(into thread: FeatureThread) async throws -> FeatureComposerDraft? {
+    func importPending(into thread: FeatureThread) async throws -> PlatformIncomingShareImport? {
         guard let pendingEnvelope, !isImporting else { return nil }
         isImporting = true
         do {
-            let draft = try await pipeline.importEnvelope(pendingEnvelope, into: thread)
+            let imported = try await pipeline.importEnvelope(pendingEnvelope, into: thread)
             self.pendingEnvelope = nil
             lastNoProjectNoticeID = nil
             isImporting = false
-            return draft
+            return imported
         } catch {
             isImporting = false
             throw error

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -470,14 +470,15 @@ final class PlatformIncomingShareCoordinator {
         }
     }
 
-    func importPending(into thread: FeatureThread) async throws {
-        guard let pendingEnvelope, !isImporting else { return }
+    func importPending(into thread: FeatureThread) async throws -> FeatureComposerDraft? {
+        guard let pendingEnvelope, !isImporting else { return nil }
         isImporting = true
         do {
-            _ = try await pipeline.importEnvelope(pendingEnvelope, into: thread)
+            let draft = try await pipeline.importEnvelope(pendingEnvelope, into: thread)
             self.pendingEnvelope = nil
             lastNoProjectNoticeID = nil
             isImporting = false
+            return draft
         } catch {
             isImporting = false
             throw error

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -247,7 +247,7 @@ struct PlatformRootView: View {
                 }
                 try await incomingShareCoordinator.importPending(into: thread)
                 navigationRequest = FeatureWorkspaceNavigationRequest(
-                    destination: .thread(id: thread.id)
+                    destination: .sharedThread(id: thread.id)
                 )
             }
             PlatformHapticEngine.shared.emit(

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -296,7 +296,7 @@ struct PlatformRootView: View {
                 navigationRequest = FeatureWorkspaceNavigationRequest(
                     destination: .sharedThread(
                         id: thread.id,
-                        draft: imported.sharedContent
+                        importDraft: imported.sharedContent
                     )
                 )
             }

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -241,7 +241,7 @@ struct PlatformRootView: View {
                           environmentID: destination.environmentID,
                           id: threadID
                       ) else {
-                    incomingShareCoordinator.requestAnotherDestination()
+                    try await incomingShareCoordinator.requestAnotherDestination()
                     model.errorMessage = "That thread is no longer available. Choose another destination."
                     return
                 }

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -1,5 +1,22 @@
 import SwiftUI
 
+@MainActor
+final class PlatformIncomingShareRoutingGate {
+    private var isRouting = false
+    private var pendingOperation: (@MainActor () async -> Void)?
+
+    func request(_ operation: @escaping @MainActor () async -> Void) async {
+        pendingOperation = operation
+        guard !isRouting else { return }
+        isRouting = true
+        while let operation = pendingOperation {
+            pendingOperation = nil
+            await operation()
+        }
+        isRouting = false
+    }
+}
+
 struct PlatformRootView: View {
     @SwiftUI.Environment(\.scenePhase) private var scenePhase
     @Bindable private var model: FeatureRootModel
@@ -12,6 +29,7 @@ struct PlatformRootView: View {
     @State private var incomingShareNeedsProject = false
     @State private var importedShareProjectID: String?
     @State private var stagedIncomingShareID: String?
+    @State private var incomingShareRoutingGate = PlatformIncomingShareRoutingGate()
     @State private var recentThreadsPersistenceTask: Task<Void, Never>?
 
     init(model: FeatureRootModel) {
@@ -228,6 +246,12 @@ struct PlatformRootView: View {
 
     @MainActor
     private func routePendingIncomingShareIfNeeded() async {
+        await incomingShareRoutingGate.request {
+            await performPendingIncomingShareRoute()
+        }
+    }
+
+    private func performPendingIncomingShareRoute() async {
         guard let envelope = incomingShareCoordinator.pendingEnvelope,
               let destination = envelope.destination,
               stagedIncomingShareID != envelope.id else { return }
@@ -266,11 +290,14 @@ struct PlatformRootView: View {
                     model.errorMessage = "That thread is no longer available. Choose another destination."
                     return
                 }
-                guard let importedDraft = try await incomingShareCoordinator.importPending(
+                guard let imported = try await incomingShareCoordinator.importPending(
                     into: thread
                 ) else { return }
                 navigationRequest = FeatureWorkspaceNavigationRequest(
-                    destination: .sharedThread(id: thread.id, draft: importedDraft)
+                    destination: .sharedThread(
+                        id: thread.id,
+                        draft: imported.sharedContent
+                    )
                 )
             }
             PlatformHapticEngine.shared.emit(

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -11,6 +11,7 @@ struct PlatformRootView: View {
     @State private var incomingShareCoordinator = PlatformIncomingShareCoordinator()
     @State private var incomingShareNeedsProject = false
     @State private var importedShareProjectID: String?
+    @State private var stagedIncomingShareID: String?
     @State private var recentThreadsPersistenceTask: Task<Void, Never>?
 
     init(model: FeatureRootModel) {
@@ -24,6 +25,14 @@ struct PlatformRootView: View {
             onNavigationRequestConsumed: { requestID in
                 guard navigationRequest?.id == requestID else { return }
                 navigationRequest = nil
+            },
+            acknowledgeIncomingShare: { shareID in
+                await acknowledgeStagedIncomingShare(id: shareID)
+            },
+            releaseIncomingSharePresentation: { shareID in
+                if stagedIncomingShareID?.caseInsensitiveCompare(shareID) == .orderedSame {
+                    stagedIncomingShareID = nil
+                }
             }
         )
         .onOpenURL { url in
@@ -106,6 +115,9 @@ struct PlatformRootView: View {
         Binding(
             get: {
                 guard !incomingShareProjects.isEmpty else { return nil }
+                guard incomingShareCoordinator.pendingEnvelope?.destination == nil else {
+                    return nil
+                }
                 return incomingShareCoordinator.pendingEnvelope
             },
             set: { value in
@@ -190,13 +202,70 @@ struct PlatformRootView: View {
         )
     }
 
-    private func refreshIncomingShares() {
+    private func refreshIncomingShares(preferredID: String? = nil) {
         guard !model.isLoading else { return }
         let hasProjects = !incomingShareProjects.isEmpty
         Task { @MainActor in
-            if await incomingShareCoordinator.refresh(hasProjects: hasProjects) {
+            if await incomingShareCoordinator.refresh(
+                preferredID: preferredID,
+                hasProjects: hasProjects
+            ) {
                 incomingShareNeedsProject = true
             }
+            await routePendingIncomingShareIfNeeded()
+        }
+    }
+
+    @MainActor
+    private func routePendingIncomingShareIfNeeded() async {
+        guard let envelope = incomingShareCoordinator.pendingEnvelope,
+              let destination = envelope.destination,
+              stagedIncomingShareID != envelope.id else { return }
+        do {
+            switch destination.kind {
+            case .newThread:
+                guard let shareID = try await incomingShareCoordinator.stagePendingForNewThread()
+                else { return }
+                stagedIncomingShareID = shareID
+                navigationRequest = FeatureWorkspaceNavigationRequest(
+                    destination: .sharedNewTask(shareID: shareID)
+                )
+            case .existingThread:
+                guard let threadID = destination.threadID,
+                      await activateEnvironmentIfNeeded(destination.environmentID),
+                      let thread = PlatformRouteResolver.thread(
+                          in: model.snapshot,
+                          environmentID: destination.environmentID,
+                          id: threadID
+                      ) else {
+                    if model.errorMessage == nil {
+                        model.errorMessage = "That thread is no longer available. Choose another destination by sharing again."
+                    }
+                    return
+                }
+                try await incomingShareCoordinator.importPending(into: thread)
+                navigationRequest = FeatureWorkspaceNavigationRequest(
+                    destination: .thread(id: thread.id)
+                )
+            }
+            PlatformHapticEngine.shared.emit(
+                .success,
+                enabled: model.snapshot.settings.hapticsEnabled
+            )
+        } catch {
+            model.errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func acknowledgeStagedIncomingShare(id: String) async {
+        do {
+            try await incomingShareCoordinator.acknowledgeStagedNewThread(id: id)
+            if stagedIncomingShareID?.caseInsensitiveCompare(id) == .orderedSame {
+                stagedIncomingShareID = nil
+            }
+        } catch {
+            model.errorMessage = error.localizedDescription
         }
     }
 
@@ -293,6 +362,8 @@ struct PlatformRootView: View {
             PlatformHapticEngine.shared.selection(
                 enabled: model.snapshot.settings.hapticsEnabled
             )
+        case let .incomingShare(id):
+            refreshIncomingShares(preferredID: id)
         }
     }
 

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -241,9 +241,8 @@ struct PlatformRootView: View {
                           environmentID: destination.environmentID,
                           id: threadID
                       ) else {
-                    if model.errorMessage == nil {
-                        model.errorMessage = "That thread is no longer available. Choose another destination by sharing again."
-                    }
+                    incomingShareCoordinator.requestAnotherDestination()
+                    model.errorMessage = "That thread is no longer available. Choose another destination."
                     return
                 }
                 try await incomingShareCoordinator.importPending(into: thread)
@@ -365,8 +364,6 @@ struct PlatformRootView: View {
             PlatformHapticEngine.shared.selection(
                 enabled: model.snapshot.settings.hapticsEnabled
             )
-        case let .incomingShare(id):
-            refreshIncomingShares(preferredID: id)
         }
     }
 

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -234,13 +234,27 @@ struct PlatformRootView: View {
                     destination: .sharedNewTask(shareID: shareID)
                 )
             case .existingThread:
-                guard let threadID = destination.threadID,
-                      await activateEnvironmentIfNeeded(destination.environmentID),
-                      let thread = PlatformRouteResolver.thread(
-                          in: model.snapshot,
-                          environmentID: destination.environmentID,
-                          id: threadID
-                      ) else {
+                guard let threadID = destination.threadID else {
+                    try await incomingShareCoordinator.requestAnotherDestination()
+                    model.errorMessage = "That thread is no longer available. Choose another destination."
+                    return
+                }
+                if let environmentID = destination.environmentID,
+                   !model.snapshot.environments.contains(where: { $0.id == environmentID }) {
+                    try await incomingShareCoordinator.requestAnotherDestination()
+                    model.errorMessage = "That thread's environment is no longer saved. Choose another destination."
+                    return
+                }
+                guard await activateEnvironmentIfNeeded(destination.environmentID) else {
+                    // Keep the saved destination so a temporarily unavailable
+                    // environment can retry when its connection recovers.
+                    return
+                }
+                guard let thread = PlatformRouteResolver.thread(
+                    in: model.snapshot,
+                    environmentID: destination.environmentID,
+                    id: threadID
+                ) else {
                     try await incomingShareCoordinator.requestAnotherDestination()
                     model.errorMessage = "That thread is no longer available. Choose another destination."
                     return

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -83,6 +83,13 @@ struct PlatformRootView: View {
         .onChange(of: model.snapshot.projects.map(\.id)) { _, _ in
             refreshIncomingShares()
         }
+        .onChange(of: incomingShareConnectionStates) { _, _ in
+            guard incomingShareCoordinator.pendingEnvelope?.destination?.kind == .existingThread,
+                  !incomingShareCoordinator.isImporting else { return }
+            Task { @MainActor in
+                await routePendingIncomingShareIfNeeded()
+            }
+        }
         .sheet(item: presentedIncomingShare, onDismiss: openImportedShareDraft) { envelope in
             PlatformIncomingShareDestinationSheet(
                 envelope: envelope,
@@ -259,9 +266,11 @@ struct PlatformRootView: View {
                     model.errorMessage = "That thread is no longer available. Choose another destination."
                     return
                 }
-                try await incomingShareCoordinator.importPending(into: thread)
+                guard let importedDraft = try await incomingShareCoordinator.importPending(
+                    into: thread
+                ) else { return }
                 navigationRequest = FeatureWorkspaceNavigationRequest(
-                    destination: .sharedThread(id: thread.id)
+                    destination: .sharedThread(id: thread.id, draft: importedDraft)
                 )
             }
             PlatformHapticEngine.shared.emit(
@@ -390,6 +399,11 @@ struct PlatformRootView: View {
         }
         guard !environment.isEnabled else { return true }
         return await model.setEnvironmentEnabled(id, enabled: true)
+    }
+
+    private var incomingShareConnectionStates: [FeatureConnection.State?] {
+        [model.snapshot.connection.state]
+            + model.snapshot.environments.map(\.connectionState)
     }
 
     /// Home revisions are coalesced by FeatureRootModel, so this performs one

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -77,6 +77,9 @@ struct PlatformRootView: View {
             synchronizeAgentAwareness()
             synchronizeCloudDelivery()
         }
+        .onChange(of: model.snapshot.settings.appearance, initial: true) { _, appearance in
+            T3SharedAppearanceStore.shared.update(appearance.sharedAppearance)
+        }
         .onChange(of: model.snapshot.projects.map(\.id)) { _, _ in
             refreshIncomingShares()
         }
@@ -414,5 +417,15 @@ struct PlatformRootView: View {
             snapshot: model.snapshot,
             liveActivitiesEnabled: model.snapshot.settings.liveActivitiesEnabled
         )
+    }
+}
+
+private extension FeatureAppearance {
+    var sharedAppearance: T3SharedAppearance {
+        switch self {
+        case .system: .system
+        case .light: .light
+        case .dark: .dark
+        }
     }
 }

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -17,6 +17,12 @@ final class PlatformIncomingShareRoutingGate {
     }
 }
 
+enum PlatformIncomingShareDestinationConnectionPolicy {
+    static func canResolveThread(connectionState: FeatureConnection.State?) -> Bool {
+        connectionState == .connected
+    }
+}
+
 struct PlatformRootView: View {
     @SwiftUI.Environment(\.scenePhase) private var scenePhase
     @Bindable private var model: FeatureRootModel
@@ -281,6 +287,11 @@ struct PlatformRootView: View {
                     // environment can retry when its connection recovers.
                     return
                 }
+                guard incomingShareDestinationIsConnected(destination.environmentID) else {
+                    // A disconnected snapshot cannot authoritatively prove that
+                    // the saved thread disappeared. Keep it queued for retry.
+                    return
+                }
                 guard let thread = PlatformRouteResolver.thread(
                     in: model.snapshot,
                     environmentID: destination.environmentID,
@@ -310,14 +321,16 @@ struct PlatformRootView: View {
     }
 
     @MainActor
-    private func acknowledgeStagedIncomingShare(id: String) async {
+    private func acknowledgeStagedIncomingShare(id: String) async -> Bool {
         do {
             try await incomingShareCoordinator.acknowledgeStagedNewThread(id: id)
             if stagedIncomingShareID?.caseInsensitiveCompare(id) == .orderedSame {
                 stagedIncomingShareID = nil
             }
+            return true
         } catch {
             model.errorMessage = error.localizedDescription
+            return false
         }
     }
 
@@ -426,6 +439,15 @@ struct PlatformRootView: View {
         }
         guard !environment.isEnabled else { return true }
         return await model.setEnvironmentEnabled(id, enabled: true)
+    }
+
+    private func incomingShareDestinationIsConnected(_ id: String?) -> Bool {
+        let state = id.flatMap { environmentID in
+            model.snapshot.environments.first(where: { $0.id == environmentID })?.connectionState
+        } ?? (id == nil ? model.snapshot.connection.state : nil)
+        return PlatformIncomingShareDestinationConnectionPolicy.canResolveThread(
+            connectionState: state
+        )
     }
 
     private var incomingShareConnectionStates: [FeatureConnection.State?] {

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -56,6 +56,7 @@ struct PlatformRootView: View {
             releaseIncomingSharePresentation: { shareID in
                 if stagedIncomingShareID?.caseInsensitiveCompare(shareID) == .orderedSame {
                     stagedIncomingShareID = nil
+                    incomingShareCoordinator.dismissStagedNewThread(id: shareID)
                 }
             }
         )

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -276,7 +276,7 @@ struct PlatformRootView: View {
                     model.errorMessage = "That thread's environment is no longer saved. Choose another destination."
                     return
                 }
-                guard await activateEnvironmentIfNeeded(destination.environmentID) else {
+                guard await enableEnvironmentIfNeeded(destination.environmentID) else {
                     // Keep the saved destination so a temporarily unavailable
                     // environment can retry when its connection recovers.
                     return

--- a/apps/swift-ios/App/Platform/PlatformShortcuts.swift
+++ b/apps/swift-ios/App/Platform/PlatformShortcuts.swift
@@ -1,25 +1,16 @@
 import AppIntents
 import Foundation
 
-struct PlatformRecentThreadRecord: Codable, Equatable, Sendable {
-    let id: String
-    let environmentID: String?
-    let wireID: String
-    let title: String
-    let environmentName: String?
-    let updatedAt: Date
-}
-
 final class PlatformRecentThreadStore: @unchecked Sendable {
     static let shared = PlatformRecentThreadStore()
 
-    private let defaults: UserDefaults
-    private let key: String
-    private let lock = NSLock()
+    private let sharedStore: T3SharedRecentThreadStore
 
-    init(defaults: UserDefaults = .standard, key: String = "swift-ios.recent-threads.v1") {
-        self.defaults = defaults
-        self.key = key
+    init(
+        defaults: UserDefaults? = UserDefaults(suiteName: T3SharedContainer.appGroupID),
+        key: String = "swift-ios.shared-recent-threads.v1"
+    ) {
+        sharedStore = T3SharedRecentThreadStore(defaults: defaults, key: key)
     }
 
     func update(from threads: [FeatureThread]) {
@@ -29,9 +20,9 @@ final class PlatformRecentThreadStore: @unchecked Sendable {
                 if lhs.updatedAt != rhs.updatedAt { return lhs.updatedAt > rhs.updatedAt }
                 return lhs.id < rhs.id
             }
-            .prefix(12)
+            .prefix(T3SharedRecentThreadStore.maximumCount)
             .map {
-                PlatformRecentThreadRecord(
+                T3SharedRecentThreadRecord(
                     id: $0.id,
                     environmentID: $0.environmentID,
                     wireID: $0.wireID ?? $0.id,
@@ -40,16 +31,11 @@ final class PlatformRecentThreadStore: @unchecked Sendable {
                     updatedAt: $0.updatedAt
                 )
             }
-        lock.withLock {
-            defaults.set(try? JSONEncoder().encode(records), forKey: key)
-        }
+        sharedStore.update(records)
     }
 
-    func records() -> [PlatformRecentThreadRecord] {
-        lock.withLock {
-            guard let data = defaults.data(forKey: key) else { return [] }
-            return (try? JSONDecoder().decode([PlatformRecentThreadRecord].self, from: data)) ?? []
-        }
+    func records() -> [T3SharedRecentThreadRecord] {
+        sharedStore.records()
     }
 }
 
@@ -70,7 +56,7 @@ struct PlatformRecentThreadEntity: AppEntity {
         )
     }
 
-    init(record: PlatformRecentThreadRecord) {
+    init(record: T3SharedRecentThreadRecord) {
         id = record.id
         environmentID = record.environmentID
         wireID = record.wireID
@@ -88,7 +74,9 @@ struct PlatformRecentThreadQuery: EntityQuery {
     }
 
     func suggestedEntities() async throws -> [PlatformRecentThreadEntity] {
-        PlatformRecentThreadStore.shared.records().map(PlatformRecentThreadEntity.init)
+        PlatformRecentThreadStore.shared.records()
+            .prefix(12)
+            .map(PlatformRecentThreadEntity.init)
     }
 }
 

--- a/apps/swift-ios/Extensions/Share/Info.plist
+++ b/apps/swift-ios/Extensions/Share/Info.plist
@@ -14,6 +14,8 @@
 				<integer>2</integer>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
 				<integer>8</integer>
+				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
+				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>

--- a/apps/swift-ios/Extensions/Share/Info.plist
+++ b/apps/swift-ios/Extensions/Share/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>$(T3CODE_SHARE_DISPLAY_NAME)</string>
+	<key>T3CodeAppGroupIdentifier</key>
+	<string>$(T3CODE_APP_GROUP_IDENTIFIER)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/apps/swift-ios/Extensions/Share/SharePayloadLoader.swift
+++ b/apps/swift-ios/Extensions/Share/SharePayloadLoader.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 struct T3LoadedSharePayload: Sendable {
     var textFragments: [String]
     var images: [T3PendingShareImage]
+    var videos: [T3PendingShareVideo]
     var warnings: [String]
 }
 
@@ -11,8 +12,10 @@ enum T3SharePayloadLoader {
     static func load(from inputItems: [Any]) async -> T3LoadedSharePayload {
         var textFragments: [String] = []
         var images: [T3PendingShareImage] = []
+        var videos: [T3PendingShareVideo] = []
         var skippedOversizedImage = false
-        var skippedExcessImage = false
+        var skippedOversizedVideo = false
+        var skippedExcessMedia = false
 
         for case let item as NSExtensionItem in inputItems {
             if let attributedText = item.attributedContentText?.string {
@@ -20,17 +23,51 @@ enum T3SharePayloadLoader {
             }
 
             for provider in item.attachments ?? [] {
-                if let imageType = provider.registeredTypeIdentifiers.first(where: {
-                    UTType($0)?.conforms(to: .image) == true
+                if let videoType = provider.registeredTypeIdentifiers.first(where: {
+                    UTType($0)?.conforms(to: .movie) == true
                 }) {
-                    guard images.count < T3IncomingShareStore.maximumImageCount else {
-                        skippedExcessImage = true
+                    guard videos.count < T3IncomingShareStore.maximumVideoCount,
+                          images.count + videos.count < T3IncomingShareStore.maximumAttachmentCount else {
+                        skippedExcessMedia = true
                         continue
                     }
                     do {
-                        let staged = try await loadStagedImage(
+                        let staged = try await loadStagedFile(
                             from: provider,
-                            typeIdentifier: imageType
+                            typeIdentifier: videoType,
+                            maximumBytes: T3IncomingShareStore.maximumVideoBytes
+                        )
+                        videos.append(
+                            T3PendingShareVideo(
+                                stagedFileURL: staged.url,
+                                byteCount: staged.byteCount,
+                                suggestedName: provider.suggestedName,
+                                typeIdentifier: videoType
+                            )
+                        )
+                    } catch T3SharePayloadLoaderError.fileTooLarge {
+                        skippedOversizedVideo = true
+                    } catch {
+                        // A movie provider is terminal even if it also vends a
+                        // thumbnail. Preserve the user's choice instead of
+                        // silently substituting a still image.
+                    }
+                    continue
+                }
+
+                if let imageType = provider.registeredTypeIdentifiers.first(where: {
+                    UTType($0)?.conforms(to: .image) == true
+                }) {
+                    guard images.count < T3IncomingShareStore.maximumImageCount,
+                          images.count + videos.count < T3IncomingShareStore.maximumAttachmentCount else {
+                        skippedExcessMedia = true
+                        continue
+                    }
+                    do {
+                        let staged = try await loadStagedFile(
+                            from: provider,
+                            typeIdentifier: imageType,
+                            maximumBytes: T3IncomingShareStore.maximumImageBytes
                         )
                         images.append(
                             T3PendingShareImage(
@@ -40,7 +77,7 @@ enum T3SharePayloadLoader {
                                 typeIdentifier: imageType
                             )
                         )
-                    } catch T3SharePayloadLoaderError.imageTooLarge {
+                    } catch T3SharePayloadLoaderError.fileTooLarge {
                         skippedOversizedImage = true
                     } catch {
                         // An image provider is terminal even if it also vends a
@@ -77,21 +114,26 @@ enum T3SharePayloadLoader {
         if skippedOversizedImage {
             warnings.append("One shared image exceeded the 10 MB attachment limit.")
         }
-        if skippedExcessImage {
+        if skippedOversizedVideo {
+            warnings.append("One shared video exceeded the 250 MB import limit.")
+        }
+        if skippedExcessMedia {
             warnings.append(
-                "Only the first \(T3IncomingShareStore.maximumImageCount) shared images were attached."
+                "Only the first \(T3IncomingShareStore.maximumAttachmentCount) shared media items were kept."
             )
         }
         return T3LoadedSharePayload(
             textFragments: textFragments,
             images: images,
+            videos: videos,
             warnings: warnings
         )
     }
 
-    private static func loadStagedImage(
+    private static func loadStagedFile(
         from provider: NSItemProvider,
-        typeIdentifier: String
+        typeIdentifier: String,
+        maximumBytes: Int
     ) async throws -> (url: URL, byteCount: Int) {
         try await withCheckedThrowingContinuation { continuation in
             provider.loadFileRepresentation(forTypeIdentifier: typeIdentifier) { url, error in
@@ -99,7 +141,9 @@ enum T3SharePayloadLoader {
                     guard let url else {
                         throw error ?? CocoaError(.fileReadUnknown)
                     }
-                    continuation.resume(returning: try stageImage(from: url))
+                    continuation.resume(
+                        returning: try stageFile(from: url, maximumBytes: maximumBytes)
+                    )
                 } catch {
                     continuation.resume(throwing: error)
                 }
@@ -110,7 +154,10 @@ enum T3SharePayloadLoader {
     /// The provider-owned URL expires when its callback returns. Stream it to
     /// an extension-owned temporary file while enforcing the byte limit, so a
     /// malicious or enormous provider never has to be materialized in memory.
-    private static func stageImage(from sourceURL: URL) throws -> (url: URL, byteCount: Int) {
+    private static func stageFile(
+        from sourceURL: URL,
+        maximumBytes: Int
+    ) throws -> (url: URL, byteCount: Int) {
         let fileManager = FileManager.default
         let stagingDirectory = fileManager.temporaryDirectory.appending(
             path: "T3CodeShareStaging",
@@ -140,8 +187,8 @@ enum T3SharePayloadLoader {
             while let chunk = try source.read(upToCount: 64 * 1_024), !chunk.isEmpty {
                 try Task.checkCancellation()
                 byteCount += chunk.count
-                guard byteCount <= T3IncomingShareStore.maximumImageBytes else {
-                    throw T3SharePayloadLoaderError.imageTooLarge
+                guard byteCount <= maximumBytes else {
+                    throw T3SharePayloadLoaderError.fileTooLarge
                 }
                 try destination.write(contentsOf: chunk)
             }
@@ -190,5 +237,5 @@ enum T3SharePayloadLoader {
 }
 
 private enum T3SharePayloadLoaderError: Error {
-    case imageTooLarge
+    case fileTooLarge
 }

--- a/apps/swift-ios/Extensions/Share/SharePayloadLoader.swift
+++ b/apps/swift-ios/Extensions/Share/SharePayloadLoader.swift
@@ -15,6 +15,8 @@ enum T3SharePayloadLoader {
         var videos: [T3PendingShareVideo] = []
         var skippedOversizedImage = false
         var skippedOversizedVideo = false
+        var skippedUnreadableImage = false
+        var skippedUnreadableVideo = false
         var skippedExcessMedia = false
 
         for case let item as NSExtensionItem in inputItems {
@@ -51,6 +53,7 @@ enum T3SharePayloadLoader {
                         // A movie provider is terminal even if it also vends a
                         // thumbnail. Preserve the user's choice instead of
                         // silently substituting a still image.
+                        skippedUnreadableVideo = true
                     }
                     continue
                 }
@@ -83,6 +86,7 @@ enum T3SharePayloadLoader {
                         // An image provider is terminal even if it also vends a
                         // URL or text representation. Falling through would
                         // silently turn a rejected attachment into other input.
+                        skippedUnreadableImage = true
                     }
                     continue
                 }
@@ -116,6 +120,12 @@ enum T3SharePayloadLoader {
         }
         if skippedOversizedVideo {
             warnings.append("One shared video exceeded the 250 MB import limit.")
+        }
+        if skippedUnreadableImage {
+            warnings.append("One shared image could not be read and was not imported.")
+        }
+        if skippedUnreadableVideo {
+            warnings.append("One shared video could not be read and was not imported.")
         }
         if skippedExcessMedia {
             warnings.append(

--- a/apps/swift-ios/Extensions/Share/ShareViewController.swift
+++ b/apps/swift-ios/Extensions/Share/ShareViewController.swift
@@ -9,16 +9,30 @@ final class T3ShareViewController: UIViewController {
         view.backgroundColor = .systemBackground
 
         let content = T3ShareExtensionView(
-            save: { [weak self] in
+            recentThreads: T3SharedRecentThreadStore.shared.records(),
+            save: { [weak self] destination in
                 let inputItems = self?.extensionContext?.inputItems ?? []
                 let payload = await T3SharePayloadLoader.load(from: inputItems)
                 return try await Task.detached {
                     try T3IncomingShareStore.write(
                         textFragments: payload.textFragments,
                         images: payload.images,
+                        videos: payload.videos,
+                        destination: destination,
                         warnings: payload.warnings
                     )
                 }.value
+            },
+            open: { [weak self] url in
+                await withCheckedContinuation { continuation in
+                    guard let context = self?.extensionContext else {
+                        continuation.resume(returning: false)
+                        return
+                    }
+                    context.open(url) { success in
+                        continuation.resume(returning: success)
+                    }
+                }
             },
             cancel: { [weak self] in
                 self?.extensionContext?.cancelRequest(withError: CocoaError(.userCancelled))
@@ -47,66 +61,65 @@ struct T3ShareExtensionView: View {
     enum Phase: Equatable {
         case ready
         case saving
-        case saved(imageCount: Int)
+        case saved(message: String)
         case failed(message: String)
     }
 
-    let save: () async throws -> T3IncomingShareEnvelope
+    let recentThreads: [T3SharedRecentThreadRecord]
+    let save: (T3IncomingShareDestination) async throws -> T3IncomingShareEnvelope
+    let open: (URL) async -> Bool
     let cancel: () -> Void
     let complete: () -> Void
 
     @State private var phase = Phase.ready
+    @State private var searchText = ""
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Button("Cancel", action: cancel)
-                    .foregroundStyle(.secondary)
+        NavigationStack {
+            Group {
+                switch phase {
+                case .ready:
+                    destinationList
+                case .saving:
+                    statusView(
+                        symbol: "arrow.down.doc",
+                        tint: Color(uiColor: .label),
+                        title: "Preparing your share",
+                        message: "Keeping a durable copy before opening T3 Code.",
+                        showsProgress: true
+                    )
+                case let .saved(message):
+                    statusView(
+                        symbol: "checkmark.circle.fill",
+                        tint: Color(uiColor: .systemGreen),
+                        title: "Ready in T3 Code",
+                        message: message,
+                        showsProgress: false
+                    )
+                case let .failed(message):
+                    statusView(
+                        symbol: "exclamationmark.triangle.fill",
+                        tint: Color(uiColor: .systemRed),
+                        title: "Could not add this",
+                        message: message,
+                        showsProgress: false
+                    )
+                }
+            }
+            .navigationTitle("Share to T3 Code")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(isSaved ? "Done" : "Cancel") {
+                        if isSaved {
+                            complete()
+                        } else {
+                            cancel()
+                        }
+                    }
                     .disabled(isSaving)
-                Spacer()
-                Text("T3 Code")
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundStyle(.primary)
-                Spacer()
-                Color.clear.frame(width: 52, height: 1)
+                }
             }
-            .padding(.horizontal, 18)
-            .padding(.vertical, 15)
-
-            Divider()
-
-            VStack(spacing: 14) {
-                Image(systemName: phaseSymbol)
-                    .font(.system(size: 32, weight: .medium))
-                    .foregroundStyle(phaseTint)
-                    .accessibilityHidden(true)
-                Text(title)
-                    .font(.system(size: 22, weight: .bold))
-                    .foregroundStyle(.primary)
-                    .multilineTextAlignment(.center)
-                Text(message)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .lineSpacing(3)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(.horizontal, 28)
-            .padding(.vertical, 24)
-
-            Button(action: primaryAction) {
-                Text(primaryTitle)
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(Color(uiColor: .systemBackground))
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 50)
-                    .background(Color(uiColor: .label), in: RoundedRectangle(cornerRadius: 13))
-            }
-            .buttonStyle(.plain)
-            .disabled(isSaving)
-            .opacity(isSaving ? 0.55 : 1)
-            .padding(.horizontal, 18)
-            .padding(.bottom, 18)
         }
         .background(Color(uiColor: .systemBackground).ignoresSafeArea())
     }
@@ -115,75 +128,164 @@ struct T3ShareExtensionView: View {
         phase == .saving
     }
 
-    private var title: String {
-        switch phase {
-        case .ready: "Add to a new task"
-        case .saving: "Saving shared content"
-        case .saved: "Ready in T3 Code"
-        case .failed: "Could not add this"
-        }
+    private var isSaved: Bool {
+        if case .saved = phase { return true }
+        return false
     }
 
-    private var message: String {
-        switch phase {
-        case .ready:
-            "Text, links, and up to eight images will be waiting in the native composer."
-        case .saving:
-            "Keeping a durable copy so nothing gets lost."
-        case let .saved(imageCount):
-            imageCount == 0
-                ? "Open T3 Code to choose a project and send it."
-                : "Saved \(imageCount) image\(imageCount == 1 ? "" : "s"). Open T3 Code to choose a project."
-        case let .failed(message):
-            message
-        }
-    }
-
-    private var phaseSymbol: String {
-        switch phase {
-        case .ready: "square.and.arrow.up"
-        case .saving: "arrow.down.doc"
-        case .saved: "checkmark.circle.fill"
-        case .failed: "exclamationmark.triangle.fill"
-        }
-    }
-
-    private var phaseTint: Color {
-        switch phase {
-        case .saved: Color(uiColor: .systemGreen)
-        case .failed: Color(uiColor: .systemRed)
-        default: Color(uiColor: .label)
-        }
-    }
-
-    private var primaryTitle: String {
-        switch phase {
-        case .ready: "Add to T3 Code"
-        case .saving: "Saving…"
-        case .saved: "Done"
-        case .failed: "Try again"
-        }
-    }
-
-    private func primaryAction() {
-        switch phase {
-        case .ready, .failed:
-            phase = .saving
-            Task {
-                do {
-                    let envelope = try await save()
-                    phase = .saved(imageCount: envelope.images.count)
-                } catch {
-                    phase = .failed(
-                        message: (error as? LocalizedError)?.errorDescription
-                            ?? "The shared content could not be saved."
-                    )
+    private var destinationList: some View {
+        List {
+            Section {
+                destinationButton(
+                    title: "New Thread",
+                    subtitle: "Choose the project in T3 Code",
+                    systemImage: "square.and.pencil"
+                ) {
+                    beginShare(to: .newThread)
                 }
             }
-        case .saved:
-            complete()
-        case .saving:
-            break
+
+            if !recentThreads.isEmpty {
+                Section(searchText.isEmpty ? "Recent Threads" : "Threads") {
+                    ForEach(filteredThreads) { thread in
+                        destinationButton(
+                            title: thread.title,
+                            subtitle: thread.environmentName,
+                            systemImage: "bubble.left.and.bubble.right"
+                        ) {
+                            beginShare(
+                                to: .existingThread(
+                                    environmentID: thread.environmentID,
+                                    threadID: thread.wireID
+                                )
+                            )
+                        }
+                    }
+                }
+            } else {
+                Section("Existing Thread") {
+                    Text("Open T3 Code once to make recent threads available here.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section {
+                Text("Text and images are staged as-is. A shared video becomes one contact-sheet image so the agent can inspect representative frames.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color(uiColor: .systemBackground))
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: "Find a thread"
+        )
+    }
+
+    private var filteredThreads: [T3SharedRecentThreadRecord] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return recentThreads }
+        return recentThreads.filter {
+            $0.title.localizedCaseInsensitiveContains(query)
+                || ($0.environmentName?.localizedCaseInsensitiveContains(query) ?? false)
+        }
+    }
+
+    private func destinationButton(
+        title: String,
+        subtitle: String?,
+        systemImage: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 28)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    if let subtitle, !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(minHeight: 48)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func statusView(
+        symbol: String,
+        tint: Color,
+        title: String,
+        message: String,
+        showsProgress: Bool
+    ) -> some View {
+        VStack(spacing: 14) {
+            if showsProgress {
+                ProgressView()
+                    .controlSize(.large)
+            } else {
+                Image(systemName: symbol)
+                    .font(.system(size: 34, weight: .medium))
+                    .foregroundStyle(tint)
+            }
+            Text(title)
+                .font(.title2.bold())
+            Text(message)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(3)
+            if case .failed = phase {
+                Button("Choose another destination") {
+                    phase = .ready
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 8)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(28)
+    }
+
+    private func beginShare(to destination: T3IncomingShareDestination) {
+        guard phase == .ready else { return }
+        phase = .saving
+        Task {
+            do {
+                let envelope = try await save(destination)
+                guard let url = T3IncomingShareStore.hostAppURL(for: envelope.id) else {
+                    throw CocoaError(.fileReadCorruptFile)
+                }
+                if await open(url) {
+                    complete()
+                } else {
+                    phase = .saved(
+                        message: "Your content is saved. Open T3 Code to continue."
+                    )
+                }
+            } catch {
+                phase = .failed(
+                    message: (error as? LocalizedError)?.errorDescription
+                        ?? "The shared content could not be saved."
+                )
+            }
         }
     }
 }

--- a/apps/swift-ios/Extensions/Share/ShareViewController.swift
+++ b/apps/swift-ios/Extensions/Share/ShareViewController.swift
@@ -10,6 +10,7 @@ final class T3ShareViewController: UIViewController {
 
         let content = T3ShareExtensionView(
             recentThreads: T3SharedRecentThreadStore.shared.records(),
+            appearance: T3SharedAppearanceStore.shared.appearance(),
             save: { [weak self] destination in
                 let inputItems = self?.extensionContext?.inputItems ?? []
                 let payload = await T3SharePayloadLoader.load(from: inputItems)
@@ -22,17 +23,6 @@ final class T3ShareViewController: UIViewController {
                         warnings: payload.warnings
                     )
                 }.value
-            },
-            open: { [weak self] url in
-                await withCheckedContinuation { continuation in
-                    guard let context = self?.extensionContext else {
-                        continuation.resume(returning: false)
-                        return
-                    }
-                    context.open(url) { success in
-                        continuation.resume(returning: success)
-                    }
-                }
             },
             cancel: { [weak self] in
                 self?.extensionContext?.cancelRequest(withError: CocoaError(.userCancelled))
@@ -66,8 +56,8 @@ struct T3ShareExtensionView: View {
     }
 
     let recentThreads: [T3SharedRecentThreadRecord]
+    let appearance: T3SharedAppearance
     let save: (T3IncomingShareDestination) async throws -> T3IncomingShareEnvelope
-    let open: (URL) async -> Bool
     let cancel: () -> Void
     let complete: () -> Void
 
@@ -121,7 +111,8 @@ struct T3ShareExtensionView: View {
                 }
             }
         }
-        .background(Color(uiColor: .systemBackground).ignoresSafeArea())
+        .preferredColorScheme(preferredColorScheme)
+        .background(T3ShareTheme.background.ignoresSafeArea())
     }
 
     private var isSaving: Bool {
@@ -177,7 +168,7 @@ struct T3ShareExtensionView: View {
             }
         }
         .scrollContentBackground(.hidden)
-        .background(Color(uiColor: .systemBackground))
+        .background(T3ShareTheme.background)
         .searchable(
             text: $searchText,
             placement: .navigationBarDrawer(displayMode: .always),
@@ -269,17 +260,8 @@ struct T3ShareExtensionView: View {
         phase = .saving
         Task {
             do {
-                let envelope = try await save(destination)
-                guard let url = T3IncomingShareStore.hostAppURL(for: envelope.id) else {
-                    throw CocoaError(.fileReadCorruptFile)
-                }
-                if await open(url) {
-                    complete()
-                } else {
-                    phase = .saved(
-                        message: "Your content is saved. Open T3 Code to continue."
-                    )
-                }
+                _ = try await save(destination)
+                phase = .saved(message: completionMessage(for: destination))
             } catch {
                 phase = .failed(
                     message: (error as? LocalizedError)?.errorDescription
@@ -288,4 +270,31 @@ struct T3ShareExtensionView: View {
             }
         }
     }
+
+    private var preferredColorScheme: ColorScheme? {
+        switch appearance {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+
+    private func completionMessage(for destination: T3IncomingShareDestination) -> String {
+        switch destination.kind {
+        case .newThread:
+            "Tap Done, then open T3 Code. The project picker will open with your content in the composer."
+        case .existingThread:
+            "Tap Done, then open T3 Code. Your content will be waiting in that thread’s composer."
+        }
+    }
+}
+
+private enum T3ShareTheme {
+    static let background = Color(
+        uiColor: UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 10 / 255, green: 10 / 255, blue: 10 / 255, alpha: 1)
+                : UIColor(red: 242 / 255, green: 242 / 255, blue: 247 / 255, alpha: 1)
+        }
+    )
 }

--- a/apps/swift-ios/Extensions/Shared/ShareInbox.swift
+++ b/apps/swift-ios/Extensions/Shared/ShareInbox.swift
@@ -8,15 +8,100 @@ struct T3IncomingShareImage: Codable, Hashable, Identifiable, Sendable {
     var byteCount: Int
 }
 
+struct T3IncomingShareVideo: Codable, Hashable, Identifiable, Sendable {
+    var id: String
+    var fileName: String
+    var typeIdentifier: String
+    var relativePath: String
+    var byteCount: Int
+}
+
+struct T3IncomingShareDestination: Codable, Hashable, Sendable {
+    enum Kind: String, Codable, Sendable {
+        case newThread
+        case existingThread
+    }
+
+    var kind: Kind
+    var environmentID: String?
+    var threadID: String?
+
+    static let newThread = T3IncomingShareDestination(
+        kind: .newThread,
+        environmentID: nil,
+        threadID: nil
+    )
+
+    static func existingThread(
+        environmentID: String?,
+        threadID: String
+    ) -> T3IncomingShareDestination {
+        T3IncomingShareDestination(
+            kind: .existingThread,
+            environmentID: environmentID,
+            threadID: threadID
+        )
+    }
+}
+
 struct T3IncomingShareEnvelope: Codable, Hashable, Identifiable, Sendable {
-    static let schemaVersion = 1
+    static let schemaVersion = 2
+    static let supportedSchemaVersions = 1...schemaVersion
 
     var schemaVersion: Int
     var id: String
     var createdAt: Date
     var text: String
     var images: [T3IncomingShareImage]
+    var videos: [T3IncomingShareVideo]
+    var destination: T3IncomingShareDestination?
     var warnings: [String]
+
+    init(
+        schemaVersion: Int = Self.schemaVersion,
+        id: String,
+        createdAt: Date,
+        text: String,
+        images: [T3IncomingShareImage],
+        videos: [T3IncomingShareVideo] = [],
+        destination: T3IncomingShareDestination? = nil,
+        warnings: [String]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.id = id
+        self.createdAt = createdAt
+        self.text = text
+        self.images = images
+        self.videos = videos
+        self.destination = destination
+        self.warnings = warnings
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case id
+        case createdAt
+        case text
+        case images
+        case videos
+        case destination
+        case warnings
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        id = try container.decode(String.self, forKey: .id)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        text = try container.decode(String.self, forKey: .text)
+        images = try container.decodeIfPresent([T3IncomingShareImage].self, forKey: .images) ?? []
+        videos = try container.decodeIfPresent([T3IncomingShareVideo].self, forKey: .videos) ?? []
+        destination = try container.decodeIfPresent(
+            T3IncomingShareDestination.self,
+            forKey: .destination
+        )
+        warnings = try container.decodeIfPresent([String].self, forKey: .warnings) ?? []
+    }
 }
 
 struct T3PendingShareImage: Sendable {
@@ -24,6 +109,52 @@ struct T3PendingShareImage: Sendable {
     var byteCount: Int
     var suggestedName: String?
     var typeIdentifier: String
+}
+
+struct T3PendingShareVideo: Sendable {
+    var stagedFileURL: URL
+    var byteCount: Int
+    var suggestedName: String?
+    var typeIdentifier: String
+}
+
+struct T3SharedRecentThreadRecord: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let environmentID: String?
+    let wireID: String
+    let title: String
+    let environmentName: String?
+    let updatedAt: Date
+}
+
+final class T3SharedRecentThreadStore: @unchecked Sendable {
+    static let shared = T3SharedRecentThreadStore()
+    static let maximumCount = 100
+
+    private let defaults: UserDefaults?
+    private let key: String
+    private let lock = NSLock()
+
+    init(
+        defaults: UserDefaults? = UserDefaults(suiteName: T3SharedContainer.appGroupID),
+        key: String = "swift-ios.shared-recent-threads.v1"
+    ) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    func update(_ records: [T3SharedRecentThreadRecord]) {
+        lock.withLock {
+            defaults?.set(try? JSONEncoder().encode(records), forKey: key)
+        }
+    }
+
+    func records() -> [T3SharedRecentThreadRecord] {
+        lock.withLock {
+            guard let data = defaults?.data(forKey: key) else { return [] }
+            return (try? JSONDecoder().decode([T3SharedRecentThreadRecord].self, from: data)) ?? []
+        }
+    }
 }
 
 enum T3IncomingShareStoreError: LocalizedError {
@@ -35,7 +166,7 @@ enum T3IncomingShareStoreError: LocalizedError {
         case .appGroupUnavailable:
             "T3 Code could not access its shared inbox."
         case .noSupportedContent:
-            "This app did not provide text, a URL, or a supported image."
+            "This app did not provide text, a URL, or supported media."
         }
     }
 }
@@ -45,12 +176,17 @@ enum T3IncomingShareStoreError: LocalizedError {
 enum T3IncomingShareStore {
     static let inboxRelativePath = "Library/Application Support/T3Code/IncomingShares"
     static let manifestFileName = "manifest.json"
+    static let maximumAttachmentCount = 8
     static let maximumImageCount = 8
     static let maximumImageBytes = 10 * 1_024 * 1_024
+    static let maximumVideoCount = 1
+    static let maximumVideoBytes = 250 * 1_024 * 1_024
 
     static func write(
         textFragments: [String],
         images: [T3PendingShareImage],
+        videos: [T3PendingShareVideo] = [],
+        destination: T3IncomingShareDestination? = nil,
         warnings initialWarnings: [String] = [],
         now: Date = Date(),
         id: String = UUID().uuidString.lowercased()
@@ -62,6 +198,9 @@ enum T3IncomingShareStore {
             for image in images {
                 try? FileManager.default.removeItem(at: image.stagedFileURL)
             }
+            for video in videos {
+                try? FileManager.default.removeItem(at: video.stagedFileURL)
+            }
         }
 
         let normalizedText = deduplicatedText(textFragments)
@@ -70,6 +209,7 @@ enum T3IncomingShareStore {
             .appending(path: id, directoryHint: .isDirectory)
         var warnings = initialWarnings
         var savedImages: [T3IncomingShareImage] = []
+        var savedVideos: [T3IncomingShareVideo] = []
         var validOverflowCount = 0
 
         do {
@@ -115,11 +255,49 @@ enum T3IncomingShareStore {
                 )
             }
 
-            if validOverflowCount > 0 {
-                warnings.append("Only the first \(maximumImageCount) shared images were attached.")
+            for video in videos {
+                let values = try? video.stagedFileURL.resourceValues(forKeys: [
+                    .fileSizeKey,
+                    .isRegularFileKey,
+                ])
+                guard values?.isRegularFile == true,
+                      let byteCount = values?.fileSize,
+                      byteCount > 0,
+                      byteCount <= maximumVideoBytes,
+                      byteCount == video.byteCount else {
+                    warnings.append("One shared video exceeded the 250 MB import limit.")
+                    continue
+                }
+                guard savedVideos.count < maximumVideoCount,
+                      savedImages.count + savedVideos.count < maximumAttachmentCount else {
+                    validOverflowCount += 1
+                    continue
+                }
+
+                let attachmentID = UUID().uuidString.lowercased()
+                let fileName = safeFileName(
+                    video.suggestedName,
+                    fallback: "shared-video-\(savedVideos.count + 1).\(fileExtension(for: video.typeIdentifier))"
+                )
+                let storedName = "\(attachmentID)-\(fileName)"
+                let fileURL = itemDirectory.appending(path: storedName, directoryHint: .notDirectory)
+                try FileManager.default.copyItem(at: video.stagedFileURL, to: fileURL)
+                savedVideos.append(
+                    T3IncomingShareVideo(
+                        id: attachmentID,
+                        fileName: fileName,
+                        typeIdentifier: video.typeIdentifier,
+                        relativePath: "\(inboxRelativePath)/\(id)/\(storedName)",
+                        byteCount: byteCount
+                    )
+                )
             }
 
-            guard !normalizedText.isEmpty || !savedImages.isEmpty else {
+            if validOverflowCount > 0 {
+                warnings.append("Only the first \(maximumAttachmentCount) shared media items were kept.")
+            }
+
+            guard !normalizedText.isEmpty || !savedImages.isEmpty || !savedVideos.isEmpty else {
                 throw T3IncomingShareStoreError.noSupportedContent
             }
 
@@ -129,6 +307,8 @@ enum T3IncomingShareStore {
                 createdAt: now,
                 text: normalizedText,
                 images: savedImages,
+                videos: savedVideos,
+                destination: destination,
                 warnings: warnings
             )
             let manifestURL = itemDirectory.appending(
@@ -159,7 +339,7 @@ enum T3IncomingShareStore {
             guard let data = try? Data(contentsOf: manifestURL) else { return nil }
             return try? decoder.decode(T3IncomingShareEnvelope.self, from: data)
         }
-        .filter { $0.schemaVersion == T3IncomingShareEnvelope.schemaVersion }
+        .filter { T3IncomingShareEnvelope.supportedSchemaVersions.contains($0.schemaVersion) }
         .sorted { $0.createdAt < $1.createdAt }
     }
 
@@ -184,10 +364,27 @@ enum T3IncomingShareStore {
     }
 
     static func fileURL(for image: T3IncomingShareImage) -> URL? {
+        fileURL(relativePath: image.relativePath)
+    }
+
+    static func fileURL(for video: T3IncomingShareVideo) -> URL? {
+        fileURL(relativePath: video.relativePath)
+    }
+
+    static func hostAppURL(for envelopeID: String) -> URL? {
+        guard UUID(uuidString: envelopeID) != nil else { return nil }
+        var components = URLComponents()
+        components.scheme = T3SharedContainer.urlScheme
+        components.host = "share"
+        components.queryItems = [URLQueryItem(name: "id", value: envelopeID)]
+        return components.url
+    }
+
+    private static func fileURL(relativePath: String) -> URL? {
         guard let root = T3SharedContainer.rootURL?.standardizedFileURL else { return nil }
         let inbox = root.appending(path: inboxRelativePath, directoryHint: .isDirectory)
             .standardizedFileURL
-        let url = root.appending(path: image.relativePath, directoryHint: .notDirectory)
+        let url = root.appending(path: relativePath, directoryHint: .notDirectory)
             .standardizedFileURL
         guard url.path.hasPrefix(inbox.path + "/") else { return nil }
         return url
@@ -216,6 +413,10 @@ enum T3IncomingShareStore {
         case "public.heic", "image/heic": "heic"
         case "public.webp", "image/webp": "webp"
         case "com.compuserve.gif", "image/gif": "gif"
+        case "public.mpeg-4", "video/mp4": "mp4"
+        case "com.apple.quicktime-movie", "video/quicktime": "mov"
+        case "public.movie": "mov"
+        case "public.mpeg", "video/mpeg": "mpeg"
         default: "png"
         }
     }

--- a/apps/swift-ios/Extensions/Shared/ShareInbox.swift
+++ b/apps/swift-ios/Extensions/Shared/ShareInbox.swift
@@ -398,6 +398,34 @@ enum T3IncomingShareStore {
         try FileManager.default.removeItem(at: itemURL)
     }
 
+    static func updateDestination(
+        id: String,
+        destination: T3IncomingShareDestination?
+    ) throws {
+        guard let containerURL = T3SharedContainer.rootURL else {
+            throw T3IncomingShareStoreError.appGroupUnavailable
+        }
+        guard UUID(uuidString: id) != nil else {
+            throw T3IncomingShareStoreError.noSupportedContent
+        }
+        let inboxURL = containerURL
+            .appending(path: inboxRelativePath, directoryHint: .isDirectory)
+            .standardizedFileURL
+        let itemURL = inboxURL
+            .appending(path: id, directoryHint: .isDirectory)
+            .standardizedFileURL
+        guard itemURL.deletingLastPathComponent() == inboxURL else {
+            throw T3IncomingShareStoreError.noSupportedContent
+        }
+        let manifestURL = itemURL.appending(path: manifestFileName, directoryHint: .notDirectory)
+        var envelope = try decoder.decode(
+            T3IncomingShareEnvelope.self,
+            from: Data(contentsOf: manifestURL)
+        )
+        envelope.destination = destination
+        try encoder.encode(envelope).write(to: manifestURL, options: .atomic)
+    }
+
     static func fileURL(for image: T3IncomingShareImage) -> URL? {
         fileURL(relativePath: image.relativePath)
     }

--- a/apps/swift-ios/Extensions/Shared/ShareInbox.swift
+++ b/apps/swift-ios/Extensions/Shared/ShareInbox.swift
@@ -261,8 +261,11 @@ enum T3IncomingShareStore {
                 guard values?.isRegularFile == true,
                       let byteCount = values?.fileSize,
                       byteCount > 0,
-                      byteCount <= maximumImageBytes,
                       byteCount == image.byteCount else {
+                    warnings.append("One shared image could not be read and was not imported.")
+                    continue
+                }
+                guard byteCount <= maximumImageBytes else {
                     warnings.append("One shared image exceeded the 10 MB attachment limit.")
                     continue
                 }
@@ -298,8 +301,11 @@ enum T3IncomingShareStore {
                 guard values?.isRegularFile == true,
                       let byteCount = values?.fileSize,
                       byteCount > 0,
-                      byteCount <= maximumVideoBytes,
                       byteCount == video.byteCount else {
+                    warnings.append("One shared video could not be read and was not imported.")
+                    continue
+                }
+                guard byteCount <= maximumVideoBytes else {
                     warnings.append("One shared video exceeded the 250 MB import limit.")
                     continue
                 }
@@ -363,7 +369,7 @@ enum T3IncomingShareStore {
         let inboxURL = containerURL.appending(path: inboxRelativePath, directoryHint: .isDirectory)
         guard let directories = try? FileManager.default.contentsOfDirectory(
             at: inboxURL,
-            includingPropertiesForKeys: [.isDirectoryKey],
+            includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey],
             options: [.skipsHiddenFiles]
         ) else {
             return []
@@ -371,7 +377,15 @@ enum T3IncomingShareStore {
 
         return directories.compactMap { directory in
             let manifestURL = directory.appending(path: manifestFileName, directoryHint: .notDirectory)
-            guard let data = try? Data(contentsOf: manifestURL) else { return nil }
+            guard let data = try? Data(contentsOf: manifestURL) else {
+                let modified = try? directory.resourceValues(
+                    forKeys: [.contentModificationDateKey]
+                ).contentModificationDate
+                if let modified, Date().timeIntervalSince(modified) > 3_600 {
+                    try? FileManager.default.removeItem(at: directory)
+                }
+                return nil
+            }
             return try? decoder.decode(T3IncomingShareEnvelope.self, from: data)
         }
         .filter { T3IncomingShareEnvelope.supportedSchemaVersions.contains($0.schemaVersion) }

--- a/apps/swift-ios/Extensions/Shared/ShareInbox.swift
+++ b/apps/swift-ios/Extensions/Shared/ShareInbox.swift
@@ -406,15 +406,6 @@ enum T3IncomingShareStore {
         fileURL(relativePath: video.relativePath)
     }
 
-    static func hostAppURL(for envelopeID: String) -> URL? {
-        guard UUID(uuidString: envelopeID) != nil else { return nil }
-        var components = URLComponents()
-        components.scheme = T3SharedContainer.urlScheme
-        components.host = "share"
-        components.queryItems = [URLQueryItem(name: "id", value: envelopeID)]
-        return components.url
-    }
-
     private static func fileURL(relativePath: String) -> URL? {
         guard let root = T3SharedContainer.rootURL?.standardizedFileURL else { return nil }
         let inbox = root.appending(path: inboxRelativePath, directoryHint: .isDirectory)

--- a/apps/swift-ios/Extensions/Shared/ShareInbox.swift
+++ b/apps/swift-ios/Extensions/Shared/ShareInbox.swift
@@ -127,6 +127,41 @@ struct T3SharedRecentThreadRecord: Codable, Equatable, Identifiable, Sendable {
     let updatedAt: Date
 }
 
+enum T3SharedAppearance: String, Codable, Equatable, Sendable {
+    case system
+    case light
+    case dark
+}
+
+final class T3SharedAppearanceStore: @unchecked Sendable {
+    static let shared = T3SharedAppearanceStore()
+
+    private let defaults: UserDefaults?
+    private let key: String
+    private let lock = NSLock()
+
+    init(
+        defaults: UserDefaults? = UserDefaults(suiteName: T3SharedContainer.appGroupID),
+        key: String = "swift-ios.shared-appearance.v1"
+    ) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    func update(_ appearance: T3SharedAppearance) {
+        lock.withLock {
+            defaults?.set(appearance.rawValue, forKey: key)
+        }
+    }
+
+    func appearance() -> T3SharedAppearance {
+        lock.withLock {
+            guard let rawValue = defaults?.string(forKey: key) else { return .system }
+            return T3SharedAppearance(rawValue: rawValue) ?? .system
+        }
+    }
+}
+
 final class T3SharedRecentThreadStore: @unchecked Sendable {
     static let shared = T3SharedRecentThreadStore()
     static let maximumCount = 100
@@ -164,7 +199,7 @@ enum T3IncomingShareStoreError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .appGroupUnavailable:
-            "T3 Code could not access its shared inbox."
+            "This build of T3 Code does not have access to its shared inbox. Install an App Group-enabled build and try again."
         case .noSupportedContent:
             "This app did not provide text, a URL, or supported media."
         }

--- a/apps/swift-ios/Extensions/Shared/SharedContainer.swift
+++ b/apps/swift-ios/Extensions/Shared/SharedContainer.swift
@@ -2,12 +2,27 @@ import Foundation
 
 enum T3SharedContainer {
     #if DEBUG
-    static let appGroupID = "group.com.t3tools.t3code.swiftui.dev"
+    static let defaultAppGroupID = "group.com.t3tools.t3code.swiftui.dev"
     static let urlScheme = "t3code-swiftui-dev"
     #else
-    static let appGroupID = "group.com.t3tools.t3code.swiftui"
+    static let defaultAppGroupID = "group.com.t3tools.t3code.swiftui"
     static let urlScheme = "t3code-swiftui"
     #endif
+
+    static var appGroupID: String {
+        configuredAppGroupID(
+            Bundle.main.object(forInfoDictionaryKey: "T3CodeAppGroupIdentifier") as? String
+        )
+    }
+
+    static func configuredAppGroupID(_ value: String?) -> String {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              value.hasPrefix("group."),
+              value.count > "group.".count else {
+            return defaultAppGroupID
+        }
+        return value
+    }
 
     static var rootURL: URL? {
         FileManager.default.containerURL(

--- a/apps/swift-ios/Extensions/Tests/ExtensionContractTests.swift
+++ b/apps/swift-ios/Extensions/Tests/ExtensionContractTests.swift
@@ -27,6 +27,17 @@ final class ExtensionContractTests: XCTestCase {
         XCTAssertNil(T3IncomingShareStore.hostAppURL(for: "../not-valid"))
     }
 
+    func testSharedContainerAcceptsAConfiguredTeamSpecificAppGroup() {
+        XCTAssertEqual(
+            T3SharedContainer.configuredAppGroupID("group.com.saphid.t3code.swiftui.dev"),
+            "group.com.saphid.t3code.swiftui.dev"
+        )
+        XCTAssertEqual(
+            T3SharedContainer.configuredAppGroupID("not-an-app-group"),
+            T3SharedContainer.defaultAppGroupID
+        )
+    }
+
     func testLiveActivityDecodesTheRelayAPNSEnvelope() throws {
         let props = #"{"title":"T3 Code","subtitle":"2 active agents, 1 needs attention","activeCount":2,"updatedAt":"2026-08-01T12:00:00.000Z","activities":[{"environmentId":"env-1","threadId":"thread-working","projectTitle":"t3code","threadTitle":"Build the native app","modelTitle":"GPT-5.6 Sol","phase":"running","status":"Working","updatedAt":"2026-08-01T12:00:00.000Z","deepLink":"/env-1/thread-working"},{"environmentId":"env-2","threadId":"thread-approval","projectTitle":"uploadthing","threadTitle":"Ship upload recovery","modelTitle":"Claude Opus 5","phase":"waiting_for_approval","status":"Approval","updatedAt":"2026-08-01T11:59:00.000Z","deepLink":"/env-2/thread-approval"}]}"#
         let state = LiveActivityAttributes.ContentState(

--- a/apps/swift-ios/Extensions/Tests/ExtensionContractTests.swift
+++ b/apps/swift-ios/Extensions/Tests/ExtensionContractTests.swift
@@ -3,6 +3,30 @@ import XCTest
 @testable import T3Code
 
 final class ExtensionContractTests: XCTestCase {
+    func testIncomingShareDecodesLegacyEnvelopeWithoutDestinationOrVideos() throws {
+        let data = Data(#"{"createdAt":"2026-08-10T01:02:03Z","id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","images":[],"schemaVersion":1,"text":"Legacy","warnings":[]}"#.utf8)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let envelope = try decoder.decode(T3IncomingShareEnvelope.self, from: data)
+
+        XCTAssertEqual(envelope.schemaVersion, 1)
+        XCTAssertEqual(envelope.text, "Legacy")
+        XCTAssertTrue(envelope.videos.isEmpty)
+        XCTAssertNil(envelope.destination)
+    }
+
+    func testIncomingShareHostURLTargetsExactEnvelope() throws {
+        let id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        let url = try XCTUnwrap(T3IncomingShareStore.hostAppURL(for: id))
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+        XCTAssertEqual(components.scheme, T3SharedContainer.urlScheme)
+        XCTAssertEqual(components.host, "share")
+        XCTAssertEqual(components.queryItems, [URLQueryItem(name: "id", value: id)])
+        XCTAssertNil(T3IncomingShareStore.hostAppURL(for: "../not-valid"))
+    }
+
     func testLiveActivityDecodesTheRelayAPNSEnvelope() throws {
         let props = #"{"title":"T3 Code","subtitle":"2 active agents, 1 needs attention","activeCount":2,"updatedAt":"2026-08-01T12:00:00.000Z","activities":[{"environmentId":"env-1","threadId":"thread-working","projectTitle":"t3code","threadTitle":"Build the native app","modelTitle":"GPT-5.6 Sol","phase":"running","status":"Working","updatedAt":"2026-08-01T12:00:00.000Z","deepLink":"/env-1/thread-working"},{"environmentId":"env-2","threadId":"thread-approval","projectTitle":"uploadthing","threadTitle":"Ship upload recovery","modelTitle":"Claude Opus 5","phase":"waiting_for_approval","status":"Approval","updatedAt":"2026-08-01T11:59:00.000Z","deepLink":"/env-2/thread-approval"}]}"#
         let state = LiveActivityAttributes.ContentState(

--- a/apps/swift-ios/Extensions/Tests/ExtensionContractTests.swift
+++ b/apps/swift-ios/Extensions/Tests/ExtensionContractTests.swift
@@ -16,17 +16,6 @@ final class ExtensionContractTests: XCTestCase {
         XCTAssertNil(envelope.destination)
     }
 
-    func testIncomingShareHostURLTargetsExactEnvelope() throws {
-        let id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-        let url = try XCTUnwrap(T3IncomingShareStore.hostAppURL(for: id))
-        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
-
-        XCTAssertEqual(components.scheme, T3SharedContainer.urlScheme)
-        XCTAssertEqual(components.host, "share")
-        XCTAssertEqual(components.queryItems, [URLQueryItem(name: "id", value: id)])
-        XCTAssertNil(T3IncomingShareStore.hostAppURL(for: "../not-valid"))
-    }
-
     func testSharedContainerAcceptsAConfiguredTeamSpecificAppGroup() {
         XCTAssertEqual(
             T3SharedContainer.configuredAppGroupID("group.com.saphid.t3code.swiftui.dev"),

--- a/apps/swift-ios/Extensions/Widgets/Info.plist
+++ b/apps/swift-ios/Extensions/Widgets/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>$(T3CODE_WIDGET_DISPLAY_NAME)</string>
+	<key>T3CodeAppGroupIdentifier</key>
+	<string>$(T3CODE_APP_GROUP_IDENTIFIER)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -24,7 +24,7 @@ public struct ThreadDetailView: View {
     @State private var sharedAttachmentOverflowCount = 0
     @State private var didRestoreDraft = false
     @State private var restoredImportedShareIDs: Set<String> = []
-    @State private var handledComposerDraftReloadRevision: Int
+    @State private var handledComposerDraftReloadRevision: Int?
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var toolSurface: FeatureThreadToolSurface?
     @FocusState private var composerFocused: Bool
@@ -44,7 +44,10 @@ public struct ThreadDetailView: View {
         self.composerDraftReloadRevision = composerDraftReloadRevision
         self.composerDraftReloadImports = composerDraftReloadImports
         _handledComposerDraftReloadRevision = State(
-            initialValue: composerDraftReloadRevision
+            initialValue: FeatureComposerIncomingShareReloadPolicy.initialHandledRevision(
+                revision: composerDraftReloadRevision,
+                imports: composerDraftReloadImports
+            )
         )
         self.submitMessage = submitMessage
         self.onNavigateBack = onNavigateBack
@@ -92,6 +95,13 @@ public struct ThreadDetailView: View {
         )) {
             guard handledComposerDraftReloadRevision != composerDraftReloadRevision,
                   didRestoreDraft else { return }
+            let restoredImportIDs = FeatureComposerIncomingShareReloadPolicy.restoredImportIDs(
+                composerDraftReloadImports,
+                restoredShareIDs: restoredImportedShareIDs
+            )
+            if !restoredImportIDs.isEmpty {
+                onComposerDraftReloadHandled(restoredImportIDs)
+            }
             let pendingImports = FeatureComposerIncomingShareReloadPolicy.pendingImports(
                 composerDraftReloadImports,
                 restoredShareIDs: restoredImportedShareIDs
@@ -744,6 +754,13 @@ struct FeatureComposerIncomingShareMergeResult {
 }
 
 enum FeatureComposerIncomingShareReloadPolicy {
+    static func initialHandledRevision(
+        revision: Int,
+        imports: [FeatureComposerIncomingShareDraft]
+    ) -> Int? {
+        imports.isEmpty ? revision : nil
+    }
+
     static func appending(
         _ imported: FeatureComposerIncomingShareDraft,
         to imports: [FeatureComposerIncomingShareDraft],
@@ -758,6 +775,15 @@ enum FeatureComposerIncomingShareReloadPolicy {
         restoredShareIDs: Set<String>
     ) -> [FeatureComposerIncomingShareDraft] {
         imports.filter { !restoredShareIDs.contains($0.shareID) }
+    }
+
+    static func restoredImportIDs(
+        _ imports: [FeatureComposerIncomingShareDraft],
+        restoredShareIDs: Set<String>
+    ) -> [String] {
+        imports.compactMap {
+            restoredShareIDs.contains($0.shareID) ? $0.shareID : nil
+        }
     }
 
     static func removing(

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -20,6 +20,7 @@ public struct ThreadDetailView: View {
     @State private var isSending = false
     @State private var isLoading = true
     @State private var sendFailed = false
+    @State private var sharedAttachmentOverflowCount = 0
     @State private var didRestoreDraft = false
     @State private var handledComposerDraftReloadRevision: Int
     @State private var draftSaveTask: Task<Void, Never>?
@@ -84,8 +85,18 @@ public struct ThreadDetailView: View {
         .task(id: composerDraftReloadRevision) {
             guard handledComposerDraftReloadRevision != composerDraftReloadRevision,
                   let composerDraftReloadDraft else { return }
-            handledComposerDraftReloadRevision = composerDraftReloadRevision
-            await reloadImportedDraft(composerDraftReloadDraft)
+            guard FeatureComposerDraftReloadPolicy.shouldMergeIntoLiveComposer(
+                didRestoreDraft: didRestoreDraft
+            ) else {
+                // The initial restoration reads the already-imported draft from
+                // the store. Retrying the delta afterward would append its text
+                // a second time.
+                handledComposerDraftReloadRevision = composerDraftReloadRevision
+                return
+            }
+            if await reloadImportedDraft(composerDraftReloadDraft) {
+                handledComposerDraftReloadRevision = composerDraftReloadRevision
+            }
         }
         .onChange(of: draft) { scheduleDraftSave() }
         .onChange(of: attachments) { scheduleDraftSave() }
@@ -121,6 +132,20 @@ public struct ThreadDetailView: View {
             Button("OK") {}
         } message: {
             Text("Your draft is still here. Check your connection and try again.")
+        }
+        .alert(
+            "Remove attachments before sending",
+            isPresented: Binding(
+                get: { sharedAttachmentOverflowCount > 0 },
+                set: { if !$0 { sharedAttachmentOverflowCount = 0 } }
+            )
+        ) {
+            Button("OK") {}
+        } message: {
+            Text(
+                "The shared attachments were kept. Remove "
+                    + "\(sharedAttachmentOverflowCount) before sending this draft."
+            )
         }
         .simultaneousGesture(edgeBackGesture)
     }
@@ -489,19 +514,27 @@ public struct ThreadDetailView: View {
     }
 
     @MainActor
-    private func reloadImportedDraft(_ importedDraft: FeatureComposerDraft) async {
-        let baseline = composerDraft
+    private func reloadImportedDraft(_ importedDraft: FeatureComposerDraft) async -> Bool {
+        guard didRestoreDraft else { return false }
         let key = draftKey
         let pendingSave = draftSaveTask
         draftSaveTask = nil
         pendingSave?.cancel()
         await pendingSave?.value
-        guard !Task.isCancelled else { return }
+        guard !Task.isCancelled else { return false }
 
-        restoreDraft(importedDraft, from: baseline)
+        let mergeResult = FeatureComposerIncomingShareMerge.merge(
+            current: composerDraft,
+            incoming: importedDraft
+        )
+        let merged = mergeResult.draft
+        draft = merged.text
+        attachments = merged.attachments
+        sharedAttachmentOverflowCount = mergeResult.attachmentOverflowCount
         draftSaveTask?.cancel()
         draftSaveTask = nil
         try? await draftStore.setDraft(composerDraft, for: key)
+        return true
     }
 
     @MainActor
@@ -657,6 +690,53 @@ enum FeatureComposerDraftRestoration {
                 ? saved.startFromOrigin
                 : current.startFromOrigin
         )
+    }
+}
+
+enum FeatureComposerIncomingShareMerge {
+    static func merge(
+        current: FeatureComposerDraft,
+        incoming: FeatureComposerDraft,
+        maximumAttachmentCount: Int = 8
+    ) -> FeatureComposerIncomingShareMergeResult {
+        let incomingText = incoming.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let mergedText: String
+        if incomingText.isEmpty {
+            mergedText = current.text
+        } else if current.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            mergedText = incomingText
+        } else {
+            mergedText = "\(current.text)\n\n\(incomingText)"
+        }
+
+        let currentAttachmentIDs = Set(current.attachments.map(\.id))
+        let uniqueIncomingAttachments = incoming.attachments.filter {
+            !currentAttachmentIDs.contains($0.id)
+        }
+        let mergedAttachments = current.attachments + uniqueIncomingAttachments
+        return FeatureComposerIncomingShareMergeResult(
+            draft: FeatureComposerDraft(
+                text: mergedText,
+                attachments: mergedAttachments,
+                selection: current.selection,
+                workspace: current.workspace
+            ),
+            attachmentOverflowCount: max(
+                0,
+                mergedAttachments.count - maximumAttachmentCount
+            )
+        )
+    }
+}
+
+struct FeatureComposerIncomingShareMergeResult {
+    let draft: FeatureComposerDraft
+    let attachmentOverflowCount: Int
+}
+
+enum FeatureComposerDraftReloadPolicy {
+    static func shouldMergeIntoLiveComposer(didRestoreDraft: Bool) -> Bool {
+        didRestoreDraft
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -739,6 +739,15 @@ struct FeatureComposerIncomingShareMergeResult {
 }
 
 enum FeatureComposerIncomingShareReloadPolicy {
+    static func appending(
+        _ imported: FeatureComposerIncomingShareDraft,
+        to imports: [FeatureComposerIncomingShareDraft],
+        maximumCount: Int = 32
+    ) -> [FeatureComposerIncomingShareDraft] {
+        let deduplicated = imports.filter { $0.shareID != imported.shareID }
+        return Array((deduplicated + [imported]).suffix(maximumCount))
+    }
+
     static func pendingImports(
         _ imports: [FeatureComposerIncomingShareDraft],
         restoredShareIDs: Set<String>

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -12,6 +12,7 @@ public struct ThreadDetailView: View {
     let composerDraftReloadImports: [FeatureComposerIncomingShareDraft]
     let submitMessage: (FeatureMessageSubmission) async -> Bool
     let onNavigateBack: () -> Void
+    let onComposerDraftReloadHandled: ([String]) -> Void
     private let draftStore: FeatureComposerDraftStore
 
     @State private var draft = ""
@@ -35,6 +36,7 @@ public struct ThreadDetailView: View {
         composerDraftReloadImports: [FeatureComposerIncomingShareDraft] = [],
         submitMessage: @escaping (FeatureMessageSubmission) async -> Bool,
         onNavigateBack: @escaping () -> Void = {},
+        onComposerDraftReloadHandled: @escaping ([String]) -> Void = { _ in },
         draftStore: FeatureComposerDraftStore = .shared
     ) {
         self.model = model
@@ -46,6 +48,7 @@ public struct ThreadDetailView: View {
         )
         self.submitMessage = submitMessage
         self.onNavigateBack = onNavigateBack
+        self.onComposerDraftReloadHandled = onComposerDraftReloadHandled
         self.draftStore = draftStore
     }
 
@@ -89,12 +92,14 @@ public struct ThreadDetailView: View {
         )) {
             guard handledComposerDraftReloadRevision != composerDraftReloadRevision,
                   didRestoreDraft else { return }
-            for imported in FeatureComposerIncomingShareReloadPolicy.pendingImports(
+            let pendingImports = FeatureComposerIncomingShareReloadPolicy.pendingImports(
                 composerDraftReloadImports,
                 restoredShareIDs: restoredImportedShareIDs
-            ) {
+            )
+            for imported in pendingImports {
                 guard await reloadImportedDraft(imported.draft) else { return }
                 restoredImportedShareIDs.insert(imported.shareID)
+                onComposerDraftReloadHandled([imported.shareID])
             }
             handledComposerDraftReloadRevision = composerDraftReloadRevision
         }
@@ -753,6 +758,14 @@ enum FeatureComposerIncomingShareReloadPolicy {
         restoredShareIDs: Set<String>
     ) -> [FeatureComposerIncomingShareDraft] {
         imports.filter { !restoredShareIDs.contains($0.shareID) }
+    }
+
+    static func removing(
+        shareIDs: [String],
+        from imports: [FeatureComposerIncomingShareDraft]
+    ) -> [FeatureComposerIncomingShareDraft] {
+        let handled = Set(shareIDs.map { $0.lowercased() })
+        return imports.filter { !handled.contains($0.shareID.lowercased()) }
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -9,6 +9,7 @@ public struct ThreadDetailView: View {
     @Bindable var model: FeatureRootModel
     let thread: FeatureThread
     let composerDraftReloadRevision: Int
+    let composerDraftReloadDraft: FeatureComposerDraft?
     let submitMessage: (FeatureMessageSubmission) async -> Bool
     let onNavigateBack: () -> Void
     private let draftStore: FeatureComposerDraftStore
@@ -20,6 +21,7 @@ public struct ThreadDetailView: View {
     @State private var isLoading = true
     @State private var sendFailed = false
     @State private var didRestoreDraft = false
+    @State private var handledComposerDraftReloadRevision: Int
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var toolSurface: FeatureThreadToolSurface?
     @FocusState private var composerFocused: Bool
@@ -28,6 +30,7 @@ public struct ThreadDetailView: View {
         model: FeatureRootModel,
         thread: FeatureThread,
         composerDraftReloadRevision: Int = 0,
+        composerDraftReloadDraft: FeatureComposerDraft? = nil,
         submitMessage: @escaping (FeatureMessageSubmission) async -> Bool,
         onNavigateBack: @escaping () -> Void = {},
         draftStore: FeatureComposerDraftStore = .shared
@@ -35,6 +38,10 @@ public struct ThreadDetailView: View {
         self.model = model
         self.thread = thread
         self.composerDraftReloadRevision = composerDraftReloadRevision
+        self.composerDraftReloadDraft = composerDraftReloadDraft
+        _handledComposerDraftReloadRevision = State(
+            initialValue: composerDraftReloadRevision
+        )
         self.submitMessage = submitMessage
         self.onNavigateBack = onNavigateBack
         self.draftStore = draftStore
@@ -74,8 +81,11 @@ public struct ThreadDetailView: View {
             await restoreDraft(from: restoreBaseline, key: restoreKey)
             isLoading = false
         }
-        .onChange(of: composerDraftReloadRevision) {
-            reloadImportedDraft()
+        .task(id: composerDraftReloadRevision) {
+            guard handledComposerDraftReloadRevision != composerDraftReloadRevision,
+                  let composerDraftReloadDraft else { return }
+            handledComposerDraftReloadRevision = composerDraftReloadRevision
+            await reloadImportedDraft(composerDraftReloadDraft)
         }
         .onChange(of: draft) { scheduleDraftSave() }
         .onChange(of: attachments) { scheduleDraftSave() }
@@ -478,13 +488,20 @@ public struct ThreadDetailView: View {
         FeatureComposerDraftStore.threadKey(currentThread)
     }
 
-    private func reloadImportedDraft() {
-        draftSaveTask?.cancel()
+    @MainActor
+    private func reloadImportedDraft(_ importedDraft: FeatureComposerDraft) async {
         let baseline = composerDraft
         let key = draftKey
-        Task { @MainActor in
-            await restoreDraft(from: baseline, key: key)
-        }
+        let pendingSave = draftSaveTask
+        draftSaveTask = nil
+        pendingSave?.cancel()
+        await pendingSave?.value
+        guard !Task.isCancelled else { return }
+
+        restoreDraft(importedDraft, from: baseline)
+        draftSaveTask?.cancel()
+        draftSaveTask = nil
+        try? await draftStore.setDraft(composerDraft, for: key)
     }
 
     @MainActor
@@ -492,6 +509,11 @@ public struct ThreadDetailView: View {
         let saved = try? await draftStore.draft(for: key)
         guard !Task.isCancelled else { return }
 
+        restoreDraft(saved, from: baseline)
+    }
+
+    @MainActor
+    private func restoreDraft(_ saved: FeatureComposerDraft?, from baseline: FeatureComposerDraft) {
         let liveDraft = composerDraft
         var restored = FeatureComposerDraftRestoration.merge(
             saved: saved,

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -8,6 +8,7 @@ public struct ThreadDetailView: View {
 
     @Bindable var model: FeatureRootModel
     let thread: FeatureThread
+    let composerDraftReloadRevision: Int
     let submitMessage: (FeatureMessageSubmission) async -> Bool
     let onNavigateBack: () -> Void
     private let draftStore: FeatureComposerDraftStore
@@ -26,12 +27,14 @@ public struct ThreadDetailView: View {
     public init(
         model: FeatureRootModel,
         thread: FeatureThread,
+        composerDraftReloadRevision: Int = 0,
         submitMessage: @escaping (FeatureMessageSubmission) async -> Bool,
         onNavigateBack: @escaping () -> Void = {},
         draftStore: FeatureComposerDraftStore = .shared
     ) {
         self.model = model
         self.thread = thread
+        self.composerDraftReloadRevision = composerDraftReloadRevision
         self.submitMessage = submitMessage
         self.onNavigateBack = onNavigateBack
         self.draftStore = draftStore
@@ -70,6 +73,9 @@ public struct ThreadDetailView: View {
             _ = await model.detail(for: thread.id, force: true)
             await restoreDraft(from: restoreBaseline, key: restoreKey)
             isLoading = false
+        }
+        .onChange(of: composerDraftReloadRevision) {
+            reloadImportedDraft()
         }
         .onChange(of: draft) { scheduleDraftSave() }
         .onChange(of: attachments) { scheduleDraftSave() }
@@ -470,6 +476,15 @@ public struct ThreadDetailView: View {
 
     private var draftKey: String {
         FeatureComposerDraftStore.threadKey(currentThread)
+    }
+
+    private func reloadImportedDraft() {
+        draftSaveTask?.cancel()
+        let baseline = composerDraft
+        let key = draftKey
+        Task { @MainActor in
+            await restoreDraft(from: baseline, key: key)
+        }
     }
 
     @MainActor

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -9,7 +9,7 @@ public struct ThreadDetailView: View {
     @Bindable var model: FeatureRootModel
     let thread: FeatureThread
     let composerDraftReloadRevision: Int
-    let composerDraftReloadDraft: FeatureComposerDraft?
+    let composerDraftReloadImports: [FeatureComposerIncomingShareDraft]
     let submitMessage: (FeatureMessageSubmission) async -> Bool
     let onNavigateBack: () -> Void
     private let draftStore: FeatureComposerDraftStore
@@ -22,6 +22,7 @@ public struct ThreadDetailView: View {
     @State private var sendFailed = false
     @State private var sharedAttachmentOverflowCount = 0
     @State private var didRestoreDraft = false
+    @State private var restoredImportedShareIDs: Set<String> = []
     @State private var handledComposerDraftReloadRevision: Int
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var toolSurface: FeatureThreadToolSurface?
@@ -31,7 +32,7 @@ public struct ThreadDetailView: View {
         model: FeatureRootModel,
         thread: FeatureThread,
         composerDraftReloadRevision: Int = 0,
-        composerDraftReloadDraft: FeatureComposerDraft? = nil,
+        composerDraftReloadImports: [FeatureComposerIncomingShareDraft] = [],
         submitMessage: @escaping (FeatureMessageSubmission) async -> Bool,
         onNavigateBack: @escaping () -> Void = {},
         draftStore: FeatureComposerDraftStore = .shared
@@ -39,7 +40,7 @@ public struct ThreadDetailView: View {
         self.model = model
         self.thread = thread
         self.composerDraftReloadRevision = composerDraftReloadRevision
-        self.composerDraftReloadDraft = composerDraftReloadDraft
+        self.composerDraftReloadImports = composerDraftReloadImports
         _handledComposerDraftReloadRevision = State(
             initialValue: composerDraftReloadRevision
         )
@@ -82,21 +83,20 @@ public struct ThreadDetailView: View {
             await restoreDraft(from: restoreBaseline, key: restoreKey)
             isLoading = false
         }
-        .task(id: composerDraftReloadRevision) {
+        .task(id: FeatureComposerDraftReloadTrigger(
+            revision: composerDraftReloadRevision,
+            didRestoreDraft: didRestoreDraft
+        )) {
             guard handledComposerDraftReloadRevision != composerDraftReloadRevision,
-                  let composerDraftReloadDraft else { return }
-            guard FeatureComposerDraftReloadPolicy.shouldMergeIntoLiveComposer(
-                didRestoreDraft: didRestoreDraft
-            ) else {
-                // The initial restoration reads the already-imported draft from
-                // the store. Retrying the delta afterward would append its text
-                // a second time.
-                handledComposerDraftReloadRevision = composerDraftReloadRevision
-                return
+                  didRestoreDraft else { return }
+            for imported in FeatureComposerIncomingShareReloadPolicy.pendingImports(
+                composerDraftReloadImports,
+                restoredShareIDs: restoredImportedShareIDs
+            ) {
+                guard await reloadImportedDraft(imported.draft) else { return }
+                restoredImportedShareIDs.insert(imported.shareID)
             }
-            if await reloadImportedDraft(composerDraftReloadDraft) {
-                handledComposerDraftReloadRevision = composerDraftReloadRevision
-            }
+            handledComposerDraftReloadRevision = composerDraftReloadRevision
         }
         .onChange(of: draft) { scheduleDraftSave() }
         .onChange(of: attachments) { scheduleDraftSave() }
@@ -539,17 +539,20 @@ public struct ThreadDetailView: View {
 
     @MainActor
     private func restoreDraft(from baseline: FeatureComposerDraft, key: String) async {
-        let saved = try? await draftStore.draft(for: key)
+        let snapshot = try? await draftStore.snapshot(for: key)
         guard !Task.isCancelled else { return }
 
-        restoreDraft(saved, from: baseline)
+        restoreDraft(snapshot, from: baseline)
     }
 
     @MainActor
-    private func restoreDraft(_ saved: FeatureComposerDraft?, from baseline: FeatureComposerDraft) {
+    private func restoreDraft(
+        _ snapshot: FeatureComposerDraftSnapshot?,
+        from baseline: FeatureComposerDraft
+    ) {
         let liveDraft = composerDraft
         var restored = FeatureComposerDraftRestoration.merge(
-            saved: saved,
+            saved: snapshot?.draft,
             baseline: baseline,
             current: liveDraft
         )
@@ -561,6 +564,7 @@ public struct ThreadDetailView: View {
         draft = restored.text
         attachments = restored.attachments
         selection = restored.selection
+        restoredImportedShareIDs = snapshot?.importedShareIDs ?? []
         didRestoreDraft = true
 
         // Changes made while the file read or thread refresh was in flight did
@@ -734,10 +738,18 @@ struct FeatureComposerIncomingShareMergeResult {
     let attachmentOverflowCount: Int
 }
 
-enum FeatureComposerDraftReloadPolicy {
-    static func shouldMergeIntoLiveComposer(didRestoreDraft: Bool) -> Bool {
-        didRestoreDraft
+enum FeatureComposerIncomingShareReloadPolicy {
+    static func pendingImports(
+        _ imports: [FeatureComposerIncomingShareDraft],
+        restoredShareIDs: Set<String>
+    ) -> [FeatureComposerIncomingShareDraft] {
+        imports.filter { !restoredShareIDs.contains($0.shareID) }
     }
+}
+
+private struct FeatureComposerDraftReloadTrigger: Hashable {
+    let revision: Int
+    let didRestoreDraft: Bool
 }
 
 /// A recycled transcript surface. SwiftUI still owns each message's rendering,

--- a/apps/swift-ios/Features/Root/FeatureRootView.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootView.swift
@@ -4,14 +4,14 @@ public struct FeatureRootView: View {
     @State private var model: FeatureRootModel
     private let navigationRequest: FeatureWorkspaceNavigationRequest?
     private let onNavigationRequestConsumed: @MainActor (UUID) -> Void
-    private let acknowledgeIncomingShare: (String) async -> Void
+    private let acknowledgeIncomingShare: (String) async -> Bool
     private let releaseIncomingSharePresentation: @MainActor (String) -> Void
 
     public init(client: any FeatureClient) {
         _model = State(initialValue: FeatureRootModel(client: client))
         navigationRequest = nil
         onNavigationRequestConsumed = { _ in }
-        acknowledgeIncomingShare = { _ in }
+        acknowledgeIncomingShare = { _ in true }
         releaseIncomingSharePresentation = { _ in }
     }
 
@@ -19,7 +19,7 @@ public struct FeatureRootView: View {
         model: FeatureRootModel,
         navigationRequest: FeatureWorkspaceNavigationRequest? = nil,
         onNavigationRequestConsumed: @escaping @MainActor (UUID) -> Void = { _ in },
-        acknowledgeIncomingShare: @escaping (String) async -> Void = { _ in },
+        acknowledgeIncomingShare: @escaping (String) async -> Bool = { _ in true },
         releaseIncomingSharePresentation: @escaping @MainActor (String) -> Void = { _ in }
     ) {
         _model = State(initialValue: model)

--- a/apps/swift-ios/Features/Root/FeatureRootView.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootView.swift
@@ -4,21 +4,29 @@ public struct FeatureRootView: View {
     @State private var model: FeatureRootModel
     private let navigationRequest: FeatureWorkspaceNavigationRequest?
     private let onNavigationRequestConsumed: @MainActor (UUID) -> Void
+    private let acknowledgeIncomingShare: (String) async -> Void
+    private let releaseIncomingSharePresentation: @MainActor (String) -> Void
 
     public init(client: any FeatureClient) {
         _model = State(initialValue: FeatureRootModel(client: client))
         navigationRequest = nil
         onNavigationRequestConsumed = { _ in }
+        acknowledgeIncomingShare = { _ in }
+        releaseIncomingSharePresentation = { _ in }
     }
 
     init(
         model: FeatureRootModel,
         navigationRequest: FeatureWorkspaceNavigationRequest? = nil,
-        onNavigationRequestConsumed: @escaping @MainActor (UUID) -> Void = { _ in }
+        onNavigationRequestConsumed: @escaping @MainActor (UUID) -> Void = { _ in },
+        acknowledgeIncomingShare: @escaping (String) async -> Void = { _ in },
+        releaseIncomingSharePresentation: @escaping @MainActor (String) -> Void = { _ in }
     ) {
         _model = State(initialValue: model)
         self.navigationRequest = navigationRequest
         self.onNavigationRequestConsumed = onNavigationRequestConsumed
+        self.acknowledgeIncomingShare = acknowledgeIncomingShare
+        self.releaseIncomingSharePresentation = releaseIncomingSharePresentation
     }
 
     public var body: some View {
@@ -35,7 +43,9 @@ public struct FeatureRootView: View {
                     },
                     submitMessage: { submission in
                         await model.sendMessage(submission)
-                    }
+                    },
+                    acknowledgeIncomingShare: acknowledgeIncomingShare,
+                    releaseIncomingSharePresentation: releaseIncomingSharePresentation
                 )
             } else {
                 ConnectionOnboardingView(model: model)

--- a/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
+++ b/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
@@ -55,6 +55,12 @@ public enum FeatureComposerDraftImportError: LocalizedError, Equatable, Sendable
     }
 }
 
+public enum FeatureComposerIncomingShareRoutingResult: Equatable, Sendable {
+    case routed(FeatureComposerDraft)
+    case alreadyRouted(FeatureComposerDraft?)
+    case sourceMissing
+}
+
 /// Persists composer state independently of view navigation. Draft writes are
 /// atomic, and callers debounce high-frequency text changes before reaching
 /// this actor so image data is not repeatedly encoded for every keystroke.
@@ -236,16 +242,21 @@ public actor FeatureComposerDraftStore {
         shareID: String,
         to key: String,
         maximumAttachmentCount: Int = 8
-    ) throws -> FeatureComposerDraft? {
+    ) throws -> FeatureComposerIncomingShareRoutingResult {
         var drafts = try loadIfNeeded()
         let sourceKey = Self.incomingShareKey(shareID: shareID)
         guard let source = drafts[sourceKey] else {
-            return drafts[key]?.featureValue
+            guard let destination = drafts[key],
+                  destination.importedShareIDs?.contains(shareID) == true else {
+                return .sourceMissing
+            }
+            return .alreadyRouted(destination.featureValue)
         }
 
         var destination = drafts[key] ?? PersistedDraft(FeatureComposerDraft())
         var importedIDs = destination.importedShareIDs ?? []
-        if !importedIDs.contains(shareID) {
+        let wasAlreadyRouted = importedIDs.contains(shareID)
+        if !wasAlreadyRouted {
             let existingIDs = Set(destination.attachments.map(\.id))
             let uniqueAttachments = source.attachments.filter { !existingIDs.contains($0.id) }
             let availableCount = max(0, maximumAttachmentCount - destination.attachments.count)
@@ -271,7 +282,9 @@ public actor FeatureComposerDraftStore {
         drafts.removeValue(forKey: sourceKey)
         try persist(drafts)
         loadedDrafts = drafts
-        return destination.featureValue
+        return wasAlreadyRouted
+            ? .alreadyRouted(destination.featureValue)
+            : .routed(destination.featureValue)
     }
 
     public func removeDraft(for key: String) throws {

--- a/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
+++ b/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
@@ -228,6 +228,52 @@ public actor FeatureComposerDraftStore {
         return persisted.featureValue
     }
 
+    /// Atomically moves a share that was staged before project selection into
+    /// the chosen new-task draft. The destination ledger prevents replay from
+    /// duplicating content if the host app is interrupted during inbox cleanup.
+    @discardableResult
+    public func routeIncomingShare(
+        shareID: String,
+        to key: String,
+        maximumAttachmentCount: Int = 8
+    ) throws -> FeatureComposerDraft? {
+        var drafts = try loadIfNeeded()
+        let sourceKey = Self.incomingShareKey(shareID: shareID)
+        guard let source = drafts[sourceKey] else {
+            return drafts[key]?.featureValue
+        }
+
+        var destination = drafts[key] ?? PersistedDraft(FeatureComposerDraft())
+        var importedIDs = destination.importedShareIDs ?? []
+        if !importedIDs.contains(shareID) {
+            let existingIDs = Set(destination.attachments.map(\.id))
+            let uniqueAttachments = source.attachments.filter { !existingIDs.contains($0.id) }
+            let availableCount = max(0, maximumAttachmentCount - destination.attachments.count)
+            guard uniqueAttachments.count <= availableCount else {
+                throw FeatureComposerDraftImportError.attachmentLimitExceeded(
+                    available: availableCount
+                )
+            }
+
+            let incomingText = source.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !incomingText.isEmpty {
+                destination.text = destination.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                destination.text = destination.text.isEmpty
+                    ? incomingText
+                    : "\(destination.text)\n\n\(incomingText)"
+            }
+            destination.attachments.append(contentsOf: uniqueAttachments)
+            importedIDs.append(shareID)
+            destination.importedShareIDs = Array(importedIDs.suffix(32))
+        }
+
+        drafts[key] = destination
+        drafts.removeValue(forKey: sourceKey)
+        try persist(drafts)
+        loadedDrafts = drafts
+        return destination.featureValue
+    }
+
     public func removeDraft(for key: String) throws {
         var drafts = try loadIfNeeded()
         guard drafts.removeValue(forKey: key) != nil else { return }
@@ -256,6 +302,10 @@ public actor FeatureComposerDraftStore {
 
     public static func newTaskKey(logicalProjectID: String) -> String {
         "logical-project:\(logicalProjectID):new-task"
+    }
+
+    public static func incomingShareKey(shareID: String) -> String {
+        "incoming-share:\(shareID.lowercased())"
     }
 
     private func loadIfNeeded() throws -> [String: PersistedDraft] {

--- a/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
+++ b/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
@@ -231,6 +231,19 @@ public actor FeatureComposerDraftStore {
         loadedDrafts = drafts
     }
 
+    public func restoreDraft(
+        _ draft: FeatureComposerDraft,
+        importedShareIDs: Set<String>,
+        for key: String
+    ) throws {
+        var drafts = try loadIfNeeded()
+        var persisted = PersistedDraft(draft)
+        persisted.importedShareIDs = Array(importedShareIDs.sorted().suffix(32))
+        drafts[key] = persisted
+        try persist(drafts)
+        loadedDrafts = drafts
+    }
+
     /// Atomically imports one share-extension envelope into the latest stored
     /// draft. The share ID is committed with the content, so a host crash after
     /// this write but before inbox cleanup cannot duplicate the import.

--- a/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
+++ b/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
@@ -23,6 +23,26 @@ public struct FeatureComposerDraft: Sendable, Equatable {
     }
 }
 
+public struct FeatureComposerDraftSnapshot: Sendable, Equatable {
+    public let draft: FeatureComposerDraft?
+    public let importedShareIDs: Set<String>
+
+    public init(draft: FeatureComposerDraft?, importedShareIDs: Set<String>) {
+        self.draft = draft
+        self.importedShareIDs = importedShareIDs
+    }
+}
+
+public struct FeatureComposerIncomingShareDraft: Sendable, Equatable {
+    public let shareID: String
+    public let draft: FeatureComposerDraft
+
+    public init(shareID: String, draft: FeatureComposerDraft) {
+        self.shareID = shareID
+        self.draft = draft
+    }
+}
+
 public struct FeatureComposerWorkspaceDraft: Sendable, Equatable {
     public var mode: FeatureWorkspaceMode
     public var branch: String?
@@ -175,9 +195,18 @@ public actor FeatureComposerDraftStore {
     }
 
     public func draft(for key: String) throws -> FeatureComposerDraft? {
-        guard let draft = try loadIfNeeded()[key]?.featureValue,
-              !draft.isEmpty else { return nil }
-        return draft
+        try snapshot(for: key).draft
+    }
+
+    public func snapshot(for key: String) throws -> FeatureComposerDraftSnapshot {
+        guard let persisted = try loadIfNeeded()[key] else {
+            return FeatureComposerDraftSnapshot(draft: nil, importedShareIDs: [])
+        }
+        let draft = persisted.featureValue
+        return FeatureComposerDraftSnapshot(
+            draft: draft.isEmpty ? nil : draft,
+            importedShareIDs: Set(persisted.importedShareIDs ?? [])
+        )
     }
 
     public func setDraft(_ draft: FeatureComposerDraft, for key: String) throws {

--- a/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
+++ b/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
@@ -55,6 +55,16 @@ public enum FeatureComposerDraftImportError: LocalizedError, Equatable, Sendable
     }
 }
 
+public struct FeatureComposerDraftImportResult: Equatable, Sendable {
+    public let draft: FeatureComposerDraft
+    public let didImport: Bool
+
+    public init(draft: FeatureComposerDraft, didImport: Bool) {
+        self.draft = draft
+        self.didImport = didImport
+    }
+}
+
 public enum FeatureComposerIncomingShareRoutingResult: Equatable, Sendable {
     case routed(FeatureComposerDraft)
     case alreadyRouted(FeatureComposerDraft?)
@@ -203,10 +213,31 @@ public actor FeatureComposerDraftStore {
         for key: String,
         maximumAttachmentCount: Int = 8
     ) throws -> FeatureComposerDraft {
+        try importSharedContentResult(
+            shareID: shareID,
+            text: text,
+            attachments: attachments,
+            for: key,
+            maximumAttachmentCount: maximumAttachmentCount
+        ).draft
+    }
+
+    public func importSharedContentResult(
+        shareID: String,
+        text: String,
+        attachments: [FeatureDraftAttachment],
+        for key: String,
+        maximumAttachmentCount: Int = 8
+    ) throws -> FeatureComposerDraftImportResult {
         var drafts = try loadIfNeeded()
         var persisted = drafts[key] ?? PersistedDraft(FeatureComposerDraft())
         var importedIDs = persisted.importedShareIDs ?? []
-        guard !importedIDs.contains(shareID) else { return persisted.featureValue }
+        guard !importedIDs.contains(shareID) else {
+            return FeatureComposerDraftImportResult(
+                draft: persisted.featureValue,
+                didImport: false
+            )
+        }
 
         let existingIDs = Set(persisted.attachments.map(\.id))
         let uniqueAttachments = attachments.filter { !existingIDs.contains($0.id) }
@@ -231,7 +262,10 @@ public actor FeatureComposerDraftStore {
         drafts[key] = persisted
         try persist(drafts)
         loadedDrafts = drafts
-        return persisted.featureValue
+        return FeatureComposerDraftImportResult(
+            draft: persisted.featureValue,
+            didImport: true
+        )
     }
 
     /// Atomically moves a share that was staged before project selection into

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -788,7 +788,9 @@ public struct NewThreadView: View {
                     routingError = "The shared draft is no longer available. Share it again to retry."
                 }
             } catch {
-                saved = nil
+                saved = try? await draftStore.draft(
+                    for: FeatureComposerDraftStore.incomingShareKey(shareID: routedShareID)
+                )
                 routingError = error.localizedDescription
             }
         } else {
@@ -814,7 +816,16 @@ public struct NewThreadView: View {
             }
             return
         }
-        if let routingError { incomingShareErrorMessage = routingError }
+        if let routingError {
+            incomingShareErrorMessage = routingError
+            if let saved {
+                prompt = saved.text
+                attachments = saved.attachments
+                restoredIncomingShareID = routedShareID
+            }
+            await loadBranches()
+            return
+        }
 
         let liveDraft = composerDraft
         let liveSelectionIsExplicit = selectionIsExplicit
@@ -1137,6 +1148,12 @@ enum NewTaskIncomingShareDiscard {
         store: FeatureComposerDraftStore,
         acknowledge: (String) async -> Bool
     ) async -> NewTaskIncomingShareDiscardResult {
+        let importedShareIDs: Set<String>
+        do {
+            importedShareIDs = try await store.snapshot(for: key).importedShareIDs
+        } catch {
+            return .cleanupFailed
+        }
         do {
             try await store.removeDraft(for: key)
         } catch {
@@ -1144,7 +1161,11 @@ enum NewTaskIncomingShareDiscard {
         }
         guard await acknowledge(shareID) else {
             do {
-                try await store.setDraft(draft, for: key)
+                try await store.restoreDraft(
+                    draft,
+                    importedShareIDs: importedShareIDs,
+                    for: key
+                )
                 return .acknowledgementFailed(draftRestored: true)
             } catch {
                 return .acknowledgementFailed(draftRestored: false)

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -1129,6 +1129,7 @@ enum NewTaskIncomingShareDiscardResult: Equatable {
 }
 
 enum NewTaskIncomingShareDiscard {
+    @MainActor
     static func perform(
         shareID: String,
         draft: FeatureComposerDraft,

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -8,6 +8,7 @@ public struct NewThreadView: View {
     let onCreateProject: @MainActor () -> Void
     private let draftStore: FeatureComposerDraftStore
     private let initialProjectID: String?
+    private let acknowledgeIncomingShare: (String) async -> Void
 
     @State private var projectID = ""
     @State private var prompt = ""
@@ -30,6 +31,7 @@ public struct NewThreadView: View {
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var immediateDraftSaveTasks: [String: Task<Void, Never>] = [:]
     @State private var submittedSuccessfully = false
+    @State private var pendingIncomingShareID: String?
     @FocusState private var promptFocused: Bool
 
     public init(
@@ -38,6 +40,8 @@ public struct NewThreadView: View {
         onCreated: @escaping (FeatureThread) -> Void,
         onCreateProject: @escaping @MainActor () -> Void = {},
         initialProjectID: String? = nil,
+        incomingShareID: String? = nil,
+        acknowledgeIncomingShare: @escaping (String) async -> Void = { _ in },
         draftStore: FeatureComposerDraftStore = .shared
     ) {
         self.model = model
@@ -45,7 +49,9 @@ public struct NewThreadView: View {
         self.onCreated = onCreated
         self.onCreateProject = onCreateProject
         self.initialProjectID = initialProjectID
+        self.acknowledgeIncomingShare = acknowledgeIncomingShare
         self.draftStore = draftStore
+        _pendingIncomingShareID = State(initialValue: incomingShareID)
     }
 
     public var body: some View {
@@ -88,7 +94,11 @@ public struct NewThreadView: View {
             }
         }
         .onAppear {
-            if projectID.isEmpty {
+            if pendingIncomingShareID != nil {
+                if !creationProjects.isEmpty {
+                    activePicker = .project
+                }
+            } else if projectID.isEmpty {
                 let initialProject = creationProjects.first { $0.id == initialProjectID }
                 let initialGroup = initialProject.flatMap {
                     DailyUXProjectGrouping.group(
@@ -122,6 +132,7 @@ public struct NewThreadView: View {
         .onChange(of: selectedBranch) { scheduleDraftSave() }
         .onChange(of: startFromOrigin) { scheduleDraftSave() }
         .task(id: projectID) { await restoreDraftAndLoadBranches() }
+        .task(id: pendingIncomingShareID) { await restoreIncomingShareDraft() }
         .onDisappear {
             guard !submittedSuccessfully else { return }
             persistCurrentDraftImmediately()
@@ -702,7 +713,16 @@ public struct NewThreadView: View {
               draftRestoreContext?.projectID == requestedProjectID else {
             return
         }
-        let saved = try? await draftStore.draft(for: key)
+        let routedShareID = pendingIncomingShareID
+        let saved: FeatureComposerDraft?
+        if let routedShareID {
+            saved = try? await draftStore.routeIncomingShare(
+                shareID: routedShareID,
+                to: key
+            )
+        } else {
+            saved = try? await draftStore.draft(for: key)
+        }
         guard !Task.isCancelled,
               projectID == requestedProjectID,
               draftRestoreContext?.projectID == requestedProjectID else {
@@ -744,10 +764,27 @@ public struct NewThreadView: View {
         workspaceSelectionIsExplicit = liveWorkspaceSelectionIsExplicit
             || saved?.workspace != nil
         restoredDraftProjectID = requestedProjectID
+        if let routedShareID, saved != nil {
+            pendingIncomingShareID = nil
+            await acknowledgeIncomingShare(routedShareID)
+        }
         if liveDraft != context.baseline {
             scheduleDraftSave()
         }
         await loadBranches()
+    }
+
+    @MainActor
+    private func restoreIncomingShareDraft() async {
+        guard let shareID = pendingIncomingShareID,
+              projectID.isEmpty else { return }
+        let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
+        guard let saved = try? await draftStore.draft(for: key) else { return }
+        prompt = saved.text
+        attachments = saved.attachments
+        if !creationProjects.isEmpty {
+            activePicker = .project
+        }
     }
 
     private var currentDraftKey: String? {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -8,7 +8,7 @@ public struct NewThreadView: View {
     let onCreateProject: @MainActor () -> Void
     private let draftStore: FeatureComposerDraftStore
     private let initialProjectID: String?
-    private let acknowledgeIncomingShare: (String) async -> Void
+    private let acknowledgeIncomingShare: (String) async -> Bool
 
     @State private var projectID = ""
     @State private var prompt = ""
@@ -43,7 +43,7 @@ public struct NewThreadView: View {
         onCreateProject: @escaping @MainActor () -> Void = {},
         initialProjectID: String? = nil,
         incomingShareID: String? = nil,
-        acknowledgeIncomingShare: @escaping (String) async -> Void = { _ in },
+        acknowledgeIncomingShare: @escaping (String) async -> Bool = { _ in true },
         draftStore: FeatureComposerDraftStore = .shared
     ) {
         self.model = model
@@ -778,11 +778,17 @@ public struct NewThreadView: View {
             && draftRestoreContext?.projectID == requestedProjectID
         guard routeIsCurrent else {
             if let routedShareID,
-               shouldAcknowledgeShare,
-               pendingIncomingShareID == routedShareID {
+               NewTaskIncomingShareAcknowledgementPolicy.canAcknowledge(
+                   didRoute: shouldAcknowledgeShare,
+                   routedShareID: routedShareID,
+                   pendingShareID: pendingIncomingShareID,
+                   routedProjectID: requestedProjectID,
+                   currentProjectID: projectID,
+                   restoreContextProjectID: draftRestoreContext?.projectID
+               ),
+               await acknowledgeIncomingShare(routedShareID) {
                 restoredIncomingShareID = nil
                 pendingIncomingShareID = nil
-                await acknowledgeIncomingShare(routedShareID)
             }
             return
         }
@@ -823,10 +829,11 @@ public struct NewThreadView: View {
         workspaceSelectionIsExplicit = liveWorkspaceSelectionIsExplicit
             || saved?.workspace != nil
         restoredDraftProjectID = requestedProjectID
-        if let routedShareID, shouldAcknowledgeShare {
+        if let routedShareID,
+           shouldAcknowledgeShare,
+           await acknowledgeIncomingShare(routedShareID) {
             restoredIncomingShareID = nil
             pendingIncomingShareID = nil
-            await acknowledgeIncomingShare(routedShareID)
         }
         if liveDraft != context.baseline {
             scheduleDraftSave()
@@ -977,12 +984,12 @@ public struct NewThreadView: View {
         guard let shareID = pendingIncomingShareID else { return }
         let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
         let pendingSave = immediateDraftSaveTasks.removeValue(forKey: key)
-        restoredIncomingShareID = nil
-        pendingIncomingShareID = nil
         Task { @MainActor in
             await NewTaskDraftWriteFence.cancelAndWait(pendingSave)
+            guard await acknowledgeIncomingShare(shareID) else { return }
+            restoredIncomingShareID = nil
+            pendingIncomingShareID = nil
             try? await draftStore.removeDraft(for: key)
-            await acknowledgeIncomingShare(shareID)
             dismiss()
         }
     }
@@ -1045,6 +1052,22 @@ enum NewTaskIncomingSharePersistencePolicy {
     static func canPersist(pendingShareID: String?, restoredShareID: String?) -> Bool {
         guard let pendingShareID else { return false }
         return restoredShareID == pendingShareID
+    }
+}
+
+enum NewTaskIncomingShareAcknowledgementPolicy {
+    static func canAcknowledge(
+        didRoute: Bool,
+        routedShareID: String,
+        pendingShareID: String?,
+        routedProjectID: String,
+        currentProjectID: String,
+        restoreContextProjectID: String?
+    ) -> Bool {
+        didRoute
+            && pendingShareID?.caseInsensitiveCompare(routedShareID) == .orderedSame
+            && currentProjectID == routedProjectID
+            && restoreContextProjectID == routedProjectID
     }
 }
 

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -34,6 +34,8 @@ public struct NewThreadView: View {
     @State private var pendingIncomingShareID: String?
     @State private var restoredIncomingShareID: String?
     @State private var showingDiscardIncomingShare = false
+    @State private var isRoutingIncomingShare = false
+    @State private var incomingShareErrorMessage: String?
     @FocusState private var promptFocused: Bool
 
     public init(
@@ -172,6 +174,17 @@ public struct NewThreadView: View {
         } message: {
             Text("Check your connection and try again.")
         }
+        .alert(
+            "Shared draft needs attention",
+            isPresented: Binding(
+                get: { incomingShareErrorMessage != nil },
+                set: { if !$0 { incomingShareErrorMessage = nil } }
+            )
+        ) {
+            Button("OK") { incomingShareErrorMessage = nil }
+        } message: {
+            Text(incomingShareErrorMessage ?? "Try again.")
+        }
         .confirmationDialog(
             "Discard this shared draft?",
             isPresented: $showingDiscardIncomingShare,
@@ -198,7 +211,7 @@ public struct NewThreadView: View {
             }
                 .font(.body)
                 .foregroundStyle(T3Colors.textSecondary)
-                .disabled(isSubmitting)
+                .disabled(isSubmitting || isRoutingIncomingShare)
             Spacer()
         }
         .padding(.horizontal, 16)
@@ -226,7 +239,7 @@ public struct NewThreadView: View {
                         }
                 }
                 .buttonStyle(.plain)
-                .disabled(isSubmitting)
+                .disabled(isSubmitting || isRoutingIncomingShare)
                 .padding(.leading, 5)
                 .accessibilityLabel("Choose project")
                 .accessibilityValue(
@@ -268,7 +281,9 @@ public struct NewThreadView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .disabled(isSubmitting || creationEnvironments.count < 2)
+            .disabled(
+                isSubmitting || isRoutingIncomingShare || creationEnvironments.count < 2
+            )
             .accessibilityLabel("Computer")
             .accessibilityValue(environmentName)
             .offset(y: 31)
@@ -589,6 +604,9 @@ public struct NewThreadView: View {
 
     @discardableResult
     private func selectProject(_ id: String) -> Bool {
+        guard NewTaskIncomingShareRoutingPolicy.canChangeProject(
+            isRoutingIncomingShare: isRoutingIncomingShare
+        ) else { return false }
         guard id != projectID else { return true }
         guard creationProjects.contains(where: { $0.id == id }) else { return false }
         persistCurrentDraftImmediately()
@@ -735,6 +753,10 @@ public struct NewThreadView: View {
             return
         }
         let routedShareID = pendingIncomingShareID
+        if routedShareID != nil { isRoutingIncomingShare = true }
+        defer {
+            if routedShareID != nil { isRoutingIncomingShare = false }
+        }
         if let routedShareID {
             let sourceKey = FeatureComposerDraftStore.incomingShareKey(shareID: routedShareID)
             await NewTaskDraftWriteFence.wait(immediateDraftSaveTasks[sourceKey])
@@ -792,7 +814,7 @@ public struct NewThreadView: View {
             }
             return
         }
-        if let routingError { model.errorMessage = routingError }
+        if let routingError { incomingShareErrorMessage = routingError }
 
         let liveDraft = composerDraft
         let liveSelectionIsExplicit = selectionIsExplicit
@@ -984,12 +1006,22 @@ public struct NewThreadView: View {
         guard let shareID = pendingIncomingShareID else { return }
         let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
         let pendingSave = immediateDraftSaveTasks.removeValue(forKey: key)
+        let snapshot = composerDraft
         Task { @MainActor in
             await NewTaskDraftWriteFence.cancelAndWait(pendingSave)
-            guard await acknowledgeIncomingShare(shareID) else { return }
+            let result = await NewTaskIncomingShareDiscard.perform(
+                shareID: shareID,
+                draft: snapshot,
+                key: key,
+                store: draftStore,
+                acknowledge: acknowledgeIncomingShare
+            )
+            guard result == .discarded else {
+                incomingShareErrorMessage = result.userMessage
+                return
+            }
             restoredIncomingShareID = nil
             pendingIncomingShareID = nil
-            try? await draftStore.removeDraft(for: key)
             dismiss()
         }
     }
@@ -1068,6 +1100,56 @@ enum NewTaskIncomingShareAcknowledgementPolicy {
             && pendingShareID?.caseInsensitiveCompare(routedShareID) == .orderedSame
             && currentProjectID == routedProjectID
             && restoreContextProjectID == routedProjectID
+    }
+}
+
+enum NewTaskIncomingShareRoutingPolicy {
+    static func canChangeProject(isRoutingIncomingShare: Bool) -> Bool {
+        !isRoutingIncomingShare
+    }
+}
+
+enum NewTaskIncomingShareDiscardResult: Equatable {
+    case discarded
+    case cleanupFailed
+    case acknowledgementFailed(draftRestored: Bool)
+
+    var userMessage: String? {
+        switch self {
+        case .discarded:
+            nil
+        case .cleanupFailed:
+            "The shared draft couldn’t be discarded. It is still safe; try again."
+        case .acknowledgementFailed(true):
+            "The shared draft couldn’t be discarded. It was restored so you can try again."
+        case .acknowledgementFailed(false):
+            "The shared draft couldn’t be discarded. The original share is still safe; try again."
+        }
+    }
+}
+
+enum NewTaskIncomingShareDiscard {
+    static func perform(
+        shareID: String,
+        draft: FeatureComposerDraft,
+        key: String,
+        store: FeatureComposerDraftStore,
+        acknowledge: (String) async -> Bool
+    ) async -> NewTaskIncomingShareDiscardResult {
+        do {
+            try await store.removeDraft(for: key)
+        } catch {
+            return .cleanupFailed
+        }
+        guard await acknowledge(shareID) else {
+            do {
+                try await store.setDraft(draft, for: key)
+                return .acknowledgementFailed(draftRestored: true)
+            } catch {
+                return .acknowledgementFailed(draftRestored: false)
+            }
+        }
+        return .discarded
     }
 }
 

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -32,6 +32,7 @@ public struct NewThreadView: View {
     @State private var immediateDraftSaveTasks: [String: Task<Void, Never>] = [:]
     @State private var submittedSuccessfully = false
     @State private var pendingIncomingShareID: String?
+    @State private var restoredIncomingShareID: String?
     @State private var showingDiscardIncomingShare = false
     @FocusState private var promptFocused: Bool
 
@@ -116,6 +117,7 @@ public struct NewThreadView: View {
         .onChange(of: projectID) { prepareProjectIfNeeded(projectID) }
         .onChange(of: creationProjectIDs) { _, ids in
             guard !ids.contains(projectID) else { return }
+            guard pendingIncomingShareID == nil else { return }
             persistCurrentDraftImmediately()
             let previousProject = model.snapshot.projects.first { $0.id == projectID }
             let previousGroupID = previousProject.map {
@@ -737,8 +739,15 @@ public struct NewThreadView: View {
             let sourceKey = FeatureComposerDraftStore.incomingShareKey(shareID: routedShareID)
             await NewTaskDraftWriteFence.wait(immediateDraftSaveTasks[sourceKey])
         }
+        guard !Task.isCancelled,
+              projectID == requestedProjectID,
+              pendingIncomingShareID == routedShareID,
+              draftRestoreContext?.projectID == requestedProjectID else {
+            return
+        }
         let saved: FeatureComposerDraft?
         var shouldAcknowledgeShare = false
+        var routingError: String?
         if let routedShareID {
             do {
                 let result = try await draftStore.routeIncomingShare(
@@ -754,20 +763,30 @@ public struct NewThreadView: View {
                     shouldAcknowledgeShare = true
                 case .sourceMissing:
                     saved = nil
-                    model.errorMessage = "The shared draft is no longer available. Share it again to retry."
+                    routingError = "The shared draft is no longer available. Share it again to retry."
                 }
             } catch {
                 saved = nil
-                model.errorMessage = error.localizedDescription
+                routingError = error.localizedDescription
             }
         } else {
             saved = try? await draftStore.draft(for: key)
         }
-        guard !Task.isCancelled,
-              projectID == requestedProjectID,
-              draftRestoreContext?.projectID == requestedProjectID else {
+        let routeIsCurrent = !Task.isCancelled
+            && projectID == requestedProjectID
+            && pendingIncomingShareID == routedShareID
+            && draftRestoreContext?.projectID == requestedProjectID
+        guard routeIsCurrent else {
+            if let routedShareID,
+               shouldAcknowledgeShare,
+               pendingIncomingShareID == routedShareID {
+                restoredIncomingShareID = nil
+                pendingIncomingShareID = nil
+                await acknowledgeIncomingShare(routedShareID)
+            }
             return
         }
+        if let routingError { model.errorMessage = routingError }
 
         let liveDraft = composerDraft
         let liveSelectionIsExplicit = selectionIsExplicit
@@ -805,6 +824,7 @@ public struct NewThreadView: View {
             || saved?.workspace != nil
         restoredDraftProjectID = requestedProjectID
         if let routedShareID, shouldAcknowledgeShare {
+            restoredIncomingShareID = nil
             pendingIncomingShareID = nil
             await acknowledgeIncomingShare(routedShareID)
         }
@@ -819,7 +839,24 @@ public struct NewThreadView: View {
         guard let shareID = pendingIncomingShareID,
               projectID.isEmpty else { return }
         let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
-        guard let saved = try? await draftStore.draft(for: key) else { return }
+        let saved: FeatureComposerDraft?
+        let readError: String?
+        do {
+            saved = try await draftStore.draft(for: key)
+            readError = nil
+        } catch {
+            saved = nil
+            readError = error.localizedDescription
+        }
+        guard !Task.isCancelled,
+              pendingIncomingShareID == shareID,
+              projectID.isEmpty else { return }
+        if let readError {
+            model.errorMessage = readError
+            return
+        }
+        guard let saved else { return }
+        restoredIncomingShareID = shareID
         prompt = saved.text
         attachments = saved.attachments
         if !creationProjects.isEmpty {
@@ -895,6 +932,10 @@ public struct NewThreadView: View {
 
     private func scheduleIncomingShareDraftSave() {
         guard let shareID = pendingIncomingShareID,
+              NewTaskIncomingSharePersistencePolicy.canPersist(
+                  pendingShareID: shareID,
+                  restoredShareID: restoredIncomingShareID
+              ),
               !isSubmitting,
               !submittedSuccessfully else { return }
         let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
@@ -915,7 +956,11 @@ public struct NewThreadView: View {
     }
 
     private func persistIncomingShareDraftImmediately() {
-        guard let shareID = pendingIncomingShareID else { return }
+        guard let shareID = pendingIncomingShareID,
+              NewTaskIncomingSharePersistencePolicy.canPersist(
+                  pendingShareID: shareID,
+                  restoredShareID: restoredIncomingShareID
+              ) else { return }
         let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
         let previousSave = immediateDraftSaveTasks[key]
         previousSave?.cancel()
@@ -931,11 +976,13 @@ public struct NewThreadView: View {
     private func discardIncomingShare() {
         guard let shareID = pendingIncomingShareID else { return }
         let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
+        let pendingSave = immediateDraftSaveTasks.removeValue(forKey: key)
+        restoredIncomingShareID = nil
+        pendingIncomingShareID = nil
         Task { @MainActor in
-            immediateDraftSaveTasks[key]?.cancel()
+            await NewTaskDraftWriteFence.cancelAndWait(pendingSave)
             try? await draftStore.removeDraft(for: key)
             await acknowledgeIncomingShare(shareID)
-            pendingIncomingShareID = nil
             dismiss()
         }
     }
@@ -991,6 +1038,13 @@ enum NewTaskDraftWriteFence {
     static func cancelAndWait(_ task: Task<Void, Never>?) async {
         task?.cancel()
         await task?.value
+    }
+}
+
+enum NewTaskIncomingSharePersistencePolicy {
+    static func canPersist(pendingShareID: String?, restoredShareID: String?) -> Bool {
+        guard let pendingShareID else { return false }
+        return restoredShareID == pendingShareID
     }
 }
 

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -716,10 +716,15 @@ public struct NewThreadView: View {
         let routedShareID = pendingIncomingShareID
         let saved: FeatureComposerDraft?
         if let routedShareID {
-            saved = try? await draftStore.routeIncomingShare(
-                shareID: routedShareID,
-                to: key
-            )
+            do {
+                saved = try await draftStore.routeIncomingShare(
+                    shareID: routedShareID,
+                    to: key
+                )
+            } catch {
+                saved = nil
+                model.errorMessage = error.localizedDescription
+            }
         } else {
             saved = try? await draftStore.draft(for: key)
         }

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -32,6 +32,7 @@ public struct NewThreadView: View {
     @State private var immediateDraftSaveTasks: [String: Task<Void, Never>] = [:]
     @State private var submittedSuccessfully = false
     @State private var pendingIncomingShareID: String?
+    @State private var showingDiscardIncomingShare = false
     @FocusState private var promptFocused: Bool
 
     public init(
@@ -169,6 +170,16 @@ public struct NewThreadView: View {
         } message: {
             Text("Check your connection and try again.")
         }
+        .confirmationDialog(
+            "Discard this shared draft?",
+            isPresented: $showingDiscardIncomingShare,
+            titleVisibility: .visible
+        ) {
+            Button("Keep editing", role: .cancel) {}
+            Button("Discard shared draft", role: .destructive) {
+                discardIncomingShare()
+            }
+        }
         .interactiveDismissDisabled(isSubmitting)
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
@@ -176,7 +187,13 @@ public struct NewThreadView: View {
 
     private var topBar: some View {
         HStack {
-            Button("Cancel") { dismiss() }
+            Button("Cancel") {
+                if pendingIncomingShareID == nil {
+                    dismiss()
+                } else {
+                    showingDiscardIncomingShare = true
+                }
+            }
                 .font(.body)
                 .foregroundStyle(T3Colors.textSecondary)
                 .disabled(isSubmitting)
@@ -604,6 +621,8 @@ public struct NewThreadView: View {
     private func prepareProjectIfNeeded(_ id: String) {
         guard draftRestoreContext?.projectID != id else { return }
 
+        persistIncomingShareDraftImmediately()
+
         if selectionIsExplicit, let selection {
             preferredSelection = selection
         }
@@ -714,13 +733,29 @@ public struct NewThreadView: View {
             return
         }
         let routedShareID = pendingIncomingShareID
+        if let routedShareID {
+            let sourceKey = FeatureComposerDraftStore.incomingShareKey(shareID: routedShareID)
+            await NewTaskDraftWriteFence.wait(immediateDraftSaveTasks[sourceKey])
+        }
         let saved: FeatureComposerDraft?
+        var shouldAcknowledgeShare = false
         if let routedShareID {
             do {
-                saved = try await draftStore.routeIncomingShare(
+                let result = try await draftStore.routeIncomingShare(
                     shareID: routedShareID,
                     to: key
                 )
+                switch result {
+                case let .routed(draft), let .alreadyRouted(draft?):
+                    saved = draft
+                    shouldAcknowledgeShare = true
+                case .alreadyRouted(nil):
+                    saved = nil
+                    shouldAcknowledgeShare = true
+                case .sourceMissing:
+                    saved = nil
+                    model.errorMessage = "The shared draft is no longer available. Share it again to retry."
+                }
             } catch {
                 saved = nil
                 model.errorMessage = error.localizedDescription
@@ -769,7 +804,7 @@ public struct NewThreadView: View {
         workspaceSelectionIsExplicit = liveWorkspaceSelectionIsExplicit
             || saved?.workspace != nil
         restoredDraftProjectID = requestedProjectID
-        if let routedShareID, saved != nil {
+        if let routedShareID, shouldAcknowledgeShare {
             pendingIncomingShareID = nil
             await acknowledgeIncomingShare(routedShareID)
         }
@@ -830,6 +865,10 @@ public struct NewThreadView: View {
     }
 
     private func scheduleDraftSave() {
+        if projectID.isEmpty, pendingIncomingShareID != nil {
+            scheduleIncomingShareDraftSave()
+            return
+        }
         guard restoredDraftProjectID == projectID,
               !isSubmitting,
               !submittedSuccessfully,
@@ -851,6 +890,53 @@ public struct NewThreadView: View {
             } catch {
                 return
             }
+        }
+    }
+
+    private func scheduleIncomingShareDraftSave() {
+        guard let shareID = pendingIncomingShareID,
+              !isSubmitting,
+              !submittedSuccessfully else { return }
+        let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
+        let previousSave = immediateDraftSaveTasks[key]
+        previousSave?.cancel()
+        let snapshot = composerDraft
+        let task = Task { @MainActor in
+            await NewTaskDraftWriteFence.wait(previousSave)
+            do {
+                try await Task.sleep(for: .milliseconds(220))
+                try Task.checkCancellation()
+                try await draftStore.setDraft(snapshot, for: key)
+            } catch {
+                return
+            }
+        }
+        immediateDraftSaveTasks[key] = task
+    }
+
+    private func persistIncomingShareDraftImmediately() {
+        guard let shareID = pendingIncomingShareID else { return }
+        let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
+        let previousSave = immediateDraftSaveTasks[key]
+        previousSave?.cancel()
+        let snapshot = composerDraft
+        let task = Task { @MainActor in
+            await NewTaskDraftWriteFence.wait(previousSave)
+            guard !Task.isCancelled else { return }
+            try? await draftStore.setDraft(snapshot, for: key)
+        }
+        immediateDraftSaveTasks[key] = task
+    }
+
+    private func discardIncomingShare() {
+        guard let shareID = pendingIncomingShareID else { return }
+        let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
+        Task { @MainActor in
+            immediateDraftSaveTasks[key]?.cancel()
+            try? await draftStore.removeDraft(for: key)
+            await acknowledgeIncomingShare(shareID)
+            pendingIncomingShareID = nil
+            dismiss()
         }
     }
 

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -180,7 +180,7 @@ public struct NewThreadView: View {
                 discardIncomingShare()
             }
         }
-        .interactiveDismissDisabled(isSubmitting)
+        .interactiveDismissDisabled(isSubmitting || pendingIncomingShareID != nil)
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
     }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -71,9 +71,14 @@ struct FeatureNewTaskPresentationCoordinator: Equatable, Sendable {
         }
 
         guard current != nil else {
+            let displaced = deferred
+            deferred = nil
             let presentation = FeatureNewTaskPresentation(request: request)
             current = presentation
-            return FeatureNewTaskPresentationEffects(presentation: presentation)
+            return FeatureNewTaskPresentationEffects(
+                presentation: presentation,
+                released: displaced.map { [$0] } ?? []
+            )
         }
 
         let displaced = pending
@@ -146,6 +151,21 @@ struct FeatureNewTaskPresentationCoordinator: Equatable, Sendable {
             dismissalID: dismissalID,
             released: released
         )
+    }
+}
+
+enum FeatureNewTaskPresentationTiming {
+    static func requiresDismissalCallback(dismissalID: UUID, presentedID: UUID?) -> Bool {
+        presentedID == dismissalID
+    }
+
+    static func canPresent(
+        id: UUID,
+        currentID: UUID?,
+        awaitingDismissalID: UUID?,
+        presentedID: UUID?
+    ) -> Bool {
+        currentID == id && awaitingDismissalID != id && presentedID == nil
     }
 }
 
@@ -880,17 +900,33 @@ public struct WorkspaceView: View {
                 releaseIncomingSharePresentation(shareID)
             }
         }
-        if let dismissalID = effects.dismissalID,
-           presentedNewTask?.id == dismissalID {
+        if let dismissalID = effects.dismissalID {
             newTaskAwaitingDismissalID = dismissalID
-            presentedNewTask = nil
-            scheduleNewTaskDismissalFallback(id: dismissalID)
+            if FeatureNewTaskPresentationTiming.requiresDismissalCallback(
+                dismissalID: dismissalID,
+                presentedID: presentedNewTask?.id
+            ) {
+                presentedNewTask = nil
+                scheduleNewTaskDismissalFallback(id: dismissalID)
+            } else {
+                newTaskDismissalFallback?.cancel()
+                newTaskDismissalFallback = Task { @MainActor in
+                    await Task.yield()
+                    guard newTaskAwaitingDismissalID == dismissalID,
+                          presentedNewTask?.id != dismissalID else { return }
+                    completeNewTaskDismissal(id: dismissalID)
+                }
+            }
         }
         if let presentation = effects.presentation {
             Task { @MainActor in
                 await Task.yield()
-                guard newTaskPresentationCoordinator.current?.id == presentation.id,
-                      presentedNewTask == nil else { return }
+                guard FeatureNewTaskPresentationTiming.canPresent(
+                    id: presentation.id,
+                    currentID: newTaskPresentationCoordinator.current?.id,
+                    awaitingDismissalID: newTaskAwaitingDismissalID,
+                    presentedID: presentedNewTask?.id
+                ) else { return }
                 presentedNewTask = presentation
             }
         }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -4,7 +4,7 @@ import UIKit
 struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     enum Destination: Equatable, Sendable {
         case thread(id: String)
-        case sharedThread(id: String)
+        case sharedThread(id: String, draft: FeatureComposerDraft)
         case project(id: String)
         case newTask(projectID: String?)
         case sharedNewTask(shareID: String)
@@ -43,6 +43,7 @@ public struct WorkspaceView: View {
     @State private var newTaskIncomingShareID: String?
     @State private var dismissingNewTaskContext: NewTaskDismissalContext?
     @State private var threadDetailPresentationRevision = 0
+    @State private var sharedThreadDraft: FeatureComposerDraft?
     @State private var showingAddProject = false
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
@@ -283,6 +284,7 @@ public struct WorkspaceView: View {
                 model: model,
                 thread: thread,
                 composerDraftReloadRevision: threadDetailPresentationRevision,
+                composerDraftReloadDraft: sharedThreadDraft,
                 submitMessage: submitMessage,
                 onNavigateBack: closeSelectedThread
             )
@@ -599,10 +601,11 @@ public struct WorkspaceView: View {
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
             openThread(id)
-        case let .sharedThread(id):
+        case let .sharedThread(id, draft):
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
             if selectedThreadID == id {
+                sharedThreadDraft = draft
                 threadDetailPresentationRevision &+= 1
             }
             openThread(id)

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -4,7 +4,7 @@ import UIKit
 struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     enum Destination: Equatable, Sendable {
         case thread(id: String)
-        case sharedThread(id: String, draft: FeatureComposerDraft?)
+        case sharedThread(id: String, importDraft: FeatureComposerIncomingShareDraft)
         case project(id: String)
         case newTask(projectID: String?)
         case sharedNewTask(shareID: String)
@@ -43,7 +43,7 @@ public struct WorkspaceView: View {
     @State private var newTaskIncomingShareID: String?
     @State private var dismissingNewTaskContext: NewTaskDismissalContext?
     @State private var threadDetailPresentationRevision = 0
-    @State private var sharedThreadDraft: FeatureComposerDraft?
+    @State private var sharedThreadImports: [FeatureComposerIncomingShareDraft] = []
     @State private var showingAddProject = false
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
@@ -284,7 +284,7 @@ public struct WorkspaceView: View {
                 model: model,
                 thread: thread,
                 composerDraftReloadRevision: threadDetailPresentationRevision,
-                composerDraftReloadDraft: sharedThreadDraft,
+                composerDraftReloadImports: sharedThreadImports,
                 submitMessage: submitMessage,
                 onNavigateBack: closeSelectedThread
             )
@@ -601,11 +601,12 @@ public struct WorkspaceView: View {
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
             openThread(id)
-        case let .sharedThread(id, draft):
+        case let .sharedThread(id, importDraft):
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
-            if selectedThreadID == id, let draft {
-                sharedThreadDraft = draft
+            if selectedThreadID == id {
+                sharedThreadImports.removeAll { $0.shareID == importDraft.shareID }
+                sharedThreadImports.append(importDraft)
                 threadDetailPresentationRevision &+= 1
             }
             openThread(id)

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -4,7 +4,7 @@ import UIKit
 struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     enum Destination: Equatable, Sendable {
         case thread(id: String)
-        case sharedThread(id: String, draft: FeatureComposerDraft)
+        case sharedThread(id: String, draft: FeatureComposerDraft?)
         case project(id: String)
         case newTask(projectID: String?)
         case sharedNewTask(shareID: String)
@@ -604,7 +604,7 @@ public struct WorkspaceView: View {
         case let .sharedThread(id, draft):
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
-            if selectedThreadID == id {
+            if selectedThreadID == id, let draft {
                 sharedThreadDraft = draft
                 threadDetailPresentationRevision &+= 1
             }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -4,6 +4,7 @@ import UIKit
 struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     enum Destination: Equatable, Sendable {
         case thread(id: String)
+        case sharedThread(id: String)
         case project(id: String)
         case newTask(projectID: String?)
         case sharedNewTask(shareID: String)
@@ -40,6 +41,8 @@ public struct WorkspaceView: View {
     @State private var showingNewTask = false
     @State private var newTaskInitialProjectID: String?
     @State private var newTaskIncomingShareID: String?
+    @State private var dismissingNewTaskContext: NewTaskDismissalContext?
+    @State private var threadDetailPresentationRevision = 0
     @State private var showingAddProject = false
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
@@ -134,13 +137,7 @@ public struct WorkspaceView: View {
             detail
         }
         .navigationSplitViewStyle(.balanced)
-        .sheet(isPresented: $showingNewTask, onDismiss: {
-            if let shareID = newTaskIncomingShareID {
-                releaseIncomingSharePresentation(shareID)
-            }
-            newTaskInitialProjectID = nil
-            newTaskIncomingShareID = nil
-        }) {
+        .sheet(isPresented: $showingNewTask, onDismiss: newTaskDidDismiss) {
             NewThreadView(
                 model: model,
                 submit: submitNewTask,
@@ -285,6 +282,7 @@ public struct WorkspaceView: View {
             ThreadDetailView(
                 model: model,
                 thread: thread,
+                composerDraftReloadRevision: threadDetailPresentationRevision,
                 submitMessage: submitMessage,
                 onNavigateBack: closeSelectedThread
             )
@@ -601,6 +599,13 @@ public struct WorkspaceView: View {
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
             openThread(id)
+        case let .sharedThread(id):
+            guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
+            dismissTransientPresentations()
+            if selectedThreadID == id {
+                threadDetailPresentationRevision &+= 1
+            }
+            openThread(id)
         case let .project(id):
             guard model.snapshot.projects.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
@@ -618,10 +623,10 @@ public struct WorkspaceView: View {
             }
         case let .sharedNewTask(shareID):
             dismissTransientPresentations()
-            newTaskIncomingShareID = shareID
             Task { @MainActor in
                 await Task.yield()
                 newTaskInitialProjectID = nil
+                newTaskIncomingShareID = shareID
                 showingNewTask = true
             }
         }
@@ -629,10 +634,33 @@ public struct WorkspaceView: View {
     }
 
     private func dismissTransientPresentations() {
+        if showingNewTask {
+            dismissingNewTaskContext = NewTaskDismissalContext(
+                initialProjectID: newTaskInitialProjectID,
+                incomingShareID: newTaskIncomingShareID
+            )
+        }
         showingNewTask = false
         showingAddProject = false
         showingSettings = false
         renamingThread = nil
+    }
+
+    private func newTaskDidDismiss() {
+        let dismissed = dismissingNewTaskContext ?? NewTaskDismissalContext(
+            initialProjectID: newTaskInitialProjectID,
+            incomingShareID: newTaskIncomingShareID
+        )
+        let resolution = dismissed.resolve(
+            currentInitialProjectID: newTaskInitialProjectID,
+            currentIncomingShareID: newTaskIncomingShareID
+        )
+        if let shareID = resolution.releasedIncomingShareID {
+            releaseIncomingSharePresentation(shareID)
+        }
+        newTaskInitialProjectID = resolution.remainingInitialProjectID
+        newTaskIncomingShareID = resolution.remainingIncomingShareID
+        dismissingNewTaskContext = nil
     }
 
     private func projectMenuTitle(_ project: FeatureProject) -> String {
@@ -644,6 +672,32 @@ public struct WorkspaceView: View {
         }
         return "\(project.name) · \(environment.name)"
     }
+}
+
+struct NewTaskDismissalContext: Equatable {
+    let initialProjectID: String?
+    let incomingShareID: String?
+
+    func resolve(
+        currentInitialProjectID: String?,
+        currentIncomingShareID: String?
+    ) -> NewTaskDismissalResolution {
+        NewTaskDismissalResolution(
+            remainingInitialProjectID: currentInitialProjectID == initialProjectID
+                ? nil
+                : currentInitialProjectID,
+            remainingIncomingShareID: currentIncomingShareID == incomingShareID
+                ? nil
+                : currentIncomingShareID,
+            releasedIncomingShareID: incomingShareID
+        )
+    }
+}
+
+struct NewTaskDismissalResolution: Equatable {
+    let remainingInitialProjectID: String?
+    let remainingIncomingShareID: String?
+    let releasedIncomingShareID: String?
 }
 
 private extension FeatureDraftAttachment {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -19,6 +19,136 @@ struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     }
 }
 
+struct FeatureNewTaskPresentationRequest: Equatable, Sendable {
+    let initialProjectID: String?
+    let incomingShareID: String?
+
+    static func newTask(initialProjectID: String?) -> Self {
+        Self(initialProjectID: initialProjectID, incomingShareID: nil)
+    }
+
+    static func sharedNewTask(shareID: String) -> Self {
+        Self(initialProjectID: nil, incomingShareID: shareID)
+    }
+}
+
+struct FeatureNewTaskPresentation: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let request: FeatureNewTaskPresentationRequest
+
+    init(id: UUID = UUID(), request: FeatureNewTaskPresentationRequest) {
+        self.id = id
+        self.request = request
+    }
+}
+
+struct FeatureNewTaskPresentationEffects: Equatable, Sendable {
+    var presentation: FeatureNewTaskPresentation?
+    var dismissalID: UUID?
+    var released: [FeatureNewTaskPresentationRequest] = []
+
+    var isEmpty: Bool {
+        presentation == nil && dismissalID == nil && released.isEmpty
+    }
+}
+
+struct FeatureNewTaskPresentationCoordinator: Equatable, Sendable {
+    private(set) var current: FeatureNewTaskPresentation?
+    private(set) var pending: FeatureNewTaskPresentationRequest?
+    private(set) var deferred: FeatureNewTaskPresentationRequest?
+    private var dismissingID: UUID?
+
+    mutating func request(
+        _ request: FeatureNewTaskPresentationRequest,
+        deferredByModal: Bool
+    ) -> FeatureNewTaskPresentationEffects {
+        if current == nil, deferredByModal {
+            let displaced = deferred
+            deferred = request
+            return FeatureNewTaskPresentationEffects(
+                released: displaced.map { [$0] } ?? []
+            )
+        }
+
+        guard current != nil else {
+            let presentation = FeatureNewTaskPresentation(request: request)
+            current = presentation
+            return FeatureNewTaskPresentationEffects(presentation: presentation)
+        }
+
+        let displaced = pending
+        pending = request
+        var effects = FeatureNewTaskPresentationEffects(
+            released: displaced.map { [$0] } ?? []
+        )
+        if dismissingID == nil, let current {
+            dismissingID = current.id
+            effects.dismissalID = current.id
+        }
+        return effects
+    }
+
+    mutating func beginDismissal(id: UUID) -> FeatureNewTaskPresentationEffects {
+        guard current?.id == id else { return FeatureNewTaskPresentationEffects() }
+        guard dismissingID == nil else { return FeatureNewTaskPresentationEffects() }
+        dismissingID = id
+        return FeatureNewTaskPresentationEffects(dismissalID: id)
+    }
+
+    mutating func completeDismissal(
+        id: UUID,
+        deferredByModal: Bool
+    ) -> FeatureNewTaskPresentationEffects {
+        guard let dismissed = current,
+              dismissed.id == id,
+              dismissingID == id else {
+            return FeatureNewTaskPresentationEffects()
+        }
+
+        current = nil
+        dismissingID = nil
+        var effects = FeatureNewTaskPresentationEffects(released: [dismissed.request])
+        guard let next = pending else { return effects }
+        pending = nil
+
+        if deferredByModal {
+            if let displaced = deferred { effects.released.append(displaced) }
+            deferred = next
+        } else {
+            let presentation = FeatureNewTaskPresentation(request: next)
+            current = presentation
+            effects.presentation = presentation
+        }
+        return effects
+    }
+
+    mutating func resumeDeferred() -> FeatureNewTaskPresentationEffects {
+        guard current == nil, let request = deferred else {
+            return FeatureNewTaskPresentationEffects()
+        }
+        deferred = nil
+        let presentation = FeatureNewTaskPresentation(request: request)
+        current = presentation
+        return FeatureNewTaskPresentationEffects(presentation: presentation)
+    }
+
+    mutating func cancelAll() -> FeatureNewTaskPresentationEffects {
+        var released: [FeatureNewTaskPresentationRequest] = []
+        let dismissalID = current?.id
+        if let current { released.append(current.request) }
+        if let pending { released.append(pending) }
+        if let deferred { released.append(deferred) }
+        current = nil
+        pending = nil
+        deferred = nil
+        dismissingID = nil
+        return FeatureNewTaskPresentationEffects(
+            dismissalID: dismissalID,
+            released: released
+        )
+    }
+}
+
 public struct WorkspaceView: View {
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -38,10 +168,11 @@ public struct WorkspaceView: View {
     @State private var isSettledExpanded = true
     @State private var isArchiveExpanded = false
     @State private var settledLimit = 12
-    @State private var showingNewTask = false
-    @State private var newTaskInitialProjectID: String?
-    @State private var newTaskIncomingShareID: String?
-    @State private var dismissingNewTaskContext: NewTaskDismissalContext?
+    @State private var newTaskPresentationCoordinator = FeatureNewTaskPresentationCoordinator()
+    @State private var presentedNewTask: FeatureNewTaskPresentation?
+    @State private var newTaskAwaitingDismissalID: UUID?
+    @State private var newTaskDismissalFallback: Task<Void, Never>?
+    @State private var consumedNavigationRequestID: UUID?
     @State private var threadDetailPresentationRevision = 0
     @State private var sharedThreadImports: [String: [FeatureComposerIncomingShareDraft]] = [:]
     @State private var showingAddProject = false
@@ -138,24 +269,25 @@ public struct WorkspaceView: View {
             detail
         }
         .navigationSplitViewStyle(.balanced)
-        .sheet(isPresented: $showingNewTask, onDismiss: newTaskDidDismiss) {
+        .sheet(item: newTaskPresentationBinding, onDismiss: newTaskDidDismiss) { presentation in
             NewThreadView(
                 model: model,
                 submit: submitNewTask,
                 onCreated: { thread in
+                    cancelNewTaskPresentations()
                     openThread(thread.id)
-                    showingNewTask = false
                 },
                 onCreateProject: openProjectCreation,
-                initialProjectID: newTaskInitialProjectID,
-                incomingShareID: newTaskIncomingShareID,
+                initialProjectID: presentation.request.initialProjectID,
+                incomingShareID: presentation.request.incomingShareID,
                 acknowledgeIncomingShare: acknowledgeIncomingShare
             )
+            .id(presentation.id)
         }
-        .sheet(isPresented: $showingAddProject) {
+        .sheet(isPresented: $showingAddProject, onDismiss: resumeModalDeferredNewTask) {
             AddProjectView(model: model)
         }
-        .sheet(isPresented: $showingSettings) {
+        .sheet(isPresented: $showingSettings, onDismiss: resumeModalDeferredNewTask) {
             SettingsView(model: model)
         }
         .alert(
@@ -186,6 +318,9 @@ public struct WorkspaceView: View {
         }
         .onChange(of: navigationRequest?.id, initial: true) { _, _ in
             consumeNavigationRequest()
+        }
+        .onChange(of: renamingThread?.id) { _, newValue in
+            if newValue == nil { resumeModalDeferredNewTask() }
         }
         // A request that arrives before its thread or project exists in the
         // snapshot stays pending; retry it as data lands so cold-start deep
@@ -585,7 +720,7 @@ public struct WorkspaceView: View {
 
     @MainActor
     private func openProjectCreation() {
-        showingNewTask = false
+        cancelNewTaskPresentations()
         showingAddProject = true
     }
 
@@ -595,15 +730,16 @@ public struct WorkspaceView: View {
 
     private func openNewTaskOrProjectCreation(initialProjectID: String?) {
         if creationProjects.isEmpty {
+            cancelNewTaskPresentations()
             showingAddProject = true
         } else {
-            newTaskInitialProjectID = initialProjectID
-            showingNewTask = true
+            requestNewTaskPresentation(.newTask(initialProjectID: initialProjectID))
         }
     }
 
     private func consumeNavigationRequest() {
-        guard let navigationRequest else { return }
+        guard let navigationRequest,
+              consumedNavigationRequestID != navigationRequest.id else { return }
         switch navigationRequest.destination {
         case let .thread(id):
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
@@ -630,51 +766,134 @@ public struct WorkspaceView: View {
                model.snapshot.projects.contains(where: { $0.id == projectID }) {
                 selectedProjectID = projectID
             }
-            dismissTransientPresentations()
-            Task { @MainActor in
-                await Task.yield()
-                openNewTaskOrProjectCreation(initialProjectID: projectID)
-            }
+            requestNewTaskPresentation(.newTask(initialProjectID: projectID))
         case let .sharedNewTask(shareID):
-            dismissTransientPresentations()
-            Task { @MainActor in
-                await Task.yield()
-                newTaskInitialProjectID = nil
-                newTaskIncomingShareID = shareID
-                showingNewTask = true
-            }
+            requestNewTaskPresentation(.sharedNewTask(shareID: shareID))
         }
+        consumedNavigationRequestID = navigationRequest.id
         onNavigationRequestConsumed(navigationRequest.id)
     }
 
     private func dismissTransientPresentations() {
-        if showingNewTask {
-            dismissingNewTaskContext = NewTaskDismissalContext(
-                initialProjectID: newTaskInitialProjectID,
-                incomingShareID: newTaskIncomingShareID
-            )
-        }
-        showingNewTask = false
+        cancelNewTaskPresentations()
         showingAddProject = false
         showingSettings = false
         renamingThread = nil
     }
 
-    private func newTaskDidDismiss() {
-        let dismissed = dismissingNewTaskContext ?? NewTaskDismissalContext(
-            initialProjectID: newTaskInitialProjectID,
-            incomingShareID: newTaskIncomingShareID
+    private var newTaskPresentationBinding: Binding<FeatureNewTaskPresentation?> {
+        Binding(
+            get: { presentedNewTask },
+            set: { next in
+                if next == nil, let current = presentedNewTask {
+                    beginNewTaskDismissal(id: current.id)
+                }
+                presentedNewTask = next
+            }
         )
-        let resolution = dismissed.resolve(
-            currentInitialProjectID: newTaskInitialProjectID,
-            currentIncomingShareID: newTaskIncomingShareID
+    }
+
+    private var isNewTaskDeferredByModal: Bool {
+        showingAddProject || showingSettings || renamingThread != nil
+    }
+
+    private func requestNewTaskPresentation(_ request: FeatureNewTaskPresentationRequest) {
+        let deferredByModal = isNewTaskDeferredByModal
+        let effects = newTaskPresentationCoordinator.request(
+            request,
+            deferredByModal: deferredByModal
         )
-        if let shareID = resolution.releasedIncomingShareID {
-            releaseIncomingSharePresentation(shareID)
+        applyNewTaskPresentationEffects(effects)
+        guard deferredByModal else { return }
+        showingAddProject = false
+        showingSettings = false
+        renamingThread = nil
+        resumeModalDeferredNewTaskAfterYield()
+    }
+
+    private func beginNewTaskDismissal(id: UUID) {
+        let effects = newTaskPresentationCoordinator.beginDismissal(id: id)
+        applyNewTaskPresentationEffects(effects)
+        scheduleNewTaskDismissalFallback(id: id)
+    }
+
+    private func completeNewTaskDismissal(id: UUID) {
+        let effects = newTaskPresentationCoordinator.completeDismissal(
+            id: id,
+            deferredByModal: isNewTaskDeferredByModal
+        )
+        guard !effects.isEmpty else { return }
+        if newTaskAwaitingDismissalID == id {
+            newTaskAwaitingDismissalID = nil
         }
-        newTaskInitialProjectID = resolution.remainingInitialProjectID
-        newTaskIncomingShareID = resolution.remainingIncomingShareID
-        dismissingNewTaskContext = nil
+        newTaskDismissalFallback?.cancel()
+        newTaskDismissalFallback = nil
+        applyNewTaskPresentationEffects(effects)
+    }
+
+    private func cancelNewTaskPresentations() {
+        newTaskDismissalFallback?.cancel()
+        newTaskDismissalFallback = nil
+        applyNewTaskPresentationEffects(newTaskPresentationCoordinator.cancelAll())
+        // The item is the UI source of truth. Clear it even if a stale
+        // callback briefly left it out of sync with the pure coordinator.
+        presentedNewTask = nil
+        newTaskAwaitingDismissalID = nil
+        newTaskDismissalFallback?.cancel()
+        newTaskDismissalFallback = nil
+    }
+
+    private func resumeModalDeferredNewTask() {
+        guard !isNewTaskDeferredByModal else { return }
+        applyNewTaskPresentationEffects(newTaskPresentationCoordinator.resumeDeferred())
+    }
+
+    private func newTaskDidDismiss() {
+        guard let id = newTaskAwaitingDismissalID else { return }
+        completeNewTaskDismissal(id: id)
+    }
+
+    private func resumeModalDeferredNewTaskAfterYield() {
+        Task { @MainActor in
+            await Task.yield()
+            resumeModalDeferredNewTask()
+        }
+    }
+
+    private func scheduleNewTaskDismissalFallback(id: UUID) {
+        newTaskDismissalFallback?.cancel()
+        newTaskDismissalFallback = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .milliseconds(900))
+            } catch {
+                return
+            }
+            completeNewTaskDismissal(id: id)
+        }
+    }
+
+    private func applyNewTaskPresentationEffects(
+        _ effects: FeatureNewTaskPresentationEffects
+    ) {
+        for request in effects.released {
+            if let shareID = request.incomingShareID {
+                releaseIncomingSharePresentation(shareID)
+            }
+        }
+        if let dismissalID = effects.dismissalID,
+           presentedNewTask?.id == dismissalID {
+            newTaskAwaitingDismissalID = dismissalID
+            presentedNewTask = nil
+            scheduleNewTaskDismissalFallback(id: dismissalID)
+        }
+        if let presentation = effects.presentation {
+            Task { @MainActor in
+                await Task.yield()
+                guard newTaskPresentationCoordinator.current?.id == presentation.id,
+                      presentedNewTask == nil else { return }
+                presentedNewTask = presentation
+            }
+        }
     }
 
     private func projectMenuTitle(_ project: FeatureProject) -> String {
@@ -704,6 +923,25 @@ struct NewTaskDismissalContext: Equatable {
                 ? nil
                 : currentIncomingShareID,
             releasedIncomingShareID: incomingShareID
+        )
+    }
+}
+
+struct NewTaskPresentationIdentity: Hashable {
+    let initialProjectID: String?
+    let incomingShareID: String?
+}
+
+enum NewTaskDismissalPolicy {
+    static func resolveStaleDismissal(
+        dismissing: NewTaskDismissalContext?,
+        currentInitialProjectID: String?,
+        currentIncomingShareID: String?
+    ) -> NewTaskDismissalResolution {
+        NewTaskDismissalResolution(
+            remainingInitialProjectID: currentInitialProjectID,
+            remainingIncomingShareID: currentIncomingShareID,
+            releasedIncomingShareID: dismissing?.incomingShareID
         )
     }
 }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -612,7 +612,7 @@ public struct WorkspaceView: View {
         case let .sharedThread(id, importDraft):
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
-            if selectedThreadID == id, let importDraft {
+            if let importDraft {
                 sharedThreadImports[id] = FeatureComposerIncomingShareReloadPolicy.appending(
                     importDraft,
                     to: sharedThreadImports[id] ?? []

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -6,6 +6,7 @@ struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
         case thread(id: String)
         case project(id: String)
         case newTask(projectID: String?)
+        case sharedNewTask(shareID: String)
     }
 
     let id: UUID
@@ -25,6 +26,8 @@ public struct WorkspaceView: View {
     private let onNavigationRequestConsumed: @MainActor (UUID) -> Void
     private let submitNewTask: (NewTaskRequest) async -> FeatureThread?
     private let submitMessage: (FeatureMessageSubmission) async -> Bool
+    private let acknowledgeIncomingShare: (String) async -> Void
+    private let releaseIncomingSharePresentation: @MainActor (String) -> Void
 
     @State private var selectedThreadID: String?
     @State private var selectedProjectID: String?
@@ -36,6 +39,7 @@ public struct WorkspaceView: View {
     @State private var settledLimit = 12
     @State private var showingNewTask = false
     @State private var newTaskInitialProjectID: String?
+    @State private var newTaskIncomingShareID: String?
     @State private var showingAddProject = false
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
@@ -55,7 +59,9 @@ public struct WorkspaceView: View {
             navigationRequest: nil,
             onNavigationRequestConsumed: { _ in },
             submitNewTask: submitNewTask,
-            submitMessage: submitMessage
+            submitMessage: submitMessage,
+            acknowledgeIncomingShare: { _ in },
+            releaseIncomingSharePresentation: { _ in }
         )
     }
 
@@ -64,11 +70,15 @@ public struct WorkspaceView: View {
         navigationRequest: FeatureWorkspaceNavigationRequest?,
         onNavigationRequestConsumed: @escaping @MainActor (UUID) -> Void,
         submitNewTask: ((NewTaskRequest) async -> FeatureThread?)? = nil,
-        submitMessage: ((FeatureMessageSubmission) async -> Bool)? = nil
+        submitMessage: ((FeatureMessageSubmission) async -> Bool)? = nil,
+        acknowledgeIncomingShare: @escaping (String) async -> Void = { _ in },
+        releaseIncomingSharePresentation: @escaping @MainActor (String) -> Void = { _ in }
     ) {
         self.model = model
         self.navigationRequest = navigationRequest
         self.onNavigationRequestConsumed = onNavigationRequestConsumed
+        self.acknowledgeIncomingShare = acknowledgeIncomingShare
+        self.releaseIncomingSharePresentation = releaseIncomingSharePresentation
         self.submitNewTask = submitNewTask ?? { request in
             do {
                 let thread = try await model.client.createThreadAndSend(
@@ -124,7 +134,13 @@ public struct WorkspaceView: View {
             detail
         }
         .navigationSplitViewStyle(.balanced)
-        .sheet(isPresented: $showingNewTask) {
+        .sheet(isPresented: $showingNewTask, onDismiss: {
+            if let shareID = newTaskIncomingShareID {
+                releaseIncomingSharePresentation(shareID)
+            }
+            newTaskInitialProjectID = nil
+            newTaskIncomingShareID = nil
+        }) {
             NewThreadView(
                 model: model,
                 submit: submitNewTask,
@@ -133,7 +149,9 @@ public struct WorkspaceView: View {
                     showingNewTask = false
                 },
                 onCreateProject: openProjectCreation,
-                initialProjectID: newTaskInitialProjectID
+                initialProjectID: newTaskInitialProjectID,
+                incomingShareID: newTaskIncomingShareID,
+                acknowledgeIncomingShare: acknowledgeIncomingShare
             )
         }
         .sheet(isPresented: $showingAddProject) {
@@ -597,6 +615,14 @@ public struct WorkspaceView: View {
             Task { @MainActor in
                 await Task.yield()
                 openNewTaskOrProjectCreation(initialProjectID: projectID)
+            }
+        case let .sharedNewTask(shareID):
+            dismissTransientPresentations()
+            newTaskIncomingShareID = shareID
+            Task { @MainActor in
+                await Task.yield()
+                newTaskInitialProjectID = nil
+                showingNewTask = true
             }
         }
         onNavigationRequestConsumed(navigationRequest.id)

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -43,7 +43,7 @@ public struct WorkspaceView: View {
     @State private var newTaskIncomingShareID: String?
     @State private var dismissingNewTaskContext: NewTaskDismissalContext?
     @State private var threadDetailPresentationRevision = 0
-    @State private var sharedThreadImports: [FeatureComposerIncomingShareDraft] = []
+    @State private var sharedThreadImports: [String: [FeatureComposerIncomingShareDraft]] = [:]
     @State private var showingAddProject = false
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
@@ -284,7 +284,7 @@ public struct WorkspaceView: View {
                 model: model,
                 thread: thread,
                 composerDraftReloadRevision: threadDetailPresentationRevision,
-                composerDraftReloadImports: sharedThreadImports,
+                composerDraftReloadImports: sharedThreadImports[id] ?? [],
                 submitMessage: submitMessage,
                 onNavigateBack: closeSelectedThread
             )
@@ -605,8 +605,10 @@ public struct WorkspaceView: View {
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
             if selectedThreadID == id {
-                sharedThreadImports.removeAll { $0.shareID == importDraft.shareID }
-                sharedThreadImports.append(importDraft)
+                sharedThreadImports[id] = FeatureComposerIncomingShareReloadPolicy.appending(
+                    importDraft,
+                    to: sharedThreadImports[id] ?? []
+                )
                 threadDetailPresentationRevision &+= 1
             }
             openThread(id)

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -4,7 +4,7 @@ import UIKit
 struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     enum Destination: Equatable, Sendable {
         case thread(id: String)
-        case sharedThread(id: String, importDraft: FeatureComposerIncomingShareDraft)
+        case sharedThread(id: String, importDraft: FeatureComposerIncomingShareDraft?)
         case project(id: String)
         case newTask(projectID: String?)
         case sharedNewTask(shareID: String)
@@ -27,7 +27,7 @@ public struct WorkspaceView: View {
     private let onNavigationRequestConsumed: @MainActor (UUID) -> Void
     private let submitNewTask: (NewTaskRequest) async -> FeatureThread?
     private let submitMessage: (FeatureMessageSubmission) async -> Bool
-    private let acknowledgeIncomingShare: (String) async -> Void
+    private let acknowledgeIncomingShare: (String) async -> Bool
     private let releaseIncomingSharePresentation: @MainActor (String) -> Void
 
     @State private var selectedThreadID: String?
@@ -64,7 +64,7 @@ public struct WorkspaceView: View {
             onNavigationRequestConsumed: { _ in },
             submitNewTask: submitNewTask,
             submitMessage: submitMessage,
-            acknowledgeIncomingShare: { _ in },
+            acknowledgeIncomingShare: { _ in true },
             releaseIncomingSharePresentation: { _ in }
         )
     }
@@ -75,7 +75,7 @@ public struct WorkspaceView: View {
         onNavigationRequestConsumed: @escaping @MainActor (UUID) -> Void,
         submitNewTask: ((NewTaskRequest) async -> FeatureThread?)? = nil,
         submitMessage: ((FeatureMessageSubmission) async -> Bool)? = nil,
-        acknowledgeIncomingShare: @escaping (String) async -> Void = { _ in },
+        acknowledgeIncomingShare: @escaping (String) async -> Bool = { _ in true },
         releaseIncomingSharePresentation: @escaping @MainActor (String) -> Void = { _ in }
     ) {
         self.model = model
@@ -286,7 +286,15 @@ public struct WorkspaceView: View {
                 composerDraftReloadRevision: threadDetailPresentationRevision,
                 composerDraftReloadImports: sharedThreadImports[id] ?? [],
                 submitMessage: submitMessage,
-                onNavigateBack: closeSelectedThread
+                onNavigateBack: closeSelectedThread,
+                onComposerDraftReloadHandled: { shareIDs in
+                    guard let imports = sharedThreadImports[id] else { return }
+                    let pending = FeatureComposerIncomingShareReloadPolicy.removing(
+                        shareIDs: shareIDs,
+                        from: imports
+                    )
+                    sharedThreadImports[id] = pending.isEmpty ? nil : pending
+                }
             )
             .id(id)
         } else {
@@ -604,7 +612,7 @@ public struct WorkspaceView: View {
         case let .sharedThread(id, importDraft):
             guard model.snapshot.threads.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
-            if selectedThreadID == id {
+            if selectedThreadID == id, let importDraft {
                 sharedThreadImports[id] = FeatureComposerIncomingShareReloadPolicy.appending(
                     importDraft,
                     to: sharedThreadImports[id] ?? []

--- a/apps/swift-ios/Resources/Info.plist
+++ b/apps/swift-ios/Resources/Info.plist
@@ -40,6 +40,8 @@
     <string>$(T3CODE_CLERK_PUBLISHABLE_KEY)</string>
     <key>T3ConnectRelayHTTPURL</key>
     <string>$(T3CODE_RELAY_URL)</string>
+    <key>T3CodeAppGroupIdentifier</key>
+    <string>$(T3CODE_APP_GROUP_IDENTIFIER)</string>
     <key>UIBackgroundModes</key>
     <array>
         <string>fetch</string>

--- a/apps/swift-ios/Tests/CoreTests/WorkspaceContractTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WorkspaceContractTests.swift
@@ -1,29 +1,31 @@
+import Testing
 import XCTest
 @testable import T3Code
 
+@Suite("New task presentation lifecycle")
 @MainActor
-final class WorkspaceContractTests: XCTestCase {
-    func testLatestNewTaskRequestWaitsForCurrentDismissalAndGetsFreshIdentity() {
+struct FeatureNewTaskPresentationCoordinatorTests {
+    @Test func latestRequestWaitsForCurrentDismissalAndGetsFreshIdentity() throws {
         let first = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-1")
         let replacement = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-2")
         var coordinator = FeatureNewTaskPresentationCoordinator()
 
         let initial = coordinator.request(first, deferredByModal: false)
-        let firstID = try! XCTUnwrap(initial.presentation?.id)
-        XCTAssertEqual(initial.presentation?.request, first)
+        let firstID = try #require(initial.presentation?.id)
+        #expect(initial.presentation?.request == first)
 
         let queued = coordinator.request(replacement, deferredByModal: false)
-        XCTAssertEqual(queued.dismissalID, firstID)
-        XCTAssertNil(queued.presentation)
-        XCTAssertEqual(coordinator.pending, replacement)
+        #expect(queued.dismissalID == firstID)
+        #expect(queued.presentation == nil)
+        #expect(coordinator.pending == replacement)
 
         let completed = coordinator.completeDismissal(id: firstID, deferredByModal: false)
-        XCTAssertEqual(completed.released, [first])
-        XCTAssertEqual(completed.presentation?.request, replacement)
-        XCTAssertNotEqual(completed.presentation?.id, firstID)
+        #expect(completed.released == [first])
+        #expect(completed.presentation?.request == replacement)
+        #expect(completed.presentation?.id != firstID)
     }
 
-    func testOverwrittenPendingShareIsReleasedExactlyOnce() {
+    @Test func overwrittenPendingShareIsReleasedExactlyOnce() {
         let active = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-1")
         let firstShare = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-1")
         let latestShare = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-2")
@@ -33,16 +35,19 @@ final class WorkspaceContractTests: XCTestCase {
         _ = coordinator.request(firstShare, deferredByModal: false)
         let overwritten = coordinator.request(latestShare, deferredByModal: false)
 
-        XCTAssertEqual(overwritten.released, [firstShare])
-        XCTAssertEqual(coordinator.pending, latestShare)
-        XCTAssertNil(coordinator.completeDismissal(id: UUID(), deferredByModal: false).presentation)
-        XCTAssertEqual(coordinator.pending, latestShare)
+        #expect(overwritten.released == [firstShare])
+        #expect(coordinator.pending == latestShare)
+        #expect(coordinator.completeDismissal(
+            id: UUID(),
+            deferredByModal: false
+        ).presentation == nil)
+        #expect(coordinator.pending == latestShare)
     }
 
-    func testDismissalCompletionIsIdempotentAndRejectsStaleCallbacks() {
+    @Test func dismissalCompletionIsIdempotentAndRejectsStaleCallbacks() throws {
         let share = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-1")
         var coordinator = FeatureNewTaskPresentationCoordinator()
-        let presentation = try! XCTUnwrap(
+        let presentation = try #require(
             coordinator.request(share, deferredByModal: false).presentation
         )
         _ = coordinator.beginDismissal(id: presentation.id)
@@ -56,15 +61,15 @@ final class WorkspaceContractTests: XCTestCase {
             deferredByModal: false
         )
 
-        XCTAssertEqual(first.released, [share])
-        XCTAssertTrue(duplicate.isEmpty)
-        XCTAssertNil(coordinator.current)
+        #expect(first.released == [share])
+        #expect(duplicate.isEmpty)
+        #expect(coordinator.current == nil)
     }
 
-    func testDismissalCompletionRequiresAnExplicitMatchingDismissalStart() {
+    @Test func dismissalCompletionRequiresAnExplicitMatchingDismissalStart() throws {
         let request = FeatureNewTaskPresentationRequest.newTask(initialProjectID: nil)
         var coordinator = FeatureNewTaskPresentationCoordinator()
-        let presentation = try! XCTUnwrap(
+        let presentation = try #require(
             coordinator.request(request, deferredByModal: false).presentation
         )
 
@@ -73,29 +78,29 @@ final class WorkspaceContractTests: XCTestCase {
             deferredByModal: false
         )
 
-        XCTAssertTrue(unrelatedDisappearance.isEmpty)
-        XCTAssertEqual(coordinator.current, presentation)
+        #expect(unrelatedDisappearance.isEmpty)
+        #expect(coordinator.current == presentation)
     }
 
-    func testFallbackCompletionPromotesTheSameLatestRequest() {
+    @Test func fallbackCompletionPromotesTheSameLatestRequest() throws {
         let first = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-1")
         let replacement = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-2")
         var coordinator = FeatureNewTaskPresentationCoordinator()
-        let firstID = try! XCTUnwrap(
+        let firstID = try #require(
             coordinator.request(first, deferredByModal: false).presentation?.id
         )
         _ = coordinator.request(replacement, deferredByModal: false)
 
         let fallback = coordinator.completeDismissal(id: firstID, deferredByModal: false)
 
-        XCTAssertEqual(fallback.presentation?.request, replacement)
-        XCTAssertEqual(fallback.released, [first])
-        XCTAssertTrue(
+        #expect(fallback.presentation?.request == replacement)
+        #expect(fallback.released == [first])
+        #expect(
             coordinator.completeDismissal(id: firstID, deferredByModal: false).isEmpty
         )
     }
 
-    func testLatestModalDeferredRequestResumesAfterModalDismissal() {
+    @Test func latestModalDeferredRequestResumesAfterModalDismissal() {
         let firstShare = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-1")
         let latest = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-2")
         var coordinator = FeatureNewTaskPresentationCoordinator()
@@ -103,47 +108,93 @@ final class WorkspaceContractTests: XCTestCase {
         let first = coordinator.request(firstShare, deferredByModal: true)
         let second = coordinator.request(latest, deferredByModal: true)
 
-        XCTAssertTrue(first.isEmpty)
-        XCTAssertEqual(second.released, [firstShare])
-        XCTAssertEqual(coordinator.deferred, latest)
+        #expect(first.isEmpty)
+        #expect(second.released == [firstShare])
+        #expect(coordinator.deferred == latest)
         let resumed = coordinator.resumeDeferred()
-        XCTAssertEqual(resumed.presentation?.request, latest)
-        XCTAssertTrue(coordinator.resumeDeferred().isEmpty)
+        #expect(resumed.presentation?.request == latest)
+        #expect(coordinator.resumeDeferred().isEmpty)
     }
 
-    func testThreadOrProjectRouteCancelsEveryQueuedNewTaskWithoutGhostReopen() {
+    @Test func directRequestReleasesAPreviouslyDeferredShare() {
+        let deferred = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-modal")
+        let direct = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-2")
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+        _ = coordinator.request(deferred, deferredByModal: true)
+
+        let effects = coordinator.request(direct, deferredByModal: false)
+
+        #expect(effects.presentation?.request == direct)
+        #expect(effects.released == [deferred])
+        #expect(coordinator.deferred == nil)
+        #expect(coordinator.current?.request == direct)
+    }
+
+    @Test func supersededRequestBeforePresentationCompletesAfterYield() throws {
+        let first = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-1")
+        let replacement = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-2")
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+        let initial = try #require(
+            coordinator.request(first, deferredByModal: false).presentation
+        )
+
+        let queued = coordinator.request(replacement, deferredByModal: false)
+
+        #expect(queued.dismissalID == initial.id)
+        #expect(!FeatureNewTaskPresentationTiming.requiresDismissalCallback(
+            dismissalID: initial.id,
+            presentedID: nil
+        ))
+        #expect(!FeatureNewTaskPresentationTiming.canPresent(
+            id: initial.id,
+            currentID: coordinator.current?.id,
+            awaitingDismissalID: queued.dismissalID,
+            presentedID: nil
+        ))
+
+        let completed = coordinator.completeDismissal(
+            id: initial.id,
+            deferredByModal: false
+        )
+        #expect(completed.presentation?.request == replacement)
+    }
+
+    @Test func threadOrProjectRouteCancelsEveryQueuedTaskWithoutGhostReopen() throws {
         let active = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-1")
         let pending = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-2")
         var coordinator = FeatureNewTaskPresentationCoordinator()
-        let activeID = try! XCTUnwrap(
+        let activeID = try #require(
             coordinator.request(active, deferredByModal: false).presentation?.id
         )
         _ = coordinator.request(pending, deferredByModal: false)
 
         let cancelled = coordinator.cancelAll()
 
-        XCTAssertEqual(Set(cancelled.released.compactMap(\.incomingShareID)), ["share-1", "share-2"])
-        XCTAssertEqual(cancelled.dismissalID, activeID)
-        XCTAssertNil(coordinator.current)
-        XCTAssertNil(coordinator.pending)
-        XCTAssertTrue(
+        #expect(Set(cancelled.released.compactMap(\.incomingShareID)) == ["share-1", "share-2"])
+        #expect(cancelled.dismissalID == activeID)
+        #expect(coordinator.current == nil)
+        #expect(coordinator.pending == nil)
+        #expect(
             coordinator.completeDismissal(id: activeID, deferredByModal: false).isEmpty
         )
-        XCTAssertTrue(coordinator.resumeDeferred().isEmpty)
+        #expect(coordinator.resumeDeferred().isEmpty)
     }
 
-    func testRouteCancellationAlsoClearsModalDeferredShareExactlyOnce() {
+    @Test func routeCancellationAlsoClearsModalDeferredShareExactlyOnce() {
         let deferred = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-modal")
         var coordinator = FeatureNewTaskPresentationCoordinator()
         _ = coordinator.request(deferred, deferredByModal: true)
 
         let cancelled = coordinator.cancelAll()
 
-        XCTAssertEqual(cancelled.released, [deferred])
-        XCTAssertTrue(coordinator.cancelAll().released.isEmpty)
-        XCTAssertTrue(coordinator.resumeDeferred().isEmpty)
+        #expect(cancelled.released == [deferred])
+        #expect(coordinator.cancelAll().released.isEmpty)
+        #expect(coordinator.resumeDeferred().isEmpty)
     }
+}
 
+@MainActor
+final class WorkspaceContractTests: XCTestCase {
     func testVCSStatusSnapshotDecodesTaggedEffectRPCShape() throws {
         let data = Data(
             """

--- a/apps/swift-ios/Tests/CoreTests/WorkspaceContractTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WorkspaceContractTests.swift
@@ -3,6 +3,147 @@ import XCTest
 
 @MainActor
 final class WorkspaceContractTests: XCTestCase {
+    func testLatestNewTaskRequestWaitsForCurrentDismissalAndGetsFreshIdentity() {
+        let first = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-1")
+        let replacement = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-2")
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+
+        let initial = coordinator.request(first, deferredByModal: false)
+        let firstID = try! XCTUnwrap(initial.presentation?.id)
+        XCTAssertEqual(initial.presentation?.request, first)
+
+        let queued = coordinator.request(replacement, deferredByModal: false)
+        XCTAssertEqual(queued.dismissalID, firstID)
+        XCTAssertNil(queued.presentation)
+        XCTAssertEqual(coordinator.pending, replacement)
+
+        let completed = coordinator.completeDismissal(id: firstID, deferredByModal: false)
+        XCTAssertEqual(completed.released, [first])
+        XCTAssertEqual(completed.presentation?.request, replacement)
+        XCTAssertNotEqual(completed.presentation?.id, firstID)
+    }
+
+    func testOverwrittenPendingShareIsReleasedExactlyOnce() {
+        let active = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-1")
+        let firstShare = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-1")
+        let latestShare = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-2")
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+
+        _ = coordinator.request(active, deferredByModal: false)
+        _ = coordinator.request(firstShare, deferredByModal: false)
+        let overwritten = coordinator.request(latestShare, deferredByModal: false)
+
+        XCTAssertEqual(overwritten.released, [firstShare])
+        XCTAssertEqual(coordinator.pending, latestShare)
+        XCTAssertNil(coordinator.completeDismissal(id: UUID(), deferredByModal: false).presentation)
+        XCTAssertEqual(coordinator.pending, latestShare)
+    }
+
+    func testDismissalCompletionIsIdempotentAndRejectsStaleCallbacks() {
+        let share = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-1")
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+        let presentation = try! XCTUnwrap(
+            coordinator.request(share, deferredByModal: false).presentation
+        )
+        _ = coordinator.beginDismissal(id: presentation.id)
+
+        let first = coordinator.completeDismissal(
+            id: presentation.id,
+            deferredByModal: false
+        )
+        let duplicate = coordinator.completeDismissal(
+            id: presentation.id,
+            deferredByModal: false
+        )
+
+        XCTAssertEqual(first.released, [share])
+        XCTAssertTrue(duplicate.isEmpty)
+        XCTAssertNil(coordinator.current)
+    }
+
+    func testDismissalCompletionRequiresAnExplicitMatchingDismissalStart() {
+        let request = FeatureNewTaskPresentationRequest.newTask(initialProjectID: nil)
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+        let presentation = try! XCTUnwrap(
+            coordinator.request(request, deferredByModal: false).presentation
+        )
+
+        let unrelatedDisappearance = coordinator.completeDismissal(
+            id: presentation.id,
+            deferredByModal: false
+        )
+
+        XCTAssertTrue(unrelatedDisappearance.isEmpty)
+        XCTAssertEqual(coordinator.current, presentation)
+    }
+
+    func testFallbackCompletionPromotesTheSameLatestRequest() {
+        let first = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-1")
+        let replacement = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-2")
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+        let firstID = try! XCTUnwrap(
+            coordinator.request(first, deferredByModal: false).presentation?.id
+        )
+        _ = coordinator.request(replacement, deferredByModal: false)
+
+        let fallback = coordinator.completeDismissal(id: firstID, deferredByModal: false)
+
+        XCTAssertEqual(fallback.presentation?.request, replacement)
+        XCTAssertEqual(fallback.released, [first])
+        XCTAssertTrue(
+            coordinator.completeDismissal(id: firstID, deferredByModal: false).isEmpty
+        )
+    }
+
+    func testLatestModalDeferredRequestResumesAfterModalDismissal() {
+        let firstShare = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-1")
+        let latest = FeatureNewTaskPresentationRequest.newTask(initialProjectID: "project-2")
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+
+        let first = coordinator.request(firstShare, deferredByModal: true)
+        let second = coordinator.request(latest, deferredByModal: true)
+
+        XCTAssertTrue(first.isEmpty)
+        XCTAssertEqual(second.released, [firstShare])
+        XCTAssertEqual(coordinator.deferred, latest)
+        let resumed = coordinator.resumeDeferred()
+        XCTAssertEqual(resumed.presentation?.request, latest)
+        XCTAssertTrue(coordinator.resumeDeferred().isEmpty)
+    }
+
+    func testThreadOrProjectRouteCancelsEveryQueuedNewTaskWithoutGhostReopen() {
+        let active = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-1")
+        let pending = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-2")
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+        let activeID = try! XCTUnwrap(
+            coordinator.request(active, deferredByModal: false).presentation?.id
+        )
+        _ = coordinator.request(pending, deferredByModal: false)
+
+        let cancelled = coordinator.cancelAll()
+
+        XCTAssertEqual(Set(cancelled.released.compactMap(\.incomingShareID)), ["share-1", "share-2"])
+        XCTAssertEqual(cancelled.dismissalID, activeID)
+        XCTAssertNil(coordinator.current)
+        XCTAssertNil(coordinator.pending)
+        XCTAssertTrue(
+            coordinator.completeDismissal(id: activeID, deferredByModal: false).isEmpty
+        )
+        XCTAssertTrue(coordinator.resumeDeferred().isEmpty)
+    }
+
+    func testRouteCancellationAlsoClearsModalDeferredShareExactlyOnce() {
+        let deferred = FeatureNewTaskPresentationRequest.sharedNewTask(shareID: "share-modal")
+        var coordinator = FeatureNewTaskPresentationCoordinator()
+        _ = coordinator.request(deferred, deferredByModal: true)
+
+        let cancelled = coordinator.cancelAll()
+
+        XCTAssertEqual(cancelled.released, [deferred])
+        XCTAssertTrue(coordinator.cancelAll().released.isEmpty)
+        XCTAssertTrue(coordinator.resumeDeferred().isEmpty)
+    }
+
     func testVCSStatusSnapshotDecodesTaggedEffectRPCShape() throws {
         let data = Data(
             """

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -222,6 +222,78 @@ struct ComposerDraftStoreTests {
         #expect(merged.workspace == fallbackWorkspace)
     }
 
+    @Test func incomingShareAppendsToTheCurrentComposer() {
+        let liveDraft = FeatureComposerDraft(
+            text: "Typed before import",
+            attachments: [FeatureDraftAttachment(
+                data: Data([0x01]),
+                filename: "live.png",
+                mimeType: "image/png"
+            )]
+        )
+        let importedAttachment = FeatureDraftAttachment(
+            data: Data([0x02]),
+            filename: "shared.png",
+            mimeType: "image/png"
+        )
+        let incomingDraft = FeatureComposerDraft(
+            text: "Shared content",
+            attachments: [importedAttachment]
+        )
+
+        let result = FeatureComposerIncomingShareMerge.merge(
+            current: liveDraft,
+            incoming: incomingDraft
+        )
+
+        #expect(result.draft.text == "Typed before import\n\nShared content")
+        #expect(result.draft.attachments == liveDraft.attachments + [importedAttachment])
+        #expect(result.attachmentOverflowCount == 0)
+    }
+
+    @Test func incomingShareMergeKeepsAttachmentsAndReportsTheRequiredRemovalCount() {
+        let currentAttachments = (0..<8).map { value in
+            FeatureDraftAttachment(
+                data: Data([UInt8(value)]),
+                filename: "live-\(value).png",
+                mimeType: "image/png"
+            )
+        }
+        let incoming = FeatureComposerDraft(
+            text: "Shared",
+            attachments: [FeatureDraftAttachment(
+                data: Data([0xFF]),
+                filename: "shared.png",
+                mimeType: "image/png"
+            )]
+        )
+
+        let result = FeatureComposerIncomingShareMerge.merge(
+            current: FeatureComposerDraft(text: "   ", attachments: currentAttachments),
+            incoming: incoming
+        )
+
+        #expect(result.draft.text == "Shared")
+        #expect(result.draft.attachments == currentAttachments + incoming.attachments)
+        #expect(result.attachmentOverflowCount == 1)
+    }
+
+    @Test func importDuringInitialRestoreIsConsumedExactlyOnceByRestoration() {
+        let baseline = FeatureComposerDraft(text: "Before")
+        let persistedImport = FeatureComposerDraft(text: "Before\n\nShared")
+
+        #expect(!FeatureComposerDraftReloadPolicy.shouldMergeIntoLiveComposer(
+            didRestoreDraft: false
+        ))
+        let restored = FeatureComposerDraftRestoration.merge(
+            saved: persistedImport,
+            baseline: baseline,
+            current: baseline
+        )
+
+        #expect(restored.text == "Before\n\nShared")
+    }
+
     @Test func successfulSubmissionFenceWaitsForCancelledDraftWrites() async {
         let started = AsyncStream<Void>.makeStream()
         let release = AsyncStream<Void>.makeStream()

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -323,6 +323,26 @@ struct ComposerDraftStoreTests {
         #expect(pending.map(\.shareID) == ["pending-one", "pending-two"])
     }
 
+    @Test func handledReloadImportsArePrunedBeforeAComposerCanBeRecreated() {
+        let imports = [
+            FeatureComposerIncomingShareDraft(
+                shareID: "SHARE-ONE",
+                draft: FeatureComposerDraft(text: "First")
+            ),
+            FeatureComposerIncomingShareDraft(
+                shareID: "share-two",
+                draft: FeatureComposerDraft(text: "Second")
+            ),
+        ]
+
+        let remaining = FeatureComposerIncomingShareReloadPolicy.removing(
+            shareIDs: ["share-one"],
+            from: imports
+        )
+
+        #expect(remaining.map(\.shareID) == ["share-two"])
+    }
+
     @Test func reloadQueueMatchesThePersistedLedgerWindowAndDeduplicatesReplays() {
         var imports: [FeatureComposerIncomingShareDraft] = []
         for index in 0..<34 {
@@ -389,6 +409,25 @@ struct ComposerDraftStoreTests {
         #expect(!NewTaskIncomingSharePersistencePolicy.canPersist(
             pendingShareID: nil,
             restoredShareID: "share-a"
+        ))
+    }
+
+    @Test func routedShareAcknowledgementRequiresTheOriginalProjectContext() {
+        #expect(NewTaskIncomingShareAcknowledgementPolicy.canAcknowledge(
+            didRoute: true,
+            routedShareID: "share-a",
+            pendingShareID: "SHARE-A",
+            routedProjectID: "project-a",
+            currentProjectID: "project-a",
+            restoreContextProjectID: "project-a"
+        ))
+        #expect(!NewTaskIncomingShareAcknowledgementPolicy.canAcknowledge(
+            didRoute: true,
+            routedShareID: "share-a",
+            pendingShareID: "share-a",
+            routedProjectID: "project-a",
+            currentProjectID: "project-b",
+            restoreContextProjectID: "project-b"
         ))
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -319,8 +319,29 @@ struct ComposerDraftStoreTests {
             imports,
             restoredShareIDs: ["already-restored"]
         )
+        let restored = FeatureComposerIncomingShareReloadPolicy.restoredImportIDs(
+            imports,
+            restoredShareIDs: ["already-restored"]
+        )
 
         #expect(pending.map(\.shareID) == ["pending-one", "pending-two"])
+        #expect(restored == ["already-restored"])
+    }
+
+    @Test func initialReloadProcessesImportsDeliveredWithANewThreadDetail() {
+        let imported = FeatureComposerIncomingShareDraft(
+            shareID: "share-on-open",
+            draft: FeatureComposerDraft(text: "Open in another thread")
+        )
+
+        #expect(FeatureComposerIncomingShareReloadPolicy.initialHandledRevision(
+            revision: 7,
+            imports: [imported]
+        ) == nil)
+        #expect(FeatureComposerIncomingShareReloadPolicy.initialHandledRevision(
+            revision: 7,
+            imports: []
+        ) == 7)
     }
 
     @Test func handledReloadImportsArePrunedBeforeAComposerCanBeRecreated() {
@@ -450,7 +471,12 @@ struct ComposerDraftStoreTests {
         let shareID = "share-discard-retry"
         let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
         let draft = FeatureComposerDraft(text: "Keep me safe")
-        try await store.setDraft(draft, for: key)
+        _ = try await store.importSharedContent(
+            shareID: shareID,
+            text: draft.text,
+            attachments: [],
+            for: key
+        )
 
         let result = await NewTaskIncomingShareDiscard.perform(
             shareID: shareID,
@@ -462,6 +488,7 @@ struct ComposerDraftStoreTests {
 
         #expect(result == .acknowledgementFailed(draftRestored: true))
         #expect(try await store.draft(for: key) == draft)
+        #expect(try await store.snapshot(for: key).importedShareIDs == [shareID])
     }
 
     @Test func successfulDiscardRemovesTheStagedDraftBeforeAcknowledging() async throws {

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -323,6 +323,32 @@ struct ComposerDraftStoreTests {
         #expect(pending.map(\.shareID) == ["pending-one", "pending-two"])
     }
 
+    @Test func reloadQueueMatchesThePersistedLedgerWindowAndDeduplicatesReplays() {
+        var imports: [FeatureComposerIncomingShareDraft] = []
+        for index in 0..<34 {
+            imports = FeatureComposerIncomingShareReloadPolicy.appending(
+                FeatureComposerIncomingShareDraft(
+                    shareID: "share-\(index)",
+                    draft: FeatureComposerDraft(text: "Shared \(index)")
+                ),
+                to: imports
+            )
+        }
+        imports = FeatureComposerIncomingShareReloadPolicy.appending(
+            FeatureComposerIncomingShareDraft(
+                shareID: "share-33",
+                draft: FeatureComposerDraft(text: "Replayed 33")
+            ),
+            to: imports
+        )
+
+        #expect(imports.count == 32)
+        #expect(imports.first?.shareID == "share-2")
+        #expect(imports.last?.shareID == "share-33")
+        #expect(imports.last?.draft.text == "Replayed 33")
+        #expect(imports.filter { $0.shareID == "share-33" }.count == 1)
+    }
+
     @Test func successfulSubmissionFenceWaitsForCancelledDraftWrites() async {
         let started = AsyncStream<Void>.makeStream()
         let release = AsyncStream<Void>.makeStream()

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -267,10 +267,16 @@ struct ComposerDraftStoreTests {
 
     @Test func sharedThreadNavigationRequestsAComposerReload() {
         let request = FeatureWorkspaceNavigationRequest(
-            destination: .sharedThread(id: "thread-1")
+            destination: .sharedThread(
+                id: "thread-1",
+                draft: FeatureComposerDraft(text: "Shared")
+            )
         )
 
-        #expect(request.destination == .sharedThread(id: "thread-1"))
+        #expect(request.destination == .sharedThread(
+            id: "thread-1",
+            draft: FeatureComposerDraft(text: "Shared")
+        ))
         #expect(request.destination != .thread(id: "thread-1"))
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -278,20 +278,49 @@ struct ComposerDraftStoreTests {
         #expect(result.attachmentOverflowCount == 1)
     }
 
-    @Test func importDuringInitialRestoreIsConsumedExactlyOnceByRestoration() {
-        let baseline = FeatureComposerDraft(text: "Before")
-        let persistedImport = FeatureComposerDraft(text: "Before\n\nShared")
-
-        #expect(!FeatureComposerDraftReloadPolicy.shouldMergeIntoLiveComposer(
-            didRestoreDraft: false
-        ))
-        let restored = FeatureComposerDraftRestoration.merge(
-            saved: persistedImport,
-            baseline: baseline,
-            current: baseline
+    @Test func draftSnapshotReportsWhichShareImportsRestorationConsumed() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let key = "environment:one:thread:one"
+        _ = try await store.importSharedContent(
+            shareID: "share-one",
+            text: "Shared",
+            attachments: [],
+            for: key
         )
 
-        #expect(restored.text == "Before\n\nShared")
+        let snapshot = try await store.snapshot(for: key)
+
+        #expect(snapshot.draft?.text == "Shared")
+        #expect(snapshot.importedShareIDs == ["share-one"])
+    }
+
+    @Test func reloadPolicyRetainsEveryShareNotConsumedByInitialRestoration() {
+        let imports = [
+            FeatureComposerIncomingShareDraft(
+                shareID: "already-restored",
+                draft: FeatureComposerDraft(text: "First")
+            ),
+            FeatureComposerIncomingShareDraft(
+                shareID: "pending-one",
+                draft: FeatureComposerDraft(text: "Second")
+            ),
+            FeatureComposerIncomingShareDraft(
+                shareID: "pending-two",
+                draft: FeatureComposerDraft(text: "Third")
+            ),
+        ]
+
+        let pending = FeatureComposerIncomingShareReloadPolicy.pendingImports(
+            imports,
+            restoredShareIDs: ["already-restored"]
+        )
+
+        #expect(pending.map(\.shareID) == ["pending-one", "pending-two"])
     }
 
     @Test func successfulSubmissionFenceWaitsForCancelledDraftWrites() async {
@@ -338,16 +367,20 @@ struct ComposerDraftStoreTests {
     }
 
     @Test func sharedThreadNavigationRequestsAComposerReload() {
+        let importDraft = FeatureComposerIncomingShareDraft(
+            shareID: "share-1",
+            draft: FeatureComposerDraft(text: "Shared")
+        )
         let request = FeatureWorkspaceNavigationRequest(
             destination: .sharedThread(
                 id: "thread-1",
-                draft: FeatureComposerDraft(text: "Shared")
+                importDraft: importDraft
             )
         )
 
         #expect(request.destination == .sharedThread(
             id: "thread-1",
-            draft: FeatureComposerDraft(text: "Shared")
+            importDraft: importDraft
         ))
         #expect(request.destination != .thread(id: "thread-1"))
     }

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -431,6 +431,68 @@ struct ComposerDraftStoreTests {
         ))
     }
 
+    @Test func projectSelectionIsLockedWhileAnIncomingShareRouteIsCommitting() {
+        #expect(NewTaskIncomingShareRoutingPolicy.canChangeProject(
+            isRoutingIncomingShare: false
+        ))
+        #expect(!NewTaskIncomingShareRoutingPolicy.canChangeProject(
+            isRoutingIncomingShare: true
+        ))
+    }
+
+    @Test func failedDiscardAcknowledgementRestoresTheStagedDraft() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let shareID = "share-discard-retry"
+        let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
+        let draft = FeatureComposerDraft(text: "Keep me safe")
+        try await store.setDraft(draft, for: key)
+
+        let result = await NewTaskIncomingShareDiscard.perform(
+            shareID: shareID,
+            draft: draft,
+            key: key,
+            store: store,
+            acknowledge: { _ in false }
+        )
+
+        #expect(result == .acknowledgementFailed(draftRestored: true))
+        #expect(try await store.draft(for: key) == draft)
+    }
+
+    @Test func successfulDiscardRemovesTheStagedDraftBeforeAcknowledging() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let shareID = "share-discard-success"
+        let key = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
+        let draft = FeatureComposerDraft(text: "Discard me")
+        try await store.setDraft(draft, for: key)
+        let draftWasRemoved = ComposerDraftTestFlag()
+
+        let result = await NewTaskIncomingShareDiscard.perform(
+            shareID: shareID,
+            draft: draft,
+            key: key,
+            store: store,
+            acknowledge: { _ in
+                await draftWasRemoved.set((try? await store.draft(for: key)) == nil)
+                return true
+            }
+        )
+
+        #expect(result == .discarded)
+        #expect(await draftWasRemoved.value)
+        #expect(try await store.draft(for: key) == nil)
+    }
+
     @Test func sharedThreadNavigationRequestsAComposerReload() {
         let importDraft = FeatureComposerIncomingShareDraft(
             shareID: "share-1",
@@ -480,5 +542,13 @@ struct ComposerDraftStoreTests {
             remainingIncomingShareID: nil,
             releasedIncomingShareID: "share-a"
         ))
+    }
+}
+
+private actor ComposerDraftTestFlag {
+    private(set) var value = false
+
+    func set(_ value: Bool) {
+        self.value = value
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -264,4 +264,45 @@ struct ComposerDraftStoreTests {
             restoredShareID: "share-a"
         ))
     }
+
+    @Test func sharedThreadNavigationRequestsAComposerReload() {
+        let request = FeatureWorkspaceNavigationRequest(
+            destination: .sharedThread(id: "thread-1")
+        )
+
+        #expect(request.destination == .sharedThread(id: "thread-1"))
+        #expect(request.destination != .thread(id: "thread-1"))
+    }
+
+    @Test func dismissingOldShareSheetPreservesReplacementContext() {
+        let resolution = NewTaskDismissalContext(
+            initialProjectID: "project-a",
+            incomingShareID: "share-a"
+        ).resolve(
+            currentInitialProjectID: nil,
+            currentIncomingShareID: "share-b"
+        )
+
+        #expect(resolution == NewTaskDismissalResolution(
+            remainingInitialProjectID: nil,
+            remainingIncomingShareID: "share-b",
+            releasedIncomingShareID: "share-a"
+        ))
+    }
+
+    @Test func dismissingCurrentShareSheetClearsItsContext() {
+        let resolution = NewTaskDismissalContext(
+            initialProjectID: "project-a",
+            incomingShareID: "share-a"
+        ).resolve(
+            currentInitialProjectID: "project-a",
+            currentIncomingShareID: "share-a"
+        )
+
+        #expect(resolution == NewTaskDismissalResolution(
+            remainingInitialProjectID: nil,
+            remainingIncomingShareID: nil,
+            releasedIncomingShareID: "share-a"
+        ))
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -245,4 +245,23 @@ struct ComposerDraftStoreTests {
         #expect(await eventIterator.next() == "write finished")
         #expect(await eventIterator.next() == "draft removed")
     }
+
+    @Test func incomingSharePersistenceWaitsForTheMatchingRestore() {
+        #expect(!NewTaskIncomingSharePersistencePolicy.canPersist(
+            pendingShareID: "share-a",
+            restoredShareID: nil
+        ))
+        #expect(!NewTaskIncomingSharePersistencePolicy.canPersist(
+            pendingShareID: "share-a",
+            restoredShareID: "share-b"
+        ))
+        #expect(NewTaskIncomingSharePersistencePolicy.canPersist(
+            pendingShareID: "share-a",
+            restoredShareID: "share-a"
+        ))
+        #expect(!NewTaskIncomingSharePersistencePolicy.canPersist(
+            pendingShareID: nil,
+            restoredShareID: "share-a"
+        ))
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 

--- a/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
@@ -70,6 +70,7 @@ struct PlatformDeepLinkTests {
             .project(environmentID: "environment 1", projectID: "project/1"),
             .thread(environmentID: "environment 1", threadID: "thread 1"),
             .newTask(environmentID: "environment 1", projectID: "project 1"),
+            .incomingShare(id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
             .connection(endpoint: "https://remote.example.com", token: "PAIR"),
         ]
 
@@ -78,6 +79,18 @@ struct PlatformDeepLinkTests {
             #expect(url.scheme == PlatformRoute.nativeScheme)
             let parsed = try PlatformDeepLinkParser.parse(url)
             #expect(parsed == route, "Failed to round-trip \(route) through \(url.absoluteString)")
+        }
+    }
+
+    @Test
+    func incomingShareRouteRequiresAUUID() throws {
+        #expect(
+            try PlatformDeepLinkParser.parse(
+                "t3code-swiftui://share?id=AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+            ) == .incomingShare(id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        )
+        #expect(throws: PlatformDeepLinkError.invalidIdentifier) {
+            try PlatformDeepLinkParser.parse("t3code-swiftui://share?id=not-a-uuid")
         }
     }
 

--- a/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
@@ -70,7 +70,6 @@ struct PlatformDeepLinkTests {
             .project(environmentID: "environment 1", projectID: "project/1"),
             .thread(environmentID: "environment 1", threadID: "thread 1"),
             .newTask(environmentID: "environment 1", projectID: "project 1"),
-            .incomingShare(id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
             .connection(endpoint: "https://remote.example.com", token: "PAIR"),
         ]
 
@@ -79,18 +78,6 @@ struct PlatformDeepLinkTests {
             #expect(url.scheme == PlatformRoute.nativeScheme)
             let parsed = try PlatformDeepLinkParser.parse(url)
             #expect(parsed == route, "Failed to round-trip \(route) through \(url.absoluteString)")
-        }
-    }
-
-    @Test
-    func incomingShareRouteRequiresAUUID() throws {
-        #expect(
-            try PlatformDeepLinkParser.parse(
-                "t3code-swiftui://share?id=AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
-            ) == .incomingShare(id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-        )
-        #expect(throws: PlatformDeepLinkError.invalidIdentifier) {
-            try PlatformDeepLinkParser.parse("t3code-swiftui://share?id=not-a-uuid")
         }
     }
 

--- a/apps/swift-ios/Tests/PlatformTests/PlatformFeedbackTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformFeedbackTests.swift
@@ -49,7 +49,7 @@ struct PlatformFeedbackTests {
     }
 
     @Test
-    func recentThreadStoreSortsLimitsAndSkipsArchived() throws {
+    func recentThreadStoreSortsAndSkipsArchived() throws {
         let suiteName = "PlatformFeedbackTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -66,7 +66,7 @@ struct PlatformFeedbackTests {
         store.update(from: threads)
         let records = store.records()
 
-        #expect(records.count == 12)
+        #expect(records.count == 13)
         #expect(records.first?.id == "thread-12")
         #expect(!records.contains { $0.id == "thread-13" })
     }

--- a/apps/swift-ios/Tests/PlatformTests/PlatformFeedbackTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformFeedbackTests.swift
@@ -71,6 +71,18 @@ struct PlatformFeedbackTests {
         #expect(!records.contains { $0.id == "thread-13" })
     }
 
+    @Test
+    func sharedAppearanceStoreDefaultsToSystemAndRoundTripsDarkMode() throws {
+        let suiteName = "PlatformFeedbackTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = T3SharedAppearanceStore(defaults: defaults)
+
+        #expect(store.appearance() == .system)
+        store.update(.dark)
+        #expect(store.appearance() == .dark)
+    }
+
     private func thread(
         id: String,
         state: FeatureThreadState,

--- a/apps/swift-ios/Tests/PlatformTests/PlatformFeedbackTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformFeedbackTests.swift
@@ -54,21 +54,21 @@ struct PlatformFeedbackTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = PlatformRecentThreadStore(defaults: defaults, key: "recent")
-        var threads = (0 ..< 14).map { index in
+        var threads = (0 ..< 102).map { index in
             thread(
                 id: "thread-\(index)",
                 state: .idle,
                 updatedAt: Date(timeIntervalSince1970: TimeInterval(index))
             )
         }
-        threads[13].isArchived = true
+        threads[101].isArchived = true
 
         store.update(from: threads)
         let records = store.records()
 
-        #expect(records.count == 13)
-        #expect(records.first?.id == "thread-12")
-        #expect(!records.contains { $0.id == "thread-13" })
+        #expect(records.count == T3SharedRecentThreadStore.maximumCount)
+        #expect(records.first?.id == "thread-100")
+        #expect(!records.contains { $0.id == "thread-101" })
     }
 
     @Test

--- a/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
@@ -266,6 +266,68 @@ struct PlatformIncomingShareTests {
     }
 
     @Test
+    func replayAfterInboxRemovalFailureStillReturnsTheShareIdentityAndDelta() async throws {
+        let recorder = IncomingShareTestRecorder()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let envelope = Self.envelope(text: "Shared once")
+        let thread = FeatureThread(
+            id: "thread:environment:thread",
+            wireID: "thread",
+            projectID: "project",
+            environmentID: "environment",
+            title: "Thread"
+        )
+        let pipeline = PlatformIncomingSharePipeline(
+            source: PlatformIncomingShareSource(
+                loadAll: { [envelope] },
+                data: { _ in Data() },
+                remove: { id in
+                    await recorder.record("remove:\(id)")
+                    if await recorder.events.count == 1 {
+                        throw IncomingShareTestError.removeFailed
+                    }
+                }
+            ),
+            drafts: PlatformIncomingShareDraftRepository(
+                importContent: { shareID, text, attachments, key, maximumCount in
+                    let result = try await store.importSharedContentResult(
+                        shareID: shareID,
+                        text: text,
+                        attachments: attachments,
+                        for: key,
+                        maximumAttachmentCount: maximumCount
+                    )
+                    return PlatformIncomingShareDraftImport(
+                        draft: result.draft,
+                        didImport: result.didImport
+                    )
+                }
+            )
+        )
+
+        do {
+            _ = try await pipeline.importEnvelope(envelope, into: thread)
+            Issue.record("Expected inbox removal to fail")
+        } catch {
+            #expect(error as? IncomingShareTestError == .removeFailed)
+        }
+
+        let replay = try await pipeline.importEnvelope(envelope, into: thread)
+        let snapshot = try await store.snapshot(for: FeatureComposerDraftStore.threadKey(thread))
+
+        #expect(replay.sharedContent.shareID == envelope.id)
+        #expect(replay.sharedContent.draft.text == "Shared once")
+        #expect(snapshot.draft?.text == "Shared once")
+        #expect(snapshot.importedShareIDs == [envelope.id])
+        #expect(await recorder.events.count == 2)
+    }
+
+    @Test
     func existingThreadImportUsesItsDraftAndRepresentsVideoAsAContactSheet() async throws {
         let recorder = IncomingShareTestRecorder()
         let videoID = "12345678-1234-1234-1234-123456789abc"
@@ -314,8 +376,11 @@ struct PlatformIncomingShareTests {
 
         #expect(captured?.key == FeatureComposerDraftStore.threadKey(thread))
         #expect(imported.draft.text.contains("Review this"))
-        #expect(imported.sharedContent?.text.contains("Shared video: reference.mov") == true)
-        #expect(imported.sharedContent?.attachments.first?.id.uuidString.lowercased() == videoID)
+        #expect(imported.sharedContent.shareID == envelope.id)
+        #expect(imported.sharedContent.draft.text.contains("Shared video: reference.mov"))
+        #expect(
+            imported.sharedContent.draft.attachments.first?.id.uuidString.lowercased() == videoID
+        )
         #expect(await recorder.events == [
             "video:\(videoID)",
             "import:\(envelope.id)",
@@ -545,6 +610,7 @@ struct PlatformIncomingShareTests {
 
 private enum IncomingShareTestError: Error, Equatable {
     case imageFailed
+    case removeFailed
     case saveFailed
 }
 

--- a/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
@@ -4,6 +4,33 @@ import Testing
 
 @Suite("Incoming share import")
 struct PlatformIncomingShareTests {
+    @Test @MainActor
+    func routingGateCoalescesARequestThatArrivesWhileRouting() async {
+        let gate = PlatformIncomingShareRoutingGate()
+        let started = AsyncStream<Void>.makeStream()
+        let release = AsyncStream<Void>.makeStream()
+        var runCount = 0
+
+        let first = Task { @MainActor in
+            await gate.request {
+                runCount += 1
+                if runCount == 1 {
+                    started.continuation.yield()
+                    for await _ in release.stream { break }
+                }
+            }
+        }
+        var startedIterator = started.stream.makeAsyncIterator()
+        _ = await startedIterator.next()
+
+        await gate.request { runCount += 1 }
+        await gate.request { runCount += 10 }
+        release.continuation.yield()
+        await first.value
+
+        #expect(runCount == 11)
+    }
+
     @Test
     func persistsMergedDraftBeforeRemovingInboxEnvelope() async throws {
         let recorder = IncomingShareTestRecorder()
@@ -55,7 +82,7 @@ struct PlatformIncomingShareTests {
                     )
                     await recorder.capture(draft: draft, key: key)
                     await recorder.record("import:\(key)")
-                    return draft
+                    return PlatformIncomingShareDraftImport(draft: draft, didImport: true)
                 }
             ),
             prepareImage: { data, ordinal in
@@ -127,7 +154,10 @@ struct PlatformIncomingShareTests {
             drafts: PlatformIncomingShareDraftRepository(
                 importContent: { _, _, _, _, _ in
                     await recorder.record("import")
-                    return FeatureComposerDraft()
+                    return PlatformIncomingShareDraftImport(
+                        draft: FeatureComposerDraft(),
+                        didImport: true
+                    )
                 }
             ),
             prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
@@ -173,13 +203,14 @@ struct PlatformIncomingShareTests {
             drafts: PlatformIncomingShareDraftRepository(
                 importContent: { shareID, text, attachments, key, maximumCount in
                     await recorder.record("import")
-                    return try await store.importSharedContent(
+                    let draft = try await store.importSharedContent(
                         shareID: shareID,
                         text: text,
                         attachments: attachments,
                         for: key,
                         maximumAttachmentCount: maximumCount
                     )
+                    return PlatformIncomingShareDraftImport(draft: draft, didImport: true)
                 }
             ),
             prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
@@ -221,7 +252,7 @@ struct PlatformIncomingShareTests {
         var edited = once
         edited.text += "\nUser edit"
         try await store.setDraft(edited, for: key)
-        let twice = try await store.importSharedContent(
+        let replay = try await store.importSharedContentResult(
             shareID: "share-id",
             text: "Shared",
             attachments: [attachment],
@@ -230,7 +261,8 @@ struct PlatformIncomingShareTests {
 
         #expect(once.text == "Existing\n\nShared")
         #expect(once.attachments == [attachment])
-        #expect(twice == edited)
+        #expect(replay.draft == edited)
+        #expect(!replay.didImport)
     }
 
     @Test
@@ -265,7 +297,10 @@ struct PlatformIncomingShareTests {
                         key: key
                     )
                     await recorder.record("import:\(shareID)")
-                    return FeatureComposerDraft(text: text, attachments: attachments)
+                    return PlatformIncomingShareDraftImport(
+                        draft: FeatureComposerDraft(text: text, attachments: attachments),
+                        didImport: true
+                    )
                 }
             ),
             prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) },
@@ -278,9 +313,9 @@ struct PlatformIncomingShareTests {
         let captured = await recorder.capturedDraft
 
         #expect(captured?.key == FeatureComposerDraftStore.threadKey(thread))
-        #expect(imported.text.contains("Review this"))
-        #expect(imported.text.contains("Shared video: reference.mov"))
-        #expect(imported.attachments.first?.id.uuidString.lowercased() == videoID)
+        #expect(imported.draft.text.contains("Review this"))
+        #expect(imported.sharedContent?.text.contains("Shared video: reference.mov") == true)
+        #expect(imported.sharedContent?.attachments.first?.id.uuidString.lowercased() == videoID)
         #expect(await recorder.events == [
             "video:\(videoID)",
             "import:\(envelope.id)",
@@ -306,13 +341,14 @@ struct PlatformIncomingShareTests {
             ),
             drafts: PlatformIncomingShareDraftRepository(
                 importContent: { shareID, text, attachments, key, maximumCount in
-                    try await store.importSharedContent(
+                    let draft = try await store.importSharedContent(
                         shareID: shareID,
                         text: text,
                         attachments: attachments,
                         for: key,
                         maximumAttachmentCount: maximumCount
                     )
+                    return PlatformIncomingShareDraftImport(draft: draft, didImport: true)
                 }
             ),
             prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
@@ -371,7 +407,12 @@ struct PlatformIncomingShareTests {
                     remove: { _ in }
                 ),
                 drafts: PlatformIncomingShareDraftRepository(
-                    importContent: { _, _, _, _, _ in FeatureComposerDraft() }
+                    importContent: { _, _, _, _, _ in
+                        PlatformIncomingShareDraftImport(
+                            draft: FeatureComposerDraft(),
+                            didImport: true
+                        )
+                    }
                 ),
                 prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
             )
@@ -397,7 +438,12 @@ struct PlatformIncomingShareTests {
                     updateDestination: { _, _ in }
                 ),
                 drafts: PlatformIncomingShareDraftRepository(
-                    importContent: { _, _, _, _, _ in FeatureComposerDraft() }
+                    importContent: { _, _, _, _, _ in
+                        PlatformIncomingShareDraftImport(
+                            draft: FeatureComposerDraft(),
+                            didImport: true
+                        )
+                    }
                 ),
                 prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
             )
@@ -421,7 +467,12 @@ struct PlatformIncomingShareTests {
                     remove: { _ in }
                 ),
                 drafts: PlatformIncomingShareDraftRepository(
-                    importContent: { _, _, _, _, _ in FeatureComposerDraft() }
+                    importContent: { _, _, _, _, _ in
+                        PlatformIncomingShareDraftImport(
+                            draft: FeatureComposerDraft(),
+                            didImport: true
+                        )
+                    }
                 ),
                 prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
             )

--- a/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
@@ -363,6 +363,31 @@ struct PlatformIncomingShareTests {
 
     @Test
     @MainActor
+    func staleThreadDestinationCanFallBackToThePicker() async {
+        var envelope = Self.envelope(text: "Pending")
+        envelope.destination = .existingThread(environmentID: "env", threadID: "deleted")
+        let coordinator = PlatformIncomingShareCoordinator(
+            pipeline: PlatformIncomingSharePipeline(
+                source: PlatformIncomingShareSource(
+                    loadAll: { [envelope] },
+                    data: { _ in Data() },
+                    remove: { _ in }
+                ),
+                drafts: PlatformIncomingShareDraftRepository(
+                    importContent: { _, _, _, _, _ in FeatureComposerDraft() }
+                ),
+                prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
+            )
+        )
+
+        _ = await coordinator.refresh(hasProjects: true)
+        coordinator.requestAnotherDestination()
+
+        #expect(coordinator.pendingEnvelope?.destination == nil)
+    }
+
+    @Test
+    @MainActor
     func preferredEnvelopeDoesNotFallBackToAnotherPendingShare() async {
         let envelope = Self.envelope(text: "Do not route me")
         let coordinator = PlatformIncomingShareCoordinator(

--- a/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
@@ -329,12 +329,34 @@ struct PlatformIncomingShareTests {
             shareID: envelope.id,
             to: destinationKey
         )
-        #expect(routed?.text == "Choose my project")
+        guard case let .routed(routedDraft) = routed else {
+            Issue.record("Expected the staged share to be routed")
+            return
+        }
+        #expect(routedDraft.text == "Choose my project")
         #expect(try await store.draft(for: transferKey) == nil)
-        #expect(try await store.draft(for: destinationKey) == routed)
+        #expect(try await store.draft(for: destinationKey) == routedDraft)
 
         try await pipeline.acknowledgeEnvelope(id: envelope.id)
         #expect(await recorder.events == ["remove:\(envelope.id)"])
+    }
+
+    @Test
+    func missingStagedShareNeverMasqueradesAsAnExistingDestinationDraft() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureComposerDraftStore(fileURL: directory.appending(path: "drafts.json"))
+        let key = "new-task:project"
+        try await store.setDraft(FeatureComposerDraft(text: "Existing text"), for: key)
+
+        let result = try await store.routeIncomingShare(
+            shareID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            to: key
+        )
+
+        #expect(result == .sourceMissing)
+        #expect(try await store.draft(for: key)?.text == "Existing text")
     }
 
     @Test
@@ -363,7 +385,7 @@ struct PlatformIncomingShareTests {
 
     @Test
     @MainActor
-    func staleThreadDestinationCanFallBackToThePicker() async {
+    func staleThreadDestinationCanFallBackToThePicker() async throws {
         var envelope = Self.envelope(text: "Pending")
         envelope.destination = .existingThread(environmentID: "env", threadID: "deleted")
         let coordinator = PlatformIncomingShareCoordinator(
@@ -371,7 +393,8 @@ struct PlatformIncomingShareTests {
                 source: PlatformIncomingShareSource(
                     loadAll: { [envelope] },
                     data: { _ in Data() },
-                    remove: { _ in }
+                    remove: { _ in },
+                    updateDestination: { _, _ in }
                 ),
                 drafts: PlatformIncomingShareDraftRepository(
                     importContent: { _, _, _, _, _ in FeatureComposerDraft() }
@@ -381,7 +404,7 @@ struct PlatformIncomingShareTests {
         )
 
         _ = await coordinator.refresh(hasProjects: true)
-        coordinator.requestAnotherDestination()
+        try await coordinator.requestAnotherDestination()
 
         #expect(coordinator.pendingEnvelope?.destination == nil)
     }

--- a/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
@@ -32,6 +32,19 @@ struct PlatformIncomingShareTests {
     }
 
     @Test
+    func threadDestinationResolutionRequiresAnAuthoritativeConnectedSnapshot() {
+        #expect(PlatformIncomingShareDestinationConnectionPolicy.canResolveThread(
+            connectionState: .connected
+        ))
+        #expect(!PlatformIncomingShareDestinationConnectionPolicy.canResolveThread(
+            connectionState: .disconnected
+        ))
+        #expect(!PlatformIncomingShareDestinationConnectionPolicy.canResolveThread(
+            connectionState: nil
+        ))
+    }
+
+    @Test
     func persistsMergedDraftBeforeRemovingInboxEnvelope() async throws {
         let recorder = IncomingShareTestRecorder()
         let directory = FileManager.default.temporaryDirectory
@@ -266,7 +279,7 @@ struct PlatformIncomingShareTests {
     }
 
     @Test
-    func replayAfterInboxRemovalFailureStillReturnsTheShareIdentityAndDelta() async throws {
+    func replayAfterInboxRemovalFailureSuppressesAnAlreadyImportedDelta() async throws {
         let recorder = IncomingShareTestRecorder()
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -320,8 +333,7 @@ struct PlatformIncomingShareTests {
         let replay = try await pipeline.importEnvelope(envelope, into: thread)
         let snapshot = try await store.snapshot(for: FeatureComposerDraftStore.threadKey(thread))
 
-        #expect(replay.sharedContent.shareID == envelope.id)
-        #expect(replay.sharedContent.draft.text == "Shared once")
+        #expect(replay.sharedContent == nil)
         #expect(snapshot.draft?.text == "Shared once")
         #expect(snapshot.importedShareIDs == [envelope.id])
         #expect(await recorder.events.count == 2)
@@ -372,14 +384,15 @@ struct PlatformIncomingShareTests {
         )
 
         let imported = try await pipeline.importEnvelope(envelope, into: thread)
+        let sharedContent = try #require(imported.sharedContent)
         let captured = await recorder.capturedDraft
 
         #expect(captured?.key == FeatureComposerDraftStore.threadKey(thread))
         #expect(imported.draft.text.contains("Review this"))
-        #expect(imported.sharedContent.shareID == envelope.id)
-        #expect(imported.sharedContent.draft.text.contains("Shared video: reference.mov"))
+        #expect(sharedContent.shareID == envelope.id)
+        #expect(sharedContent.draft.text.contains("Shared video: reference.mov"))
         #expect(
-            imported.sharedContent.draft.attachments.first?.id.uuidString.lowercased() == videoID
+            sharedContent.draft.attachments.first?.id.uuidString.lowercased() == videoID
         )
         #expect(await recorder.events == [
             "video:\(videoID)",

--- a/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
@@ -234,6 +234,110 @@ struct PlatformIncomingShareTests {
     }
 
     @Test
+    func existingThreadImportUsesItsDraftAndRepresentsVideoAsAContactSheet() async throws {
+        let recorder = IncomingShareTestRecorder()
+        let videoID = "12345678-1234-1234-1234-123456789abc"
+        let envelope = Self.envelope(
+            text: "Review this",
+            videos: [Self.video(id: videoID)]
+        )
+        let thread = FeatureThread(
+            id: "thread:environment:thread",
+            wireID: "thread",
+            projectID: "project",
+            environmentID: "environment",
+            title: "Existing"
+        )
+        let pipeline = PlatformIncomingSharePipeline(
+            source: PlatformIncomingShareSource(
+                loadAll: { [envelope] },
+                data: { _ in Data() },
+                videoURL: { video in
+                    await recorder.record("video:\(video.id)")
+                    return URL(fileURLWithPath: "/tmp/video.mov")
+                },
+                remove: { id in await recorder.record("remove:\(id)") }
+            ),
+            drafts: PlatformIncomingShareDraftRepository(
+                importContent: { shareID, text, attachments, key, _ in
+                    await recorder.capture(
+                        draft: FeatureComposerDraft(text: text, attachments: attachments),
+                        key: key
+                    )
+                    await recorder.record("import:\(shareID)")
+                    return FeatureComposerDraft(text: text, attachments: attachments)
+                }
+            ),
+            prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) },
+            prepareVideo: { _, _, _ in
+                Self.attachment(id: UUID(), value: 9)
+            }
+        )
+
+        let imported = try await pipeline.importEnvelope(envelope, into: thread)
+        let captured = await recorder.capturedDraft
+
+        #expect(captured?.key == FeatureComposerDraftStore.threadKey(thread))
+        #expect(imported.text.contains("Review this"))
+        #expect(imported.text.contains("Shared video: reference.mov"))
+        #expect(imported.attachments.first?.id.uuidString.lowercased() == videoID)
+        #expect(await recorder.events == [
+            "video:\(videoID)",
+            "import:\(envelope.id)",
+            "remove:\(envelope.id)",
+        ])
+    }
+
+    @Test
+    func newThreadShareStaysDurableUntilProjectSelectionRoutesIt() async throws {
+        let recorder = IncomingShareTestRecorder()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let envelope = Self.envelope(text: "Choose my project")
+        let pipeline = PlatformIncomingSharePipeline(
+            source: PlatformIncomingShareSource(
+                loadAll: { [envelope] },
+                data: { _ in Data() },
+                remove: { id in await recorder.record("remove:\(id)") }
+            ),
+            drafts: PlatformIncomingShareDraftRepository(
+                importContent: { shareID, text, attachments, key, maximumCount in
+                    try await store.importSharedContent(
+                        shareID: shareID,
+                        text: text,
+                        attachments: attachments,
+                        for: key,
+                        maximumAttachmentCount: maximumCount
+                    )
+                }
+            ),
+            prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
+        )
+
+        _ = try await pipeline.stageEnvelopeForNewThread(envelope)
+        let transferKey = FeatureComposerDraftStore.incomingShareKey(shareID: envelope.id)
+        #expect(try await store.draft(for: transferKey)?.text == "Choose my project")
+        #expect(await recorder.events.isEmpty)
+
+        let project = Self.project()
+        let destinationKey = FeatureComposerDraftStore.newTaskKey(project: project)
+        let routed = try await store.routeIncomingShare(
+            shareID: envelope.id,
+            to: destinationKey
+        )
+        #expect(routed?.text == "Choose my project")
+        #expect(try await store.draft(for: transferKey) == nil)
+        #expect(try await store.draft(for: destinationKey) == routed)
+
+        try await pipeline.acknowledgeEnvelope(id: envelope.id)
+        #expect(await recorder.events == ["remove:\(envelope.id)"])
+    }
+
+    @Test
     @MainActor
     func noProjectNoticeKeepsEnvelopePendingAndOnlyReportsOnce() async {
         let envelope = Self.envelope(text: "Pending")
@@ -257,9 +361,37 @@ struct PlatformIncomingShareTests {
         #expect(coordinator.pendingEnvelope == envelope)
     }
 
+    @Test
+    @MainActor
+    func preferredEnvelopeDoesNotFallBackToAnotherPendingShare() async {
+        let envelope = Self.envelope(text: "Do not route me")
+        let coordinator = PlatformIncomingShareCoordinator(
+            pipeline: PlatformIncomingSharePipeline(
+                source: PlatformIncomingShareSource(
+                    loadAll: { [envelope] },
+                    data: { _ in Data() },
+                    remove: { _ in }
+                ),
+                drafts: PlatformIncomingShareDraftRepository(
+                    importContent: { _, _, _, _, _ in FeatureComposerDraft() }
+                ),
+                prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
+            )
+        )
+
+        #expect(
+            !(await coordinator.refresh(
+                preferredID: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                hasProjects: true
+            ))
+        )
+        #expect(coordinator.pendingEnvelope == nil)
+    }
+
     private static func envelope(
         text: String = "",
-        images: [T3IncomingShareImage] = []
+        images: [T3IncomingShareImage] = [],
+        videos: [T3IncomingShareVideo] = []
     ) -> T3IncomingShareEnvelope {
         T3IncomingShareEnvelope(
             schemaVersion: T3IncomingShareEnvelope.schemaVersion,
@@ -267,6 +399,7 @@ struct PlatformIncomingShareTests {
             createdAt: Date(timeIntervalSince1970: 100),
             text: text,
             images: images,
+            videos: videos,
             warnings: []
         )
     }
@@ -277,6 +410,16 @@ struct PlatformIncomingShareTests {
             fileName: "reference.png",
             typeIdentifier: "public.png",
             relativePath: "image.png",
+            byteCount: 2
+        )
+    }
+
+    private static func video(id: String) -> T3IncomingShareVideo {
+        T3IncomingShareVideo(
+            id: id,
+            fileName: "reference.mov",
+            typeIdentifier: "com.apple.quicktime-movie",
+            relativePath: "video.mov",
             byteCount: 2
         )
     }

--- a/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
@@ -456,6 +456,39 @@ struct PlatformIncomingShareTests {
     }
 
     @Test
+    func failedNewThreadRouteKeepsTheStagedSourceAndDestination() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let shareID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        let sourceKey = FeatureComposerDraftStore.incomingShareKey(shareID: shareID)
+        let destinationKey = "new-task:full-project"
+        let stagedAttachment = Self.attachment(id: UUID(), value: 9)
+        let destination = FeatureComposerDraft(
+            text: "Existing task",
+            attachments: (0..<8).map { Self.attachment(id: UUID(), value: UInt8($0)) }
+        )
+        _ = try await store.importSharedContent(
+            shareID: shareID,
+            text: "Still staged",
+            attachments: [stagedAttachment],
+            for: sourceKey
+        )
+        try await store.setDraft(destination, for: destinationKey)
+
+        await #expect(throws: FeatureComposerDraftImportError.self) {
+            try await store.routeIncomingShare(shareID: shareID, to: destinationKey)
+        }
+
+        #expect(try await store.draft(for: sourceKey)?.text == "Still staged")
+        #expect(try await store.draft(for: sourceKey)?.attachments == [stagedAttachment])
+        #expect(try await store.draft(for: destinationKey) == destination)
+    }
+
+    @Test
     func missingStagedShareNeverMasqueradesAsAnExistingDestinationDraft() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appending(path: UUID().uuidString, directoryHint: .isDirectory)
@@ -500,6 +533,36 @@ struct PlatformIncomingShareTests {
         #expect(coordinator.pendingEnvelope == envelope)
         #expect(!(await coordinator.refresh(hasProjects: false)))
         #expect(coordinator.pendingEnvelope == envelope)
+    }
+
+    @Test
+    @MainActor
+    func dismissedStagedShareDoesNotImmediatelyPresentAgain() async {
+        let envelope = Self.envelope(text: "Dismiss for this app session")
+        let coordinator = PlatformIncomingShareCoordinator(
+            pipeline: PlatformIncomingSharePipeline(
+                source: PlatformIncomingShareSource(
+                    loadAll: { [envelope] },
+                    data: { _ in Data() },
+                    remove: { _ in }
+                ),
+                drafts: PlatformIncomingShareDraftRepository(
+                    importContent: { _, _, _, _, _ in
+                        PlatformIncomingShareDraftImport(
+                            draft: FeatureComposerDraft(),
+                            didImport: true
+                        )
+                    }
+                ),
+                prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
+            )
+        )
+
+        _ = await coordinator.refresh(hasProjects: true)
+        coordinator.dismissStagedNewThread(id: envelope.id.uppercased())
+        _ = await coordinator.refresh(hasProjects: true)
+
+        #expect(coordinator.pendingEnvelope == nil)
     }
 
     @Test


### PR DESCRIPTION
## What

Serializes New Task presentation requests so deep links, Share Drafts, modal replacement, and stale dismissal callbacks cannot reopen or release the wrong draft.

## Scope

One focused lifecycle commit stacked on #5976. The conflict resolution preserves the final Share Drafts reload/release behavior and replaces the older sheet booleans with the coordinator.

## Verification

- WorkspaceContractTests: 12 tests passed
- Exact stacked head compiled in the focused native test run
- Coverage includes latest-request wins, stale dismissal rejection, fallback completion, deferred modal resume, ghost-reopen prevention, and exactly-once share release

## Dependencies and gate

- Depends on #5976
- Physical Share Drafts acceptance remains blocked by the development profile lacking the App Group entitlement
- Draft pending parent PR and maintainer direction

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden incoming share task presentation lifecycle with video support and destination routing
> - The share extension UI now prompts users to select a destination (new thread or existing thread from recent threads) before saving, and persists videos alongside images and the chosen destination.
> - Shared video attachments are now imported as JPEG contact sheets generated from sampled frames via `PlatformSharedVideoProcessor`, with file validation (size, container location, byte count) before processing.
> - `WorkspaceView` replaces its boolean-driven New Task sheet with an identity-based coordinator (`FeatureNewTaskPresentationCoordinator`) that queues, defers, and serializes presentations to prevent overlapping navigations.
> - `NewThreadView` can now accept an incoming shared draft, auto-restore it before a project is chosen, debounce-save it, route it into a selected project's draft, and show a confirmation dialog on discard.
> - `ThreadDetailView` merges pending incoming share drafts into the active composer after initial draft restore, deduplicates attachments by ID, and shows an alert when imported attachments exceed the allowed count.
> - Shared storage models (`T3SharedRecentThreadStore`, `T3SharedAppearanceStore`, `T3IncomingShareDestination`, `T3IncomingShareVideo`) are introduced and used across the app, share extension, and widgets via a configurable app group identifier read from Info.plist.
> - Risk: Schema version bumped from 1 to 2 for share envelopes; legacy v1 envelopes are handled via defaulting missing fields during decode.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f735294. 15 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: chain
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: #5976
Merge order: #5976 → #6144
Validation status: Blocked: latest native SwiftUI check fails; fix and revalidate the current head. Revalidate after the dependency chain lands. The unrelated Vercel authorization failure is a maintainer-side gate.
<!-- swiftui-delivery:end -->
