### PR TITLE
feat(web): show plan progress in sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -15,6 +15,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
+  resolveSidebarPlanProgressSegments,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveSidebarThreadStatus,
@@ -710,6 +711,65 @@ describe("resolveSidebarThreadStatus", () => {
 
   it("defaults to ready with no session", () => {
     expect(resolveSidebarThreadStatus({ ...idle, session: null })).toBe("ready");
+  });
+});
+
+describe("resolveSidebarPlanProgressSegments", () => {
+  const progress = {
+    step: "Test the sidebar",
+    completedSteps: 2,
+    totalSteps: 5,
+  };
+
+  it("marks completed, current, and pending plan steps while working", () => {
+    expect(
+      resolveSidebarPlanProgressSegments({ status: "working", planProgress: progress }),
+    ).toEqual([
+      { position: 1, status: "completed" },
+      { position: 2, status: "completed" },
+      { position: 3, status: "current" },
+      { position: 4, status: "pending" },
+      { position: 5, status: "pending" },
+    ]);
+  });
+
+  it("hides progress when work settles or every step is complete", () => {
+    expect(resolveSidebarPlanProgressSegments({ status: "ready", planProgress: progress })).toEqual(
+      [],
+    );
+    expect(resolveSidebarPlanProgressSegments({ status: "working", planProgress: null })).toEqual(
+      [],
+    );
+    expect(
+      resolveSidebarPlanProgressSegments({
+        status: "working",
+        planProgress: { ...progress, completedSteps: 0, totalSteps: 0 },
+      }),
+    ).toEqual([]);
+    expect(
+      resolveSidebarPlanProgressSegments({
+        status: "working",
+        planProgress: { ...progress, completedSteps: progress.totalSteps },
+      }),
+    ).toEqual([]);
+  });
+
+  it("caps large plans to a proportional eight-segment visual", () => {
+    const segments = resolveSidebarPlanProgressSegments({
+      status: "working",
+      planProgress: { ...progress, completedSteps: 50, totalSteps: 100 },
+    });
+
+    expect(segments).toEqual([
+      { position: 1, status: "completed" },
+      { position: 2, status: "completed" },
+      { position: 3, status: "completed" },
+      { position: 4, status: "completed" },
+      { position: 5, status: "current" },
+      { position: 6, status: "pending" },
+      { position: 7, status: "pending" },
+      { position: 8, status: "pending" },
+    ]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -480,6 +480,46 @@ export function resolveSidebarThreadStatus(thread: SidebarThreadStatusInput): Si
   return "ready";
 }
 
+export interface SidebarPlanProgressSegment {
+  position: number;
+  status: "completed" | "current" | "pending";
+}
+
+const SIDEBAR_PLAN_PROGRESS_SEGMENT_LIMIT = 8;
+
+export function resolveSidebarPlanProgressSegments(input: {
+  status: SidebarThreadStatus;
+  planProgress: SidebarThreadSummary["planProgress"];
+}): SidebarPlanProgressSegment[] {
+  const progress = input.planProgress;
+  if (
+    input.status !== "working" ||
+    progress == null ||
+    progress.totalSteps === 0 ||
+    progress.completedSteps >= progress.totalSteps
+  ) {
+    return [];
+  }
+
+  // Sidebar rows are virtualized and can show many live threads at once. Keep
+  // large plans on a fixed visual scale instead of creating one DOM node per
+  // provider-reported step; the progressbar ARIA values retain exact totals.
+  const segmentCount = Math.min(progress.totalSteps, SIDEBAR_PLAN_PROGRESS_SEGMENT_LIMIT);
+  const completedSegmentCount = Math.floor(
+    (progress.completedSteps / progress.totalSteps) * segmentCount,
+  );
+
+  return Array.from({ length: segmentCount }, (_, index) => ({
+    position: index + 1,
+    status:
+      index < completedSegmentCount
+        ? "completed"
+        : index === completedSegmentCount
+          ? "current"
+          : "pending",
+  }));
+}
+
 /** NaN-safe Date.parse for sort comparators: a malformed timestamp must not
     poison the whole ordering, so it sinks to the epoch instead. */
 export function parseTimestampMs(isoDate: string): number {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -128,6 +128,7 @@ import {
   orderItemsByPreferredIds,
   planPinnedReorder,
   resolveAdjacentThreadId,
+  resolveSidebarPlanProgressSegments,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
   searchSidebarThreadsByTitle,
@@ -760,6 +761,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // switching sidebars must not light up every historical thread as unread.
   const isUnread = hasUnseenCompletion({ ...thread, lastVisitedAt });
   const status = resolveSidebarThreadStatus(thread);
+  const planProgressSegments = resolveSidebarPlanProgressSegments({
+    status,
+    planProgress: thread.planProgress,
+  });
   // A woken thread reappears at its original position (the sort is
   // deliberately static), so the pill has to carry the weight. Snoozing is
   // an explicit act, so the pill clears only when the user re-engages:
@@ -1436,6 +1441,33 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               ) : (
                 <span className="flex-1" />
               )}
+              {planProgressSegments.length > 0 && thread.planProgress ? (
+                <span
+                  role="progressbar"
+                  aria-label={`Plan progress: ${thread.planProgress.completedSteps} of ${thread.planProgress.totalSteps} steps completed`}
+                  aria-valuemin={0}
+                  aria-valuemax={thread.planProgress.totalSteps}
+                  aria-valuenow={thread.planProgress.completedSteps}
+                  aria-valuetext={`Step ${thread.planProgress.completedSteps + 1} of ${thread.planProgress.totalSteps}: ${thread.planProgress.step}`}
+                  data-testid="sidebar-plan-progress"
+                  className="inline-flex max-w-16 shrink-0 items-center gap-0.5 overflow-hidden"
+                >
+                  {planProgressSegments.map((segment) => (
+                    <span
+                      key={segment.position}
+                      aria-hidden
+                      className={cn(
+                        "h-[3px] w-2.5 min-w-px rounded-full",
+                        segment.status === "completed"
+                          ? "bg-success"
+                          : segment.status === "current"
+                            ? "bg-primary"
+                            : "bg-muted-foreground/25",
+                      )}
+                    />
+                  ))}
+                </span>
+              ) : null}
               {terminalStatusIcon}
               {prBadge}
               {diff ? (


### PR DESCRIPTION
## What Changed

- Show live segmented plan progress beside the status of each working thread in the web sidebar.
- Distinguish completed, current, and pending steps while hiding absent, settled, empty, or fully completed plans.
- Keep large plans bounded to an eight-segment proportional view so virtualized sidebar rows remain compact; exact totals remain available through progress-bar semantics.
- Cover the resolver's normal, hidden, and large-plan states with focused unit tests.

## Why

The sidebar currently reports that an agent is working, but it does not show how far the active plan has advanced. That makes parallel threads harder to scan and forces users to open a thread just to understand its current progress.

The thread summary already carries transient `planProgress`, so this change renders that existing state at the row boundary without adding a wire contract, server state, or provider-specific path.

## UI Changes

### Before

<img width="1280" height="720" alt="Sidebar thread row before plan progress is shown" src="https://github.com/user-attachments/assets/fce7e054-0517-4f66-a17a-7e9cdaca914d" />

### After

<img width="1280" height="720" alt="Sidebar thread row showing live segmented plan progress" src="https://github.com/user-attachments/assets/2698e405-a067-49e9-ac41-d6c20ea70ecd" />

### Interaction

https://github.com/user-attachments/assets/b4ccda86-20a9-4da3-a1a0-8b93a6215191

## Validation

- `vp test run --project unit src/components/Sidebar.logic.test.ts` — 103 tests passed
- `vp run --filter @t3tools/web typecheck`
- `vp fmt --check src/components/Sidebar.logic.ts src/components/Sidebar.logic.test.ts src/components/Sidebar.tsx`
- `vp lint --report-unused-disable-directives src/components/Sidebar.logic.ts src/components/Sidebar.logic.test.ts src/components/Sidebar.tsx`
- `git diff --check`
- Local web UI inspection across idle, partially complete, and completed plan states

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

---

Generated with gpt-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that renders existing thread planProgress state in the sidebar, with no auth, data, or API contract changes.
> 
> **Overview**
> Shows **live segmented plan progress** on working thread rows in the sidebar, so users can scan how far each active plan has advanced without opening the thread.
> 
> Adds `resolveSidebarPlanProgressSegments` to map existing `planProgress` into completed/current/pending segments, hiding progress when the thread is settled, empty, or fully complete. Large plans are capped to a proportional **8-segment** visual while exact totals stay available via progressbar ARIA attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2583d0ef5b7f2f6436a9a172e95f8fbc3672668b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show plan progress segments in sidebar thread rows
> - Adds a compact progress bar to `SidebarThreadRow` that renders only when a thread is in `working` status with partial plan progress (i.e. `completedSteps < totalSteps` and `totalSteps > 0`).
> - Introduces `resolveSidebarPlanProgressSegments` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/6212/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to compute up to 8 proportional segments, each labeled `completed`, `current`, or `pending`.
> - Progress bar includes ARIA attributes (`aria-valuemin`, `aria-valuemax`, `aria-valuenow`, `aria-valuetext`) reflecting exact step counts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2583d0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->