### PR TITLE
fix(web): keep interrupted environment queries pending

### DIFF
--- a/apps/web/src/state/query.test.ts
+++ b/apps/web/src/state/query.test.ts
@@ -1,0 +1,35 @@
+import * as Cause from "effect/Cause";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const harness = vi.hoisted(() => ({
+  result: null as AsyncResult.AsyncResult<unknown, unknown> | null,
+  refresh: vi.fn(),
+}));
+
+vi.mock("@effect/atom-react", () => ({
+  useAtomRefresh: () => harness.refresh,
+  useAtomValue: () => harness.result,
+}));
+
+import { useEnvironmentQuery } from "./query";
+
+describe("useEnvironmentQuery", () => {
+  it("keeps an interrupted request pending instead of exposing an internal error", () => {
+    harness.result = AsyncResult.failure(Cause.interrupt(1));
+
+    const query = useEnvironmentQuery(Atom.make(harness.result));
+
+    expect(query.error).toBeNull();
+    expect(query.isPending).toBe(true);
+  });
+
+  it("continues to expose genuine environment failures", () => {
+    harness.result = AsyncResult.failure(Cause.fail(new Error("GitHub did not answer.")));
+
+    const query = useEnvironmentQuery(Atom.make(harness.result));
+
+    expect(query.error).toBe("GitHub did not answer.");
+    expect(query.isPending).toBe(false);
+  });
+});

--- a/apps/web/src/state/query.ts
+++ b/apps/web/src/state/query.ts
@@ -27,10 +27,11 @@ export function useEnvironmentQuery<A, E>(
   const selectedAtom = atom ?? EMPTY_ASYNC_RESULT_ATOM;
   const result = useAtomValue(selectedAtom);
   const refresh = useAtomRefresh(selectedAtom);
+  const interrupted = result._tag === "Failure" && Cause.hasInterruptsOnly(result.cause);
   return {
     data: Option.getOrNull(AsyncResult.value(result)),
-    error: result._tag === "Failure" ? formatError(result.cause) : null,
-    isPending: atom !== null && result.waiting,
+    error: result._tag === "Failure" && !interrupted ? formatError(result.cause) : null,
+    isPending: atom !== null && (result.waiting || interrupted),
     refresh,
   };
 }


### PR DESCRIPTION
## What Changed

- Prevent cancelled requests from appearing as errors.
- Keep showing real errors when something actually goes wrong.
- Add tests for both cases.

## Why

T3 Code was cancelling requests when reconnecting and I was seeing a confusing internal message:

`All fibers interrupted without error`

This made the Pull Requests page look broken even though retrying often worked. This PR adds an update to show the normal loading state until a new result arrives.

I tested this both before and after with a couple projects. The logs showed several cancelled pull-request requests, followed by a successful response. After the fix, the error screen did not appear.

## UI Changes

There is no new design. The app now shows its existing loading state instead of an internal error.

Screenshot from before:

<img width="465" height="296" alt="Could not load pull requests error" src="https://github.com/user-attachments/assets/32002806-d11b-4457-a9ce-483ce5a15b35" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `useEnvironmentQuery` to treat interrupted failures as pending
> When an environment query is interrupted (e.g. due to cancellation), `useEnvironmentQuery` previously surfaced the interruption as an error. It now checks `Cause.hasInterruptsOnly` on failure causes and, if true, treats the result as pending with no error instead. Only genuine (non-interrupted) failures expose an error message. Tests in [query.test.ts](https://github.com/pingdotgg/t3code/pull/6233/files#diff-e270f494d4a812045f777068cd8cf4145957f720a4c688bb08570b6937e35cf3) cover both cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c80679.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->