### PR TITLE
fix(web): remove the terminal pane's app-canvas gutter

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -859,7 +859,7 @@ export function TerminalViewport({
   return (
     <div
       ref={containerRef}
-      className="relative h-full w-full overflow-hidden rounded-[4px] bg-background"
+      className="relative h-full w-full overflow-hidden bg-[var(--terminal-background)]"
     />
   );
 }
@@ -1359,7 +1359,12 @@ export default function ThreadTerminalDrawer({
       )}
 
       <div className="min-h-0 w-full flex-1">
-        <div className={`flex h-full min-h-0 ${hasTerminalSidebar ? "gap-1.5" : ""}`}>
+        <div
+          className={cn(
+            "flex h-full min-h-0 bg-[var(--terminal-background)]",
+            hasTerminalSidebar && "gap-1.5",
+          )}
+        >
           <div className="min-w-0 flex-1">
             {isSplitView ? (
               <div
@@ -1394,7 +1399,7 @@ export default function ThreadTerminalDrawer({
                         }
                       }}
                     >
-                      <div className="h-full p-1">
+                      <div className="h-full">
                         <TerminalViewport
                           advancedTypography={advancedTypography}
                           threadRef={threadRef}
@@ -1422,7 +1427,7 @@ export default function ThreadTerminalDrawer({
                 })}
               </div>
             ) : (
-              <div className="h-full p-1">
+              <div className="h-full">
                 <TerminalViewport
                   advancedTypography={advancedTypography}
                   key={resolvedActiveTerminalId}


### PR DESCRIPTION
## Demo
<img width="2688" height="560" alt="01-single-terminal-repro-theme" src="https://github.com/user-attachments/assets/6cd8ab18-f46b-4e81-8acf-1c47b4695178" />
<img width="2688" height="560" alt="02-split-view-with-tab-sidebar" src="https://github.com/user-attachments/assets/80f8a617-3256-44ab-be50-70e05fff7d7c" />
<img width="80" height="160" alt="03-sidebar-gutter" src="https://github.com/user-attachments/assets/24f87991-6eec-4c1b-847d-c00c9636e90c" />
<img width="2688" height="560" alt="04-built-in-theme-light" src="https://github.com/user-attachments/assets/d39e9d37-bb33-47a2-bdef-66df92c5b880" />
<img width="2688" height="560" alt="05-built-in-theme-dark" src="https://github.com/user-attachments/assets/d4556ba2-e4f9-406e-8008-b29320389bad" />

## Problem


<img width="929" height="306" alt="Screenshot 2026-08-11 at 5 25 59 PM" src="https://github.com/user-attachments/assets/83d197c9-5799-4351-8344-c871fe6b81bd" />
<img width="980" height="324" alt="Screenshot 2026-08-11 at 5 26 09 PM" src="https://github.com/user-attachments/assets/5234231b-5dbf-4dfa-8084-21c30bd6837a" />

In a theme whose terminal surface differs from the app canvas, the terminal pane is framed by a light seam:

- `TerminalViewport`'s mount was wrapped in a `p-1` div, so 4px of `--background` showed on all four sides of the pane.
- The mount itself was `rounded-[4px] bg-background` under `overflow-hidden`, so the clipped corners exposed the canvas color as four nubs.
- The `gap-1.5` gutter before the terminal tab sidebar showed the same canvas color.

Stock light and dark themes hide this because they define `--terminal-background: var(--background)`. It only surfaces on themes that set the two independently — e.g. an imported VS Code light theme with `terminal.background: #f6f8fa` over `editor.background: #ffffff`.

## Why the gutter is not needed

The terminal already has breathing room, inside the canvas and in the terminal's own color:

- `apps/web/src/terminal/ghostty/surface.ts` insets the grid by `CONTENT_PADDING` (4px).
- `apps/web/src/terminal/ghostty/renderer.ts` fills the entire canvas with the terminal background on every full repaint.

The DOM `p-1` was a second 4px inset stacked on top of that one, in the app canvas color — the only one that could ever read as a frame.

## Change

- Drop `p-1` from both the split and single-terminal wrappers.
- Drop `rounded-[4px]` and paint the mount with `--terminal-background`, so a sub-cell sliver at the right or bottom edge (the grid rounds down to whole cells) matches the terminal rather than the canvas.
- Paint the terminal row with `--terminal-background` so the sidebar gutter matches too.

## Validation

Reproduced with an imported VS Code light theme (`terminal.background: #f6f8fa`, `editor.background: #ffffff`), driving the real app in a browser and measuring the mount rect against the drawer rect:

| | drawer rect | canvas rect |
|---|---|---|
| before | 256, 720, 1344×280 | 260, 725, 1336×271 — inset 4px on every side |
| after | 256, 720, 1344×280 | 256, 721, 1344×279 — flush; the 1px top is the drawer's `border-t` |

Pixel samples at the pane's bottom-left corner: `#ffffff` across the 4px band before, `#f6f8fa` throughout after. Sidebar gutter: `#ffffff` before, `#f6f8fa` after.

Checked in the app across single-terminal, split view with the tab sidebar, built-in light, and built-in dark — every pane edge samples to a single uniform color, with no contrasting frame.

`@t3tools/web` typecheck clean; 2199 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CSS/layout tweak in the terminal drawer UI with no logic, auth, or data-handling changes.
> 
> **Overview**
> Removes the **app-canvas gutter** around the terminal pane so themes with a distinct `--terminal-background` no longer show a light frame.
> 
> Drops the `p-1` wrappers around `TerminalViewport` (single and split) and paints the mount/`flex` container with `--terminal-background` instead of `bg-background` + `rounded-[4px]`. The terminal already insets content via `CONTENT_PADDING`, so the DOM padding was a redundant second inset in the wrong color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d4ab2cc2668f755264478cb932bd8530ca6077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove gutter padding and rounded corners from the terminal pane
> Removes `p-1` padding from the inner terminal containers in `ThreadTerminalDrawer` and drops the `rounded-[4px]` class from `TerminalViewport`, eliminating the visible gutter around the terminal canvas. Both components now use `bg-[var(--terminal-background)]` for consistent background coloring.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33573c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->