### PR TITLE
fix(web): render dropdowns above toasts

### DIFF
--- a/apps/web/src/components/ui/autocomplete.tsx
+++ b/apps/web/src/components/ui/autocomplete.tsx
@@ -97,7 +97,7 @@ function AutocompletePopup({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="z-50 select-none"
+        className="z-[130] select-none"
         data-slot="autocomplete-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -163,7 +163,7 @@ function ComboboxPopup({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="z-50 select-none"
+        className="z-[130] select-none"
         data-slot="combobox-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -42,7 +42,7 @@ function MenuPopup({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="z-[60]"
+        className="z-[130]"
         data-slot="menu-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -42,7 +42,7 @@ function PopoverPopup({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="z-[60] h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-transform data-instant:transition-none"
+        className="z-[130] h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-transform data-instant:transition-none"
         data-slot="popover-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -132,7 +132,7 @@ function SelectPopup({
         alignItemWithTrigger={alignItemWithTrigger}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="z-50 select-none"
+        className="z-[130] select-none"
         data-slot="select-positioner"
         side={side}
         sideOffset={sideOffset}


### PR DESCRIPTION
## Problem

A toast that arrives while a dropdown is open paints straight over it.

The toast viewport sits at `z-index: 100` (`apps/web/src/components/ui/toast.tsx:562`), while the popup positioners sit well below it:

| layer | before |
|---|---|
| dialog / sheet / command palette | 50 |
| select / combobox / autocomplete | 50 |
| menu / popover | 60 |
| **toast viewport** | **100** |

So every toast outranks every dropdown. The `z-[calc(9999-var(--toast-index))]` on the individual toasts only orders them against each other inside the viewport's stacking context — the viewport's `z-100` is what beats the menu.

It isn't only cosmetic: the toast viewport also takes pointer events, so a click aimed at a covered menu item lands on the toast (or its dismiss button) and fires the wrong thing.

## Fix

Move the five popup positioners to `z-index: 130`.

Toasts keep their place above every ordinary surface, dialogs and sheets included — a toast usually reports the result of something you did inside one. The single exception is now the dropdown the user is actively holding open: that is the focused interaction, while a toast is ambient and dismisses itself a few seconds later. The transient thing should yield to the interactive one.

130 also clears the theme inspector cluster (`index.css:1203` spotlight 100, `:1230` hover 101, `ThemeEditorPanel.tsx:1036` panel 110, `index.css:1213` its popovers 120), so dropdowns opened from the theme editor keep working.

Resulting order: dialog/sheet 50 → toast 100 → theme editor 110/120 → dropdowns 130.

## Before / After

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/Brechard/t3code/assets/dropdowns-above-toasts/before.png" width="420"> | <img src="https://raw.githubusercontent.com/Brechard/t3code/assets/dropdowns-above-toasts/after.png" width="420"> |

The toast covers the editor list and swallows clicks meant for it; afterwards the menu sits on top and the toast tucks in behind.

## Notes

- `select.tsx:146` and `:166` keep their `z-50`. Those are the scroll-up/down arrows inside the popup, scoped to the popup's own stacking context.
- Verified in the running dev app: `[data-slot="menu-positioner"]` computes to `z-index: 130`, and hit-testing a point inside the overlap now returns the menu item rather than the toast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only z-index tweaks on overlay positioners; no logic, auth, or data changes, with a small chance of unexpected overlap with other high z-index UI.
> 
> **Overview**
> **Raises popup stacking** so open dropdowns stay above the toast layer (`z-100`) and remain clickable when a toast appears.
> 
> The positioner `className` on **autocomplete**, **combobox**, **menu**, **popover**, and **select** changes from `z-50` / `z-[60]` to **`z-[130]`**, putting active menus above toasts while still below nothing critical beyond the theme-editor cluster described in the PR. Scroll arrows inside select popups keep their local `z-50`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7649f65eabe5c85cc10e6be0d6dbe0865a0d7870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render dropdowns above toasts by raising z-index to 130
> Increases the `z-index` of positioner elements in autocomplete, combobox, menu, popover, and select components from `z-50`/`z-[60]` to `z-[130]`, ensuring dropdowns render above toast notifications.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7649f65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->