### PR TITLE
fix(shared): parse owner/repo from credentialed and ssh-port GitHub remotes

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2286,7 +2286,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
   );
 
   it.effect(
-    "returns existing cross-repo PR metadata using the fork owner selector",
+    "returns existing cross-repo PR metadata for credentialed GitHub remotes",
     () =>
       Effect.gen(function* () {
         const repoDir = yield* makeTempDir("t3code-git-manager-");
@@ -2298,7 +2298,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         yield* configureVisibleRemoteUrlWithLocalRewrite(
           repoDir,
           "fork-seed",
-          "git@github.com:octocat/codething-mvp.git",
+          "https://x-access-token:ghp_ABC@github.com/octocat/codething-mvp.git",
           forkDir,
         );
 

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -34,6 +34,7 @@ import {
   detectSourceControlProviderFromGitRemoteUrl,
   mergeGitStatusParts,
   normalizeGitRemoteUrl,
+  parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
   resolveAutoFeatureBranchName,
   sanitizeBranchFragment,
   sanitizeFeatureBranchName,
@@ -220,20 +221,6 @@ function resolvePullRequestWorktreeLocalBranchName(
   const sanitizedHeadBranch = sanitizeBranchFragment(pullRequest.headBranch).trim();
   const suffix = sanitizedHeadBranch.length > 0 ? sanitizedHeadBranch : "head";
   return `t3code/pr-${pullRequest.number}/${suffix}`;
-}
-
-function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string | null {
-  const trimmed = url?.trim() ?? "";
-  if (trimmed.length === 0) {
-    return null;
-  }
-
-  const match =
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
-      trimmed,
-    );
-  const repositoryNameWithOwner = match?.[1]?.trim() ?? "";
-  return repositoryNameWithOwner.length > 0 ? repositoryNameWithOwner : null;
 }
 
 function parseRepositoryOwnerLogin(nameWithOwner: string | null): string | null {

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -51,6 +51,26 @@ describe("parseGitHubRepositoryNameWithOwnerFromRemoteUrl", () => {
       parseGitHubRepositoryNameWithOwnerFromRemoteUrl("https://github.com/T3Tools/T3Code.git"),
     ).toBe("T3Tools/T3Code");
   });
+
+  it("extracts owner/repo from credentialed and ssh-port GitHub remotes", () => {
+    // Token-embedded HTTPS clones (common in CI).
+    expect(
+      parseGitHubRepositoryNameWithOwnerFromRemoteUrl(
+        "https://x-access-token:ghp_ABC@github.com/T3Tools/T3Code.git",
+      ),
+    ).toBe("T3Tools/T3Code");
+    expect(
+      parseGitHubRepositoryNameWithOwnerFromRemoteUrl("https://T3Tools@github.com/T3Tools/T3Code"),
+    ).toBe("T3Tools/T3Code");
+    // ssh:// remote with an explicit port.
+    expect(
+      parseGitHubRepositoryNameWithOwnerFromRemoteUrl("ssh://git@github.com:22/T3Tools/T3Code.git"),
+    ).toBe("T3Tools/T3Code");
+    // A non-GitHub host that merely embeds github.com in userinfo is not GitHub.
+    expect(
+      parseGitHubRepositoryNameWithOwnerFromRemoteUrl("https://github.com.evil.test/a/b.git"),
+    ).toBeNull();
+  });
 });
 
 describe("isTemporaryWorktreeBranch", () => {

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -150,8 +150,11 @@ export function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | nu
     return null;
   }
 
+  // Allow optional userinfo on the https form (credentialed clones like
+  // https://x-access-token:TOKEN@github.com/owner/repo used by CI) and an
+  // optional port on the ssh form (ssh://git@github.com:22/owner/repo).
   const match =
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
+    /^(?:git@github\.com:|ssh:\/\/git@github\.com(?::\d+)?\/|https:\/\/(?:[^/@\s]+@)?github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
       trimmed,
     );
   const repositoryNameWithOwner = match?.[1]?.trim() ?? "";


### PR DESCRIPTION
## What Changed

`parseGitHubRepositoryNameWithOwnerFromRemoteUrl` (`packages/shared/src/git.ts`) now accepts optional userinfo on the `https://` form and an optional port on the `ssh://` form. Added a test.

## Why

The parser matched only bare `https://github.com/...` and `ssh://git@github.com/...` shapes, so two common real-world remotes returned `null`:

- credentialed HTTPS clones like `https://x-access-token:TOKEN@github.com/owner/repo` (how CI/token workflows clone), and
- `ssh://` remotes with an explicit port, e.g. `ssh://git@github.com:22/owner/repo`.

This was an internal inconsistency: `detectSourceControlProviderFromRemoteUrl` already recognizes those exact URLs as GitHub, but the `owner/repo` needed for PR/repo features couldn't be extracted from them.

The userinfo character class excludes `/` and `@` so it can't span into the host, and a look-alike like `https://github.com.evil.test/a/b` still returns `null` (covered by a test).

Verified: the new test fails on current code and passes with the change (reverted-source re-run); full `packages/shared` toolchain green (`vp test`, `tsgo`, `vp lint`, `vp fmt`).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitHub remotes are parsed into owner/repo for PR matching. A regex miss or over-match could skip or mis-associate fork PRs, though tests cover the new shapes and a non-GitHub look-alike.
> 
> **Overview**
> `parseGitHubRepositoryNameWithOwnerFromRemoteUrl` now extracts `owner/repo` from HTTPS remotes with userinfo (CI token clones) and `ssh://` remotes with an explicit port. That unblocks fork/PR head matching when the remote is GitHub but the old regex returned `null`.
> 
> The parser is no longer duplicated in `GitManager`; it imports the shared helper. Tests cover token/user HTTPS URLs, `ssh://git@github.com:22/...`, and a look-alike host that must still fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e697ada7c459e1ca0412538aa65806dfee1d368c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseGitHubRepositoryNameWithOwnerFromRemoteUrl` for credentialed and SSH-port GitHub remotes
> - Expands the regex in [packages/shared/src/git.ts](https://github.com/pingdotgg/t3code/pull/6188/files#diff-e52ee60f55e13d4ce4a00279168044882e11385edf15a01ad8073cd1442f5785) to accept optional userinfo in HTTPS GitHub URLs and an optional port in SSH GitHub URLs, while keeping strict `github.com` host matching.
> - Removes the local copy in [apps/server/src/git/GitManager.ts](https://github.com/pingdotgg/t3code/pull/6188/files#diff-cd0cda31b0a40baa44db979a23ee89f041c9bae39aa597513a8628cccebd0337) and imports the shared helper instead.
> - Updates tests in both packages to cover credentialed HTTPS, explicit SSH port, and a negative case where a non-GitHub host embeds `github.com` in userinfo.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e697ada.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->