### PR TITLE
fix(web): clean up composer resize animation

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -9,7 +9,7 @@ import {
   HistoryIcon,
   MonitorIcon,
 } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
 import { useProject, useThread, useThreadShellsForProjectRefs } from "../state/entities";
@@ -218,16 +218,20 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
 /**
  * Collapse the strip's labels to icons only when the text no longer fits.
  *
- * Hidden labels stay measurable (they collapse to invisible absolute boxes,
- * which keep their natural width), so the required width can be recomputed in
- * either state on every pass - no remembered widths that could go stale or
- * latch the strip compact. A small hysteresis keeps the boundary from
- * flapping between states.
+ * Hidden labels stay measurable because their inner text keeps its natural
+ * width while the outer layout box collapses. This lets every pass recompute
+ * the expanded width without remembered values that could go stale or latch
+ * the strip compact. A small hysteresis keeps the boundary from flapping.
  */
 const COMPACT_EXPAND_HYSTERESIS_PX = 16;
+const COMPOSER_CONTEXT_MOTION_DURATION_MS = 180;
+const COMPOSER_CONTEXT_MOTION_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+const COMPOSER_CONTEXT_CONTROL_SELECTOR = "[data-composer-context-control]";
 
 function useLabelsOverflow(element: HTMLDivElement | null): boolean {
   const [overflows, setOverflows] = useState(false);
+  const pendingControlRectsRef = useRef<Map<HTMLElement, DOMRect> | null>(null);
+  const controlAnimationsRef = useRef(new Map<HTMLElement, Animation>());
   // A render-synced mirror instead of useEffectEvent: the compiler memoizes
   // the event callback, which left observers reading the first render's null
   // element forever.
@@ -241,7 +245,7 @@ function useLabelsOverflow(element: HTMLDivElement | null): boolean {
     if (available === 0) return;
     // flex-1 stretches the groups to fill the strip, so their own boxes always
     // measure "full". Sum the laid-out content instead, skipping hidden form
-    // artifacts and absolutely-positioned nodes (the compact-hidden labels).
+    // artifacts and other out-of-flow nodes.
     const contentWidth = (parent: Element): number => {
       const gap = Number.parseFloat(getComputedStyle(parent).columnGap) || 0;
       let width = 0;
@@ -283,8 +287,70 @@ function useLabelsOverflow(element: HTMLDivElement | null): boolean {
         needed += Math.max(0, textWidth - label.clientWidth);
       }
     }
-    setOverflows(compact ? needed > available - COMPACT_EXPAND_HYSTERESIS_PX : needed > available);
+    const nextOverflows = compact
+      ? needed > available - COMPACT_EXPAND_HYSTERESIS_PX
+      : needed > available;
+    if (nextOverflows !== compact) {
+      pendingControlRectsRef.current = new Map(
+        Array.from(current.querySelectorAll<HTMLElement>(COMPOSER_CONTEXT_CONTROL_SELECTOR)).map(
+          (control) => [control, control.getBoundingClientRect()],
+        ),
+      );
+    }
+    setOverflows(nextOverflows);
   }, []);
+
+  useLayoutEffect(() => {
+    const previousRects = pendingControlRectsRef.current;
+    if (!previousRects) return;
+    pendingControlRectsRef.current = null;
+
+    for (const animation of controlAnimationsRef.current.values()) {
+      animation.cancel();
+    }
+    controlAnimationsRef.current.clear();
+
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    for (const [control, previousRect] of previousRects) {
+      if (!control.isConnected) continue;
+      const nextRect = control.getBoundingClientRect();
+      const deltaX = previousRect.left - nextRect.left;
+      const deltaY = previousRect.top - nextRect.top;
+      if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) continue;
+
+      const animation = control.animate(
+        [
+          { transform: `translate3d(${deltaX}px, ${deltaY}px, 0)` },
+          { transform: "translate3d(0, 0, 0)" },
+        ],
+        {
+          duration: COMPOSER_CONTEXT_MOTION_DURATION_MS,
+          easing: COMPOSER_CONTEXT_MOTION_EASING,
+          fill: "backwards",
+        },
+      );
+      controlAnimationsRef.current.set(control, animation);
+      animation.addEventListener(
+        "finish",
+        () => {
+          if (controlAnimationsRef.current.get(control) === animation) {
+            controlAnimationsRef.current.delete(control);
+          }
+        },
+        { once: true },
+      );
+    }
+  }, [overflows]);
+
+  useEffect(
+    () => () => {
+      for (const animation of controlAnimationsRef.current.values()) {
+        animation.cancel();
+      }
+    },
+    [],
+  );
 
   // Label widths can change without the strip box moving (font family or
   // size preferences), so re-measure on every render as well as on resize
