### PR TITLE
fix(server): support Bedrock Codex model slugs

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -21,11 +21,18 @@
  *
  * @module provider/Drivers/CodexDriver
  */
-import { CodexSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import {
+  CodexSettings,
+  ProviderDriverKind,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -149,26 +156,31 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         env: processEnv,
       });
 
-      // `makeCodexAdapter` and `makeCodexTextGeneration` have `never` error
-      // channels at construction time — their failure modes are all on the
-      // per-operation closures they return. No `mapError` wrapper is needed
-      // here; the registry only has to worry about snapshot-build and
-      // spawner-availability failures surfaced from `checkCodexProviderStatus`
-      // below.
+      // `makeCodexAdapter` has a `never` error channel at construction time;
+      // its failure modes are all on the per-operation closures it returns.
       const adapter = yield* makeCodexAdapter(effectiveConfig, {
         instanceId,
         environment: processEnv,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       });
-      const textGeneration = yield* makeCodexTextGeneration(effectiveConfig, processEnv);
 
       // Build a managed snapshot whose settings never change — mutations come
       // in as instance rebuilds from the registry rather than in-place
       // updates. Pre-provide `ChildProcessSpawner` so the check fits
       // `makeManagedServerProvider.checkProvider`'s `R = never`.
+      // Text generation waits for the first probe attempt, then reads the
+      // latest successful built-in catalog without blocking later operations.
+      const modelCatalog = yield* Ref.make<ReadonlyArray<ServerProviderModel>>([]);
+      const modelCatalogReady = yield* Deferred.make<void>();
       const checkProvider = checkCodexProviderStatus(effectiveConfig, undefined, processEnv).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.tap((provider) =>
+          provider.models.some((model) => !model.isCustom)
+            ? Ref.set(modelCatalog, provider.models)
+            : Effect.void,
+        ),
+        Effect.ensuring(Deferred.succeed(modelCatalogReady, undefined).pipe(Effect.asVoid)),
       );
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CodexSettings>>({
@@ -196,6 +208,11 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
               cause,
             }),
         ),
