### PR TITLE
feat(clients): reload provider sessions per thread without restarting T3 Code

### DIFF
--- a/apps/mobile/src/features/threads/ThreadGitControls.tsx
+++ b/apps/mobile/src/features/threads/ThreadGitControls.tsx
@@ -70,6 +70,7 @@ type ThreadGitHeaderActionItems = {
   readonly terminal: HeaderItem;
   readonly files: HeaderItem;
   readonly git: HeaderItem;
+  readonly reloadSession: HeaderItem | null;
 };
 type QuickActionIcon =
   | "arrow.down.circle"
@@ -104,6 +105,11 @@ type ThreadGitControlsProps = ThreadGitMenuProps & {
   readonly onOpenTerminal: (terminalId?: string | null) => void;
   readonly onOpenNewTerminal: () => void;
   readonly onRunProjectScript: (script: ProjectScript) => Promise<void>;
+  readonly reloadSessionControl?: {
+    readonly accessibilityLabel: string;
+    readonly disabled: boolean;
+    readonly onPress: () => void;
+  };
 };
 
 function useThreadGitControlModel(props: ThreadGitMenuProps) {
@@ -366,6 +372,19 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
         type: "menu",
         variant: "plain",
       },
+      reloadSession: props.reloadSessionControl
+        ? {
+            accessibilityLabel: props.reloadSessionControl.accessibilityLabel,
+            disabled: props.reloadSessionControl.disabled,
+            icon: { name: "arrow.clockwise", type: "sfSymbol" },
+            identifier: "thread-right-reload-session",
+            label: "Reload session",
+            onPress: props.reloadSessionControl.onPress,
+            sharesBackground: true,
+            type: "button",
+            variant: "plain",
+          }
+        : null,
     }),
     [
       model.currentBranchLabel,
@@ -385,6 +404,7 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
       props.onOpenTerminal,
       props.onRunProjectScript,
       props.projectScripts,
+      props.reloadSessionControl,
       props.terminalSessions,
     ],
   );
@@ -393,7 +413,13 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
 export function useThreadGitRightHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
   return useMemo(
-    () => [actionItems.git, actionItems.files, actionItems.terminal] as HeaderItems,
+    () =>
+      [
+        actionItems.git,
+        actionItems.files,
+        actionItems.terminal,
+        ...(actionItems.reloadSession ? [actionItems.reloadSession] : []),
+      ] as HeaderItems,
     [actionItems],
   );
 }
@@ -401,7 +427,13 @@ export function useThreadGitRightHeaderItems(props: ThreadGitControlsProps): Hea
 export function useThreadGitCenterHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
   return useMemo(
-    () => [actionItems.files, actionItems.git, actionItems.terminal] as HeaderItems,
+    () =>
+      [
+        actionItems.files,
+        actionItems.git,
+        actionItems.terminal,
+        ...(actionItems.reloadSession ? [actionItems.reloadSession] : []),
+      ] as HeaderItems,
     [actionItems],
   );
 }
