### PR TITLE
feat(orchestration): hand off provider context

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -55,7 +55,11 @@ import {
 import { ControlPill, ControlPillMenu } from "../../components/ControlPill";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
-import { buildModelOptions, groupByProvider } from "../../lib/modelOptions";
+import {
+  buildModelOptions,
+  groupByProvider,
+  resolveThreadProviderGroups,
+} from "../../lib/modelOptions";
 import { useScaledTextRole } from "../settings/appearance/useScaledTextRole";
 import type { RemoteClientConnectionState } from "../../lib/connection";
 import {
@@ -606,11 +610,15 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     [props.serverConfig, currentModelSelection],
   );
   const providerGroups = useMemo(() => groupByProvider(modelOptions), [modelOptions]);
-  // An existing thread is bound to its harness: sessions can't move between
-  // provider instances, so the picker only offers the thread's own group.
   const threadProviderGroups = useMemo(
-    () => providerGroups.filter((group) => group.providerKey === currentModelSelection.instanceId),
-    [providerGroups, currentModelSelection.instanceId],
+    () =>
+      resolveThreadProviderGroups({
+        providerGroups,
+        currentProviderInstanceId: currentModelSelection.instanceId,
+        supportsProviderHandoff:
+          props.serverConfig?.environment.capabilities.providerHandoff === true,
+      }),
+    [providerGroups, currentModelSelection.instanceId, props.serverConfig],
   );
   const currentModelOption =
     modelOptions.find(

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -261,9 +261,8 @@ type SubmenuPage =
  * changes size. Model changes stage until Save — while staged, the settings
  * rows edit the staged model's options and Save applies everything together.
  *
- * Callers control which harnesses are offered via providerGroups: an
- * existing thread must pass only its own provider's group, since a session
- * can't switch harness mid-thread.
+ * Callers control which harnesses are offered via providerGroups. Servers
+ * that support provider handoff may offer every configured provider here.
  *
  * Rendered through an RN Modal (not the root OverlayPortal) so it also
  * presents above natively-presented form sheets like the new-task draft.

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -7,6 +7,7 @@ import {
   groupByProvider,
   resolveDefaultableModelSelection,
   resolveSelectableModelSelection,
+  resolveThreadProviderGroups,
 } from "./modelOptions";
 
 describe("mobile model options", () => {
@@ -170,5 +171,27 @@ describe("mobile model options", () => {
     expect(resolveDefaultableModelSelection(config, legacy)).toBeNull();
     // Offline: nothing to validate against, selection passes through.
     expect(resolveDefaultableModelSelection(null, legacy)).toBe(legacy);
+  });
+
+  it("offers every provider only when the server supports thread handoff", () => {
+    const providerGroups = [
+      { providerKey: "claude", providerLabel: "Claude", models: [] },
+      { providerKey: "codex", providerLabel: "Codex", models: [] },
+    ];
+
+    expect(
+      resolveThreadProviderGroups({
+        providerGroups,
+        currentProviderInstanceId: "claude",
+        supportsProviderHandoff: false,
+      }),
+    ).toEqual([providerGroups[0]]);
+    expect(
+      resolveThreadProviderGroups({
+        providerGroups,
+        currentProviderInstanceId: "claude",
+        supportsProviderHandoff: true,
+      }),
+    ).toBe(providerGroups);
   });
 });

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -187,3 +187,13 @@ export function groupByProvider(options: ReadonlyArray<ModelOption>): ReadonlyAr
     models: group.models,
   }));
 }
+
+export function resolveThreadProviderGroups(input: {
+  readonly providerGroups: ReadonlyArray<ProviderGroup>;
+  readonly currentProviderInstanceId: string;
+  readonly supportsProviderHandoff: boolean;
+}): ReadonlyArray<ProviderGroup> {
+  return input.supportsProviderHandoff
+    ? input.providerGroups
+    : input.providerGroups.filter((group) => group.providerKey === input.currentProviderInstanceId);
+}

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -71,6 +71,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.connectionProbe).toBe(true);
       expect(second.capabilities.pullRequests).toBe(true);
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
+      expect(second.capabilities.providerHandoff).toBe(true);
     }),
   );
 

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -149,6 +149,7 @@ export const make = Effect.gen(function* () {
       threadPinning: true,
       threadPinReorder: true,
       threadTitleRegeneration: true,
+      providerHandoff: true,
       ...(serverSelfUpdate === null ? {} : { serverSelfUpdate }),
       ...(serverSelfUpdate === "boot-service" ? { serverSelfUpdateProgress: true } : {}),
     },

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2310,8 +2310,8 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.runtimeMode).toBe("full-access");
   });
 
