### PR TITLE
feat(web): use self-hosted Inter as Windows default font

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -198,6 +198,9 @@
           }
         };
 
+        if (/^win(dows)?/i.test(navigator.platform)) {
+          document.documentElement.classList.add("windows");
+        }
         try {
           const storedTheme = window.localStorage.getItem("t3code:theme");
           const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@effect/atom-react": "catalog:",
+    "@fontsource-variable/inter": "^5.3.0",
     "@formkit/auto-animate": "^0.9.0",
     "@legendapp/list": "3.3.3",
     "@lexical/react": "^0.41.0",

--- a/apps/web/src/appearanceFonts.test.ts
+++ b/apps/web/src/appearanceFonts.test.ts
@@ -7,6 +7,7 @@ import {
   clampPromptFontSize,
   DEFAULT_CODE_FONT_STACK,
   DEFAULT_SANS_FONT_STACK,
+  WINDOWS_SANS_FONT_STACK,
   appearanceFontStack,
   cssFontFamilies,
   resolveDefaultFamilyLabel,
@@ -67,6 +68,12 @@ describe("appearanceFontStack", () => {
 
   it("falls back to the default stack when unset", () => {
     expect(appearanceFontStack("", DEFAULT_SANS_FONT_STACK)).toBe(DEFAULT_SANS_FONT_STACK);
+  });
+
+  it("prepends to the Windows stack on Windows so Inter stays in the fallback chain", () => {
+    expect(appearanceFontStack("Cascadia Code", WINDOWS_SANS_FONT_STACK)).toBe(
+      `"Cascadia Code", ${WINDOWS_SANS_FONT_STACK}`,
+    );
   });
 });
 

--- a/apps/web/src/appearanceFonts.ts
+++ b/apps/web/src/appearanceFonts.ts
@@ -20,6 +20,9 @@ import {
 export const DEFAULT_SANS_FONT_STACK =
   '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
 
+export const WINDOWS_SANS_FONT_STACK =
+  '"Inter Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
+
 // Concrete names first: some engines alias `ui-monospace` to the
 // proportional system UI font, which would break every code surface.
 export const DEFAULT_CODE_FONT_STACK =

--- a/apps/web/src/appearanceFonts.ts
+++ b/apps/web/src/appearanceFonts.ts
@@ -103,8 +103,15 @@ export function applyAppearanceFontVariables(
   root: HTMLElement,
   preferences: AppearanceFontPreferences,
 ): void {
+  const windowsSans = root.classList.contains("windows");
   const families: ReadonlyArray<readonly [variable: string, custom: string, fallback: string]> = [
-    ["--font-sans", preferences.sans, DEFAULT_SANS_FONT_STACK],
+    // On Windows the stylesheet default already prefers Inter, so custom
+    // families must prepend to the same stack or glyph fallbacks skip it.
+    [
+      "--font-sans",
+      preferences.sans,
+      windowsSans ? WINDOWS_SANS_FONT_STACK : DEFAULT_SANS_FONT_STACK,
+    ],
     ["--font-mono", preferences.code, DEFAULT_CODE_FONT_STACK],
     // The composer falls back to whatever the sans preference resolves to.
     ["--font-composer", preferences.composer, "var(--font-sans)"],

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1084,7 +1084,11 @@ function useFontDefaultFamilies() {
     : DEFAULT_SANS_FONT_STACK;
   const defaults = useMemo(
     () => ({
-      sans: resolveDefaultFamilyLabel(sansStack) ?? "System default",
+      // The canvas probe cannot measure the bundled Inter webfont before it
+      // renders, so on Windows fall back to naming it directly.
+      sans:
+        resolveDefaultFamilyLabel(sansStack) ??
+        (isWindowsPlatform(navigator.platform) ? "Inter Variable" : "System default"),
       code: resolveDefaultFamilyLabel(DEFAULT_CODE_FONT_STACK) ?? "System monospace",
     }),
     [sansStack],

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -75,7 +75,7 @@ import {
   sortProviderInstanceEntries,
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
-import { isMacPlatform } from "../../lib/utils";
+import { isMacPlatform, isWindowsPlatform } from "../../lib/utils";
 import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
@@ -96,6 +96,7 @@ import { Input } from "../ui/input";
 import {
   DEFAULT_CODE_FONT_STACK,
   DEFAULT_SANS_FONT_STACK,
+  WINDOWS_SANS_FONT_STACK,
   isFontFamilyAvailable,
   isMonospaceFamily,
   resolveDefaultFamilyLabel,
@@ -1078,15 +1079,15 @@ export function AppearanceSettingsPanel() {
 
 function useFontDefaultFamilies() {
   const settings = usePrimarySettings();
-  // An unset preference shows the font it resolves to on this machine; the
-  // default stacks are the platform's own faces, so the name is probed, not
-  // hardcoded.
+  const sansStack = isWindowsPlatform(navigator.platform)
+    ? WINDOWS_SANS_FONT_STACK
+    : DEFAULT_SANS_FONT_STACK;
   const defaults = useMemo(
     () => ({
-      sans: resolveDefaultFamilyLabel(DEFAULT_SANS_FONT_STACK) ?? "System default",
+      sans: resolveDefaultFamilyLabel(sansStack) ?? "System default",
       code: resolveDefaultFamilyLabel(DEFAULT_CODE_FONT_STACK) ?? "System monospace",
     }),
-    [],
+    [sansStack],
   );
   return {
     sans: defaults.sans,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1442,6 +1442,11 @@ body {
   --desktop-window-right-resize-inset: 6px;
 }
 
+html.windows {
+  --font-sans:
+    "Inter Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+}
+
 /* App-chrome grain. Baked into each surface's own background (behind
    content) rather than a fixed overlay on top: a full-viewport overlay
    forces the compositor to re-blend every frame any animation produces,

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import { createHashHistory, createBrowserHistory } from "@tanstack/react-router"
 
 import "./index.css";
 
+import "@fontsource-variable/inter/wght.css";
 import { isElectron } from "./env";
 import { ManagedRelayAuthProvider } from "./cloud/managedAuth";
 import { hasCloudPublicConfig } from "./cloud/publicConfig";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       '@effect/atom-react':
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))(react@19.2.6)(scheduler@0.27.0)
+      '@fontsource-variable/inter':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@formkit/auto-animate':
         specifier: ^0.9.0
         version: 0.9.0
@@ -2707,6 +2710,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/inter@5.3.0':
+    resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
 
   '@formkit/auto-animate@0.9.0':
     resolution: {integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==}
@@ -12804,6 +12810,8 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/inter@5.3.0': {}
 
   '@formkit/auto-animate@0.9.0': {}
 


### PR DESCRIPTION
## What Changed

Self-host Inter (variable font) and use it for the Windows UI:

- Add `@fontsource-variable/inter` (bundled, no CDN, works offline in Electron).
- Gate it behind a `windows` class on `<html>`, set pre-paint in `index.html`, so only Windows renders Inter. macOS/Linux keep the system default stack untouched.
- `--font-sans` on Windows becomes `"Inter Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`. Segoe UI stays as the fallback, so a load failure degrades cleanly.
- User-chosen fonts in Settings -> Appearance still win: the runtime writes `--font-sans` inline, which overrides the stylesheet.
- Show "Inter Variable" as the resolved default family in the interface font picker on Windows, mirroring what actually renders.
- Code/mono and terminal fonts are untouched.

## Why

The Windows default UI font (Segoe UI) renders poorly in this app and looks bad . Inter is a first-party quality UI font, and the macOS/Linux defaults (SF Pro / system-ui) already look good, so the change is scoped to Windows only. Self-hosting keeps it offline-capable and consistent across installs instead of depending on a CDN. 

## UI Changes

Before (Windows, Segoe UI) :

<img width="1917" height="1035" alt="t3-code-before" src="https://github.com/user-attachments/assets/0c049780-e549-4c55-a683-41b2ea07b368" />


After (Windows, Inter) : 

<img width="1914" height="1024" alt="t3-code-after" src="https://github.com/user-attachments/assets/ab9d8cda-92a0-42c8-b6fe-40bf34cec15d" />

## Checklist

- [x] This PR is small and focused 
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes *(needs your two screenshots)*
- [ ] I included a video for animation/interaction changes *(N/A - no motion involve*


 






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Windows UI sans typography and appearance CSS variables; no auth, data, or business-logic changes. Slight bundle size increase from the self-hosted font.
> 
> **Overview**
> **Windows-only default UI typography** now prefers bundled **Inter Variable** instead of Segoe UI, while macOS and Linux keep the existing system stacks.
> 
> The PR adds `@fontsource-variable/inter` and loads it from `main.tsx`. Pre-paint boot code in `index.html` adds a `windows` class on `<html>` when `navigator.platform` looks like Windows; `index.css` uses that to set `--font-sans` with Inter first and Segoe UI still in the fallback chain.
> 
> Runtime appearance wiring in `appearanceFonts.ts` introduces `WINDOWS_SANS_FONT_STACK` and makes `applyAppearanceFontVariables` prepend custom interface fonts to that stack on Windows so user picks in Settings stay consistent with the CSS default. The interface font picker labels the unset default as **Inter Variable** on Windows when probing cannot see the webfont yet. Code/mono and terminal fonts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f055535931410b5ee27b4075a9e7e6dffcdc84a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use self-hosted Inter Variable as the default sans-serif font on Windows
> - Detects Windows at startup via `navigator.platform` and adds a `windows` class to `<html>`, which triggers an `Inter Variable` font stack in both the CSS defaults and the `--font-sans` CSS variable.
> - Loads the Inter Variable font via a side-effect import of `@fontsource-variable/inter` in [main.tsx](https://github.com/pingdotgg/t3code/pull/6151/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b).
> - Updates `useFontDefaultFamilies` in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/6151/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) to show 'Inter Variable' as the default sans label on Windows.
> - Behavioral Change: Windows users now see Inter Variable instead of the system default sans-serif font (typically Segoe UI).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f055535.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->