### PR TITLE
feat(desktop): add local file mentions

### DIFF
--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,7 +5,7 @@ import type {
   DesktopPreviewTabState,
 } from "@t3tools/contracts";
 import { exposeClerkBridge } from "@clerk/electron/preload";
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 
 import * as IpcChannels from "./ipc/channels.ts";
 
@@ -97,6 +97,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   setWslDistro: (distro) => ipcRenderer.invoke(IpcChannels.SET_WSL_DISTRO_CHANNEL, distro),
   setWslOnly: (enabled) => ipcRenderer.invoke(IpcChannels.SET_WSL_ONLY_CHANNEL, enabled),
   pickFolder: (options) => ipcRenderer.invoke(IpcChannels.PICK_FOLDER_CHANNEL, options),
+  getPathForFile: (file) => webUtils.getPathForFile(file),
   pickThemeFiles: () => ipcRenderer.invoke(IpcChannels.PICK_THEME_FILES_CHANNEL, undefined),
   setTheme: (theme) => ipcRenderer.invoke(IpcChannels.SET_THEME_CHANNEL, theme),
   showContextMenu: (items, position) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6321,6 +6321,9 @@ function ChatViewContent(props: ChatViewProps) {
                             isLocalDraftThread={isLocalDraftThread}
                             forceExpandedOnMobile={forceExpandedMobileComposer && isDraftHeroState}
                             projectSelectionRequired={isLocalDraftThread && activeProject === null}
+                            canUseDesktopFilePaths={
+                              environmentId === primaryEnvironment?.environmentId
+                            }
                             phase={phase}
                             isConnecting={isConnecting}
                             isSendBusy={isSendBusy}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6322,7 +6322,7 @@ function ChatViewContent(props: ChatViewProps) {
                             forceExpandedOnMobile={forceExpandedMobileComposer && isDraftHeroState}
                             projectSelectionRequired={isLocalDraftThread && activeProject === null}
                             canUseDesktopFilePaths={
-                              environmentId === primaryEnvironment?.environmentId
+                              activeThreadEnvironmentId === primaryEnvironment?.environmentId
                             }
                             phase={phase}
                             isConnecting={isConnecting}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -46,6 +46,7 @@ import {
   dataTransferHasComposerMention,
   makeComposerMentionDragHandlers,
 } from "./composerMentionDrag";
+import { prepareComposerFileUpload } from "./composerFileUpload";
 import {
   type ComposerImageAttachment,
   type DraftId,
@@ -505,6 +506,7 @@ export interface ChatComposerProps {
   isLocalDraftThread: boolean;
   forceExpandedOnMobile: boolean;
   projectSelectionRequired: boolean;
+  canUseDesktopFilePaths: boolean;
 
   // Session phase
   phase: SessionPhase;
@@ -614,6 +616,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     isLocalDraftThread: _isLocalDraftThread,
     forceExpandedOnMobile,
     projectSelectionRequired,
+    canUseDesktopFilePaths,
     phase,
     isConnecting,
     isSendBusy,
@@ -2371,13 +2374,53 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Callbacks: paste / drag
   // ------------------------------------------------------------------
+  const addComposerFiles = (files: File[]): { handled: boolean; insertedPaths: boolean } => {
+    const prepared = prepareComposerFileUpload(files, {
+      allowLocalPaths: canUseDesktopFilePaths,
+      getPathForFile: window.desktopBridge?.getPathForFile,
+    });
+    let handled = false;
+    let insertedPaths = false;
+    if (prepared.paths.length > 0) {
+      handled = true;
+      const mentions = prepared.paths.map(serializeComposerFileLink).join(" ");
+      insertedPaths = insertComposerTextAtEnd(`${mentions} `, { ensureLeadingBoundary: true });
+      if (!insertedPaths) {
+        toastManager.add({
+          type: "error",
+          title: "Unable to add files",
+          description: "The composer is busy; try again once it is ready.",
+        });
+      }
+    }
+    if (prepared.imageFiles.length > 0) {
+      handled = true;
+      void addComposerImages(prepared.imageFiles);
+    }
+    if (prepared.unresolvedNames.length > 0) {
+      toastManager.add({
+        type: "error",
+        title: "Unable to add files",
+        description: `Could not read the local path for ${prepared.unresolvedNames.join(", ")}.`,
+      });
+    }
+    if (prepared.unsupportedNames.length > 0) {
+      handled = true;
+      toastManager.add({
+        type: "warning",
+        title: "File uploads aren't supported here",
+        description: "Non-image files can only be added to this computer's local environment.",
+      });
+    }
+    return { handled, insertedPaths };
+  };
+
   const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
     const files = Array.from(event.clipboardData.files);
     if (files.length === 0) return;
-    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) return;
-    event.preventDefault();
-    void addComposerImages(imageFiles);
+    if (addComposerFiles(files).handled) {
+      event.preventDefault();
+    }
   };
 
   const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
@@ -2411,8 +2454,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     dragDepthRef.current = 0;
     setIsDragOverComposer(false);
     const files = Array.from(event.dataTransfer.files);
-    void addComposerImages(files);
-    focusComposer();
+    const result = addComposerFiles(files);
+    if (!result.insertedPaths) {
+      focusComposer();
+    }
   };
 
   const insertComposerTextAtEnd = (

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2398,6 +2398,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       void addComposerImages(prepared.imageFiles);
     }
     if (prepared.unresolvedNames.length > 0) {
+      handled = true;
       toastManager.add({
         type: "error",
         title: "Unable to add files",

--- a/apps/web/src/components/chat/composerFileUpload.test.ts
+++ b/apps/web/src/components/chat/composerFileUpload.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { prepareComposerFileUpload } from "./composerFileUpload";
+
+describe("prepareComposerFileUpload", () => {
+  it("keeps images as attachments and resolves other files through Electron", () => {
+    const image = { name: "photo.png", type: "image/png", path: "C:\\files\\photo.png" };
+    const document = { name: "notes.txt", type: "text/plain", path: "C:\\files\\notes.txt" };
+
+    expect(
+      prepareComposerFileUpload([image, document], {
+        allowLocalPaths: true,
+        getPathForFile: (file) => file.path,
+      }),
+    ).toEqual({
+      imageFiles: [image],
+      paths: ["C:\\files\\notes.txt"],
+      unresolvedNames: [],
+      unsupportedNames: [],
+    });
+  });
+
+  it("reports non-image files on a remote desktop environment", () => {
+    const image = { name: "photo.png", type: "image/png" };
+    const document = { name: "notes.txt", type: "text/plain" };
+    const getPathForFile = (file: typeof document) => `C:\\files\\${file.name}`;
+
+    expect(
+      prepareComposerFileUpload([image, document], { allowLocalPaths: false, getPathForFile }),
+    ).toEqual({
+      imageFiles: [image],
+      paths: [],
+      unresolvedNames: [],
+      unsupportedNames: ["notes.txt"],
+    });
+  });
+
+  it("ignores non-image files outside the desktop app", () => {
+    const image = { name: "photo.png", type: "image/png" };
+    const document = { name: "notes.txt", type: "text/plain" };
+
+    expect(prepareComposerFileUpload([image, document], { allowLocalPaths: false })).toEqual({
+      imageFiles: [image],
+      paths: [],
+      unresolvedNames: [],
+      unsupportedNames: [],
+    });
+  });
+
+  it("reports files whose local path is unavailable", () => {
+    const document = { name: "notes.txt", type: "text/plain" };
+
+    expect(
+      prepareComposerFileUpload([document], {
+        allowLocalPaths: true,
+        getPathForFile: () => "",
+      }).unresolvedNames,
+    ).toEqual(["notes.txt"]);
+  });
+});

--- a/apps/web/src/components/chat/composerFileUpload.ts
+++ b/apps/web/src/components/chat/composerFileUpload.ts
@@ -1,0 +1,51 @@
+export interface ComposerUploadFile {
+  readonly name: string;
+  readonly type: string;
+}
+
+export interface ComposerFileUploadOptions<TFile> {
+  readonly allowLocalPaths: boolean;
+  readonly getPathForFile?: ((file: TFile) => string) | undefined;
+}
+
+export function prepareComposerFileUpload<TFile extends ComposerUploadFile>(
+  files: ReadonlyArray<TFile>,
+  options: ComposerFileUploadOptions<TFile>,
+): {
+  readonly imageFiles: TFile[];
+  readonly paths: string[];
+  readonly unresolvedNames: string[];
+  readonly unsupportedNames: string[];
+} {
+  const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+  const otherFiles = files.filter((file) => !file.type.startsWith("image/"));
+  if (!options.allowLocalPaths) {
+    return {
+      imageFiles,
+      paths: [],
+      unresolvedNames: [],
+      unsupportedNames: options.getPathForFile ? otherFiles.map((file) => file.name) : [],
+    };
+  }
+  if (!options.getPathForFile) {
+    return { imageFiles, paths: [], unresolvedNames: [], unsupportedNames: [] };
+  }
+  const paths: string[] = [];
+  const unresolvedNames: string[] = [];
+
+  for (const file of otherFiles) {
+    let path = "";
+    try {
+      path = options.getPathForFile(file).trim();
+    } catch {
+      path = "";
+    }
+    if (path) {
+      paths.push(path);
+    } else {
+      unresolvedNames.push(file.name);
+    }
+  }
+
+  return { imageFiles, paths, unresolvedNames, unsupportedNames: [] };
+}

--- a/apps/web/src/pierre-icons.test.ts
+++ b/apps/web/src/pierre-icons.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "vite-plus/test";
 
 import {
+  basenameOfPath,
   hasSpecificPierreIconForFileName,
   resolvePierreIconForEntry,
   syntheticFileNameForLanguageId,
@@ -8,6 +9,11 @@ import {
 } from "./pierre-icons";
 
 describe("Pierre file icons", () => {
+  it("extracts filenames from Unix and Windows paths", () => {
+    assert.equal(basenameOfPath("/Users/cole/project/notes.txt"), "notes.txt");
+    assert.equal(basenameOfPath("C:\\Users\\cole\\project\\notes.txt"), "notes.txt");
+  });
+
   it("uses Pierre exact filename and complete-set extension mappings", () => {
     assert.equal(resolvePierreIconForEntry("Dockerfile", "file")?.token, "docker");
     assert.equal(resolvePierreIconForEntry("src/Button.tsx", "file")?.token, "react");

--- a/apps/web/src/pierre-icons.ts
+++ b/apps/web/src/pierre-icons.ts
@@ -75,8 +75,8 @@ const LANGUAGE_EXTENSION_ALIASES: Record<string, string> = {
 };
 
 export function basenameOfPath(pathValue: string): string {
-  const slashIndex = pathValue.lastIndexOf("/");
-  return slashIndex === -1 ? pathValue : pathValue.slice(slashIndex + 1);
+  const separatorIndex = Math.max(pathValue.lastIndexOf("/"), pathValue.lastIndexOf("\\"));
+  return separatorIndex === -1 ? pathValue : pathValue.slice(separatorIndex + 1);
 }
 
 export function inferEntryKindFromPath(pathValue: string): "file" | "directory" {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1036,6 +1036,7 @@ export interface DesktopBridge {
   setWslDistro: (distro: string | null) => Promise<DesktopWslState>;
   setWslOnly: (enabled: boolean) => Promise<DesktopWslState>;
   pickFolder: (options?: PickFolderOptions) => Promise<string | null>;
+  getPathForFile?: (file: File) => string;
   /**
    * Multi-select JSON file picker that opens in the VS Code extensions
    * directory when one exists. Optional: older desktop builds lack it, and


### PR DESCRIPTION
## What changed

- render dropped or pasted non-image desktop files as compact file mentions
- keep the full absolute path in the composer payload while showing only the filename
- preserve image attachments on web, desktop, and mobile
- limit local-path mentions to the desktop app's primary environment
- warn when non-image files are dropped into a remote desktop environment
- block native paste when a local file path cannot be resolved

## Why

Plain absolute paths are noisy in the composer, but uploading arbitrary files would introduce remote-transfer and file-size concerns. Desktop-local file mentions keep the UI readable while giving the agent the exact path it needs. Remote environments reject these files because a path from the client computer would not exist on the host computer.

## Screenshots

### JAR

<img width="1001" height="391" alt="JAR file mention" src="https://github.com/user-attachments/assets/c1a0bbb7-0733-476d-8b82-671c8ca3421e" />

### PDF

<img width="976" height="417" alt="PDF file mention" src="https://github.com/user-attachments/assets/18bb2389-33c3-4aec-aba7-22a358f14341" />

## Validation

- `vp test run apps/web/src/components/chat/composerFileUpload.test.ts apps/web/src/pierre-icons.test.ts`
- targeted `vp lint` for changed files
- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/desktop typecheck`
- `pnpm --filter @t3tools/contracts typecheck`
- `git diff --check origin/main...HEAD`

Built with GPT-5.6-Sol using the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local file path mentions to desktop chat composer via drag and paste
> - Adds `getPathForFile` to `DesktopBridge` (via Electron's `webUtils`) and exposes it to the renderer in [preload.ts](https://github.com/pingdotgg/t3code/pull/6203/files#diff-eae0078d2bf4ac4beed2884f918b2816a97752917390f09980ba2cfad8c42cac).
> - Introduces [composerFileUpload.ts](https://github.com/pingdotgg/t3code/pull/6203/files#diff-336e00aad644d93291461570a2fc5bc1e49f557c355151b524a5aedec06c54cf) to partition dropped/pasted files into images (attached) and non-images (inserted as local file path mentions when on desktop).
> - Paste and drag-and-drop in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/6203/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) now route all files through this utility; non-image files on desktop become inline path mentions, while unsupported or unresolved files trigger error/warning toasts.
> - Fixes `basenameOfPath` in [pierre-icons.ts](https://github.com/pingdotgg/t3code/pull/6203/files#diff-3302f2965f1a3a2c319814debc1fff0b8c7e2a112aa07c57ea7490674b6f8881) to handle Windows backslash separators.
> - Behavioral Change: non-image files pasted or dropped in remote (non-desktop) environments now show a warning toast instead of being silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6df5f1c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6df5f1c9375e4899be80c2c1b8c24aaa29bd7662. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->