### PR TITLE
fix(web): attach preview annotation screenshots in the desktop app

### DIFF
--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -414,7 +414,7 @@ describe("PreviewView navigation", () => {
     expect(mocks.addPreviewAnnotation).toHaveBeenCalledWith(TEST_THREAD_REF, annotation);
   });
 
-  it("still sends when screenshot attachment conversion fails", async () => {
+  it("drops the screenshot claim when attachment conversion fails", async () => {
     const annotation = {
       id: "annotation-2",
       pageUrl: "https://example.com/dashboard",
@@ -434,7 +434,9 @@ describe("PreviewView navigation", () => {
     };
     const onSendAnnotation = vi.fn();
     mocks.pickElement.mockResolvedValue({ annotation, submission: "send" });
-    mocks.previewAnnotationScreenshotFile.mockRejectedValue(new Error("conversion failed"));
+    mocks.previewAnnotationScreenshotFile.mockImplementation(() => {
+      throw new Error("conversion failed");
+    });
 
     renderToStaticMarkup(
       <PreviewView
@@ -446,7 +448,12 @@ describe("PreviewView navigation", () => {
     );
     mocks.toggleAnnotation?.();
 
-    await vi.waitFor(() => expect(onSendAnnotation).toHaveBeenCalledWith(annotation, null));
+    // The prompt advertises the crop off `screenshot`, so a failed conversion
+    // has to clear it — otherwise the agent is told to look at an image that
+    // was never attached.
+    const withoutScreenshot = { ...annotation, screenshot: null };
+    await vi.waitFor(() => expect(onSendAnnotation).toHaveBeenCalledWith(withoutScreenshot, null));
+    expect(mocks.addPreviewAnnotation).toHaveBeenCalledWith(TEST_THREAD_REF, withoutScreenshot);
     expect(mocks.addImage).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -557,15 +557,23 @@ export function PreviewView({
       try {
         const result = await previewBridge.pickElement(runtimeTabId);
         if (!result) return;
-        const { annotation, submission } = result;
-        addPreviewAnnotation(threadRef, annotation);
+        const { annotation: capturedAnnotation, submission } = result;
         let screenshotFile: File | null = null;
         try {
-          screenshotFile = await previewAnnotationScreenshotFile(annotation);
-        } catch {
+          screenshotFile = previewAnnotationScreenshotFile(capturedAnnotation);
+        } catch (error) {
           // The structured annotation is still sendable when converting its
           // optional screenshot into a composer attachment fails.
+          console.error("Could not convert preview annotation screenshot.", error);
         }
+        // The prompt advertises the crop off `screenshot`, so an annotation
+        // whose attachment did not survive must not keep it — otherwise the
+        // agent is told to look at an image it never received.
+        const annotation =
+          capturedAnnotation.screenshot && !screenshotFile
+            ? { ...capturedAnnotation, screenshot: null }
+            : capturedAnnotation;
+        addPreviewAnnotation(threadRef, annotation);
         const image =
           screenshotFile && annotation.screenshot
             ? ({

--- a/apps/web/src/lib/imageCompression.ts
+++ b/apps/web/src/lib/imageCompression.ts
@@ -85,7 +85,7 @@ function dataUrlByteLength(dataUrl: string): number {
 }
 
 /** Base64 payload of a data URL decoded back into a `File`. */
-function dataUrlToFile(dataUrl: string, name: string, mimeType: string): File {
+export function dataUrlToFile(dataUrl: string, name: string, mimeType: string): File {
   const payload = dataUrl.slice(dataUrl.indexOf(",") + 1);
   const binary = atob(payload);
   const bytes = new Uint8Array(binary.length);

--- a/apps/web/src/lib/previewAnnotation.test.ts
+++ b/apps/web/src/lib/previewAnnotation.test.ts
@@ -5,6 +5,7 @@ import {
   appendPreviewAnnotationPrompt,
   buildPreviewAnnotationPrompt,
   extractTrailingPreviewAnnotation,
+  previewAnnotationScreenshotFile,
 } from "./previewAnnotation";
 
 const annotation: PreviewAnnotationPayload = {
@@ -83,5 +84,42 @@ describe("preview annotations", () => {
     expect(extractedSecond.annotation?.id).toBe("annotation_2");
     expect(extractedFirst.annotation?.id).toBe("annotation_1");
     expect(extractedFirst.promptText).toBe("Fix this");
+  });
+});
+
+describe("preview annotation screenshots", () => {
+  it("decodes the crop into a named file", () => {
+    const file = previewAnnotationScreenshotFile(annotation);
+    expect(file?.name).toBe("preview-annotation-annotation_1.png");
+    expect(file?.type).toBe("image/png");
+    expect(file?.size).toBe(1);
+  });
+
+  it("returns null when the annotation carries no crop", () => {
+    expect(previewAnnotationScreenshotFile({ ...annotation, screenshot: null })).toBe(null);
+  });
+
+  it("returns null for a data URL that is not base64", () => {
+    expect(
+      previewAnnotationScreenshotFile({
+        ...annotation,
+        screenshot: { ...annotation.screenshot!, dataUrl: "data:image/png,notbase64" },
+      }),
+    ).toBe(null);
+  });
+
+  // The desktop renderer's CSP allows `data:` for `img-src` but not for
+  // `connect-src`, so fetching the crop is blocked there and the screenshot
+  // silently never reaches the composer. Decode it in place instead.
+  it("never fetches the data URL", () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() => {
+      throw new Error("connect-src blocks data: URLs in the desktop renderer");
+    }) as typeof globalThis.fetch;
+    try {
+      expect(previewAnnotationScreenshotFile(annotation)).not.toBe(null);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/apps/web/src/lib/previewAnnotation.ts
+++ b/apps/web/src/lib/previewAnnotation.ts
@@ -1,5 +1,6 @@
 import type { PreviewAnnotationPayload } from "@t3tools/contracts";
 import { buildElementContextBlock, normalizeElementContextSelection } from "./elementContext";
+import { dataUrlToFile } from "./imageCompression";
 
 const TRAILING_PREVIEW_ANNOTATION_BLOCK_PATTERN =
   /\n*<preview_annotation>\n((?:(?!<preview_annotation>)[\s\S])*)\n<\/preview_annotation>\s*$/;
@@ -99,13 +100,20 @@ export function extractTrailingPreviewAnnotation(prompt: string): ExtractedPrevi
   };
 }
 
-export async function previewAnnotationScreenshotFile(
-  annotation: PreviewAnnotationPayload,
-): Promise<File | null> {
+const BASE64_DATA_URL_PATTERN = /^data:([^;,]*);base64,/;
+
+/**
+ * Decodes the captured crop in place rather than `fetch`ing its data URL. The
+ * desktop renderer is served over a custom scheme whose CSP allows `data:` for
+ * `img-src` but not for `connect-src`, so a fetch is blocked there and the
+ * screenshot never reaches the composer. Returns null when the crop is missing
+ * or is not a base64 data URL; callers must then drop the annotation's
+ * screenshot so the prompt does not advertise an attachment that never landed.
+ */
+export function previewAnnotationScreenshotFile(annotation: PreviewAnnotationPayload): File | null {
   if (!annotation.screenshot) return null;
-  const response = await fetch(annotation.screenshot.dataUrl);
-  const blob = await response.blob();
-  return new File([blob], `preview-annotation-${annotation.id}.png`, {
-    type: blob.type || "image/png",
-  });
+  const { dataUrl } = annotation.screenshot;
+  const match = BASE64_DATA_URL_PATTERN.exec(dataUrl);
+  if (!match) return null;
+  return dataUrlToFile(dataUrl, `preview-annotation-${annotation.id}.png`, match[1] || "image/png");
 }


### PR DESCRIPTION
Preview annotations never attached their screenshot in the desktop app. The crop was captured fine, but converting it into a composer attachment used `fetch()` on a `data:` URL, and the desktop renderer's CSP allows `data:` for `img-src` and `font-src` but not for `connect-src` — the directive that governs fetch. The call was blocked and swallowed by an empty catch, so the image was silently dropped.

The prompt still told the agent "The attached screenshot is the annotated preview crop", because that sentence is built from `annotation.screenshot` rather than from the attachment that actually landed. The agent was told to look at an image it never received.

Draw annotations made it visible, since strokes carry no element context and the image is the whole payload. Select and region picks were losing their screenshots too, but still read well from their `<element_context>` text.

Decode the crop with the existing `dataUrlToFile` helper instead of fetching it, and clear `screenshot` when the attachment does not survive so a failed conversion stops the prompt from promising an image.

### Before

The annotation arrives as metadata only, and the agent says so.

![Before](https://raw.githubusercontent.com/glauber-sampaio/t3code/issue-assets/images/attach-preview-before.png)

### After

The crop is attached and the agent can read it.

![After](https://raw.githubusercontent.com/glauber-sampaio/t3code/issue-assets/images/attach-preview-after.png)

Verification:
- `vp test run apps/web/src/lib/previewAnnotation.test.ts apps/web/src/lib/imageCompression.test.ts apps/web/src/components/preview/PreviewView.test.tsx` (28 tests)
- `vp run --filter @t3tools/web typecheck`
- targeted `vp lint` and `vp fmt` for changed files
- Verified in the desktop app, before and after, as above

Model: Claude Opus 5 | Harness: Claude Code in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how preview annotation images are converted and attached to the composer/agent prompt, which can affect what the agent receives. Scoped bug fix with focused tests, but regressions would silently drop or misadvertise screenshots.
> 
> **Overview**
> **Fixes desktop preview annotation screenshots never reaching the composer.** Conversion previously `fetch`ed a `data:` URL, which the desktop CSP blocks via `connect-src`, so the image was silently dropped while the prompt still claimed a screenshot was attached.
> 
> `previewAnnotationScreenshotFile` now **decodes the crop in place** with `dataUrlToFile` instead of fetching. If conversion fails or returns null, `PreviewView` **clears `screenshot` on the annotation** so the prompt no longer advertises an image the agent never received.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 751def618c5e43e374753d606453fe569143a56c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix preview annotation screenshot attachment in the desktop app
> - Replaces the async fetch-based screenshot conversion in `previewAnnotationScreenshotFile` with a synchronous base64 decode using `dataUrlToFile`, avoiding a network fetch against the data URL.
> - Returns `null` for missing or non-base64 screenshots instead of attempting a fetch.
> - When conversion fails or yields no file, the annotation's `screenshot` field is cleared before being added and sent, rather than sending stale screenshot data.
> - Exports `dataUrlToFile` from [`imageCompression.ts`](https://github.com/pingdotgg/t3code/pull/6242/files#diff-45be3413d97dec09e8b54b67318f942fcea98f9fa4e5cf9431708df5fa6fb94d) so it can be used by [`previewAnnotation.ts`](https://github.com/pingdotgg/t3code/pull/6242/files#diff-4f6516f29e073bf9d9f15f429f23d915b31313516e21ce1915bfb98e71416788).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 751def6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->