### PR TITLE
fix(mobile): stabilize scroll-to-end control

### DIFF
--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -77,7 +77,10 @@ import {
   ThreadComposer,
 } from "./ThreadComposer";
 import { ThreadFeed } from "./ThreadFeed";
-import { shouldShowThreadFeedScrollToEnd } from "./thread-feed-live-follow";
+import {
+  resolveThreadFeedAtEndState,
+  shouldShowThreadFeedScrollToEnd,
+} from "./thread-feed-live-follow";
 import type { ThreadContentPresentation } from "./threadContentPresentation";
 
 export interface ThreadDetailScreenProps {
@@ -459,6 +462,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
 
   useLayoutEffect(() => {
     selectedThreadKeyRef.current = selectedThreadKey;
+    setFeedAtEndState((current) => resolveThreadFeedAtEndState(current, selectedThreadKey));
   }, [selectedThreadKey]);
 
   useEffect(() => {

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -77,6 +77,7 @@ import {
   ThreadComposer,
 } from "./ThreadComposer";
 import { ThreadFeed } from "./ThreadFeed";
+import { shouldShowThreadFeedScrollToEnd } from "./thread-feed-live-follow";
 import type { ThreadContentPresentation } from "./threadContentPresentation";
 
 export interface ThreadDetailScreenProps {
@@ -261,6 +262,10 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const [composerExpanded, setComposerExpanded] = useState(false);
   const [anchorMessageId, setAnchorMessageId] = useState<MessageId | null>(null);
   const [endFollowEnabled, setEndFollowEnabled] = useState(true);
+  const [feedAtEndState, setFeedAtEndState] = useState(() => ({
+    threadKey: selectedThreadKey,
+    isAtEnd: true,
+  }));
   // Android keys the safe-area padding on keyboard visibility (#5988): the
   // back gesture closes the keyboard while the editor stays focused, and a
   // focus-keyed inset would leave the toolbar under the gesture bar. iOS must
@@ -538,7 +543,17 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
     });
   }, [freeze, scrollMessageToEnd]);
 