@@ -486,6 +518,15 @@ export function ThreadGitControls(props: ThreadGitControlsProps) {
           disabled={!props.canOpenFiles}
           icon="folder"
           onPress={model.openFiles}
+          separateBackground
+        />
+      ) : null}
+      {showActionControls && props.reloadSessionControl ? (
+        <NativeHeaderToolbar.Button
+          accessibilityLabel={props.reloadSessionControl.accessibilityLabel}
+          disabled={props.reloadSessionControl.disabled}
+          icon="arrow.clockwise"
+          onPress={props.reloadSessionControl.onPress}
           separateBackground
         />
       ) : null}

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -882,6 +882,7 @@ function ThreadRouteContent(
     <>
       {activeInspectorRenderer ? <InspectorPaneRoleActivation /> : null}
       <NativeStackScreenOptions
+        optionsVersion={reloadAvailability}
         options={{
           // Android draws its own in-flow header (AndroidScreenHeader below);
           // the native stack header stays iOS-only.

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -521,7 +521,7 @@ function ThreadRouteContent(
 
     const result = await stopThreadSession({
       environmentId: latestThread.environmentId,
-      input: { threadId: latestThread.id },
+      input: { threadId: latestThread.id, onlyIfIdle: true },
     });
     if (result._tag === "Failure") {
       if (!isAtomCommandInterrupted(result)) {

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -12,8 +12,13 @@ import {
   requestOlderThreadTurns,
   threadHasOlderTurns,
 } from "@t3tools/client-runtime/state/threads";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import { threadSessionReloadAvailability } from "@t3tools/client-runtime/state/thread-session";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
-import { Platform, ScrollView, View } from "react-native";
+import { Alert, Platform, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useWorkspaceState } from "../../state/workspace";
 import { useEnvironmentQuery } from "../../state/query";
@@ -214,6 +219,11 @@ function ThreadRouteContent(
   const gitActions = useSelectedThreadGitActions();
   const requests = useSelectedThreadRequests();
   const interruptThreadTurn = useAtomCommand(threadEnvironment.interruptTurn, "thread interrupt");
+  const stopThreadSession = useAtomCommand(threadEnvironment.stopSession, {
+    reportFailure: false,
+  });
+  const reloadThreadRef = useRef(selectedThread);
+  reloadThreadRef.current = selectedThread;
   const navigation = useNavigation();
   const params = props.route.params;
   const environmentIdRaw = firstRouteParam(params.environmentId);
@@ -496,6 +506,51 @@ function ThreadRouteContent(
       },
     });
   }, [interruptThreadTurn, selectedThread]);
+  const handleReloadAgentSession = useCallback(async () => {
+    const latestThread = reloadThreadRef.current;
+    const sessionStatus = latestThread?.session?.status ?? null;
+    const reloadAvailability = threadSessionReloadAvailability(sessionStatus);
+    if (reloadAvailability === "disabled") {
+      Alert.alert(
+        "Could not reload agent session",
+        "Wait for the active turn to finish before reloading the session.",
+      );
+      return;
+    }
+    if (!latestThread || reloadAvailability === "hidden") return;
+
+    const result = await stopThreadSession({
+      environmentId: latestThread.environmentId,
+      input: { threadId: latestThread.id },
+    });
+    if (result._tag === "Failure") {
+      if (!isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        Alert.alert(
+          "Could not reload agent session",
+          error instanceof Error ? error.message : "An error occurred.",
+        );
+      }
+      return;
+    }
+    Alert.alert(
+      "Agent session will reload",
+      "Your next message will resume this thread with current provider and MCP settings.",
+    );
+  }, [stopThreadSession]);
+  const sessionStatus = selectedThread?.session?.status ?? null;
+  const reloadAvailability = threadSessionReloadAvailability(sessionStatus);
+  const reloadSessionControl = useMemo(
+    () =>
+      reloadAvailability !== "hidden"
+        ? {
+            accessibilityLabel: "Reload agent session",
+            disabled: reloadAvailability === "disabled",
+            onPress: () => void handleReloadAgentSession(),
+          }
+        : undefined,
+    [handleReloadAgentSession, reloadAvailability],
+  );
 
   const handleOpenTerminal = useCallback(
     (nextTerminalId?: string | null) => {
@@ -632,6 +687,7 @@ function ThreadRouteContent(
     onOpenTerminal: handleOpenTerminal,
     onOpenNewTerminal: handleOpenNewTerminal,
     onRunProjectScript: handleRunProjectScript,
+    reloadSessionControl,
     onPull: gitActions.onPullSelectedThreadBranch,
     onRunAction: gitActions.onRunSelectedThreadGitAction,
   };
@@ -715,6 +771,14 @@ function ThreadRouteContent(
         onPress: handleToggleInspector,
       });
     }
+    if (reloadSessionControl) {
+      actions.push({
+        accessibilityLabel: reloadSessionControl.accessibilityLabel,
+        disabled: reloadSessionControl.disabled,
+        icon: "arrow.clockwise",
+        onPress: reloadSessionControl.onPress,
+      });
+    }
     return actions;
   }, [
     fileInspector.supported,
@@ -723,6 +787,7 @@ function ThreadRouteContent(
     handleOpenGitInspector,
     handleToggleInspector,
     props.onReturnToThread,
+    reloadSessionControl,
     selectedThreadCwd,
     selectedThreadProject?.workspaceRoot,
   ]);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2943,4 +2943,67 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.providerInstanceId).toBe(ProviderInstanceId.make("codex_work"));
     expect(thread?.session?.activeTurnId).toBeNull();
   });
