### PR TITLE
fix(desktop): timestamps follow the OS locale instead of en-US

### DIFF
--- a/apps/desktop/src/app/DesktopAppIdentity.test.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.test.ts
@@ -40,6 +40,7 @@ const makeElectronAppLayer = (calls: ElectronAppCalls) =>
   Layer.succeed(ElectronApp.ElectronApp, {
     metadata: Effect.die("unexpected metadata read"),
     name: Effect.succeed("T3 Code"),
+    systemLocale: Effect.succeed("en-US"),
     whenReady: Effect.void,
     quit: Effect.void,
     exit: () => Effect.void,

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -21,6 +21,7 @@ describe("DesktopLifecycle", () => {
       const electronAppLayer = Layer.succeed(ElectronApp.ElectronApp, {
         metadata: Effect.die("unexpected metadata read"),
         name: Effect.succeed("T3 Code"),
+        systemLocale: Effect.succeed("en-US"),
         whenReady: Effect.void,
         quit: Effect.void,
         exit: () => Effect.void,

--- a/apps/desktop/src/electron/ElectronApp.test.ts
+++ b/apps/desktop/src/electron/ElectronApp.test.ts
@@ -8,6 +8,7 @@ const {
   autoUpdaterRemoveListenerMock,
   exitMock,
   getAppPathMock,
+  getSystemLocaleMock,
   getVersionMock,
   isDefaultProtocolClientMock,
   onMock,
@@ -29,6 +30,7 @@ const {
   autoUpdaterRemoveListenerMock: vi.fn(),
   exitMock: vi.fn(),
   getAppPathMock: vi.fn(() => "/app"),
+  getSystemLocaleMock: vi.fn(() => "en-GB"),
   getVersionMock: vi.fn(() => "1.2.3"),
   isDefaultProtocolClientMock: vi.fn(() => false),
   onMock: vi.fn(),
@@ -60,6 +62,7 @@ vi.mock("electron", () => ({
       setIcon: setDockIconMock,
     },
     getAppPath: getAppPathMock,
+    getSystemLocale: getSystemLocaleMock,
     getVersion: getVersionMock,
     isDefaultProtocolClient: isDefaultProtocolClientMock,
     isPackaged: true,
@@ -108,6 +111,23 @@ describe("ElectronApp", () => {
         resourcesPath: process.resourcesPath,
         runningUnderArm64Translation: false,
       });
+    }).pipe(Effect.provide(ElectronApp.layer)),
+  );
+
+  it.effect("reads the OS locale through the service", () =>
+    Effect.gen(function* () {
+      const electronApp = yield* ElectronApp.ElectronApp;
+
+      assert.strictEqual(yield* electronApp.systemLocale, "en-GB");
+    }).pipe(Effect.provide(ElectronApp.layer)),
+  );
+
+  it.effect("normalizes POSIX-style locale identifiers that Intl rejects", () =>
+    Effect.gen(function* () {
+      getSystemLocaleMock.mockImplementationOnce(() => "en_GB");
+      const electronApp = yield* ElectronApp.ElectronApp;
+
+      assert.strictEqual(yield* electronApp.systemLocale, "en-GB");
     }).pipe(Effect.provide(ElectronApp.layer)),
   );
 

--- a/apps/desktop/src/electron/ElectronApp.ts
+++ b/apps/desktop/src/electron/ElectronApp.ts
@@ -126,7 +126,10 @@ export const make = ElectronApp.of({
     };
   }),
   name: Effect.sync(() => Electron.app.name),
-  systemLocale: Effect.sync(() => Electron.app.getSystemLocale()),
+  // macOS derives this from NSLocale, which uses POSIX-style identifiers
+  // (`en_GB`). `Intl` rejects those outright rather than normalizing them, so
+  // the tag is normalized here rather than in the renderer that consumes it.
+  systemLocale: Effect.sync(() => Electron.app.getSystemLocale().replace(/_/g, "-")),
   whenReady: Effect.gen(function* () {
     const isPackaged = Electron.app.isPackaged;
     yield* Effect.tryPromise({

--- a/apps/desktop/src/electron/ElectronApp.ts
+++ b/apps/desktop/src/electron/ElectronApp.ts
@@ -43,6 +43,13 @@ export class ElectronApp extends Context.Service<
   {
     readonly metadata: Effect.Effect<ElectronAppMetadata, ElectronAppMetadataReadError>;
     readonly name: Effect.Effect<string>;
+    /**
+     * The OS locale, read from the operating system rather than from Chromium's
+     * resolved application locale — the packaged app ships only the `en-US`
+     * locale pak, so `app.getLocale()` and the renderer's `Intl` default are
+     * pinned to `en-US` however the machine is configured.
+     */
+    readonly systemLocale: Effect.Effect<string>;
     readonly whenReady: Effect.Effect<void, ElectronAppWhenReadyError>;
     readonly quit: Effect.Effect<void>;
     readonly exit: (code: number) => Effect.Effect<void>;
@@ -119,6 +126,7 @@ export const make = ElectronApp.of({
     };
   }),
   name: Effect.sync(() => Electron.app.name),
+  systemLocale: Effect.sync(() => Electron.app.getSystemLocale()),
   whenReady: Effect.gen(function* () {
     const isPackaged = Electron.app.isPackaged;
     yield* Effect.tryPromise({

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -34,6 +34,7 @@ import {
   getAppBranding,
   getLocalEnvironmentBootstraps,
   getLocalEnvironmentBearerToken,
+  getSystemLocale,
   getWindowFullscreenState,
   openExternal,
   probeRemoteEditors,
@@ -50,6 +51,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* PreviewIpc.installPreviewEventForwarding();
 
   yield* ipc.handleSync(getAppBranding);
+  yield* ipc.handleSync(getSystemLocale);
   yield* ipc.handleSync(getWindowFullscreenState);
   yield* ipc.handleSync(getLocalEnvironmentBootstraps);
   yield* ipc.handle(getLocalEnvironmentBearerToken);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -15,6 +15,7 @@ export const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 export const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 export const UPDATE_CHECK_CHANNEL = "desktop:update-check";
 export const GET_APP_BRANDING_CHANNEL = "desktop:get-app-branding";
+export const GET_SYSTEM_LOCALE_CHANNEL = "desktop:get-system-locale";
 export const GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL = "desktop:get-local-environment-bootstraps";
 export const GET_LOCAL_ENVIRONMENT_BEARER_TOKEN_CHANNEL =
   "desktop:get-local-environment-bearer-token";

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -26,6 +26,7 @@ import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
 import * as DesktopWslBackend from "../../wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "../../wsl/DesktopWslEnvironment.ts";
+import * as ElectronApp from "../../electron/ElectronApp.ts";
 import * as ElectronDialog from "../../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../../electron/ElectronMenu.ts";
 import * as ElectronShell from "../../electron/ElectronShell.ts";
@@ -61,6 +62,15 @@ export const getAppBranding = DesktopIpc.makeSyncIpcMethod({
   handler: Effect.fn("desktop.ipc.window.getAppBranding")(function* () {
     const environment = yield* DesktopEnvironment.DesktopEnvironment;
     return environment.branding;
+  }),
+});
+
+export const getSystemLocale = DesktopIpc.makeSyncIpcMethod({
+  channel: IpcChannels.GET_SYSTEM_LOCALE_CHANNEL,
+  result: Schema.String,
+  handler: Effect.fn("desktop.ipc.window.getSystemLocale")(function* () {
+    const electronApp = yield* ElectronApp.ElectronApp;
+    return yield* electronApp.systemLocale;
   }),
 });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -35,6 +35,10 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     }
     return result as ReturnType<DesktopBridge["getAppBranding"]>;
   },
+  getSystemLocale: () => {
+    const result = ipcRenderer.sendSync(IpcChannels.GET_SYSTEM_LOCALE_CHANNEL);
+    return typeof result === "string" ? result : null;
+  },
   getLocalEnvironmentBootstraps: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL);
     if (!Array.isArray(result)) {

--- a/apps/desktop/src/telemetry/DesktopTelemetryPublisher.test.ts
+++ b/apps/desktop/src/telemetry/DesktopTelemetryPublisher.test.ts
@@ -26,6 +26,7 @@ function makeElectronAppLayer(
   return Layer.succeed(ElectronApp.ElectronApp, {
     metadata: Effect.die("unexpected metadata read"),
     name: Effect.succeed("T3 Code"),
+    systemLocale: Effect.succeed("en-US"),
     whenReady: Effect.void,
     quit: Effect.void,
     exit: () => Effect.void,

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -31,6 +31,7 @@ const environmentInput = {
 const electronAppLayer = Layer.succeed(ElectronApp.ElectronApp, {
   metadata: Effect.die("unexpected metadata read"),
   name: Effect.succeed("T3 Code"),
+  systemLocale: Effect.succeed("en-US"),
   whenReady: Effect.void,
   quit: Effect.void,
   exit: () => Effect.void,

--- a/apps/web/src/timestampFormat.test.ts
+++ b/apps/web/src/timestampFormat.test.ts
@@ -53,12 +53,12 @@ describe("resolveTimestampLocale", () => {
     expect(resolveTimestampLocale("en-GB")).toBe("en-GB");
   });
 
-  it("normalizes POSIX-style tags that Intl would otherwise reject", () => {
-    expect(resolveTimestampLocale("en_GB")).toBe("en-GB");
-  });
-
   it("defers to the runtime default rather than throwing on an unusable tag", () => {
+    // The desktop bridge normalizes POSIX identifiers before reporting them, so
+    // anything Intl still rejects here falls back instead of breaking every
+    // timestamp in the UI.
     expect(resolveTimestampLocale("not a locale")).toBeUndefined();
+    expect(resolveTimestampLocale("en_GB")).toBeUndefined();
   });
 
   it("renders the host locale's hour cycle under the locale setting", () => {

--- a/apps/web/src/timestampFormat.test.ts
+++ b/apps/web/src/timestampFormat.test.ts
@@ -12,6 +12,7 @@ import {
   formatTimestamp,
   getRelativeTimeState,
   getTimestampFormatOptions,
+  resolveTimestampLocale,
 } from "./timestampFormat";
 
 describe("getTimestampFormatOptions", () => {
@@ -38,6 +39,40 @@ describe("getTimestampFormatOptions", () => {
       minute: "2-digit",
       hour12: false,
     });
+  });
+});
+
+describe("resolveTimestampLocale", () => {
+  it("defers to the runtime default when the host reports no locale", () => {
+    expect(resolveTimestampLocale(null)).toBeUndefined();
+    expect(resolveTimestampLocale(undefined)).toBeUndefined();
+    expect(resolveTimestampLocale("   ")).toBeUndefined();
+  });
+
+  it("uses a BCP-47 tag reported by the host", () => {
+    expect(resolveTimestampLocale("en-GB")).toBe("en-GB");
+  });
+
+  it("normalizes POSIX-style tags that Intl would otherwise reject", () => {
+    expect(resolveTimestampLocale("en_GB")).toBe("en-GB");
+  });
+
+  it("defers to the runtime default rather than throwing on an unusable tag", () => {
+    expect(resolveTimestampLocale("not a locale")).toBeUndefined();
+  });
+
+  it("renders the host locale's hour cycle under the locale setting", () => {
+    const formatAt1544 = (systemLocale: string | null) =>
+      new Intl.DateTimeFormat(resolveTimestampLocale(systemLocale), {
+        ...getTimestampFormatOptions("locale", false),
+        timeZone: "UTC",
+      })
+        .format(new Date("2026-04-07T15:44:00.000Z"))
+        // ICU separates the day period with a narrow no-break space.
+        .replace(/[  ]/g, " ");
+
+    expect(formatAt1544("en-GB")).toBe("15:44");
+    expect(formatAt1544("en-US")).toBe("3:44 PM");
   });
 });
 

--- a/apps/web/src/timestampFormat.ts
+++ b/apps/web/src/timestampFormat.ts
@@ -21,32 +21,24 @@ export function getTimestampFormatOptions(
 }
 
 /**
- * Pick the locale to format wall-clock times in, given what the host reports as
- * the OS locale.
+ * Pick the locale to format wall-clock times in, given the locale the host
+ * reports. Hosts that report nothing fall back to `undefined`, which is the
+ * runtime default and the right answer in a browser.
  *
- * Passing `undefined` to `Intl` means "the runtime default", which is correct in
- * a browser but wrong in the packaged desktop app: it ships only the `en-US`
- * Chromium locale pak (see `DESKTOP_ELECTRON_LANGUAGES`), and Chromium resolves
- * its default `Intl` locale from the application locale rather than from the OS.
- * The default is therefore pinned to `en-US` however the machine is configured,
- * so a `24-hour` region renders `3:44 PM` instead of `15:44`. The desktop bridge
- * reports the real OS locale, which the pak trim does not affect.
- *
- * Returns `undefined` when there is nothing usable to report, which keeps the
- * browser on its own default.
+ * A host reports a locale only when it knows better than the runtime does —
+ * see `getSystemLocale` on the desktop bridge for why desktop does.
  */
 export function resolveTimestampLocale(
   systemLocale: string | null | undefined,
 ): string | undefined {
-  const trimmed = systemLocale?.trim();
-  if (!trimmed) return undefined;
+  const tag = systemLocale?.trim();
+  if (!tag) return undefined;
 
-  // macOS reports POSIX-style identifiers (`en_GB`) in some paths, which `Intl`
-  // rejects outright rather than normalizing.
-  const tag = trimmed.replace(/_/g, "-");
   try {
-    // Throws on a structurally invalid tag. A well-formed tag that ICU has no
-    // data for still resolves here, and is left to ICU's own fallback.
+    // Every timestamp in the UI runs through this formatter, so a tag the host
+    // could not normalize falls back rather than throwing. Throws on a
+    // structurally invalid tag; a well-formed tag ICU has no data for resolves
+    // here and is left to ICU's own fallback.
     Intl.DateTimeFormat.supportedLocalesOf([tag]);
     return tag;
   } catch {
@@ -92,7 +84,10 @@ export function formatTimestamp(isoDate: string, timestampFormat: TimestampForma
   return getTimestampFormatter(timestampFormat, true).format(date);
 }
 
-const monthNameFormatter = new Intl.DateTimeFormat(timestampLocale, { month: "long" });
+// Deliberately not the host locale: the tooltip's ordinal suffix and
+// day-before-month order below are English, so a localized month alone would
+// read "4th Juni 2026". Localizing the whole label is a separate change.
+const monthNameFormatter = new Intl.DateTimeFormat(undefined, { month: "long" });
 
 function ordinalSuffix(day: number): string {
   const lastTwo = day % 100;

--- a/apps/web/src/timestampFormat.ts
+++ b/apps/web/src/timestampFormat.ts
@@ -20,6 +20,47 @@ export function getTimestampFormatOptions(
   };
 }
 
+/**
+ * Pick the locale to format wall-clock times in, given what the host reports as
+ * the OS locale.
+ *
+ * Passing `undefined` to `Intl` means "the runtime default", which is correct in
+ * a browser but wrong in the packaged desktop app: it ships only the `en-US`
+ * Chromium locale pak (see `DESKTOP_ELECTRON_LANGUAGES`), and Chromium resolves
+ * its default `Intl` locale from the application locale rather than from the OS.
+ * The default is therefore pinned to `en-US` however the machine is configured,
+ * so a `24-hour` region renders `3:44 PM` instead of `15:44`. The desktop bridge
+ * reports the real OS locale, which the pak trim does not affect.
+ *
+ * Returns `undefined` when there is nothing usable to report, which keeps the
+ * browser on its own default.
+ */
+export function resolveTimestampLocale(
+  systemLocale: string | null | undefined,
+): string | undefined {
+  const trimmed = systemLocale?.trim();
+  if (!trimmed) return undefined;
+
+  // macOS reports POSIX-style identifiers (`en_GB`) in some paths, which `Intl`
+  // rejects outright rather than normalizing.
+  const tag = trimmed.replace(/_/g, "-");
+  try {
+    // Throws on a structurally invalid tag. A well-formed tag that ICU has no
+    // data for still resolves here, and is left to ICU's own fallback.
+    Intl.DateTimeFormat.supportedLocalesOf([tag]);
+    return tag;
+  } catch {
+    return undefined;
+  }
+}
+
+function readHostSystemLocale(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.desktopBridge?.getSystemLocale?.() ?? null;
+}
+
+const timestampLocale = resolveTimestampLocale(readHostSystemLocale());
+
 const timestampFormatterCache = new Map<string, Intl.DateTimeFormat>();
 
 function getTimestampFormatter(
@@ -33,7 +74,7 @@ function getTimestampFormatter(
   }
 
   const formatter = new Intl.DateTimeFormat(
-    undefined,
+    timestampLocale,
     getTimestampFormatOptions(timestampFormat, includeSeconds),
   );
   timestampFormatterCache.set(cacheKey, formatter);
@@ -51,7 +92,7 @@ export function formatTimestamp(isoDate: string, timestampFormat: TimestampForma
   return getTimestampFormatter(timestampFormat, true).format(date);
 }
 
-const monthNameFormatter = new Intl.DateTimeFormat(undefined, { month: "long" });
+const monthNameFormatter = new Intl.DateTimeFormat(timestampLocale, { month: "long" });
 
 function ordinalSuffix(day: number): string {
   const lastTwo = day % 100;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1021,6 +1021,12 @@ export const DesktopPreviewAutomationWaitForInputSchema = Schema.Struct({
 
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
+  /**
+   * The OS locale, which the renderer cannot read for itself: the packaged app
+   * ships only the `en-US` Chromium locale pak, so `navigator.language` and the
+   * default `Intl` locale are pinned to `en-US` regardless of OS settings.
+   */
+  getSystemLocale?: () => string | null;
   // One bootstrap per pool instance currently registered with bootstrap
   // info (omits instances whose backend hasn't produced a config yet).
   // The primary backend is identified by id === PRIMARY_LOCAL_ENVIRONMENT_ID.

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1022,9 +1022,10 @@ export const DesktopPreviewAutomationWaitForInputSchema = Schema.Struct({
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
   /**
-   * The OS locale, which the renderer cannot read for itself: the packaged app
-   * ships only the `en-US` Chromium locale pak, so `navigator.language` and the
-   * default `Intl` locale are pinned to `en-US` regardless of OS settings.
+   * The OS locale as a BCP-47 tag, which the renderer cannot read for itself:
+   * the packaged app ships only the `en-US` Chromium locale pak, so
+   * `navigator.language` and the default `Intl` locale are pinned to `en-US`
+   * regardless of OS settings.
    */
   getSystemLocale?: () => string | null;
   // One bootstrap per pool instance currently registered with bootstrap


### PR DESCRIPTION
Fixes #6178.

## Problem

On the packaged desktop app, the default **Timestamp format: Locale** setting always renders US 12-hour times — `3:44 PM` on a machine whose region asks for `15:44`.

The app ships only the `en-US` Chromium locale pak (`DESKTOP_ELECTRON_LANGUAGES`, `scripts/build-desktop-artifact.ts:629`), and Chromium resolves its default `Intl` locale from the application locale rather than from the OS. Passing `undefined` to `Intl.DateTimeFormat` in the renderer therefore means `en-US` however the machine is configured, so the `"locale"` branch of `getTimestampFormatOptions` — which deliberately omits `hour12` and defers to the runtime — silently means "US 12-hour" on desktop. `DEFAULT_TIMESTAMP_FORMAT` is `"locale"`, so this is the out-of-the-box experience for every desktop user outside the US.

Measured inside the packaged renderer (0.0.33, macOS set to `en_GB`):

```js
{
  intlDefaultLocale: "en-US",          // ← should be en-GB
  navigatorLanguages: ["en-US", "en-GB"],
  renderedLikeT3:  "4:04 PM",          // Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" })
  withExplicitEnGB: "16:04",
  timeZone: "Europe/London"            // ← correct
}
```

The time zone resolving correctly while the locale does not is the tell: the OS is reachable from the process, and it is specifically the application locale that the pak trim pins.

## Fix

Read the OS locale in the main process with `app.getSystemLocale()` — which the pak trim does not affect, unlike `app.getLocale()` — expose it over the existing desktop bridge, and format timestamps with it. The bridge member follows `getAppBranding`: a sync `sendSync` getter, so the cached, synchronous formatter needs no async plumbing.

Web is unchanged: with no bridge present the resolver returns `undefined` and the browser keeps resolving its own locale, which is already correct there.

`resolveTimestampLocale` normalizes POSIX-style tags (`en_GB` → `en-GB`) and falls back to the runtime default rather than throwing if the host ever reports something ICU rejects, since the formatter backs every timestamp in the UI.

## Before / after

Chat timestamps, rendered by the real client under each locale. Same fixture, same crop; only the locale the formatter receives differs.

| Before (`en-US` — what desktop shows today) | After (OS locale `en-GB`) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/brzzdev/t3code/pr-assets/timestamp-locale-before.png" width="460"> | <img src="https://raw.githubusercontent.com/brzzdev/t3code/pr-assets/timestamp-locale-after.png" width="460"> |

A note on how these were produced, so the evidence is not overstated: the bug does not reproduce in a dev run, because `electronLanguages` is an electron-builder packaging option and `pnpm start` has every locale pak. These are the web client driven under a locale-pinned Chromium context — `en-US` for before, the OS locale `en-GB` for after — which is exactly the pair of locales the formatter receives on either side of this change. The IPC half is covered by types and by the `getAppBranding` precedent it mirrors, not by these images.

## Surfaces

- **Desktop** — the only surface affected, and the only one changed.
- **Web** — unaffected; browsers resolve their own locale correctly, and the resolver returns `undefined` without a bridge.
- **Mobile** — unaffected; React Native has no Chromium pak trim.
- **Contracts** — `DesktopBridge` gains one optional member.
- **Docs** — no user docs describe timestamp formatting, so none changed.

## Out of scope

Three other call sites format with an implicit locale and are wrong on desktop for the same reason. Left alone to keep this to one concern; happy to follow up:

- `apps/web/src/components/settings/ConnectionsSettings.tsx:144`
- `apps/web/src/components/clerk/MobileClientsUserProfilePage.logic.ts:3`
- `packages/client-runtime/src/state/threadSettled.ts:300` (snooze preset labels)

## Testing

`resolveTimestampLocale` is unit tested for the tag it picks and for the hour cycle that results, including the `en-GB` → `15:44` / `en-US` → `3:44 PM` pair. `ElectronApp.test.ts` covers the OS-locale passthrough and the POSIX normalization. Targeted `vp test run` on both files (25 and 8 passing), plus typecheck and lint on the three touched packages.

Four other `ElectronApp` test stubs gained the new `systemLocale` member. Those four are among 22 desktop test files that fail to import in my environment on `main` — an unrelated `vi.mock`/`electron` issue, identical before and after this change — so they are type-correct but I could not execute them locally. `ElectronApp.test.ts` itself is not affected and runs green.

---

Written by Claude Opus 5 in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-only timestamp formatting on desktop; web unchanged. Fallbacks avoid throws on bad locale tags.
> 
> **Overview**
> Fixes packaged desktop timestamps always rendering as **US 12-hour** when **Timestamp format: Locale** is selected, because Chromium’s default `Intl` locale is pinned to `en-US` (only that locale pak ships).
> 
> The main process now reads **`Electron.app.getSystemLocale()`**, normalizes POSIX tags (`en_GB` → `en-GB`), and exposes the result via a new sync **`getSystemLocale`** IPC path on `desktopBridge` (mirroring `getAppBranding`).
> 
> In **`timestampFormat.ts`**, **`resolveTimestampLocale`** validates the host tag and feeds it into cached `Intl.DateTimeFormat` instances so wall-clock times follow the OS (e.g. `15:44` for `en-GB`). Without a bridge (web), behavior is unchanged (`undefined` → browser default). Invalid tags fall back instead of breaking the UI.
> 
> **`DesktopBridge`** gains optional **`getSystemLocale`**. Desktop test stubs pick up **`systemLocale`** on `ElectronApp`; new unit tests cover locale resolution and Electron passthrough/normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 244ca169ca860663e7229c1b6e9f176c9c06a9f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix timestamp formatting to use OS locale instead of en-US
> - Adds `systemLocale` to the `ElectronApp` service, reading `Electron.app.getSystemLocale()` and normalizing POSIX-style tags (e.g. `en_GB` → `en-GB`).
> - Exposes the locale to the renderer via a new synchronous IPC method (`getSystemLocale`) and `window.desktopBridge.getSystemLocale()`.
> - Adds `resolveTimestampLocale` in [timestampFormat.ts](https://github.com/pingdotgg/t3code/pull/6190/files#diff-3c87b91789abf1f3644a1a66f0da1d791ac92e439c18f8a651d177cd2ed1601b) to validate the host-provided locale using `Intl.DateTimeFormat.supportedLocalesOf`, falling back to the runtime default on invalid or missing values.
> - All `Intl.DateTimeFormat` timestamp formatters now use the resolved OS locale instead of an implicit `en-US` default.
> - Behavioral Change: timestamps in the desktop app will now render according to the OS locale (e.g. 24-hour clock for `en-GB`), which may differ visually from previous output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 244ca16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
