### PR TITLE
fix(web): use a clearer pull action icon

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -22,6 +22,7 @@ import { flushSync } from "react-dom";
 import {
   CheckIcon,
   ChevronDownIcon,
+  CloudDownloadIcon,
   CloudUploadIcon,
   ExternalLinkIcon,
   GitBranchPlusIcon,
@@ -357,7 +358,7 @@ function GitQuickActionIcon({
   const iconClassName = "size-3.5";
   if (quickAction.kind === "open_pr") return <SourceControlIcon className={iconClassName} />;
   if (quickAction.kind === "open_publish") return <CloudUploadIcon className={iconClassName} />;
-  if (quickAction.kind === "run_pull") return <InfoIcon className={iconClassName} />;
+  if (quickAction.kind === "run_pull") return <CloudDownloadIcon className={iconClassName} />;
   if (quickAction.kind === "run_action") {
     if (quickAction.action === "commit") return <GitCommitIcon className={iconClassName} />;
     if (quickAction.action === "push" || quickAction.action === "commit_push") {


### PR DESCRIPTION
The pull quick action currently uses a generic info icon, making its behavior difficult to identify at a glance.

Replace it with Lucide CloudDownloadIcon, pairing the pull action with the CloudUploadIcon already used for push.

## Screenshots

| Before | After |
| --- | --- |
| ![Pull action before](https://i0sunrls1q.ufs.sh/f/WUwVZNM2UgSAkl7GYIj20PN4DKzjRsmJIMtAgboah1QGe7vV) | ![Pull action after](https://i0sunrls1q.ufs.sh/f/WUwVZNM2UgSAyVrdv8C6hdqSwIz9yfngXAc8Nkj3veRtpuT2) |

## Verification

- `vp run --filter @t3tools/web typecheck`
- `vp lint apps/web/src/components/GitActionsControl.tsx --report-unused-disable-directives`

Generated with GPT-5.6 Sol via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic icon swap in GitActionsControl with no behavior or logic changes.
> 
> **Overview**
> The git quick-action control now shows **Lucide `CloudDownloadIcon`** for the **Pull** action (`run_pull`) instead of the generic **`InfoIcon`**, so pull is visually distinct and aligned with **`CloudUploadIcon`** already used for push/publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b180cf6fd45a7323214b184aad1224661e1c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `InfoIcon` with `CloudDownloadIcon` for the pull action in `GitQuickActionIcon`
> The `run_pull` quick action in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/6194/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) was using `InfoIcon`, which does not visually represent a pull/download operation. It now uses `CloudDownloadIcon` from `lucide-react`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00b180c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->