### PR TITLE
fix(web): move command palette list a page at a time with PageUp/PageDown

### DIFF
--- a/patches/@base-ui__react@1.5.0.patch
+++ b/patches/@base-ui__react@1.5.0.patch
@@ -1,0 +1,236 @@
+diff --git a/esm/floating-ui-react/hooks/useListNavigation.js b/esm/floating-ui-react/hooks/useListNavigation.js
+index e7adca5a55c3906462b320b9488e1ff07642d32f..c3ff8b2c356240078aface81583ee2f71ee99981 100644
+--- a/esm/floating-ui-react/hooks/useListNavigation.js
++++ b/esm/floating-ui-react/hooks/useListNavigation.js
+@@ -16,6 +16,69 @@ import { activeElement, contains, getFloatingFocusElement, getTarget, isTypeable
+ import { enqueueFocus } from "../utils/enqueueFocus.js";
+ import { isVirtualClick, isVirtualPointerEvent, stopEvent } from "../utils/event.js";
+ export const ESCAPE = 'Escape';
++const PAGE_UP = 'PageUp';
++const PAGE_DOWN = 'PageDown';
++
++// Returns the height of the closest scrolling ancestor, which is the area a
++// page key moves through. An ancestor counts as scrolling when it clips its
++// content and its content is taller than it is, which also covers containers
++// scrolled programmatically behind `overflow: hidden`. Falls back to the window
++// height when the list is not inside a scroll container. The element's own view
++// is used rather than the global one so the measurement is correct for a list
++// rendered inside an iframe.
++function getListViewportHeight(element) {
++  const view = element.ownerDocument.defaultView;
++  if (!view) {
++    return 0;
++  }
++  let node = element.parentElement;
++  while (node) {
++    const overflowY = view.getComputedStyle(node).overflowY;
++    if (
++      overflowY !== 'visible' &&
++      node.clientHeight > 0 &&
++      node.scrollHeight > node.clientHeight
++    ) {
++      return node.clientHeight;
++    }
++    node = node.parentElement;
++  }
++  return view.innerHeight;
++}
++
++// Counts how many items fit in the viewport starting from the current one, so
++// a page key moves by a screenful of items. Items are compared by their laid-out
++// position rather than by summing their heights, so group headings, separators,
++// margins and gaps between items all count towards the screenful.
++function getListPageSize(list, startIndex, decrement) {
++  const startElement = list[startIndex];
++  if (!startElement) {
++    return 1;
++  }
++  const viewportHeight = getListViewportHeight(startElement);
++  if (viewportHeight <= 0) {
++    return 1;
++  }
++  const startRect = startElement.getBoundingClientRect();
++  const edge = decrement ? startRect.bottom - viewportHeight : startRect.top + viewportHeight;
++  let count = 0;
++  for (
++    let index = startIndex;
++    decrement ? index >= 0 : index < list.length;
++    index += decrement ? -1 : 1
++  ) {
++    const element = list[index];
++    if (!element) {
++      continue;
++    }
++    const rect = element.getBoundingClientRect();
++    if (decrement ? rect.top < edge : rect.bottom > edge) {
++      break;
++    }
++    count += 1;
++  }
++  return Math.max(1, count);
++}
+ function doSwitch(orientation, vertical, horizontal) {
+   switch (orientation) {
+     case 'vertical':
+@@ -332,6 +395,41 @@ export function useListNavigation(context, props) {
+       }
+     }
+ 
++    // Page keys move the highlight by a screenful of items. They step through
++    // the list in a straight line, so they are only handled for a vertical
++    // single-column list; a grid or a horizontal list keeps the key's default
++    // behaviour. They are handled outside the block above because PageUp and
++    // PageDown do not move the caret in a single-line input, so a typeable
++    // reference does not need to keep them.
++    if (
++      (event.key === PAGE_UP || event.key === PAGE_DOWN) &&
++      cols <= 1 &&
++      orientation === 'vertical'
++    ) {
++      stopEvent(event);
++      const decrement = event.key === PAGE_UP;
++      if (isIndexOutOfListBounds(listRef.current, currentIndex)) {
++        indexRef.current = decrement ? maxIndex : minIndex;
++      } else {
++        const pageSize = getListPageSize(listRef.current, currentIndex, decrement);
++        const targetIndex = decrement
++          ? Math.max(minIndex, currentIndex - pageSize)
++          : Math.min(maxIndex, currentIndex + pageSize);
++        indexRef.current = isListIndexDisabled(listRef.current, targetIndex, disabledIndices)
++          ? findNonDisabledListIndex(listRef.current, {
++              startingIndex: targetIndex,
++              decrement,
++              disabledIndices
++            })
++          : targetIndex;
++        if (isIndexOutOfListBounds(listRef.current, indexRef.current)) {
++          indexRef.current = decrement ? minIndex : maxIndex;
++        }
++      }
++      onNavigate(event);
++      return;
++    }
++
+     // Grid navigation.
+     if (cols > 1) {
+       const sizes = Array.from({
+diff --git a/floating-ui-react/hooks/useListNavigation.js b/floating-ui-react/hooks/useListNavigation.js
+index e4bcab6cebb00aeb9b83aaf70e9ceb91c23e5e08..391aa1165202b88b2e266d6362c528dcb4cd2a1f 100644
+--- a/floating-ui-react/hooks/useListNavigation.js
++++ b/floating-ui-react/hooks/useListNavigation.js
+@@ -23,6 +23,69 @@ var _element = require("../utils/element");
+ var _enqueueFocus = require("../utils/enqueueFocus");
+ var _event = require("../utils/event");
+ const ESCAPE = exports.ESCAPE = 'Escape';
++const PAGE_UP = 'PageUp';
++const PAGE_DOWN = 'PageDown';
++
++// Returns the height of the closest scrolling ancestor, which is the area a
++// page key moves through. An ancestor counts as scrolling when it clips its
++// content and its content is taller than it is, which also covers containers
++// scrolled programmatically behind `overflow: hidden`. Falls back to the window
++// height when the list is not inside a scroll container. The element's own view
++// is used rather than the global one so the measurement is correct for a list
++// rendered inside an iframe.
++function getListViewportHeight(element) {
++  const view = element.ownerDocument.defaultView;
++  if (!view) {
++    return 0;
++  }
++  let node = element.parentElement;
++  while (node) {
++    const overflowY = view.getComputedStyle(node).overflowY;
++    if (
++      overflowY !== 'visible' &&
++      node.clientHeight > 0 &&
++      node.scrollHeight > node.clientHeight
++    ) {
++      return node.clientHeight;
++    }
++    node = node.parentElement;
++  }
++  return view.innerHeight;
++}
++
++// Counts how many items fit in the viewport starting from the current one, so
++// a page key moves by a screenful of items. Items are compared by their laid-out
++// position rather than by summing their heights, so group headings, separators,
++// margins and gaps between items all count towards the screenful.
++function getListPageSize(list, startIndex, decrement) {
++  const startElement = list[startIndex];
++  if (!startElement) {
++    return 1;
++  }
++  const viewportHeight = getListViewportHeight(startElement);
++  if (viewportHeight <= 0) {
++    return 1;
++  }
++  const startRect = startElement.getBoundingClientRect();
++  const edge = decrement ? startRect.bottom - viewportHeight : startRect.top + viewportHeight;
++  let count = 0;
++  for (
++    let index = startIndex;
++    decrement ? index >= 0 : index < list.length;
++    index += decrement ? -1 : 1
++  ) {
++    const element = list[index];
++    if (!element) {
++      continue;
++    }
++    const rect = element.getBoundingClientRect();
++    if (decrement ? rect.top < edge : rect.bottom > edge) {
++      break;
++    }
++    count += 1;
++  }
++  return Math.max(1, count);
++}
+ function doSwitch(orientation, vertical, horizontal) {
+   switch (orientation) {
+     case 'vertical':
+@@ -339,6 +402,45 @@ function useListNavigation(context, props) {
+       }
+     }
+ 
++    // Page keys move the highlight by a screenful of items. They step through
++    // the list in a straight line, so they are only handled for a vertical
++    // single-column list; a grid or a horizontal list keeps the key's default
++    // behaviour. They are handled outside the block above because PageUp and
++    // PageDown do not move the caret in a single-line input, so a typeable
++    // reference does not need to keep them.
++    if (
++      (event.key === PAGE_UP || event.key === PAGE_DOWN) &&
++      cols <= 1 &&
++      orientation === 'vertical'
++    ) {
++      (0, _event.stopEvent)(event);
++      const decrement = event.key === PAGE_UP;
++      if ((0, _composite.isIndexOutOfListBounds)(listRef.current, currentIndex)) {
++        indexRef.current = decrement ? maxIndex : minIndex;
++      } else {
++        const pageSize = getListPageSize(listRef.current, currentIndex, decrement);
++        const targetIndex = decrement
++          ? Math.max(minIndex, currentIndex - pageSize)
++          : Math.min(maxIndex, currentIndex + pageSize);
++        indexRef.current = (0, _composite.isListIndexDisabled)(
++          listRef.current,
++          targetIndex,
++          disabledIndices
++        )
++          ? (0, _composite.findNonDisabledListIndex)(listRef.current, {
++              startingIndex: targetIndex,
++              decrement,
++              disabledIndices
++            })
++          : targetIndex;
++        if ((0, _composite.isIndexOutOfListBounds)(listRef.current, indexRef.current)) {
++          indexRef.current = decrement ? minIndex : maxIndex;
++        }
++      }
++      onNavigate(event);
++      return;
++    }
++
+     // Grid navigation.
+     if (cols > 1) {
+       const sizes = Array.from({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,7 @@ overrides:
 packageExtensionsChecksum: sha256-CUzzeefpj3gNFrCKNBhV9FOaniNbrLdKyIhWQyXuaiE=
 
 patchedDependencies:
+  '@base-ui/react@1.5.0': 4f1d7a9f76dd7288f1980d8cc8925f0285eba4a735e0ba5acbe6df29032fb60c
   '@effect/vitest@4.0.0-beta.103': a16b1e870d8c29e4a98b17cc4c638a4ff471753d8ca3487f78a22b759caf951b
   '@expo/metro-config@56.0.14': 8cb08b5bb7051ed9d2dbe46a2c293c5a1e17f1bd6ddf30de27909e18c921ff46
   '@ff-labs/fff-node@0.9.4': 2b16019ce7ab61aec6478dd02f79ef468cc1d5c51e9d00764f7d2ab8167210c8
@@ -511,7 +512,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: ^1.4.1
-        version: 1.5.0(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.5.0(patch_hash=4f1d7a9f76dd7288f1980d8cc8925f0285eba4a735e0ba5acbe6df29032fb60c)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/electron':
         specifier: 0.0.24
         version: 0.0.24(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -11421,7 +11422,7 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.5.0(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@base-ui/react@1.5.0(patch_hash=4f1d7a9f76dd7288f1980d8cc8925f0285eba4a735e0ba5acbe6df29032fb60c)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@base-ui/utils': 0.2.9(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -122,6 +122,7 @@ packageExtensions:
       vite: "catalog:"
 
 patchedDependencies:
+  "@base-ui/react@1.5.0": patches/@base-ui__react@1.5.0.patch
   "@effect/vitest@4.0.0-beta.103": patches/@effect__vitest@4.0.0-beta.103.patch
   "@expo/metro-config@56.0.14": patches/@expo%2Fmetro-config@56.0.14.patch
   "@ff-labs/fff-node@0.9.4": patches/@ff-labs__fff-node@0.9.4.patch


### PR DESCRIPTION
## What Changed

- PageUp and PageDown now move the highlighted row in command palette lists by one screenful instead of doing nothing.
- Only vertical single-column lists are handled. A grid (`cols > 1`) or a horizontal list keeps the key's default behaviour, so no key is swallowed where a straight-line jump would land in an unrelated column.
- The step is measured from the laid-out positions of the rows rather than by summing row heights, so group headings, separators, margins and gaps all count towards a screenful.
- The highlight stops on the first and last row instead of wrapping around.

The behaviour is added by a patch on `@base-ui/react`, registered the same way as the other patches in `patches/`. Base UI owns the list navigation and has no case for the page keys, and its public API exposes no way to set the highlighted index: `onItemHighlighted` only reports changes, and `actionsRef` carries just `unmount`. Both the ESM and CommonJS builds that ship in the package are patched, so every bundle gets the same behaviour.

## Why

The folder list in the "New project" dialog is the clearest case. It lists every directory in the current path, so it is routinely longer than the popup, and the only way through it was one arrow press per row. The other dialogs built on the same palette (file picker, project content search, favicon picker) had the same gap.

Home and End already work, so the page keys were the only missing step size.

Reported as #6159.

## UI Changes

No visual change; this is keyboard behaviour only.

Measured on the "New project" folder list with 31 folders, a 330px list viewport and 32px rows, so one page is 10 rows:

| Key | Highlighted row |
| --- | --- |
| ArrowDown | 0 |
| PageDown | 10 -> 20 -> 30 |
| PageDown at the end | stays on 30 |
| PageUp | 20 -> 10 -> 0 |
| PageUp at the start | stays on 0 |

The highlighted row was scrolled into view at every step. Checked on Windows in the dev build, both with real key presses and with dispatched key events.

Measured again on a two-group list (Actions and Projects, nine rows, one 28px heading between the groups, same 330px viewport) to check that headings count: summing row heights gives a step of nine rows, measuring positions gives eight. The eighth row is the one the heading pushes off screen.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI changes are not applicable - no visual change, keyboard behaviour only
- [ ] I included a video for animation/interaction changes - not included; the behaviour is described with measured row indices above
