### PR TITLE
fix(desktop): agent shells inherit a UTF-8 locale on macOS

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -152,6 +152,85 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
+  it.effect("hydrates the locale from the login shell on macOS", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () =>
+          envOutput({
+            PATH: "/opt/homebrew/bin:/usr/bin",
+            LANG: "de_DE.UTF-8",
+          }),
+      });
+
+      assert.equal(env.LANG, "de_DE.UTF-8");
+    }),
+  );
+
+  it.effect("preserves an inherited locale over the login shell on macOS", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+        LANG: "en_US.UTF-8",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () =>
+          envOutput({
+            PATH: "/opt/homebrew/bin:/usr/bin",
+            LANG: "de_DE.UTF-8",
+          }),
+      });
+
+      assert.equal(env.LANG, "en_US.UTF-8");
+    }),
+  );
+
+  it.effect("falls back to C.UTF-8 when no locale is available on macOS", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () => envOutput({ PATH: "/opt/homebrew/bin:/usr/bin" }),
+      });
+
+      assert.equal(env.LANG, "C.UTF-8");
+      assert.equal(env.LC_ALL, undefined);
+      assert.equal(env.LC_CTYPE, undefined);
+    }),
+  );
+
+  it.effect("does not apply the locale fallback on linux", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        handler: () => envOutput({ PATH: "/home/linuxbrew/.linuxbrew/bin:/usr/bin" }),
+      });
+
+      assert.equal(env.LANG, undefined);
+    }),
+  );
+
   it.effect("hydrates PATH and missing SSH_AUTH_SOCK from the login shell on linux", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -195,7 +195,7 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
-  it.effect("falls back to C.UTF-8 when no locale is available on macOS", () =>
+  it.effect("falls back to a UTF-8 LC_CTYPE when no locale is available on macOS", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {
         SHELL: "/bin/zsh",
@@ -208,9 +208,9 @@ describe("DesktopShellEnvironment", () => {
         handler: () => envOutput({ PATH: "/opt/homebrew/bin:/usr/bin" }),
       });
 
-      assert.equal(env.LANG, "C.UTF-8");
+      assert.equal(env.LANG, undefined);
       assert.equal(env.LC_ALL, undefined);
-      assert.equal(env.LC_CTYPE, undefined);
+      assert.equal(env.LC_CTYPE, "en_US.UTF-8");
     }),
   );
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -195,6 +195,29 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
+  it.effect("does not mix login-shell locale categories into an inherited locale", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+        LANG: "en_US.UTF-8",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () =>
+          envOutput({
+            PATH: "/opt/homebrew/bin:/usr/bin",
+            LC_ALL: "de_DE.UTF-8",
+          }),
+      });
+
+      assert.equal(env.LANG, "en_US.UTF-8");
+      assert.equal(env.LC_ALL, undefined);
+    }),
+  );
+
   it.effect("falls back to a UTF-8 LC_CTYPE when no locale is available on macOS", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -71,6 +71,9 @@ const LOGIN_SHELL_ENV_NAMES = [
   "PATH",
   "DBUS_SESSION_BUS_ADDRESS",
   "DISPLAY",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
   "SSH_AUTH_SOCK",
   "HOMEBREW_PREFIX",
   "HOMEBREW_CELLAR",
@@ -84,6 +87,8 @@ const LOGIN_SHELL_ENV_NAMES = [
   "WAYLAND_DISPLAY",
 ] as const;
 const WINDOWS_PROFILE_ENV_NAMES = ["PATH", "FNM_DIR", "FNM_MULTISHELL_PATH"] as const;
+const LOCALE_ENV_NAMES = ["LANG", "LC_ALL", "LC_CTYPE"] as const;
+const FALLBACK_LOCALE = "C.UTF-8";
 const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
 const LOGIN_SHELL_TIMEOUT = Duration.seconds(5);
 const LAUNCHCTL_TIMEOUT = Duration.seconds(2);
@@ -462,6 +467,9 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
       "HOMEBREW_PREFIX",
       "HOMEBREW_CELLAR",
       "HOMEBREW_REPOSITORY",
+      "LANG",
+      "LC_ALL",
+      "LC_CTYPE",
       "XDG_CONFIG_HOME",
       "XDG_DATA_HOME",
       "XDG_RUNTIME_DIR",
@@ -470,6 +478,17 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
       if (!config.env[name] && shellEnvironment[name]) {
         config.env[name] = shellEnvironment[name];
       }
+    }
+
+    // GUI launches inherit no locale from launchd, so spawned agents land in the C
+    // locale and pbcopy decodes their UTF-8 output as MacRoman. C.UTF-8 is what
+    // /etc/zprofile already falls back to: it fixes the codeset while keeping
+    // C-stable collation and formatting, so output parsing is unaffected.
+    if (
+      config.platform === "darwin" &&
+      LOCALE_ENV_NAMES.every((name) => Option.isNone(trimNonEmpty(config.env[name])))
+    ) {
+      config.env.LANG = FALLBACK_LOCALE;
     }
 
     if (

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -467,9 +467,6 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
       "HOMEBREW_PREFIX",
       "HOMEBREW_CELLAR",
       "HOMEBREW_REPOSITORY",
-      "LANG",
-      "LC_ALL",
-      "LC_CTYPE",
       "XDG_CONFIG_HOME",
       "XDG_DATA_HOME",
       "XDG_RUNTIME_DIR",
@@ -480,16 +477,27 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
       }
     }
 
