### PR TITLE
fix(server): prevent silent session forks when switching provider accounts

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2448,6 +2448,75 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("surfaces a stopped-session restart failure without binding a replacement", async () => {
+    const harness = await createHarness({
+      startSessionEffect: () =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: "codex",
+            method: "startSession",
+            detail: "Persisted provider resume state is incompatible with the requested instance.",
+          }),
+        ),
+    });
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-stopped-restart-failure"),
+        threadId: ThreadId.make("thread-1"),
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "stopped",
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-stopped-restart-failure"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-stopped-restart-failure"),
+          role: "user",
+          text: "continue",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await harness.drain();
+
+    expect(harness.startSession).toHaveBeenCalledTimes(1);
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    expect(harness.runtimeSessions).toHaveLength(0);
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session).toMatchObject({
+      threadId: "thread-1",
+      status: "error",
+      providerInstanceId: "codex",
+    });
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
+    ).toMatchObject({
+      payload: {
+        detail: expect.stringContaining("resume state is incompatible"),
+      },
+    });
+  });
+
   it("reacts to thread.turn.interrupt-requested by calling provider interrupt", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -4,7 +4,7 @@ import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { describe } from "vite-plus/test";
-import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
+import { DEFAULT_MODEL } from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 
@@ -17,7 +17,6 @@ import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
   hasConfiguredMcpServer,
-  isRecoverableThreadResumeError,
   openCodexThread,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
@@ -345,58 +344,10 @@ describe("codexSessionAppServerArgs", () => {
   });
 });
 
