### PR TITLE
fix(web): remove projects with archived threads

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -74,7 +74,6 @@ import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
-import { projectDeleteCommandInput } from "../lib/projectRemoval";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isMacPlatform } from "../lib/utils";
 import {
@@ -1445,11 +1444,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   );
 
   const removeProject = useCallback(
-    async (member: SidebarProjectGroupMember) => {
+    async (member: SidebarProjectGroupMember, options: { force?: boolean } = {}) => {
       const memberProjectRef = scopeProjectRef(member.environmentId, member.id);
       const result = await deleteProject({
         environmentId: member.environmentId,
-        input: projectDeleteCommandInput(member.id),
+        input: {
+          projectId: member.id,
+          ...(options.force === true ? { force: true } : {}),
+        },
       });
       if (result._tag === "Failure") {
         return result;
@@ -1500,25 +1502,24 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                   const confirmed = await api.dialogs.confirm(
                     latestProjectThreads.length > 0
                       ? [
-                          `Remove project "${member.title}" and permanently delete every thread attached to it, including archived threads?`,
+                          `Remove project "${member.title}" and delete its ${latestProjectThreads.length} thread${
+                            latestProjectThreads.length === 1 ? "" : "s"
+                          }?`,
                           `Path: ${member.workspaceRoot}`,
                           ...(member.environmentLabel
                             ? [`Environment: ${member.environmentLabel}`]
                             : []),
-                          `This includes ${latestProjectThreads.length} unarchived thread${
-                            latestProjectThreads.length === 1 ? "" : "s"
-                          } and permanently clears their conversation history.`,
+                          "This permanently clears conversation history for those threads.",
                           "This removes only this project entry.",
                           "This action cannot be undone.",
                         ].join("\n")
                       : [
-                          `Remove project "${member.title}" and permanently delete every thread attached to it, including archived threads?`,
+                          `Remove project "${member.title}"?`,
                           `Path: ${member.workspaceRoot}`,
                           ...(member.environmentLabel
                             ? [`Environment: ${member.environmentLabel}`]
                             : []),
                           "This removes only this project entry.",
-                          "This action cannot be undone.",
                         ].join("\n"),
                     { variant: "destructive" },
                   );
@@ -1526,7 +1527,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                     return;
                   }
 
-                  const result = await removeProject(member);
+                  const result = await removeProject(member, { force: true });
                   if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
                     const error = squashAtomCommandFailure(result);
                     toastManager.add(
@@ -1564,11 +1565,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       }
 
       const message = [
-        `Remove project "${member.title}" and permanently delete every thread attached to it, including archived threads?`,
+        `Remove project "${member.title}"?`,
         `Path: ${member.workspaceRoot}`,
         ...(member.environmentLabel ? [`Environment: ${member.environmentLabel}`] : []),
         "This removes only this project entry.",
-        "This action cannot be undone.",
       ].join("\n");
       const confirmed = await api.dialogs.confirm(message, { variant: "destructive" });
       if (!confirmed) {

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -74,6 +74,7 @@ import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
+import { projectDeleteCommandInput } from "../lib/projectRemoval";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isMacPlatform } from "../lib/utils";
 import {
@@ -1444,14 +1445,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   );
 
   const removeProject = useCallback(
-    async (member: SidebarProjectGroupMember, options: { force?: boolean } = {}) => {
+    async (member: SidebarProjectGroupMember) => {
       const memberProjectRef = scopeProjectRef(member.environmentId, member.id);
       const result = await deleteProject({
         environmentId: member.environmentId,
-        input: {
-          projectId: member.id,
-          ...(options.force === true ? { force: true } : {}),
-        },
+        input: projectDeleteCommandInput(member.id),
       });
       if (result._tag === "Failure") {
         return result;
@@ -1502,24 +1500,25 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                   const confirmed = await api.dialogs.confirm(
                     latestProjectThreads.length > 0
                       ? [
-                          `Remove project "${member.title}" and delete its ${latestProjectThreads.length} thread${
-                            latestProjectThreads.length === 1 ? "" : "s"
-                          }?`,
+                          `Remove project "${member.title}" and permanently delete every thread attached to it, including archived threads?`,
                           `Path: ${member.workspaceRoot}`,
                           ...(member.environmentLabel
                             ? [`Environment: ${member.environmentLabel}`]
                             : []),
-                          "This permanently clears conversation history for those threads.",
+                          `This includes ${latestProjectThreads.length} unarchived thread${
+                            latestProjectThreads.length === 1 ? "" : "s"
+                          } and permanently clears their conversation history.`,
                           "This removes only this project entry.",
                           "This action cannot be undone.",
                         ].join("\n")
                       : [
-                          `Remove project "${member.title}"?`,
+                          `Remove project "${member.title}" and permanently delete every thread attached to it, including archived threads?`,
                           `Path: ${member.workspaceRoot}`,
                           ...(member.environmentLabel
                             ? [`Environment: ${member.environmentLabel}`]
                             : []),
                           "This removes only this project entry.",
+                          "This action cannot be undone.",
                         ].join("\n"),
                     { variant: "destructive" },
                   );
@@ -1527,7 +1526,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                     return;
                   }
 
-                  const result = await removeProject(member, { force: true });
+                  const result = await removeProject(member);
                   if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
                     const error = squashAtomCommandFailure(result);
                     toastManager.add(
@@ -1565,10 +1564,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       }
 
       const message = [
-        `Remove project "${member.title}"?`,
+        `Remove project "${member.title}" and permanently delete every thread attached to it, including archived threads?`,
         `Path: ${member.workspaceRoot}`,
         ...(member.environmentLabel ? [`Environment: ${member.environmentLabel}`] : []),
         "This removes only this project entry.",
+        "This action cannot be undone.",
       ].join("\n");
       const confirmed = await api.dialogs.confirm(message, { variant: "destructive" });
       if (!confirmed) {

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -46,6 +46,7 @@ import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { useT3ProjectFileState } from "../../hooks/useT3ProjectFileScripts";
 import { shortcutLabelForCommand } from "../../keybindings";
 import { keybindingValueForCommand } from "../../lib/projectScriptKeybindings";
+import { projectDeleteCommandInput } from "../../lib/projectRemoval";
 import { readLocalApi } from "../../localApi";
 import {
   buildProjectScript,
@@ -681,9 +682,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
       const confirmed = await settlePromise(() =>
         api.dialogs.confirm(
           [
-            projectThreads.length > 0
-              ? `Remove project "${targetLabel}" and delete its ${projectThreads.length} thread${projectThreads.length === 1 ? "" : "s"}?`
-              : `Remove project "${targetLabel}"?`,
+            `Remove "${targetLabel}" and permanently delete every thread attached to ${members.length === 1 ? "this project entry" : "these project entries"}, including archived threads?`,
             ...(singleMember
               ? [
                   `Path: ${singleMember.workspaceRoot}`,
@@ -693,8 +692,11 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                 ]
               : [`This removes ${members.length} grouped project entries.`]),
             ...(projectThreads.length > 0
-              ? ["This permanently clears conversation history for those threads."]
+              ? [
+                  `This includes ${projectThreads.length} unarchived thread${projectThreads.length === 1 ? "" : "s"}.`,
+                ]
               : []),
+            "This permanently clears all associated conversation history.",
             isWholeGroup
               ? "This removes only the project entries, not the files on disk."
               : "Other entries in this grouped project are unaffected.",
@@ -707,17 +709,10 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
 
       const draftStore = useComposerDraftStore.getState();
       for (const member of members) {
-        const memberThreads = projectThreads.filter(
-          (thread) =>
-            thread.environmentId === member.environmentId && thread.projectId === member.id,
-        );
         const result = mapAtomCommandResult(
           await deleteProject({
             environmentId: member.environmentId,
-            input: {
-              projectId: member.id,
-              ...(memberThreads.length > 0 ? { force: true } : {}),
-            },
+            input: projectDeleteCommandInput(member.id),
           }),
           () => undefined,
         );
@@ -955,8 +950,8 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
               </button>
               <div className="shrink-0 border-l border-border/60 px-2 tabular-nums">
                 {selectedCheckoutThreadCount === 1
-                  ? "1 thread"
-                  : `${selectedCheckoutThreadCount} threads`}
+                  ? "1 unarchived thread"
+                  : `${selectedCheckoutThreadCount} unarchived threads`}
               </div>
             </div>
           </div>
@@ -1148,8 +1143,8 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
             }
             description={
               group.memberProjects.length > 1
-                ? `Deletes all ${group.memberProjects.length} checkout entries and their threads on every machine. Files on disk are not touched.`
-                : "Deletes the project entry and its threads. Files on disk are not touched."
+                ? `Deletes all ${group.memberProjects.length} checkout entries and all their threads, including archived threads, on every machine. Files on disk are not touched.`
+                : "Deletes the project entry and all its threads, including archived threads. Files on disk are not touched."
             }
             control={
               <Button

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -1152,7 +1152,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                 onClick={() => void removeMembers(group.memberProjects)}
               >
                 <Trash2Icon />
-                {group.memberProjects.length > 1 ? "Remove all entries" : "Remove project"}
+                Remove project
               </Button>
             }
           />

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -45,8 +45,9 @@ import {
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { useT3ProjectFileState } from "../../hooks/useT3ProjectFileScripts";
 import { shortcutLabelForCommand } from "../../keybindings";
+import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { keybindingValueForCommand } from "../../lib/projectScriptKeybindings";
-import { projectDeleteCommandInput } from "../../lib/projectRemoval";
+import { projectDeleteCommandInput, projectThreadCount } from "../../lib/projectRemoval";
 import { readLocalApi } from "../../localApi";
 import {
   buildProjectScript,
@@ -309,6 +310,23 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const serverProviders = useAtomValue(primaryServerProvidersAtom);
   const threads = useThreadShells();
+  const groupEnvironmentIds = useMemo(
+    () => [...new Set(group.memberProjects.map((member) => member.environmentId))],
+    [group.memberProjects],
+  );
+  const {
+    snapshots: archivedThreadSnapshots,
+    error: archivedThreadsError,
+    isLoading: archivedThreadsLoading,
+  } = useArchivedThreadSnapshots(groupEnvironmentIds);
+  const archivedThreads = useMemo(
+    () =>
+      archivedThreadSnapshots.flatMap(({ environmentId, snapshot }) =>
+        snapshot.threads.map((thread) => ({ ...thread, environmentId })),
+      ),
+    [archivedThreadSnapshots],
+  );
+  const knownThreads = useMemo(() => [...threads, ...archivedThreads], [archivedThreads, threads]);
   const updateProject = useAtomCommand(projectEnvironment.update, { reportFailure: false });
   const deleteProject = useAtomCommand(projectEnvironment.delete, { reportFailure: false });
   const upsertKeybinding = useAtomCommand(serverEnvironment.upsertKeybinding, {
@@ -340,12 +358,12 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
 
   const threadCountByMember = useMemo(() => {
     const counts = new Map<string, number>();
-    for (const thread of threads) {
+    for (const thread of knownThreads) {
       const key = `${thread.environmentId}:${thread.projectId}`;
       counts.set(key, (counts.get(key) ?? 0) + 1);
     }
     return counts;
-  }, [threads]);
+  }, [knownThreads]);
   const reportFailure = useCallback((title: string, result: AtomCommandResult<void, unknown>) => {
     if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) return;
     const error = squashAtomCommandFailure(result);
@@ -672,8 +690,19 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
       const api = readLocalApi();
       if (!api) return;
 
+      if (archivedThreadsError) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not check archived threads",
+            description: archivedThreadsError,
+          }),
+        );
+        return;
+      }
+
       const memberKeys = new Set(members.map(memberKey));
-      const projectThreads = threads.filter((thread) =>
+      const projectThreads = knownThreads.filter((thread) =>
         memberKeys.has(`${thread.environmentId}:${thread.projectId}`),
       );
       const isWholeGroup = members.length === group.memberProjects.length;
@@ -693,7 +722,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
               : [`This removes ${members.length} grouped project entries.`]),
             ...(projectThreads.length > 0
               ? [
-                  `This includes ${projectThreads.length} unarchived thread${projectThreads.length === 1 ? "" : "s"}.`,
+                  `This includes ${projectThreads.length} thread${projectThreads.length === 1 ? "" : "s"}.`,
                 ]
               : []),
             "This permanently clears all associated conversation history.",
@@ -709,10 +738,11 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
 
       const draftStore = useComposerDraftStore.getState();
       for (const member of members) {
+        const memberThreadCount = projectThreadCount(member, projectThreads);
         const result = mapAtomCommandResult(
           await deleteProject({
             environmentId: member.environmentId,
-            input: projectDeleteCommandInput(member.id),
+            input: projectDeleteCommandInput(member.id, memberThreadCount),
           }),
           () => undefined,
         );
@@ -735,12 +765,13 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
       }
     },
     [
+      archivedThreadsError,
       deleteProject,
       group.displayName,
       group.memberProjects.length,
+      knownThreads,
       navigate,
       reportFailure,
-      threads,
     ],
   );
 
@@ -950,8 +981,8 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
               </button>
               <div className="shrink-0 border-l border-border/60 px-2 tabular-nums">
                 {selectedCheckoutThreadCount === 1
-                  ? "1 unarchived thread"
-                  : `${selectedCheckoutThreadCount} unarchived threads`}
+                  ? "1 thread"
+                  : `${selectedCheckoutThreadCount} threads`}
               </div>
             </div>
           </div>
@@ -1004,6 +1035,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                 <Button
                   size="xs"
                   variant="destructive-outline"
+                  disabled={archivedThreadsLoading}
                   onClick={() => void removeMembers([selectedCheckout])}
                 >
                   <Trash2Icon className="size-3.5" />
@@ -1149,6 +1181,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
             control={
               <Button
                 variant="destructive-outline"
+                disabled={archivedThreadsLoading}
                 onClick={() => void removeMembers(group.memberProjects)}
               >
                 <Trash2Icon />

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -47,7 +47,11 @@ import { useT3ProjectFileState } from "../../hooks/useT3ProjectFileScripts";
 import { shortcutLabelForCommand } from "../../keybindings";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { keybindingValueForCommand } from "../../lib/projectScriptKeybindings";
-import { projectDeleteCommandInput, projectThreadCount } from "../../lib/projectRemoval";
+import {
+  hasArchivedThreadSnapshotFailure,
+  projectDeleteCommandInput,
+  projectThreadCount,
+} from "../../lib/projectRemoval";
 import { readLocalApi } from "../../localApi";
 import {
   buildProjectScript,
@@ -317,6 +321,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
   const {
     snapshots: archivedThreadSnapshots,
     error: archivedThreadsError,
+    failedEnvironmentIds: archivedThreadsFailedEnvironmentIds,
     isLoading: archivedThreadsLoading,
   } = useArchivedThreadSnapshots(groupEnvironmentIds);
   const archivedThreads = useMemo(
@@ -690,7 +695,10 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
       const api = readLocalApi();
       if (!api) return;
 
-      if (archivedThreadsError) {
+      if (
+        archivedThreadsError &&
+        hasArchivedThreadSnapshotFailure(members, archivedThreadsFailedEnvironmentIds)
+      ) {
         toastManager.add(
           stackedThreadToast({
             type: "error",
@@ -766,6 +774,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
     },
     [
       archivedThreadsError,
+      archivedThreadsFailedEnvironmentIds,
       deleteProject,
       group.displayName,
       group.memberProjects.length,

--- a/apps/web/src/lib/archivedThreadsState.ts
+++ b/apps/web/src/lib/archivedThreadsState.ts
@@ -29,6 +29,7 @@ export function refreshArchivedThreadsForEnvironment(environmentId: EnvironmentI
 export function useArchivedThreadSnapshots(environmentIds: ReadonlyArray<EnvironmentId>): {
   readonly snapshots: ReadonlyArray<ArchivedSnapshotEntry>;
   readonly error: string | null;
+  readonly failedEnvironmentIds: ReadonlyArray<EnvironmentId>;
   readonly isLoading: boolean;
   readonly refresh: () => void;
 } {

--- a/apps/web/src/lib/projectRemoval.test.ts
+++ b/apps/web/src/lib/projectRemoval.test.ts
@@ -1,13 +1,51 @@
-import { ProjectId } from "@t3tools/contracts";
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { projectDeleteCommandInput } from "./projectRemoval";
+import { projectDeleteCommandInput, projectThreadCount } from "./projectRemoval";
 
 describe("projectDeleteCommandInput", () => {
   it("force-deletes threads even when only archived threads exist", () => {
-    expect(projectDeleteCommandInput(ProjectId.make("project-1"))).toEqual({
+    const project = {
+      environmentId: EnvironmentId.make("environment-1"),
+      id: ProjectId.make("project-1"),
+    };
+    const archivedThreads = [
+      {
+        environmentId: project.environmentId,
+        projectId: project.id,
+      },
+    ];
+
+    expect(
+      projectDeleteCommandInput(project.id, projectThreadCount(project, archivedThreads)),
+    ).toEqual({
       projectId: "project-1",
       force: true,
     });
+  });
+
+  it("does not force an empty project when the same project id has threads in another environment", () => {
+    const projectId = ProjectId.make("shared-project-id");
+    const environmentOneProject = {
+      environmentId: EnvironmentId.make("environment-1"),
+      id: projectId,
+    };
+    const environmentTwoProject = {
+      environmentId: EnvironmentId.make("environment-2"),
+      id: projectId,
+    };
+    const threads = [
+      {
+        environmentId: environmentTwoProject.environmentId,
+        projectId,
+      },
+    ];
+
+    expect(
+      projectDeleteCommandInput(projectId, projectThreadCount(environmentOneProject, threads)),
+    ).toEqual({ projectId });
+    expect(
+      projectDeleteCommandInput(projectId, projectThreadCount(environmentTwoProject, threads)),
+    ).toEqual({ projectId, force: true });
   });
 });

--- a/apps/web/src/lib/projectRemoval.test.ts
+++ b/apps/web/src/lib/projectRemoval.test.ts
@@ -1,0 +1,13 @@
+import { ProjectId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { projectDeleteCommandInput } from "./projectRemoval";
+
+describe("projectDeleteCommandInput", () => {
+  it("force-deletes threads even when only archived threads exist", () => {
+    expect(projectDeleteCommandInput(ProjectId.make("project-1"))).toEqual({
+      projectId: "project-1",
+      force: true,
+    });
+  });
+});

--- a/apps/web/src/lib/projectRemoval.test.ts
+++ b/apps/web/src/lib/projectRemoval.test.ts
@@ -1,7 +1,24 @@
 import { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { projectDeleteCommandInput, projectThreadCount } from "./projectRemoval";
+import {
+  hasArchivedThreadSnapshotFailure,
+  projectDeleteCommandInput,
+  projectThreadCount,
+} from "./projectRemoval";
+
+describe("hasArchivedThreadSnapshotFailure", () => {
+  it("only reports failures for environments being removed", () => {
+    const environmentOne = EnvironmentId.make("environment-1");
+    const environmentTwo = EnvironmentId.make("environment-2");
+    const failedEnvironmentIds = [environmentTwo];
+
+    expect([
+      hasArchivedThreadSnapshotFailure([{ environmentId: environmentOne }], failedEnvironmentIds),
+      hasArchivedThreadSnapshotFailure([{ environmentId: environmentTwo }], failedEnvironmentIds),
+    ]).toEqual([false, true]);
+  });
+});
 
 describe("projectDeleteCommandInput", () => {
   it("force-deletes threads even when only archived threads exist", () => {

--- a/apps/web/src/lib/projectRemoval.ts
+++ b/apps/web/src/lib/projectRemoval.ts
@@ -1,9 +1,37 @@
-import type { ProjectId } from "@t3tools/contracts";
+import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
 
-/** Archived threads are absent from the live shell snapshot, so confirmed project removal must force deletion. */
-export function projectDeleteCommandInput(projectId: ProjectId): {
+interface ProjectRemovalTarget {
+  readonly environmentId: EnvironmentId;
+  readonly id: ProjectId;
+}
+
+interface ProjectRemovalThread {
+  readonly environmentId: EnvironmentId;
   readonly projectId: ProjectId;
-  readonly force: true;
+}
+
+export function projectThreadCount(
+  project: ProjectRemovalTarget,
+  threads: ReadonlyArray<ProjectRemovalThread>,
+): number {
+  let count = 0;
+  for (const thread of threads) {
+    if (thread.environmentId === project.environmentId && thread.projectId === project.id) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function projectDeleteCommandInput(
+  projectId: ProjectId,
+  threadCount: number,
+): {
+  readonly projectId: ProjectId;
+  readonly force?: true;
 } {
-  return { projectId, force: true };
+  return {
+    projectId,
+    ...(threadCount > 0 ? { force: true as const } : {}),
+  };
 }

--- a/apps/web/src/lib/projectRemoval.ts
+++ b/apps/web/src/lib/projectRemoval.ts
@@ -1,0 +1,9 @@
+import type { ProjectId } from "@t3tools/contracts";
+
+/** Archived threads are absent from the live shell snapshot, so confirmed project removal must force deletion. */
+export function projectDeleteCommandInput(projectId: ProjectId): {
+  readonly projectId: ProjectId;
+  readonly force: true;
+} {
+  return { projectId, force: true };
+}

--- a/apps/web/src/lib/projectRemoval.ts
+++ b/apps/web/src/lib/projectRemoval.ts
@@ -10,6 +10,13 @@ interface ProjectRemovalThread {
   readonly projectId: ProjectId;
 }
 
+export function hasArchivedThreadSnapshotFailure(
+  projects: ReadonlyArray<{ readonly environmentId: EnvironmentId }>,
+  failedEnvironmentIds: ReadonlyArray<EnvironmentId>,
+): boolean {
+  return projects.some((project) => failedEnvironmentIds.includes(project.environmentId));
+}
+
 export function projectThreadCount(
   project: ProjectRemovalTarget,
   threads: ReadonlyArray<ProjectRemovalThread>,

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -1,4 +1,6 @@
-# Customize a project icon
+# Project settings
+
+## Customize a project icon
 
 T3 Code selects a project icon automatically. It checks `t3.json`, common favicon and app icon
 paths, and icon links in project HTML files.
@@ -14,3 +16,12 @@ T3 Code supports SVG, PNG, ICO, JPEG, GIF, AVIF, and WebP files. The selected pa
 each checkout in the project group and appears on your connected clients.
 
 To use automatic detection again, select **Automatic**.
+
+## Remove a project
+
+1. Open the project settings.
+2. Under **Danger**, select **Remove project**.
+3. Confirm the removal.
+
+Removing a project deletes its T3 Code entry and all associated conversation history, including
+archived threads. Files in the project's workspace remain on disk.

--- a/packages/client-runtime/src/state/archivedThreads.test.ts
+++ b/packages/client-runtime/src/state/archivedThreads.test.ts
@@ -33,6 +33,7 @@ it("does not expose an archived snapshot failure message", () => {
   expect(registry.get(snapshotsAtom(makeArchivedThreadsEnvironmentKey([environmentId])))).toEqual({
     snapshots: [],
     error: "Failed to load archived threads.",
+    failedEnvironmentIds: [environmentId],
     isLoading: false,
   });
 

--- a/packages/client-runtime/src/state/archivedThreads.ts
+++ b/packages/client-runtime/src/state/archivedThreads.ts
@@ -13,6 +13,7 @@ export interface ArchivedSnapshotEntry {
 export interface ArchivedThreadSnapshotsState {
   readonly snapshots: ReadonlyArray<ArchivedSnapshotEntry>;
   readonly error: string | null;
+  readonly failedEnvironmentIds: ReadonlyArray<EnvironmentId>;
   readonly isLoading: boolean;
 }
 
@@ -46,6 +47,7 @@ export function createArchivedThreadSnapshotsAtomFamily<E>(options: {
   return Atom.family((environmentKey: string) =>
     Atom.make((get): ArchivedThreadSnapshotsState => {
       const snapshots: ArchivedSnapshotEntry[] = [];
+      const failedEnvironmentIds: EnvironmentId[] = [];
       let error: string | null = null;
       let isLoading = false;
 
@@ -58,12 +60,13 @@ export function createArchivedThreadSnapshotsAtomFamily<E>(options: {
           snapshots.push({ environmentId, snapshot });
         }
 
-        if (error === null && result._tag === "Failure") {
-          error = "Failed to load archived threads.";
+        if (result._tag === "Failure") {
+          failedEnvironmentIds.push(environmentId);
+          error ??= "Failed to load archived threads.";
         }
       }
 
-      return { snapshots, error, isLoading };
+      return { snapshots, error, failedEnvironmentIds, isLoading };
     }).pipe(Atom.withLabel(`${options.labelPrefix}:${environmentKey}`)),
   );
 }


### PR DESCRIPTION
## Problem

Project removal counted only unarchived threads from the live shell snapshot. A project containing only archived threads therefore appeared empty, sent a non-forced delete command, and failed the server invariant instead of being removed.

<img width="1749" height="1130" alt="image" src="https://github.com/user-attachments/assets/884f6183-04be-4ef8-a570-50ae0cfc3eb3" />


## Fix

- always force thread deletion after the user confirms project removal in Settings or the sidebar
- make the destructive confirmation and checkout count explicit about archived versus unarchived threads
- document that removing a project clears all conversation history but leaves workspace files on disk
- add a regression test for the archived-only case


<img width="1473" height="1038" alt="image" src="https://github.com/user-attachments/assets/88505704-2be1-4ab4-bec5-689a87b34333" />



Implemented with GPT-5.6 Sol in the T3 Code Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project deletion to include archived threads by always passing `force: true`
> - Adds a `projectDeleteCommandInput` helper in [`projectRemoval.ts`](https://github.com/pingdotgg/t3code/pull/6225/files#diff-c436d07f9ef782e22c19eb06a9a6873042fce46395aa8e9c2a378fcf64011f21) that always returns `{ projectId, force: true }`, since archived threads are absent from live shell snapshots and require a forced delete.
> - Updates project removal flows in [`LegacySidebar.tsx`](https://github.com/pingdotgg/t3code/pull/6225/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86) and [`ProjectSettingsPanel.tsx`](https://github.com/pingdotgg/t3code/pull/6225/files#diff-0240d4863349583155edae77c3bfab65683d7e019508379850a5b96167960cdc) to use this helper, removing previous conditional logic around the `force` flag.
> - Updates confirmation dialog copy in both components to explicitly state that all threads, including archived ones, will be permanently deleted.
> - Behavioral Change: Projects that previously failed to remove archived threads will now have all associated threads deleted on removal.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2a918c2. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->