### PR TITLE
fix(web): make Windows file links clickable

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -74,7 +74,7 @@ import {
 } from "../markdown-clipboard";
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
-  normalizeMarkdownLinkDestination,
+  normalizeMarkdownFileLinkHrefKey,
   remarkRewriteWindowsFileLinks,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
@@ -887,11 +887,6 @@ function extractMarkdownLinkHrefs(text: string): string[] {
   return hrefs;
 }
 
-function normalizeMarkdownLinkHrefKey(href: string): string {
-  const normalizedHref = normalizeMarkdownLinkDestination(href);
-  return rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
-}
-
 const MARKDOWN_LINK_FAVICON_CLASS_NAME = "block size-full shrink-0 select-none";
 
 /** Hosts whose favicon request already failed this session — skip straight to the globe. */
@@ -1352,7 +1347,7 @@ function ChatMarkdown({
       NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>
     >();
     for (const href of extractMarkdownLinkHrefs(text)) {
-      const normalizedHref = normalizeMarkdownLinkHrefKey(href);
+      const normalizedHref = normalizeMarkdownFileLinkHrefKey(href);
       if (metaByHref.has(normalizedHref)) continue;
       const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
       if (meta) {
@@ -1546,7 +1541,7 @@ function ChatMarkdown({
         );
       },
       a({ node, href, children, ...props }) {
-        const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
+        const normalizedHref = href ? normalizeMarkdownFileLinkHrefKey(href) : "";
         const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -75,6 +75,7 @@ import {
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
   normalizeMarkdownLinkDestination,
+  remarkRewriteWindowsFileLinks,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
@@ -162,6 +163,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
 
 const CHAT_MARKDOWN_REMARK_PLUGINS = [
   remarkGfm,
+  remarkRewriteWindowsFileLinks,
   remarkGithubAlerts,
   remarkNormalizeListItemIndentation,
   remarkPreserveCodeMeta,
@@ -170,6 +172,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS = [
 
 const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
   remarkGfm,
+  remarkRewriteWindowsFileLinks,
   remarkGithubAlerts,
   remarkNormalizeListItemIndentation,
   remarkBreaks,

--- a/apps/web/src/filePathDisplay.test.ts
+++ b/apps/web/src/filePathDisplay.test.ts
@@ -21,6 +21,15 @@ describe("formatWorkspaceRelativePath", () => {
     ).toBe("t3code/apps/web/src/session-logic.ts:501");
   });
 
+  it("keeps absolute windows paths outside the workspace unchanged", () => {
+    expect(
+      formatWorkspaceRelativePath(
+        "C:/Users/mike/dev-stuff/other-project/src/main.ts",
+        "C:/Users/mike/dev-stuff/t3code",
+      ),
+    ).toBe("C:/Users/mike/dev-stuff/other-project/src/main.ts");
+  });
+
   it("keeps paths already rooted at the workspace label stable", () => {
     expect(
       formatWorkspaceRelativePath(

--- a/apps/web/src/filePathDisplay.ts
+++ b/apps/web/src/filePathDisplay.ts
@@ -21,6 +21,10 @@ function stripRelativePrefixes(path: string): string {
   return path.replace(/^\.\/+/, "").replace(/^\/+/, "");
 }
 
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith("/") || /^[A-Za-z]:\//.test(path);
+}
+
 export function formatWorkspaceRelativePath(
   pathWithPosition: string,
   workspaceRoot: string | undefined,
@@ -44,7 +48,7 @@ export function formatWorkspaceRelativePath(
     } else if (pathForCompare.startsWith(workspaceWithSeparator)) {
       const relativeSuffix = normalizedPath.slice(normalizedWorkspaceRoot.length + 1);
       displayPath = `${workspaceLabel}/${relativeSuffix}`;
-    } else if (!normalizedPath.startsWith("/")) {
+    } else if (!isAbsolutePath(normalizedPath)) {
       const relativePath = stripRelativePrefixes(normalizedPath);
       displayPath = pathForCompare.startsWith(workspaceLabelWithSeparator)
         ? normalizedPath

--- a/apps/web/src/markdown-links-rendering.test.tsx
+++ b/apps/web/src/markdown-links-rendering.test.tsx
@@ -42,6 +42,14 @@ describe("Windows markdown file link rendering", () => {
     );
   });
 
+  it("percent-encodes a unicode drive-path href through HTML sanitization", () => {
+    const path = "C:/Users/mike/dev-stuff/文档/apps/web/src/markdown-links.ts";
+
+    expect(renderMarkdown(`[markdown-links.ts](${path}) is open above.`)).toContain(
+      '<a href="C:/Users/mike/dev-stuff/%E6%96%87%E6%A1%A3/apps/web/src/markdown-links.ts">markdown-links.ts</a>',
+    );
+  });
+
   it("still removes unsafe schemes", () => {
     expect(renderMarkdown("[unsafe](javascript:alert(1))")).not.toContain("href=");
   });

--- a/apps/web/src/markdown-links-rendering.test.tsx
+++ b/apps/web/src/markdown-links-rendering.test.tsx
@@ -34,6 +34,14 @@ describe("Windows markdown file link rendering", () => {
     );
   });
 
+  it("canonicalizes a backslash drive-path href through HTML sanitization", () => {
+    const path = "C:\\Users\\mike\\dev-stuff\\t3code\\apps\\web\\src\\markdown-links.ts";
+
+    expect(renderMarkdown(`[markdown-links.ts](${path}) is open above.`)).toContain(
+      '<a href="C:/Users/mike/dev-stuff/t3code/apps/web/src/markdown-links.ts">markdown-links.ts</a>',
+    );
+  });
+
   it("still removes unsafe schemes", () => {
     expect(renderMarkdown("[unsafe](javascript:alert(1))")).not.toContain("href=");
   });

--- a/apps/web/src/markdown-links-rendering.test.tsx
+++ b/apps/web/src/markdown-links-rendering.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import { describe, expect, it } from "vite-plus/test";
+
+import { remarkRewriteWindowsFileLinks, rewriteMarkdownFileUriHref } from "./markdown-links";
+
+const sanitizeSchema = {
+  ...defaultSchema,
+  protocols: {
+    ...defaultSchema.protocols,
+    href: [...(defaultSchema.protocols?.href ?? []), "file"],
+  },
+} satisfies Parameters<typeof rehypeSanitize>[0];
+
+function renderMarkdown(markdown: string): string {
+  return renderToStaticMarkup(
+    <ReactMarkdown
+      remarkPlugins={[remarkRewriteWindowsFileLinks]}
+      rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
+      urlTransform={(href) => rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href)}
+    >
+      {markdown}
+    </ReactMarkdown>,
+  );
+}
+
+describe("Windows markdown file link rendering", () => {
+  it("preserves a drive-path href through HTML sanitization", () => {
+    const path = "C:/Users/mike/dev-stuff/t3code/apps/web/src/markdown-links.ts";
+
+    expect(renderMarkdown(`[markdown-links.ts](${path}) is open above.`)).toContain(
+      `<a href="${path}">markdown-links.ts</a>`,
+    );
+  });
+
+  it("still removes unsafe schemes", () => {
+    expect(renderMarkdown("[unsafe](javascript:alert(1))")).not.toContain("href=");
+  });
+});

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -36,6 +36,14 @@ describe("rewriteMarkdownFileUriHref", () => {
 });
 
 describe("resolveMarkdownFileLinkTarget", () => {
+  it("resolves windows drive paths", () => {
+    expect(
+      resolveMarkdownFileLinkTarget(
+        "C:/Users/mike/dev-stuff/t3code/apps/web/src/markdown-links.ts",
+      ),
+    ).toBe("C:/Users/mike/dev-stuff/t3code/apps/web/src/markdown-links.ts");
+  });
+
   it("resolves absolute posix file paths", () => {
     expect(resolveMarkdownFileLinkTarget("/Users/julius/project/AGENTS.md")).toBe(
       "/Users/julius/project/AGENTS.md",

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  normalizeMarkdownFileLinkHrefKey,
   normalizeMarkdownLinkDestination,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
@@ -15,6 +16,27 @@ describe("normalizeMarkdownLinkDestination", () => {
         "C:\\Users\\mike\\dev-stuff\\t3code\\apps\\web\\src\\markdown-links.ts",
       ),
     ).toBe("C:/Users/mike/dev-stuff/t3code/apps/web/src/markdown-links.ts");
+  });
+});
+
+describe("normalizeMarkdownFileLinkHrefKey", () => {
+  it("uses the same key for raw and encoded unicode drive paths", () => {
+    const encodedPath = "C:/Users/mike/dev-stuff/%E6%96%87%E6%A1%A3/apps/web/src/markdown-links.ts";
+
+    expect(
+      normalizeMarkdownFileLinkHrefKey(
+        "C:\\Users\\mike\\dev-stuff\\文档\\apps\\web\\src\\markdown-links.ts",
+      ),
+    ).toBe(encodedPath);
+    expect(normalizeMarkdownFileLinkHrefKey(encodedPath)).toBe(encodedPath);
+  });
+
+  it("preserves existing encoded octets", () => {
+    expect(
+      normalizeMarkdownFileLinkHrefKey(
+        "C:/Users/mike/dev-stuff/t3code/apps/web/src/file%2520name.ts",
+      ),
+    ).toBe("C:/Users/mike/dev-stuff/t3code/apps/web/src/file%2520name.ts");
   });
 });
 

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  normalizeMarkdownLinkDestination,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
 } from "./markdown-links";
+
+describe("normalizeMarkdownLinkDestination", () => {
+  it("canonicalizes backslashes in windows drive paths", () => {
+    expect(
+      normalizeMarkdownLinkDestination(
+        "C:\\Users\\mike\\dev-stuff\\t3code\\apps\\web\\src\\markdown-links.ts",
+      ),
+    ).toBe("C:/Users/mike/dev-stuff/t3code/apps/web/src/markdown-links.ts");
+  });
+});
 
 describe("rewriteMarkdownFileUriHref", () => {
   it("rewrites file uri hrefs into direct path hrefs", () => {

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -61,7 +61,10 @@ function unwrapMarkdownLinkDestination(value: string): string {
 }
 
 export function normalizeMarkdownLinkDestination(value: string): string {
-  return unwrapMarkdownLinkDestination(value.trim());
+  const normalizedValue = unwrapMarkdownLinkDestination(value.trim());
+  return WINDOWS_DRIVE_PATH_PATTERN.test(normalizedValue)
+    ? normalizedValue.replaceAll("\\", "/")
+    : normalizedValue;
 }
 
 function stripSearchAndHash(value: string): { path: string; hash: string } {
@@ -126,7 +129,7 @@ export function remarkRewriteWindowsFileLinks() {
       if ((node.type === "link" || node.type === "definition") && typeof node.url === "string") {
         const normalizedUrl = normalizeMarkdownLinkDestination(node.url);
         if (WINDOWS_DRIVE_PATH_PATTERN.test(normalizedUrl)) {
-          node.url = `file:///${normalizedUrl.replaceAll("\\", "/")}`;
+          node.url = `file:///${normalizedUrl}`;
         }
       }
       node.children?.forEach(visit);

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -108,6 +108,34 @@ export function rewriteMarkdownFileUriHref(href: string | undefined): string | n
   return `${target.path}${target.hash}`;
 }
 
+interface MarkdownLinkNode {
+  type?: string;
+  url?: unknown;
+  children?: MarkdownLinkNode[];
+}
+
+/**
+ * rehype-sanitize reads the drive letter in `C:/path` as a URL scheme and
+ * removes the href before react-markdown's URL transform can normalize it.
+ * Convert only Windows drive-path destinations into the already-allowed file
+ * URI form while the document is still mdast.
+ */
+export function remarkRewriteWindowsFileLinks() {
+  return (tree: MarkdownLinkNode) => {
+    const visit = (node: MarkdownLinkNode) => {
+      if ((node.type === "link" || node.type === "definition") && typeof node.url === "string") {
+        const normalizedUrl = normalizeMarkdownLinkDestination(node.url);
+        if (WINDOWS_DRIVE_PATH_PATTERN.test(normalizedUrl)) {
+          node.url = `file:///${normalizedUrl.replaceAll("\\", "/")}`;
+        }
+      }
+      node.children?.forEach(visit);
+    };
+
+    visit(tree);
+  };
+}
+
 function looksLikePosixFilesystemPath(path: string): boolean {
   if (!path.startsWith("/")) return false;
   if (POSIX_FILE_ROOT_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -111,6 +111,15 @@ export function rewriteMarkdownFileUriHref(href: string | undefined): string | n
   return `${target.path}${target.hash}`;
 }
 
+export function normalizeMarkdownFileLinkHrefKey(href: string): string {
+  const normalizedHref = normalizeMarkdownLinkDestination(href);
+  const rewrittenHref = rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
+  if (!WINDOWS_DRIVE_PATH_PATTERN.test(rewrittenHref)) return rewrittenHref;
+
+  const target = parseFileUrlHref(`file:///${rewrittenHref}`, { decodePath: false });
+  return target ? `${target.path}${target.hash}` : rewrittenHref;
+}
+
 interface MarkdownLinkNode {
   type?: string;
   url?: unknown;


### PR DESCRIPTION
## Problem

On Windows, Markdown links with direct drive paths such as `[artifact](C:/Users/.../artifact.mp4)` rendered as blue text with no usable target. `rehype-sanitize` interpreted the drive letter as a URL scheme and removed the `href` before React Markdown's URL transform could normalize it.

## Fix

Rewrite only Windows drive-path link destinations to the already-allowed `file:///` form while the document is still Markdown AST. The existing URL transform then restores the drive path and sends it through T3 Code's existing file-link renderer. Forward- and backslash drive paths, including encoded and unencoded Unicode segments, are canonicalized to the same lookup key, while unsafe schemes remain subject to the normal sanitizer.

Absolute Windows paths outside the workspace also remain absolute in tooltips and copied paths. The composer's existing mention-chip behavior is unchanged and out of scope.

## Before

The label looked like a link, but it had no target and could not be clicked.

![Before: Windows drive-path link rendered without a usable target](https://raw.githubusercontent.com/peculiarnewbie/t3code/46c7185d76166ffd4975bb31df54a21984574642/before.png)

## After

The same destination reaches the existing file-link component; hovering reveals the full path and the link is actionable.

![After: Windows drive-path link rendered as an actionable file chip](https://raw.githubusercontent.com/peculiarnewbie/t3code/46c7185d76166ffd4975bb31df54a21984574642/after.png)

## Verification

- `vp test run apps/web/src/markdown-links.test.ts apps/web/src/markdown-links-rendering.test.tsx apps/web/src/filePathDisplay.test.ts` — 46 tests passed
- `vp run --filter @t3tools/web typecheck`
- Targeted `vp lint` and `vp fmt --check` for all six changed files
- Manually verified in the Windows web client; desktop inherits the same web renderer

Implemented with GPT-5.6-Sol in the Codex harness via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches markdown href sanitization and file-link resolution, which are security-adjacent URL handling paths. Scope is narrow and unsafe schemes still go through the existing sanitizer.
> 
> **Overview**
> **Fixes Windows drive-path markdown links** (e.g. `C:/...` or `C:\\...`) that rendered as non-clickable text because `rehype-sanitize` treated the drive letter as a URL scheme and stripped the `href`.
> 
> Adds `remarkRewriteWindowsFileLinks`, which rewrites only Windows drive destinations to allowed `file:///` form in mdast before sanitization. The existing URL transform then restores the drive path for the normal file-link renderer. Also canonicalizes backslash/unicode variants into a shared lookup key via `normalizeMarkdownFileLinkHrefKey`.
> 
> Separately, `formatWorkspaceRelativePath` now treats Windows drive paths as absolute, so paths outside the workspace stay absolute in tooltips/copied paths instead of getting a workspace label prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e0324411aac84b98ba5cab41cc2a9100d2298df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows file path links to be clickable in chat markdown
> - Adds `remarkRewriteWindowsFileLinks` remark plugin to convert Windows drive-path links (e.g. `C:\foo`) into `file:///C:/...` URIs before HTML sanitization, preventing the sanitizer from stripping them.
> - Adds `normalizeMarkdownFileLinkHrefKey` to produce stable canonical keys for Windows file links regardless of backslashes or percent-encoding, replacing the local helper in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/6237/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05).
> - Fixes `formatWorkspaceRelativePath` in [filePathDisplay.ts](https://github.com/pingdotgg/t3code/pull/6237/files#diff-7640b2df83d60fd94a94f484d23cf365a93878741c5a21cb2ae57e8e4559600b) to avoid prefixing absolute Windows drive paths with the workspace label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e03244.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->