### PR TITLE
fix(ssh): let cold remote servers finish starting

### DIFF
--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -45,6 +45,16 @@ const makeSuccessfulProcess = (stdout: string) => {
   });
 };
 
+const makeDelayedSuccessfulProcess = (stdout: string, delayMs: number) => {
+  const process = makeSuccessfulProcess(stdout);
+  return {
+    ...process,
+    exitCode: Effect.sleep(Duration.millis(delayMs)).pipe(
+      Effect.as(ChildProcessSpawner.ExitCode(0)),
+    ),
+  };
+};
+
 const makeRunningProcess = (onKill: () => void) => {
   let finish: ((exitCode: ChildProcessSpawner.ExitCode) => void) | null = null;
   return ChildProcessSpawner.makeHandle({
@@ -173,6 +183,7 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteLaunchScript(), '--base-dir "$DEFAULT_SERVER_HOME"');
     assert.notInclude(buildRemoteLaunchScript(), "server-home");
     assert.include(buildRemoteLaunchScript(), "Remote T3 server did not become ready");
+    assert.include(buildRemoteLaunchScript(), 'wait_ready "60000"');
     assert.include(buildRemoteLaunchScript({ packageSpec: "t3@nightly" }), "t3@nightly");
     assert.include(
       buildRemotePairingScript(target),
@@ -230,6 +241,29 @@ describe("ssh tunnel scripts", () => {
 
     return Effect.gen(function* () {
       const result = yield* launchOrReuseRemoteServer(target);
+      assert.equal(result.remotePort, 3774);
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("allows cold remote launches to exceed the default SSH command timeout", () => {
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(makeDelayedSuccessfulProcess('{"remotePort":3774}\n', 75_000)),
+    );
+    const spawnerLayer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner);
+    const processLayer = Layer.mergeAll(NodeServices.layer, spawnerLayer, TestClock.layer());
+
+    return Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(launchOrReuseRemoteServer(target));
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust(Duration.seconds(75));
+
+      const result = yield* Fiber.join(fiber);
       assert.equal(result.remotePort, 3774);
     }).pipe(Effect.provide(processLayer));
   });

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -54,7 +54,8 @@ const REMOTE_PORT_SCAN_WINDOW = 200;
 const SSH_READY_TIMEOUT_MS = 20_000;
 const SSH_READY_PROBE_TIMEOUT_MS = 1_000;
 const TUNNEL_SHUTDOWN_TIMEOUT_MS = 2_000;
-const REMOTE_READY_TIMEOUT_MS = 15_000;
+const REMOTE_READY_TIMEOUT_MS = 60_000;
+const REMOTE_LAUNCH_TIMEOUT_MS = 90_000;
 const REMOTE_REUSE_READY_TIMEOUT_MS = 2_000;
 
 export interface RemoteT3RunnerOptions {
@@ -705,6 +706,7 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
     const result = yield* runSshCommand(target, {
       remoteCommandArgs: ["sh", "-s", "--", remoteStateKey(target)],
       stdin: buildRemoteLaunchScript(runner),
+      timeoutMs: REMOTE_LAUNCH_TIMEOUT_MS,
       ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
       ...(input?.batchMode === undefined ? {} : { batchMode: input.batchMode }),
       ...(input?.interactiveAuth === undefined ? {} : { interactiveAuth: input.interactiveAuth }),


### PR DESCRIPTION
Cold SSH environments can spend longer than 15 seconds downloading the T3 CLI and starting the server. The launcher then terminates npm before the server becomes ready, surfacing a misleading SIGTERM failure.

Give remote startup 60 seconds and the surrounding SSH launch command 90 seconds so the readiness window has enough headroom. A focused regression test covers a successful 75-second cold launch.

Fixes #2770.

Verification:
- `vp test run packages/ssh/src`
- `vp run --filter @t3tools/ssh typecheck`
- `vp fmt --check packages/ssh/src/tunnel.ts packages/ssh/src/tunnel.test.ts`

Generated with GPT-5.6 Sol using Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timeout-only changes in SSH remote launch with a focused regression test; no auth or data-path changes.
> 
> **Overview**
> Cold SSH launches were failing because the **remote** readiness window was only 15s while npm/T3 install and boot can take much longer, and the surrounding SSH session could still time out before the launch script finished.
> 
> This raises the embedded `wait_ready` budget to **60s** (`REMOTE_READY_TIMEOUT_MS`) and sets an explicit **90s** `timeoutMs` on the remote launch `runSshCommand` so the client waits longer than the on-host readiness loop. Tests assert the launch script uses `wait_ready "60000"` and add a regression where a **75s** delayed SSH response still returns a valid `remotePort`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a914b8755e7f830f51ae76a54777c90964e990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase SSH remote launch timeout to allow cold remote servers to finish starting
> - Increases `REMOTE_READY_TIMEOUT_MS` from 15s to 60s and adds a new `REMOTE_LAUNCH_TIMEOUT_MS` constant of 90s in [tunnel.ts](https://github.com/pingdotgg/t3code/pull/6168/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072).
> - Passes `REMOTE_LAUNCH_TIMEOUT_MS` as the `timeoutMs` option to `runSshCommand` in `launchOrReuseRemoteServer`, overriding the shorter default SSH command timeout.
> - Adds a test covering a 75-second delayed remote launch using `TestClock` to verify the extended timeout works end-to-end.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87a914b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->