### PR TITLE
fix(desktop): report the component source file when picking an element

### DIFF
--- a/apps/desktop/src/preview/PickPreload.ts
+++ b/apps/desktop/src/preview/PickPreload.ts
@@ -16,6 +16,7 @@ import type {
 
 import { resolveAnnotationSubmission } from "./AnnotationKeyboard.ts";
 import { previewAnnotationStyles } from "./AnnotationStyles.generated.ts";
+import { pickedElementSource } from "./PickedElementSource.ts";
 import {
   ANNOTATION_CAPTURED_CHANNEL,
   ANNOTATION_THEME_CHANNEL,
@@ -255,7 +256,7 @@ async function captureElement(element: Element): Promise<PickedElementPayload | 
       selector: context.selector,
       htmlPreview: context.htmlPreview ?? "",
       componentName: context.componentName,
-      source: stack[0] ?? null,
+      source: pickedElementSource(context) ?? stack[0] ?? null,
       stack,
       styles: context.styles ?? "",
       pickedAt: new Date().toISOString(),

--- a/apps/desktop/src/preview/PickedElementSource.test.ts
+++ b/apps/desktop/src/preview/PickedElementSource.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { pickedElementSource } from "./PickedElementSource.ts";
+
+describe("pickedElementSource", () => {
+  it("reports the resolved file, line, and column", () => {
+    expect(
+      pickedElementSource({
+        componentName: "Home",
+        filePath: "/repo/src/app/page.tsx",
+        lineNumber: 12,
+        columnNumber: 19,
+      }),
+    ).toEqual({
+      functionName: "Home",
+      fileName: "/repo/src/app/page.tsx",
+      lineNumber: 12,
+      columnNumber: 19,
+    });
+  });
+
+  // react-grab resolves the source location separately from the call stack, so
+  // this must survive a component that reports no stack at all — the case that
+  // used to leave every pick without a file.
+  it("reports a file even when only the path resolved", () => {
+    expect(
+      pickedElementSource({
+        componentName: null,
+        filePath: "/repo/src/app/page.tsx",
+        lineNumber: null,
+        columnNumber: null,
+      }),
+    ).toEqual({
+      functionName: null,
+      fileName: "/repo/src/app/page.tsx",
+      lineNumber: null,
+      columnNumber: null,
+    });
+  });
+
+  it("yields nothing without a path, so the caller can fall back to the stack", () => {
+    expect(
+      pickedElementSource({
+        componentName: "Home",
+        filePath: null,
+        lineNumber: 12,
+        columnNumber: 19,
+      }),
+    ).toBe(null);
+  });
+});

--- a/apps/desktop/src/preview/PickedElementSource.ts
+++ b/apps/desktop/src/preview/PickedElementSource.ts
@@ -1,0 +1,31 @@
+/**
+ * Maps react-grab's element context onto the source frame the picker reports.
+ * Lives in its own module, free of both electron and react-grab at runtime, so
+ * it is trivially unit-testable — `PickPreload.ts` installs listeners on import
+ * and cannot be loaded from a test.
+ */
+import type { PickedElementStackFrame } from "@t3tools/contracts";
+
+/**
+ * react-grab resolves an element's source location independently of its call
+ * stack, so a component whose stack came back empty can still know its file.
+ * Reading only the first stack frame therefore dropped the file and line for
+ * most picks, leaving the agent with a selector and no route back to source.
+ *
+ * Structurally typed rather than taking `ReactGrabElementContext` so callers
+ * only have to supply what is actually read.
+ */
+export function pickedElementSource(context: {
+  readonly componentName: string | null;
+  readonly filePath: string | null;
+  readonly lineNumber: number | null;
+  readonly columnNumber: number | null;
+}): PickedElementStackFrame | null {
+  if (!context.filePath) return null;
+  return {
+    functionName: context.componentName,
+    fileName: context.filePath,
+    lineNumber: context.lineNumber,
+    columnNumber: context.columnNumber,
+  };
+}

--- a/apps/web/src/lib/elementContext.test.ts
+++ b/apps/web/src/lib/elementContext.test.ts
@@ -223,7 +223,7 @@ describe("buildElementContextBlock + appendElementContextsToPrompt", () => {
     expect(block).toContain("- <SubmitButton> (Button.tsx:12):");
     expect(block).toContain("  url: https://example.com/dashboard");
     expect(block).toContain("  selector: button.submit");
-    expect(block).toContain("  source: /repo/src/Button.tsx:12:5");
+    expect(block).toContain("  component defined at: /repo/src/Button.tsx:12:5");
     expect(block).toContain("  html:");
     expect(block).toContain("  styles:");
   });
@@ -237,7 +237,7 @@ describe("buildElementContextBlock + appendElementContextsToPrompt", () => {
         "- <SubmitButton> (Button.tsx:12):",
         "  url: https://example.com/dashboard",
         "  selector: button.submit",
-        "  source: /repo/src/Button.tsx:12:5",
+        "  component defined at: /repo/src/Button.tsx:12:5",
         "  html:",
         '  <button class="submit">Save</button>',
         "  styles:",

--- a/apps/web/src/lib/elementContext.ts
+++ b/apps/web/src/lib/elementContext.ts
@@ -156,7 +156,12 @@ function buildSingleContextLines(context: ElementContextSelection): string[] {
       lineNumber != null
         ? `${fileName}:${lineNumber}${columnNumber != null ? `:${columnNumber}` : ""}`
         : fileName;
-    lines.push(`  source: ${location}`);
+    // Deliberately not labelled `source`. The location resolves to where the
+    // enclosing component is defined, not to the picked element's own markup,
+    // so a bare `source:` reads as a precise pointer and sends the agent to the
+    // wrong line. Naming the relationship keeps it useful as a starting file
+    // without implying the element lives there.
+    lines.push(`  component defined at: ${location}`);
   }
   const html = context.htmlPreview.trim();
   if (html.length > 0) {


### PR DESCRIPTION
Picked elements carried a component name and a selector but almost never a file, so an agent asked about an element had no route back to the code and had to search for it.

`captureElement` derived the source frame from `stack[0]`, but react-grab resolves an element's source location independently of its call stack — they come from separate resolvers — and exposes it as `filePath`, `lineNumber`, and `columnNumber` on the context. Those were never read, so any component whose stack came back empty reported no source at all, which is the common case.

Prefer the resolved location and keep the first stack frame as a fallback. Picks now report `<Home> (page.tsx:12)` with a full location line instead of a selector alone.

The location resolves to where the enclosing component is defined rather than the element's own markup, so it is labelled `component defined at:` instead of `source:`. A bare `source:` reads as a precise pointer to the clicked element and sends the agent to the wrong line inside the right file.

The mapping lives in its own module because `PickPreload.ts` installs listeners on import and cannot be loaded from a test.

Verification:
- `vp test run apps/desktop/src/preview/PickedElementSource.test.ts apps/desktop/src/preview/PickPreload.test.ts apps/web/src/lib/elementContext.test.ts` (31 tests)
- `vp run --filter @t3tools/desktop --filter @t3tools/web typecheck`
- targeted `vp lint` and `vp fmt` for changed files
- Verified in the desktop app against a Next.js dev server: picks report a full file, line, and column

Model: Claude Opus 5 | Harness: Claude Code in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested fix to element-pick metadata and prompt wording. No auth, security, or data-handling changes.
> 
> **Overview**
> **Element picks now include a usable source file.** `captureElement` previously took only `stack[0]`, which is often empty, so picks usually had a selector and no route back to code.
> 
> It now prefers react-grab's independently resolved `filePath` / line / column via a new `pickedElementSource` helper, falling back to the stack when needed.
> 
> In agent prompts, that location is labelled **`component defined at:`** instead of `source:`, since it points at the enclosing component definition rather than the clicked element's markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3cf7f5f2319f81b9f487dc96b8aab3e224c4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report the component source file when picking an element
> - Introduces [`pickedElementSource`](https://github.com/pingdotgg/t3code/pull/6244/files#diff-011fff7d6de02fe9cc95344aefbdc7c4a5f77bf39f6e82fa5dfcc650bccfe064), which maps element context fields (file path, line, column) to a stack-frame-shaped source object, returning `null` when no file path is present.
> - Updates [`captureElement`](https://github.com/pingdotgg/t3code/pull/6244/files#diff-a19a7f6aa07147ba64b95dfc017ebf3427a82f067b93b614488e7485689df0b1) to prefer the resolved source from `pickedElementSource` over the first computed stack frame, so `PickedElementPayload.source` is populated even when the call stack is empty.
> - Renames the source location label in serialized element context from `source:` to `component defined at:` to clarify it refers to the enclosing component, not the picked element's markup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf3cf7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->