-    // GUI launches inherit no locale from launchd, so spawned agents land in the C
-    // locale and pbcopy decodes their UTF-8 output as MacRoman. Older supported
-    // macOS releases do not provide C.UTF-8, so set only LC_CTYPE to a UTF-8 locale
-    // available on those releases. Leaving LANG unset keeps C-stable collation and
-    // formatting, so output parsing is unaffected.
+    // Locale variables form one precedence group: LC_ALL can override an inherited
+    // LANG or LC_CTYPE, so only hydrate the group when the process has none of them.
     if (
       config.platform === "darwin" &&
       LOCALE_ENV_NAMES.every((name) => Option.isNone(trimNonEmpty(config.env[name])))
     ) {
-      config.env.LC_CTYPE = FALLBACK_LC_CTYPE;
+      for (const name of LOCALE_ENV_NAMES) {
+        const value = trimNonEmpty(shellEnvironment[name]);
+        if (Option.isSome(value)) {
+          config.env[name] = value.value;
+        }
+      }
+
+      // GUI launches inherit no locale from launchd, so spawned agents land in the C
+      // locale and pbcopy decodes their UTF-8 output as MacRoman. Older supported
+      // macOS releases do not provide C.UTF-8, so set only LC_CTYPE to a UTF-8 locale
+      // available on those releases. Leaving LANG unset keeps C-stable collation and
+      // formatting, so output parsing is unaffected.
+      if (LOCALE_ENV_NAMES.every((name) => Option.isNone(trimNonEmpty(config.env[name])))) {
+        config.env.LC_CTYPE = FALLBACK_LC_CTYPE;
+      }
     }
 
     if (

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -88,7 +88,7 @@ const LOGIN_SHELL_ENV_NAMES = [
 ] as const;
 const WINDOWS_PROFILE_ENV_NAMES = ["PATH", "FNM_DIR", "FNM_MULTISHELL_PATH"] as const;
 const LOCALE_ENV_NAMES = ["LANG", "LC_ALL", "LC_CTYPE"] as const;
-const FALLBACK_LOCALE = "C.UTF-8";
+const FALLBACK_LC_CTYPE = "en_US.UTF-8";
 const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
 const LOGIN_SHELL_TIMEOUT = Duration.seconds(5);
 const LAUNCHCTL_TIMEOUT = Duration.seconds(2);
@@ -481,14 +481,15 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
     }
 
     // GUI launches inherit no locale from launchd, so spawned agents land in the C
