### PR TITLE
feat(swift-ios): add swipe-down command palette

### DIFF
--- a/apps/swift-ios/Features/Workspace/FeatureCommandPaletteModel.swift
+++ b/apps/swift-ios/Features/Workspace/FeatureCommandPaletteModel.swift
@@ -1,0 +1,378 @@
+import CoreGraphics
+import Foundation
+
+enum FeatureCommandPaletteAction: Hashable {
+    case newTask(projectID: String?)
+    case chooseNewTaskProject
+    case addProject
+    case settings
+    case openThread(id: String)
+    case openProject(id: String)
+}
+
+struct FeatureCommandPaletteItem: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let detail: String?
+    let searchTerms: [String]
+    let systemImage: String
+    let action: FeatureCommandPaletteAction
+    let showsDisclosure: Bool
+
+    init(
+        id: String,
+        title: String,
+        detail: String? = nil,
+        searchTerms: [String] = [],
+        systemImage: String,
+        action: FeatureCommandPaletteAction,
+        showsDisclosure: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.searchTerms = searchTerms
+        self.systemImage = systemImage
+        self.action = action
+        self.showsDisclosure = showsDisclosure
+    }
+}
+
+struct FeatureCommandPaletteGroup: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let items: [FeatureCommandPaletteItem]
+}
+
+enum FeatureCommandPaletteMode: Equatable {
+    case root
+    case newTaskProjectPicker
+}
+
+enum FeatureCommandPaletteGesture {
+    static let maximumStartY: CGFloat = 88
+    static let minimumDownwardTranslation: CGFloat = 72
+
+    static func shouldPresent(startY: CGFloat, translation: CGSize) -> Bool {
+        guard startY <= maximumStartY,
+              translation.height >= minimumDownwardTranslation else {
+            return false
+        }
+
+        return translation.height > abs(translation.width) * 1.15
+    }
+}
+
+enum FeatureCommandPaletteCatalog {
+    static let recentThreadLimit = 12
+
+    static func groups(
+        snapshot: FeatureSnapshot,
+        projects: [FeatureProject],
+        activeProjectID: String?,
+        query: String
+    ) -> [FeatureCommandPaletteGroup] {
+        let actions = actionItems(projects: projects, activeProjectID: activeProjectID)
+        let rawQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let actionsOnly = rawQuery.first == ">"
+        let searchQuery = actionsOnly
+            ? String(rawQuery.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
+            : rawQuery
+
+        if searchQuery.isEmpty {
+            if actionsOnly {
+                return group(id: "actions", title: "Actions", items: actions)
+            }
+
+            return rootGroups(
+                actions: actions,
+                recentThreads: recentThreadItems(snapshot: snapshot)
+            )
+        }
+
+        let filteredActions = matchingItems(actions, query: searchQuery)
+        var groups: [FeatureCommandPaletteGroup] = []
+        if !filteredActions.isEmpty {
+            groups.append(FeatureCommandPaletteGroup(
+                id: "actions",
+                title: "Actions",
+                items: filteredActions
+            ))
+        }
+
+        guard !actionsOnly else { return groups }
+
+        let filteredProjects = matchingItems(
+            projectItems(snapshot: snapshot, projects: projects),
+            query: searchQuery
+        )
+        if !filteredProjects.isEmpty {
+            groups.append(FeatureCommandPaletteGroup(
+                id: "projects-search",
+                title: "Projects",
+                items: filteredProjects
+            ))
+        }
+
+        let filteredThreads = matchingItems(
+            threadItems(snapshot: snapshot),
+            query: searchQuery
+        )
+        if !filteredThreads.isEmpty {
+            groups.append(FeatureCommandPaletteGroup(
+                id: "threads-search",
+                title: "Threads",
+                items: filteredThreads
+            ))
+        }
+
+        return groups
+    }
+
+    static func newTaskProjectGroups(
+        snapshot: FeatureSnapshot,
+        projects: [FeatureProject],
+        query: String
+    ) -> [FeatureCommandPaletteGroup] {
+        let items = matchingItems(
+            projectItems(
+                snapshot: snapshot,
+                projects: projects,
+                action: { .newTask(projectID: $0.id) },
+                idPrefix: "new-task-in"
+            ),
+            query: query
+        )
+        guard !items.isEmpty else { return [] }
+        return [FeatureCommandPaletteGroup(id: "projects", title: "Projects", items: items)]
+    }
+
+    private static func rootGroups(
+        actions: [FeatureCommandPaletteItem],
+        recentThreads: [FeatureCommandPaletteItem]
+    ) -> [FeatureCommandPaletteGroup] {
+        var groups: [FeatureCommandPaletteGroup] = []
+        if !actions.isEmpty {
+            groups.append(FeatureCommandPaletteGroup(
+                id: "actions",
+                title: "Actions",
+                items: actions
+            ))
+        }
+        if !recentThreads.isEmpty {
+            groups.append(FeatureCommandPaletteGroup(
+                id: "recent-threads",
+                title: "Recent Threads",
+                items: recentThreads
+            ))
+        }
+        return groups
+    }
+
+    private static func actionItems(
+        projects: [FeatureProject],
+        activeProjectID: String?
+    ) -> [FeatureCommandPaletteItem] {
+        var items: [FeatureCommandPaletteItem] = []
+        if !projects.isEmpty {
+            let activeProject = projects.first { $0.id == activeProjectID } ?? projects.first
+            if let activeProject {
+                items.append(FeatureCommandPaletteItem(
+                    id: "action:new-task",
+                    title: "New task in \(activeProject.name)",
+                    detail: activeProject.path,
+                    searchTerms: [
+                        "new task", "new thread", "chat", "create", "draft",
+                        activeProject.name, activeProject.path,
+                    ],
+                    systemImage: "square.and.pencil",
+                    action: .newTask(projectID: activeProject.id)
+                ))
+            }
+
+            items.append(FeatureCommandPaletteItem(
+                id: "action:new-task-in",
+                title: "New task in…",
+                detail: "Choose a project",
+                searchTerms: ["new task", "new thread", "project", "choose", "select"],
+                systemImage: "square.and.pencil",
+                action: .chooseNewTaskProject,
+                showsDisclosure: true
+            ))
+        }
+
+        items.append(FeatureCommandPaletteItem(
+            id: "action:add-project",
+            title: "Add project",
+            detail: "Local folder or remote repository",
+            searchTerms: [
+                "add project", "folder", "directory", "browse", "clone", "remote",
+                "repository", "repo", "git", "github", "gitlab", "bitbucket", "azure",
+                "devops", "url", "environment",
+            ],
+            systemImage: "folder.badge.plus",
+            action: .addProject
+        ))
+        items.append(FeatureCommandPaletteItem(
+            id: "action:settings",
+            title: "Open settings",
+            detail: "Preferences and connections",
+            searchTerms: ["settings", "preferences", "configuration", "connections"],
+            systemImage: "slider.horizontal.3",
+            action: .settings
+        ))
+        return items
+    }
+
+    private static func recentThreadItems(
+        snapshot: FeatureSnapshot
+    ) -> [FeatureCommandPaletteItem] {
+        Array(threadItems(snapshot: snapshot).prefix(recentThreadLimit))
+    }
+
+    private static func projectItems(
+        snapshot: FeatureSnapshot,
+        projects: [FeatureProject],
+        action: (FeatureProject) -> FeatureCommandPaletteAction = { .openProject(id: $0.id) },
+        idPrefix: String = "project"
+    ) -> [FeatureCommandPaletteItem] {
+        let environmentNames = Dictionary(
+            uniqueKeysWithValues: snapshot.environments.map { ($0.id, $0.name) }
+        )
+
+        return projects
+            .sorted { left, right in
+                let nameOrder = left.name.localizedStandardCompare(right.name)
+                if nameOrder != .orderedSame { return nameOrder == .orderedAscending }
+                return left.id < right.id
+            }
+            .map { project in
+                let environment = environmentNames[project.environmentID]
+                let detail = [project.path, environment]
+                    .compactMap { $0?.isEmpty == false ? $0 : nil }
+                    .joined(separator: " · ")
+                return FeatureCommandPaletteItem(
+                    id: "\(idPrefix):\(project.id)",
+                    title: project.name,
+                    detail: detail.isEmpty ? nil : detail,
+                    searchTerms: [project.name, project.path, environment ?? ""],
+                    systemImage: "folder",
+                    action: action(project)
+                )
+            }
+    }
+
+    private static func threadItems(snapshot: FeatureSnapshot) -> [FeatureCommandPaletteItem] {
+        let projectsByID = Dictionary(uniqueKeysWithValues: snapshot.projects.map { ($0.id, $0) })
+        let environmentNames = Dictionary(
+            uniqueKeysWithValues: snapshot.environments.map { ($0.id, $0.name) }
+        )
+
+        return snapshot.threads
+            .filter { !$0.isArchived }
+            .sorted { left, right in
+                let leftDate = left.lastActivityAt ?? left.updatedAt
+                let rightDate = right.lastActivityAt ?? right.updatedAt
+                if leftDate != rightDate { return leftDate > rightDate }
+                return left.id < right.id
+            }
+            .map { thread in
+                let project = projectsByID[thread.projectID]
+                let environment = thread.environmentID.flatMap { environmentNames[$0] }
+                    ?? thread.environmentName
+                let detail = [
+                    project?.name,
+                    thread.branch.map { "#\($0)" },
+                    environment,
+                ]
+                    .compactMap { $0?.isEmpty == false ? $0 : nil }
+                    .joined(separator: " · ")
+                return FeatureCommandPaletteItem(
+                    id: "thread:\(thread.id)",
+                    title: thread.title,
+                    detail: detail.isEmpty ? nil : detail,
+                    searchTerms: [
+                        thread.title,
+                        thread.preview ?? "",
+                        thread.branch ?? "",
+                        project?.name ?? "",
+                        project?.path ?? "",
+                        environment ?? "",
+                    ],
+                    systemImage: "message",
+                    action: .openThread(id: thread.id)
+                )
+            }
+    }
+
+    private static func matchingItems(
+        _ items: [FeatureCommandPaletteItem],
+        query: String
+    ) -> [FeatureCommandPaletteItem] {
+        let tokens = normalizedTokens(query)
+        guard !tokens.isEmpty else { return items }
+
+        return items.enumerated()
+            .compactMap { index, item -> (item: FeatureCommandPaletteItem, score: Int, index: Int)? in
+                guard let score = matchScore(item: item, tokens: tokens) else { return nil }
+                return (item, score, index)
+            }
+            .sorted { left, right in
+                if left.score != right.score { return left.score > right.score }
+                return left.index < right.index
+            }
+            .map(\.item)
+    }
+
+    private static func matchScore(
+        item: FeatureCommandPaletteItem,
+        tokens: [String]
+    ) -> Int? {
+        let fields = [item.title, item.detail ?? ""] + item.searchTerms
+        var score = 0
+
+        for token in tokens {
+            var tokenScore: Int?
+            for (index, field) in fields.enumerated() {
+                guard field.localizedCaseInsensitiveContains(token) else { continue }
+                let normalizedField = field.folding(
+                    options: [.diacriticInsensitive, .caseInsensitive],
+                    locale: .current
+                )
+                let normalizedToken = token.folding(
+                    options: [.diacriticInsensitive, .caseInsensitive],
+                    locale: .current
+                )
+                let fieldScore: Int
+                if normalizedField == normalizedToken {
+                    fieldScore = 300
+                } else if normalizedField.hasPrefix(normalizedToken) {
+                    fieldScore = 200
+                } else {
+                    fieldScore = 100
+                }
+                tokenScore = max(tokenScore ?? 0, fieldScore - min(index, 20))
+            }
+            guard let tokenScore else { return nil }
+            score += tokenScore
+        }
+
+        return score
+    }
+
+    private static func normalizedTokens(_ query: String) -> [String] {
+        query
+            .split(whereSeparator: \.isWhitespace)
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func group(
+        id: String,
+        title: String,
+        items: [FeatureCommandPaletteItem]
+    ) -> [FeatureCommandPaletteGroup] {
+        guard !items.isEmpty else { return [] }
+        return [FeatureCommandPaletteGroup(id: id, title: title, items: items)]
+    }
+}

--- a/apps/swift-ios/Features/Workspace/FeatureCommandPaletteView.swift
+++ b/apps/swift-ios/Features/Workspace/FeatureCommandPaletteView.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+
+struct FeatureCommandPaletteView: View {
+    @SwiftUI.Environment(\.dismiss) private var dismiss
+    @Bindable var model: FeatureRootModel
+
+    let activeProjectID: String?
+    let onSelect: (FeatureCommandPaletteAction) -> Void
+
+    @State private var mode: FeatureCommandPaletteMode = .root
+    @State private var query = ""
+    @FocusState private var searchIsFocused: Bool
+
+    init(
+        model: FeatureRootModel,
+        activeProjectID: String?,
+        onSelect: @escaping (FeatureCommandPaletteAction) -> Void
+    ) {
+        self.model = model
+        self.activeProjectID = activeProjectID
+        self.onSelect = onSelect
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                searchField
+                Divider()
+                    .overlay(T3Colors.border)
+                results
+            }
+            .background(T3Colors.background)
+            .navigationTitle(mode == .root ? "Command palette" : "New task in…")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    if mode == .newTaskProjectPicker {
+                        Button {
+                            mode = .root
+                            query = ""
+                            focusSearch()
+                        } label: {
+                            Label("Back", systemImage: "chevron.left")
+                        }
+                    } else {
+                        Button("Done") { dismiss() }
+                    }
+                }
+
+                if mode == .newTaskProjectPicker {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .onAppear { focusSearch() }
+    }
+
+    private var availableProjects: [FeatureProject] {
+        DailyUXCreationContext.projects(in: model.snapshot)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 9) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(T3Colors.textTertiary)
+            TextField(
+                mode == .root
+                    ? "Search commands, projects, and threads…"
+                    : "Search projects…",
+                text: $query
+            )
+            .focused($searchIsFocused)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .submitLabel(.search)
+            .accessibilityIdentifier("command-palette-search")
+            .accessibilityHint("Type greater-than to show actions only.")
+
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                    focusSearch()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(T3Colors.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(minHeight: T3Metrics.minimumTapTarget)
+        .background(T3Colors.input, in: RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(T3Colors.inputBorder, lineWidth: 1)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var results: some View {
+        let groups = currentGroups
+        if groups.isEmpty {
+            VStack(spacing: 10) {
+                Image(systemName: "magnifyingglass")
+                    .font(.title2)
+                    .foregroundStyle(T3Colors.textTertiary)
+                Text(mode == .root ? "No matching commands, projects, or threads." : "No matching projects.")
+                    .font(T3Typography.supporting)
+                    .foregroundStyle(T3Colors.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(24)
+        } else {
+            List {
+                ForEach(groups) { group in
+                    Section(group.title) {
+                        ForEach(group.items) { item in
+                            Button {
+                                select(item)
+                            } label: {
+                                paletteRow(item)
+                            }
+                            .buttonStyle(.plain)
+                            .listRowBackground(T3Colors.background)
+                            .accessibilityIdentifier("command-palette-item-\(item.id)")
+                        }
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+        }
+    }
+
+    private var currentGroups: [FeatureCommandPaletteGroup] {
+        switch mode {
+        case .root:
+            return FeatureCommandPaletteCatalog.groups(
+                snapshot: model.snapshot,
+                projects: availableProjects,
+                activeProjectID: activeProjectID,
+                query: query
+            )
+        case .newTaskProjectPicker:
+            return FeatureCommandPaletteCatalog.newTaskProjectGroups(
+                snapshot: model.snapshot,
+                projects: availableProjects,
+                query: query
+            )
+        }
+    }
+
+    private func paletteRow(_ item: FeatureCommandPaletteItem) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: item.systemImage)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(T3Colors.textSecondary)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title)
+                    .font(T3Typography.control)
+                    .foregroundStyle(T3Colors.textPrimary)
+                    .lineLimit(1)
+                if let detail = item.detail {
+                    Text(detail)
+                        .font(T3Typography.supporting)
+                        .foregroundStyle(T3Colors.textSecondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            if item.showsDisclosure {
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(T3Colors.textTertiary)
+            }
+        }
+        .frame(minHeight: T3Metrics.minimumTapTarget)
+        .contentShape(Rectangle())
+    }
+
+    private func select(_ item: FeatureCommandPaletteItem) {
+        switch item.action {
+        case .chooseNewTaskProject:
+            mode = .newTaskProjectPicker
+            query = ""
+            focusSearch()
+        default:
+            dismiss()
+            onSelect(item.action)
+        }
+    }
+
+    private func focusSearch() {
+        Task { @MainActor in
+            await Task.yield()
+            searchIsFocused = true
+        }
+    }
+}

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -38,6 +38,7 @@ public struct WorkspaceView: View {
     @State private var newTaskInitialProjectID: String?
     @State private var showingAddProject = false
     @State private var showingSettings = false
+    @State private var showingCommandPalette = false
     @State private var renamingThread: FeatureThread?
     @State private var renameTitle = ""
     @State private var sidebarBoundaryNow = Date.now
@@ -142,6 +143,13 @@ public struct WorkspaceView: View {
         .sheet(isPresented: $showingSettings) {
             SettingsView(model: model)
         }
+        .sheet(isPresented: $showingCommandPalette) {
+            FeatureCommandPaletteView(
+                model: model,
+                activeProjectID: commandPaletteActiveProjectID,
+                onSelect: handleCommandPaletteAction
+            )
+        }
         .alert(
             "Rename thread",
             isPresented: Binding(
@@ -186,6 +194,7 @@ public struct WorkspaceView: View {
                 return
             }
         }
+        .highPriorityGesture(commandPaletteGesture)
     }
 
     private var sidebar: some View {
@@ -510,6 +519,26 @@ public struct WorkspaceView: View {
         DailyUXCreationContext.projects(in: model.snapshot)
     }
 
+    private var commandPaletteActiveProjectID: String? {
+        if let selectedProjectID {
+            return selectedProjectID
+        }
+        if let selectedThreadID,
+           let selectedThread = model.snapshot.threads.first(where: {
+               $0.id == selectedThreadID
+           }) {
+            return selectedThread.projectID
+        }
+        return creationProjects.first?.id
+    }
+
+    private var connectionEnvironmentName: String {
+        model.snapshot.connection.environmentName
+            ?? model.snapshot.environments.first(where: \.isActive)?.name
+            ?? model.snapshot.environments.first?.name
+            ?? "Server"
+    }
+
     private var unreachableEnvironments: [FeatureEnvironment] {
         model.snapshot.environments.filter {
             $0.isEnabled && $0.connectionState == .disconnected
@@ -574,6 +603,41 @@ public struct WorkspaceView: View {
             newTaskInitialProjectID = initialProjectID
             showingNewTask = true
         }
+    }
+
+    private func handleCommandPaletteAction(_ action: FeatureCommandPaletteAction) {
+        Task { @MainActor in
+            await Task.yield()
+            switch action {
+            case let .newTask(projectID):
+                openNewTaskOrProjectCreation(initialProjectID: projectID)
+            case .addProject:
+                showingAddProject = true
+            case .settings:
+                showingSettings = true
+            case let .openThread(id):
+                openThread(id)
+            case let .openProject(id):
+                selectedProjectID = id
+                closeSelectedThread()
+            case .chooseNewTaskProject:
+                break
+            }
+        }
+    }
+
+    private var commandPaletteGesture: some Gesture {
+        DragGesture(minimumDistance: 24, coordinateSpace: .global)
+            .onEnded { value in
+                guard FeatureCommandPaletteGesture.shouldPresent(
+                    startY: value.startLocation.y,
+                    translation: value.translation
+                ) else {
+                    return
+                }
+                isSearchFocused = false
+                showingCommandPalette = true
+            }
     }
 
     private func consumeNavigationRequest() {

--- a/apps/swift-ios/Tests/FeatureTests/FeatureCommandPaletteTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureCommandPaletteTests.swift
@@ -1,0 +1,188 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import T3Code
+
+@Suite("Command palette")
+struct FeatureCommandPaletteTests {
+    @Test
+    func rootContainsElectronParityActionsAndRecentThreads() {
+        let project = FeatureProject(
+            id: "project-1",
+            environmentID: "studio",
+            name: "T3 Code",
+            path: "/projects/t3-code"
+        )
+        let thread = FeatureThread(
+            id: "thread-1",
+            projectID: project.id,
+            environmentID: project.environmentID,
+            title: "Fix the command palette",
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+        let snapshot = FeatureSnapshot(
+            environments: [
+                .init(
+                    id: project.environmentID,
+                    name: "Studio",
+                    endpoint: "https://studio.example",
+                    isActive: true,
+                    connectionState: .connected
+                ),
+            ],
+            projects: [project],
+            threads: [thread]
+        )
+
+        let groups = FeatureCommandPaletteCatalog.groups(
+            snapshot: snapshot,
+            projects: [project],
+            activeProjectID: project.id,
+            query: ""
+        )
+
+        #expect(groups.map(\.id) == ["actions", "recent-threads"])
+        #expect(groups[0].items.map(\.title) == [
+            "New task in T3 Code",
+            "New task in…",
+            "Add project",
+            "Open settings",
+        ])
+        #expect(groups[1].items.map(\.title) == ["Fix the command palette"])
+    }
+
+    @Test
+    func normalSearchAddsProjectAndThreadResultsWhileActionFilterHidesThem() {
+        let project = FeatureProject(
+            id: "project-1",
+            environmentID: "studio",
+            name: "T3 Code",
+            path: "/projects/t3-code"
+        )
+        let thread = FeatureThread(
+            id: "thread-1",
+            projectID: project.id,
+            environmentID: project.environmentID,
+            title: "Release checklist",
+            preview: "Check the repository status",
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+        let snapshot = FeatureSnapshot(projects: [project], threads: [thread])
+
+        let searchGroups = FeatureCommandPaletteCatalog.groups(
+            snapshot: snapshot,
+            projects: [project],
+            activeProjectID: nil,
+            query: "t3"
+        )
+        #expect(searchGroups.map(\.id) == ["actions", "projects-search", "threads-search"])
+        #expect(searchGroups[1].items.first?.action == .openProject(id: project.id))
+        #expect(searchGroups[2].items.first?.action == .openThread(id: thread.id))
+
+        let actionGroups = FeatureCommandPaletteCatalog.groups(
+            snapshot: snapshot,
+            projects: [project],
+            activeProjectID: nil,
+            query: "> repository"
+        )
+        #expect(actionGroups.map(\.id) == ["actions"])
+        #expect(actionGroups[0].items.map(\.title) == ["Add project"])
+    }
+
+    @Test
+    func recentThreadsAreNewestFirstCappedAndExcludeArchivedThreads() {
+        let project = FeatureProject(
+            id: "project-1",
+            environmentID: "studio",
+            name: "T3 Code",
+            path: "/projects/t3-code"
+        )
+        let threads = (0..<14).map { index in
+            FeatureThread(
+                id: "thread-\(index)",
+                projectID: project.id,
+                title: "Thread \(index)",
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(index))
+            )
+        } + [
+            FeatureThread(
+                id: "archived",
+                projectID: project.id,
+                title: "Archived",
+                updatedAt: Date(timeIntervalSince1970: 100),
+                isArchived: true
+            ),
+        ]
+
+        let groups = FeatureCommandPaletteCatalog.groups(
+            snapshot: FeatureSnapshot(projects: [project], threads: threads),
+            projects: [project],
+            activeProjectID: nil,
+            query: ""
+        )
+        let recent = groups.first { $0.id == "recent-threads" }?.items ?? []
+
+        #expect(recent.count == FeatureCommandPaletteCatalog.recentThreadLimit)
+        #expect(recent.first?.title == "Thread 13")
+        #expect(recent.last?.title == "Thread 2")
+        #expect(!recent.contains { $0.title == "Archived" })
+    }
+
+    @Test
+    func projectPickerUsesProjectSearchAndNewTaskActions() {
+        let projects = [
+            FeatureProject(
+                id: "z",
+                environmentID: "studio",
+                name: "Zebra",
+                path: "/z"
+            ),
+            FeatureProject(
+                id: "a",
+                environmentID: "studio",
+                name: "Alpha",
+                path: "/alpha"
+            ),
+        ]
+
+        let groups = FeatureCommandPaletteCatalog.newTaskProjectGroups(
+            snapshot: FeatureSnapshot(projects: projects),
+            projects: projects,
+            query: ""
+        )
+
+        #expect(groups[0].items.map(\.title) == ["Alpha", "Zebra"])
+        #expect(groups[0].items.map(\.action) == [
+            .newTask(projectID: "a"),
+            .newTask(projectID: "z"),
+        ])
+    }
+
+    @Test
+    func swipeDownOnlyPresentsFromTheTopEdge() {
+        #expect(
+            FeatureCommandPaletteGesture.shouldPresent(
+                startY: 20,
+                translation: CGSize(width: 2, height: 90)
+            )
+        )
+        #expect(
+            !FeatureCommandPaletteGesture.shouldPresent(
+                startY: 120,
+                translation: CGSize(width: 0, height: 90)
+            )
+        )
+        #expect(
+            !FeatureCommandPaletteGesture.shouldPresent(
+                startY: 20,
+                translation: CGSize(width: 80, height: 90)
+            )
+        )
+        #expect(
+            !FeatureCommandPaletteGesture.shouldPresent(
+                startY: 20,
+                translation: CGSize(width: 0, height: -90)
+            )
+        )
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 


### PR DESCRIPTION
## What

Adds a native swipe-down command palette with recent threads, projects, new-task, add-project, and settings actions.

## Scope

This is the single extracted feature commit: the palette model, palette view, WorkspaceView presentation gesture, and its focused tests. It excludes the surrounding personal release history.

## Verification

- `HomeThreadMetadataTests` fixture repair is the first commit in this chained head; `FeatureCommandPaletteTests`: 5 passed.
- Focused exact-candidate Simulator run on iPhone 17 Pro (`4401D856-DE6C-4769-A649-468778C929F6`): 10/10 passed (5 metadata tests plus 5 command-palette tests), with zero failures.
- Exact candidate `e9909d4ae133c7ede5e09c3cb453d5ed45aea1a0` built, installed, and launched successfully as `com.t3tools.t3code.swiftui.dev`.
- The runtime smoke reached the SwiftUI pairing screen. The Simulator HID cannot emit touch-move events for this top-edge gesture, so physical swipe acceptance remains a device gate.
- Independent review attempts: the first direct `claude --model claude-opus-5 --effort high` launch exited 1 at the Claude session limit; a post-reset read-only launch produced no verdict after approximately six minutes and was interrupted with only `Execution error` output. No independent model identity or findings are claimed.

## Dependencies and gate

- #6146 remains chained behind #6130; the fixture commit is replayed in this head so current-head native CI can validate before #6130 lands.
- Keep merge order `#6130 → #6146`; after #6130 lands, drop the duplicate fixture parent when refreshing the chain.
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add swipe-down command palette to iOS workspace view
> - Adds a command palette sheet to [`WorkspaceView`](https://github.com/pingdotgg/t3code/pull/6146/files#diff-06a43c1b27d1a4bc0456aef6f149417250cdee6930e57b06458c76f9c606b644) triggered by a downward drag gesture starting within 88pt of the top edge with at least 72pt of vertical travel.
> - The palette ([`FeatureCommandPaletteView`](https://github.com/pingdotgg/t3code/pull/6146/files#diff-5a34ead43e7cc2b0dee94bf099803f694b2b24df0f0e194697d6de35243a22ba)) supports two modes: a root view with actions and search across projects and threads, and a project picker for "New task in…" navigation.
> - Search results are scored and ranked using token-based matching across title, detail, and search terms fields; prefixing the query with `>` filters to actions only.
> - Selecting an action routes to the appropriate handler in `WorkspaceView`: opening a thread, switching to a project, starting a new task, or presenting the add-project or settings sheets.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2293598. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- swiftui-delivery:start -->
Delivery: chain
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: #6130
Merge order: #6130 → #6146
Validation status: Current head `e9909d4ae133c7ede5e09c3cb453d5ed45aea1a0` is mergeable and non-conflicting. Actionable checks are green: Contract fixtures and native tests, Test, Check, Mobile Native Static Analysis, Release Smoke, and Macroscope correctness. Keep #6146 behind #6130 until that dependency lands; then drop the duplicate fixture parent when refreshing the chain. The unrelated Vercel authorization failure remains a maintainer-side gate.
<!-- swiftui-delivery:end -->