### PR TITLE
fix(swift-ios): remove composer line cap

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -198,7 +198,7 @@ struct FeatureComposerView: View {
                 axis: .vertical
             )
                 .font(T3Typography.composer)
-                .lineLimit(1...7)
+                .modifier(FeatureComposerGrowingTextInput())
                 .focused(focused)
                 // Return is always editing input. Sending is deliberately button-only.
                 .submitLabel(.return)
@@ -444,6 +444,23 @@ struct FeatureComposerView: View {
         } else if FeatureComposerSubmissionPolicy.allowsSend(for: .explicitButton),
                   canSend {
             onSend()
+        }
+    }
+}
+
+struct FeatureComposerGrowingTextInput: ViewModifier {
+    static let maximumLineCount: Int? = nil
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if let maximumLineCount = Self.maximumLineCount {
+            content
+                .lineLimit(1...maximumLineCount)
+                .layoutPriority(1)
+        } else {
+            content
+                .lineLimit(1...)
+                .layoutPriority(1)
         }
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -1,8 +1,70 @@
+import SwiftUI
 import Testing
 @testable import T3Code
 
 @Suite("Composer power features")
 struct FeatureComposerPowerTests {
+    @MainActor
+    @Test
+    func composerTextInputGrowsBeyondThreeLinesWithoutANumericCap() {
+        #expect(FeatureComposerGrowingTextInput.maximumLineCount == nil)
+
+        let threeLineHeight = composerHeight(lineCount: 3)
+        let tenLineHeight = composerHeight(lineCount: 10)
+        let elevenLineHeight = composerHeight(lineCount: 11)
+        let thirtyLineHeight = composerHeight(lineCount: 30)
+        let measuredLineHeight = elevenLineHeight - tenLineHeight
+
+        #expect(thirtyLineHeight > threeLineHeight + (measuredLineHeight * 20))
+    }
+
+    @MainActor
+    @Test
+    func composerTextInputYieldsToTheAvailableViewportForVeryTallDrafts() {
+        let viewportHeight: CGFloat = 500
+
+        #expect(composerHeight(lineCount: 100, maximumHeight: viewportHeight) <= viewportHeight)
+    }
+
+    @MainActor
+    private func composerHeight(
+        lineCount: Int,
+        maximumHeight: CGFloat = .greatestFiniteMagnitude
+    ) -> CGFloat {
+        let text = Array(repeating: "A full visible prompt line", count: lineCount)
+            .joined(separator: "\n")
+        let controller = UIHostingController(
+            rootView: ComposerHarness(text: text)
+                .frame(width: 320)
+        )
+
+        return controller.sizeThatFits(
+            in: CGSize(width: 320, height: maximumHeight)
+        ).height
+    }
+
+    private struct ComposerHarness: View {
+        let text: String
+
+        @FocusState private var focused: Bool
+
+        var body: some View {
+            FeatureComposerView(
+                text: .constant(text),
+                selection: .constant(nil),
+                attachments: .constant([]),
+                providers: [],
+                threadSelection: nil,
+                isSending: false,
+                isWorking: false,
+                focused: $focused,
+                onSend: {},
+                onStop: {},
+                forceExpanded: true
+            )
+        }
+    }
+
     @Test
     func detectsCommandsModelsSkillsAndPathsAtTheCursor() {
         #expect(

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadMetadataTests.swift
@@ -130,7 +130,9 @@ struct HomeThreadMetadataTests {
                     path: "/work/t3code"
                 ),
             ],
-            providers: [FeatureProvider(id: "claude", name: "Claude")]
+            providersByEnvironment: [
+                "device": [FeatureProvider(id: "claude", name: "Claude")],
+            ]
         )
 
         #expect(thread.homeEnvironmentLabel(in: snapshot) == "steambox")
@@ -162,9 +164,11 @@ struct HomeThreadMetadataTests {
                 ),
             ],
             threads: [knownThread, customThread],
-            providers: [
-                FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
-                FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+            providersByEnvironment: [
+                "device": [
+                    FeatureProvider(id: "work-claude", name: "Claude Code", driver: "custom"),
+                    FeatureProvider(id: "acme-agent", name: "Acme Agent", driver: "custom"),
+                ],
             ]
         )
 


### PR DESCRIPTION
## What

Removes the numeric seven-line composer cap while keeping very tall drafts bounded by the available viewport.

## Scope

The feature remains one composer commit touching only `FeatureComposerView` and `FeatureComposerPowerTests`. This chain head also contains dependency #6130's test-only provider-catalog fixture repair so the current native gate exercises the declared merge order.

## Verification

- Approved unlimited-composer behavior is preserved; the line-cap policy is now explicit and testable (`maximumLineCount == nil`).
- `FeatureComposerPowerTests` + `HomeThreadMetadataTests`: 15 passed on the isolated composer iPhone Simulator / iOS 26.5; xcresult `Test-T3Code-2026.08.12_23-25-23-+1000.xcresult`
- Mutation proof: restoring the former maximum to `7` makes `composerTextInputGrowsBeyondThreeLinesWithoutANumericCap` fail (xcodebuild exit 65).
- `node scripts/generate-swift-wire-fixtures.ts --check`: passed
- Exact candidate built, installed, and launched on iPhone Simulator
- Connected Simulator proof: the composer renders nine wrapped lines beyond the former seven-line cap while remaining viewport-bounded: [current screenshot](https://github.com/saphid/t3code/blob/6932ba115/pr-media/swiftui-fix-next-20260811/pr6147-exact-composer-growth.jpg)
- Original motion proof: [composer-growth.mp4](https://github.com/saphid/t3code/blob/2ee258dd1/pr-media/swiftui-composer-growth/composer-growth.mp4)
- Direct Claude Opus 5 high review approved the production behavior and dependency repair, then identified a false-negative height guard; that guard was replaced and mutation-proven. A fresh rereview launch exited 1 after the Claude session limit was exhausted. Current-head CI independently passes the replacement guard and repaired fixtures.

## Dependency and gate

- The provider-catalog fixture repair is owned by #6130 (`d185ff05361a3ee825455df6d4068ccd4c590cec`).
- The approved unlimited-composer behavior follows it as the second commit.
- The unrelated Vercel authorization failure is a maintainer-side external gate.

<!-- swiftui-delivery:start -->
Delivery: chain
Validated against Theo commit: f98cab553546558e28d6e22f3dbe9807ecc3325f
Depends on: #6130
Merge order: #6130 → #6147
Validation status: Current-head actionable CI/review is green; local fixture generation, 15 focused native tests, deterministic cap-regression mutation, direct Opus review response, and connected Simulator validation pass. Mergeable and non-conflicting; revalidate after #6130 lands.
<!-- swiftui-delivery:end -->
