### PR TITLE
fix(web): open diff files from nested projects

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -134,6 +134,9 @@ export default function DiffPanel({
       : null,
   );
   const activeCwd = activeThread?.worktreePath ?? activeProject?.workspaceRoot;
+  const activeRepositoryRoot = activeThread?.worktreePath
+    ? undefined
+    : activeProject?.repositoryIdentity?.rootPath;
   const serverConfig = useAtomValue(
     serverEnvironment.configValueAtom(activeThread?.environmentId ?? null),
   );
@@ -443,6 +446,7 @@ export default function DiffPanel({
         threadRef: routeThreadRef,
         filePath,
         activeCwd,
+        repositoryRoot: activeRepositoryRoot,
         openInEditor: (targetPath) => {
           void (async () => {
             const result = await openInPreferredEditor(targetPath);
@@ -462,7 +466,7 @@ export default function DiffPanel({
         },
       });
     },
-    [activeCwd, openInPreferredEditor, routeThreadRef],
+    [activeCwd, activeRepositoryRoot, openInPreferredEditor, routeThreadRef],
   );
   const toggleDiffFileCollapsed = useCallback(
     (fileKey: string) => {

--- a/apps/web/src/diffFileActions.test.ts
+++ b/apps/web/src/diffFileActions.test.ts
@@ -2,7 +2,7 @@ import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { openDiffFilePrimaryAction } from "./diffFileActions";
+import { openDiffFilePrimaryAction, resolveDiffPathForWorkspace } from "./diffFileActions";
 import { selectThreadRightPanelState, useRightPanelStore } from "./rightPanelStore";
 
 const THREAD_REF = scopeThreadRef(
@@ -48,4 +48,77 @@ describe("openDiffFilePrimaryAction", () => {
       "/repo/project/apps/web/src/components/DiffPanel.tsx",
     );
   });
+
+  it("opens repository-relative diff files from a nested project", () => {
+    const openInEditor = vi.fn();
+
+    openDiffFilePrimaryAction({
+      threadRef: THREAD_REF,
+      filePath: "frontend/Dockerfile",
+      activeCwd: "/repo/frontend",
+      repositoryRoot: "/repo",
+      openInEditor,
+    });
+
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, THREAD_REF),
+    ).toMatchObject({
+      isOpen: true,
+      activeSurfaceId: "file:Dockerfile",
+    });
+    expect(openInEditor).not.toHaveBeenCalled();
+  });
+
+  it("preserves repository-relative paths in a separate worktree", () => {
+    expect(
+      resolveDiffPathForWorkspace({
+        filePath: "frontend/Dockerfile",
+        workspaceRoot: "/worktrees/feature",
+        repositoryRoot: "/repo",
+      }),
+    ).toBe("frontend/Dockerfile");
+  });
+
+  it("handles Windows roots and mixed diff separators", () => {
+    expect(
+      resolveDiffPathForWorkspace({
+        filePath: "Frontend/src\\index.ts",
+        workspaceRoot: "C:\\repo\\frontend",
+        repositoryRoot: "C:\\repo",
+      }),
+    ).toBe("src/index.ts");
+  });
+
+  it.each([
+    { workspaceRoot: "/frontend", repositoryRoot: "/" },
+    { workspaceRoot: "C:\\frontend", repositoryRoot: "C:\\" },
+  ])("handles filesystem roots: $repositoryRoot", ({ workspaceRoot, repositoryRoot }) => {
+    expect(
+      resolveDiffPathForWorkspace({
+        filePath: "frontend/index.ts",
+        workspaceRoot,
+        repositoryRoot,
+      }),
+    ).toBe("index.ts");
+  });
+
+  it.each(["backend/server.ts", "frontend2/app.ts", "frontend/../secret.ts", "C:secret.ts"])(
+    "does not open an out-of-project diff path: %s",
+    (filePath) => {
+      const openInEditor = vi.fn();
+
+      openDiffFilePrimaryAction({
+        threadRef: THREAD_REF,
+        filePath,
+        activeCwd: "/repo/frontend",
+        repositoryRoot: "/repo",
+        openInEditor,
+      });
+
+      expect(
+        selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, THREAD_REF),
+      ).toMatchObject({ isOpen: false });
+      expect(openInEditor).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/web/src/diffFileActions.ts
+++ b/apps/web/src/diffFileActions.ts
@@ -1,4 +1,5 @@
 import type { ScopedThreadRef } from "@t3tools/contracts";
+import { isWindowsAbsolutePath, normalizeProjectPathForComparison } from "@t3tools/shared/path";
 
 import { useRightPanelStore } from "./rightPanelStore";
 import { resolvePathLinkTarget } from "./terminal-links";
@@ -7,19 +8,93 @@ interface OpenDiffFilePrimaryActionInput {
   readonly threadRef: ScopedThreadRef | null;
   readonly filePath: string;
   readonly activeCwd: string | undefined;
+  readonly repositoryRoot?: string | undefined;
   readonly openInEditor: (targetPath: string) => void;
+}
+
+function normalizedRelativePathSegments(filePath: string): ReadonlyArray<string> | null {
+  if (filePath.startsWith("/") || isWindowsAbsolutePath(filePath) || /^[a-zA-Z]:/.test(filePath)) {
+    return null;
+  }
+
+  const segments = filePath
+    .replaceAll("\\", "/")
+    .split("/")
+    .filter((segment) => segment.length > 0 && segment !== ".");
+  if (segments.length === 0 || segments.includes("..")) return null;
+  return segments;
+}
+
+function repositoryRelativeWorkspaceSegments(
+  workspaceRoot: string | undefined,
+  repositoryRoot: string | undefined,
+): ReadonlyArray<string> | null {
+  if (!workspaceRoot || !repositoryRoot) return null;
+
+  const normalizedWorkspaceRoot = normalizeProjectPathForComparison(workspaceRoot);
+  const normalizedRepositoryRoot = normalizeProjectPathForComparison(repositoryRoot);
+  if (normalizedWorkspaceRoot === normalizedRepositoryRoot) return [];
+
+  const separator = normalizedRepositoryRoot.includes("\\") ? "\\" : "/";
+  const repositoryPrefix = normalizedRepositoryRoot.endsWith(separator)
+    ? normalizedRepositoryRoot
+    : `${normalizedRepositoryRoot}${separator}`;
+  if (!normalizedWorkspaceRoot.startsWith(repositoryPrefix)) return null;
+
+  return normalizedWorkspaceRoot
+    .slice(repositoryPrefix.length)
+    .split(/[\\/]+/)
+    .filter(Boolean);
+}
+
+export function resolveDiffPathForWorkspace(input: {
+  readonly filePath: string;
+  readonly workspaceRoot: string | undefined;
+  readonly repositoryRoot: string | undefined;
+}): string | null {
+  const fileSegments = normalizedRelativePathSegments(input.filePath);
+  if (!fileSegments) return null;
+
+  const workspaceSegments = repositoryRelativeWorkspaceSegments(
+    input.workspaceRoot,
+    input.repositoryRoot,
+  );
+  if (!workspaceSegments || workspaceSegments.length === 0) {
+    return fileSegments.join("/");
+  }
+
+  const caseInsensitive = input.repositoryRoot
+    ? isWindowsAbsolutePath(input.repositoryRoot)
+    : false;
+  const belongsToWorkspace = workspaceSegments.every((segment, index) => {
+    const candidate = fileSegments[index];
+    if (candidate === undefined) return false;
+    return caseInsensitive ? candidate.toLowerCase() === segment : candidate === segment;
+  });
+  if (!belongsToWorkspace) return null;
+
+  const relativeSegments = fileSegments.slice(workspaceSegments.length);
+  return relativeSegments.length > 0 ? relativeSegments.join("/") : null;
 }
 
 export function openDiffFilePrimaryAction({
   threadRef,
   filePath,
   activeCwd,
+  repositoryRoot,
   openInEditor,
 }: OpenDiffFilePrimaryActionInput): void {
+  const workspaceFilePath = resolveDiffPathForWorkspace({
+    filePath,
+    workspaceRoot: activeCwd,
+    repositoryRoot,
+  });
+  if (!workspaceFilePath) return;
+
   if (threadRef) {
-    useRightPanelStore.getState().openFile(threadRef, filePath);
+    useRightPanelStore.getState().openFile(threadRef, workspaceFilePath);
     return;
   }
 
-  openInEditor(activeCwd ? resolvePathLinkTarget(filePath, activeCwd) : filePath);
+  openInEditor(activeCwd ? resolvePathLinkTarget(workspaceFilePath, activeCwd) : workspaceFilePath);
 }


### PR DESCRIPTION
Projects nested inside a Git repository receive repository-relative diff paths, but the file viewer reads paths from the project root. Clicking `frontend/Dockerfile` from a `frontend` project therefore tries to open `frontend/frontend/Dockerfile`.

Diff paths are now translated to the active workspace before opening. Paths outside the configured project stay closed, Windows separators are handled, and separate worktrees retain their repository-relative paths.

Fixes #6166

Tests:
- `pnpm exec vp test run apps/web/src/diffFileActions.test.ts`
- `pnpm --filter @t3tools/web typecheck`

Generated with GPT-5.6 Sol in T3 Code's Codex harness, with a focused GPT-5.6 Terra review through Pi.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized diff-click handling with explicit rejection of out-of-project paths; no auth or data-layer changes.
> 
> **Overview**
> Fixes diff file clicks for **projects nested inside a Git repo**: Git reports paths like `frontend/Dockerfile`, but the in-app file viewer expects paths relative to the project root, which previously produced doubled paths (e.g. `frontend/frontend/Dockerfile`).
> 
> **`resolveDiffPathForWorkspace`** strips the workspace’s prefix under the repository root before opening in the right panel or external editor. Paths that don’t belong to the active project are ignored; separate worktrees keep full repo-relative paths when workspace isn’t under the main repo root. **Windows** separators and case-insensitive matching are handled.
> 
> **`DiffPanel`** supplies `repositoryRoot` from the project (skipped when the thread uses a worktree).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f074a32f79514b59232742d783ddd448fd5ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix diff file opening for nested projects in `DiffPanel`
> - Adds `resolveDiffPathForWorkspace` in [`diffFileActions.ts`](https://github.com/pingdotgg/t3code/pull/6174/files#diff-78d51000cb5eeb768ed6637ce82c8c342215d4f7836c8fc76b794f84154d017a) to validate and normalize diff file paths against the workspace root, supporting Windows paths and mixed separators.
> - `openDiffFilePrimaryAction` now early-returns when a diff path is invalid, absolute, or outside the current workspace; valid paths use a workspace-relative path when opening the right panel or external editor.
> - `DiffPanel` derives a `repositoryRoot` from the active project and forwards it to `openDiffFilePrimaryAction` so repository-relative paths can be resolved correctly for nested projects.
> - Behavioral Change: diff files whose paths do not resolve within the active workspace now silently no-op instead of attempting to open.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8f074a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->