-  const showScrollToEndButton = contentPresentationKind === "ready" && !endFollowEnabled;
+  const handleFeedAtEndChange = useCallback(
+    (isAtEnd: boolean) => {
+      setFeedAtEndState({ threadKey: selectedThreadKey, isAtEnd });
+    },
+    [selectedThreadKey],
+  );
+  const feedIsAtEnd =
+    feedAtEndState.threadKey === selectedThreadKey ? feedAtEndState.isAtEnd : true;
+  const showScrollToEndButton =
+    contentPresentationKind === "ready" &&
+    shouldShowThreadFeedScrollToEnd({ endFollowEnabled, isAtEnd: feedIsAtEnd });
   const isDarkMode = useColorScheme() === "dark";
 
   const handleFeedTouchStart = useCallback((event: GestureResponderEvent) => {
@@ -602,6 +617,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
             usesAutomaticContentInsets={props.usesAutomaticContentInsets}
             onHeaderMaterialVisibilityChange={props.onHeaderMaterialVisibilityChange}
             onEndFollowEnabledChange={setEndFollowEnabled}
+            onAtEndChange={handleFeedAtEndChange}
             skills={selectedProviderSkills}
             loadEarlier={props.loadEarlier ?? null}
           />
@@ -627,7 +643,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
             {showScrollToEndButton ? (
               <Animated.View
                 pointerEvents="box-none"
-                className="absolute -top-11 left-0 right-0 z-20 items-center"
+                className="absolute -top-24 left-0 right-0 z-20 items-center"
                 entering={FadeInDown.duration(160)}
                 exiting={FadeOut.duration(100)}
               >

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -155,6 +155,7 @@ export interface ThreadFeedProps {
   readonly usesAutomaticContentInsets?: boolean;
   readonly onHeaderMaterialVisibilityChange?: (visible: boolean) => void;
   readonly onEndFollowEnabledChange?: (enabled: boolean) => void;
+  readonly onAtEndChange?: (isAtEnd: boolean) => void;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
   /** Non-null when older turns exist beyond the loaded window. */
   readonly loadEarlier?: {
@@ -1345,6 +1346,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
   // when the list actually returns to the end (or on send / thread switch).
   const [endFollowEnabled, setEndFollowEnabled] = useState(true);
   const endFollowEnabledRef = useRef(true);
+  const isAtEndRef = useRef(true);
   // A "user scroll session" spans from drag start through the end of its
   // momentum; only motion inside a session can break follow, so MVCP
   // compensations and programmatic scrolls never strand a follower.
@@ -1365,6 +1367,16 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       setEndFollow(resolveThreadFeedLiveFollow(endFollowEnabledRef.current, event));
     },
     [setEndFollow],
+  );
+  const setIsAtEnd = useCallback(
+    (isAtEnd: boolean) => {
+      if (isAtEndRef.current === isAtEnd) {
+        return;
+      }
+      isAtEndRef.current = isAtEnd;
+      props.onAtEndChange?.(isAtEnd);
+    },
+    [props.onAtEndChange],
   );
   const [interactionState, setInteractionState] = useState<{
     readonly copiedRowId: string | null;
@@ -1485,6 +1497,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       // remains inside LegendList's at-end tolerance.
       const listState = props.listRef.current?.getState();
       if (listState) {
+        setIsAtEnd(listState.isAtEnd);
         transitionEndFollow({
           type: "scroll",
           isAtEnd: listState.isAtEnd,
@@ -1492,7 +1505,13 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
         });
       }
     },
-    [reportHeaderMaterialVisibility, anchorTopInset, props.listRef, transitionEndFollow],
+    [
+      reportHeaderMaterialVisibility,
+      anchorTopInset,
+      props.listRef,
+      setIsAtEnd,
+      transitionEndFollow,
+    ],
   );
   const clearUserScrollSettle = useCallback(() => {
     if (userScrollSettleTimerRef.current !== null) {
@@ -1566,15 +1585,17 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
   useEffect(() => {
     clearUserScrollSettle();
     userScrollSessionRef.current = false;
+    setIsAtEnd(true);
     transitionEndFollow({ type: "reset" });
-  }, [clearUserScrollSettle, feedThreadKey, transitionEndFollow]);
+  }, [clearUserScrollSettle, feedThreadKey, setIsAtEnd, transitionEndFollow]);
   useEffect(() => {
     if (props.anchorMessageId !== null) {
       clearUserScrollSettle();
       userScrollSessionRef.current = false;
+      setIsAtEnd(true);
       transitionEndFollow({ type: "reset" });
     }
-  }, [clearUserScrollSettle, props.anchorMessageId, transitionEndFollow]);
+  }, [clearUserScrollSettle, props.anchorMessageId, setIsAtEnd, transitionEndFollow]);
 
   const expandedWorkGroupIds = useMemo(() => {
     const ids = new Set<string>();

--- a/apps/mobile/src/features/threads/thread-feed-live-follow.test.ts
+++ b/apps/mobile/src/features/threads/thread-feed-live-follow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   resolveThreadFeedLiveFollow,
+  resolveThreadFeedAtEndState,
   shouldShowThreadFeedScrollToEnd,
 } from "./thread-feed-live-follow";
 
@@ -98,5 +99,21 @@ describe("shouldShowThreadFeedScrollToEnd", () => {
         isAtEnd: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveThreadFeedAtEndState", () => {
+  it("resets at-end state when returning to a previously scrolled thread", () => {
+    const threadAAwayFromEnd = {
+      threadKey: "thread-a",
+      isAtEnd: false,
+    } as const;
+    const threadBAtEnd = resolveThreadFeedAtEndState(threadAAwayFromEnd, "thread-b");
+
+    expect(threadBAtEnd).toEqual({ threadKey: "thread-b", isAtEnd: true });
+    expect(resolveThreadFeedAtEndState(threadBAtEnd, "thread-a")).toEqual({
+      threadKey: "thread-a",
+      isAtEnd: true,
+    });
   });
 });

--- a/apps/mobile/src/features/threads/thread-feed-live-follow.test.ts
+++ b/apps/mobile/src/features/threads/thread-feed-live-follow.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveThreadFeedLiveFollow } from "./thread-feed-live-follow";
+import {
+  resolveThreadFeedLiveFollow,
+  shouldShowThreadFeedScrollToEnd,
+} from "./thread-feed-live-follow";
 
 describe("resolveThreadFeedLiveFollow", () => {
   it("pauses immediately when the user starts scrolling", () => {
@@ -66,5 +69,34 @@ describe("resolveThreadFeedLiveFollow", () => {
 
   it("re-arms after an explicit reset", () => {
     expect(resolveThreadFeedLiveFollow(false, { type: "reset" })).toBe(true);
+  });
+});
+
+describe("shouldShowThreadFeedScrollToEnd", () => {
+  it("stays hidden when a drag starts at the actual end", () => {
+    expect(
+      shouldShowThreadFeedScrollToEnd({
+        endFollowEnabled: false,
+        isAtEnd: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("appears only after the feed moves away from the actual end", () => {
+    expect(
+      shouldShowThreadFeedScrollToEnd({
+        endFollowEnabled: false,
+        isAtEnd: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays hidden while live follow is enabled", () => {
+    expect(
+      shouldShowThreadFeedScrollToEnd({
+        endFollowEnabled: true,
+        isAtEnd: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/mobile/src/features/threads/thread-feed-live-follow.ts
+++ b/apps/mobile/src/features/threads/thread-feed-live-follow.ts
@@ -40,3 +40,18 @@ export function shouldShowThreadFeedScrollToEnd(input: {
 }): boolean {
   return !input.endFollowEnabled && !input.isAtEnd;
 }
+
+export interface ThreadFeedAtEndState {
+  readonly threadKey: string;
+  readonly isAtEnd: boolean;
+}
+
+export function resolveThreadFeedAtEndState(
+  current: ThreadFeedAtEndState,
+  selectedThreadKey: string,
+): ThreadFeedAtEndState {
+  if (current.threadKey === selectedThreadKey) {
+    return current;
+  }
+  return { threadKey: selectedThreadKey, isAtEnd: true };
+}

--- a/apps/mobile/src/features/threads/thread-feed-live-follow.ts
+++ b/apps/mobile/src/features/threads/thread-feed-live-follow.ts
@@ -33,3 +33,10 @@ export function resolveThreadFeedLiveFollow(
       return current;
   }
 }
+
+export function shouldShowThreadFeedScrollToEnd(input: {
+  readonly endFollowEnabled: boolean;
+  readonly isAtEnd: boolean;
+}): boolean {
+  return !input.endFollowEnabled && !input.isAtEnd;
+}


### PR DESCRIPTION
## Problem

Follow-up to #5986, which introduced the mobile scroll-to-end button.

The mobile scroll-to-end button could briefly appear while dragging at the actual end of a thread because its visibility followed the live-follow latch alone.

The button also overlapped messages and alerts shown above the composer, making both elements harder to see and use.

## Fix

Track whether the feed is actually at the end separately from whether live follow is enabled. The button now appears only when live follow is paused and the feed is away from the end.

Raise the button slightly and keep it in a fixed position above composer messages and alerts so the elements no longer overlap.

## Validation

- `vp test run apps/mobile/src/features/threads/thread-feed-live-follow.test.ts`
- `vp run --filter @t3tools/mobile typecheck`
- Targeted formatting and lint checks
- Standalone Android Preview APK built and tested on an OPPO CPH2707

## Before

<!-- Attach the before video here. -->

https://github.com/user-attachments/assets/cfc5ca8e-44bc-440b-a46b-3d50a97b2f95





## After

<!-- Attach the after video here. -->

https://github.com/user-attachments/assets/f4347672-3bde-4665-9eba-66413d304037



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only scroll affordance and positioning tweaks in the mobile thread feed, with no auth, data, or backend impact.
> 
> **Overview**
> Prevents the mobile **scroll-to-end** button from briefly appearing when a drag starts while already at the live edge.
> 
> `ThreadFeed` now reports actual at-end state separately from the live-follow latch. The button shows only when follow is paused **and** the feed is away from the end, with thread-switch state reset via `resolveThreadFeedAtEndState`.
> 
> Also raises the floating control (`-top-11` → `-top-24`) so it no longer overlaps composer messages and alerts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 904a5b65cf20e68cd4aeed7bc86dcacc3d5428a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix scroll-to-end button visibility in thread feed to hide when feed is already at end
> - Adds `shouldShowThreadFeedScrollToEnd` to gate button visibility on both live follow being paused and the feed not being at the end — previously the button could appear even when already at the end.
> - Tracks per-thread at-end state in `ThreadDetailScreen` via a new `feedAtEndState` keyed by thread key, reset to `true` on thread switch or anchor-based jumps.
> - Exposes an `onAtEndChange` callback on `ThreadFeed` to propagate scroll position changes to the parent.
> - Moves the scroll-to-end button container position from `-top-11` to `-top-24`, rendering it higher above the composer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 904a5b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->