### PR TITLE
fix(shared): normalize a bare Windows drive root the same as C:\ / C:/

### DIFF
--- a/packages/shared/src/path.test.ts
+++ b/packages/shared/src/path.test.ts
@@ -4,6 +4,8 @@ import {
   isUncPath,
   isWindowsAbsolutePath,
   isWindowsDrivePath,
+  normalizeProjectPathForComparison,
+  normalizeProjectPathForDispatch,
 } from "./path.ts";
 
 describe("path helpers", () => {
@@ -30,5 +32,15 @@ describe("path helpers", () => {
     expect(isExplicitRelativePath("./repo")).toBe(true);
     expect(isExplicitRelativePath("..\\repo")).toBe(true);
     expect(isExplicitRelativePath("~/repo")).toBe(false);
+  });
+
+  it("normalizes a bare Windows drive root the same as one with a trailing separator", () => {
+    // `C:`, `C:\` and `C:/` all refer to the drive root and must compare equal.
+    expect(normalizeProjectPathForDispatch("C:")).toBe("C:\\");
+    expect(normalizeProjectPathForComparison("C:")).toBe("c:\\");
+    expect(normalizeProjectPathForComparison("C:")).toBe(normalizeProjectPathForComparison("C:\\"));
+    expect(normalizeProjectPathForComparison("C:")).toBe(normalizeProjectPathForComparison("C:/"));
+    // Non-root drive paths keep their trailing separator trimmed as before.
+    expect(normalizeProjectPathForDispatch("C:\\repo\\")).toBe("C:\\repo");
   });
 });

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -22,7 +22,11 @@ export function isExplicitRelativePath(value: string): boolean {
 }
 
 function isRootPath(value: string): boolean {
-  return value === "/" || value === "\\" || /^[a-zA-Z]:[/\\]?$/.test(value);
+  // The drive separator is required: a bare `C:` is not the drive root (it
+  // means "current directory on C:"), and treating it as already-canonical
+  // would leave it as `C:` while `C:\` and `C:/` normalize to the drive root,
+  // so the same location would fail project identity/dedup comparisons.
+  return value === "/" || value === "\\" || /^[a-zA-Z]:[/\\]$/.test(value);
 }
 
 function trimTrailingPathSeparators(value: string): string {


### PR DESCRIPTION
## What Changed

`isRootPath` (`packages/shared/src/path.ts`) now requires the drive separator (`^[a-zA-Z]:[/\\]$` instead of `[/\\]?`), so a bare `C:` normalizes to the drive root like `C:\` and `C:/`. Added a test.

## Why

With the separator optional, a bare `C:` was treated as already-canonical and `trimTrailingPathSeparators` returned it unchanged as `C:`, while `C:\` and `C:/` normalize to the drive root. The canonical project-path-identity helpers `normalizeProjectPathForComparison` / `normalizeProjectPathForDispatch` — used for project matching and preference-key dedup across the server, client-runtime, and web — therefore treated `C:` and `C:\` as **different** locations, so a project rooted at a bare drive silently failed identity/dedup checks against the same drive expressed as `C:\`.

Requiring the separator makes a bare `C:` fall through to the existing canonicalizer, which appends the separator, so `C:`, `C:\`, and `C:/` all normalize to the same root. This is also more correct semantically: bare `C:` in Windows means "current directory on C:", not the drive root. Non-root paths and the `/` / `\` roots are unaffected.

Verified: the new test fails on current code and passes with the change (reverted-source re-run); full `packages/shared` toolchain green (`vp test`, `tsgo`, `vp lint`, `vp fmt`).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized path-normalization fix with a regression test; behavior change only affects edge-case Windows drive-root strings used for project identity.
> 
> **Overview**
> **Windows drive-root normalization** in `packages/shared/src/path.ts` is tightened so `C:`, `C:\`, and `C:/` compare as the same project location.
> 
> `isRootPath` now only treats drive roots that include a separator (`^[a-zA-Z]:[/\\]$`), not a bare `C:`. That lets bare `C:` go through the existing trim/canonicalize path (which appends `\`), aligning with how `normalizeProjectPathForComparison` and `normalizeProjectPathForDispatch` are used for project matching and dedup on server, client-runtime, and web. Non-root paths and `/` / `\` roots are unchanged.
> 
> A focused unit test covers dispatch/comparison equality and confirms non-root trailing-separator trimming still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 487219f7d908904e4bd5b5711e7ebedef00694d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isRootPath` to treat bare Windows drive `C:` as non-root
> A bare drive specifier like `C:` was incorrectly treated as a Windows drive root. The fix tightens the regex in `isRootPath` ([path.ts](https://github.com/pingdotgg/t3code/pull/6189/files#diff-a6dcd13f037888374578fe1868ce4b81f2b2d558164c779d0dfac8ef45b061f4)) to require a trailing separator, so only `C:\` or `C:/` match as roots. As a result, `normalizeProjectPathForDispatch("C:")` now returns `"C:\\"`  and `normalizeProjectPathForComparison("C:")` returns `"c:\\"`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 487219f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->