-  it("rejects provider changes after a thread is already bound to a session provider", async () => {
-    const harness = await createHarness();
+  it("hands a running thread off to a different provider with prior context", async () => {
+    const harness = await createHarness({ requiresNewThreadForModelChange: true });
     const now = "2026-01-01T00:00:00.000Z";
 
     await Effect.runPromise(
@@ -2355,6 +2355,96 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    await harness.drain();
+
+    const restartRequest = harness.startSession.mock.calls[1]?.[1];
+    expect(restartRequest).toMatchObject({
+      provider: "claudeAgent",
+      providerInstanceId: "claudeAgent",
+      modelSelection: { instanceId: "claudeAgent", model: "claude-opus-4-6" },
+    });
+    expect(restartRequest).not.toHaveProperty("resumeCursor");
+    expect(harness.stopSession.mock.calls.length).toBe(0);
+
+    const secondSend = harness.sendTurn.mock.calls[1]?.[0];
+    expect(secondSend).toMatchObject({
+      threadId: "thread-1",
+      modelSelection: { instanceId: "claudeAgent", model: "claude-opus-4-6" },
+    });
+    expect(secondSend).toHaveProperty("input", expect.stringContaining("[Conversation handoff]"));
+    expect(secondSend).toHaveProperty("input", expect.stringContaining("User:\nfirst"));
+    expect(secondSend).toHaveProperty("input", expect.stringMatching(/second$/));
+    expect((secondSend as { input: string }).input.match(/\nsecond/g)).toHaveLength(1);
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.threadId).toBe("thread-1");
+    expect(thread?.session?.providerName).toBe("claudeAgent");
+    expect(thread?.modelSelection).toMatchObject({
+      instanceId: "claudeAgent",
+      model: "claude-opus-4-6",
+    });
+    expect(thread?.session?.runtimeMode).toBe("approval-required");
+    expect(
+      thread?.activities.find((activity) => activity.kind === "thread.model-changed"),
+    ).toMatchObject({
+      summary: "Switched model to claude-opus-4-6",
+      payload: {
+        fromInstanceId: "codex",
+        toInstanceId: "claudeAgent",
+        isHandoff: true,
+      },
+    });
+  });
+
+  it("does not record a provider handoff when the destination session fails to start", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-provider-handoff-failure-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-provider-handoff-failure-1"),
+          role: "user",
+          text: "first",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    harness.startSession.mockImplementationOnce(
+      (_: unknown, __: unknown) => Effect.fail("destination unavailable") as never,
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-provider-handoff-failure-2"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-provider-handoff-failure-2"),
+          role: "user",
+          text: "continue with claude",
+          attachments: [],
+        },
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          model: "claude-opus-4-6",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
     await waitFor(async () => {
       const readModel = await harness.readModel();
       const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
@@ -2363,26 +2453,21 @@ describe("ProviderCommandReactor", () => {
         false
       );
     });
+    await harness.drain();
 
-    expect(harness.startSession.mock.calls.length).toBe(1);
+    expect(harness.startSession.mock.calls.length).toBe(2);
     expect(harness.sendTurn.mock.calls.length).toBe(1);
     expect(harness.stopSession.mock.calls.length).toBe(0);
-
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-    expect(thread?.session?.threadId).toBe("thread-1");
+    expect(thread?.modelSelection.instanceId).toBe("codex");
     expect(thread?.session?.providerName).toBe("codex");
-    expect(thread?.session?.runtimeMode).toBe("approval-required");
-    expect(
-      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
-    ).toMatchObject({
-      payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
-      },
-    });
+    expect(thread?.activities.some((activity) => activity.kind === "thread.model-changed")).toBe(
+      false,
+    );
   });
 
