### PR TITLE
fix(server): upgrade the actually-installed Homebrew formula

### DIFF
--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -331,6 +331,31 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  it("keeps the tap-qualified Homebrew formula when the Cellar path only has the bare name", () => {
+    expect(
+      scopedPackageToolUpdate.resolve({
+        binaryPath: "/opt/homebrew/bin/scoped-package-tool",
+        resolvedCommandPath: "/opt/homebrew/bin/scoped-package-tool",
+        realCommandPath: "/opt/homebrew/Cellar/scoped-package-tool/1.0.0/bin/scoped-package-tool",
+        env: {
+          PATH: "",
+        },
+      }),
+    ).toEqual({
+      provider: driver("scopedPackageTool"),
+      packageName: "@example/scoped-package-tool",
+      update: {
+        command: "brew upgrade example/tap/scoped-package-tool",
+
+        executable: "brew",
+
+        args: ["upgrade", "example/tap/scoped-package-tool"],
+
+        lockKey: "homebrew",
+      },
+    });
+  });
+
   it("upgrades the actually-installed Homebrew formula, not the definition's default", () => {
     expect(
       packageToolUpdate.resolve({

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -331,6 +331,31 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  it("upgrades the actually-installed Homebrew formula, not the definition's default", () => {
+    expect(
+      packageToolUpdate.resolve({
+        binaryPath: "/opt/homebrew/bin/package-tool",
+        resolvedCommandPath: "/opt/homebrew/bin/package-tool",
+        realCommandPath: "/opt/homebrew/Cellar/package-tool@latest/1.2.3/bin/package-tool",
+        env: {
+          PATH: "",
+        },
+      }),
+    ).toEqual({
+      provider: driver("packageTool"),
+      packageName: "@example/package-tool",
+      update: {
+        command: "brew upgrade package-tool@latest",
+
+        executable: "brew",
+
+        args: ["upgrade", "package-tool@latest"],
+
+        lockKey: "homebrew",
+      },
+    });
+  });
+
   it.effect(
     "switches native-package-tool to native updates when the binary resolves through the native installer",
     () =>

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -332,6 +332,31 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  it("upgrades the actually-installed Homebrew formula, not the definition's default", () => {
+    expect(
+      packageToolUpdate.resolve({
+        binaryPath: "/opt/homebrew/bin/package-tool",
+        resolvedCommandPath: "/opt/homebrew/bin/package-tool",
+        realCommandPath: "/opt/homebrew/Cellar/package-tool@latest/1.2.3/bin/package-tool",
+        env: {
+          PATH: "",
+        },
+      }),
+    ).toEqual({
+      provider: driver("packageTool"),
+      packageName: "@example/package-tool",
+      update: {
+        command: "brew upgrade package-tool@latest",
+
+        executable: "brew",
+
+        args: ["upgrade", "package-tool@latest"],
+
+        lockKey: "homebrew",
+      },
+    });
+  });
+
   it.effect(
     "switches native-package-tool to native updates when the binary resolves through the native installer",
     () =>

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -332,6 +332,31 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  it("keeps the tap-qualified Homebrew formula when the Cellar path only has the bare name", () => {
+    expect(
+      scopedPackageToolUpdate.resolve({
+        binaryPath: "/opt/homebrew/bin/scoped-package-tool",
+        resolvedCommandPath: "/opt/homebrew/bin/scoped-package-tool",
+        realCommandPath: "/opt/homebrew/Cellar/scoped-package-tool/1.0.0/bin/scoped-package-tool",
+        env: {
+          PATH: "",
+        },
+      }),
+    ).toEqual({
+      provider: driver("scopedPackageTool"),
+      packageName: "@example/scoped-package-tool",
+      update: {
+        command: "brew upgrade example/tap/scoped-package-tool",
+
+        executable: "brew",
+
+        args: ["upgrade", "example/tap/scoped-package-tool"],
+
+        lockKey: "homebrew",
+      },
+    });
+  });
+
   it("upgrades the actually-installed Homebrew formula, not the definition's default", () => {
     expect(
       packageToolUpdate.resolve({

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -180,8 +180,10 @@ function makeVitePlusGlobalProviderMaintenanceCapabilities(
 
 function makeHomebrewProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
+  installedFormula?: string | null,
 ): ProviderMaintenanceCapabilities {
-  if (!definition.homebrewFormula) {
+  const formula = installedFormula ?? definition.homebrewFormula;
+  if (!formula) {
     return makeManualOnlyProviderMaintenanceCapabilities({
       provider: definition.provider,
       packageName: definition.npmPackageName,
@@ -192,9 +194,15 @@ function makeHomebrewProviderMaintenanceCapabilities(
     provider: definition.provider,
     packageName: definition.npmPackageName,
     updateExecutable: "brew",
-    updateArgs: ["upgrade", definition.homebrewFormula],
+    updateArgs: ["upgrade", formula],
     updateLockKey: "homebrew",
   });
+}
+
+function extractHomebrewFormulaFromPath(commandPath: string): string | null {
+  const normalized = commandPath.replaceAll("\\", "/");
+  const match = /\/(?:cellar|caskroom)\/([^/]+)\//i.exec(normalized);
+  return match ? match[1] : null;
 }
 
 function makeNativeProviderMaintenanceCapabilities(
@@ -304,7 +312,10 @@ export function resolvePackageManagedProviderMaintenance(
       return makeNpmGlobalProviderMaintenanceCapabilities(definition);
     }
     if (commandPaths.some(isHomebrewCommandPath)) {
-      return makeHomebrewProviderMaintenanceCapabilities(definition);
+      const installedFormula = commandPaths
+        .map(extractHomebrewFormulaFromPath)
+        .find((formula) => formula !== null);
+      return makeHomebrewProviderMaintenanceCapabilities(definition, installedFormula ?? null);
     }
   }
 

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -178,11 +178,32 @@ function makeVitePlusGlobalProviderMaintenanceCapabilities(
   });
 }
 
+function homebrewFormulaBasename(formula: string): string {
+  const segments = formula.split("/");
+  return segments[segments.length - 1];
+}
+
+function resolveHomebrewFormula(
+  definition: PackageManagedProviderMaintenanceDefinition,
+  installedFormula: string | null,
+): string | null {
+  if (!installedFormula) {
+    return definition.homebrewFormula;
+  }
+  if (
+    definition.homebrewFormula &&
+    homebrewFormulaBasename(definition.homebrewFormula) === installedFormula
+  ) {
+    return definition.homebrewFormula;
+  }
+  return installedFormula;
+}
+
 function makeHomebrewProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
   installedFormula?: string | null,
 ): ProviderMaintenanceCapabilities {
-  const formula = installedFormula ?? definition.homebrewFormula;
+  const formula = resolveHomebrewFormula(definition, installedFormula ?? null);
   if (!formula) {
     return makeManualOnlyProviderMaintenanceCapabilities({
       provider: definition.provider,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -188,11 +188,32 @@ function makeVitePlusGlobalProviderMaintenanceCapabilities(
   });
 }
 
+function homebrewFormulaBasename(formula: string): string {
+  const segments = formula.split("/");
+  return segments[segments.length - 1];
+}
+
+function resolveHomebrewFormula(
+  definition: PackageManagedProviderMaintenanceDefinition,
+  installedFormula: string | null,
+): string | null {
+  if (!installedFormula) {
+    return definition.homebrewFormula;
+  }
+  if (
+    definition.homebrewFormula &&
+    homebrewFormulaBasename(definition.homebrewFormula) === installedFormula
+  ) {
+    return definition.homebrewFormula;
+  }
+  return installedFormula;
+}
+
 function makeHomebrewProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
   installedFormula?: string | null,
 ): ProviderMaintenanceCapabilities {
-  const formula = installedFormula ?? definition.homebrewFormula;
+  const formula = resolveHomebrewFormula(definition, installedFormula ?? null);
   if (!formula) {
     return makeManualOnlyProviderMaintenanceCapabilities({
       provider: definition.provider,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -190,8 +190,10 @@ function makeVitePlusGlobalProviderMaintenanceCapabilities(
 
 function makeHomebrewProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
+  installedFormula?: string | null,
 ): ProviderMaintenanceCapabilities {
-  if (!definition.homebrewFormula) {
+  const formula = installedFormula ?? definition.homebrewFormula;
+  if (!formula) {
     return makeManualOnlyProviderMaintenanceCapabilities({
       provider: definition.provider,
       packageName: definition.npmPackageName,
@@ -202,9 +204,15 @@ function makeHomebrewProviderMaintenanceCapabilities(
     provider: definition.provider,
     packageName: definition.npmPackageName,
     updateExecutable: "brew",
-    updateArgs: ["upgrade", definition.homebrewFormula],
+    updateArgs: ["upgrade", formula],
     updateLockKey: "homebrew",
   });
+}
+
+function extractHomebrewFormulaFromPath(commandPath: string): string | null {
+  const normalized = commandPath.replaceAll("\\", "/");
+  const match = /\/(?:cellar|caskroom)\/([^/]+)\//i.exec(normalized);
+  return match ? match[1] : null;
 }
 
 function makeNativeProviderMaintenanceCapabilities(
@@ -314,7 +322,10 @@ export function resolvePackageManagedProviderMaintenance(
       return makeNpmGlobalProviderMaintenanceCapabilities(definition);
     }
     if (commandPaths.some(isHomebrewCommandPath)) {
-      return makeHomebrewProviderMaintenanceCapabilities(definition);
+      const installedFormula = commandPaths
+        .map(extractHomebrewFormulaFromPath)
+        .find((formula) => formula !== null);
+      return makeHomebrewProviderMaintenanceCapabilities(definition, installedFormula ?? null);
     }
   }
 


### PR DESCRIPTION
## Problem

Auto updating provider in T3 Code Desktop for macOS (e.g., `claude-code`) would fail because `claude-code` was installed using homebrew using the command `brew install claude-code@latest` rather than `brew install claude-code`. T3 Code would try to run `brew upgrade claude-code` which fails. The correct approach is to find the right install variant of `claude-code` actually installed on the machine. This PR does that and automatically calls `brew install claude-code@latest`.

## What Changed

Provider auto-update no longer relies solely on each driver's hardcoded default Homebrew formula name. `resolvePackageManagedProviderMaintenance` now extracts the actual installed formula name from the resolved Homebrew Cellar/Caskroom path (e.g. `.../Caskroom/claude-code@latest/2.1.228/claude`) and runs `brew upgrade` against that formula, falling back to the driver's default when the path can't be parsed.

## Why

`ClaudeDriver.ts` hardcodes `homebrewFormula: "claude-code"`. Anyone who installed via `brew install claude-code@latest` (a different formula from plain `claude-code`) gets `brew upgrade claude-code` from the in-app update control, which fails loudly:

```
$ brew upgrade claude-code
==> Downloading Homebrew API data
Error: Cask 'claude-code' is not installed.
$ echo $?
1
```

Fixes #6245

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

## Test plan

- `pnpm exec vitest run src/provider/providerMaintenance.test.ts` — 18/18 pass, including a new case covering a Homebrew install under a different formula name than the driver's default
- Verified against this machine's actual `claude` install (`/opt/homebrew/bin/claude` → `/opt/homebrew/Caskroom/claude-code@latest/2.1.228/claude`): resolver now produces `brew upgrade claude-code@latest` instead of the failing `brew upgrade claude-code`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to provider maintenance command resolution with new unit tests; no auth or data-path impact.
> 
> **Overview**
> **Provider auto-update** now builds `brew upgrade` from the formula name on disk, not only each driver’s default `homebrewFormula`.
> 
> When a binary resolves through Homebrew, the resolver parses the installed formula from Cellar/Caskroom paths (e.g. `package-tool@latest` or `claude-code@latest`) and passes it into Homebrew maintenance capabilities. `resolveHomebrewFormula` keeps tap-qualified names like `example/tap/scoped-package-tool` when the path basename matches the definition; otherwise it uses the detected installed name. If nothing can be resolved, behavior still falls back to the definition default or manual-only updates.
> 
> Tests cover tap-qualified formulas and variant formula names that differ from the driver default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71fabd03de595b059f3b79b9b8f2192871be775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Homebrew upgrade to target the actually-installed formula instead of the definition default
> - Adds `extractHomebrewFormulaFromPath` to detect the installed Homebrew formula from a binary's Cellar/Caskroom path, and `resolveHomebrewFormula` to pick between the installed and definition formulas, preferring the tap-qualified definition name when basenames match.
> - Updates `makeHomebrewProviderMaintenanceCapabilities` to accept an optional installed formula and use the resolved formula in the `brew upgrade` command, falling back to manual-only capabilities when no formula is available.
> - Updates `resolvePackageManagedProviderMaintenance` to extract the installed formula from command paths and pass it into the capabilities factory.
> - Behavioral Change: `brew upgrade` commands now target the detected installed formula (e.g. `package-tool@latest`) rather than the static definition formula when they differ.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d71fabd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->