@@ -403,7 +469,7 @@ export const BranchToolbar = memo(function BranchToolbar({
     <div
       ref={setStripElement}
       data-compact={labelsOverflow ? "" : undefined}
-      className="chat-composer-context-strip group/composer-context -mt-4 mx-auto flex w-[calc(100%-2.75rem)] max-w-[calc(48rem-2.75rem)] items-center gap-2 ps-1 pe-2 pt-5 pb-1"
+      className="chat-composer-context-strip group/composer-context -mt-4 mx-auto flex w-[calc(100%-2.75rem)] max-w-[calc(48rem-2.75rem)] items-center gap-2 overflow-x-clip overflow-y-visible ps-1 pe-2 pt-5 pb-1"
     >
       {isMobile && showGitControls ? (
         <MobileRunContextSelector
@@ -431,7 +497,11 @@ export const BranchToolbar = memo(function BranchToolbar({
                 {...(showEnvironmentPicker && onEnvironmentChange ? { onEnvironmentChange } : {})}
               />
               {showGitControls ? (
-                <Separator orientation="vertical" className="mx-0.5 h-3.5!" />
+                <Separator
+                  orientation="vertical"
+                  className="mx-0.5 h-3.5!"
+                  data-composer-context-control
+                />
               ) : null}
             </>
           )}

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -714,7 +714,10 @@ export function BranchToolbarBranchSelector({
       open={isBranchMenuOpen}
       value={resolvedActiveBranch}
     >
-      <div className={cn("flex min-w-0 items-center gap-1", className)}>
+      <div
+        className={cn("flex min-w-0 items-center gap-1", className)}
+        data-composer-context-control
+      >
         {branchPr && branchPrStatus ? (
           <Tooltip>
             <TooltipTrigger
@@ -751,9 +754,14 @@ export function BranchToolbarBranchSelector({
             <GitBranchIcon className="size-3 shrink-0 opacity-70" />
             <span
               data-composer-label
-              className="min-w-0 max-w-[240px] truncate transition-[max-width,opacity] duration-300 ease-out group-data-[compact]/composer-context:max-w-0 group-data-[compact]/composer-context:opacity-0"
+              className="min-w-0 max-w-[240px] group-data-[compact]/composer-context:max-w-0"
             >
-              {triggerLabel}
+              <span
+                data-composer-label-motion
+                className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:-translate-x-1 group-data-[compact]/composer-context:scale-x-95 group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+              >
+                {triggerLabel}
+              </span>
             </span>
             <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
           </ComboboxTrigger>

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -758,7 +758,7 @@ export function BranchToolbarBranchSelector({
             >
               <span
                 data-composer-label-motion
-                className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+                className="block w-full min-w-0 max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
               >
                 {triggerLabel}
               </span>

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -758,7 +758,7 @@ export function BranchToolbarBranchSelector({
             >
               <span
                 data-composer-label-motion
-                className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:-translate-x-1 group-data-[compact]/composer-context:scale-x-95 group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+                className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
               >
                 {triggerLabel}
               </span>

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -84,6 +84,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
         size="xs"
         className="min-w-0 shrink font-medium"
         aria-label="Workspace"
+        data-composer-context-control
       >
         {effectiveEnvMode === "worktree" ? (
           <FolderGit2Icon className="size-3" />
@@ -94,9 +95,14 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
         )}
         <span
           data-composer-label
-          className="min-w-0 max-w-[240px] truncate transition-[max-width,opacity] duration-300 ease-out group-data-[compact]/composer-context:max-w-0 group-data-[compact]/composer-context:opacity-0"
+          className="min-w-0 max-w-[240px] group-data-[compact]/composer-context:max-w-0"
         >
-          <SelectValue />
+          <span
+            data-composer-label-motion
+            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:-translate-x-1 group-data-[compact]/composer-context:scale-x-95 group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+          >
+            <SelectValue />
+          </span>
         </span>
       </SelectTrigger>
       <SelectPopup>

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -99,7 +99,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
         >
           <span
             data-composer-label-motion
-            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:-translate-x-1 group-data-[compact]/composer-context:scale-x-95 group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
           >
             <SelectValue />
           </span>

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -50,7 +50,10 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
 
   if (envLocked) {
     return (
-      <span className="inline-flex h-7 shrink-0 items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:h-6 sm:text-xs">
+      <span
+        className="inline-flex h-7 shrink-0 items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:h-6 sm:text-xs"
+        data-composer-context-control
+      >
         {activeWorktreePath ? (
           <>
             <FolderGitIcon className="size-3" />

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -99,7 +99,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
         >
           <span
             data-composer-label-motion
-            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+            className="block w-full min-w-0 max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
           >
             <SelectValue />
           </span>

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -48,7 +48,10 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
   // only thing in the strip.
   if (envLocked || onEnvironmentChange === undefined) {
     return (
-      <span className="inline-flex h-7 min-w-0 max-w-full items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:h-6 sm:text-xs">
+      <span
+        className="inline-flex h-7 min-w-0 max-w-full items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:h-6 sm:text-xs"
+        data-composer-context-control
+      >
         {activeEnvironment?.isPrimary ? (
           <MonitorIcon className="size-3 shrink-0" />
         ) : (
@@ -56,9 +59,14 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
         )}
         <span
           data-composer-label
-          className="min-w-0 max-w-[240px] truncate transition-[max-width,opacity] duration-300 ease-out group-data-[compact]/composer-context:max-w-0 group-data-[compact]/composer-context:opacity-0"
+          className="min-w-0 max-w-[240px] group-data-[compact]/composer-context:max-w-0"
         >
-          {activeEnvironment?.label ?? "Run on"}
+          <span
+            data-composer-label-motion
+            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:-translate-x-1 group-data-[compact]/composer-context:scale-x-95 group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+          >
+            {activeEnvironment?.label ?? "Run on"}
+          </span>
         </span>
       </span>
     );
@@ -76,6 +84,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
         size="xs"
         className="min-w-0 max-w-full font-medium"
         aria-label="Run on"
+        data-composer-context-control
       >
         {activeEnvironment?.isPrimary ? (
           <MonitorIcon className="size-3 shrink-0" />
@@ -84,9 +93,14 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
         )}
         <span
           data-composer-label
-          className="min-w-0 max-w-[240px] truncate transition-[max-width,opacity] duration-300 ease-out group-data-[compact]/composer-context:max-w-0 group-data-[compact]/composer-context:opacity-0"
+          className="min-w-0 max-w-[240px] group-data-[compact]/composer-context:max-w-0"
         >
-          <SelectValue />
+          <span
+            data-composer-label-motion
+            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:-translate-x-1 group-data-[compact]/composer-context:scale-x-95 group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+          >
+            <SelectValue />
+          </span>
         </span>
       </SelectTrigger>
       <SelectPopup>

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -63,7 +63,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
         >
           <span
             data-composer-label-motion
-            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+            className="block w-full min-w-0 max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
           >
             {activeEnvironment?.label ?? "Run on"}
           </span>
@@ -97,7 +97,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
         >
           <span
             data-composer-label-motion
-            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+            className="block w-full min-w-0 max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
           >
             <SelectValue />
           </span>

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -63,7 +63,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
         >
           <span
             data-composer-label-motion
-            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:-translate-x-1 group-data-[compact]/composer-context:scale-x-95 group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
           >
             {activeEnvironment?.label ?? "Run on"}
           </span>
@@ -97,7 +97,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
         >
           <span
             data-composer-label-motion
-            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:-translate-x-1 group-data-[compact]/composer-context:scale-x-95 group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+            className="block w-max max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
           >
             <SelectValue />
           </span>


### PR DESCRIPTION
## What Changed

- Move composer context controls together when the right sidebar changes the available width.
- Use an interruptible 180 ms FLIP animation for fast open and close reversals.
- Keep horizontal paint inside the toolbar while preserving vertical overflow.
- Truncate long labels before they reach the chevrons.
- Use opacity only when reduced motion is enabled.

## Why

The old animation changed label width over 300 ms while the surrounding controls moved at a different speed. This made the toolbar feel disconnected.

Controls could also paint outside the composer during the transition. In narrow layouts, long labels could overlap their chevrons.

The new animation moves the controls and labels together. It stays inside the toolbar and handles quick direction changes without removing the animation.

## UI Changes

- **Before video:**

https://github.com/user-attachments/assets/231b7903-8203-4bb5-a498-97030db0a303

- **After video:**

https://github.com/user-attachments/assets/9ba7073e-8020-430c-991c-ca9c3a059897

## Verification

- [x] `vp test run apps/web/src/components/BranchToolbar.logic.test.ts apps/web/src/components/composerFooterLayout.test.ts`
- [x] `vp run --filter @t3tools/web typecheck`
- [x] Targeted lint and formatting for the four changed components
- [x] Manual open, close, and rapid-reversal checks in the web client

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before and after videos for the animation change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only animation and layout tweaks in the composer toolbar; no auth, data, or API changes.
> 
> **Overview**
> **Replaces the composer context strip’s 300ms label width fade with a coordinated compact/expand transition** so environment, workspace, and branch controls move together when width changes (e.g. sidebar resize).
> 
> `useLabelsOverflow` now snapshots `[data-composer-context-control]` rects before toggling compact state and runs a **180ms FLIP `translate3d` animation** in `useLayoutEffect`, with prior animations cancelled for quick reversals and **no motion when `prefers-reduced-motion`**. Labels use an outer `data-composer-label` shell (max-width collapse) plus an inner `data-composer-label-motion` span for opacity/transform; **reduced motion keeps opacity-only** transitions.
> 
> The context strip gains **`overflow-x-clip`** to contain horizontal paint during transitions. Child selectors mark controls with `data-composer-context-control` (including the vertical separator between environment and git controls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7755d240796b2e19f74a4bfca70d9f4c12e457d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add FLIP-style reposition animation to composer toolbar compact/expand transitions
> - Adds animation to the composer-context controls in [`BranchToolbar`](https://github.com/pingdotgg/t3code/pull/6209/files#diff-698af5019ef8a26d8e1653085b9e61762e35f389e79e62d402760255625b0a10) when the toolbar switches between compact and expanded states, using a FLIP approach (record pre-change rects, apply translate3d from old to new positions).
> - Updates [`BranchToolbarBranchSelector`](https://github.com/pingdotgg/t3code/pull/6209/files#diff-95e72064c321265e2363abda12fd803f217db7d06a32a076ea7337d942367734), [`BranchToolbarEnvModeSelector`](https://github.com/pingdotgg/t3code/pull/6209/files#diff-f6e603d70ca6bba6f4bb6ec0c74ab245223570c8a33c292fb1d25529770f3f67), and [`BranchToolbarEnvironmentSelector`](https://github.com/pingdotgg/t3code/pull/6209/files#diff-3759c9280378eadf1bb9c4b0f2e904767a2ba23386070a9a38f60a6ae124278a) to opt into the animation via `data-composer-context-control` and to wrap label content in `data-composer-label-motion` spans for smoother label collapse.
> - Animation is skipped when `prefers-reduced-motion` is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7755d24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->