+      );
+      const textGeneration = yield* makeCodexTextGeneration(
+        effectiveConfig,
+        processEnv,
+        Deferred.await(modelCatalogReady).pipe(Effect.andThen(Ref.get(modelCatalog))),
       );
 
       return {

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -4,21 +4,40 @@ import {
   applyPreferredCodexDefaultModel,
   isLegacyCodexModel,
   mapCodexModelCapabilities,
+  resolveCodexCatalogModelSlug,
 } from "./CodexProvider.ts";
 
-it("keeps only the GPT-5.6 Codex family out of legacy models", () => {
+it("keeps provider-qualified GPT-5.6 Codex models out of legacy models", () => {
   assert.deepStrictEqual(
-    ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.4"].map((model) => [
-      model,
-      isLegacyCodexModel(model),
-    ]),
+    ["gpt-5.6-luna", "openai.gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.4"].map(
+      (model) => [model, isLegacyCodexModel(model)],
+    ),
     [
       ["gpt-5.6-luna", false],
+      ["openai.gpt-5.6-luna", false],
       ["gpt-5.6-terra", false],
       ["gpt-5.6-sol", false],
       ["gpt-5.4", true],
     ],
   );
+});
+
+it("resolves an unqualified model through the live Bedrock catalog", () => {
+  const models = [
+    {
+      slug: "openai.gpt-5.6-luna",
+      name: "GPT-5.6-Luna",
+      isCustom: false,
+      capabilities: null,
+    },
+  ];
+
+  assert.strictEqual(resolveCodexCatalogModelSlug("gpt-5.6-luna", models), "openai.gpt-5.6-luna");
+  assert.strictEqual(
+    resolveCodexCatalogModelSlug("openai.gpt-5.6-luna", models),
+    "openai.gpt-5.6-luna",
+  );
+  assert.strictEqual(resolveCodexCatalogModelSlug("custom-model", models), "custom-model");
 });
 
 it("maps current Codex model capability fields", () => {
@@ -144,6 +163,25 @@ it("prefers sol over terra when both are available", () => {
   ]);
 
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.6-sol");
+});
+
+it("preserves a provider-qualified preferred default slug", () => {
+  const models = applyPreferredCodexDefaultModel([
+    {
+      slug: "openai.gpt-5.6-terra",
+      name: "GPT-5.6-Terra",
+      isCustom: false,
+      capabilities: null,
+    },
+    {
+      slug: "openai.gpt-5.6-sol",
+      name: "GPT-5.6-Sol",
+      isCustom: false,
+      capabilities: null,
+    },
+  ]);
+
+  assert.strictEqual(models.find((model) => model.isDefault)?.slug, "openai.gpt-5.6-sol");
 });
 
 it("keeps Codex's own default when no preferred model is available", () => {

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -63,9 +63,33 @@ const REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
 
 const DEFAULT_SERVICE_TIER_ID = "default";
 const CURRENT_CODEX_MODELS = new Set(["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]);
+const CODEX_BEDROCK_MODEL_PREFIX = "openai.";
+
+function codexBaseModelSlug(model: string): string {
+  return model.startsWith(CODEX_BEDROCK_MODEL_PREFIX)
+    ? model.slice(CODEX_BEDROCK_MODEL_PREFIX.length)
+    : model;
+}
 
 export function isLegacyCodexModel(model: string): boolean {
-  return !CURRENT_CODEX_MODELS.has(model);
+  return !CURRENT_CODEX_MODELS.has(codexBaseModelSlug(model));
+}
+
+export function resolveCodexCatalogModelSlug(
+  requestedModel: string,
+  models: ReadonlyArray<ServerProviderModel>,
+): string {
+  const exactMatch = models.find((model) => model.slug === requestedModel);
+  if (exactMatch) {
+    return exactMatch.slug;
+  }
+  if (requestedModel.startsWith(CODEX_BEDROCK_MODEL_PREFIX)) {
+    return requestedModel;
+  }
+  return (
+    models.find((model) => !model.isCustom && codexBaseModelSlug(model.slug) === requestedModel)
+      ?.slug ?? requestedModel
+  );
 }
 
 function reasoningEffortLabel(reasoningEffort: string): string {
@@ -207,14 +231,17 @@ function parseCodexModelListResponse(
 export function applyPreferredCodexDefaultModel(
   models: ReadonlyArray<ServerProviderModel>,
 ): ReadonlyArray<ServerProviderModel> {
-  const preferredSlug = PREFERRED_DEFAULT_CODEX_MODELS.find((slug) =>
-    models.some((model) => model.slug === slug && !model.isCustom),
-  );
-  if (!preferredSlug) {
+  const preferredModel = PREFERRED_DEFAULT_CODEX_MODELS.flatMap((preferredSlug) => {
+    const model = models.find(
+      (candidate) => !candidate.isCustom && codexBaseModelSlug(candidate.slug) === preferredSlug,
+    );
+    return model ? [model] : [];
+  })[0];
+  if (!preferredModel) {
     return models;
   }
   return models.map((model) => {
-    if (model.slug === preferredSlug) {
+    if (model.slug === preferredModel.slug) {
       return model.isDefault ? model : { ...model, isDefault: true };
     }
     if (!model.isDefault) {

--- a/apps/server/src/textGeneration/CodexTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.test.ts
@@ -9,7 +9,12 @@ import * as Schema from "effect/Schema";
 import { createModelSelection } from "@t3tools/shared/model";
 import { expect } from "vite-plus/test";
 
-import { CodexSettings, ProviderInstanceId, TextGenerationError } from "@t3tools/contracts";
+import {
+  CodexSettings,
+  ProviderInstanceId,
+  type ServerProviderModel,
+  TextGenerationError,
+} from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
 import * as TextGeneration from "./TextGeneration.ts";
@@ -191,6 +196,7 @@ function withFakeCodexEnv<A, E, R>(
     stdinMustNotContain?: string;
     launchArgs?: string;
     environment?: NodeJS.ProcessEnv;
+    modelCatalog?: ReadonlyArray<ServerProviderModel>;
   },
   effectFn: (textGeneration: TextGeneration.TextGeneration["Service"]) => Effect.Effect<A, E, R>,
 ) {
@@ -199,7 +205,11 @@ function withFakeCodexEnv<A, E, R>(
     const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-codex-text-" });
     const codexPath = yield* makeFakeCodexBinary(tempDir, input);
     const config = decodeCodexSettings({ binaryPath: codexPath, launchArgs: input.launchArgs });
-    const textGeneration = yield* makeCodexTextGeneration(config, input.environment);
+    const textGeneration = yield* makeCodexTextGeneration(
+      config,
+      input.environment,
+      Effect.succeed(input.modelCatalog ?? []),
+    );
     return yield* effectFn(textGeneration);
   }).pipe(Effect.scoped);
 }
@@ -301,6 +311,30 @@ it.layer(CodexTextGenerationTestLayer)("CodexTextGeneration", (it) => {
           stagedSummary: "M README.md",
           stagedPatch: "diff --git a/README.md b/README.md",
           modelSelection: DEFAULT_TEST_MODEL_SELECTION,
+        }),
+    ),
+  );
+
+  it.effect("uses the provider-qualified model slug from the live Codex catalog", () =>
+    withFakeCodexEnv(
+      {
+        output: JSON.stringify({ title: "Bedrock model resolution" }),
+        requireArg: "openai.gpt-5.6-luna",
+        forbidArg: "gpt-5.6-luna",
+        modelCatalog: [
+          {
+            slug: "openai.gpt-5.6-luna",
+            name: "GPT-5.6-Luna",
+            isCustom: false,
+            capabilities: null,
+          },
+        ],
+      },
+      (textGeneration) =>
+        textGeneration.generateThreadTitle({
+          cwd: process.cwd(),
+          message: "Resolve this background generation model.",
+          modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.6-luna"),
         }),
     ),
   );

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -11,6 +11,7 @@ import {
   type CodexSettings,
   DEFAULT_TEXT_GENERATION_REASONING_EFFORT,
   type ModelSelection,
+  type ServerProviderModel,
   TextGenerationError,
 } from "@t3tools/contracts";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
@@ -20,6 +21,7 @@ import { resolveAttachmentPath } from "../attachmentStore.ts";
 import * as ServerConfig from "../config.ts";
 import { expandHomePath } from "../pathExpansion.ts";
 import { codexExecLaunchArgs, resolveCodexLaunchArgs } from "../provider/Layers/codexLaunchArgs.ts";
+import { resolveCodexCatalogModelSlug } from "../provider/Layers/CodexProvider.ts";
 import * as TextGeneration from "./TextGeneration.ts";
 import {
   buildBranchNamePrompt,
@@ -46,6 +48,7 @@ const encodeJsonString = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknow
 export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(function* (
   codexConfig: CodexSettings,
   environment?: NodeJS.ProcessEnv,
+  modelCatalog: Effect.Effect<ReadonlyArray<ServerProviderModel>> = Effect.succeed([]),
 ) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -183,6 +186,7 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
         getModelSelectionStringOptionValue(modelSelection, "reasoningEffort") ??
         DEFAULT_TEXT_GENERATION_REASONING_EFFORT;
       const serviceTier = getCodexServiceTierOptionValue(modelSelection);
+      const model = resolveCodexCatalogModelSlug(modelSelection.model, yield* modelCatalog);
       const spawnCommand = yield* resolveSpawnCommand(
         codexConfig.binaryPath || "codex",
         [
@@ -193,7 +197,7 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
           "-s",
           "read-only",
           "--model",
-          modelSelection.model,
+          model,
           "--config",
           `model_reasoning_effort="${reasoningEffort}"`,
           ...(serviceTier ? ["--config", `service_tier="${serviceTier}"`] : []),


### PR DESCRIPTION
## What Changed

Codex now treats provider-qualified Bedrock model IDs such as `openai.gpt-5.6-luna` as the same current model family as their canonical IDs. Preferred defaults keep the exact slug returned by the live catalog.

Background title, branch, commit, and PR generation waits for the first provider probe, then resolves an unqualified selection against the latest successful built-in catalog before launching `codex exec`. Exact selections remain unchanged.

## Why

Bedrock-backed Codex returns provider-qualified model IDs. T3 Code previously marked those models as legacy and passed the unqualified default to background generation, even when the live catalog only contained the qualified slug. Interactive turns could work while automatic text generation failed.

## Testing

- `pnpm exec vp test run apps/server/src/provider/Layers/CodexProvider.test.ts apps/server/src/textGeneration/CodexTextGeneration.test.ts apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts` (31 passed)
- `pnpm exec vp run --filter ./apps/server typecheck`
- `pnpm exec vp run --filter ./apps/server build:bundle`
- Targeted `vp lint`, `vp fmt --check`, and `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable to this server-only fix
- [x] A video is not applicable to this server-only fix

---

Implemented with OpenAI Codex in the Codex desktop app.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Bedrock Codex model slug resolution in 'CodexProvider'
> - `CodexProvider.isLegacyCodexModel` now strips the `openai.` prefix before checking legacy status, preventing false positives for current Bedrock models
> - Adds `CodexProvider.resolveCodexCatalogModelSlug` to map unqualified model names to provider-qualified slugs from the live model catalog
> - `CodexDriver` captures the live model catalog during provider initialization and passes it to `CodexTextGeneration`, which uses it to resolve the `--model` argument for the Codex CLI
> - Risk: `CodexProvider.applyPreferredCodexDefaultModel` now matches unqualified preferred slugs against base catalog slugs instead of exact string equality, which may change default model selection for existing configurations
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 468cd74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->