-describe("isRecoverableThreadResumeError", () => {
-  it("matches missing thread errors", () => {
-    NodeAssert.equal(
-      isRecoverableThreadResumeError(
-        new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
-          errorMessage: "Thread does not exist",
-        }),
-      ),
-      true,
-    );
-  });
-
-  it("ignores non-recoverable resume errors", () => {
-    NodeAssert.equal(
-      isRecoverableThreadResumeError(
-        new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
-          errorMessage: "Permission denied",
-        }),
-      ),
-      false,
-    );
-  });
-
-  it("ignores unrelated missing-resource errors that do not mention threads", () => {
-    NodeAssert.equal(
-      isRecoverableThreadResumeError(
-        new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
-          errorMessage: "Config file not found",
-        }),
-      ),
-      false,
-    );
-    NodeAssert.equal(
-      isRecoverableThreadResumeError(
-        new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
-          errorMessage: "Model does not exist",
-        }),
-      ),
-      false,
-    );
-  });
-});
-
 describe("openCodexThread", () => {
-  it.effect("falls back to thread/start when resume fails recoverably", () =>
+  it.effect("propagates missing-thread resume failures without starting a new thread", () =>
     Effect.gen(function* () {
       const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
-      const started = makeThreadOpenResponse("fresh-thread");
       const client = {
         request: <M extends "thread/start" | "thread/resume">(
           method: M,
@@ -411,24 +362,26 @@ describe("openCodexThread", () => {
               }),
             );
           }
-          return Effect.succeed(started as CodexRpc.ClientRequestResponsesByMethod[M]);
+          return Effect.succeed(
+            makeThreadOpenResponse("fresh-thread") as CodexRpc.ClientRequestResponsesByMethod[M],
+          );
         },
       };
 
-      const opened = yield* openCodexThread({
+      const error = yield* openCodexThread({
         client,
-        threadId: ThreadId.make("thread-1"),
         runtimeMode: "full-access",
         cwd: "/tmp/project",
         requestedModel: "gpt-5.3-codex",
         serviceTier: undefined,
         resumeThreadId: "stale-thread",
-      });
+      }).pipe(Effect.flip);
 
-      NodeAssert.equal(opened.thread.id, "fresh-thread");
+      NodeAssert.ok(isCodexAppServerRequestError(error));
+      NodeAssert.equal(error.errorMessage, "thread not found");
       NodeAssert.deepStrictEqual(
         calls.map((call) => call.method),
-        ["thread/resume", "thread/start"],
+        ["thread/resume"],
       );
     }),
   );
@@ -456,7 +409,6 @@ describe("openCodexThread", () => {
 
       const error = yield* openCodexThread({
         client,
-        threadId: ThreadId.make("thread-1"),
         runtimeMode: "full-access",
         cwd: "/tmp/project",
         requestedModel: "gpt-5.3-codex",

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -52,13 +52,6 @@ const BENIGN_ERROR_LOG_SNIPPETS = [
   "state db record_discrepancy: find_thread_path_by_id_str_in_subdir, falling_back",
 ];
 const CODEX_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
-const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
-  "not found",
-  "missing thread",
-  "no such thread",
-  "unknown thread",
-  "does not exist",
-];
 
 export function hasConfiguredMcpServer(appServerArgs: ReadonlyArray<string> | undefined): boolean {
   return appServerArgs?.some((argument) => argument.includes("mcp_servers.")) === true;
@@ -433,14 +426,6 @@ function classifyCodexStderrLine(rawLine: string): { readonly message: string } 
   return { message: line };
 }
 
-export function isRecoverableThreadResumeError(error: unknown): boolean {
-  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
-  if (!message.includes("thread")) {
-    return false;
-  }
-  return RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS.some((snippet) => message.includes(snippet));
-}
-
 type CodexThreadOpenResponse =
   | CodexRpc.ClientRequestResponsesByMethod["thread/start"]
   | CodexRpc.ClientRequestResponsesByMethod["thread/resume"];
@@ -456,7 +441,6 @@ interface CodexThreadOpenClient {
 
 export const openCodexThread = (input: {
   readonly client: CodexThreadOpenClient;
-  readonly threadId: ThreadId;
   readonly runtimeMode: RuntimeMode;
   readonly cwd: string;
   readonly requestedModel: string | undefined;
@@ -475,22 +459,10 @@ export const openCodexThread = (input: {
     return input.client.request("thread/start", startParams);
   }
 
-  return input.client
-    .request("thread/resume", {
-      threadId: resumeThreadId,
-      ...startParams,
-    })
-    .pipe(
-      Effect.catchIf(isRecoverableThreadResumeError, (error) =>
-        Effect.logWarning("codex app-server thread resume fell back to fresh start", {
-          threadId: input.threadId,
-          requestedRuntimeMode: input.runtimeMode,
-          resumeThreadId,
-          recoverable: true,
-          cause: error,
-        }).pipe(Effect.andThen(input.client.request("thread/start", startParams))),
-      ),
-    );
+  return input.client.request("thread/resume", {
+    threadId: resumeThreadId,
+    ...startParams,
+  });
 };
 
 function readNotificationThreadId(notification: CodexServerNotification): string | undefined {
@@ -1690,7 +1662,6 @@ export const makeCodexSessionRuntime = (
 
       const opened = yield* openCodexThread({
         client,
-        threadId: options.threadId,
         runtimeMode: options.runtimeMode,
         cwd: options.cwd,
         requestedModel,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -30,6 +30,7 @@ import * as Metric from "effect/Metric";
 import * as Option from "effect/Option";
 import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
@@ -74,6 +75,7 @@ const claudeAgentInstanceId = ProviderInstanceId.make("claudeAgent");
 const CODEX_DRIVER = ProviderDriverKind.make("codex");
 const CLAUDE_AGENT_DRIVER = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER = ProviderDriverKind.make("cursor");
+const encodeUnknownJsonString = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
@@ -318,6 +320,79 @@ function makeProviderServiceLayer() {
     cursor,
     layer,
   };
+}
+
+function makeMultiInstanceRegistry(
+  instances: ReadonlyArray<{
+    readonly instanceId: ProviderInstanceId;
+    readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
+    readonly continuationKey: string;
+  }>,
+) {
+  const byInstanceId = new Map(instances.map((instance) => [instance.instanceId, instance]));
+  const unsupported = (instanceId: ProviderInstanceId) =>
+    new ProviderUnsupportedError({
+      provider: String(instanceId),
+    });
+  const getByInstance = vi.fn((instanceId: ProviderInstanceId) => {
+    const instance = byInstanceId.get(instanceId);
+    return instance ? Effect.succeed(instance.adapter) : Effect.fail(unsupported(instanceId));
+  });
+  const getInstanceInfo = vi.fn((instanceId: ProviderInstanceId) => {
+    const instance = byInstanceId.get(instanceId);
+    if (!instance) {
+      return Effect.fail(unsupported(instanceId));
+    }
+    return Effect.succeed({
+      instanceId,
+      driverKind: instance.adapter.provider,
+      displayName: undefined,
+      enabled: true,
+      continuationIdentity: {
+        driverKind: instance.adapter.provider,
+        continuationKey: instance.continuationKey,
+      },
+    });
+  });
+  const registry: ProviderAdapterRegistry.ProviderAdapterRegistry["Service"] = {
+    getByInstance,
+    getInstanceInfo,
+    listInstances: () => Effect.succeed(instances.map((instance) => instance.instanceId)),
+    listProviders: () =>
+      Effect.succeed(Array.from(new Set(instances.map((instance) => instance.adapter.provider)))),
+    streamChanges: Stream.empty,
+    subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), (pubsub) =>
+      PubSub.subscribe(pubsub),
+    ),
+  };
+  return { registry, getByInstance, getInstanceInfo };
+}
+
+function makeIsolatedProviderServiceLayer(
+  registry: ProviderAdapterRegistry.ProviderAdapterRegistry["Service"],
+) {
+  const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+    Layer.provide(SqlitePersistenceMemory),
+  );
+  const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+  return Layer.mergeAll(
+    makeProviderServiceLive().pipe(
+      Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+      Layer.provide(directoryLayer),
+      Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(serverConfigTestLayer),
+      Layer.provideMerge(AnalyticsService.layerTest),
+      Layer.provide(
+        Layer.succeed(
+          ProviderEventLoggers.ProviderEventLoggers,
+          ProviderEventLoggers.NoOpProviderEventLoggers,
+        ),
+      ),
+    ),
+    directoryLayer,
+    runtimeRepositoryLayer,
+    NodeServices.layer,
+  );
 }
 
 it.effect("ProviderServiceLive catches stopAll failures during shutdown", () =>
@@ -591,6 +666,223 @@ it.effect("ProviderServiceLive rejects new sessions for disabled custom instance
     assert.equal(codex.startSession.mock.calls.length, 0);
   }).pipe(Effect.provide(NodeServices.layer)),
 );
+
+it.effect("carries persisted cursor and cwd across continuation-compatible instances", () => {
+  const sourceInstanceId = ProviderInstanceId.make("codex_personal");
+  const targetInstanceId = ProviderInstanceId.make("codex_proxy");
+  const source = makeFakeCodexAdapter();
+  const target = makeFakeCodexAdapter();
+  const registry = makeMultiInstanceRegistry([
+    {
+      instanceId: sourceInstanceId,
+      adapter: source.adapter,
+      continuationKey: "codex:home:/tmp/shared-codex-home",
+    },
+    {
+      instanceId: targetInstanceId,
+      adapter: target.adapter,
+      continuationKey: "codex:home:/tmp/shared-codex-home",
+    },
+  ]);
+  const layer = makeIsolatedProviderServiceLayer(registry.registry);
+
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-compatible-instance-switch");
+    const resumeCursor = { threadId: "codex-session-original" };
+    yield* directory.upsert({
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: sourceInstanceId,
+      runtimeMode: "full-access",
+      status: "stopped",
+      resumeCursor,
+      runtimePayload: { cwd: "/tmp/original-project" },
+    });
+    target.startSession.mockClear();
+
+    yield* provider.startSession(threadId, {
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: targetInstanceId,
+      runtimeMode: "full-access",
+    });
+
+    assert.equal(target.startSession.mock.calls.length, 1);
+    assert.deepEqual(target.startSession.mock.calls[0]?.[0], {
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: targetInstanceId,
+      runtimeMode: "full-access",
+      cwd: "/tmp/original-project",
+      resumeCursor,
+    });
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("preserves a persisted binding when continuation identities are incompatible", () => {
+  const sourceInstanceId = ProviderInstanceId.make("codex_personal");
+  const targetInstanceId = ProviderInstanceId.make("codex_proxy");
+  const source = makeFakeCodexAdapter();
+  const target = makeFakeCodexAdapter();
+  const registry = makeMultiInstanceRegistry([
+    {
+      instanceId: sourceInstanceId,
+      adapter: source.adapter,
+      continuationKey: "codex:home:/tmp/personal-codex-home",
+    },
+    {
+      instanceId: targetInstanceId,
+      adapter: target.adapter,
+      continuationKey: "codex:home:/tmp/proxy-codex-home",
+    },
+  ]);
+  const layer = makeIsolatedProviderServiceLayer(registry.registry);
+
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-incompatible-instance-switch");
+    yield* directory.upsert({
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: sourceInstanceId,
+      runtimeMode: "full-access",
+      status: "stopped",
+      resumeCursor: { threadId: "codex-session-original" },
+      runtimePayload: { cwd: "/tmp/original-project" },
+    });
+    const before = Option.getOrThrow(yield* directory.getBinding(threadId));
+    const beforeBytes = encodeUnknownJsonString(before);
+    registry.getByInstance.mockClear();
+    target.startSession.mockClear();
+
+    for (const _attempt of [1, 2]) {
+      const failure = yield* provider
+        .startSession(threadId, {
+          threadId,
+          provider: CODEX_DRIVER,
+          providerInstanceId: targetInstanceId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.flip);
+      assert.instanceOf(failure, ProviderValidationError);
+      assert.include(failure.issue, "provider resume state is incompatible");
+    }
+
+    const after = Option.getOrThrow(yield* directory.getBinding(threadId));
+    assert.equal(encodeUnknownJsonString(after), beforeBytes);
+    assert.equal(registry.getByInstance.mock.calls.length, 0);
+    assert.equal(target.startSession.mock.calls.length, 0);
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("keeps fresh-start behavior when a cross-instance binding has no cursor", () => {
+  const sourceInstanceId = ProviderInstanceId.make("codex_personal");
+  const targetInstanceId = ProviderInstanceId.make("codex_proxy");
+  const source = makeFakeCodexAdapter();
+  const target = makeFakeCodexAdapter();
+  const registry = makeMultiInstanceRegistry([
+    {
+      instanceId: sourceInstanceId,
+      adapter: source.adapter,
+      continuationKey: "codex:home:/tmp/personal-codex-home",
+    },
+    {
+      instanceId: targetInstanceId,
+      adapter: target.adapter,
+      continuationKey: "codex:home:/tmp/proxy-codex-home",
+    },
+  ]);
+  const layer = makeIsolatedProviderServiceLayer(registry.registry);
+
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-cross-instance-fresh-start");
+    yield* directory.upsert({
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: sourceInstanceId,
+      runtimeMode: "full-access",
+      status: "stopped",
+      resumeCursor: null,
+      runtimePayload: { cwd: "/tmp/original-project" },
+    });
+    registry.getInstanceInfo.mockClear();
+    target.startSession.mockClear();
+
+    const session = yield* provider.startSession(threadId, {
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: targetInstanceId,
+      cwd: "/tmp/new-project",
+      runtimeMode: "full-access",
+    });
+
+    assert.equal(session.providerInstanceId, targetInstanceId);
+    assert.equal(target.startSession.mock.calls.length, 1);
+    assert.equal(target.startSession.mock.calls[0]?.[0].resumeCursor, undefined);
+    assert.equal(target.startSession.mock.calls[0]?.[0].cwd, "/tmp/new-project");
+    assert.deepEqual(
+      registry.getInstanceInfo.mock.calls.map(([instanceId]) => instanceId),
+      [targetInstanceId],
+    );
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("preserves a persisted cursor when its previous instance is unavailable", () => {
+  const sourceInstanceId = ProviderInstanceId.make("codex_removed");
+  const targetInstanceId = ProviderInstanceId.make("codex_proxy");
+  const target = makeFakeCodexAdapter();
+  const registry = makeMultiInstanceRegistry([
+    {
+      instanceId: targetInstanceId,
+      adapter: target.adapter,
+      continuationKey: "codex:home:/tmp/proxy-codex-home",
+    },
+  ]);
+  const layer = makeIsolatedProviderServiceLayer(registry.registry);
+
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-removed-source-instance");
+    yield* directory.upsert({
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: sourceInstanceId,
+      runtimeMode: "full-access",
+      status: "stopped",
+      resumeCursor: { threadId: "codex-session-original" },
+      runtimePayload: { cwd: "/tmp/original-project" },
+    });
+    const before = Option.getOrThrow(yield* directory.getBinding(threadId));
+    const beforeBytes = encodeUnknownJsonString(before);
+    registry.getByInstance.mockClear();
+    target.startSession.mockClear();
+
+    const failure = yield* provider
+      .startSession(threadId, {
+        threadId,
+        provider: CODEX_DRIVER,
+        providerInstanceId: targetInstanceId,
+        runtimeMode: "full-access",
+      })
+      .pipe(Effect.flip);
+
+    assert.instanceOf(failure, ProviderValidationError);
+    assert.include(
+      failure.issue,
+      `previous provider instance '${sourceInstanceId}' is unavailable`,
+    );
+    const after = Option.getOrThrow(yield* directory.getBinding(threadId));
+    assert.equal(encodeUnknownJsonString(after), beforeBytes);
+    assert.equal(registry.getByInstance.mock.calls.length, 0);
+    assert.equal(target.startSession.mock.calls.length, 0);
+  }).pipe(Effect.provide(layer));
+});
 
 const routing = makeProviderServiceLayer();
 
@@ -1144,6 +1436,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
   it.effect("stops stale sessions in other providers after a successful replacement start", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService.ProviderService;
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
       const threadId = asThreadId("thread-provider-replacement");
 
       const codexSession = yield* provider.startSession(threadId, {
@@ -1156,6 +1449,12 @@ routing.layer("ProviderServiceLive routing", (it) => {
 
       routing.codex.stopSession.mockClear();
       routing.claude.stopSession.mockClear();
+      yield* directory.upsert({
+        threadId,
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        resumeCursor: null,
+      });
 
       const claudeSession = yield* provider.startSession(threadId, {
         provider: ProviderDriverKind.make("claudeAgent"),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -778,6 +778,59 @@ it.effect("preserves a persisted binding when continuation identities are incomp
   }).pipe(Effect.provide(layer));
 });
 
+it.effect("uses a requested cursor without validating stale persisted resume state", () => {
+  const sourceInstanceId = ProviderInstanceId.make("codex_removed");
+  const targetInstanceId = ProviderInstanceId.make("codex_proxy");
+  const target = makeFakeCodexAdapter();
+  const registry = makeMultiInstanceRegistry([
+    {
+      instanceId: targetInstanceId,
+      adapter: target.adapter,
+      continuationKey: "codex:home:/tmp/proxy-codex-home",
+    },
+  ]);
+  const layer = makeIsolatedProviderServiceLayer(registry.registry);
+
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-requested-cursor-instance-switch");
+    const requestedResumeCursor = { threadId: "codex-session-requested" };
+    yield* directory.upsert({
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: sourceInstanceId,
+      runtimeMode: "full-access",
+      status: "stopped",
+      resumeCursor: { threadId: "codex-session-stale" },
+      runtimePayload: { cwd: "/tmp/stale-project" },
+    });
+    registry.getInstanceInfo.mockClear();
+    target.startSession.mockClear();
+
+    yield* provider.startSession(threadId, {
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: targetInstanceId,
+      resumeCursor: requestedResumeCursor,
+      runtimeMode: "full-access",
+    });
+
+    assert.equal(target.startSession.mock.calls.length, 1);
+    assert.deepEqual(target.startSession.mock.calls[0]?.[0], {
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: targetInstanceId,
+      resumeCursor: requestedResumeCursor,
+      runtimeMode: "full-access",
+    });
+    assert.deepEqual(
+      registry.getInstanceInfo.mock.calls.map(([instanceId]) => instanceId),
+      [targetInstanceId],
+    );
+  }).pipe(Effect.provide(layer));
+});
+
 it.effect("keeps fresh-start behavior when a cross-instance binding has no cursor", () => {
   const sourceInstanceId = ProviderInstanceId.make("codex_personal");
   const targetInstanceId = ProviderInstanceId.make("codex_proxy");

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -721,6 +721,60 @@ it.effect("carries persisted cursor and cwd across continuation-compatible insta
   }).pipe(Effect.provide(layer));
 });
 
+it.effect("carries Claude Code history across account instances sharing a home", () => {
+  const sourceInstanceId = ProviderInstanceId.make("claude_personal");
+  const targetInstanceId = ProviderInstanceId.make("claude_proxy");
+  const source = makeFakeCodexAdapter(CLAUDE_AGENT_DRIVER);
+  const target = makeFakeCodexAdapter(CLAUDE_AGENT_DRIVER);
+  const registry = makeMultiInstanceRegistry([
+    {
+      instanceId: sourceInstanceId,
+      adapter: source.adapter,
+      continuationKey: "claude:home:/tmp/shared-claude-home",
+    },
+    {
+      instanceId: targetInstanceId,
+      adapter: target.adapter,
+      continuationKey: "claude:home:/tmp/shared-claude-home",
+    },
+  ]);
+  const layer = makeIsolatedProviderServiceLayer(registry.registry);
+
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-compatible-claude-account-switch");
+    const resumeCursor = { resume: "47e58912-274d-49fe-94c7-95b8c817f115" };
+    yield* directory.upsert({
+      threadId,
+      provider: CLAUDE_AGENT_DRIVER,
+      providerInstanceId: sourceInstanceId,
+      runtimeMode: "full-access",
+      status: "stopped",
+      resumeCursor,
+      runtimePayload: { cwd: "/tmp/original-project" },
+    });
+    target.startSession.mockClear();
+
+    yield* provider.startSession(threadId, {
+      threadId,
+      provider: CLAUDE_AGENT_DRIVER,
+      providerInstanceId: targetInstanceId,
+      runtimeMode: "full-access",
+    });
+
+    assert.equal(target.startSession.mock.calls.length, 1);
+    assert.deepEqual(target.startSession.mock.calls[0]?.[0], {
+      threadId,
+      provider: CLAUDE_AGENT_DRIVER,
+      providerInstanceId: targetInstanceId,
+      runtimeMode: "full-access",
+      cwd: "/tmp/original-project",
+      resumeCursor,
+    });
+  }).pipe(Effect.provide(layer));
+});
+
 it.effect("preserves a persisted binding when continuation identities are incompatible", () => {
   const sourceInstanceId = ProviderInstanceId.make("codex_personal");
   const targetInstanceId = ProviderInstanceId.make("codex_proxy");

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -569,12 +569,15 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         const persistedResumeCursor = persistedBinding?.resumeCursor;
         const hasPersistedResumeCursor =
           persistedResumeCursor !== null && persistedResumeCursor !== undefined;
+        const hasRequestedResumeCursor =
+          input.resumeCursor !== null && input.resumeCursor !== undefined;
         let canReusePersistedState = persistedBinding?.providerInstanceId === resolvedInstanceId;
         // Instance ids are routing labels, while continuation identities describe
         // where provider-owned resume state lives. A persisted cursor may cross
         // labels only when both instances can resolve that same state.
         if (
           persistedBinding !== undefined &&
+          !hasRequestedResumeCursor &&
           hasPersistedResumeCursor &&
           persistedBinding.providerInstanceId !== resolvedInstanceId
         ) {

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -566,31 +566,65 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           );
         }
         const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        const persistedResumeCursor = persistedBinding?.resumeCursor;
+        const hasPersistedResumeCursor =
+          persistedResumeCursor !== null && persistedResumeCursor !== undefined;
+        let canReusePersistedState = persistedBinding?.providerInstanceId === resolvedInstanceId;
+        // Instance ids are routing labels, while continuation identities describe
+        // where provider-owned resume state lives. A persisted cursor may cross
+        // labels only when both instances can resolve that same state.
+        if (
+          persistedBinding !== undefined &&
+          hasPersistedResumeCursor &&
+          persistedBinding.providerInstanceId !== resolvedInstanceId
+        ) {
+          const previousInstanceId = yield* requireBindingInstanceId(
+            "ProviderService.startSession",
+            persistedBinding,
+          );
+          const previousInstanceInfo = yield* registry
+            .getInstanceInfo(previousInstanceId)
+            .pipe(
+              Effect.mapError((cause) =>
+                toValidationError(
+                  "ProviderService.startSession",
+                  `Thread '${threadId}' cannot switch to instance '${resolvedInstanceId}' because previous provider instance '${previousInstanceId}' is unavailable and its persisted resume state cannot be verified.`,
+                  cause,
+                ),
+              ),
+            );
+          if (
+            previousInstanceInfo.continuationIdentity.driverKind !==
+              instanceInfo.continuationIdentity.driverKind ||
+            previousInstanceInfo.continuationIdentity.continuationKey !==
+              instanceInfo.continuationIdentity.continuationKey
+          ) {
+            return yield* toValidationError(
+              "ProviderService.startSession",
+              `Thread '${threadId}' cannot switch from instance '${previousInstanceId}' to '${resolvedInstanceId}' because their provider resume state is incompatible.`,
+            );
+          }
+          canReusePersistedState = true;
+        }
         const effectiveResumeCursor =
           input.resumeCursor ??
-          (persistedBinding?.providerInstanceId === resolvedInstanceId
-            ? persistedBinding.resumeCursor
-            : undefined);
+          (canReusePersistedState ? persistedBinding?.resumeCursor : undefined);
         const effectiveCwd =
           input.cwd ??
-          (persistedBinding?.providerInstanceId === resolvedInstanceId
-            ? readPersistedCwd(persistedBinding.runtimePayload)
-            : undefined);
+          (canReusePersistedState ? readPersistedCwd(persistedBinding?.runtimePayload) : undefined);
         yield* Effect.annotateCurrentSpan({
           "provider.kind": resolvedProvider,
           "provider.resume_cursor.source":
             input.resumeCursor !== undefined
               ? "request"
-              : effectiveResumeCursor !== undefined &&
-                  persistedBinding?.providerInstanceId === resolvedInstanceId
+              : effectiveResumeCursor !== undefined && canReusePersistedState
                 ? "persisted"
                 : "none",
           "provider.resume_cursor.present": effectiveResumeCursor !== undefined,
           "provider.cwd.source":
             input.cwd !== undefined
               ? "request"
-              : effectiveCwd !== undefined &&
-                  persistedBinding?.providerInstanceId === resolvedInstanceId
+              : effectiveCwd !== undefined && canReusePersistedState
                 ? "persisted"
                 : "none",
           "provider.cwd.effective": effectiveCwd ?? "",


### PR DESCRIPTION
## What changed

Threads can move between provider instances for different accounts—for example, a proxy-backed Codex account and a personal Codex account. T3 previously discarded the stored resume cursor whenever the instance ID changed, even when both instances used the same continuation storage. Codex could also replace a failed resume with a fresh thread. Together, those paths left the UI transcript intact while silently dropping the provider's native context.

Provider instance switches now compare continuation identities. Compatible Codex and Claude Code instances retain the existing cursor and cwd; incompatible or missing source instances fail before adapter startup and preserve the original binding. Codex resume failures now surface instead of falling back to `thread/start`.

An explicitly supplied resume cursor remains authoritative. Cursor, Grok, and OpenCode keep instance-scoped continuation identities.

Related: #4766 and #5433.

## Validation

- `pnpm exec vp test run apps/server/src/provider/Layers/CodexSessionRuntime.test.ts apps/server/src/provider/Layers/ProviderService.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts apps/server/src/provider/Layers/CodexAdapter.test.ts` — 123 tests passed
- `pnpm exec vp run --filter t3 typecheck`
- Targeted provider lint, formatting, and `git diff --check`

Model: GPT-5.6 Sol · Harness: Codex in T3 Code