+
+  it("starts a new provider process on the first turn after a session reload", async () => {
+    const harness = await createHarness();
+    const threadId = ThreadId.make("thread-1");
+    const firstCreatedAt = "2026-01-01T00:00:00.000Z";
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-session-reload-first-turn"),
+        threadId,
+        message: {
+          messageId: asMessageId("user-message-session-reload-first"),
+          role: "user",
+          text: "first",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: firstCreatedAt,
+      }),
+    );
+    await harness.drain();
+    expect(harness.startSession).toHaveBeenCalledTimes(1);
+    expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.session.stop",
+        commandId: CommandId.make("cmd-session-reload-stop"),
+        threadId,
+        createdAt: "2026-01-01T00:00:01.000Z",
+      }),
+    );
+    await harness.drain();
+    expect(harness.stopSession).toHaveBeenCalledTimes(1);
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-session-reload-second-turn"),
+        threadId,
+        message: {
+          messageId: asMessageId("user-message-session-reload-second"),
+          role: "user",
+          text: "second",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:02.000Z",
+      }),
+    );
+    await harness.drain();
+
+    expect(harness.startSession).toHaveBeenCalledTimes(2);
+    expect(harness.sendTurn).toHaveBeenCalledTimes(2);
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      threadId,
+      provider: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex"),
+    });
+  });
 });

--- a/apps/server/src/orchestration/decider.settled.test.ts
+++ b/apps/server/src/orchestration/decider.settled.test.ts
@@ -569,4 +569,47 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
       ]);
     }),
   );
