### PR TITLE
feat(web): compact sidebar footer actions

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -5,7 +5,7 @@ import {
   SettingsIcon,
 } from "lucide-react";
 import { memo, useCallback } from "react";
-import { Link, useCanGoBack, useLocation, useNavigate } from "@tanstack/react-router";
+import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 
 import { useEnvironmentIdentificationMode } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
@@ -27,8 +27,9 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "../ui/sidebar";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { SidebarProviderUpdatePill } from "./SidebarProviderUpdatePill";
-import { SidebarUpdatePill } from "./SidebarUpdatePill";
+import { SidebarUpdateArchitectureWarning, SidebarUpdatePill } from "./SidebarUpdatePill";
 
 export const SidebarChromeHeader = memo(function SidebarChromeHeader({
   isElectron,
@@ -119,7 +120,6 @@ function T3Wordmark() {
 export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
   const navigate = useNavigate();
   const { isMobile, setOpenMobile } = useSidebar();
-  const canGoBack = useCanGoBack();
   const currentFooterPage = useLocation({
     select: (location) =>
       location.pathname === "/usage"
@@ -154,54 +154,72 @@ export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
 
   const handleBackClick = useCallback(() => {
     closeMobileSidebar();
-    if (canGoBack) {
-      window.history.back();
-      return;
-    }
     void navigate({ to: "/" });
-  }, [canGoBack, closeMobileSidebar, navigate]);
+  }, [closeMobileSidebar, navigate]);
 
   return (
     <SidebarFooter className="p-[var(--sidebar-content-inset)]">
       <SidebarProviderUpdatePill />
-      <SidebarUpdatePill />
-      <SidebarMenu>
-        {currentFooterPage === "pull-requests" ? (
-          <SidebarMenuItem>
-            <SidebarMenuButton onClick={handleBackClick}>
-              <ArrowLeftIcon />
-              <span>Back</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        ) : pullRequestsSupported ? (
-          <SidebarMenuItem>
-            <SidebarMenuButton onClick={handlePullRequestsClick}>
-              <GitPullRequestIcon />
-              <span>Pull Requests</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        ) : null}
-        {currentFooterPage === "usage" ? (
-          <SidebarMenuItem>
+      <SidebarUpdateArchitectureWarning />
+      <SidebarMenu className="flex-row items-center">
+        {currentFooterPage ? (
+          <SidebarMenuItem className="min-w-0 flex-1">
             <SidebarMenuButton onClick={handleBackClick}>
               <ArrowLeftIcon />
               <span>Back</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
         ) : (
-          <SidebarMenuItem>
-            <SidebarMenuButton onClick={handleUsageClick}>
-              <ChartNoAxesColumnIcon />
-              <span>Usage</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
+          <>
+            <SidebarMenuItem className="shrink-0">
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <SidebarMenuButton
+                      aria-label="Settings"
+                      onClick={handleSettingsClick}
+                      size="icon"
+                    >
+                      <SettingsIcon />
+                    </SidebarMenuButton>
+                  }
+                />
+                <TooltipPopup side="top">Settings</TooltipPopup>
+              </Tooltip>
+            </SidebarMenuItem>
+            {pullRequestsSupported ? (
+              <SidebarMenuItem className="shrink-0">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <SidebarMenuButton
+                        aria-label="Pull Requests"
+                        onClick={handlePullRequestsClick}
+                        size="icon"
+                      >
+                        <GitPullRequestIcon />
+                      </SidebarMenuButton>
+                    }
+                  />
+                  <TooltipPopup side="top">Pull Requests</TooltipPopup>
+                </Tooltip>
+              </SidebarMenuItem>
+            ) : null}
+            <SidebarMenuItem className="shrink-0">
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <SidebarMenuButton aria-label="Usage" onClick={handleUsageClick} size="icon">
+                      <ChartNoAxesColumnIcon />
+                    </SidebarMenuButton>
+                  }
+                />
+                <TooltipPopup side="top">Usage</TooltipPopup>
+              </Tooltip>
+            </SidebarMenuItem>
+          </>
         )}
-        <SidebarMenuItem>
-          <SidebarMenuButton onClick={handleSettingsClick}>
-            <SettingsIcon />
-            <span>Settings</span>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
+        <SidebarUpdatePill />
       </SidebarMenu>
     </SidebarFooter>
   );

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -1,10 +1,12 @@
-import { DownloadIcon, RotateCwIcon, TriangleAlertIcon, XIcon } from "lucide-react";
+import { DownloadIcon, RefreshCwIcon, RotateCwIcon, TriangleAlertIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { isElectron } from "../../env";
+import { cn } from "../../lib/utils";
 import { ensureLocalApi } from "../../localApi";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import {
+  canCheckForUpdate,
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
@@ -12,12 +14,12 @@ import {
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
-  shouldShowDesktopUpdateButton,
   shouldToastDesktopUpdateActionResult,
 } from "../desktopUpdate.logic";
 import { showDesktopUpdateDownloadedToast } from "../desktopUpdate.toast";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { Separator } from "../ui/separator";
+import { SidebarMenuItem } from "../ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 function keyReleaseNoteItems(items: ReadonlyArray<string>) {
@@ -41,16 +43,29 @@ function SidebarUpdateReleaseNotesTooltip({
   }
 
   return (
-    <div className="w-120 max-w-[calc(100vw-2rem)] text-left">
+    <div className="w-fit max-w-[min(24rem,calc(100vw-2rem))] text-left">
       <div className="px-1">
-        <div className="text-sm leading-5 font-medium">{tooltip}</div>
+        {state.status === "available" ? (
+          <div>
+            <div className="whitespace-nowrap text-sm leading-5 font-medium">
+              Update ready to download
+            </div>
+            {state.availableVersion ? (
+              <div className="mt-0.5 text-xs leading-4 text-update-foreground">
+                {state.availableVersion}
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <div className="text-sm leading-5 font-medium">{tooltip}</div>
+        )}
       </div>
       <div className="max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
         {state.releaseNotes.map((releaseNote, index) => (
           <div key={releaseNote.version}>
             {index > 0 && <Separator className="my-3 bg-border/60" />}
             <section>
-              <h3 className="text-muted-foreground text-xs leading-4 font-semibold">
+              <h3 className="text-foreground text-xs leading-4 font-semibold">
                 {index === 0 ? "What's changed" : `Changes in ${releaseNote.version}`}
               </h3>
               <ul className="mt-2 space-y-1.5 pl-4 text-xs leading-5 text-popover-foreground/90">
@@ -68,24 +83,50 @@ function SidebarUpdateReleaseNotesTooltip({
   );
 }
 
-export function SidebarUpdatePill() {
+export function SidebarUpdateArchitectureWarning() {
+  return isElectron ? <SidebarUpdateArchitectureWarningContent /> : null;
+}
+
+function SidebarUpdateArchitectureWarningContent() {
   const state = useDesktopUpdateState();
-  const [dismissed, setDismissed] = useState(false);
+  const visible = shouldShowArm64IntelBuildWarning(state);
+  const description = state && visible ? getArm64IntelBuildWarningDescription(state) : null;
+
+  if (!visible || !description) return null;
+
+  return (
+    <Alert variant="warning" className="rounded-2xl border-warning/40 bg-warning/8 text-xs">
+      <TriangleAlertIcon />
+      <AlertTitle>Intel build on Apple Silicon</AlertTitle>
+      <AlertDescription>{description}</AlertDescription>
+    </Alert>
+  );
+}
+
+export function SidebarUpdatePill() {
+  return isElectron ? <SidebarUpdateControl /> : null;
+}
+
+function SidebarUpdateControl() {
+  const state = useDesktopUpdateState();
   const [isActionPending, setIsActionPending] = useState(false);
 
-  const visible = isElectron && shouldShowDesktopUpdateButton(state) && !dismissed;
-  const tooltip = state ? getDesktopUpdateButtonTooltip(state) : "Update available";
-  const disabled = isDesktopUpdateButtonDisabled(state);
   const action = state ? resolveDesktopUpdateButtonAction(state) : "none";
-
-  const showArm64Warning = isElectron && shouldShowArm64IntelBuildWarning(state);
-  const arm64Description =
-    state && showArm64Warning ? getArm64IntelBuildWarningDescription(state) : null;
+  const isDownloading = state?.status === "downloading";
+  const isUpdateState = action !== "none" || isDownloading;
+  const tooltip = isUpdateState
+    ? state
+      ? getDesktopUpdateButtonTooltip(state)
+      : "Update available"
+    : state?.status === "checking"
+      ? "Checking for updates…"
+      : "Check for updates";
+  const disabled = isUpdateState ? isDesktopUpdateButtonDisabled(state) : !canCheckForUpdate(state);
 
   const handleAction = useCallback(async () => {
     const bridge = window.desktopBridge;
     if (!bridge || !state) return;
-    if (disabled || action === "none" || isActionPending) return;
+    if (disabled || isActionPending) return;
 
     setIsActionPending(true);
 
@@ -165,99 +206,92 @@ export function SidebarUpdatePill() {
           );
         })
         .finally(() => setIsActionPending(false));
+      return;
     }
+
+    void bridge
+      .checkForUpdate()
+      .then((result) => {
+        if (result.checked) return;
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not check for updates",
+            description:
+              result.state.message ?? "Automatic updates are not available in this build.",
+          }),
+        );
+      })
+      .catch((error) => {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not check for updates",
+            description: error instanceof Error ? error.message : "Update check failed.",
+          }),
+        );
+      })
+      .finally(() => setIsActionPending(false));
   }, [action, disabled, isActionPending, state]);
 
-  if (!visible && !showArm64Warning) return null;
-
   return (
-    <div className="flex flex-col gap-1">
-      {showArm64Warning && arm64Description && (
-        <Alert variant="warning" className="rounded-2xl border-warning/40 bg-warning/8 text-xs">
-          <TriangleAlertIcon />
-          <AlertTitle>Intel build on Apple Silicon</AlertTitle>
-          <AlertDescription>{arm64Description}</AlertDescription>
-        </Alert>
-      )}
-      {visible && (
-        <div
-          className={`group/update relative flex h-7 w-full items-center rounded-lg bg-update-surface text-xs font-medium text-update-foreground ${
-            disabled ? " cursor-not-allowed opacity-60" : ""
-          }`}
-        >
-          <div className="pointer-events-none absolute inset-0 rounded-lg transition-colors group-has-[button.update-main:hover]/update:bg-update/12" />
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <button
-                  type="button"
-                  aria-label={tooltip}
-                  aria-disabled={disabled || isActionPending || undefined}
-                  disabled={disabled || isActionPending}
-                  className="update-main relative flex h-full flex-1 items-center gap-2 px-2 enabled:cursor-pointer"
-                  onClick={handleAction}
-                >
-                  {action === "install" ? (
-                    <>
-                      <RotateCwIcon className="size-3.5" />
-                      <span>Restart to update</span>
-                    </>
-                  ) : state?.status === "downloading" ? (
-                    <>
-                      <DownloadIcon className="size-3.5" />
-                      <span>
-                        Downloading
-                        {typeof state.downloadPercent === "number"
-                          ? ` (${Math.floor(state.downloadPercent)}%)`
-                          : "…"}
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <DownloadIcon className="size-3.5" />
-                      <span>Update available</span>
-                    </>
-                  )}
-                </button>
-              }
-            />
-            <TooltipPopup
-              align="start"
-              className={
-                state?.channel === "nightly" && state.releaseNotes.length > 0
-                  ? // pointer-events-auto overrides the positioner's pointer-events-none so the
-                    // release notes stay open (and scrollable) when the cursor moves into them.
-                    "pointer-events-auto max-w-none text-balance"
-                  : undefined
-              }
-              side="top"
-            >
-              {state ? (
-                <SidebarUpdateReleaseNotesTooltip state={state} tooltip={tooltip} />
-              ) : (
-                tooltip
+    <SidebarMenuItem className="ml-auto shrink-0">
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              aria-label={tooltip}
+              aria-disabled={disabled || isActionPending || undefined}
+              disabled={disabled || isActionPending}
+              className={cn(
+                "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors enabled:cursor-pointer focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60",
+                isUpdateState
+                  ? "bg-update-surface text-update-foreground enabled:hover:bg-update/12"
+                  : "text-[var(--sidebar-icon-color)] enabled:hover:bg-sidebar-row-hover enabled:hover:text-sidebar-foreground",
               )}
-            </TooltipPopup>
-          </Tooltip>
-          {action === "download" && (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <button
-                    type="button"
-                    aria-label="Dismiss update"
-                    className="mr-1 inline-flex size-5 items-center justify-center rounded-md text-update-foreground transition-colors"
-                    onClick={() => setDismissed(true)}
-                  >
-                    <XIcon className="size-3.5" />
-                  </button>
+              onClick={handleAction}
+            >
+              {action === "install" ? (
+                <RotateCwIcon className="size-4" />
+              ) : isUpdateState ? (
+                <DownloadIcon className="size-4" />
+              ) : (
+                <RefreshCwIcon
+                  className={cn("size-4", state?.status === "checking" && "animate-spin")}
+                />
+              )}
+            </button>
+          }
+        />
+        <TooltipPopup
+          align="center"
+          className={
+            isUpdateState && state?.channel === "nightly" && state.releaseNotes.length > 0
+              ? // pointer-events-auto overrides the positioner's pointer-events-none so the
+                // release notes stay open (and scrollable) when the cursor moves into them.
+                "pointer-events-auto max-w-none text-balance"
+              : undefined
+          }
+          side="top"
+          style={
+            isUpdateState
+              ? {
+                  background:
+                    "color-mix(in srgb, var(--update) 18%, color-mix(in srgb, var(--popover) var(--glass-opacity), transparent))",
+                  borderColor: "var(--update-foreground)",
                 }
-              />
-              <TooltipPopup side="top">Dismiss until next launch</TooltipPopup>
-            </Tooltip>
+              : undefined
+          }
+          variant={isUpdateState ? "glass" : "default"}
+        >
+          {isUpdateState && state ? (
+            <SidebarUpdateReleaseNotesTooltip state={state} tooltip={tooltip} />
+          ) : (
+            tooltip
           )}
-        </div>
-      )}
-    </div>
+        </TooltipPopup>
+      </Tooltip>
+    </SidebarMenuItem>
   );
 }


### PR DESCRIPTION
## Problem

The sidebar footer gave three secondary destinations full-width rows, consuming space that is more useful for threads. Its history-based back action could also bounce between Usage and Pull Requests instead of returning to the normal sidebar.

## What changed

- Condenses Settings, Pull Requests, and Usage into a left-aligned row of icon actions with centered tooltips.
- Gives Usage and Pull Requests one full-width Back action that always returns to the thread list.
- Places the Electron-only update control at the right of the same row: refresh checks for updates, then changes into the download or restart action when an update is available.
- Keeps update details in a content-sized, update-tinted glass tooltip.

## Root cause

The footer treated utility destinations as primary navigation rows, and special-page navigation relied on browser history rather than an explicit destination.

## Before / After

### Before

![Sidebar footer before](https://raw.githubusercontent.com/maria-rcks/t3code/pr-assets-compact-sidebar-footer-20260811/pr-assets/compact-sidebar-footer-before.png)

### After

![Sidebar footer after](https://raw.githubusercontent.com/maria-rcks/t3code/pr-assets-compact-sidebar-footer-20260811/pr-assets/compact-sidebar-footer-after.png)

## Impact

The shared web/desktop sidebar preserves more vertical space and has predictable navigation. Update controls remain desktop-only; mobile is unaffected.

## Validation

- `vp lint apps/web/src/components/sidebar/SidebarChrome.tsx apps/web/src/components/sidebar/SidebarUpdatePill.tsx`
- `vp test run apps/web/src/components/desktopUpdate.logic.test.ts apps/web/src/state/desktopUpdate.test.ts apps/web/src/components/ui/sidebar.test.tsx` (40 tests passed)
- `git diff --check`

Built with GPT-5.6 Sol in T3 Code via the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compact sidebar footer into icon buttons with tooltips and add update check action
> - Replaces the sidebar footer's text-based controls with icon-only `SidebarMenuButton` components (Settings, Pull Requests, Usage), each wrapped in a tooltip, laid out in a single `flex-row` menu.
> - Adds an explicit "Check for updates" action to `SidebarUpdateControl` when no update is in progress; removes the manual dismiss button.
> - Introduces `SidebarUpdateArchitectureWarning` to display an alert when Electron is running an Intel build on Apple Silicon.
> - The back button now always navigates to `/` instead of attempting `window.history.back()`.
> - Behavioral Change: the update pill is no longer dismissible and is always visible in Electron.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84454d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar footer layout and navigation tweaks. Update check/download/install still use the existing desktop bridge; no auth or data-path changes.
> 
> **Overview**
> **Compacts the sidebar footer** into a single icon row and makes Back navigation always return to the thread list.
> 
> Settings, Pull Requests, and Usage become icon-only buttons with tooltips instead of full-width labeled rows. On Usage/PR pages, a single full-width **Back** button always navigates to `/` (no more `history.back()` bouncing between those pages).
> 
> The Electron update control sits on the right of the same row: idle state is a **Check for updates** refresh button, then it switches to download/restart when an update is available. The dismissible full-width update pill is removed, and the Intel-on-Apple-Silicon warning is split into its own `SidebarUpdateArchitectureWarning` above the row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84454d7be40eaf49579abbfbb281441c85cc9997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->