### PR TITLE
fix(server): installed editors no longer go undetected on Windows

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -158,17 +158,18 @@ it.effect("discovers editors through the service API", () =>
 );
 
 it.effect("memoizes editor discovery and refreshes after the cache window", () => {
-  let statCalls = 0;
+  let readDirCalls = 0;
   const fileInfo = { type: "File" } as FileSystem.File.Info;
   const launcherLayer = ExternalLauncher.layer.pipe(
     Layer.provide(
       Layer.mergeAll(
         FileSystem.layerNoop({
-          stat: () =>
+          readDirectory: () =>
             Effect.sync(() => {
-              statCalls += 1;
-              return fileInfo;
+              readDirCalls += 1;
+              return ["code.CMD"];
             }),
+          stat: () => Effect.succeed(fileInfo),
         }),
         Path.layer,
         Layer.succeed(
@@ -184,20 +185,19 @@ it.effect("memoizes editor discovery and refreshes after the cache window", () =
 
     const first = yield* launcher.resolveAvailableEditors();
     assert.equal(first.includes("vscode"), true);
-    const statCallsAfterFirstScan = statCalls;
-    assert.isAbove(statCallsAfterFirstScan, 0);
+    assert.equal(readDirCalls, 1);
 
-    // Past the shared command-resolution cache TTL (30s) but within the
+    // Past the shared directory-listing cache TTL (30s) but within the
     // discovery cache window: the memoized set is reused without any scan.
     yield* TestClock.adjust("31 seconds");
     const second = yield* launcher.resolveAvailableEditors();
     assert.deepEqual([...second], [...first]);
-    assert.equal(statCalls, statCallsAfterFirstScan);
+    assert.equal(readDirCalls, 1);
 
     // Past the discovery cache window the next call rescans.
     yield* TestClock.adjust("30 seconds");
     yield* launcher.resolveAvailableEditors();
-    assert.isAbove(statCalls, statCallsAfterFirstScan);
+    assert.equal(readDirCalls, 2);
   }).pipe(
     Effect.provide(
       Layer.mergeAll(
@@ -224,17 +224,18 @@ it.effect("memoizes editor discovery and refreshes after the cache window", () =
 it.effect("rescans after an interrupted discovery instead of caching the interrupt", () => {
   const fileInfo = { type: "File" } as FileSystem.File.Info;
   let blockFirstScan = true;
-  let scans = 0;
+  let statCalls = 0;
   const launcherLayer = ExternalLauncher.layer.pipe(
     Layer.provide(
       Layer.mergeAll(
         FileSystem.layerNoop({
+          readDirectory: () => Effect.succeed(["code.CMD"]),
           // The first scan parks inside `stat` so the interrupt lands while
           // discovery is in flight, which is what a client disconnecting
           // mid-connect does to the shared effect.
           stat: () =>
             Effect.gen(function* () {
-              scans += 1;
+              statCalls += 1;
               if (blockFirstScan) {
                 return yield* Effect.never;
               }
@@ -259,10 +260,10 @@ it.effect("rescans after an interrupted discovery instead of caching the interru
 
     // The next connect must still get a real answer well inside the TTL.
     blockFirstScan = false;
-    scans = 0;
+    statCalls = 0;
     const editors = yield* launcher.resolveAvailableEditors();
     assert.equal(editors.includes("vscode"), true);
-    assert.isAbove(scans, 0);
+    assert.isAbove(statCalls, 0);
   }).pipe(
     Effect.provide(
       Layer.mergeAll(

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -303,7 +303,7 @@ const resolveAvailableEditors = Effect.fn("externalLauncher.resolveAvailableEdit
 // Editor discovery walks PATH for every known editor and runs for every
 // client connect (the server config embeds the available editors). Memoize
 // the discovered set for a bounded window so repeat connects skip even the
-// per-command cache lookups in @t3tools/shared/shell.
+// per-directory listing lookups in @t3tools/shared/shell.
 //
 // This deliberately does not use `Effect.cachedWithTTL`: that memoizes the
 // first caller's Exit whatever it is, including an interrupt. Callers run this

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -2,6 +2,9 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -365,6 +368,77 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
       expect(result._tag).toBe("Failure");
     }),
   );
+
+  it.effect("matches a Windows PATH entry regardless of file name case", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-shell-" });
+      yield* fileSystem.writeFileString(path.join(binDir, "code.cmd"), "@echo off\r\n");
+
+      const resolved = yield* resolveCommandPath("code", {
+        env: { PATH: binDir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+      }).pipe(Effect.provideService(HostProcessPlatform, "win32"));
+
+      expect(resolved.toLowerCase()).toBe(path.join(binDir, "code.cmd").toLowerCase());
+    }).pipe(Effect.scoped),
+  );
+
+  // A directory can grant search permission without read permission, so a
+  // failed listing must fall back to probing the candidate paths.
+  it.effect("probes a PATH directory that cannot be listed", () =>
+    Effect.gen(function* () {
+      const resolved = yield* resolveCommandPath("code", {
+        env: { PATH: "C:\\search-only", PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+      }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
+
+      expect(resolved._tag).toBe("Success");
+    }).pipe(
+      Effect.provide(
+        FileSystem.layerNoop({
+          readDirectory: () =>
+            Effect.fail(
+              PlatformError.systemError({
+                _tag: "PermissionDenied",
+                module: "FileSystem",
+                method: "readDirectory",
+              }),
+            ),
+          stat: () => Effect.succeed({ type: "File" } as FileSystem.File.Info),
+        }),
+      ),
+    ),
+  );
+
+  it.effect("skips a PATH directory that does not exist", () => {
+    let statCalls = 0;
+    return Effect.gen(function* () {
+      const resolved = yield* resolveCommandPath("code", {
+        env: { PATH: "C:\\missing", PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+      }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
+
+      expect(resolved._tag).toBe("Failure");
+      expect(statCalls).toBe(0);
+    }).pipe(
+      Effect.provide(
+        FileSystem.layerNoop({
+          readDirectory: () =>
+            Effect.fail(
+              PlatformError.systemError({
+                _tag: "NotFound",
+                module: "FileSystem",
+                method: "readDirectory",
+              }),
+            ),
+          stat: () =>
+            Effect.sync(() => {
+              statCalls += 1;
+              return { type: "File" } as FileSystem.File.Info;
+            }),
+        }),
+      ),
+    );
+  });
 });
 
 effectIt.layer(NodeServices.layer)("resolveSpawnCommand", (it) => {

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -384,61 +384,56 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
     }).pipe(Effect.scoped),
   );
 
-  // A directory can grant search permission without read permission, so a
-  // failed listing must fall back to probing the candidate paths.
-  it.effect("probes a PATH directory that cannot be listed", () =>
-    Effect.gen(function* () {
-      const resolved = yield* resolveCommandPath("code", {
-        env: { PATH: "C:\\search-only", PATHEXT: ".COM;.EXE;.BAT;.CMD" },
-      }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
-
-      expect(resolved._tag).toBe("Success");
-    }).pipe(
-      Effect.provide(
-        FileSystem.layerNoop({
-          readDirectory: () =>
-            Effect.fail(
-              PlatformError.systemError({
-                _tag: "PermissionDenied",
-                module: "FileSystem",
-                method: "readDirectory",
-              }),
-            ),
-          stat: () => Effect.succeed({ type: "File" } as FileSystem.File.Info),
+  const failingListingLayer = (reason: PlatformError.SystemErrorTag, onStat: () => void) =>
+    FileSystem.layerNoop({
+      readDirectory: () =>
+        Effect.fail(
+          PlatformError.systemError({
+            _tag: reason,
+            module: "FileSystem",
+            method: "readDirectory",
+          }),
+        ),
+      stat: () =>
+        Effect.sync(() => {
+          onStat();
+          return { type: "File" } as FileSystem.File.Info;
         }),
-      ),
-    ),
-  );
+    });
 
-  it.effect("skips a PATH directory that does not exist", () => {
-    let statCalls = 0;
-    return Effect.gen(function* () {
-      const resolved = yield* resolveCommandPath("code", {
-        env: { PATH: "C:\\missing", PATHEXT: ".COM;.EXE;.BAT;.CMD" },
-      }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
+  // A listing that did not happen proves nothing. Trusting it would hide an
+  // installed command for the whole cache window, so anything short of proof
+  // that the directory cannot hold a command falls back to probing.
+  for (const reason of ["PermissionDenied", "Busy", "Unknown"] as const) {
+    it.effect(`probes a PATH directory that fails to list with ${reason}`, () =>
+      Effect.gen(function* () {
+        // A distinct directory per case: the listing cache is keyed by
+        // directory and shared process-wide, so a reused path would answer
+        // from the previous case instead of exercising this one.
+        const resolved = yield* resolveCommandPath("code", {
+          env: { PATH: `C:\\unreadable-${reason}`, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+        }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
 
-      expect(resolved._tag).toBe("Failure");
-      expect(statCalls).toBe(0);
-    }).pipe(
-      Effect.provide(
-        FileSystem.layerNoop({
-          readDirectory: () =>
-            Effect.fail(
-              PlatformError.systemError({
-                _tag: "NotFound",
-                module: "FileSystem",
-                method: "readDirectory",
-              }),
-            ),
-          stat: () =>
-            Effect.sync(() => {
-              statCalls += 1;
-              return { type: "File" } as FileSystem.File.Info;
-            }),
-        }),
-      ),
+        expect(resolved._tag).toBe("Success");
+      }).pipe(Effect.provide(failingListingLayer(reason, () => undefined))),
     );
-  });
+  }
+
+  // A directory that is absent or is not a walkable directory at all can never
+  // hold a command, so it should be skipped.
+  for (const reason of ["NotFound", "BadResource"] as const) {
+    it.effect(`skips a PATH directory that fails to list with ${reason}`, () => {
+      let statCalls = 0;
+      return Effect.gen(function* () {
+        const resolved = yield* resolveCommandPath("code", {
+          env: { PATH: `C:\\unusable-${reason}`, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+        }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
+
+        expect(resolved._tag).toBe("Failure");
+        expect(statCalls).toBe(0);
+      }).pipe(Effect.provide(failingListingLayer(reason, () => (statCalls += 1))));
+    });
+  }
 });
 
 effectIt.layer(NodeServices.layer)("resolveSpawnCommand", (it) => {

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -492,53 +492,73 @@ function resolveCommandCandidates(
   return Array.from(new Set(candidates));
 }
 
-// Session bootstrap resolves the same commands over and over, each PATH scan
-// costing hundreds of 'shell.isExecutableFile' filesystem probes (tens of
-// thousands per connect). Memoize the scan outcome per
-// (platform, PATH, PATHEXT, command) for a short window: repeat scans hit the
-// cache while any change to the search environment invalidates immediately.
-// Explicit-path resolution is never cached - callers probe paths they have
-// just written (e.g. managed binary installs). A "not-found" outcome is also
-// cached for the TTL, so a just-installed binary can stay invisible for up to
-// 30s unless resolved by explicit path.
+// A probe-every-combination PATH scan costs one filesystem probe per
+// (directory, command, extension). On Windows that is ~40 directories times 24
+// candidate names for a single command, and editor discovery alone resolves 22
+// commands - more than 20000 probes, which takes several seconds. Read each PATH
+// directory once instead and match candidate names against the listing: one read
+// per directory, shared by every command resolved in the same window.
+// Listings are cached per directory for a short window, so a just-installed
+// binary can stay invisible for up to 30s unless resolved by explicit path.
+// Explicit-path resolution never consults the cache - callers probe paths they
+// have just written (e.g. managed binary installs).
 // TTL expiry uses the monotonic clock (Clock.currentTimeNanos) so backward
 // wall-clock adjustments cannot keep expired entries alive.
-const COMMAND_RESOLUTION_CACHE_TTL_NANOS = 30_000_000_000n;
-const COMMAND_RESOLUTION_CACHE_MAX_ENTRIES = 512;
-const COMMAND_RESOLUTION_CACHE_KEY_SEPARATOR = String.fromCharCode(0);
+const PATH_LISTING_CACHE_TTL_NANOS = 30_000_000_000n;
+const PATH_LISTING_CACHE_MAX_ENTRIES = 256;
 
-interface CommandResolutionCacheEntry {
-  readonly resolvedPath: string | null;
+interface PathListingCacheEntry {
+  /** `null` when the directory cannot be listed. */
+  readonly names: ReadonlySet<string> | null;
   readonly expiresAtNanos: bigint;
 }
 
 // The cache lives in the Effect environment (like HostProcessPlatform above)
 // so tests and embedders can provide an isolated instance; the default is a
 // single process-wide map shared by all consumers.
-export const CommandResolutionCache = Context.Reference<Map<string, CommandResolutionCacheEntry>>(
-  "@t3tools/shared/shell/CommandResolutionCache",
+export const PathListingCache = Context.Reference<Map<string, PathListingCacheEntry>>(
+  "@t3tools/shared/shell/PathListingCache",
   {
     defaultValue: () => new Map(),
   },
 );
 
-function cacheCommandResolution(
-  cache: Map<string, CommandResolutionCacheEntry>,
-  cacheKey: string,
-  resolvedPath: string | null,
-  nowNanos: bigint,
-): void {
-  if (cache.size >= COMMAND_RESOLUTION_CACHE_MAX_ENTRIES) {
+/**
+ * Lists the file names in a PATH directory, memoized for
+ * {@link PATH_LISTING_CACHE_TTL_NANOS}. A missing or invalid directory lists as
+ * empty. A directory that denies read permission lists as `null`, which tells
+ * callers to probe candidate paths directly.
+ */
+const listPathDirectory = Effect.fn("shell.listPathDirectory")(function* (
+  directory: string,
+  platform: NodeJS.Platform,
+): Effect.fn.Return<ReadonlySet<string> | null, never, FileSystem.FileSystem> {
+  const cache = yield* PathListingCache;
+  const cacheKey = normalizePathEntryForComparison(directory, platform);
+  const nowNanos = yield* Clock.currentTimeNanos;
+  const cached = cache.get(cacheKey);
+  if (cached !== undefined && cached.expiresAtNanos > nowNanos) {
+    return cached.names;
+  }
+
+  const fileSystem = yield* FileSystem.FileSystem;
+  const entries = yield* fileSystem.readDirectory(directory).pipe(
+    Effect.catchTags({
+      PlatformError: (error) =>
+        Effect.succeed(error.reason._tag === "PermissionDenied" ? null : []),
+    }),
+  );
+  const names = entries === null ? null : new Set(entries.map((e) => e.toLowerCase()));
+
+  if (cache.size >= PATH_LISTING_CACHE_MAX_ENTRIES) {
     const oldestKey = cache.keys().next().value;
     if (oldestKey !== undefined) {
       cache.delete(oldestKey);
     }
   }
-  cache.set(cacheKey, {
-    resolvedPath,
-    expiresAtNanos: nowNanos + COMMAND_RESOLUTION_CACHE_TTL_NANOS,
-  });
-}
+  cache.set(cacheKey, { names, expiresAtNanos: nowNanos + PATH_LISTING_CACHE_TTL_NANOS });
+  return names;
+});
 
 const isExecutableFile = Effect.fn("shell.isExecutableFile")(function* (
   filePath: string,
@@ -588,19 +608,6 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
     return yield* new CommandResolutionError({ command, reason: "not-found" });
   }
 
-  const cacheKey = [platform, pathValue, windowsPathExtensions.join(";"), command].join(
-    COMMAND_RESOLUTION_CACHE_KEY_SEPARATOR,
-  );
-  const cache = yield* CommandResolutionCache;
-  const nowNanos = yield* Clock.currentTimeNanos;
-  const cached = cache.get(cacheKey);
-  if (cached !== undefined && cached.expiresAtNanos > nowNanos) {
-    if (cached.resolvedPath === null) {
-      return yield* new CommandResolutionError({ command, reason: "not-found" });
-    }
-    return cached.resolvedPath;
-  }
-
   const pathEntries: string[] = [];
   for (const entry of pathValue.split(pathDelimiterForPlatform(platform))) {
     const pathEntry = stripWrappingQuotes(entry.trim());
@@ -610,15 +617,21 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
   }
 
   for (const pathEntry of pathEntries) {
+    const names = yield* listPathDirectory(pathEntry, platform);
+
     for (const candidate of commandCandidates) {
+      // A listed directory rules candidates out by name.
+      // An unlisted one falls back to probing every candidate.
+      if (names !== null && !names.has(candidate.toLowerCase())) continue;
+
+      // A listed name only proves the entry exists; the file type and the
+      // executable bit still need a stat.
       const candidatePath = path.join(pathEntry, candidate);
       if (yield* isExecutableFile(candidatePath, platform, windowsPathExtensions)) {
-        cacheCommandResolution(cache, cacheKey, candidatePath, nowNanos);
         return candidatePath;
       }
     }
   }
-  cacheCommandResolution(cache, cacheKey, null, nowNanos);
   return yield* new CommandResolutionError({ command, reason: "not-found" });
 });
 

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -508,10 +508,18 @@ const PATH_LISTING_CACHE_TTL_NANOS = 30_000_000_000n;
 const PATH_LISTING_CACHE_MAX_ENTRIES = 256;
 
 interface PathListingCacheEntry {
-  /** `null` when the directory cannot be listed. */
+  /** `null` when the listing failed but the directory may still hold commands. */
   readonly names: ReadonlySet<string> | null;
   readonly expiresAtNanos: bigint;
 }
+
+// Failure reasons that prove the PATH entry can never hold a command, so an
+// empty listing is the correct answer.
+const UNUSABLE_DIRECTORY_REASONS: ReadonlySet<string> = new Set([
+  "NotFound",
+  "BadResource",
+  "BadArgument",
+]);
 
 // The cache lives in the Effect environment (like HostProcessPlatform above)
 // so tests and embedders can provide an isolated instance; the default is a
@@ -525,9 +533,9 @@ export const PathListingCache = Context.Reference<Map<string, PathListingCacheEn
 
 /**
  * Lists the file names in a PATH directory, memoized for
- * {@link PATH_LISTING_CACHE_TTL_NANOS}. A missing or invalid directory lists as
- * empty. A directory that denies read permission lists as `null`, which tells
- * callers to probe candidate paths directly.
+ * {@link PATH_LISTING_CACHE_TTL_NANOS}. A directory that can never hold a
+ * command lists as empty; see {@link UNUSABLE_DIRECTORY_REASONS}. Any other
+ * failure lists as `null`, which tells callers to probe candidate paths directly.
  */
 const listPathDirectory = Effect.fn("shell.listPathDirectory")(function* (
   directory: string,
@@ -545,7 +553,7 @@ const listPathDirectory = Effect.fn("shell.listPathDirectory")(function* (
   const entries = yield* fileSystem.readDirectory(directory).pipe(
     Effect.catchTags({
       PlatformError: (error) =>
-        Effect.succeed(error.reason._tag === "PermissionDenied" ? null : []),
+        Effect.succeed(UNUSABLE_DIRECTORY_REASONS.has(error.reason._tag) ? [] : null),
     }),
   );
   const names = entries === null ? null : new Set(entries.map((e) => e.toLowerCase()));


### PR DESCRIPTION
Hi, I'm a new user trying out T3 Code for the first time. I encountered a bug, so I thought I'd get some practice by using T3 Code to fix T3 Code.

Thanks for taking the time to review. I hope you'll find this valuable. Feedback is much appreciated.

> **AI Disclosure:**
> Much of this code and PR description were written with Claude Opus 5 in T3 Code.
> However, I have reviewed and revised everything myself.

## Problem

- Fixes https://github.com/pingdotgg/t3code/issues/4697

On Windows, the "Open in…" picker listed no editors and stayed disabled, even with VS Code installed.

`server.getConfig` resolves 22 editor commands through PATH under a 5s timeout that returns `[]` on expiry. The scan probed every (directory, command, extension) combination: ~40 directories × 24 candidate names × 22 commands ≈ **21,000 filesystem probes, 14.4s measured**. It never finished in time. Other platforms (Linux, macOS) have no PATHEXT and probe one candidate per directory, so they stayed well inside the budget.

## Solution

Read and cache each PATH directory once and match candidates against the listing. Same discovery: **14,375ms → 85ms**.

## The cache moved to an axis that actually repeats

**Before:** Keyed per command, and a pass resolves each command once — so the cache is never hit:

```
for each of 22 editors: cursor, trae, code, zed, idea, ...
  isCommandAvailable("code")
    PATHEXT = .COM .EXE .BAT .CMD .VBS .VBE .JS .JSE .WSF .WSH .MSC .CPL
    candidates = each extension, upper AND lower ................ 24 names

    for each of ~40 PATH directories:
      ├── stat("C:\Windows\system32\code.COM")   ✗   ← a real disk probe
      ├── stat("C:\Windows\system32\code.com")   ✗
      ├── stat("C:\Windows\system32\code.EXE")   ✗
      ├── ... 24 probes, all misses ...
      └──                                            = 24 probes / directory

    = ~960 probes for ONE command

    cache["win32|PATH|PATHEXT|code"] = result    <- written here, but a pass
                                                  resolves "code" only once,
                                                  so it is never read

 22 commands x ~960 probes  =  ~21,000 filesystem probes
                            =  14,375 ms   (measured on my machine)

 14.4s  >  5s timeout  ──►  availableEditors = []  ──►  Open disabled
```

**After:** Keyed per directory, one listing serves every command:

```
for each of 22 editors: cursor, trae, code, zed, idea, ...
  isCommandAvailable("code")
    for each of ~40 PATH directories:
      │
      ├── names = cache["C:\Windows\system32"]       <- filled by the FIRST command
      │     │       or readdir() on a miss              to touch this directory,
      |     |                                           reused by the other 21
      │     ▼
      │   { "cmd.exe", "notepad.exe", "where.exe", ... }   in memory
      │
      └── for each of 24 candidates:
            "code.com" in the set?  no  ──► skip.  no disk probe at all
            "code.cmd" in the set?  YES ──► stat(...)  ← the only probe,
                                                          and it confirms

~40 directory reads TOTAL for all 22 commands
                            =  71-101 ms   (measured on my machine)

 0.1s  <  5s timeout  ──►  ["vscode", "file-manager"]  ──►  Open enabled
```

Same 30s TTL, same monotonic-clock expiry — only the key changed.

## Results are identical

A listing match only selects *which* candidates get `stat`ed — `stat` still decides what resolves, checking file type and the executable bit exactly as before.

Names fold to lowercase on **every** platform. This is necessary because the listing introduces a userspace name comparison that didn't exist before; previously the kernel did all name matching inside `stat`. Folding can only *widen* the candidate set, and the OS validates each one anyway, so an extra match costs one `stat` — whereas exact matching would miss a real command on a case-insensitive volume (Windows, default APFS).

Two behaviors preserved deliberately: a search-only directory (read permission denied) falls back to probing candidates directly, and explicit paths never consult the cache, so a just-installed binary stays immediately visible.

## Changes

| File | |
|---|---|
| `packages/shared/src/shell.ts` | Directory listings replace per-combination probing; cache keyed by directory |
| `packages/shared/src/shell.test.ts` | +3 tests: case-insensitive match, permission-denied fallback, missing directory does zero probes |
| `apps/server/src/process/externalLauncher.test.ts` | Mocks updated; memoization test asserts one directory read per pass |
| `apps/server/src/process/externalLauncher.ts` | Stale comment |

| Before | After |
|---|---|
| <img width="396" height="96" alt="image" src="https://github.com/user-attachments/assets/a1fb5d54-2436-4803-98c9-af58613350f7" /> | <img width="395" height="131" alt="image" src="https://github.com/user-attachments/assets/2d11c160-582e-4e12-8e3e-93e207af7d42" /> |

38 tests pass; targeted lint, typecheck and format clean. Verified on Windows 11 — I have no macOS or Linux machine to test on.

## Further Reading

- Related https://github.com/pingdotgg/t3code/pull/4291
- Related https://github.com/pingdotgg/t3code/pull/5561
- May also help with https://github.com/pingdotgg/t3code/issues/5137

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [ ] ~~I included before/after screenshots for any UI changes~~ NA
- [ ] ~~I included a video for animation/interaction changes~~ NA


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared PATH command-resolution used by editor discovery and other availability checks; incorrect listing/cache behavior could hide or mis-resolve installed commands.
> 
> **Overview**
> Fixes Windows editor discovery timing out by replacing per-candidate `stat` probing with **cached PATH directory listings**.
> 
> `resolveCommandPath` now reads each PATH directory once (via `listPathDirectory` / `PathListingCache`), matches candidates against the lowercase name set, and only `stat`s hits. Unreadable directories fall back to probing; missing/unusable ones are skipped. Same 30s TTL, but keyed by directory so one listing serves every command in a scan.
> 
> Tests cover case-insensitive Windows matches, listing-failure fallbacks, and updated editor-discovery memoization expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59849f94e2fdbfa08a620e4a41fc1f42af166efc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix editor detection on Windows by switching to directory-listing-based command resolution
> - Replaces per-command resolution caching with per-directory listing cache in [`shell.ts`](https://github.com/pingdotgg/t3code/pull/6221/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce): each PATH entry is read once per 30-second window, with file names stored in lowercase for case-insensitive matching (fixing missed detections on Windows where extensions like `.CMD` differ in case).
> - PATH directories that fail listing for `NotFound` or `BadResource` reasons are skipped outright; directories that fail for other reasons (e.g. `PermissionDenied`) fall back to probing each candidate with `stat`.
> - Cache capacity is set to 256 entries (keyed per directory), shared across all command resolutions within the window.
> - Behavioral Change: command-level resolution results are no longer cached; caching now applies at the directory-listing level, so repeated lookups for different commands in the same directory share one cached listing instead of individual cached outcomes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59849f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->