### PR TITLE
fix(web): polish desktop control hierarchy

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -375,7 +375,7 @@ function SnoozePopoverButton(props: {
           />
         }
       >
-        <ClockIcon className="size-3" />
+        <ClockIcon className="size-3.5" />
       </PopoverTrigger>
       <PopoverPopup side="bottom" align="end" className="w-56" viewportClassName="p-1">
         {presets.map((preset) => (
@@ -1351,7 +1351,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                           topStatus.className,
                         )}
                       >
-                        <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
+                        <AlarmClockIcon aria-hidden className="size-3.5 shrink-0" />
                         <span role="status">{topStatus.label}</span>
                       </button>
                     ) : (
@@ -1408,7 +1408,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                         onClick={handleSettleClick}
                         className="-mr-1 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground"
                       >
-                        <CheckIcon className="size-3.5" />
+                        <CheckIcon className="size-3.5 shrink-0" />
                         Settle
                       </button>
                     ) : null}
@@ -3229,7 +3229,7 @@ export default function Sidebar() {
           // Lifted above the stage backdrop, whose fade bleeds below the
           // header and would otherwise paint across the search row's outline.
           <SidebarGroup className="relative z-[1] gap-1 p-[var(--sidebar-content-inset)]">
-            <div className="flex items-center gap-1">
+            <div className="order-2 flex items-center gap-1">
               <div className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground">
                 <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
                 <Input
@@ -3321,7 +3321,7 @@ export default function Sidebar() {
               </div>
             </div>
             {projectGroups.length > 0 ? (
-              <div className="flex items-center gap-1">
+              <div className="order-1 flex items-center gap-1">
                 <Menu open={projectScopeMenuOpen} onOpenChange={setProjectScopeMenuOpen}>
                   <MenuTrigger
                     render={

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3189,6 +3189,16 @@ export default function Sidebar() {
   // for multi-project setups.
   const handleNewThreadClick = useCallback(
     (event?: ReactMouseEvent) => {
+      // The project scope is an explicit answer to "where should this thread
+      // live?" Respect it instead of immediately asking the same question in
+      // the command palette.
+      if (scopedProjectGroup !== null) {
+        if (isMobile) setOpenMobile(false);
+        void newThreadContext.handleNewThread(
+          scopeProjectRef(scopedProjectGroup.environmentId, scopedProjectGroup.id),
+        );
+        return;
+      }
       // One project: nothing to pick, create immediately. Shift+click creates
       // directly in the current project even with several projects, skipping
       // the palette picker.
@@ -3205,7 +3215,7 @@ export default function Sidebar() {
       if (isMobile) setOpenMobile(false);
       openCommandPalette({ open: "new-thread-in" });
     },
-    [isMobile, newThreadContext, projectGroups.length, setOpenMobile],
+    [isMobile, newThreadContext, projectGroups.length, scopedProjectGroup, setOpenMobile],
   );
 
   // The button mirrors chat.new: in multi-project setups both route through
@@ -3297,7 +3307,9 @@ export default function Sidebar() {
                     />
                   </TooltipTrigger>
                   <TooltipPopup side="right">
-                    {projectGroups.length > 1 ? (
+                    {scopedProjectGroup !== null ? (
+                      `New thread in ${scopedProjectGroup.displayName}`
+                    ) : projectGroups.length > 1 ? (
                       <span className="flex flex-col gap-0.5">
                         <span>
                           {newThreadShortcutLabel

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -61,6 +61,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ComponentProps,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
@@ -195,9 +196,15 @@ const SNOOZED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:snoozed-expanded";
 
 type ThreadContextMenuState = {
   readonly items: ReadonlyArray<ContextMenuItem<ThreadActionMenuId>>;
-  readonly position: { readonly x: number; readonly y: number };
-  readonly resolve: (action: ThreadActionMenuId | undefined) => void;
+  readonly anchor: NonNullable<ComponentProps<typeof MenuPopup>["anchor"]>;
+  readonly focusTarget: HTMLElement;
 };
+
+function contextMenuAnchor(position: { readonly x: number; readonly y: number }) {
+  return {
+    getBoundingClientRect: () => DOMRect.fromRect({ x: position.x, y: position.y }),
+  };
+}
 
 function ThreadContextMenuItems({
   items,
@@ -229,24 +236,42 @@ function ThreadContextMenuItems({
 
 function ThreadContextMenu({
   menu,
+  onSelect,
   onDismiss,
 }: {
   readonly menu: ThreadContextMenuState | null;
+  readonly onSelect: (action: ThreadActionMenuId) => void;
   readonly onDismiss: () => void;
 }) {
-  const finish = (action: ThreadActionMenuId | undefined) => {
-    menu?.resolve(action);
-    onDismiss();
-  };
+  const selectedRef = useRef(false);
   return (
-    <Menu open={menu !== null} onOpenChange={(open) => !open && finish(undefined)}>
-      <MenuTrigger
-        aria-label="Thread actions"
-        className="pointer-events-none fixed size-px opacity-0"
-        style={{ left: menu?.position.x ?? 0, top: menu?.position.y ?? 0 }}
-      />
-      <MenuPopup align="start" side="bottom" sideOffset={0} className="min-w-52">
-        {menu ? <ThreadContextMenuItems items={menu.items} onSelect={finish} /> : null}
+    <Menu
+      open={menu !== null}
+      onOpenChange={(open) => {
+        if (open) return;
+        if (!selectedRef.current) {
+          menu?.focusTarget.focus();
+          onDismiss();
+        }
+        selectedRef.current = false;
+      }}
+    >
+      <MenuPopup
+        anchor={menu?.anchor}
+        align="start"
+        side="bottom"
+        sideOffset={0}
+        className="min-w-52"
+      >
+        {menu ? (
+          <ThreadContextMenuItems
+            items={menu.items}
+            onSelect={(action) => {
+              selectedRef.current = true;
+              onSelect(action);
+            }}
+          />
+        ) : null}
       </MenuPopup>
     </Menu>
   );
@@ -763,7 +788,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   onCancelRename: () => void;
   isRenaming: boolean;
   renamingTitle: string;
-  onContextMenu: (threadRef: ScopedThreadRef, position: { x: number; y: number }) => void;
+  onContextMenu: (
+    threadRef: ScopedThreadRef,
+    position: { x: number; y: number },
+    focusTarget: HTMLElement,
+  ) => void;
   onSettle: (threadRef: ScopedThreadRef) => void;
   onUnsettle: (threadRef: ScopedThreadRef) => void;
   onSnooze: (threadRef: ScopedThreadRef, preset: SnoozePreset) => void;
@@ -972,7 +1001,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   const handleContextMenu = useCallback(
     (event: ReactMouseEvent) => {
       event.preventDefault();
-      onContextMenu(threadRef, { x: event.clientX, y: event.clientY });
+      onContextMenu(
+        threadRef,
+        { x: event.clientX, y: event.clientY },
+        event.currentTarget as HTMLElement,
+      );
     },
     [onContextMenu, threadRef],
   );
@@ -1889,6 +1922,9 @@ export default function Sidebar() {
   // making the header width depend on the number or length of project names.
   const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
   const [threadContextMenu, setThreadContextMenu] = useState<ThreadContextMenuState | null>(null);
+  const threadContextMenuResolveRef = useRef<
+    ((action: ThreadActionMenuId | undefined) => void) | null
+  >(null);
   const scopedProjectGroup = useMemo(
     () =>
       projectScopeKey === null
@@ -2983,15 +3019,25 @@ export default function Sidebar() {
     (
       items: ReadonlyArray<ContextMenuItem<ThreadActionMenuId>>,
       position: { x: number; y: number },
+      focusTarget: HTMLElement,
     ) =>
       new Promise<ThreadActionMenuId | undefined>((resolve) => {
-        setThreadContextMenu({ items, position, resolve });
+        threadContextMenuResolveRef.current?.(undefined);
+        threadContextMenuResolveRef.current = resolve;
+        setThreadContextMenu({ items, anchor: contextMenuAnchor(position), focusTarget });
       }),
     [],
   );
 
+  const resolveThreadContextMenu = useCallback((action: ThreadActionMenuId | undefined) => {
+    const resolve = threadContextMenuResolveRef.current;
+    threadContextMenuResolveRef.current = null;
+    setThreadContextMenu(null);
+    resolve?.(action);
+  }, []);
+
   const handleThreadContextMenu = useCallback(
-    (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
+    (threadRef: ScopedThreadRef, position: { x: number; y: number }, focusTarget: HTMLElement) => {
       void (async () => {
         const api = readLocalApi();
         if (!api) return;
@@ -3044,6 +3090,7 @@ export default function Sidebar() {
             snoozePresets,
           }),
           position,
+          focusTarget,
         );
         if (clicked?.startsWith("snooze:")) {
           const preset = snoozePresets.find((candidate) => `snooze:${candidate.id}` === clicked);
@@ -3309,7 +3356,11 @@ export default function Sidebar() {
   const newThreadInProjectShortcutLabel = shortcutLabelForCommand(keybindings, "chat.newLocal");
   return (
     <>
-      <ThreadContextMenu menu={threadContextMenu} onDismiss={() => setThreadContextMenu(null)} />
+      <ThreadContextMenu
+        menu={threadContextMenu}
+        onSelect={(action) => resolveThreadContextMenu(action)}
+        onDismiss={() => resolveThreadContextMenu(undefined)}
+      />
       <SidebarChromeHeader isElectron={isElectron} />
       <SidebarContent
         className="gap-0"
@@ -3317,101 +3368,8 @@ export default function Sidebar() {
           // Lifted above the stage backdrop, whose fade bleeds below the
           // header and would otherwise paint across the search row's outline.
           <SidebarGroup className="relative z-[1] gap-1 p-[var(--sidebar-content-inset)]">
-            <div className="order-2 flex items-center gap-1">
-              <div className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground">
-                <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
-                <Input
-                  ref={threadSearchInputRef}
-                  nativeInput
-                  unstyled
-                  type="search"
-                  value={threadSearchQuery}
-                  onChange={(event) => {
-                    setThreadSearchQuery(event.currentTarget.value);
-                    setActiveSearchResultIndex(0);
-                  }}
-                  onKeyDown={handleThreadSearchKeyDown}
-                  placeholder="Search"
-                  aria-label="Search threads"
-                  role="combobox"
-                  aria-autocomplete="list"
-                  aria-expanded={isSearchingThreads && threadSearchResults.length > 0}
-                  aria-controls={
-                    isSearchingThreads && threadSearchResults.length > 0
-                      ? "sidebar-thread-search-results"
-                      : undefined
-                  }
-                  aria-activedescendant={
-                    isSearchingThreads && threadSearchResults[activeSearchResultIndex]
-                      ? `sidebar-thread-search-result-${activeSearchResultIndex}`
-                      : undefined
-                  }
-                  className="min-w-0 flex-1 [&_[data-slot=input]]:h-auto [&_[data-slot=input]]:p-0 [&_[data-slot=input]]:leading-normal [&_[data-slot=input]]:text-sm [&_[data-slot=input]]:font-medium [&_[data-slot=input]]:text-sidebar-foreground [&_[data-slot=input]]:placeholder:text-sidebar-muted-foreground"
-                />
-                {isSearchingThreads ? (
-                  <Button
-                    type="button"
-                    size="icon-xs"
-                    variant="ghost"
-                    className="size-5 shrink-0 rounded-sm text-sidebar-muted-foreground hover:bg-sidebar-control-surface hover:text-sidebar-foreground"
-                    aria-label="Clear thread search"
-                    onClick={() => {
-                      clearThreadSearch();
-                      threadSearchInputRef.current?.focus();
-                    }}
-                  >
-                    <XIcon className="size-3" />
-                  </Button>
-                ) : null}
-              </div>
-              <div className="shrink-0">
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <SidebarMenuButton
-                        size="icon"
-                        type="button"
-                        className="relative focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
-                        onClick={handleNewThreadClick}
-                        disabled={projects.length === 0}
-                        aria-label="New thread"
-                      />
-                    }
-                  >
-                    <SquarePenIcon />
-                    <span
-                      className="pointer-events-none absolute left-1/2 top-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-                      aria-hidden="true"
-                    />
-                  </TooltipTrigger>
-                  <TooltipPopup side="right">
-                    {scopedProjectGroup !== null ? (
-                      `New thread in ${scopedProjectGroup.displayName}`
-                    ) : projectGroups.length > 1 ? (
-                      <span className="flex flex-col gap-0.5">
-                        <span>
-                          {newThreadShortcutLabel
-                            ? `New thread (${newThreadShortcutLabel})`
-                            : "New thread"}
-                        </span>
-                        <span className="text-muted-foreground">
-                          New thread in current project: Shift+click
-                          {newThreadInProjectShortcutLabel
-                            ? ` (${newThreadInProjectShortcutLabel})`
-                            : ""}
-                        </span>
-                      </span>
-                    ) : newThreadShortcutLabel ? (
-                      `New thread (${newThreadShortcutLabel})`
-                    ) : (
-                      "New thread"
-                    )}
-                  </TooltipPopup>
-                </Tooltip>
-              </div>
-            </div>
             {projectGroups.length > 0 ? (
-              <div className="order-1 flex items-center gap-1">
+              <div className="flex items-center gap-1">
                 <Menu open={projectScopeMenuOpen} onOpenChange={setProjectScopeMenuOpen}>
                   <MenuTrigger
                     render={
@@ -3507,6 +3465,99 @@ export default function Sidebar() {
                 </Tooltip>
               </div>
             ) : null}
+            <div className="flex items-center gap-1">
+              <div className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground">
+                <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
+                <Input
+                  ref={threadSearchInputRef}
+                  nativeInput
+                  unstyled
+                  type="search"
+                  value={threadSearchQuery}
+                  onChange={(event) => {
+                    setThreadSearchQuery(event.currentTarget.value);
+                    setActiveSearchResultIndex(0);
+                  }}
+                  onKeyDown={handleThreadSearchKeyDown}
+                  placeholder="Search"
+                  aria-label="Search threads"
+                  role="combobox"
+                  aria-autocomplete="list"
+                  aria-expanded={isSearchingThreads && threadSearchResults.length > 0}
+                  aria-controls={
+                    isSearchingThreads && threadSearchResults.length > 0
+                      ? "sidebar-thread-search-results"
+                      : undefined
+                  }
+                  aria-activedescendant={
+                    isSearchingThreads && threadSearchResults[activeSearchResultIndex]
+                      ? `sidebar-thread-search-result-${activeSearchResultIndex}`
+                      : undefined
+                  }
+                  className="min-w-0 flex-1 [&_[data-slot=input]]:h-auto [&_[data-slot=input]]:p-0 [&_[data-slot=input]]:leading-normal [&_[data-slot=input]]:text-sm [&_[data-slot=input]]:font-medium [&_[data-slot=input]]:text-sidebar-foreground [&_[data-slot=input]]:placeholder:text-sidebar-muted-foreground"
+                />
+                {isSearchingThreads ? (
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    className="size-5 shrink-0 rounded-sm text-sidebar-muted-foreground hover:bg-sidebar-control-surface hover:text-sidebar-foreground"
+                    aria-label="Clear thread search"
+                    onClick={() => {
+                      clearThreadSearch();
+                      threadSearchInputRef.current?.focus();
+                    }}
+                  >
+                    <XIcon className="size-3" />
+                  </Button>
+                ) : null}
+              </div>
+              <div className="shrink-0">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <SidebarMenuButton
+                        size="icon"
+                        type="button"
+                        className="relative focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+                        onClick={handleNewThreadClick}
+                        disabled={projects.length === 0}
+                        aria-label="New thread"
+                      />
+                    }
+                  >
+                    <SquarePenIcon />
+                    <span
+                      className="pointer-events-none absolute left-1/2 top-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+                      aria-hidden="true"
+                    />
+                  </TooltipTrigger>
+                  <TooltipPopup side="right">
+                    {scopedProjectGroup !== null ? (
+                      `New thread in ${scopedProjectGroup.displayName}`
+                    ) : projectGroups.length > 1 ? (
+                      <span className="flex flex-col gap-0.5">
+                        <span>
+                          {newThreadShortcutLabel
+                            ? `New thread (${newThreadShortcutLabel})`
+                            : "New thread"}
+                        </span>
+                        <span className="text-muted-foreground">
+                          New thread in current project: Shift+click
+                          {newThreadInProjectShortcutLabel
+                            ? ` (${newThreadInProjectShortcutLabel})`
+                            : ""}
+                        </span>
+                      </span>
+                    ) : newThreadShortcutLabel ? (
+                      `New thread (${newThreadShortcutLabel})`
+                    ) : (
+                      "New thread"
+                    )}
+                  </TooltipPopup>
+                </Tooltip>
+              </div>
+            </div>
           </SidebarGroup>
         }
       >

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -29,7 +29,7 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef, ThreadId } from "@t3tools/contracts";
+import type { ContextMenuItem, ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import type { TimestampFormat } from "@t3tools/contracts/settings";
 import {
   AlarmClockIcon,
@@ -118,7 +118,7 @@ import {
 import { formatRelativeTimeLabel, parseTimestampDate } from "../timestampFormat";
 import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
-import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
+import { buildThreadActionMenuItems, type ThreadActionMenuId } from "./threadActionMenu.logic";
 import {
   buildBulkTitleRegenerationContextMenuItem,
   formatWorkingDurationLabel,
@@ -162,7 +162,17 @@ import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
-import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from "./ui/menu";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
@@ -182,6 +192,65 @@ const SETTLED_TAIL_PAGE_COUNT = 25;
 // Keep the v2 key so existing preferences survive the v2-to-default rename.
 const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:settled-expanded";
 const SNOOZED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:snoozed-expanded";
+
+type ThreadContextMenuState = {
+  readonly items: ReadonlyArray<ContextMenuItem<ThreadActionMenuId>>;
+  readonly position: { readonly x: number; readonly y: number };
+  readonly resolve: (action: ThreadActionMenuId | undefined) => void;
+};
+
+function ThreadContextMenuItems({
+  items,
+  onSelect,
+}: {
+  readonly items: ReadonlyArray<ContextMenuItem<ThreadActionMenuId>>;
+  readonly onSelect: (action: ThreadActionMenuId) => void;
+}) {
+  return items.map((item) =>
+    item.children ? (
+      <MenuSub key={item.id}>
+        <MenuSubTrigger disabled={item.disabled}>{item.label}</MenuSubTrigger>
+        <MenuSubPopup className="min-w-52">
+          <ThreadContextMenuItems items={item.children} onSelect={onSelect} />
+        </MenuSubPopup>
+      </MenuSub>
+    ) : (
+      <MenuItem
+        key={item.id}
+        disabled={item.disabled}
+        variant={item.destructive ? "destructive" : "default"}
+        onClick={() => onSelect(item.id)}
+      >
+        {item.label}
+      </MenuItem>
+    ),
+  );
+}
+
+function ThreadContextMenu({
+  menu,
+  onDismiss,
+}: {
+  readonly menu: ThreadContextMenuState | null;
+  readonly onDismiss: () => void;
+}) {
+  const finish = (action: ThreadActionMenuId | undefined) => {
+    menu?.resolve(action);
+    onDismiss();
+  };
+  return (
+    <Menu open={menu !== null} onOpenChange={(open) => !open && finish(undefined)}>
+      <MenuTrigger
+        aria-label="Thread actions"
+        className="pointer-events-none fixed size-px opacity-0"
+        style={{ left: menu?.position.x ?? 0, top: menu?.position.y ?? 0 }}
+      />
+      <MenuPopup align="start" side="bottom" sideOffset={0} className="min-w-52">
+        {menu ? <ThreadContextMenuItems items={menu.items} onSelect={finish} /> : null}
+      </MenuPopup>
+    </Menu>
+  );
+}
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -1819,6 +1888,7 @@ export default function Sidebar() {
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
   const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
+  const [threadContextMenu, setThreadContextMenu] = useState<ThreadContextMenuState | null>(null);
   const scopedProjectGroup = useMemo(
     () =>
       projectScopeKey === null
@@ -2909,6 +2979,17 @@ export default function Sidebar() {
     ],
   );
 
+  const showThreadContextMenu = useCallback(
+    (
+      items: ReadonlyArray<ContextMenuItem<ThreadActionMenuId>>,
+      position: { x: number; y: number },
+    ) =>
+      new Promise<ThreadActionMenuId | undefined>((resolve) => {
+        setThreadContextMenu({ items, position, resolve });
+      }),
+    [],
+  );
+
   const handleThreadContextMenu = useCallback(
     (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
       void (async () => {
@@ -2946,35 +3027,30 @@ export default function Sidebar() {
         const isPinned = thread.pinnedAt != null;
         // Presets resolve at menu-open time (same as the popover).
         const snoozePresets = resolveSnoozePresets(new Date(), timestampFormat);
-        const clicked = await settlePromise(() =>
-          api.contextMenu.show(
-            buildThreadActionMenuItems({
-              branch: thread.branch ?? null,
-              isPinned,
-              isSettled,
-              isSnoozed,
-              canSnoozeNow: canSnooze(thread, { now: new Date().toISOString() }),
-              isRegeneratingTitle,
-              supports: {
-                settlement: supportsSettlement,
-                snooze: supportsSnooze,
-                pinning: supportsPinning,
-                titleRegeneration: supportsTitleRegeneration,
-              },
-              snoozePresets,
-            }),
-            position,
-          ),
+        const clicked = await showThreadContextMenu(
+          buildThreadActionMenuItems({
+            branch: thread.branch ?? null,
+            isPinned,
+            isSettled,
+            isSnoozed,
+            canSnoozeNow: canSnooze(thread, { now: new Date().toISOString() }),
+            isRegeneratingTitle,
+            supports: {
+              settlement: supportsSettlement,
+              snooze: supportsSnooze,
+              pinning: supportsPinning,
+              titleRegeneration: supportsTitleRegeneration,
+            },
+            snoozePresets,
+          }),
+          position,
         );
-        if (clicked._tag === "Failure") return;
-        if (clicked.value?.startsWith("snooze:")) {
-          const preset = snoozePresets.find(
-            (candidate) => `snooze:${candidate.id}` === clicked.value,
-          );
+        if (clicked?.startsWith("snooze:")) {
+          const preset = snoozePresets.find((candidate) => `snooze:${candidate.id}` === clicked);
           if (preset) attemptSnooze(threadRef, preset);
           return;
         }
-        switch (clicked.value) {
+        switch (clicked) {
           case "new-thread-on-branch": {
             // Explicit branch carry-over: reuse the thread's worktree when it
             // has one, otherwise its branch on the local checkout.
@@ -3106,6 +3182,7 @@ export default function Sidebar() {
       markThreadUnread,
       projectCwdByKey,
       serverConfigs,
+      showThreadContextMenu,
       startThreadRename,
       updateThreadMetadata,
       timestampFormat,
@@ -3232,6 +3309,7 @@ export default function Sidebar() {
   const newThreadInProjectShortcutLabel = shortcutLabelForCommand(keybindings, "chat.newLocal");
   return (
     <>
+      <ThreadContextMenu menu={threadContextMenu} onDismiss={() => setThreadContextMenu(null)} />
       <SidebarChromeHeader isElectron={isElectron} />
       <SidebarContent
         className="gap-0"

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2205,7 +2205,9 @@ const AgentSpawnCtaRow = memo(function AgentSpawnCtaRow(props: { workEntry: Time
         {totalTokens > 0 ? (
           <span className="tabular-nums">Σ {formatSubagentTokenCount(totalTokens)}</span>
         ) : null}
-        <span className="text-info-foreground">{live ? "Open Agents ▸" : "View ▸"}</span>
+        <span className="inline-flex items-center rounded-md border border-border/60 px-1.5 py-0.5 font-sans text-foreground transition-colors hover:border-border hover:bg-accent">
+          {live ? "Open agents" : "View agents"}
+        </span>
       </span>
     </button>
   );

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1037,10 +1037,10 @@ export function PullRequestDetailPanel({
                       aria-pressed={tab === item.value}
                       onClick={() => setTab(item.value)}
                       className={cn(
-                        "rounded-md px-2 py-1 text-[11px] transition-colors",
+                        "border-b-2 border-transparent px-2 py-1 text-[11px] transition-colors",
                         tab === item.value
-                          ? "bg-accent text-foreground"
-                          : "text-muted-foreground hover:text-foreground",
+                          ? "border-foreground text-foreground"
+                          : "text-muted-foreground hover:border-border hover:text-foreground",
                       )}
                     >
                       {item.label}
@@ -1188,10 +1188,10 @@ export function PullRequestDetailPanel({
                     aria-pressed={tab === item.value}
                     onClick={() => setTab(item.value)}
                     className={cn(
-                      "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition-colors",
+                      "inline-flex items-center gap-1.5 border-b-2 border-transparent px-3 py-1.5 text-xs transition-colors",
                       tab === item.value
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:text-foreground",
+                        ? "border-foreground text-foreground"
+                        : "text-muted-foreground hover:border-border hover:text-foreground",
                     )}
                   >
                     {item.label}

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -125,13 +125,13 @@ function ExpandableHeaderSearch({
             render={
               <Button
                 type="button"
-                size="icon-xs"
+                size="icon-sm"
                 variant="ghost"
-                className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                className="text-muted-foreground hover:text-foreground"
                 onClick={() => onOpenChange(true)}
                 aria-label="Search keybindings"
               >
-                <SearchIcon className="size-3" />
+                <SearchIcon className="size-4" />
               </Button>
             }
           />
@@ -1247,13 +1247,13 @@ export function KeybindingsSettingsPanel() {
                 render={
                   <Button
                     type="button"
-                    size="icon-xs"
+                    size="icon-sm"
                     variant="ghost"
-                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                    className="text-muted-foreground hover:text-foreground"
                     onClick={() => setIsAddingBinding(true)}
                     aria-label="Add keybinding"
                   >
-                    <PlusIcon className="size-3" />
+                    <PlusIcon className="size-4" />
                   </Button>
                 }
               />
@@ -1264,14 +1264,14 @@ export function KeybindingsSettingsPanel() {
                 render={
                   <Button
                     type="button"
-                    size="icon-xs"
+                    size="icon-sm"
                     variant="ghost"
-                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                    className="text-muted-foreground hover:text-foreground"
                     disabled={!keybindingsConfigPath}
                     onClick={openKeybindingsFile}
                     aria-label="Open keybindings.json"
                   >
-                    <FileJsonIcon className="size-3" />
+                    <FileJsonIcon className="size-4" />
                   </Button>
                 }
               />

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -686,17 +686,17 @@ export function EnvironmentProviderSettings({
                   <TooltipTrigger
                     render={
                       <Button
-                        size="icon-xs"
+                        size="icon-sm"
                         variant="ghost"
-                        className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                        className="text-muted-foreground hover:text-foreground"
                         disabled={isRefreshingProviders}
                         onClick={() => void refreshProviders()}
                         aria-label="Refresh provider status"
                       >
                         {isRefreshingProviders ? (
-                          <LoaderIcon className="size-3 animate-spin" />
+                          <LoaderIcon className="size-4 animate-spin" />
                         ) : (
-                          <RefreshCwIcon className="size-3" />
+                          <RefreshCwIcon className="size-4" />
                         )}
                       </Button>
                     }

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -670,13 +670,13 @@ export function EnvironmentProviderSettings({
                   <TooltipTrigger
                     render={
                       <Button
-                        size="icon-xs"
+                        size="icon-sm"
                         variant="ghost"
-                        className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                        className="text-muted-foreground hover:text-foreground"
                         onClick={() => setIsAddInstanceDialogOpen(true)}
                         aria-label="Add provider instance"
                       >
-                        <PlusIcon className="size-3" />
+                        <PlusIcon className="size-4" />
                       </Button>
                     }
                   />

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -529,14 +529,14 @@ export function SourceControlSettingsPanel() {
       <TooltipTrigger
         render={
           <Button
-            size="icon-xs"
+            size="icon-sm"
             variant="ghost"
-            className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+            className="text-muted-foreground hover:text-foreground"
             onClick={handleScan}
             disabled={discovery.isPending}
             aria-label="Rescan server environment"
           >
-            <RefreshCwIcon className={cn("size-3", discovery.isPending && "animate-spin")} />
+            <RefreshCwIcon className={cn("size-4", discovery.isPending && "animate-spin")} />
           </Button>
         }
       />

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -20,6 +20,7 @@ import {
   makeWindow,
 } from "@t3tools/shared/usageFormat";
 import { ScrollArea } from "../ui/scroll-area";
+import { Button } from "../ui/button";
 import { SidebarInset } from "../ui/sidebar";
 import { WorkspaceBreadcrumb, WorkspaceBreadcrumbItem } from "../WorkspaceBreadcrumb";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "../../workspaceTitlebar";
@@ -156,14 +157,15 @@ export function UsagePage() {
                     </button>
                   ))}
                 </div>
-                <button
+                <Button
                   type="button"
+                  size="icon-sm"
+                  variant="ghost"
                   onClick={refreshWindow}
                   aria-label="Refresh usage"
-                  className="cursor-pointer rounded-md border border-border p-2 text-muted-foreground hover:text-foreground"
                 >
-                  <RefreshCwIcon className="size-3.5" />
-                </button>
+                  <RefreshCwIcon className="size-4" />
+                </Button>
               </div>
             </div>
 

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -909,7 +909,9 @@ function PullRequestsRouteView() {
       terminalAvailable={false}
       terminalOpen={false}
       terminalShortcutLabel={null}
-      rightPanelAvailable={rightPanelState.surfaces.length > 0}
+      // Opening the panel requires a selected PR. Retained panel surfaces alone
+      // are not enough: without a selected surface the toggle is a no-op.
+      rightPanelAvailable={rightPanelState.isOpen || selectedPullRequestSurface !== null}
       rightPanelOpen={rightPanelState.isOpen}
       rightPanelShortcutLabel={null}
       liveAgentCount={0}

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1464,14 +1464,6 @@ function PullRequestsColumn({
             }}
           />
         ) : null}
-        <Button
-          size="icon-sm"
-          variant="ghost"
-          aria-label="Refresh pull requests"
-          onClick={onRefresh}
-        >
-          <RefreshCwIcon className={cn("size-4", refreshing && "animate-spin")} />
-        </Button>
         {rightPanelControl}
       </header>
 
@@ -1487,6 +1479,14 @@ function PullRequestsColumn({
             <div ref={inFlowSearchRef} className="flex items-center gap-2">
               {searchInput}
               {filtersMenu}
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                aria-label="Refresh pull requests"
+                onClick={onRefresh}
+              >
+                <RefreshCwIcon className={cn("size-4", refreshing && "animate-spin")} />
+              </Button>
             </div>
             {/* Scrolled past this marker, the controls are gone and the title takes over. */}
             <div ref={markerRef} aria-hidden className="-mt-3 h-px w-full" />

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -909,9 +909,9 @@ function PullRequestsRouteView() {
       terminalAvailable={false}
       terminalOpen={false}
       terminalShortcutLabel={null}
-      // Opening the panel requires a selected PR. Retained panel surfaces alone
-      // are not enough: without a selected surface the toggle is a no-op.
-      rightPanelAvailable={rightPanelState.isOpen || selectedPullRequestSurface !== null}
+      // A selected PR is required for either state of this control. An open
+      // panel without one cannot be toggled meaningfully.
+      rightPanelAvailable={selectedPullRequestSurface !== null}
       rightPanelOpen={rightPanelState.isOpen}
       rightPanelShortcutLabel={null}
       liveAgentCount={0}


### PR DESCRIPTION
## What changed

- Standardized Settings header actions in Providers, Source Control, and Keybindings so equivalent controls use the same button and icon sizing.
- Moved Pull Requests refresh next to its search and filters, where the action applies.
- Disabled the Pull Requests right-panel toggle when no pull request is selected, instead of showing an active control that cannot do anything.
- Switched thread right-click actions from the native context menu to the in-app menu style already used by Pull Request overflow actions.
- Made the selected sidebar project determine where the New Thread action creates a thread.
- Aligned Pull Request detail tabs with the shared underline-tab treatment.
- Normalized Usage refresh control styling.
- Refined the subagent CTA to read as an actionable control.

## Why

Several desktop controls that serve the same purpose had different placement, sizing, or visual treatment. This made the interface feel inconsistent and, in the Pull Requests view, exposed an action that looked available even when it had no effect.

This change makes action ownership clearer and brings these controls closer to the existing desktop UI patterns.

## UI changes

### Settings action alignment

<img width="1057" height="145" alt="image" src="https://github.com/user-attachments/assets/fadcf690-dbda-428a-87ac-1005fadc9f4d" />
<img width="1064" height="154" alt="image" src="https://github.com/user-attachments/assets/d1e2b5b1-02bb-43dc-a1ec-02b692364be3" />
<img width="1055" height="167" alt="image" src="https://github.com/user-attachments/assets/09599420-d2dd-4da0-973c-442258132cb4" />


### Usage controls

<img width="1054" height="135" alt="image" src="https://github.com/user-attachments/assets/97fb4d66-6c97-459c-bfb9-e4860da0c67a" />

### Pull Requests

<img width="1064" height="148" alt="image" src="https://github.com/user-attachments/assets/b8502298-8e2e-49e6-9516-42387a106bfa" />


### Sidebar context menu

<img width="262" height="385" alt="image" src="https://github.com/user-attachments/assets/4e03dc15-396c-47a3-9ca6-69ca4e69866e" />

## Validation

- [x] `git diff --check`
- [x] Commit-time `vp fmt`
- [x] Reviewed the desktop UI states covered by the screenshots

## Checklist

- [x] UI-only changes; no server or contract changes
- [x] Documented the behavior change and rationale
- [x] Added screenshots before requesting review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a frequently used sidebar interaction by replacing native context menus with in-app menus, and alters New Thread destination when a project is scoped. Remaining changes are low-risk UI sizing and placement polish.
> 
> **Overview**
> Polishes desktop control consistency and replaces the sidebar thread right-click menu with the in-app `Menu` style.
> 
> **Sidebar:** Single-thread context actions now render via a local `ThreadContextMenu` (with submenu support) instead of the native Electron menu. When a project is scoped, **New thread** creates directly in that project. The project filter is also moved above search.
> 
> **Pull Requests:** Refresh moves next to search/filters, the right-panel toggle is only available when a PR is selected, and detail tabs switch to the shared underline style.
> 
> **Settings / Usage / Agents:** Header action buttons are standardized to `icon-sm` sizing, Usage refresh uses the shared `Button`, and the subagent CTA is restyled as a clearer actionable control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19d083328ab6a5be868e7e67f528c43aa069c4cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish desktop control hierarchy in the web sidebar and settings panels
> - Replaces the native browser context menu for sidebar threads with a custom promise-based `ThreadContextMenu` component, supporting nested submenus, destructive styling, and focus restoration to the originating element on dismiss.
> - New thread creation in the sidebar now respects the current project scope, creating directly in the scoped project instead of opening the command palette.
> - Standardises icon button sizes across settings panels (keybindings, provider, source control, usage) from `icon-xs` to `icon-sm` with larger icons.
> - Moves the pull request refresh button from the sticky header into the inline controls row, and restricts the right panel toggle to when a PR is selected.
> - Updates `PullRequestDetailPanel` tab selection style from background highlight to border-bottom.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19d0833.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->