-    // locale and pbcopy decodes their UTF-8 output as MacRoman. C.UTF-8 is what
-    // /etc/zprofile already falls back to: it fixes the codeset while keeping
-    // C-stable collation and formatting, so output parsing is unaffected.
+    // locale and pbcopy decodes their UTF-8 output as MacRoman. Older supported
+    // macOS releases do not provide C.UTF-8, so set only LC_CTYPE to a UTF-8 locale
+    // available on those releases. Leaving LANG unset keeps C-stable collation and
+    // formatting, so output parsing is unaffected.
     if (
       config.platform === "darwin" &&
       LOCALE_ENV_NAMES.every((name) => Option.isNone(trimNonEmpty(config.env[name])))
     ) {
-      config.env.LANG = FALLBACK_LOCALE;
+      config.env.LC_CTYPE = FALLBACK_LC_CTYPE;
     }
 
     if (


### PR DESCRIPTION
Fixes #6231.

GUI-launched macOS apps inherit no `LANG`/`LC_*` from launchd, so agent CLIs spawned by the desktop app ran in the `C` locale. `pbcopy` decodes stdin using the locale encoding rather than passing bytes through, so any non-ASCII text an agent copied was silently corrupted — `Grüße – ß` arrived as `Gr√º√üe ‚Äì √ü`.

`DesktopShellEnvironment` already resolves the login shell environment into `process.env`, which the backend and its agent CLIs inherit. Its allowlist just didn't include the locale. This adds `LANG`/`LC_ALL`/`LC_CTYPE` to the harvest and the existing copy-if-absent pass, then falls back to `C.UTF-8` on macOS when neither the process nor the login shell supplies one.

`C.UTF-8` rather than the user's full locale on purpose: it fixes the codeset without shifting collation or formatting, so anything parsing tool output is unaffected (`sort` gives `a b ä` under `C.UTF-8` but `a ä b` under `de_DE.UTF-8`). It's also what macOS's own `/etc/zprofile` falls back to — `env -i HOME=$HOME /bin/zsh -ilc 'echo $LANG'` returns `C.UTF-8`. `LC_ALL` is harvested but never force-set, since it would override every `LC_*` category.

Scoped to the desktop spawn path. A standalone server started without a locale would have the same problem, but that's a separate concern and I've left it out to keep this small.

Verification: 4 new tests in `DesktopShellEnvironment.test.ts` (harvest, inherited-value precedence, macOS fallback, no-fallback-on-linux); the two behavioural ones fail without the source change. `vp test` green for `@t3tools/desktop` (448 tests), typecheck and `fmt --check` clean.

No UI change, so no screenshots.

Written with Claude Opus 5, via the Claude Code CLI running inside T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent shells to inherit a UTF-8 locale on macOS
> - Adds `LANG`, `LC_ALL`, and `LC_CTYPE` to the login shell environment whitelist in [DesktopShellEnvironment.ts](https://github.com/pingdotgg/t3code/pull/6236/files#diff-ed26aa44c93ddc9fedab8bc7cf7aa64c7b0b8fc0e22a3960d5c02c30c940dabd) so they can be hydrated from the login shell.
> - On macOS, if no locale variables are present in the process environment, they are hydrated from the login shell; if still absent, `LC_CTYPE` falls back to `en_US.UTF-8`.
> - If any locale variable is already inherited, it is preserved and login-shell locale values are not mixed in. This fallback does not apply on Linux.
> - Behavioral Change: macOS agent shells that previously inherited no locale will now always have at least `LC_CTYPE=en_US.UTF-8` set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dee3e06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped macOS-only environment hydration with careful precedence and a UTF-8 LC_CTYPE fallback; no auth or data-path changes.
> 
> **Overview**
> Fixes GUI-launched macOS agent shells landing in the `C` locale, which caused `pbcopy` to corrupt non-ASCII text.
> 
> `DesktopShellEnvironment` now harvests `LANG`/`LC_ALL`/`LC_CTYPE` from the login shell and hydrates them **as a group** only when the process has none. If still unset on macOS, it falls back to `LC_CTYPE=en_US.UTF-8` (leaving `LANG` unset to keep C-stable collation/formatting). Inherited locales are preserved and not mixed with login-shell categories; Linux is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee3e063cce6c61f9804f45c676c2f3e7b3bec19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->