### PR TITLE
web/settings: fix source control scan on relay environments

### DIFF
--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -19,7 +19,7 @@ import {
 
 import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
-import { usePrimaryEnvironment } from "../../state/environments";
+import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
 import { sourceControlEnvironment } from "../../state/sourceControl";
 import { Badge } from "../ui/badge";
@@ -508,7 +508,10 @@ function EmptySourceControlDiscovery({
 }
 
 export function SourceControlSettingsPanel() {
-  const environmentId = usePrimaryEnvironment()?.environmentId ?? null;
+  const { environments } = useEnvironments();
+  const primaryEnvironment = usePrimaryEnvironment();
+  // Relay-only app.t3.codes sessions have no primary environment.
+  const environmentId = primaryEnvironment?.environmentId ?? environments[0]?.environmentId ?? null;
   const discovery = useEnvironmentQuery(
     environmentId === null
       ? null
@@ -561,7 +564,9 @@ export function SourceControlSettingsPanel() {
             >
               {result.versionControlSystems.map((item) => (
                 <DiscoveryItemRow key={`vcs:${item.kind}`} item={item}>
-                  {item.kind === "git" ? <GitFetchIntervalSettings /> : undefined}
+                  {item.kind === "git" && primaryEnvironment !== null ? (
+                    <GitFetchIntervalSettings />
+                  ) : undefined}
                 </DiscoveryItemRow>
               ))}
             </SettingsSection>
@@ -587,7 +592,7 @@ export function SourceControlSettingsPanel() {
         />
       )}
 
-      {environmentId !== null ? <SourceControlWritingSettingsSection /> : null}
+      {primaryEnvironment !== null ? <SourceControlWritingSettingsSection /> : null}
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -510,8 +510,12 @@ function EmptySourceControlDiscovery({
 export function SourceControlSettingsPanel() {
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
-  // Relay-only app.t3.codes sessions have no primary environment.
-  const environmentId = primaryEnvironment?.environmentId ?? environments[0]?.environmentId ?? null;
+  const environmentId =
+    primaryEnvironment?.connection.phase === "connected"
+      ? primaryEnvironment.environmentId
+      : (environments.find((environment) => environment.connection.phase === "connected")
+          ?.environmentId ?? null);
+  const isPrimaryEnvironment = environmentId === primaryEnvironment?.environmentId;
   const discovery = useEnvironmentQuery(
     environmentId === null
       ? null
@@ -564,7 +568,7 @@ export function SourceControlSettingsPanel() {
             >
               {result.versionControlSystems.map((item) => (
                 <DiscoveryItemRow key={`vcs:${item.kind}`} item={item}>
-                  {item.kind === "git" && primaryEnvironment !== null ? (
+                  {item.kind === "git" && isPrimaryEnvironment ? (
                     <GitFetchIntervalSettings />
                   ) : undefined}
                 </DiscoveryItemRow>
@@ -592,7 +596,7 @@ export function SourceControlSettingsPanel() {
         />
       )}
 
-      {primaryEnvironment !== null ? <SourceControlWritingSettingsSection /> : null}
+      {isPrimaryEnvironment ? <SourceControlWritingSettingsSection /> : null}
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -510,11 +510,12 @@ function EmptySourceControlDiscovery({
 export function SourceControlSettingsPanel() {
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
+  const fallbackEnvironment =
+    environments.find((environment) => environment.connection.phase === "connected") ??
+    environments[0] ??
+    null;
   const environmentId =
-    primaryEnvironment?.connection.phase === "connected"
-      ? primaryEnvironment.environmentId
-      : (environments.find((environment) => environment.connection.phase === "connected")
-          ?.environmentId ?? null);
+    primaryEnvironment?.environmentId ?? fallbackEnvironment?.environmentId ?? null;
   const isPrimaryEnvironment = environmentId === primaryEnvironment?.environmentId;
   const discovery = useEnvironmentQuery(
     environmentId === null


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Source Control settings now fall back to another environment when there is no primary, similar to how the Providers panel picks a target: primary --> first connected --> first listed. Scan/`server.discoverSourceControl` therefore runs against a T3 Connect relay environment on `app.t3.codes`, not only against a `PrimaryConnectionTarget`.

The Git fetch interval and source control writing sections are now shown only when the panel is targeting the primary environment: they read and write primary-server settings (`usePrimarySettings`/`useUpdatePrimarySettings`), which have nothing to attach to when only a fallback environment is available.

## Why

On `app.t3.codes` with a T3 Connect relay there is no `PrimaryConnectionTarget`, so `usePrimaryEnvironment()` left `environmentId` null. Scan refreshed a stub query and never called `server.discoverSourceControl`, which looked like
nothing was installed on the host even when tools like git were.


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized settings UI change with clearer environment targeting; no auth or data-path changes.
> 
> **Overview**
> **Fixes source control scan on T3 Connect relay setups** where `usePrimaryEnvironment()` returned no ID, so discovery never ran against the connected relay host.
> 
> `SourceControlSettingsPanel` now resolves `environmentId` as **primary → first connected environment → first listed environment**, matching how Providers settings pick a target. Scan and `discoverSourceControl` therefore run against the relay instead of staying on a null stub query.
> 
> When the panel is showing a **non-primary** fallback environment, **Git fetch interval** and **source control writing** sections are hidden so relay-only views do not expose primary-server settings edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82238b704b9959f05980d226c0b44dc7851033da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix source control scan in `SourceControlSettingsPanel` when no primary environment is set
> - When no primary environment exists, the component now falls back to a connected environment (where `connection.phase === "connected"`), or the first available environment.
> - Git fetch interval settings and source control writing settings are now restricted to the primary environment only, preventing them from appearing on relay environments.
> - Changes are in [SourceControlSettings.tsx](https://github.com/pingdotgg/t3code/pull/6230/files#diff-9f2e55c161725a6350a5fe7b23c2b7ada03b60855000614a443c6253ad64b625).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82238b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
