### PR TITLE
fix(web): keep sidebar wordmark visible at minimum width

### DIFF
--- a/apps/web/src/components/threadSidebarWidth.test.ts
+++ b/apps/web/src/components/threadSidebarWidth.test.ts
@@ -1,5 +1,5 @@
 // @effect-diagnostics nodeBuiltinImport:off - Regression coverage compares shipped CSS with the sidebar width contract.
-import { readFileSync } from "node:fs";
+import * as NodeFS from "node:fs";
 
 import { describe, expect, it } from "vite-plus/test";
 
@@ -36,7 +36,7 @@ describe("thread sidebar width", () => {
   });
 
   it("shows the desktop wordmark across the sidebar's full legal width range", () => {
-    const sidebarStyles = readFileSync(new URL("../index.css", import.meta.url), "utf8");
+    const sidebarStyles = NodeFS.readFileSync(new URL("../index.css", import.meta.url), "utf8");
     const desktopHeaderStyles = sidebarStyles.slice(
       sidebarStyles.indexOf("@media (min-width: 48rem)"),
       sidebarStyles.indexOf("/* Stage-channel sidebar art"),

--- a/apps/web/src/components/threadSidebarWidth.test.ts
+++ b/apps/web/src/components/threadSidebarWidth.test.ts
@@ -1,3 +1,6 @@
+// @effect-diagnostics nodeBuiltinImport:off - Regression coverage compares shipped CSS with the sidebar width contract.
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vite-plus/test";
 
 import {
@@ -30,5 +33,23 @@ describe("thread sidebar width", () => {
 
   it("keeps the sidebar minimum when the whole layout is narrower than its minimums", () => {
     expect(resolveInitialThreadSidebarWidth(900, 700)).toBe(THREAD_SIDEBAR_MIN_WIDTH);
+  });
+
+  it("shows the desktop wordmark across the sidebar's full legal width range", () => {
+    const sidebarStyles = readFileSync(new URL("../index.css", import.meta.url), "utf8");
+    const desktopHeaderStyles = sidebarStyles.slice(
+      sidebarStyles.indexOf("@media (min-width: 48rem)"),
+      sidebarStyles.indexOf("/* Stage-channel sidebar art"),
+    );
+    const stageLabelThreshold = desktopHeaderStyles.match(
+      /@container sidebar-header \(min-width: ([\d.]+)rem\) \{\s*\.sidebar-brand-stage \{\s*display: inline-flex;/,
+    )?.[1];
+
+    expect(sidebarStyles).toMatch(/\.sidebar-brand \{\s*display: none;/);
+    expect(desktopHeaderStyles).toMatch(
+      /@media \(min-width: 48rem\) \{\s*\.sidebar-brand \{\s*display: flex;/,
+    );
+    expect(THREAD_SIDEBAR_MIN_WIDTH).toBe(13 * 16);
+    expect(Number(stageLabelThreshold) * 16).toBeGreaterThan(THREAD_SIDEBAR_MIN_WIDTH);
   });
 });

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -340,10 +340,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   }
 
   @media (min-width: 48rem) {
-    @container sidebar-header (min-width: 13.5rem) {
-      .sidebar-brand {
-        display: flex;
-      }
+    .sidebar-brand {
+      display: flex;
     }
 
     @container sidebar-header (min-width: 15.75rem) {


### PR DESCRIPTION
## What Changed

- Keep the “T3 Code” wordmark visible across the full legal desktop sidebar width range, including the 13rem minimum.
- Remove the redundant wordmark container-width query. The sidebar width contract already enforces the minimum.
- Keep the mobile wordmark hidden and preserve the wider responsive threshold for optional environment labels.
- Add focused regression coverage that connects desktop wordmark visibility to the sidebar minimum.

## Why

At the 13rem sidebar minimum, the desktop sidebar border can leave the header query container slightly narrower than 13rem. As a result, both the original 13.5rem query and an exact 13rem query hide the wordmark on web, Windows (no traffic lights to account for), and macOS even though the wordmark still fits.

Showing the wordmark unconditionally inside the existing desktop media query avoids the border and fractional-rounding boundary. The optional environment label keeps its separate container query.

## UI Changes

### Before

https://github.com/user-attachments/assets/fe8c12bd-126d-4ab6-9250-44fcf84a09cb

### Afte

https://github.com/user-attachments/assets/ef5277a7-fb88-4477-817b-0f4f348f51ee

## Verification

- `vp test run apps/web/src/components/threadSidebarWidth.test.ts apps/web/src/components/SidebarStageBackdrop.test.tsx` — 14 tests passed
- `vp run --filter @t3tools/web typecheck` — passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Generated with GPT-5.6-sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only CSS visibility tweak plus a focused regression test; no auth, data, or layout contract changes beyond wordmark display.
> 
> **Overview**
> Keeps the desktop **T3 Code** wordmark visible across the full legal sidebar width range, including the `13rem` minimum.
> 
> Removes the redundant `@container sidebar-header (min-width: 13.5rem)` gate on `.sidebar-brand`, so the wordmark shows whenever the desktop media query applies. The optional stage label still uses its wider `15.75rem` container threshold.
> 
> Adds a regression test that reads `index.css` and asserts brand visibility rules stay aligned with `THREAD_SIDEBAR_MIN_WIDTH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5a52223b719c020cec6bf03f220873ba803f41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar wordmark visibility at minimum width on desktop
> Previously, `.sidebar-brand` was only shown when the `sidebar-header` container was at least `13.5rem` wide, causing the wordmark to disappear at minimum sidebar widths. The fix removes the container-width gate and makes `.sidebar-brand` unconditionally `display: flex` within the `@media (min-width: 48rem)` desktop breakpoint. The `.sidebar-brand-stage` label remains gated by `@container sidebar-header (min-width: 15.75rem)`. A new test in [threadSidebarWidth.test.ts](https://github.com/pingdotgg/t3code/pull/6246/files#diff-3c1848326b82c7b9c6f82163c3ff05a4b002635839b39a1ed22239c73212cff2) validates the CSS rules against `THREAD_SIDEBAR_MIN_WIDTH`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c5a522.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->