### PR TITLE
fix(server): tolerate SQLite write contention

### DIFF
--- a/apps/server/src/persistence/NodeSqliteClient.test.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.test.ts
@@ -1,7 +1,13 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Stream from "effect/Stream";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import * as SqliteClient from "./NodeSqliteClient.ts";
 
@@ -42,6 +48,34 @@ layer("NodeSqliteClient", (it) => {
       assert.equal(error.reason.operation, "prepare");
     }),
   );
+
+  it.effect("preserves the original failure when SQLite automatically rolls back", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`
+        CREATE TABLE rollback_entries(
+          name TEXT UNIQUE ON CONFLICT ROLLBACK
+        )
+      `;
+      yield* sql`INSERT INTO rollback_entries(name) VALUES (${"alpha"})`;
+
+      const error = yield* Effect.flip(
+        sql.withTransaction(sql`INSERT INTO rollback_entries(name) VALUES (${"alpha"})`),
+      );
+      assert.equal(error.reason.operation, "execute");
+      assert.include(String(error.reason.cause), "UNIQUE constraint failed");
+
+      yield* sql.withTransaction(sql`INSERT INTO rollback_entries(name) VALUES (${"beta"})`);
+      const rows = yield* sql<{ readonly name: string }>`
+        SELECT name FROM rollback_entries ORDER BY name
+      `;
+      assert.deepEqual(
+        rows.map((row) => row.name),
+        ["alpha", "beta"],
+      );
+    }),
+  );
 });
 
 it.effect("returns a typed failure when the database cannot be opened", () =>
@@ -53,4 +87,50 @@ it.effect("returns a typed failure when the database cannot be opened", () =>
     assert.equal(error._tag, "SqlError");
     assert.equal(error.reason.operation, "open");
   }),
+);
+
+it.effect("waits for a concurrent writer instead of failing immediately", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-sqlite-busy-" });
+      const databasePath = path.join(tempDir, "state.sqlite");
+      const context = yield* Layer.build(SqliteClient.layer({ filename: databasePath }));
+      const sql = yield* Effect.service(SqlClient.SqlClient).pipe(Effect.provide(context));
+
+      yield* sql`CREATE TABLE entries(id INTEGER PRIMARY KEY, name TEXT NOT NULL)`;
+
+      const lockHolder = yield* spawner.spawn(
+        ChildProcess.make(
+          process.execPath,
+          [
+            "-e",
+            `const { DatabaseSync } = require("node:sqlite");
+const db = new DatabaseSync(process.argv[1]);
+db.exec("BEGIN IMMEDIATE; INSERT INTO entries(name) VALUES ('child')");
+process.stdout.write("locked\\n");
+setTimeout(() => {
+  db.exec("COMMIT");
+  db.close();
+}, 300);`,
+            databasePath,
+          ],
+          { extendEnv: true },
+        ),
+      );
+      const locked = yield* lockHolder.stdout.pipe(Stream.decodeText(), Stream.runHead);
+      assert.include(Option.getOrThrow(locked), "locked");
+
+      yield* sql.withTransaction(sql`INSERT INTO entries(name) VALUES (${"parent"})`);
+      assert.equal(Number(yield* lockHolder.exitCode), 0);
+
+      const rows = yield* sql<{ readonly name: string }>`SELECT name FROM entries ORDER BY id`;
+      assert.deepEqual(
+        rows.map((row) => row.name),
+        ["child", "parent"],
+      );
+    }),
+  ).pipe(Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.ts
@@ -25,6 +25,7 @@ import { SqlError, classifySqliteError } from "effect/unstable/sql/SqlError";
 import * as Statement from "effect/unstable/sql/Statement";
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name";
+const DEFAULT_BUSY_TIMEOUT_MS = 5_000;
 
 export const TypeId: TypeId = "~local/sqlite-node/SqliteClient";
 
@@ -127,6 +128,16 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
           }),
       }).pipe(Effect.orDie),
     );
+    yield* Effect.try({
+      try: () => db.exec(`PRAGMA busy_timeout = ${DEFAULT_BUSY_TIMEOUT_MS}`),
+      catch: (cause) =>
+        new SqlError({
+          reason: classifySqliteError(cause, {
+            message: "Failed to configure database busy timeout",
+            operation: "execute",
+          }),
+        }),
+    });
 
     const statementReaderCache = new WeakMap<NodeSqlite.StatementSync, boolean>();
     const hasRows = (statement: NodeSqlite.StatementSync): boolean => {
@@ -250,6 +261,14 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
         );
       },
       executeUnprepared(sql, params, rowTransform) {
+        // SQLite can automatically roll back a transaction for some failures
+        // (for example, an ON CONFLICT ROLLBACK constraint). Effect's generic
+        // transaction cleanup still issues ROLLBACK in that case. Treat that
+        // cleanup as idempotent so its "no transaction is active" error does
+        // not replace the original database failure.
+        if (sql === "ROLLBACK" && !db.isTransaction) {
+          return Effect.succeed([]);
+        }
         const effect = prepare(sql).pipe(
           Effect.flatMap((statement) => runStatement(statement, params ?? [], false)),
         );


### PR DESCRIPTION
## Summary

- give every native SQLite connection a 5-second busy timeout so normal cross-process writers wait instead of failing immediately
- make transaction rollback cleanup idempotent when SQLite already rolled back automatically, preserving the original failure
- add regressions for real cross-process write contention and automatic rollback recovery

## Tests

- `vp test run apps/server/src/persistence/NodeSqliteClient.test.ts` (5 passed)
- `vp run --filter t3 typecheck`
- `vp fmt --check apps/server/src/persistence/NodeSqliteClient.ts apps/server/src/persistence/NodeSqliteClient.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default behavior for every Node SQLite connection and transaction failure paths in persistence; regressions could affect concurrent access and error reporting, though scope is limited to NodeSqliteClient with targeted tests.
> 
> **Overview**
> **Native SQLite connections** now run `PRAGMA busy_timeout = 5000` at open time so writers **wait up to 5 seconds** on lock contention instead of failing immediately—important when another process holds the database (e.g. CLI tools vs the server).
> 
> **Transaction cleanup** treats unprepared `ROLLBACK` as a no-op when SQLite has already ended the transaction (e.g. `ON CONFLICT ROLLBACK`), so Effect’s generic rollback step does not **mask the original execute error** with “no transaction is active.”
> 
> **Tests** cover automatic rollback error preservation (in-memory) and cross-process write waiting via a child process holding `BEGIN IMMEDIATE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58db6b46384507e85fc1406fd518234478af1472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SQLite write contention by setting busy timeout and preserving rollback errors
> - Sets `PRAGMA busy_timeout` to 5000ms on each connection in `makeWithDatabase`, causing operations to wait for locks instead of failing immediately with a busy error.
> - Fixes `executeUnprepared` to treat a `ROLLBACK` when no transaction is active as a no-op, preserving the original error from the failed operation rather than replacing it with a rollback error.
> - Adds tests in [NodeSqliteClient.test.ts](https://github.com/pingdotgg/t3code/pull/6199/files#diff-011f1a81afcf5c179401a2bf99322d8b156b7aeb673571f68d0273f4cbcfa10d) covering both the rollback error-preservation fix and concurrent writer lock waiting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58db6b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->