### PR TITLE
fix(mobile): guard App Store release versions

### DIFF
--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -45,7 +45,7 @@ on:
           - android
           - all
       version:
-        description: "For build mode, type the version from app.config.ts (it must be newer than the approved App Store version)"
+        description: "Optional build version override (blank uses app.config.ts; an override is committed before building)"
         required: false
         type: string
       message:
@@ -95,11 +95,21 @@ jobs:
             echo "EXPO_TOKEN is not available; skipping EAS production job."
           fi
 
+      - id: version_app_token
+        name: Mint release app token for version override
+        if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build' && inputs.version != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout
         if: steps.expo-token.outputs.present == 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.version_app_token.outputs.token || github.token }}
           # No sparse-checkout here: it makes actions/checkout fetch with
           # --filter=blob:none, and eas-cli archives the project via
           # `git clone --depth 1 file://<workspace>`, which fails (exit 128)
@@ -141,11 +151,54 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: eas env:pull production --non-interactive
 
-      - name: Confirm manual build version
+      - name: Apply manual version override
+        if: steps.version_app_token.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.version_app_token.outputs.token }}
+          APP_SLUG: ${{ steps.version_app_token.outputs.app-slug }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$GITHUB_REF_TYPE" != "branch" ]; then
+            echo "Version overrides require dispatching this workflow from a branch; received $GITHUB_REF_TYPE '$GITHUB_REF_NAME'." >&2
+            exit 1
+          fi
+          if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+            echo "Version override must contain two or three dot-separated integers; received '$RELEASE_VERSION'." >&2
+            exit 1
+          fi
+
+          node --input-type=module -e '
+            import fs from "node:fs";
+            const path = "apps/mobile/app.config.ts";
+            const source = fs.readFileSync(path, "utf8");
+            const next = source.replace(
+              /^(  version: ")[^"]+(".*)$/m,
+              `$1${process.env.RELEASE_VERSION}$2`,
+            );
+            if (next === source && !source.includes(`  version: "${process.env.RELEASE_VERSION}"`)) {
+              throw new Error("Could not update app version");
+            }
+            fs.writeFileSync(path, next);
+          '
+          vp fmt apps/mobile/app.config.ts
+
+          if git diff --quiet -- apps/mobile/app.config.ts; then
+            echo "app.config.ts is already at $RELEASE_VERSION; no version commit needed."
+            exit 0
+          fi
+
+          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git add apps/mobile/app.config.ts
+          git commit \
+            -m "chore(mobile): bump app version to $RELEASE_VERSION" \
+            -m "Co-authored-by: codex <codex@users.noreply.github.com>"
+          git push origin "HEAD:refs/heads/${GITHUB_REF_NAME}"
+
+      - name: Summarize manual build version
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build'
         working-directory: apps/mobile
-        env:
-          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           version="$(npx expo config --json --type public | jq -r '.version')"
           {
@@ -156,21 +209,13 @@ jobs:
             echo
             echo "> Apple closes an iOS release train after App Store approval. Before building iOS, confirm \`$version\` is newer than the approved App Store version."
           } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$REQUESTED_VERSION" != "$version" ]; then
-            echo "Version confirmation must exactly match app.config.ts ($version); received '${REQUESTED_VERSION:-<empty>}'." >&2
-            exit 1
-          fi
 
       - name: Build and submit (manual)
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build'
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        # Run submit explicitly with --wait so an App Store rejection (for
-        # example, a closed marketing-version train) fails this workflow.
-        run: |
-          eas build --platform ${{ inputs.platform }} --profile production --non-interactive
-          eas submit --platform ${{ inputs.platform }} --profile production --latest --wait --non-interactive
+        run: eas build --platform ${{ inputs.platform }} --profile production --auto-submit --non-interactive --no-wait
 
       - name: Publish OTA update (manual)
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'update'
@@ -187,10 +232,8 @@ jobs:
 
       # No --status filter on build:list: an in-queue/in-progress build must
       # count as existing, or every merge during the build window would cut a
-      # duplicate. Builds started here stay attached to this serialized run so
-      # the queued run for a later merge cannot overtake them and lose its OTA.
-      # After an errored build, retry via workflow_dispatch mode=build — pushes
-      # won't re-trigger it until the app version changes.
+      # duplicate. After an errored build, retry via workflow_dispatch
+      # mode=build — pushes won't re-trigger it until the app version changes.
       - id: store_builds
         name: Ensure store builds exist for the current app version
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'push'
@@ -208,9 +251,8 @@ jobs:
               continue
             fi
             echo "$platform: latest production build is $latest, app.config.ts says $version — building"
-            if eas build --platform "$platform" --profile production --non-interactive && \
-              eas submit --platform "$platform" --profile production --latest --wait --non-interactive; then
-              echo ":building_construction: $platform: cut and submitted production build for $version" >> "$GITHUB_STEP_SUMMARY"
+            if eas build --platform "$platform" --profile production --auto-submit --non-interactive --no-wait; then
+              echo ":building_construction: $platform: scheduled production build and submission for $version" >> "$GITHUB_STEP_SUMMARY"
             else
               failed=1
               echo ":x: $platform: production build or submission failed for $version" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -8,12 +8,14 @@ name: Mobile EAS Production
 #
 # Every merge to main that touches the mobile app reconciles, per platform:
 #   1. Store builds: if the latest production build's version differs from
-#      app.config.ts, cut a new build with --auto-submit (TestFlight +
-#      Play internal track). Bumping `version` is therefore all it takes to
+#      app.config.ts, cut a new build and submit it (TestFlight + Play internal
+#      track). Bumping `version` is therefore all it takes to
 #      start the next release train — the first build of a version enters
 #      external-TestFlight beta review immediately, and later builds of the
-#      same version auto-approve. Releasing to the App Store stays a manual
-#      App Store Connect step.
+#      same version auto-approve until that version is released. After App
+#      Store approval, Apple closes the release train and `version` must be
+#      bumped before another iOS build can be submitted. Releasing to the App
+#      Store stays a manual App Store Connect step.
 #   2. OTA: publish a production-channel update for each platform where at
 #      least one finished production build matches the current native
 #      fingerprint. Old-version binaries with a matching fingerprint receive
@@ -42,6 +44,10 @@ on:
           - ios
           - android
           - all
+      version:
+        description: "For build mode, type the version from app.config.ts (it must be newer than the approved App Store version)"
+        required: false
+        type: string
       message:
         description: "OTA update message (mode=update only)"
         required: false
@@ -135,12 +141,36 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: eas env:pull production --non-interactive
 
+      - name: Confirm manual build version
+        if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build'
+        working-directory: apps/mobile
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          version="$(npx expo config --json --type public | jq -r '.version')"
+          {
+            echo "## Manual production build"
+            echo
+            echo "- App version: \`$version\`"
+            echo "- Platform: \`${{ inputs.platform }}\`"
+            echo
+            echo "> Apple closes an iOS release train after App Store approval. Before building iOS, confirm \`$version\` is newer than the approved App Store version."
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$REQUESTED_VERSION" != "$version" ]; then
+            echo "Version confirmation must exactly match app.config.ts ($version); received '${REQUESTED_VERSION:-<empty>}'." >&2
+            exit 1
+          fi
+
       - name: Build and submit (manual)
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build'
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: eas build --platform ${{ inputs.platform }} --profile production --auto-submit --non-interactive --no-wait
+        # Run submit explicitly with --wait so an App Store rejection (for
+        # example, a closed marketing-version train) fails this workflow.
+        run: |
+          eas build --platform ${{ inputs.platform }} --profile production --non-interactive
+          eas submit --platform ${{ inputs.platform }} --profile production --latest --wait --non-interactive
 
       - name: Publish OTA update (manual)
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'update'
@@ -178,8 +208,9 @@ jobs:
               continue
             fi
             echo "$platform: latest production build is $latest, app.config.ts says $version — building"
-            if eas build --platform "$platform" --profile production --auto-submit --non-interactive; then
-              echo ":building_construction: $platform: cut production build for $version (auto-submitted)" >> "$GITHUB_STEP_SUMMARY"
+            if eas build --platform "$platform" --profile production --non-interactive && \
+              eas submit --platform "$platform" --profile production --latest --wait --non-interactive; then
+              echo ":building_construction: $platform: cut and submitted production build for $version" >> "$GITHUB_STEP_SUMMARY"
             else
               failed=1
               echo ":x: $platform: production build or submission failed for $version" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -161,7 +161,7 @@ const config: ExpoConfig = {
   slug: "t3-code",
   platforms: ["ios", "android"],
   scheme: variant.scheme,
-  version: "1.0.2",
+  version: "1.0.3",
   runtimeVersion: {
     // Fingerprint (not appVersion) so an OTA only reaches binaries whose native
     // project — native deps, config plugins, AND patches/ — matches the update.


### PR DESCRIPTION
## Problem

Apple rejected a production iOS submission because version `1.0.2` had already been approved and its release train was closed. EAS increments the developer-facing build number, but does not increment the user-facing marketing version.

## Fix

- Bump the checked-in mobile marketing version to `1.0.3`.
- Default manual production builds to the version already in `app.config.ts`.
- Add an optional workflow version override; when supplied, validate it, update and format `app.config.ts`, commit it through the release GitHub App, and push it to the dispatched branch before scheduling EAS.
- Explain closed App Store release trains in the run summary and workflow documentation.
- Keep EAS builds asynchronous with `--auto-submit --no-wait`, avoiding Blacksmith runner usage while EAS builds Android and iOS.

## Impact

The next production binaries use a valid App Store version. Routine manual builds require no version input, while a release operator can intentionally start a new version train from the workflow without preparing a separate version-bump commit.

## Validation

- Production Expo config reports `1.0.3`
- Version override transformation check
- Mobile TypeScript check
- Mobile native static lint
- Project lint
- Workflow and app-config formatting
- Git diff validation

Implemented with Codex (GPT-5) in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production mobile release automation and commits version bumps via a GitHub App; mistakes could cut wrong store binaries or miss submission failures because builds still use async `--auto-submit --no-wait`.
> 
> **Overview**
> Bumps the Expo marketing version in `app.config.ts` from **1.0.2** to **1.0.3** so the next store binaries use a fresh App Store version after a closed release train.
> 
> Extends **manual** `workflow_dispatch` production builds with an optional **version** input: when set, the workflow mints a release GitHub App token, rewrites `apps/mobile/app.config.ts`, formats, and commits/pushes the bump to the dispatch branch before building. Manual build runs also write a job summary that shows the resolved app version and warns that iOS needs a version newer than what Apple has already approved.
> 
> On **push** auto store builds, `eas build` now passes **`--no-wait`** (same as manual), so CI schedules build+auto-submit asynchronously and summarizes “scheduled” instead of blocking on completion. Workflow comments document that Apple closes an iOS release train after App Store approval and that `version` must be bumped before another iOS submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d39fe666850a45ff07e1a53e38d40777337633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard App Store release versions with a manual version override in the mobile EAS production workflow
> - Adds a `version` input to the `workflow_dispatch` trigger in [mobile-eas-production.yml](.github/workflows/mobile-eas-production.yml); when provided, the workflow validates the version format, commits a version bump to [app.config.ts](apps/mobile/app.config.ts), and pushes the change before building.
> - Mints a GitHub App token (via `actions/create-github-app-token`) on manual dispatch with a version override so the workflow can commit and push to the branch.
> - Both manual and push-triggered EAS builds now run with `--no-wait`, making the build submission non-blocking.
> - Bumps the app version in [app.config.ts](apps/mobile/app.config.ts) from `1.0.2` to `1.0.3`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8d39fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->