### PR TITLE
fix(desktop): focus the preview guest when annotation starts

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -1494,6 +1494,7 @@ describe("PreviewManager", () => {
           getTitle: () => "Example",
           isLoading: () => false,
           isFocused: () => true,
+          focus: vi.fn(),
           getZoomFactor: () => 1,
           setZoomFactor: vi.fn(),
           on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
@@ -1527,6 +1528,44 @@ describe("PreviewManager", () => {
 
         listeners.get("did-start-navigation")?.({}, "https://example.com/next", false, true);
         expect(yield* Fiber.join(pick)).toBeNull();
+      }),
+    ),
+  );
+
+  // `isFocused()` reports true for the attached view even while the app
+  // renderer still owns the keystrokes, so guarding the focus call on it left
+  // annotation shortcuts — including Escape — dead until the user clicked
+  // inside the page.
+  effectIt.effect("focuses the guest when element picking starts even if it reports focus", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const focus = vi.fn();
+        fromId.mockReturnValue({
+          id: 42,
+          isDestroyed: () => false,
+          getType: () => "webview",
+          getURL: () => "https://example.com",
+          getTitle: () => "Example",
+          isLoading: () => false,
+          isFocused: () => true,
+          focus,
+          getZoomFactor: () => 1,
+          setZoomFactor: vi.fn(),
+          on: vi.fn(),
+          once: vi.fn(),
+          off: vi.fn(),
+          ipc: { on: vi.fn(), off: vi.fn(), removeListener: vi.fn() },
+          send: vi.fn(),
+          navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+          setWindowOpenHandler: vi.fn(),
+        } as never);
+
+        yield* manager.createTab("tab_1");
+        yield* manager.registerWebview("tab_1", 42);
+        yield* manager.pickElement("tab_1").pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+
+        expect(focus).toHaveBeenCalled();
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1894,7 +1894,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             wc.ipc.on(ELEMENT_PICKED_CHANNEL, onMessage);
             wc.once("destroyed", onDestroyed);
             wc.once("did-start-navigation", onNavigated);
-            if (!wc.isFocused()) wc.focus();
+            // Unconditional: `isFocused()` reports true for the attached view
+            // even while the app renderer still owns the keystrokes, so the
+            // guard used to skip the one call that hands the guest its
+            // keyboard. Annotation shortcuts then went nowhere until the user
+            // clicked inside the page.
+            wc.focus();
             wc.send(START_PICK_CHANNEL, annotationTheme);
           });
           yield* Ref.update(pickSessionsRef, (sessions) =>


### PR DESCRIPTION
Starting annotation left the keyboard with the app renderer, so Escape did not cancel the overlay and the annotation tool shortcuts did nothing until the user clicked inside the page.

`pickElement` guarded the focus handoff on `wc.isFocused()`, which reports true for the attached WebContentsView even while the app still owns the keystrokes. The guard skipped the one call that hands the guest its keyboard. Clicking in the page performed the transfer the guard had skipped, which is why it appeared to work after a click.

Focus unconditionally. The regression test pins the case the guard got wrong — `isFocused()` returning true — which is also why the existing mock never needed a `focus` method.

Verification:
- `vp test run apps/desktop/src/preview/Manager.test.ts` (34 tests)
- `vp run --filter @t3tools/desktop typecheck`
- targeted `vp lint` and `vp fmt` for changed files
- Verified in the desktop app: Escape now cancels annotation without clicking into the page first

Model: Claude Opus 5 | Harness: Claude Code in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small focus-handoff fix in preview annotation start, with a targeted regression test and no auth or data-path changes.
> 
> **Overview**
> Fixes annotation keyboard shortcuts (including Escape) staying dead until the user clicked into the preview page.
> 
> `pickElement` previously skipped `wc.focus()` when `isFocused()` returned true. That API reports focus for the attached view even while the app renderer still owns keystrokes, so the handoff never happened. Focus is now unconditional, with a regression test covering the `isFocused() === true` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31897d3c93766b61a3053be21ad83a258633b8c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always focus the preview guest webContents when annotation picking starts
> Previously, `PreviewManager.registerPickElement` only called `wc.focus()` if `wc.isFocused()` returned false, which could skip the focus call when the webContents incorrectly reported itself as focused. The fix removes the conditional and always calls `wc.focus()` before sending `START_PICK_CHANNEL`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31897d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->