### PR TITLE
fix(ssh): preserve remote runtime during tunnel recovery

### DIFF
--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -338,6 +338,75 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(processLayer));
   });
 
+  it.effect("recreates a stale local tunnel without stopping the remote server", () => {
+    let localTunnelReady = true;
+    let remoteLaunchCount = 0;
+    let tunnelKillCount = 0;
+    let stopCommandCount = 0;
+    const conditionalHttpClient = HttpClient.make((request) =>
+      localTunnelReady
+        ? Effect.succeed(HttpClientResponse.fromWeb(request, new Response("", { status: 200 })))
+        : Effect.succeed(HttpClientResponse.fromWeb(request, new Response("", { status: 503 }))),
+    );
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-N")) {
+          localTunnelReady = true;
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          });
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          remoteLaunchCount += 1;
+          return makeSuccessfulProcess('{"remotePort":3773,"serverKind":"managed"}\n');
+        }
+        if (args.includes("sh")) {
+          stopCommandCount += 1;
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, conditionalHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const manager = yield* SshEnvironmentManager;
+        yield* manager.ensureEnvironment(target);
+        localTunnelReady = false;
+        const reconnectFiber = yield* Effect.forkChild(manager.ensureEnvironment(target));
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust(Duration.millis(2_500));
+        yield* Fiber.join(reconnectFiber);
+
+        assert.equal(remoteLaunchCount, 2);
+        assert.equal(tunnelKillCount, 1);
+        assert.equal(stopCommandCount, 0);
+      }).pipe(Effect.provide(layer)),
+    ).pipe(
+      Effect.andThen(
+        Effect.sync(() => {
+          assert.equal(tunnelKillCount, 2);
+          assert.equal(stopCommandCount, 0);
+        }),
+      ),
+    );
+  });
+
   it.effect("closes the tunnel scope and starts fresh after disconnect", () => {
     const spawnedCommands: Array<ReadonlyArray<string>> = [];
     let tunnelKillCount = 0;

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -1360,9 +1360,6 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ),
     );
     tunnels.set(input.key, tunnelEntry);
-    const spawnerService = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const fileSystemService = yield* FileSystem.FileSystem;
-    const pathService = yield* Path.Path;
     yield* Scope.addFinalizer(
       entryScope,
       Effect.gen(function* () {
@@ -1376,33 +1373,12 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
           remotePort: tunnelEntry.remotePort,
         });
         tunnels.delete(tunnelEntry.key);
-        const authSecret = authSecrets.get(tunnelEntry.key) ?? null;
-        yield* Effect.all(
-          [
-            tunnelEntry.process.kill({
-              killSignal: "SIGTERM",
-              forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
-            }),
-            stopRemoteServer(
-              tunnelEntry.target,
-              authSecret === null
-                ? {
-                    batchMode: "yes",
-                    interactiveAuth: false,
-                  }
-                : {
-                    authSecret,
-                    batchMode: "no",
-                    interactiveAuth: true,
-                  },
-            ).pipe(
-              Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawnerService),
-              Effect.provideService(FileSystem.FileSystem, fileSystemService),
-              Effect.provideService(Path.Path, pathService),
-            ),
-          ],
-          { concurrency: "unbounded" },
-        ).pipe(Effect.ignore);
+        yield* tunnelEntry.process
+          .kill({
+            killSignal: "SIGTERM",
+            forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
+          })
+          .pipe(Effect.ignore);
         yield* Effect.logDebug("ssh.environment.tunnel.finalizer.succeeded", {
           ...sshTargetLogFields(tunnelEntry.target),
           key: tunnelEntry.key,
@@ -1578,13 +1554,11 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       yield* closeTunnelEntry(entry);
     }
     yield* cancelPendingTunnelEntry(key, resolvedTarget);
-    if (entry === null) {
-      yield* runWithSshAuth({
-        key,
-        target: resolvedTarget,
-        operation: (authOptions) => stopRemoteServer(resolvedTarget, authOptions),
-      });
-    }
+    yield* runWithSshAuth({
+      key,
+      target: resolvedTarget,
+      operation: (authOptions) => stopRemoteServer(resolvedTarget, authOptions),
+    });
     yield* Effect.logInfo("ssh.environment.disconnect.succeeded", {
       ...sshTargetLogFields(resolvedTarget),
       key,


### PR DESCRIPTION
Summary:

- Keep the remote T3 runtime alive when a desktop SSH tunnel becomes stale or the desktop app exits.
- Rebuild only the failed local forward during automatic reconnect.
- Stop the remote runtime only when the user explicitly disconnects the environment.

Validation:

- All 26 SSH package tests pass.
- SSH package typecheck passes.
- Formatting passes.

The regression simulates a stale local forward and proves recovery creates a fresh tunnel without issuing the remote stop command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SSH tunnel lifecycle and remote process teardown, so incorrect finalizer/disconnect behavior could leave remote servers running or fail to clean them up.
> 
> **Overview**
> **Keeps the remote T3 runtime alive** when a local SSH tunnel goes stale or the desktop app exits. Tunnel finalizers now only kill the local forward process instead of also calling `stopRemoteServer`.
> 
> Remote stop is reserved for **explicit disconnect**: `disconnectEnvironment` always stops the remote runtime, whether or not a local tunnel entry exists.
> 
> Adds a regression test that simulates a stale local forward and asserts reconnect rebuilds the tunnel without issuing a remote stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed5c27dfdcaec7975d546c2084cc11eca5e3eb06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve remote runtime when recovering a stale SSH tunnel
> - The scope finalizer in [`tunnel.ts`](https://github.com/pingdotgg/t3code/pull/6217/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072) no longer stops the remote server when a tunnel entry is torn down; it only kills the local tunnel process.
> - `disconnectEnvironment` now always issues a remote stop command when disconnecting, regardless of whether an active tunnel entry existed.
> - A new test in [`tunnel.test.ts`](https://github.com/pingdotgg/t3code/pull/6217/files#diff-76d3724ec8959625b119aff8272a5d733f73551706a487e303ddbd13e10a06ad) verifies that reconnecting a stale local tunnel does not stop the remote server mid-cycle.
> - Behavioral Change: closing a tunnel scope previously stopped the remote server; it no longer does, so remote processes survive local tunnel restarts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed5c27d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->