### PR TITLE
fix(web): align the snoozed thread wake icon

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1205,11 +1205,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     aria-label="Wake thread now"
                     onClick={handleUnsnoozeClick}
                     className={cn(
-                      "pointer-events-none absolute inset-y-0 right-0 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-2 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:opacity-100",
+                      "pointer-events-none absolute inset-y-0 right-0 -mr-1 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:opacity-100",
                       isWoke && "group-hover/sidebar-row:static",
                     )}
                   >
-                    <AlarmClockOffIcon className="size-3" />
+                    <AlarmClockOffIcon className="mb-px size-3" />
                   </button>
                 )
               ) : !props.settlementSupported ? null : variantAction === "unsettle" ? (


### PR DESCRIPTION
The wake icon on a snoozed thread sat farther left and slightly higher than the undo icon on the settled thread below it. Hovering between the two sections made the sidebar actions look misaligned.

The wake control now uses the same right offset, horizontal padding, and icon baseline as the settled control, bringing the two icons into alignment. This only changes the wake control's appearance; its hover, focus, and click behavior are unchanged.

## Verification

- `vp lint apps/web/src/components/Sidebar.tsx`
- `vp run --filter @t3tools/web typecheck`
- Compared the supplied before and after recordings by hovering the snoozed wake icon and the settled-thread undo icon below it.

## Before and after

https://github.com/user-attachments/assets/2e86429d-dab7-4bdb-bb15-0fb4d42ff160


https://github.com/user-attachments/assets/55a2334e-cd3f-4693-a235-cf7b518fac85


---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only tweak to one sidebar row action; no logic, API, or data changes.
> 
> **Overview**
> **Sidebar slim rows:** The snoozed thread **Wake thread now** hover control is visually matched to the settled row **Un-settle** control so adjacent shelf actions line up.
> 
> The wake button now uses the same right offset (`-mr-1`), horizontal padding (`px-1.5`), and icon baseline (`mb-px` on `AlarmClockOffIcon`) as the unsettle button. Hover, focus, and click behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82feb77d8742126135a50049e061ace336332a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align the unsnooze icon in the sidebar thread row
> Adjusts padding and margin on the 'Wake thread now' button in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/6215/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and adds a 1px bottom offset to the `AlarmClockOffIcon` to correct its vertical alignment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82feb77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->