+
+  it.effect("rejects an onlyIfIdle session stop when a turn became active", () =>
+    Effect.gen(function* () {
+      const stopCommand = (commandId: string) =>
+        ({
+          type: "thread.session.stop",
+          commandId: CommandId.make(commandId),
+          threadId: ThreadId.make("thread-1"),
+          createdAt: NOW,
+          onlyIfIdle: true,
+        }) as const;
+
+      const stopped = yield* decideOrchestrationCommand({
+        command: stopCommand("cmd-stop-idle"),
+        readModel: makeReadModel(null, null, makeSession("ready")),
+      });
+      const stoppedEvents = Array.isArray(stopped) ? stopped : [stopped];
+      expect(stoppedEvents.map((event) => event.type)).toEqual(["thread.session-stop-requested"]);
+
+      for (const status of ["starting", "running"] as const) {
+        const error = yield* decideOrchestrationCommand({
+          command: stopCommand(`cmd-stop-active-${status}`),
+          readModel: makeReadModel(null, null, makeSession(status)),
+        }).pipe(Effect.flip);
+        expect(error._tag).toBe("OrchestrationCommandInvariantError");
+      }
+
+      const queuedMessage: OrchestrationThread["messages"][number] = {
+        id: MessageId.make("message-reload-race"),
+        role: "user",
+        text: "Continue",
+        turnId: null,
+        streaming: false,
+        createdAt: NOW,
+        updatedAt: NOW,
+      };
+      const queuedError = yield* decideOrchestrationCommand({
+        command: stopCommand("cmd-stop-queued-turn"),
+        readModel: makeReadModel(null, null, makeSession("ready"), [], [queuedMessage]),
+      }).pipe(Effect.flip);
+      expect(queuedError._tag).toBe("OrchestrationCommandInvariantError");
+    }),
+  );
 });

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1126,18 +1126,27 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
-      // Settle-cleanup stops are conditional: between the settle landing and
-      // this command, another client may have re-engaged the thread (a turn
-      // start unsettles it and brings the session alive). Commands are
-      // decided serially against this read model, so checking here — not in
-      // the dispatcher's pre-settle snapshot — closes that race.
-      if (command.onlyIfSettled === true) {
+      if (command.onlyIfIdle === true || command.onlyIfSettled === true) {
         const sessionComingAlive =
           thread.session?.status === "starting" || thread.session?.status === "running";
+        const queuedTurnStart = threadHasQueuedTurnStart(thread, command.createdAt);
+
+        // Reload actions are offered from a client snapshot, but another
+        // client may start a turn before the stop is decided. The decider is
+        // the atomic boundary: whichever command lands first wins without a
+        // stale reload interrupting work that is already in flight.
+        if (command.onlyIfIdle === true && (sessionComingAlive || queuedTurnStart)) {
+          return yield* new OrchestrationCommandInvariantError({
+            commandType: command.type,
+            detail: `thread ${command.threadId} has work in flight; skipping idle-only session stop`,
+          });
+        }
+
+        // Settle-cleanup stops are conditional: between the settle landing
+        // and this command, another client may have re-engaged the thread.
         if (
-          thread.settledOverride !== "settled" ||
-          sessionComingAlive ||
-          threadHasQueuedTurnStart(thread, command.createdAt)
+          command.onlyIfSettled === true &&
+          (thread.settledOverride !== "settled" || sessionComingAlive || queuedTurnStart)
         ) {
           return yield* Effect.fail(
             new OrchestrationCommandInvariantError({

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -4,6 +4,7 @@ import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environ
 import { canCreateProjectInEnvironment } from "@t3tools/client-runtime/operations/projects";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
+import { threadSessionReloadAvailability } from "@t3tools/client-runtime/state/thread-session";
 import {
   canPreloadBrowsePath,
   createBrowseNavigationCoordinator,
@@ -36,6 +37,7 @@ import {
   LinkIcon,
   MessageSquareIcon,
   PaletteIcon,
+  RefreshCwIcon,
   SettingsIcon,
   SquarePenIcon,
   TextSearchIcon,
@@ -57,6 +59,7 @@ import { useAtomValue } from "@effect/atom-react";
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useReloadThreadSession } from "../hooks/useReloadThreadSession";
 import { useClientSettings } from "../hooks/useSettings";
 import { useTheme } from "../hooks/useTheme";
 import { readLocalApi } from "../localApi";
@@ -578,6 +581,7 @@ function OpenCommandPaletteDialog(props: {
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
+  const reloadThreadSession = useReloadThreadSession();
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
@@ -1406,6 +1410,26 @@ function OpenCommandPaletteDialog(props: {
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
       groups: [{ value: "projects", label: "Projects", items: projectThreadItems }],
     });
+  }
+
+  if (activeThread) {
+    const reloadAvailability = threadSessionReloadAvailability(
+      activeThread.session?.status ?? null,
+    );
+    if (reloadAvailability !== "hidden") {
+      actionItems.push({
+        kind: "action",
+        value: "action:reload-agent-session",
+        searchTerms: ["reload agent session", "restart provider", "refresh mcp", "computer use"],
+        title: "Reload agent session",
+        description: "Use current provider and MCP settings on the next message",
+        icon: <RefreshCwIcon className={ITEM_ICON_CLASS} />,
+        disabled: reloadAvailability === "disabled",
+        run: async () => {
+          await reloadThreadSession(scopeThreadRef(activeThread.environmentId, activeThread.id));
+        },
+      });
+    }
   }
 
   actionItems.push({

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -97,6 +97,7 @@ import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore"
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useReloadThreadSession } from "../hooks/useReloadThreadSession";
 import { openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings } from "../hooks/useSettings";
@@ -1610,6 +1611,7 @@ export default function Sidebar() {
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
   });
+  const reloadThreadSession = useReloadThreadSession();
   const { copyToClipboard: copyPathToClipboard } = useCopyToClipboard<{ path: string }>({
     onCopy: ({ path }) => {
       toastManager.add({
@@ -2955,6 +2957,7 @@ export default function Sidebar() {
               isSnoozed,
               canSnoozeNow: canSnooze(thread, { now: new Date().toISOString() }),
               isRegeneratingTitle,
+              sessionStatus: thread.session?.status ?? null,
               supports: {
                 settlement: supportsSettlement,
                 snooze: supportsSnooze,
@@ -3016,6 +3019,10 @@ export default function Sidebar() {
           case "rename":
             startThreadRename(threadRef, thread.title);
             return;
+          case "reload-session": {
+            await reloadThreadSession(threadRef);
+            return;
+          }
           case "regenerate-title": {
             if (isRegeneratingTitle) return;
             const result = await updateThreadMetadata({
@@ -3107,6 +3114,7 @@ export default function Sidebar() {
       projectCwdByKey,
       serverConfigs,
       startThreadRename,
+      reloadThreadSession,
       updateThreadMetadata,
       timestampFormat,
     ],

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -9,6 +9,7 @@ const baseState: ThreadActionMenuState = {
   isSnoozed: false,
   canSnoozeNow: true,
   isRegeneratingTitle: false,
+  sessionStatus: "ready",
   supports: { settlement: true, snooze: true, pinning: true, titleRegeneration: true },
   snoozePresets: [
     { id: "hour", label: "In 1 hour", whenLabel: "3:00 PM", snoozedUntil: "2026-08-07T15:00:00Z" },
@@ -26,7 +27,7 @@ describe("buildThreadActionMenuItems", () => {
         ...baseState,
         supports: { settlement: false, snooze: false, pinning: false, titleRegeneration: false },
       }),
-    ).toEqual(["rename", "mark-unread", "copy-path", "copy-thread-id", "delete"]);
+    ).toEqual(["reload-session", "rename", "mark-unread", "copy-path", "copy-thread-id", "delete"]);
   });
 
   it("includes branch items only for threads with a branch", () => {
@@ -57,6 +58,21 @@ describe("buildThreadActionMenuItems", () => {
       (candidate) => candidate.id === "regenerate-title",
     );
     expect(item).toMatchObject({ label: "Regenerating…", disabled: true });
+  });
+
+  it("offers session reload without interrupting an active turn", () => {
+    const ready = buildThreadActionMenuItems(baseState).find(
+      (candidate) => candidate.id === "reload-session",
+    );
+    expect(ready).toMatchObject({ label: "Reload agent session", disabled: false });
+
+    const running = buildThreadActionMenuItems({ ...baseState, sessionStatus: "running" }).find(
+      (candidate) => candidate.id === "reload-session",
+    );
+    expect(running).toMatchObject({ label: "Reload agent session", disabled: true });
+
+    expect(ids({ ...baseState, sessionStatus: "stopped" })).not.toContain("reload-session");
+    expect(ids({ ...baseState, sessionStatus: null })).not.toContain("reload-session");
   });
 
   it("marks delete as destructive and keeps it last", () => {

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -1,5 +1,6 @@
-import type { ContextMenuItem } from "@t3tools/contracts";
+import type { ContextMenuItem, OrchestrationSessionStatus } from "@t3tools/contracts";
 import type { SnoozePreset } from "@t3tools/client-runtime/state/thread-settled";
+import { threadSessionReloadAvailability } from "@t3tools/client-runtime/state/thread-session";
 
 /**
  * Ids for the per-thread action menu. Snooze presets are dispatched as
@@ -17,6 +18,7 @@ export type ThreadActionMenuId =
   | "unsnooze"
   | "rename"
   | "regenerate-title"
+  | "reload-session"
   | "mark-unread"
   | "copy-path"
   | "copy-branch"
@@ -30,6 +32,7 @@ export interface ThreadActionMenuState {
   readonly isSnoozed: boolean;
   readonly canSnoozeNow: boolean;
   readonly isRegeneratingTitle: boolean;
+  readonly sessionStatus: OrchestrationSessionStatus | null;
   readonly supports: {
     readonly settlement: boolean;
     readonly snooze: boolean;
@@ -47,6 +50,7 @@ export interface ThreadActionMenuState {
 export function buildThreadActionMenuItems(
   state: ThreadActionMenuState,
 ): ReadonlyArray<ContextMenuItem<ThreadActionMenuId>> {
+  const reloadAvailability = threadSessionReloadAvailability(state.sessionStatus);
   return [
     ...(state.branch
       ? [
@@ -86,6 +90,15 @@ export function buildThreadActionMenuItems(
                   label: `${preset.label} (${preset.whenLabel})`,
                 })),
               },
+        ]
+      : []),
+    ...(reloadAvailability !== "hidden"
+      ? [
+          {
+            id: "reload-session" as const,
+            label: "Reload agent session",
+            disabled: reloadAvailability === "disabled",
+          },
         ]
       : []),
     { id: "rename", label: "Rename thread" },

--- a/apps/web/src/hooks/useReloadThreadSession.ts
+++ b/apps/web/src/hooks/useReloadThreadSession.ts
@@ -1,0 +1,65 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import { threadSessionReloadAvailability } from "@t3tools/client-runtime/state/thread-session";
+import { useCallback } from "react";
+
+import { stackedThreadToast, toastManager } from "../components/ui/toast";
+import { readThreadShell } from "../state/entities";
+import { threadEnvironment } from "../state/threads";
+import { useAtomCommand } from "../state/use-atom-command";
+
+export function useReloadThreadSession() {
+  const stopThreadSession = useAtomCommand(threadEnvironment.stopSession, {
+    reportFailure: false,
+  });
+
+  return useCallback(
+    async (threadRef: ScopedThreadRef) => {
+      const availability = threadSessionReloadAvailability(
+        readThreadShell(threadRef)?.session?.status ?? null,
+      );
+      if (availability === "disabled") {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not reload agent session",
+            description: "Wait for the active turn to finish before reloading the session.",
+          }),
+        );
+        return;
+      }
+      if (availability === "hidden") return;
+
+      const result = await stopThreadSession({
+        environmentId: threadRef.environmentId,
+        input: { threadId: threadRef.threadId },
+      });
+      if (result._tag === "Failure") {
+        if (!isAtomCommandInterrupted(result)) {
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not reload agent session",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        }
+        return;
+      }
+
+      toastManager.add(
+        stackedThreadToast({
+          type: "success",
+          title: "Agent session will reload",
+          description:
+            "Your next message will resume this thread with current provider and MCP settings.",
+        }),
+      );
+    },
+    [stopThreadSession],
+  );
+}

--- a/apps/web/src/hooks/useReloadThreadSession.ts
+++ b/apps/web/src/hooks/useReloadThreadSession.ts
@@ -35,7 +35,7 @@ export function useReloadThreadSession() {
 
       const result = await stopThreadSession({
         environmentId: threadRef.environmentId,
-        input: { threadId: threadRef.threadId },
+        input: { threadId: threadRef.threadId, onlyIfIdle: true },
       });
       if (result._tag === "Failure") {
         if (!isAtomCommandInterrupted(result)) {

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -33,6 +33,7 @@ import { readLocalApi } from "../localApi";
 import { useUiStateStore } from "../uiStateStore";
 import { useCopyToClipboard } from "./useCopyToClipboard";
 import { useNewThreadHandler } from "./useHandleNewThread";
+import { useReloadThreadSession } from "./useReloadThreadSession";
 import { useClientSettings } from "./useSettings";
 import { useThreadActions } from "./useThreadActions";
 
@@ -77,6 +78,7 @@ export function useThreadActionMenu(input: {
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
   });
+  const reloadThreadSession = useReloadThreadSession();
   const handleNewThread = useNewThreadHandler();
   const markThreadUnread = useUiStateStore((s) => s.markThreadUnread);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
@@ -137,6 +139,7 @@ export function useThreadActionMenu(input: {
           isSnoozed: supports.snooze && effectiveSnoozed(thread, { now: now.toISOString() }),
           canSnoozeNow: canSnooze(thread, { now: now.toISOString() }),
           isRegeneratingTitle,
+          sessionStatus: thread.session?.status ?? null,
           supports,
           snoozePresets,
         });
@@ -216,6 +219,10 @@ export function useThreadActionMenu(input: {
           case "rename":
             onStartRename();
             return;
+          case "reload-session": {
+            await reloadThreadSession(threadRef);
+            return;
+          }
           case "regenerate-title":
             if (isRegeneratingTitle) return;
             await reportFailure("Failed to regenerate thread title", () =>
@@ -297,6 +304,7 @@ export function useThreadActionMenu(input: {
       projectCwd,
       settleThread,
       snoozeThread,
+      reloadThreadSession,
       threadRef,
       timestampFormat,
       unpinThread,

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -22,3 +22,14 @@ pill** fallback because their colors are not controlled by T3 Code.
 To generate a fresh title from the conversation, open a thread's context menu and choose
 **Regenerate title**. While T3 Code is generating it, the action reads **Regenerating…** and cannot
 be selected again. The option is hidden when the connected environment needs a server update.
+
+## Reload an agent session
+
+Reload a thread's agent session after changing provider configuration, enabling an MCP server, or
+connecting an integration such as Computer Use. On web and desktop, open the thread actions from
+the thread title or sidebar row and choose **Reload agent session**, or run the same action from the
+command palette. On mobile, use the reload button in the thread toolbar.
+
+Reloading stops only that thread's provider process. Your next message resumes the same provider
+conversation with the current configuration; other threads and the T3 Code environment keep
+running. The action is unavailable while a turn is starting or running.

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -143,6 +143,10 @@
       "types": "./src/state/threadSearch.ts",
       "default": "./src/state/threadSearch.ts"
     },
+    "./state/thread-session": {
+      "types": "./src/state/threadSession.ts",
+      "default": "./src/state/threadSession.ts"
+    },
     "./state/vcs": {
       "types": "./src/state/vcs.ts",
       "default": "./src/state/vcs.ts"

--- a/packages/client-runtime/src/operations/commands.test.ts
+++ b/packages/client-runtime/src/operations/commands.test.ts
@@ -108,6 +108,7 @@ describe("environment commands", () => {
         commandId: CommandId.make("queued-command"),
         threadId: ThreadId.make("thread-1"),
         createdAt: "2026-06-06T00:01:00.000Z",
+        onlyIfIdle: true,
       }).pipe(Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor));
 
       expect(dispatched).toEqual([
@@ -116,6 +117,7 @@ describe("environment commands", () => {
           commandId: "queued-command",
           threadId: "thread-1",
           createdAt: "2026-06-06T00:01:00.000Z",
+          onlyIfIdle: true,
         },
       ]);
     }).pipe(Effect.provide(TEST_CRYPTO_LAYER)),

--- a/packages/client-runtime/src/state/threadSession.test.ts
+++ b/packages/client-runtime/src/state/threadSession.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { threadSessionReloadAvailability } from "./threadSession.ts";
+
+describe("threadSessionReloadAvailability", () => {
+  it.each(["idle", "ready", "interrupted", "error"] as const)("allows reload from %s", (status) => {
+    expect(threadSessionReloadAvailability(status)).toBe("available");
+  });
+
+  it.each(["starting", "running"] as const)("protects an active turn in %s", (status) => {
+    expect(threadSessionReloadAvailability(status)).toBe("disabled");
+  });
+
+  it.each([null, "stopped"] as const)("hides reload for %s", (status) => {
+    expect(threadSessionReloadAvailability(status)).toBe("hidden");
+  });
+});

--- a/packages/client-runtime/src/state/threadSession.ts
+++ b/packages/client-runtime/src/state/threadSession.ts
@@ -1,0 +1,11 @@
+import type { OrchestrationSessionStatus } from "@t3tools/contracts";
+
+export type ThreadSessionReloadAvailability = "available" | "disabled" | "hidden";
+
+export function threadSessionReloadAvailability(
+  status: OrchestrationSessionStatus | null,
+): ThreadSessionReloadAvailability {
+  if (status === null || status === "stopped") return "hidden";
+  if (status === "starting" || status === "running") return "disabled";
+  return "available";
+}

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -887,6 +887,9 @@ const ThreadSessionStopCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   createdAt: IsoDateTime,
+  // User-requested reloads must not interrupt work that became active after
+  // the client rendered or dispatched the action.
+  onlyIfIdle: Schema.optional(Schema.Boolean),
   // Settle-cleanup stops are conditional: the decider drops the stop if the
   // thread was re-engaged (unsettled, session starting/running, or a queued
   // turn start) between the settle and this command. Guarding in the decider


### PR DESCRIPTION
## What changed

Provider processes load MCP servers and runtime configuration when they start. Existing threads therefore required a full T3 Code restart to pick up changes such as enabling Computer Use.

This adds **Reload agent session** to thread actions and the command palette on web/desktop, plus thread controls on mobile. It stops only that thread's provider process; the next message starts a new process and resumes the stored provider conversation with current configuration. Other threads and the environment keep running.

Reload reuses the existing stop/resume lifecycle and works across Codex, Claude Code, Cursor, Grok, and OpenCode. An idle-only precondition is checked atomically by the decider, so a stale client cannot interrupt a turn started elsewhere.

Closes #5437.

## Screenshots

| Before | After |
| --- | --- |
| ![Thread actions without reload](https://raw.githubusercontent.com/DavidIlie/t3code/pr-assets-reload-provider-session/before-reload-agent-session.png) | ![Thread actions with Reload agent session](https://raw.githubusercontent.com/DavidIlie/t3code/pr-assets-reload-provider-session/after-reload-agent-session.png) |

## Validation

- 107 focused client, orchestration, reactor, and provider tests passed
- Contracts, client-runtime, web, mobile, and server typechecks passed
- Targeted lint, formatting, and `git diff --check`
- Isolated web pass confirmed reload followed by a successful resumed turn through a fresh provider process

Model: GPT-5.6 Sol · Harness: Codex in T3 Code
