### PR TITLE
fix(preview): validate popup URLs before loading

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -160,6 +160,8 @@ interface TestCapturedPreviewImage {
 const makeTestPreviewWebContents = (
   capturePage: () => Promise<TestCapturedPreviewImage>,
   id = 42,
+  loadURL = vi.fn(async () => undefined),
+  setWindowOpenHandler = vi.fn(),
 ) =>
   ({
     id,
@@ -170,12 +172,13 @@ const makeTestPreviewWebContents = (
     isLoading: () => false,
     getZoomFactor: () => 1,
     setZoomFactor: vi.fn(),
+    loadURL,
     on: vi.fn(),
     off: vi.fn(),
     ipc: { on: vi.fn(), off: vi.fn() },
     send: webviewSend,
     navigationHistory: { canGoBack: () => false, canGoForward: () => false },
-    setWindowOpenHandler: vi.fn(),
+    setWindowOpenHandler,
     debugger: {
       isAttached: () => false,
       attach: vi.fn(),
@@ -229,6 +232,53 @@ describe("PreviewManager", () => {
     createFromPath.mockClear();
     webviewSend.mockClear();
   });
+
+  effectIt.effect("validates preview popup URLs before loading them", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const loadURL = vi.fn(async () => undefined);
+        const setWindowOpenHandler = vi.fn();
+        const webContents = makeTestPreviewWebContents(
+          async () => ({
+            toJPEG: () => Buffer.from("popup-url-validation"),
+            getSize: () => ({ width: 1, height: 1 }),
+          }),
+          42,
+          loadURL,
+          setWindowOpenHandler,
+        );
+        fromId.mockReturnValue(webContents);
+
+        yield* manager.createTab("tab_popup_url_validation");
+        yield* manager.registerWebview("tab_popup_url_validation", 42);
+
+        expect(setWindowOpenHandler).toHaveBeenCalledOnce();
+        const handler = setWindowOpenHandler.mock.calls[0]?.[0] as
+          | ((details: { readonly url: string }) => { readonly action: string })
+          | undefined;
+        expect(handler).toBeDefined();
+        if (!handler) return;
+
+        for (const url of [
+          "",
+          "data:text/html,<script>document.body.innerText='blocked'</script>",
+          "file:///tmp/preview.html",
+          "javascript:document.body.innerText='blocked'",
+          "http://[::1",
+        ]) {
+          expect(handler({ url })).toEqual({ action: "deny" });
+        }
+        expect(loadURL).not.toHaveBeenCalled();
+
+        expect(handler({ url: "http://localhost:3200" })).toEqual({ action: "deny" });
+        expect(handler({ url: "https://example.com/path" })).toEqual({ action: "deny" });
+        yield* Effect.yieldNow;
+
+        expect(loadURL).toHaveBeenNthCalledWith(1, "http://localhost:3200/");
+        expect(loadURL).toHaveBeenNthCalledWith(2, "https://example.com/path");
+      }),
+    ),
+  );
 
   effectIt.effect("reports an unregistered webview as temporarily unavailable", () =>
     withManager((manager) =>

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1407,9 +1407,15 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         wc.on("did-fail-load", failed as never);
         wc.ipc.on(HUMAN_INPUT_CHANNEL, humanInput);
         wc.setWindowOpenHandler(({ url }) => {
+          let normalizedUrl: string;
+          try {
+            normalizedUrl = normalizePreviewUrl(url);
+          } catch {
+            return { action: "deny" };
+          }
           runFork(
             attemptPromise({ operation: "openPreviewWindow", tabId, webContentsId: wc.id }, () =>
-              wc.loadURL(url),
+              wc.loadURL(normalizedUrl),
             ).pipe(Effect.ignore),
           );
           return { action: "deny" };


### PR DESCRIPTION
## Summary

- validate preview popup URLs through the existing `normalizePreviewUrl` allowlist before calling `webContents.loadURL`
- keep the existing same-tab popup behavior for normalized `http://` and `https://` URLs
- add regression coverage for `data:`, `file:`, `javascript:`, empty/malformed, and valid HTTP(S) popup URLs

## Why

The preview `setWindowOpenHandler` previously denied the new window but still loaded its raw URL into the current preview webContents. That bypassed the normal preview URL normalization path. An HTTP preview could therefore navigate the preview to a `data:` document and execute arbitrary JavaScript inside the preview surface.

The fix keeps the preview URL contract consistent across normal navigation and popup navigation. Unsupported schemes are rejected before `loadURL` is scheduled.

## Verification

- `pnpm --filter @t3tools/desktop exec vp test run src/preview/Manager.test.ts` — 34 passed
- `pnpm --filter @t3tools/desktop typecheck` — passed (existing suggestions only)
- `pnpm lint` — passed (existing unused-disable warning only)
- `pnpm fmt:check` — passed
- Electron 41.5.0 / Chrome 146.0.7680.216 harness — `data:` target rejected, no marker executed, original HTTP URL remained loaded

The full desktop suite was also run; 17 unrelated Windows/macOS path/platform assertions fail in this Windows runner. No `Manager.test.ts` test failed.

This PR is a defense-in-depth URL-validation fix. It does not claim RCE, arbitrary IPC, host auth-cookie theft, or credential exfiltration; the preview sandbox and separate session boundary remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit adf11323deea1e5f869a07d22db871a6385be9bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate and normalize popup URLs in preview window open handler
> In `setWindowOpenHandler`, the URL from a popup request is now passed through `normalizePreviewUrl` before loading. If normalization throws, the handler returns `{ action: "deny" }` without calling `loadURL`. If it succeeds, `loadURL` is called with the normalized URL in a forked effect while still denying the window open.
>
> - Behavioral Change: Previously, popup URLs were loaded without validation; now malformed or unsafe URLs are silently denied and never loaded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adf1132.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->