### PR TITLE
fix(shared): match source-control providers by DNS label

### DIFF
--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -75,4 +75,33 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
       baseUrl: "https://self-hosted.example.test:8443",
     });
   });
+
+  it("matches self-hosted providers by complete DNS labels", () => {
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://github.example.com/owner/repo.git")?.kind,
+    ).toBe("github");
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://gitlab.example.com/group/repo.git")?.kind,
+    ).toBe("gitlab");
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://bitbucket.example.com/workspace/repo.git")
+        ?.kind,
+    ).toBe("bitbucket");
+  });
+
+  it("does not match provider names embedded in unrelated DNS labels", () => {
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://notgithub.example.com/owner/repo.git")
+        ?.kind,
+    ).toBe("unknown");
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://notgitlab.example.com/group/repo.git")
+        ?.kind,
+    ).toBe("unknown");
+    expect(
+      detectSourceControlProviderFromRemoteUrl(
+        "https://notbitbucket.example.com/workspace/repo.git",
+      )?.kind,
+    ).toBe("unknown");
+  });
 });

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -167,12 +167,16 @@ function toBaseUrl(host: string): string {
   return `https://${host}`;
 }
 
+function hasDnsLabel(host: string, label: string): boolean {
+  return host.split(".").includes(label);
+}
+
 function isGitHubHost(host: string): boolean {
-  return host === "github.com" || host.includes("github");
+  return host === "github.com" || hasDnsLabel(host, "github");
 }
 
 function isGitLabHost(host: string): boolean {
-  return host === "gitlab.com" || host.includes("gitlab");
+  return host === "gitlab.com" || hasDnsLabel(host, "gitlab");
 }
 
 function isAzureDevOpsHost(host: string): boolean {
@@ -180,7 +184,7 @@ function isAzureDevOpsHost(host: string): boolean {
 }
 
 function isBitbucketHost(host: string): boolean {
-  return host === "bitbucket.org" || host.includes("bitbucket");
+  return host === "bitbucket.org" || hasDnsLabel(host, "bitbucket");
 }
 
 export function detectSourceControlProviderFromRemoteUrl(


### PR DESCRIPTION
An unrelated Git host such as `notgithub.example.com` is currently treated as GitHub because provider detection uses substring matching.

Provider names now have to appear as complete DNS labels. This keeps self-hosted names such as `github.company.com` working while leaving embedded names unknown.

Fixes #5932

Tests:
- `pnpm exec vp test run packages/shared/src/sourceControl.test.ts`
- `pnpm --filter @t3tools/shared typecheck`

Generated with GPT-5.6 Sol in T3 Code's Codex harness, with a focused GPT-5.6 Luna review through Pi.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to hostname heuristics in shared detection logic; behavior becomes more accurate with no auth or data-path changes.
> 
> **Overview**
> **Fixes misclassification of Git remotes** where hosts like `notgithub.example.com` were treated as GitHub/GitLab/Bitbucket because provider checks used substring matching on the hostname.
> 
> Provider detection for GitHub, GitLab, and Bitbucket now uses a **`hasDnsLabel` helper** that requires the provider name to appear as a **full DNS label** (dot-separated segment), while still recognizing official domains (`github.com`, etc.) and self-hosted patterns such as `github.example.com`. **Tests** cover both self-hosted label matches and embedded-name false positives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88108cc43e0c018089319a561de784a5c1c30569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix source-control provider detection to match by full DNS label
> Replaces substring checks (`host.includes(...)`) with a new `hasDnsLabel` helper that splits the host on `.` and checks for an exact label match. This prevents hosts like `notgithub.example.com` from being misclassified as GitHub, while still matching self-hosted instances like `github.example.com`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88108cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->