-  it("rejects cross-driver provider changes after the existing thread session has stopped", async () => {
+  it("hands off after restart using the last-bound session provider", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -2426,24 +2511,27 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(async () => {
-      const readModel = await harness.readModel();
-      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-      return (
-        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
-        false
-      );
-    });
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    await harness.drain();
 
-    expect(harness.startSession.mock.calls.length).toBe(0);
-    expect(harness.sendTurn.mock.calls.length).toBe(0);
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      provider: "claudeAgent",
+      providerInstanceId: "claudeAgent",
+    });
+    expect(harness.startSession.mock.calls[0]?.[1]).not.toHaveProperty("resumeCursor");
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toHaveProperty("input", "continue with claude");
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.providerName).toBe("claudeAgent");
+    expect(thread?.modelSelection.instanceId).toBe("claudeAgent");
     expect(
-      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
+      thread?.activities.find((activity) => activity.kind === "thread.model-changed"),
     ).toMatchObject({
       payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
+        fromInstanceId: "codex",
+        toInstanceId: "claudeAgent",
+        isHandoff: true,
       },
     });
   });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -4,6 +4,7 @@ import {
   EventId,
   type ModelSelection,
   type OrchestrationEvent,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -45,6 +46,10 @@ import {
 } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
+import {
+  HANDOFF_TRANSCRIPT_MAX_CHARS,
+  renderProviderHandoffPrelude,
+} from "../providerHandoffTranscript.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
 
@@ -520,7 +525,7 @@ const make = Effect.gen(function* () {
       activeSession !== undefined &&
       activeSession.providerInstanceId !== undefined
         ? activeSession.providerInstanceId
-        : thread.modelSelection.instanceId;
+        : (thread.session?.providerInstanceId ?? thread.modelSelection.instanceId);
     const desiredModelSelection = requestedModelSelection ?? thread.modelSelection;
     const desiredInstanceId = desiredModelSelection.instanceId;
     const currentInfo = yield* providerService.getInstanceInfo(currentInstanceId).pipe(
@@ -558,6 +563,12 @@ const make = Effect.gen(function* () {
       });
     }
     const preferredProvider: ProviderDriverKind = desiredDriverKind;
+    const isProviderHandoff =
+      requestedModelSelection !== undefined &&
+      requestedModelSelection.instanceId !== currentInstanceId &&
+      (currentInfo.driverKind !== desiredInfo.driverKind ||
+        currentInfo.continuationIdentity.continuationKey !==
+          desiredInfo.continuationIdentity.continuationKey);
     if (options?.pendingTurnStart === true && thread.session?.status !== "running") {
       yield* setThreadSession({
         threadId,
@@ -574,7 +585,7 @@ const make = Effect.gen(function* () {
         createdAt,
       });
     }
-    if (thread.session !== null) {
+    if (thread.session !== null && !isProviderHandoff) {
       yield* rejectStartedThreadModelChangeIfRequired({
         threadId,
         currentModelSelection:
@@ -588,29 +599,50 @@ const make = Effect.gen(function* () {
         requestedModelSelection,
       });
     }
-    if (
+    const persistHandoffModelSelection = Effect.gen(function* () {
+      if (!isProviderHandoff) {
+        return;
+      }
+      yield* orchestrationEngine.dispatch({
+        type: "thread.meta.update",
+        commandId: yield* serverCommandId("provider-handoff-model-selection"),
+        threadId,
+        modelSelection: desiredModelSelection,
+      });
+    });
+    const currentModel = activeSession?.model ?? thread.modelSelection.model;
+    const modelSelectionChangedForStartedThread =
       thread.session !== null &&
       requestedModelSelection !== undefined &&
-      requestedModelSelection.instanceId !== currentInstanceId
-    ) {
-      if (currentInfo.driverKind !== desiredInfo.driverKind) {
-        return yield* new ProviderAdapterRequestError({
-          provider: preferredProvider,
-          method: "thread.turn.start",
-          detail: `Thread '${threadId}' is bound to driver '${currentInfo.driverKind}' and cannot switch to '${desiredInfo.driverKind}'.`,
-        });
+      (desiredInstanceId !== currentInstanceId || desiredModelSelection.model !== currentModel);
+    const appendModelChangedNotice = Effect.gen(function* () {
+      if (!modelSelectionChangedForStartedThread) {
+        return;
       }
-      if (
-        currentInfo.continuationIdentity.continuationKey !==
-        desiredInfo.continuationIdentity.continuationKey
-      ) {
-        return yield* new ProviderAdapterRequestError({
-          provider: preferredProvider,
-          method: "thread.turn.start",
-          detail: `Thread '${threadId}' cannot switch from instance '${currentInstanceId}' to '${desiredInstanceId}' because their provider resume state is incompatible.`,
-        });
-      }
-    }
+      yield* orchestrationEngine.dispatch({
+        type: "thread.activity.append",
+        commandId: yield* serverCommandId("thread-model-changed-notice"),
+        threadId,
+        activity: {
+          id: yield* serverEventId(),
+          tone: "info",
+          kind: "thread.model-changed",
+          summary: `Switched model to ${desiredModelSelection.model}`,
+          payload: {
+            fromInstanceId: String(currentInstanceId),
+            fromModel: currentModel,
+            fromDriverKind: currentInfo.driverKind,
+            toInstanceId: String(desiredInstanceId),
+            toModel: desiredModelSelection.model,
+            toDriverKind: desiredInfo.driverKind,
+            isHandoff: isProviderHandoff,
+          },
+          turnId: null,
+          createdAt,
+        },
+        createdAt,
+      });
+    });
     const project = yield* resolveProject(thread.projectId);
     const effectiveCwd = resolveThreadWorkspaceCwd({
       thread,
@@ -687,12 +719,14 @@ const make = Effect.gen(function* () {
         !shouldRestartForModelChange &&
         !shouldRestartForModelSelectionChange
       ) {
-        return existingSessionThreadId;
+        yield* appendModelChangedNotice;
+        return { threadId: existingSessionThreadId, handedOff: false };
       }
 
-      const resumeCursor = shouldRestartForModelChange
-        ? undefined
-        : (activeSession?.resumeCursor ?? undefined);
+      const resumeCursor =
+        shouldRestartForModelChange || isProviderHandoff
+          ? undefined
+          : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
         threadId,
         existingSessionThreadId,
@@ -710,6 +744,7 @@ const make = Effect.gen(function* () {
         instanceChanged,
         shouldRestartForModelChange,
         shouldRestartForModelSelectionChange,
+        isProviderHandoff,
         hasResumeCursor: resumeCursor !== undefined,
       });
       const restartedSession = yield* startProviderSession(
@@ -724,17 +759,22 @@ const make = Effect.gen(function* () {
         cwd: restartedSession.cwd,
       });
       yield* bindSessionToThread(restartedSession);
-      return restartedSession.threadId;
+      yield* persistHandoffModelSelection;
+      yield* appendModelChangedNotice;
+      return { threadId: restartedSession.threadId, handedOff: isProviderHandoff };
     }
 
     const startedSession = yield* startProviderSession(undefined);
     yield* bindSessionToThread(startedSession);
-    return startedSession.threadId;
+    yield* persistHandoffModelSelection;
+    yield* appendModelChangedNotice;
+    return { threadId: startedSession.threadId, handedOff: isProviderHandoff };
   });
 
   const buildSendTurnRequestForThread = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
     readonly messageText: string;
+    readonly messageId?: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
     readonly modelSelection?: ModelSelection;
     readonly interactionMode?: "default" | "plan";
@@ -746,7 +786,7 @@ const make = Effect.gen(function* () {
         new Error(`Thread '${input.threadId}' was not found in read model.`),
       );
     }
-    yield* ensureSessionForThread(input.threadId, input.createdAt, {
+    const ensuredSession = yield* ensureSessionForThread(input.threadId, input.createdAt, {
       ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
       pendingTurnStart: true,
     });
@@ -754,6 +794,20 @@ const make = Effect.gen(function* () {
       threadModelSelections.set(input.threadId, input.modelSelection);
     }
     const normalizedInput = toNonEmptyProviderInput(input.messageText);
+    const handoffPrelude = ensuredSession.handedOff
+      ? renderProviderHandoffPrelude({
+          messages: thread.messages,
+          activities: thread.activities,
+          ...(input.messageId !== undefined ? { excludeMessageId: input.messageId } : {}),
+          maxChars: Math.min(
+            HANDOFF_TRANSCRIPT_MAX_CHARS,
+            PROVIDER_SEND_TURN_MAX_INPUT_CHARS - (normalizedInput?.length ?? 0) - 1_000,
+          ),
+        })
+      : undefined;
+    const inputWithHandoffPrelude = handoffPrelude
+      ? [handoffPrelude, normalizedInput].filter(Boolean).join("\n\n")
+      : normalizedInput;
     const normalizedAttachments = input.attachments ?? [];
     const activeSession = yield* providerService
       .listSessions()
@@ -785,7 +839,7 @@ const make = Effect.gen(function* () {
 
     return {
       threadId: input.threadId,
-      ...(normalizedInput ? { input: normalizedInput } : {}),
+      ...(inputWithHandoffPrelude ? { input: inputWithHandoffPrelude } : {}),
       ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
       ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
       ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
@@ -1163,6 +1217,7 @@ const make = Effect.gen(function* () {
 
     const sendTurnRequest = yield* buildSendTurnRequestForThread({
       threadId: event.payload.threadId,
+      messageId: event.payload.messageId,
       messageText: message.text,
       ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
       ...(event.payload.modelSelection !== undefined

--- a/apps/server/src/orchestration/providerHandoffTranscript.test.ts
+++ b/apps/server/src/orchestration/providerHandoffTranscript.test.ts
@@ -1,0 +1,161 @@
+import {
+  EventId,
+  MessageId,
+  type OrchestrationMessage,
+  type OrchestrationThreadActivity,
+  TurnId,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { renderProviderHandoffPrelude } from "./providerHandoffTranscript.ts";
+
+const NOW = "2026-01-01T00:00:00.000Z";
+
+function message(
+  id: string,
+  role: OrchestrationMessage["role"],
+  text: string,
+  createdAt: string = NOW,
+): OrchestrationMessage {
+  return {
+    id: MessageId.make(id),
+    role,
+    text,
+    turnId: TurnId.make("turn-1"),
+    streaming: false,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+function activity(overrides: {
+  readonly id: string;
+  readonly kind: string;
+  readonly summary: string;
+  readonly createdAt: string;
+  readonly payload?: Record<string, unknown>;
+}): OrchestrationThreadActivity {
+  return {
+    id: EventId.make(overrides.id),
+    tone: "tool",
+    kind: overrides.kind,
+    summary: overrides.summary,
+    payload: overrides.payload ?? {},
+    turnId: TurnId.make("turn-1"),
+    createdAt: overrides.createdAt,
+  };
+}
+
+describe("renderProviderHandoffPrelude", () => {
+  it("renders prior messages in order and excludes the in-flight message", () => {
+    const prelude = renderProviderHandoffPrelude({
+      messages: [
+        message("m1", "user", "hello"),
+        message("m2", "assistant", "hi there", "2026-01-01T00:00:01.000Z"),
+        message("m3", "system", "internal note", "2026-01-01T00:00:02.000Z"),
+        message("m4", "user", "continue with Codex", "2026-01-01T00:00:03.000Z"),
+      ],
+      excludeMessageId: "m4",
+    });
+
+    expect(prelude).toContain("[Conversation handoff]");
+    expect(prelude).toContain("User:\nhello");
+    expect(prelude).toContain("Assistant:\nhi there");
+    expect(prelude).not.toContain("internal note");
+    expect(prelude).not.toContain("continue with Codex");
+    expect(prelude!.indexOf("hello")).toBeLessThan(prelude!.indexOf("hi there"));
+  });
+
+  it("carries completed tool work with output and changed files", () => {
+    const prelude = renderProviderHandoffPrelude({
+      messages: [message("m1", "user", "inspect and fix it")],
+      activities: [
+        activity({
+          id: "a1",
+          kind: "tool.completed",
+          summary: "Ran command",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          payload: {
+            itemType: "command_execution",
+            data: {
+              item: {
+                id: "cmd-1",
+                command: "vp test run feature.test.ts",
+                exitCode: 0,
+                aggregatedOutput: "1 passed",
+              },
+            },
+          },
+        }),
+        activity({
+          id: "a2",
+          kind: "tool.completed",
+          summary: "Edited files",
+          createdAt: "2026-01-01T00:00:02.000Z",
+          payload: {
+            itemType: "file_change",
+            data: { item: { id: "edit-1", changes: [{ path: "src/feature.ts" }] } },
+          },
+        }),
+      ],
+    });
+
+    expect(prelude).toContain("[$] vp test run feature.test.ts (exit 0)");
+    expect(prelude).toContain("1 passed");
+    expect(prelude).toContain("[edit] src/feature.ts");
+  });
+
+  it("prefers a terminal tool result over a longer streaming update", () => {
+    const streamingOutput = "still running ".repeat(40);
+    const prelude = renderProviderHandoffPrelude({
+      messages: [message("m1", "user", "run it")],
+      activities: [
+        activity({
+          id: "a1",
+          kind: "tool.updated",
+          summary: "Running",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          payload: {
+            itemType: "command_execution",
+            data: { item: { id: "cmd-1", command: "flaky", aggregatedOutput: streamingOutput } },
+          },
+        }),
+        activity({
+          id: "a2",
+          kind: "tool.completed",
+          summary: "Ran command",
+          createdAt: "2026-01-01T00:00:02.000Z",
+          payload: {
+            itemType: "command_execution",
+            data: {
+              item: { id: "cmd-1", command: "flaky", exitCode: 1, aggregatedOutput: "failed" },
+            },
+          },
+        }),
+      ],
+    });
+
+    expect(prelude!.match(/\[\$\] flaky/g)).toHaveLength(1);
+    expect(prelude).toContain("[$] flaky (exit 1)");
+    expect(prelude).toContain("failed");
+    expect(prelude).not.toContain(streamingOutput);
+  });
+
+  it("keeps the newest complete entries within the character budget", () => {
+    const messages = Array.from({ length: 50 }, (_, index) =>
+      message(
+        `m${index}`,
+        index % 2 === 0 ? "user" : "assistant",
+        `message ${index} ${"x".repeat(200)}`,
+        `2026-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+      ),
+    );
+    const prelude = renderProviderHandoffPrelude({ messages, maxChars: 2_000 });
+
+    expect(prelude).toBeDefined();
+    expect(prelude!.length).toBeLessThanOrEqual(2_000);
+    expect(prelude).toContain("[Older history omitted for length]");
+    expect(prelude).toContain("message 49");
+    expect(prelude).not.toContain("message 0 ");
+  });
+});

--- a/apps/server/src/orchestration/providerHandoffTranscript.ts
+++ b/apps/server/src/orchestration/providerHandoffTranscript.ts
@@ -1,0 +1,357 @@
+/**
+ * Renders the orchestration read model into a provider-neutral prelude.
+ *
+ * Provider-native resume cursors cannot cross driver or continuation
+ * boundaries. A fresh destination session receives this prelude on its first
+ * turn so it can continue from T3 Code's canonical conversation and tool log.
+ */
+import type { OrchestrationMessage, OrchestrationThreadActivity } from "@t3tools/contracts";
+import * as Predicate from "effect/Predicate";
+
+export const HANDOFF_TRANSCRIPT_MAX_CHARS = 80_000;
+const TOOL_OUTPUT_MAX_CHARS = 600;
+const TOOL_SUBJECT_MAX_CHARS = 300;
+const MAX_CHANGED_FILES = 12;
+
+const HANDOFF_HEADER = [
+  "[Conversation handoff]",
+  "You are taking over an existing conversation that was previously handled by a different AI assistant.",
+  'The transcript below is the conversation so far. "User:" lines are from the user; "Assistant:" lines were written by the previous assistant.',
+  'Lines in [brackets] are tools the previous assistant invoked, including commands ("$"), file edits ("edit"), reads, MCP calls, and other tools. Treat them as a log of work already performed.',
+  "--- transcript start ---",
+].join("\n");
+
+const HANDOFF_FOOTER = [
+  "--- transcript end ---",
+  "Continue naturally from where the conversation left off. The workspace already reflects any changes above. Do not introduce yourself again or mention this handoff unless the user asks.",
+].join("\n");
+
+const TRUNCATION_NOTICE = "[Older history omitted for length]";
+const ENTRY_SEPARATOR = "\n\n";
+
+interface TranscriptEntry {
+  readonly createdAt: string;
+  readonly text: string;
+}
+
+function recordOrNull(value: unknown): Record<PropertyKey, unknown> | null {
+  return Predicate.isObject(value) ? value : null;
+}
+
+function nonEmptyStringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}… [truncated]` : value;
+}
+
+function toolCallGroupKey(
+  activity: OrchestrationThreadActivity,
+  payload: Record<PropertyKey, unknown>,
+) {
+  const data = recordOrNull(payload.data);
+  const item = recordOrNull(data?.item);
+  return (
+    nonEmptyStringOrNull(payload.toolCallId) ??
+    nonEmptyStringOrNull(payload.callId) ??
+    nonEmptyStringOrNull(payload.id) ??
+    nonEmptyStringOrNull(data?.toolCallId) ??
+    nonEmptyStringOrNull(item?.id) ??
+    activity.id
+  );
+}
+
+function isToolTrailActivity(activity: OrchestrationThreadActivity): boolean {
+  return (
+    activity.kind === "tool.updated" ||
+    activity.kind === "tool.completed" ||
+    activity.kind === "task.completed"
+  );
+}
+
+function isTerminalToolActivity(activity: OrchestrationThreadActivity): boolean {
+  return activity.kind === "tool.completed" || activity.kind === "task.completed";
+}
+
+function finiteNumberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function toolItem(payload: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> | null {
+  return recordOrNull(recordOrNull(payload.data)?.item);
+}
+
+function toolItemType(payload: Record<PropertyKey, unknown>): string | null {
+  return nonEmptyStringOrNull(payload.itemType) ?? nonEmptyStringOrNull(toolItem(payload)?.type);
+}
+
+function stripExitMarker(value: string | null): { text: string | null; exitCode: number | null } {
+  if (!value) {
+    return { text: null, exitCode: null };
+  }
+  const match = /^([\s\S]*?)(?:\s*<exited with exit code (\d+)>)\s*$/i.exec(value.trim());
+  if (!match) {
+    return { text: value.trim() || null, exitCode: null };
+  }
+  return {
+    text: match[1]!.trim() || null,
+    exitCode: Number.parseInt(match[2]!, 10),
+  };
+}
+
+function toolCommand(payload: Record<PropertyKey, unknown>): string | null {
+  const item = toolItem(payload);
+  const input = recordOrNull(item?.input);
+  const detail = stripExitMarker(nonEmptyStringOrNull(payload.detail));
+  return (
+    nonEmptyStringOrNull(item?.command) ??
+    nonEmptyStringOrNull(input?.command) ??
+    (toolItemType(payload) === "command_execution" ? detail.text : null)
+  );
+}
+
+function toolExitCode(payload: Record<PropertyKey, unknown>): number | null {
+  const rawOutput = recordOrNull(recordOrNull(payload.data)?.rawOutput);
+  return (
+    finiteNumberOrNull(toolItem(payload)?.exitCode) ??
+    finiteNumberOrNull(rawOutput?.exitCode) ??
+    stripExitMarker(nonEmptyStringOrNull(payload.detail)).exitCode
+  );
+}
+
+function pushFile(target: string[], seen: Set<string>, value: unknown): void {
+  const normalized = nonEmptyStringOrNull(value);
+  if (normalized && !seen.has(normalized)) {
+    seen.add(normalized);
+    target.push(normalized);
+  }
+}
+
+function collectFiles(value: unknown, target: string[], seen: Set<string>, depth: number): void {
+  if (depth > 4 || target.length >= MAX_CHANGED_FILES) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectFiles(entry, target, seen, depth + 1);
+      if (target.length >= MAX_CHANGED_FILES) return;
+    }
+    return;
+  }
+  const record = recordOrNull(value);
+  if (!record) {
+    return;
+  }
+  pushFile(target, seen, record.path);
+  pushFile(target, seen, record.filePath);
+  pushFile(target, seen, record.relativePath);
+  pushFile(target, seen, record.newPath);
+  pushFile(target, seen, record.oldPath);
+  for (const key of ["item", "result", "input", "changes", "files", "edits", "patches"]) {
+    if (key in record) {
+      collectFiles(record[key], target, seen, depth + 1);
+      if (target.length >= MAX_CHANGED_FILES) return;
+    }
+  }
+}
+
+function toolChangedFiles(payload: Record<PropertyKey, unknown>): string[] {
+  const files: string[] = [];
+  collectFiles(recordOrNull(payload.data), files, new Set<string>(), 0);
+  return files;
+}
+
+function toolStatus(payload: Record<PropertyKey, unknown>): string | null {
+  return nonEmptyStringOrNull(payload.status) ?? nonEmptyStringOrNull(toolItem(payload)?.status);
+}
+
+function toolOutput(payload: Record<PropertyKey, unknown>, command: string | null): string | null {
+  const data = recordOrNull(payload.data);
+  const item = toolItem(payload);
+  const rawOutput = recordOrNull(data?.rawOutput);
+  const detailText = stripExitMarker(nonEmptyStringOrNull(payload.detail)).text;
+  const candidates = [
+    item?.aggregatedOutput,
+    data?.aggregatedOutput,
+    rawOutput?.content,
+    rawOutput?.stdout,
+    item?.output,
+    data?.output,
+    item?.stdout,
+    data?.stdout,
+    rawOutput?.stderr,
+    item?.stderr,
+    data?.stderr,
+    detailText && detailText !== command ? detailText : null,
+  ];
+  for (const candidate of candidates) {
+    const text = nonEmptyStringOrNull(candidate);
+    if (text) {
+      return truncate(text, TOOL_OUTPUT_MAX_CHARS);
+    }
+  }
+  const totalFiles = finiteNumberOrNull(rawOutput?.totalFiles);
+  if (totalFiles !== null) {
+    return `${totalFiles} file${totalFiles === 1 ? "" : "s"}${rawOutput?.truncated === true ? "+" : ""}`;
+  }
+  return null;
+}
+
+function describeTool(
+  activity: OrchestrationThreadActivity,
+  payload: Record<PropertyKey, unknown>,
+): { tag: string; subject: string } | null {
+  const itemType = toolItemType(payload);
+  const command = toolCommand(payload);
+  const files = toolChangedFiles(payload);
+  const fileList = files.length > 0 ? files.join(", ") : null;
+  const title = nonEmptyStringOrNull(payload.title) ?? nonEmptyStringOrNull(activity.summary);
+
+  if (activity.kind === "task.completed") {
+    return title ? { tag: "task", subject: title } : null;
+  }
+
+  let tag: string;
+  let subject: string | null;
+  switch (itemType) {
+    case "command_execution":
+      tag = "$";
+      subject = command ?? title;
+      break;
+    case "file_change":
+      tag = "edit";
+      subject = fileList ?? title;
+      break;
+    case "mcp_tool_call":
+      tag = "mcp";
+      subject = title ?? command;
+      break;
+    case "web_search":
+      tag = "search";
+      subject = title ?? command;
+      break;
+    case "image_view":
+      tag = "view";
+      subject = fileList ?? title;
+      break;
+    case "dynamic_tool_call":
+    case "collab_agent_tool_call":
+      tag = "tool";
+      subject = title ?? command ?? fileList;
+      break;
+    default:
+      tag = "tool";
+      subject = command ?? fileList ?? title;
+      break;
+  }
+  return subject ? { tag, subject: truncate(subject, TOOL_SUBJECT_MAX_CHARS) } : null;
+}
+
+function buildToolTrailLine(activity: OrchestrationThreadActivity): string | null {
+  const payload = recordOrNull(activity.payload) ?? {};
+  const described = describeTool(activity, payload);
+  if (!described) {
+    return null;
+  }
+  const command = toolCommand(payload);
+  const exitCode = toolExitCode(payload);
+  const status = toolStatus(payload)?.toLowerCase();
+  const statusSuffix =
+    exitCode !== null
+      ? ` (exit ${exitCode})`
+      : status === "failed" || status === "error" || status === "declined"
+        ? ` (${status})`
+        : "";
+  const output = toolOutput(payload, command);
+  return `[${described.tag}] ${described.subject}${statusSuffix}${output ? `\n→ ${output}` : ""}`;
+}
+
+function collectToolTrailEntries(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): TranscriptEntry[] {
+  const byGroup = new Map<string, { entry: TranscriptEntry; terminal: boolean }>();
+  for (const activity of activities) {
+    if (!isToolTrailActivity(activity)) {
+      continue;
+    }
+    const line = buildToolTrailLine(activity);
+    if (!line) {
+      continue;
+    }
+    const key = toolCallGroupKey(activity, recordOrNull(activity.payload) ?? {});
+    const terminal = isTerminalToolActivity(activity);
+    const existing = byGroup.get(key);
+    if (
+      !existing ||
+      (terminal && !existing.terminal) ||
+      (terminal === existing.terminal && line.length > existing.entry.text.length)
+    ) {
+      byGroup.set(key, { entry: { createdAt: activity.createdAt, text: line }, terminal });
+    }
+  }
+  return Array.from(byGroup.values()).map((value) => value.entry);
+}
+
+/**
+ * Keeps the newest complete entries that fit `maxChars`. The in-flight user
+ * message must be excluded because the caller appends it after this prelude.
+ */
+export function renderProviderHandoffPrelude(input: {
+  readonly messages: ReadonlyArray<OrchestrationMessage>;
+  readonly activities?: ReadonlyArray<OrchestrationThreadActivity>;
+  readonly excludeMessageId?: string;
+  readonly maxChars?: number;
+}): string | undefined {
+  const maxChars = input.maxChars ?? HANDOFF_TRANSCRIPT_MAX_CHARS;
+  const messageEntries: TranscriptEntry[] = input.messages
+    .filter((message) => message.id !== input.excludeMessageId)
+    .filter((message) => message.role === "user" || message.role === "assistant")
+    .map((message) => ({
+      createdAt: message.createdAt,
+      text: `${message.role === "user" ? "User" : "Assistant"}:\n${message.text.trim()}`,
+      hasText: message.text.trim().length > 0,
+    }))
+    .filter((entry) => entry.hasText)
+    .map(({ createdAt, text }) => ({ createdAt, text }));
+
+  const toolEntries = collectToolTrailEntries(input.activities ?? []);
+  if (messageEntries.length === 0 && toolEntries.length === 0) {
+    return undefined;
+  }
+
+  const entries = [...messageEntries, ...toolEntries]
+    .toSorted((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .map((entry) => entry.text);
+  const frameCost =
+    HANDOFF_HEADER.length +
+    HANDOFF_FOOTER.length +
+    TRUNCATION_NOTICE.length +
+    ENTRY_SEPARATOR.length * 3;
+  const entryBudget = maxChars - frameCost;
+  if (entryBudget <= 0) {
+    return undefined;
+  }
+
+  const kept: string[] = [];
+  let used = 0;
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const entry = entries[index]!;
+    const cost = entry.length + ENTRY_SEPARATOR.length;
+    if (used + cost > entryBudget) {
+      break;
+    }
+    kept.unshift(entry);
+    used += cost;
+  }
+  if (kept.length === 0) {
+    return undefined;
+  }
+
+  return [
+    HANDOFF_HEADER,
+    ...(kept.length < entries.length ? [TRUNCATION_NOTICE] : []),
+    ...kept,
+    HANDOFF_FOOTER,
+  ].join(ENTRY_SEPARATOR);
+}

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -373,6 +373,42 @@ describe("getStartedThreadModelChangeBlockReason", () => {
         "This provider does not allow switching models after a conversation has started.",
     });
   });
+
+  it("allows switching away from a restricted provider when handoff is supported", () => {
+    expect(
+      getStartedThreadModelChangeBlockReason({
+        providers,
+        hasStartedSession: true,
+        supportsProviderHandoff: true,
+        currentModelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-build",
+        },
+        nextModelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5.4",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("still blocks restricted same-provider model changes when handoff is supported", () => {
+    expect(
+      getStartedThreadModelChangeBlockReason({
+        providers,
+        hasStartedSession: true,
+        supportsProviderHandoff: true,
+        currentModelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-build",
+        },
+        nextModelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-other",
+        },
+      }),
+    ).not.toBeNull();
+  });
 });
 
 describe("resolveSendEnvMode", () => {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -408,6 +408,7 @@ export function deriveLockedProvider(input: {
 export function getStartedThreadModelChangeBlockReason(input: {
   providers: ReadonlyArray<Pick<ServerProvider, "instanceId" | "requiresNewThreadForModelChange">>;
   hasStartedSession: boolean;
+  supportsProviderHandoff?: boolean;
   currentModelSelection: ModelSelection;
   currentProviderInstanceId?: ModelSelection["instanceId"] | null | undefined;
   nextModelSelection: ModelSelection;
@@ -422,6 +423,12 @@ export function getStartedThreadModelChangeBlockReason(input: {
   if (
     currentModelSelection.instanceId === input.nextModelSelection.instanceId &&
     currentModelSelection.model === input.nextModelSelection.model
+  ) {
+    return null;
+  }
+  if (
+    input.supportsProviderHandoff === true &&
+    currentModelSelection.instanceId !== input.nextModelSelection.instanceId
   ) {
     return null;
   }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1982,6 +1982,8 @@ function ChatViewContent(props: ChatViewProps) {
   const serverConfig = activeThread
     ? (activeEnvironment?.serverConfig ?? null)
     : (primaryEnvironment?.serverConfig ?? null);
+  const supportsProviderHandoff = serverConfig?.environment.capabilities.providerHandoff === true;
+  const modelPickerLockedProvider = supportsProviderHandoff ? null : lockedProvider;
   const pullRequestsCapabilityKnown = serverConfig !== null;
   const supportsPullRequests = serverConfig?.environment.capabilities.pullRequests === true;
   const versionMismatch = resolveServerConfigVersionMismatch(serverConfig);
@@ -2173,7 +2175,8 @@ function ChatViewContent(props: ChatViewProps) {
     providerStatuses,
     selectedProviderByThreadId ?? threadProvider,
   );
-  const selectedProvider: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
+  const selectedProvider: ProviderDriverKind =
+    modelPickerLockedProvider ?? unlockedSelectedProvider;
   const phase = derivePhase(activeThread?.session ?? null);
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
   const workLogEntries = useMemo(() => deriveWorkLogEntries(threadActivities), [threadActivities]);
@@ -5813,13 +5816,14 @@ function ChatViewContent(props: ChatViewProps) {
       const reason = getStartedThreadModelChangeBlockReason({
         providers: providerStatuses,
         hasStartedSession: activeThread.session !== null,
+        supportsProviderHandoff,
         currentModelSelection: activeThread.modelSelection,
         currentProviderInstanceId: activeThread.session?.providerInstanceId ?? null,
         nextModelSelection: { instanceId, model },
       });
       return reason ? `${reason.description} Start a new thread to use this model.` : null;
     },
-    [activeThread, providerStatuses],
+    [activeThread, providerStatuses, supportsProviderHandoff],
   );
 
   const onProviderModelSelect = useCallback(
@@ -5831,14 +5835,14 @@ function ChatViewContent(props: ChatViewProps) {
       const entry = providerStatuses.find((snapshot) => snapshot.instanceId === instanceId);
       const resolvedDriverKind = entry?.driver ?? null;
       if (
-        lockedProvider !== null &&
+        modelPickerLockedProvider !== null &&
         resolvedDriverKind !== null &&
-        resolvedDriverKind !== lockedProvider
+        resolvedDriverKind !== modelPickerLockedProvider
       ) {
         scheduleComposerFocus();
         return;
       }
-      if (lockedProvider !== null && activeThread.session?.providerInstanceId) {
+      if (modelPickerLockedProvider !== null && activeThread.session?.providerInstanceId) {
         const currentEntry = providerStatuses.find(
           (snapshot) => snapshot.instanceId === activeThread.session?.providerInstanceId,
         );
@@ -5868,6 +5872,7 @@ function ChatViewContent(props: ChatViewProps) {
       const modelChangeBlockReason = getStartedThreadModelChangeBlockReason({
         providers: providerStatuses,
         hasStartedSession: activeThread.session !== null,
+        supportsProviderHandoff,
         currentModelSelection: activeThread.modelSelection,
         currentProviderInstanceId: activeThread.session?.providerInstanceId ?? null,
         nextModelSelection,
@@ -5890,12 +5895,13 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [
       activeThread,
-      lockedProvider,
+      modelPickerLockedProvider,
       scheduleComposerFocus,
       setComposerDraftModelSelection,
       setStickyComposerModelSelection,
       providerStatuses,
       settings,
+      supportsProviderHandoff,
     ],
   );
   const onEnvModeChange = useCallback(
@@ -6340,7 +6346,7 @@ function ChatViewContent(props: ChatViewProps) {
                             activeProposedPlan={activeProposedPlan}
                             runtimeMode={runtimeMode}
                             interactionMode={interactionMode}
-                            lockedProvider={lockedProvider}
+                            lockedProvider={modelPickerLockedProvider}
                             providerStatuses={providerStatuses as ServerProvider[]}
                             activeProjectDefaultModelSelection={
                               activeProject?.defaultModelSelection

--- a/docs/user/provider-handoff.md
+++ b/docs/user/provider-handoff.md
@@ -1,0 +1,19 @@
+# Continue A Thread With Another Provider
+
+You can continue an existing thread with another configured provider or account from the model
+picker in the message composer. Choose the destination provider and model, then send your next
+message normally.
+
+When the destination can resume the existing provider session, T3 Code keeps using that native
+history. When it cannot—such as moving from Claude to Codex, or between isolated accounts—T3 Code
+starts a fresh destination session and sends it a bounded handoff containing the recent
+conversation and completed tool work. Your project, branch, worktree, permission mode, and T3 Code
+thread stay the same.
+
+The handoff is sent only with the first message to the new provider. Older history may be omitted
+from very long threads to stay within provider input limits. The workspace remains the source of
+truth for file changes already made.
+
+If another provider does not appear in the picker, confirm that it is enabled, installed, and
+authenticated in Settings. A server version that does not support provider handoff keeps existing
+threads locked to their compatible provider group.

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -86,14 +86,14 @@ blurred by default; click the blurred email to reveal it.
 
 ## Can I Switch Claude Accounts In An Existing Thread?
 
-Usually, no.
-
-T3 Code only offers Claude providers that use the same config directory for an existing thread. A
-different config directory is treated as a different Claude environment.
+Yes. Choose another account or provider from the model picker and send your next message. A Claude
+provider with a different config directory starts a fresh session with a bounded handoff of the T3
+Code conversation and completed tool work. See
+[Continue A Thread With Another Provider](./provider-handoff.md).
 
 This is different from the recommended Codex setup. Claude Code keeps account and local state across
 multiple files under its config directory, so T3 Code keeps separate config directories isolated
-instead of trying to share part of the state.
+instead of trying to share provider-native state between them.
 
 ## I Want To Use OpenRouter
 

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -102,7 +102,12 @@ values are stored as server secrets and are not sent back to the app after savin
 
 ## Can I Switch Accounts In An Existing Thread?
 
-Yes, when both Codex providers share the same `CODEX_HOME path`.
+Yes. Choose another account or provider from the model picker and send your next message. See
+[Continue A Thread With Another Provider](./provider-handoff.md) for how T3 Code carries context
+when the destination cannot resume the same provider session.
+
+When both Codex providers share the same `CODEX_HOME path`, T3 Code can continue the native Codex
+session directly.
 
 For example:
 
@@ -111,11 +116,11 @@ Codex Work      CODEX_HOME path: ~/.codex
 Codex Personal  CODEX_HOME path: ~/.codex, Shadow home path: ~/.codex_p
 ```
 
-Those two providers are considered compatible for continuation, so the locked model picker can show
-both.
+Those two providers are considered compatible for native continuation.
 
 If you add a third Codex provider with a completely different `CODEX_HOME path`, T3 Code treats it
-as a different workspace. It will not be offered for existing threads created under `~/.codex`.
+as a different provider workspace. Switching to it starts a fresh Codex session with a bounded
+handoff of the T3 Code conversation and completed tool work.
 
 ## If Both Accounts Look The Same
 

--- a/packages/contracts/src/environment.test.ts
+++ b/packages/contracts/src/environment.test.ts
@@ -26,4 +26,17 @@ describe("ExecutionEnvironmentDescriptor", () => {
       }).capabilities.pullRequests,
     ).toBe(true);
   });
+
+  it("treats a missing provider-handoff capability as unsupported under version skew", () => {
+    expect(decodeDescriptor(descriptor).capabilities.providerHandoff).toBeUndefined();
+  });
+
+  it("preserves an advertised provider-handoff capability", () => {
+    expect(
+      decodeDescriptor({
+        ...descriptor,
+        capabilities: { ...descriptor.capabilities, providerHandoff: true },
+      }).capabilities.providerHandoff,
+    ).toBe(true);
+  });
 });

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -67,6 +67,9 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   /** Server understands regenerateTitle on thread.meta.update. Absent on
       older servers, so clients hide the action instead of sending it. */
   threadTitleRegeneration: Schema.optionalKey(Schema.Boolean),
+  /** Server can start a fresh provider session and replay bounded thread
+      context when a started thread switches to an incompatible provider. */
+  providerHandoff: Schema.optionalKey(Schema.Boolean),
   /** The update path clients should offer for this server. Absent on
       servers that must be relaunched manually (dev checkouts, Windows
       foreground runs, pre-update servers). */


### PR DESCRIPTION
## What Changed

- Allow started threads to switch to another provider or incompatible provider instance.
- Start a fresh destination session and prepend bounded conversation plus completed tool context to its first turn.
- Advertise the capability and unlock provider groups on web, desktop, and mobile while keeping older servers locked.
- Persist the destination selection only after startup succeeds and append a visible model-change activity.
- Document provider handoff and its input-limit behavior.

## Why

The current orchestrator rejects cross-driver continuation, so a thread becomes stranded when its provider reaches a usage limit. PR #2829 contains the intended orchestration-v2 experience, but that work is not on main and depends on a much larger orchestrator replacement. This ports the same user-facing behavior onto the current session boundary without importing orchestration-v2.

Provider-native resume state is reused when compatible. Otherwise T3 Code starts a clean destination session and derives the handoff from its canonical message and tool log.

## UI Changes

Before, a started thread only exposed its compatible provider group. After, servers advertising provider handoff expose every configured provider in the existing model picker on web, desktop, and mobile.

Screenshots were not captured because browser verification was not authorized for this worktree.

## Verification

- 101 focused tests passed across reactor, transcript, contracts, web, mobile, and server environment coverage.
- Targeted typechecks passed for contracts, server, web, and mobile.
- Targeted lint and formatting checks passed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable; no motion changes)

Implemented with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core turn-start and session restart logic in ProviderCommandReactor, including when model metadata and activities are persisted; incorrect handoff or rollback could strand threads or send wrong context to providers.
> 
> **Overview**
> **Started threads can switch to another provider** when the server advertises `providerHandoff`. Cross-driver or incompatible-instance moves no longer fail at turn start; the orchestrator starts a fresh destination session (no resume cursor), prepends a bounded **conversation handoff** transcript to the first turn, persists the new model only after startup succeeds, and records a `thread.model-changed` activity with `isHandoff: true`.
> 
> The **`providerHandoff` capability** is added to environment contracts and server descriptors. **Web and mobile** unlock the model picker to all configured providers when the flag is set (web still blocks same-provider “requires new thread” model changes). **Mobile** uses `resolveThreadProviderGroups` for the same behavior.
> 
> New **`renderProviderHandoffPrelude`** builds the handoff from user/assistant messages and completed tool work, with length limits and user docs for Claude/Codex account switching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10f67b26e0120efc78b51702d4142947b0d2f70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider handoff to allow switching providers mid-thread with context replay
> - Introduces a `providerHandoff` capability flag in `ExecutionEnvironmentCapabilities` that servers advertise when cross-provider switching is supported; the server always sets this to `true`.
> - When a model selection targets an incompatible provider (different driver kind or continuation key), `ProviderCommandReactor` restarts the session and prepends a bounded handoff prelude to the next turn instead of rejecting the change.
> - The prelude is built by `renderProviderHandoffPrelude` in [providerHandoffTranscript.ts](https://github.com/pingdotgg/t3code/pull/6213/files#diff-aa88f8c4387a8c09c1fed4dc7620ed416d3e3c3ca8e27f5eb753f6051d71eb51), which collects recent messages and tool activities, selects the newest entries within `HANDOFF_TRANSCRIPT_MAX_CHARS`, and emits a provider-neutral transcript.
> - The web model picker (`ChatView`) and mobile composer (`ThreadComposer`) unlock cross-provider selection when the server advertises handoff support; `getStartedThreadModelChangeBlockReason` is updated to allow cross-provider changes in this case.
> - A `thread.model-changed` activity is recorded on handoff and thread meta is updated with the new `modelSelection`; resume cursors are not reused across incompatible providers.
> - Risk: the handoff prelude is bounded but still adds latency to the first turn with the new provider; tool output truncation and ordering heuristics may omit context that the destination provider would benefit from.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e10f67b. 12 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->