### PR TITLE
fix(web): freeze idle agent elapsed timers

### DIFF
--- a/apps/web/src/components/AgentsPanel.test.tsx
+++ b/apps/web/src/components/AgentsPanel.test.tsx
@@ -1,0 +1,71 @@
+import type {
+  AgentPanelModel,
+  RuntimeSubagent,
+} from "@t3tools/client-runtime/state/subagentRuntime";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { AgentsPanel } from "./AgentsPanel";
+
+function idleAgent(overrides: Partial<RuntimeSubagent> = {}): RuntimeSubagent {
+  return {
+    id: "agent-1",
+    kind: "subagent",
+    title: "agent-1",
+    role: null,
+    model: null,
+    effort: null,
+    status: "idle",
+    activationCount: 1,
+    usage: null,
+    progress: null,
+    lastToolName: null,
+    result: null,
+    error: null,
+    outputFile: null,
+    parentAgentId: null,
+    agentIndex: null,
+    phaseIndex: null,
+    phaseTitle: null,
+    attempt: null,
+    workflowName: null,
+    phases: [],
+    runHandles: null,
+    recentActivity: [],
+    firstSeenAt: "2026-08-11T21:49:13.000Z",
+    startedAt: "2026-08-11T21:49:13.000Z",
+    completedAt: null,
+    updatedAt: "2026-08-11T22:07:16.000Z",
+    ...overrides,
+  };
+}
+
+function panelModel(agent: RuntimeSubagent): AgentPanelModel {
+  return {
+    workflows: [],
+    directAgents: [agent],
+    runningCount: 0,
+    waitingCount: 0,
+    idleCount: 1,
+    settledCount: 0,
+    totalTokens: 0,
+    hasAgents: true,
+    liveCount: 0,
+  };
+}
+
+describe("AgentsPanel elapsed time", () => {
+  it("freezes an idle agent at its idle transition", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-11T22:34:00.000Z"));
+
+    try {
+      const markup = renderToStaticMarkup(<AgentsPanel model={panelModel(idleAgent())} />);
+
+      expect(markup).toContain("18m 03s");
+      expect(markup).not.toContain("44m 47s");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -87,6 +87,9 @@ function AgentElapsed({ agent }: { agent: RuntimeSubagent }) {
   const textRef = useRef<HTMLSpanElement>(null);
   const live = agent.status === "running" || agent.status === "waiting";
   const startedAt = agent.startedAt;
+  // Idle is resumable, so it has no completedAt. Its latest update is the
+  // transition that ended the current activation and must freeze the timer.
+  const endedAt = live ? null : (agent.completedAt ?? agent.updatedAt);
 
   useEffect(() => {
     if (!live || !startedAt) {
@@ -107,7 +110,7 @@ function AgentElapsed({ agent }: { agent: RuntimeSubagent }) {
   }
   return (
     <span ref={textRef} className="tabular-nums">
-      {elapsedBetween(startedAt, live ? null : agent.completedAt)}
+      {elapsedBetween(startedAt, endedAt)}
     </span>
   );
 }


### PR DESCRIPTION
## Problem

Codex child agents remain idle and resumable after a turn, so they intentionally have no terminal `completedAt`. The Agents panel treats those rows as non-live but passed that missing timestamp to `elapsedBetween`, which falls back to `Date.now()`. Their displayed run duration therefore kept accumulating idle time whenever the panel rendered.

For example, a child that ran from 21:49:13 to 22:07:16 displayed `44m 47s` at 22:34 instead of freezing at its actual `18m 03s` duration.

## Fix

- Freeze non-live rows at `completedAt` when available.
- Fall back to `updatedAt` for resumable idle agents, matching the settled-idle behavior from the earlier snapshot implementation.
- Add a focused SSR regression test using the observed timestamps.

## Review history

This exact failure mode was [reported by Macroscope during review of #5219](https://github.com/pingdotgg/t3code/pull/5219#discussion_r3698183383), including the same `updatedAt` recommendation. The finding was automatically marked "No longer relevant as of 4622c3a", but that commit changed timeline folding and its tests rather than `AgentsPanel`; the elapsed-time calculation remained unchanged and the bug shipped.

## Verification

- `pnpm exec vp test run apps/web/src/components/AgentsPanel.test.tsx`
- `pnpm exec vp lint apps/web/src/components/AgentsPanel.tsx apps/web/src/components/AgentsPanel.test.tsx`
- `pnpm exec vp fmt --check apps/web/src/components/AgentsPanel.tsx apps/web/src/components/AgentsPanel.test.tsx`
- `pnpm --filter @t3tools/web typecheck`

Made by gpt-5.6-sol using the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Freeze elapsed timers for idle agents at their last update time
> In [AgentsPanel.tsx](https://github.com/pingdotgg/t3code/pull/6238/files#diff-10464442e3a11a770b2b1a5718e7a452453347c492f6aa0533f267063e2c6494), the `AgentElapsed` component previously had no `endedAt` for non-live agents without a `completedAt` (e.g. idle agents), causing the timer to keep counting against the current time. It now uses `completedAt ?? updatedAt` as the freeze point for all non-live agents. A test suite in [AgentsPanel.test.tsx](https://github.com/pingdotgg/t3code/pull/6238/files#diff-fcddc6f0b1f4f11e7367af5de55984b86bc2f39c0eb62477dd4bb7406ac4e37c) verifies the frozen elapsed time is rendered correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4684703. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->