### PR TITLE
fix(shared): detect Azure DevOps SSH remotes (ssh.dev.azure.com)

### DIFF
--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -57,6 +57,22 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
     ).toBe("bitbucket");
   });
 
+  it("detects Azure DevOps SSH remotes", () => {
+    // The default Azure DevOps SSH clone URL uses the ssh.dev.azure.com host.
+    expect(
+      detectSourceControlProviderFromRemoteUrl("git@ssh.dev.azure.com:v3/org/project/repo")?.kind,
+    ).toBe("azure-devops");
+    expect(
+      detectSourceControlProviderFromRemoteUrl("ssh://git@ssh.dev.azure.com:22/v3/org/project/repo")
+        ?.kind,
+    ).toBe("azure-devops");
+    // Legacy visualstudio.com SSH host stays classified too.
+    expect(
+      detectSourceControlProviderFromRemoteUrl("git@vs-ssh.visualstudio.com:v3/org/project/repo")
+        ?.kind,
+    ).toBe("azure-devops");
+  });
+
   it("preserves ports while classifying by hostname", () => {
     expect(
       detectSourceControlProviderFromRemoteUrl("https://gitlab.com:8443/group/repo.git"),

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -176,7 +176,15 @@ function isGitLabHost(host: string): boolean {
 }
 
 function isAzureDevOpsHost(host: string): boolean {
-  return host === "dev.azure.com" || host.endsWith(".visualstudio.com");
+  // `ssh.dev.azure.com` is the default Azure DevOps SSH clone host
+  // (git@ssh.dev.azure.com:v3/org/project/repo), so match any `*.dev.azure.com`
+  // subdomain, not just the bare `dev.azure.com`. Legacy hosts stay under
+  // `.visualstudio.com` (including `vs-ssh.visualstudio.com`).
+  return (
+    host === "dev.azure.com" ||
+    host.endsWith(".dev.azure.com") ||
+    host.endsWith(".visualstudio.com")
+  );
 }
 
 function isBitbucketHost(host: string): boolean {


### PR DESCRIPTION
## What Changed

`isAzureDevOpsHost` (`packages/shared/src/sourceControl.ts`) now matches any `*.dev.azure.com` subdomain, not just the bare `dev.azure.com`. Added a test.

## Why

The **default** Azure DevOps Git SSH clone URL is `git@ssh.dev.azure.com:v3/{org}/{project}/{repo}`, whose host is `ssh.dev.azure.com` — which is neither exactly `dev.azure.com` nor a `.visualstudio.com` domain. None of the other detectors match it either (they look for the substrings `github`/`gitlab`/`bitbucket`), so `detectSourceControlProviderFromRemoteUrl` classified **every Azure DevOps SSH remote** as `kind: "unknown"`, even though the HTTPS remote for the same repo resolves to `azure-devops`.

The leading dot in `.endsWith(".dev.azure.com")` keeps this tight — `evil-dev.azure.com.attacker.test` still does not match — and the legacy `vs-ssh.visualstudio.com` SSH host stays classified via the existing `.visualstudio.com` suffix.

Verified: the new test fails on the current code and passes with the change (confirmed by reverting only the source and re-running); full `packages/shared` toolchain green (`vp test`, `tsgo`, `vp lint`, `vp fmt`).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted hostname rule change with new unit tests; no auth or data-path changes.
> 
> **Overview**
> **Azure DevOps SSH clone URLs** (`git@ssh.dev.azure.com:v3/...`) were classified as `unknown` because host detection only matched `dev.azure.com` and `*.visualstudio.com`, not `ssh.dev.azure.com` or other `*.dev.azure.com` hosts.
> 
> `isAzureDevOpsHost` now also treats hosts ending in **`.dev.azure.com`** as Azure DevOps (with the leading dot kept to avoid overly broad matches). Tests cover default SSH, `ssh://` with port, and legacy `vs-ssh.visualstudio.com`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24807c66661abf7347d3ee7c385eae917d034560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Azure DevOps SSH remote detection for `ssh.dev.azure.com` hosts
> Expands `isAzureDevOpsHost` in [sourceControl.ts](https://github.com/pingdotgg/t3code/pull/6187/files#diff-cb400671e313566c053c016f281d8ebad90db5adcec2fee1dea13d296d8b789d) to match hosts ending with `.dev.azure.com` (e.g. `ssh.dev.azure.com`), in addition to the existing `dev.azure.com` and `*.visualstudio.com` patterns. A new test case covers both `ssh://` and scp-like SSH clone URL forms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24807c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->