### PR TITLE
fix(server): prevent blank active turn IDs from blocking startup

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -471,6 +471,213 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
     }),
   );
 
+  it.effect("normalizes blank session active turn ids at every snapshot read boundary", () =>
+    Effect.gen(function* () {
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`DELETE FROM projection_thread_sessions`;
+      yield* sql`DELETE FROM projection_threads`;
+      yield* sql`DELETE FROM projection_projects`;
+      yield* sql`DELETE FROM projection_state`;
+
+      yield* sql`
+        INSERT INTO projection_projects (
+          project_id,
+          title,
+          workspace_root,
+          default_model_selection_json,
+          scripts_json,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES (
+          'project-blank-active-turn',
+          'Blank Active Turn',
+          '/tmp/blank-active-turn',
+          '{"provider":"codex","model":"gpt-5-codex"}',
+          '[]',
+          '2026-08-11T00:00:00.000Z',
+          '2026-08-11T00:00:01.000Z',
+          NULL
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_threads (
+          thread_id,
+          project_id,
+          title,
+          model_selection_json,
+          runtime_mode,
+          interaction_mode,
+          branch,
+          worktree_path,
+          latest_turn_id,
+          latest_user_message_at,
+          pending_approval_count,
+          pending_user_input_count,
+          has_actionable_proposed_plan,
+          created_at,
+          updated_at,
+          archived_at,
+          deleted_at
+        )
+        VALUES
+          (
+            'thread-active-blank',
+            'project-blank-active-turn',
+            'Active Blank',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            '2026-08-11T00:00:02.000Z',
+            '2026-08-11T00:00:03.000Z',
+            NULL,
+            NULL
+          ),
+          (
+            'thread-active-valid',
+            'project-blank-active-turn',
+            'Active Valid',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            '2026-08-11T00:00:04.000Z',
+            '2026-08-11T00:00:05.000Z',
+            NULL,
+            NULL
+          ),
+          (
+            'thread-archived-whitespace',
+            'project-blank-active-turn',
+            'Archived Whitespace',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            '2026-08-11T00:00:06.000Z',
+            '2026-08-11T00:00:07.000Z',
+            '2026-08-11T00:00:08.000Z',
+            NULL
+          )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_thread_sessions (
+          thread_id,
+          status,
+          provider_name,
+          runtime_mode,
+          active_turn_id,
+          last_error,
+          updated_at
+        )
+        VALUES
+          (
+            'thread-active-blank',
+            'ready',
+            'codex',
+            'full-access',
+            '',
+            NULL,
+            '2026-08-11T00:00:09.000Z'
+          ),
+          (
+            'thread-active-valid',
+            'running',
+            'codex',
+            'full-access',
+            'turn-valid',
+            NULL,
+            '2026-08-11T00:00:10.000Z'
+          ),
+          (
+            'thread-archived-whitespace',
+            'ready',
+            'codex',
+            'full-access',
+            '   ',
+            NULL,
+            '2026-08-11T00:00:11.000Z'
+          )
+      `;
+
+      const commandReadModel = yield* snapshotQuery.getCommandReadModel();
+      assert.equal(
+        commandReadModel.threads.find((thread) => thread.id === "thread-active-blank")?.session
+          ?.activeTurnId,
+        null,
+      );
+      assert.equal(
+        commandReadModel.threads.find((thread) => thread.id === "thread-archived-whitespace")
+          ?.session?.activeTurnId,
+        null,
+      );
+      assert.equal(
+        commandReadModel.threads.find((thread) => thread.id === "thread-active-valid")?.session
+          ?.activeTurnId,
+        asTurnId("turn-valid"),
+      );
+
+      const shellSnapshot = yield* snapshotQuery.getShellSnapshot();
+      assert.equal(
+        shellSnapshot.threads.find((thread) => thread.id === "thread-active-blank")?.session
+          ?.activeTurnId,
+        null,
+      );
+      assert.equal(
+        shellSnapshot.threads.find((thread) => thread.id === "thread-active-valid")?.session
+          ?.activeTurnId,
+        asTurnId("turn-valid"),
+      );
+
+      const archivedShellSnapshot = yield* snapshotQuery.getArchivedShellSnapshot();
+      assert.equal(
+        archivedShellSnapshot.threads.find((thread) => thread.id === "thread-archived-whitespace")
+          ?.session?.activeTurnId,
+        null,
+      );
+
+      const threadShell = yield* snapshotQuery.getThreadShellById(
+        ThreadId.make("thread-active-blank"),
+      );
+      assert.equal(threadShell._tag, "Some");
+      if (threadShell._tag === "Some") {
+        assert.equal(threadShell.value.session?.activeTurnId, null);
+      }
+
+      const threadDetail = yield* snapshotQuery.getThreadDetailById(
+        ThreadId.make("thread-active-blank"),
+      );
+      assert.equal(threadDetail._tag, "Some");
+      if (threadDetail._tag === "Some") {
+        assert.equal(threadDetail.value.session?.activeTurnId, null);
+      }
+    }),
+  );
+
   it.effect("keeps archived threads out of the main shell snapshot", () =>
     Effect.gen(function* () {
       const snapshotQuery = yield* ProjectionSnapshotQuery;

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -592,7 +592,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           provider_session_id AS "providerSessionId",
           provider_thread_id AS "providerThreadId",
           runtime_mode AS "runtimeMode",
-          active_turn_id AS "activeTurnId",
+          CASE WHEN TRIM(active_turn_id) = '' THEN NULL ELSE active_turn_id END AS "activeTurnId",
           last_error AS "lastError",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
@@ -613,7 +613,10 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.provider_session_id AS "providerSessionId",
           sessions.provider_thread_id AS "providerThreadId",
           sessions.runtime_mode AS "runtimeMode",
-          sessions.active_turn_id AS "activeTurnId",
+          CASE
+            WHEN TRIM(sessions.active_turn_id) = '' THEN NULL
+            ELSE sessions.active_turn_id
+          END AS "activeTurnId",
           sessions.last_error AS "lastError",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
@@ -638,7 +641,10 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.provider_session_id AS "providerSessionId",
           sessions.provider_thread_id AS "providerThreadId",
           sessions.runtime_mode AS "runtimeMode",
-          sessions.active_turn_id AS "activeTurnId",
+          CASE
+            WHEN TRIM(sessions.active_turn_id) = '' THEN NULL
+            ELSE sessions.active_turn_id
+          END AS "activeTurnId",
           sessions.last_error AS "lastError",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
@@ -1035,7 +1041,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           provider_name AS "providerName",
           provider_instance_id AS "providerInstanceId",
           runtime_mode AS "runtimeMode",
-          active_turn_id AS "activeTurnId",
+          CASE WHEN TRIM(active_turn_id) = '' THEN NULL ELSE active_turn_id END AS "activeTurnId",
           last_error AS "lastError",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -1,4 +1,4 @@
-import { ProjectId, ThreadId, ProviderInstanceId } from "@t3tools/contracts";
+import { ProjectId, ThreadId, TurnId, ProviderInstanceId } from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -7,13 +7,16 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { SqlitePersistenceMemory } from "./Sqlite.ts";
 import { ProjectionProjectRepositoryLive } from "./ProjectionProjects.ts";
+import { ProjectionThreadSessionRepositoryLive } from "./ProjectionThreadSessions.ts";
 import { ProjectionThreadRepositoryLive } from "./ProjectionThreads.ts";
 import { ProjectionProjectRepository } from "../Services/ProjectionProjects.ts";
+import { ProjectionThreadSessionRepository } from "../Services/ProjectionThreadSessions.ts";
 import { ProjectionThreadRepository } from "../Services/ProjectionThreads.ts";
 
 const projectionRepositoriesLayer = it.layer(
   Layer.mergeAll(
     ProjectionProjectRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+    ProjectionThreadSessionRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     ProjectionThreadRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     SqlitePersistenceMemory,
   ),
@@ -199,6 +202,54 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
       assert.strictEqual(updated?.snoozedUntil, null);
       assert.strictEqual(updated?.snoozedAt, null);
       assert.strictEqual(updated?.pinnedAt, null);
+    }),
+  );
+
+  it.effect("normalizes blank active turn ids when reading thread sessions", () =>
+    Effect.gen(function* () {
+      const sessions = yield* ProjectionThreadSessionRepository;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`
+        INSERT INTO projection_thread_sessions (
+          thread_id,
+          status,
+          provider_name,
+          runtime_mode,
+          active_turn_id,
+          last_error,
+          updated_at
+        )
+        VALUES
+          (
+            'thread-session-blank',
+            'ready',
+            'codex',
+            'full-access',
+            '   ',
+            NULL,
+            '2026-08-11T00:00:00.000Z'
+          ),
+          (
+            'thread-session-valid',
+            'running',
+            'codex',
+            'full-access',
+            'turn-valid',
+            NULL,
+            '2026-08-11T00:00:01.000Z'
+          )
+      `;
+
+      const blank = yield* sessions.getByThreadId({
+        threadId: ThreadId.make("thread-session-blank"),
+      });
+      assert.strictEqual(Option.getOrNull(blank)?.activeTurnId, null);
+
+      const valid = yield* sessions.getByThreadId({
+        threadId: ThreadId.make("thread-session-valid"),
+      });
+      assert.strictEqual(Option.getOrNull(valid)?.activeTurnId, TurnId.make("turn-valid"));
     }),
   );
 });

--- a/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
@@ -63,7 +63,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           provider_name AS "providerName",
           provider_instance_id AS "providerInstanceId",
           runtime_mode AS "runtimeMode",
-          active_turn_id AS "activeTurnId",
+          CASE WHEN TRIM(active_turn_id) = '' THEN NULL ELSE active_turn_id END AS "activeTurnId",
           last_error AS "lastError",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions


### PR DESCRIPTION
## What changed

A blank `projection_thread_sessions.active_turn_id` failed strict `TurnId` decoding while the command read model loaded every session row. One malformed projection row could therefore prevent the backend from becoming ready.

All five session read boundaries now normalize empty and whitespace-only values to SQL `NULL` before decoding. Valid IDs and the strict `Schema.NullOr(TurnId)` contract are unchanged. This is read-side resilience for legacy, foreign, or manually altered projection rows; the typed writer cannot produce the invalid value.

## Validation

- `pnpm exec vp test run apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts apps/server/src/persistence/Layers/ProjectionRepositories.test.ts` — 25 tests passed
- `pnpm exec vp run --filter t3 typecheck`
- Targeted lint, formatting, and `git diff --check`

Model: GPT-5.6 Sol · Harness: Codex in T3 Code
