### PR TITLE
fix(connection): keep Windows reconnects responsive

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -350,7 +350,12 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
   const threadPlanProgress = yield* ThreadPlanProgressService;
   const sql = yield* SqlClient.SqlClient;
   const repositoryIdentityResolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
-  const repositoryIdentityResolutionConcurrency = 4;
+  // A cold shell snapshot may contain hundreds of workspaces. Git process
+  // startup is comparatively expensive on Windows, so a four-wide queue can
+  // hold the initial WebSocket subscription open for tens of seconds. Keep the
+  // fan-out bounded while allowing enough parallelism to finish before the
+  // client's slow-request threshold.
+  const repositoryIdentityResolutionConcurrency = 16;
   const resolveRepositoryIdentitiesForProjects = Effect.fn(
     "ProjectionSnapshotQuery.resolveRepositoryIdentitiesForProjects",
   )(function* (

--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -27,6 +27,8 @@ const makeTempDir = Effect.gen(function* () {
   });
 });
 
+const normalizePathSeparators = (value: string) => value.replaceAll("\\", "/");
+
 const writeTextFile = Effect.fn("writeTextFile")(function* (
   cwd: string,
   relativePath: string,
@@ -58,7 +60,33 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("favicon.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("favicon.svg");
+      }),
+    );
+
+    it.effect("caches repeated favicon discovery for the same project", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
+        let statCalls = 0;
+        const resolver = yield* makeResolverWithFileSystem(
+          FileSystem.FileSystem.of({
+            ...fileSystem,
+            stat: (path) =>
+              Effect.sync(() => {
+                statCalls += 1;
+              }).pipe(Effect.andThen(fileSystem.stat(path))),
+          }),
+        );
+
+        const first = yield* resolver.resolvePath(cwd);
+        const callsAfterFirstResolve = statCalls;
+        const second = yield* resolver.resolvePath(cwd);
+
+        expect(first).toBe(second);
+        expect(callsAfterFirstResolve).toBeGreaterThan(0);
+        expect(statCalls).toBe(callsAfterFirstResolve);
       }),
     );
 
@@ -73,7 +101,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("brand/mark.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("brand/mark.svg");
       }),
     );
 
@@ -87,7 +115,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd, "brand/custom.svg");
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("brand/custom.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("brand/custom.svg");
       }),
     );
 
@@ -100,7 +128,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd, "brand/missing.svg");
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("favicon.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("favicon.svg");
       }),
     );
 
@@ -114,7 +142,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("favicon.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("favicon.svg");
       }),
     );
 
@@ -128,7 +156,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("favicon.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("favicon.svg");
       }),
     );
 
@@ -156,7 +184,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("public/brand/logo.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("public/brand/logo.svg");
       }),
     );
 
@@ -181,7 +209,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("public/brand/logo.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("public/brand/logo.svg");
       }),
     );
 
@@ -199,7 +227,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("public/brand/logo.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("public/brand/logo.svg");
       }),
     );
 
@@ -217,7 +245,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("public/brand/logo.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("public/brand/logo.svg");
       }),
     );
 
@@ -235,7 +263,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("public/brand/logo.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("public/brand/logo.svg");
       }),
     );
 
@@ -383,7 +411,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).not.toBeNull();
-        expect(resolved).toContain("public/brand/logo.svg");
+        expect(normalizePathSeparators(resolved ?? "")).toContain("public/brand/logo.svg");
       }),
     );
   });

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -6,8 +6,11 @@
  *
  * @module ProjectFaviconResolver
  */
+import * as Cache from "effect/Cache";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -62,6 +65,8 @@ const LINK_ICON_HTML_RE =
   /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i;
 const ICON_REL_RE = /\brel\s*:\s*["'](?:icon|shortcut icon)["']/i;
 const ICON_HREF_RE = /\bhref\s*:\s*["']([^"'?]+)/i;
+const FAVICON_RESOLUTION_CACHE_CAPACITY = 1_024;
+const FAVICON_RESOLUTION_CACHE_TTL = Duration.minutes(5);
 
 export class ProjectFaviconResolutionError extends Schema.TaggedErrorClass<ProjectFaviconResolutionError>()(
   "ProjectFaviconResolutionError",
@@ -175,9 +180,10 @@ export const make = Effect.gen(function* () {
     return null;
   });
 
-  const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = Effect.fn(
-    "ProjectFaviconResolver.resolvePath",
-  )(function* (cwd, faviconPath) {
+  const resolvePathUncached = Effect.fn("ProjectFaviconResolver.resolvePathUncached")(function* (
+    cwd: string,
+    faviconPath?: string,
+  ): Effect.fn.Return<string | null, ProjectFaviconResolutionError> {
     const projectCwd = yield* workspacePaths.normalizeWorkspaceRoot(cwd).pipe(
       Effect.mapError(
         (cause) =>
@@ -259,6 +265,28 @@ export const make = Effect.gen(function* () {
 
     return null;
   });
+
+  const resolutionCache = yield* Cache.makeWith<
+    string,
+    string | null,
+    ProjectFaviconResolutionError
+  >(
+    (key) => {
+      const [cwd, faviconPath] = JSON.parse(key) as readonly [string, string | null];
+      return resolvePathUncached(cwd, faviconPath ?? undefined);
+    },
+    {
+      capacity: FAVICON_RESOLUTION_CACHE_CAPACITY,
+      timeToLive: Exit.match({
+        onSuccess: () => FAVICON_RESOLUTION_CACHE_TTL,
+        onFailure: () => Duration.zero,
+      }),
+    },
+  );
+
+  const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = Effect.fn(
+    "ProjectFaviconResolver.resolvePath",
+  )((cwd, faviconPath) => Cache.get(resolutionCache, JSON.stringify([cwd, faviconPath ?? null])));
 
   return ProjectFaviconResolver.of({ resolvePath });
 });

--- a/apps/server/src/project/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.test.ts
@@ -6,6 +6,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import { TestClock } from "effect/testing";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as ProcessRunner from "../processRunner.ts";
 import * as RepositoryIdentityResolver from "./RepositoryIdentityResolver.ts";
@@ -35,6 +36,47 @@ const makeRepositoryIdentityResolverTestLayer = (options: {
   ).pipe(Layer.provide(ProcessRunner.layer));
 
 it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
+  it.effect("coalesces concurrent reconnect lookups without respawning Git", () =>
+    Effect.gen(function* () {
+      const invocations: string[] = [];
+      const processRunner = ProcessRunner.ProcessRunner.of({
+        run: (input) =>
+          Effect.sync(() => {
+            invocations.push(input.args.join(" "));
+            const isTopLevelLookup = input.args.includes("rev-parse");
+            return {
+              stdout: isTopLevelLookup
+                ? "C:/repo\n"
+                : "origin\thttps://github.com/T3Tools/t3code.git (fetch)\n",
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+              stdoutInvalidUtf8: false,
+              stderrInvalidUtf8: false,
+            };
+          }),
+      });
+      const resolver = yield* RepositoryIdentityResolver.make({ cacheCapacity: 16 }).pipe(
+        Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
+      );
+
+      const identities = yield* Effect.all(
+        Array.from({ length: 100 }, () => resolver.resolve("C:\\repo")),
+        { concurrency: "unbounded" },
+      );
+      const repeated = yield* resolver.resolve("C:\\repo");
+
+      expect(
+        identities.every((identity) => identity?.canonicalKey === "github.com/t3tools/t3code"),
+      ).toBe(true);
+      expect(repeated?.canonicalKey).toBe("github.com/t3tools/t3code");
+      expect(invocations.filter((invocation) => invocation.includes("rev-parse"))).toHaveLength(1);
+      expect(invocations.filter((invocation) => invocation.includes("remote -v"))).toHaveLength(1);
+    }),
+  );
+
   it.effect("normalizes equivalent GitHub remotes into a stable repository identity", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/project/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.ts
@@ -12,9 +12,9 @@ import * as Layer from "effect/Layer";
 
 import * as ProcessRunner from "../processRunner.ts";
 
-const DEFAULT_REPOSITORY_IDENTITY_CACHE_CAPACITY = 512;
-const DEFAULT_POSITIVE_CACHE_TTL = Duration.minutes(1);
-const DEFAULT_NEGATIVE_CACHE_TTL = Duration.minutes(1);
+const DEFAULT_REPOSITORY_IDENTITY_CACHE_CAPACITY = 1_024;
+const DEFAULT_POSITIVE_CACHE_TTL = Duration.minutes(30);
+const DEFAULT_NEGATIVE_CACHE_TTL = Duration.minutes(5);
 
 export interface RepositoryIdentityResolverOptions {
   readonly cacheCapacity?: number;
@@ -139,6 +139,13 @@ export const make = Effect.fn("RepositoryIdentityResolver.make")(function* (
   options: RepositoryIdentityResolverOptions = {},
 ) {
   const processRunner = yield* ProcessRunner.ProcessRunner;
+  const timeToLive = Exit.match<RepositoryIdentity | null, never, Duration.Input, Duration.Input>({
+    onSuccess: (value) =>
+      value === null
+        ? (options.negativeCacheTtl ?? DEFAULT_NEGATIVE_CACHE_TTL)
+        : (options.positiveCacheTtl ?? DEFAULT_POSITIVE_CACHE_TTL),
+    onFailure: () => Duration.zero,
+  });
 
   const repositoryIdentityCache = yield* Cache.makeWith<string, RepositoryIdentity | null>(
     (cacheKey) =>
@@ -147,24 +154,28 @@ export const make = Effect.fn("RepositoryIdentityResolver.make")(function* (
       ),
     {
       capacity: options.cacheCapacity ?? DEFAULT_REPOSITORY_IDENTITY_CACHE_CAPACITY,
-      timeToLive: Exit.match({
-        onSuccess: (value) =>
-          value === null
-            ? (options.negativeCacheTtl ?? DEFAULT_NEGATIVE_CACHE_TTL)
-            : (options.positiveCacheTtl ?? DEFAULT_POSITIVE_CACHE_TTL),
-        onFailure: () => Duration.zero,
-      }),
+      timeToLive,
+    },
+  );
+
+  // Resolving the cache key itself launches `git rev-parse`. Cache the full
+  // cwd lookup as well as the root-keyed remote lookup so every reconnect does
+  // not respawn Git once per visible project (especially costly on Windows).
+  const repositoryIdentityByCwdCache = yield* Cache.makeWith<string, RepositoryIdentity | null>(
+    (cwd) =>
+      resolveRepositoryIdentityCacheKey(cwd).pipe(
+        Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
+        Effect.flatMap((cacheKey) => Cache.get(repositoryIdentityCache, cacheKey)),
+      ),
+    {
+      capacity: options.cacheCapacity ?? DEFAULT_REPOSITORY_IDENTITY_CACHE_CAPACITY,
+      timeToLive,
     },
   );
 
   const resolve: RepositoryIdentityResolver["Service"]["resolve"] = Effect.fn(
     "RepositoryIdentityResolver.resolve",
-  )(function* (cwd) {
-    const cacheKey = yield* resolveRepositoryIdentityCacheKey(cwd).pipe(
-      Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
-    );
-    return yield* Cache.get(repositoryIdentityCache, cacheKey);
-  });
+  )((cwd) => Cache.get(repositoryIdentityByCwdCache, cwd));
 
   return RepositoryIdentityResolver.of({ resolve });
 });

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -31,7 +31,7 @@
  *   1. Read the current `ServerSettings` once and use it to seed the
  *      registry's initial state via `ProviderInstanceRegistryMutableLayer`.
  *   2. Fork a daemon fiber (lifetime tied to the layer's scope) that
- *      subscribes to `ServerSettingsService.streamChanges` and calls
+ *      acquires `ServerSettingsService.subscribeChanges` and calls
  *      `ProviderInstanceRegistryMutator.reconcile` on every emission.
  *
  * Failures inside the watcher are logged and swallowed so a single bad
@@ -118,7 +118,8 @@ const SettingsWatcherLive = Layer.effectDiscard(
   Effect.gen(function* () {
     const mutator = yield* ProviderInstanceRegistryMutator;
     const serverSettings = yield* ServerSettingsService;
-    yield* serverSettings.streamChanges.pipe(
+    const settingsChanges = yield* serverSettings.subscribeChanges;
+    yield* settingsChanges.pipe(
       Stream.runForEach((next) =>
         mutator
           .reconcile(deriveProviderInstanceConfigMap(next))
@@ -128,14 +129,14 @@ const SettingsWatcherLive = Layer.effectDiscard(
             ),
           ),
       ),
-      Effect.forkScoped,
+      Effect.forkScoped({ startImmediately: true }),
     );
   }),
 );
 
 /**
  * Hydrate `ProviderInstanceRegistry` from `ServerSettings` and keep it in
- * sync with subsequent `streamChanges` emissions.
+ * sync with subsequent `subscribeChanges` emissions.
  *
  * The Layer's two halves:
  *   - `ProviderInstanceRegistryMutableLayer` produces the registry +

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -68,6 +69,7 @@ process.env.T3CODE_CURSOR_ENABLED = "1";
 
 const encoder = new TextEncoder();
 const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
+const yieldToHostScheduler = TestClock.withLive(Effect.sleep("10 millis"));
 
 const TestHttpClientLive = Layer.succeed(
   HttpClient.HttpClient,
@@ -1010,6 +1012,9 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               getSnapshot: Effect.succeed(initialProvider),
               refresh: Effect.succeed(refreshedProvider),
               streamChanges: Stream.fromPubSub(changes),
+              subscribeChanges: PubSub.subscribe(changes).pipe(
+                Effect.map((subscription) => Stream.fromSubscription(subscription)),
+              ),
             },
             adapter: {} as ProviderInstance["adapter"],
             textGeneration: {} as ProviderInstance["textGeneration"],
@@ -1062,7 +1067,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               attempt += 1
             ) {
               yield* TestClock.adjust("10 millis");
-              yield* Effect.yieldNow;
+              yield* yieldToHostScheduler;
               cachedProvider = yield* readProviderStatusCache(filePath);
             }
 
@@ -1139,6 +1144,9 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 getSnapshot: Effect.succeed(initialProvider),
                 refresh: Effect.succeed(authoritativeProvider),
                 streamChanges: Stream.fromPubSub(changes),
+                subscribeChanges: PubSub.subscribe(changes).pipe(
+                  Effect.map((subscription) => Stream.fromSubscription(subscription)),
+                ),
               },
               adapter: {} as ProviderInstance["adapter"],
               textGeneration: {} as ProviderInstance["textGeneration"],
@@ -1187,7 +1195,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 attempt += 1
               ) {
                 yield* TestClock.adjust("10 millis");
-                yield* Effect.yieldNow;
+                yield* yieldToHostScheduler;
                 cachedProvider = yield* readProviderStatusCache(filePath);
               }
 
@@ -1200,7 +1208,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 attempt += 1
               ) {
                 yield* TestClock.adjust("10 millis");
-                yield* Effect.yieldNow;
+                yield* yieldToHostScheduler;
                 cachedProvider = yield* readProviderStatusCache(filePath);
               }
 
@@ -1606,7 +1614,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               attempts += 1
             ) {
               yield* TestClock.adjust("10 millis");
-              yield* Effect.yieldNow;
+              yield* yieldToHostScheduler;
               initialProviders = yield* registry.getProviders;
             }
             const initialCodex = initialProviders.find(
@@ -1645,7 +1653,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                   return providers;
                 }
                 yield* TestClock.adjust("50 millis");
-                yield* Effect.yieldNow;
+                yield* yieldToHostScheduler;
               }
               return yield* registry.getProviders;
             });
@@ -2184,6 +2192,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         });
 
         return Effect.gen(function* () {
+          const path = yield* Path.Path;
           const status = yield* checkClaudeProviderStatus(
             {
               ...defaultClaudeSettings,
@@ -2194,7 +2203,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           assert.strictEqual(status.status, "ready");
           assert.deepStrictEqual(
             recorded.commands.map((command) => command.env?.CLAUDE_CONFIG_DIR),
-            [claudeConfigDir],
+            [path.resolve(claudeConfigDir)],
           );
         }).pipe(Effect.provide(recorded.layer));
       });

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -204,6 +204,9 @@ const buildSnapshotSource = (instance: ProviderInstance): ProviderSnapshotSource
   getSnapshot: instance.snapshot.getSnapshot,
   refresh: instance.snapshot.refresh,
   streamChanges: instance.snapshot.streamChanges,
+  ...(instance.snapshot.subscribeChanges === undefined
+    ? {}
+    : { subscribeChanges: instance.snapshot.subscribeChanges }),
 });
 
 export const ProviderRegistryLive = Layer.effect(
@@ -569,9 +572,13 @@ export const ProviderRegistryLive = Layer.effect(
         // the current read or the active subscriber observes the result.
         for (const [, instance] of newlyAdded) {
           const source = buildSnapshotSource(instance);
-          yield* Stream.runForEach(source.streamChanges, (provider) =>
+          const sourceChanges =
+            source.subscribeChanges === undefined
+              ? source.streamChanges
+              : yield* source.subscribeChanges;
+          yield* Stream.runForEach(sourceChanges, (provider) =>
             correlateSnapshotWithSource(source, provider).pipe(Effect.flatMap(syncProvider)),
-          ).pipe(Effect.forkScoped);
+          ).pipe(Effect.forkScoped({ startImmediately: true }));
         }
         yield* Effect.yieldNow;
 
@@ -690,7 +697,7 @@ export const ProviderRegistryLive = Layer.effect(
     yield* Stream.runForEach(
       Stream.fromSubscription(instanceChanges),
       () => syncLiveSourcesAndContinue,
-    ).pipe(Effect.forkScoped);
+    ).pipe(Effect.forkScoped({ startImmediately: true }));
 
     const recoverRefreshFailure = Effect.fn("recoverRefreshFailure")(function* (
       cause: Cause.Cause<unknown>,

--- a/apps/server/src/provider/Services/ServerProvider.ts
+++ b/apps/server/src/provider/Services/ServerProvider.ts
@@ -1,5 +1,6 @@
 import type { ServerProvider } from "@t3tools/contracts";
 import type * as Effect from "effect/Effect";
+import type * as Scope from "effect/Scope";
 import type * as Stream from "effect/Stream";
 import type { ProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
 
@@ -8,4 +9,10 @@ export interface ServerProviderShape {
   readonly getSnapshot: Effect.Effect<ServerProvider>;
   readonly refresh: Effect.Effect<ServerProvider>;
   readonly streamChanges: Stream.Stream<ServerProvider>;
+  /**
+   * Acquire a change subscription in the calling fiber before a consumer is
+   * forked. This closes the startup window where a lazy stream subscription
+   * can miss a provider update on a busy event loop.
+   */
+  readonly subscribeChanges?: Effect.Effect<Stream.Stream<ServerProvider>, never, Scope.Scope>;
 }

--- a/apps/server/src/provider/builtInProviderCatalog.ts
+++ b/apps/server/src/provider/builtInProviderCatalog.ts
@@ -14,4 +14,5 @@ export type ProviderSnapshotSource = {
   readonly getSnapshot: ServerProviderShape["getSnapshot"];
   readonly refresh: ServerProviderShape["refresh"];
   readonly streamChanges: Stream.Stream<ServerProvider>;
+  readonly subscribeChanges?: ServerProviderShape["subscribeChanges"];
 };

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -225,5 +225,10 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     get streamChanges() {
       return Stream.fromPubSub(changesPubSub);
     },
+    get subscribeChanges() {
+      return PubSub.subscribe(changesPubSub).pipe(
+        Effect.map((subscription) => Stream.fromSubscription(subscription)),
+      );
+    },
   } satisfies ServerProviderShape;
 });

--- a/packages/client-runtime/src/state/assets.test.ts
+++ b/packages/client-runtime/src/state/assets.test.ts
@@ -1,14 +1,46 @@
 import { describe, expect, it } from "@effect/vitest";
-import { EnvironmentId } from "@t3tools/contracts";
+import { EnvironmentId, WS_METHODS } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Latch from "effect/Latch";
 import * as Layer from "effect/Layer";
-import { Atom } from "effect/unstable/reactivity";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
+import { Atom, AtomRegistry } from "effect/unstable/reactivity";
 
-import type { EnvironmentRegistry } from "../connection/registry.ts";
+import {
+  AVAILABLE_CONNECTION_STATE,
+  PrimaryConnectionTarget,
+  type PreparedConnection,
+  type SupervisorConnectionState,
+} from "../connection/model.ts";
+import * as EnvironmentRegistry from "../connection/registry.ts";
+import * as EnvironmentSupervisor from "../connection/supervisor.ts";
+import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
+import type { RpcSession } from "../rpc/session.ts";
 import {
   createAssetEnvironmentAtoms,
   InvalidAssetCollectionKeyError,
   parseAssetCollectionKey,
 } from "./assets.ts";
+import { executeAtomQuery } from "./runtime.ts";
+
+const TARGET = new PrimaryConnectionTarget({
+  environmentId: EnvironmentId.make("environment-1"),
+  label: "Test environment",
+  httpBaseUrl: "https://environment.example.test",
+  wsBaseUrl: "wss://environment.example.test",
+});
+
+function session(client: WsRpcProtocolClient): RpcSession {
+  return {
+    client,
+    initialConfig: Effect.never,
+    ready: Effect.void,
+    probe: Effect.void,
+    closed: Effect.never,
+  };
+}
 
 describe("asset collection keys", () => {
   it("preserves malformed JSON and its native cause", () => {
@@ -35,7 +67,7 @@ describe("asset collection keys", () => {
 describe("createAssetEnvironmentAtoms", () => {
   it("keys asset URL queries by environment and resource", () => {
     const runtime = Atom.runtime(Layer.empty) as unknown as Atom.AtomRuntime<
-      EnvironmentRegistry,
+      EnvironmentRegistry.EnvironmentRegistry,
       never
     >;
     const assets = createAssetEnvironmentAtoms(runtime);
@@ -94,7 +126,7 @@ describe("createAssetEnvironmentAtoms", () => {
 
   it("keys collections while preserving independent resource queries", () => {
     const runtime = Atom.runtime(Layer.empty) as unknown as Atom.AtomRuntime<
-      EnvironmentRegistry,
+      EnvironmentRegistry.EnvironmentRegistry,
       never
     >;
     const assets = createAssetEnvironmentAtoms(runtime);
@@ -117,4 +149,100 @@ describe("createAssetEnvironmentAtoms", () => {
       }),
     ).not.toBe(assets.createUrls({ environmentId, resources }));
   });
+
+  it.effect("limits reconnect asset URL fan-out to eight active RPCs", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const release = Latch.makeUnsafe();
+        const reachedLimit = Latch.makeUnsafe();
+        let active = 0;
+        let maximumActive = 0;
+        let started = 0;
+        const client = {
+          [WS_METHODS.assetsCreateUrl]: (input: {
+            readonly resource: { readonly _tag: "project-favicon"; readonly cwd: string };
+          }) =>
+            Effect.sync(() => {
+              active += 1;
+              started += 1;
+              maximumActive = Math.max(maximumActive, active);
+              if (active === 8) reachedLimit.openUnsafe();
+            }).pipe(
+              Effect.andThen(release.await),
+              Effect.as({
+                relativeUrl: `/api/assets/${encodeURIComponent(input.resource.cwd)}`,
+                expiresAt: 1_000_000,
+              }),
+              Effect.ensuring(
+                Effect.sync(() => {
+                  active -= 1;
+                }),
+              ),
+            ),
+        } as unknown as WsRpcProtocolClient;
+        const connectionState: SupervisorConnectionState = {
+          ...AVAILABLE_CONNECTION_STATE,
+          desired: true,
+          network: "online",
+          phase: "connected",
+          attempt: 1,
+          generation: 1,
+        };
+        const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
+          target: TARGET,
+          state: yield* SubscriptionRef.make(connectionState),
+          session: yield* SubscriptionRef.make(Option.some(session(client))),
+          prepared: yield* SubscriptionRef.make(Option.none<PreparedConnection>()),
+          connect: Effect.void,
+          disconnect: Effect.void,
+          retryNow: Effect.void,
+        } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+        const run: EnvironmentRegistry.EnvironmentRegistry["Service"]["run"] = (
+          _environmentId,
+          effect,
+        ) => Effect.provideService(effect, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+        const followStream: EnvironmentRegistry.EnvironmentRegistry["Service"]["followStream"] = (
+          _environmentId,
+          stream,
+        ) => Stream.provideService(stream, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+        const environmentRegistry = EnvironmentRegistry.EnvironmentRegistry.of({
+          run,
+          followStream,
+        } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
+        const runtime = Atom.runtime(
+          Layer.succeed(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+        );
+        const assets = createAssetEnvironmentAtoms(runtime);
+        const registry = yield* Effect.acquireRelease(Effect.sync(AtomRegistry.make), (current) =>
+          Effect.sync(() => current.dispose()),
+        );
+        const queries = Array.from({ length: 24 }, (_, index) =>
+          executeAtomQuery(
+            registry,
+            assets.createUrl({
+              environmentId: TARGET.environmentId,
+              input: {
+                resource: {
+                  _tag: "project-favicon",
+                  cwd: `/repo/${index}`,
+                },
+              },
+            }),
+            { reportDefect: false, reportFailure: false },
+          ),
+        );
+
+        yield* reachedLimit.await.pipe(Effect.timeout("5 seconds"));
+        expect(active).toBe(8);
+        expect(started).toBe(8);
+        expect(maximumActive).toBe(8);
+
+        release.openUnsafe();
+        const results = yield* Effect.promise(() => Promise.all(queries));
+        expect(results.every((result) => result._tag === "Success")).toBe(true);
+        expect(started).toBe(24);
+        expect(maximumActive).toBe(8);
+      }),
+    ),
+  );
 });

--- a/packages/client-runtime/src/state/assets.ts
+++ b/packages/client-runtime/src/state/assets.ts
@@ -1,13 +1,16 @@
 import { AssetResource, EnvironmentId, WS_METHODS } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import { Atom } from "effect/unstable/reactivity";
 
 import type { EnvironmentRegistry } from "../connection/registry.ts";
-import { createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
+import { type EnvironmentRpcInput, request } from "../rpc/client.ts";
+import { createEnvironmentQueryAtomFamily } from "./runtime.ts";
 
 const ASSET_URL_REFRESH_INTERVAL_MS = 30 * 60_000;
 const ASSET_URL_STALE_TIME_MS = 5 * 60_000;
 const ASSET_URL_IDLE_TTL_MS = 60 * 60_000;
+const ASSET_URL_REQUEST_CONCURRENCY = 8;
 
 export class InvalidAssetCollectionKeyError extends Schema.TaggedErrorClass<InvalidAssetCollectionKeyError>()(
   "InvalidAssetCollectionKeyError",
@@ -46,12 +49,17 @@ export function resolveAssetUrl(httpBaseUrl: string, relativeUrl: string): strin
 export function createAssetEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
 ) {
-  const createUrl = createEnvironmentRpcQueryAtomFamily(runtime, {
+  // A reconnect revalidates every mounted project favicon atom at once. Keep
+  // that fan-out below the server and browser request-pressure thresholds;
+  // queued effects remain interruptible if the connection generation changes.
+  const requestSemaphore = Semaphore.makeUnsafe(ASSET_URL_REQUEST_CONCURRENCY);
+  const createUrl = createEnvironmentQueryAtomFamily(runtime, {
     label: "environment-data:assets:create-url",
-    tag: WS_METHODS.assetsCreateUrl,
     staleTimeMs: ASSET_URL_STALE_TIME_MS,
     idleTtlMs: ASSET_URL_IDLE_TTL_MS,
     refreshIntervalMs: ASSET_URL_REFRESH_INTERVAL_MS,
+    execute: (input: EnvironmentRpcInput<typeof WS_METHODS.assetsCreateUrl>) =>
+      requestSemaphore.withPermits(1)(request(WS_METHODS.assetsCreateUrl, input)),
   });
   const createUrlsFamily = Atom.family((key: string) => {
     const [environmentId, resources] = parseAssetCollectionKey(key);

--- a/packages/shared/src/logging.test.ts
+++ b/packages/shared/src/logging.test.ts
@@ -71,13 +71,15 @@ describe("RotatingFileSink", () => {
 
   it("only treats a missing log file as an empty current size", () => {
     const directory = makeTempDirectory();
-    const filePath = NodePath.join(directory, "a".repeat(300));
+    const filePath = NodePath.join(directory, "invalid\0path");
 
     const thrown = captureError(() => new RotatingFileSink({ filePath, maxBytes: 1, maxFiles: 1 }));
 
     expect(thrown).toBeInstanceOf(RotatingFileSinkError);
     expect(thrown).toMatchObject({ operation: "read", filePath });
-    expect((thrown as RotatingFileSinkError).cause).toMatchObject({ code: "ENAMETOOLONG" });
+    expect((thrown as RotatingFileSinkError).cause).toMatchObject({
+      code: "ERR_INVALID_ARG_VALUE",
+    });
   });
 
   it("starts an absent log file at zero bytes", () => {
@@ -102,6 +104,45 @@ describe("RotatingFileSink", () => {
     });
 
     const thrown = captureError(() => sink.write("entry"));
+
+    expect(thrown).toBeInstanceOf(RotatingFileSinkError);
+    expect(thrown).toMatchObject({ operation: "write", filePath });
+    expect((thrown as RotatingFileSinkError).cause).toMatchObject({ code: "EISDIR" });
+  });
+
+  it("serializes concurrent asynchronous writes and rotation", async () => {
+    const directory = makeTempDirectory();
+    const filePath = NodePath.join(directory, "log.ndjson");
+    const sink = new RotatingFileSink({
+      filePath,
+      maxBytes: 6,
+      maxFiles: 2,
+      throwOnError: true,
+    });
+
+    await Promise.all([
+      sink.writeAsync("aa"),
+      sink.writeAsync("bb"),
+      sink.writeAsync("cccc"),
+      sink.writeAsync("dd"),
+    ]);
+
+    expect(NodeFS.readFileSync(filePath, "utf8")).toBe("ccccdd");
+    expect(NodeFS.readFileSync(`${filePath}.1`, "utf8")).toBe("aabb");
+  });
+
+  it("preserves asynchronous write failures", async () => {
+    const directory = makeTempDirectory();
+    const filePath = NodePath.join(directory, "log.ndjson");
+    NodeFS.mkdirSync(filePath);
+    const sink = new RotatingFileSink({
+      filePath,
+      maxBytes: Number.MAX_SAFE_INTEGER,
+      maxFiles: 1,
+      throwOnError: true,
+    });
+
+    const thrown = await sink.writeAsync("entry").catch((cause: unknown) => cause);
 
     expect(thrown).toBeInstanceOf(RotatingFileSinkError);
     expect(thrown).toMatchObject({ operation: "write", filePath });

--- a/packages/shared/src/logging.ts
+++ b/packages/shared/src/logging.ts
@@ -47,6 +47,7 @@ export class RotatingFileSink {
   private readonly maxFiles: number;
   private readonly throwOnError: boolean;
   private currentSize = 0;
+  private asyncWriteQueue: Promise<void> = Promise.resolve();
 
   constructor(options: RotatingFileSinkOptions) {
     if (options.maxBytes < 1) {
@@ -108,6 +109,23 @@ export class RotatingFileSink {
     }
   }
 
+  /**
+   * Appends without blocking the Node.js event loop. Calls are serialized so
+   * rotation and size accounting remain deterministic under concurrent load.
+   *
+   * A sink instance should use either `write` or `writeAsync`, not both.
+   */
+  writeAsync(chunk: string | Buffer): Promise<void> {
+    const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    if (buffer.length === 0) return this.asyncWriteQueue;
+
+    const write = this.asyncWriteQueue.then(() => this.writeBufferAsync(buffer));
+    // Keep the queue usable after a surfaced write failure. The returned
+    // promise still rejects for callers configured with throwOnError.
+    this.asyncWriteQueue = write.catch(() => undefined);
+    return write;
+  }
+
   private rotate(): void {
     try {
       const oldest = this.withSuffix(this.maxFiles);
@@ -140,6 +158,63 @@ export class RotatingFileSink {
     }
   }
 
+  private async writeBufferAsync(buffer: Buffer): Promise<void> {
+    try {
+      if (this.currentSize > 0 && this.currentSize + buffer.length > this.maxBytes) {
+        await this.rotateAsync();
+      }
+
+      await NodeFS.promises.appendFile(this.filePath, buffer);
+      this.currentSize += buffer.length;
+    } catch (cause) {
+      if (isRotatingFileSinkError(cause)) {
+        throw cause;
+      }
+      if (this.throwOnError) {
+        throw new RotatingFileSinkError({
+          operation: "write",
+          filePath: this.filePath,
+          cause,
+        });
+      }
+      this.currentSize = await this.readCurrentSizeAsync();
+    }
+  }
+
+  private async rotateAsync(): Promise<void> {
+    try {
+      const oldest = this.withSuffix(this.maxFiles);
+      await NodeFS.promises.rm(oldest, { force: true });
+
+      for (let index = this.maxFiles - 1; index >= 1; index -= 1) {
+        const source = this.withSuffix(index);
+        const target = this.withSuffix(index + 1);
+        try {
+          await NodeFS.promises.rename(source, target);
+        } catch (cause) {
+          if (!isFileNotFoundError(cause)) throw cause;
+        }
+      }
+
+      try {
+        await NodeFS.promises.rename(this.filePath, this.withSuffix(1));
+      } catch (cause) {
+        if (!isFileNotFoundError(cause)) throw cause;
+      }
+
+      this.currentSize = 0;
+    } catch (cause) {
+      if (this.throwOnError) {
+        throw new RotatingFileSinkError({
+          operation: "rotate",
+          filePath: this.filePath,
+          cause,
+        });
+      }
+      this.currentSize = await this.readCurrentSizeAsync();
+    }
+  }
+
   private pruneOverflowBackups(): void {
     try {
       const dir = NodePath.dirname(this.filePath);
@@ -164,6 +239,21 @@ export class RotatingFileSink {
   private readCurrentSize(): number {
     try {
       return NodeFS.statSync(this.filePath).size;
+    } catch (cause) {
+      if (isFileNotFoundError(cause)) {
+        return 0;
+      }
+      throw new RotatingFileSinkError({
+        operation: "read",
+        filePath: this.filePath,
+        cause,
+      });
+    }
+  }
+
+  private async readCurrentSizeAsync(): Promise<number> {
+    try {
+      return (await NodeFS.promises.stat(this.filePath)).size;
     } catch (cause) {
       if (isFileNotFoundError(cause)) {
         return 0;

--- a/packages/shared/src/observability.ts
+++ b/packages/shared/src/observability.ts
@@ -349,8 +349,10 @@ export const makeTraceSink = Effect.fn("makeTraceSink")(function* (options: Trac
     count: 0,
     durationMs: 0,
   };
+  let flushQueue: Promise<void> = Promise.resolve();
+  let thresholdFlushScheduled = false;
 
-  const flushUnsafe = () => {
+  const flushUnsafe = async () => {
     if (buffer.length === 0) {
       return;
     }
@@ -378,9 +380,11 @@ export const makeTraceSink = Effect.fn("makeTraceSink")(function* (options: Trac
       const chunk = records.slice(persistedCount, nextIndex).join("");
       const startedAt = performance.now();
       try {
-        sink.write(chunk);
+        await sink.writeAsync(chunk);
       } catch {
-        buffer.unshift(...records.slice(persistedCount));
+        // Keep failed records ahead of anything pushed while the asynchronous
+        // write was in flight so retry order remains stable.
+        buffer = [...records.slice(persistedCount), ...buffer];
         return;
       }
       pendingFlushStats = {
@@ -392,16 +396,40 @@ export const makeTraceSink = Effect.fn("makeTraceSink")(function* (options: Trac
     }
   };
 
-  const flush = Effect.sync(() => {
-    flushUnsafe();
-    const stats = pendingFlushStats;
-    pendingFlushStats = {
-      logicalWriteBytes: 0,
-      count: 0,
-      durationMs: 0,
-    };
-    return stats;
-  }).pipe(
+  const enqueueThresholdFlush = (): void => {
+    if (thresholdFlushScheduled) return;
+    thresholdFlushScheduled = true;
+    const queued = flushQueue.then(async () => {
+      try {
+        await flushUnsafe();
+      } finally {
+        thresholdFlushScheduled = false;
+      }
+    });
+    // `flushUnsafe` handles persistence failures by restoring records. Keep a
+    // defensive rejection handler here so one defect cannot poison the queue.
+    flushQueue = queued.catch(() => undefined);
+  };
+
+  const flushAndTakeStats = (): Promise<TraceSinkFlushStats> => {
+    const queued = flushQueue.then(async () => {
+      await flushUnsafe();
+      const stats = pendingFlushStats;
+      pendingFlushStats = {
+        logicalWriteBytes: 0,
+        count: 0,
+        durationMs: 0,
+      };
+      return stats;
+    });
+    flushQueue = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
+  };
+
+  const flush = Effect.promise(flushAndTakeStats).pipe(
     Effect.flatMap((stats) =>
       stats.count > 0 && options.onFlush ? options.onFlush(stats).pipe(Effect.ignore) : Effect.void,
     ),
@@ -419,7 +447,7 @@ export const makeTraceSink = Effect.fn("makeTraceSink")(function* (options: Trac
       try {
         buffer.push(`${JSON.stringify(record)}\n`);
         if (buffer.length >= FLUSH_BUFFER_THRESHOLD) {
-          flushUnsafe();
+          enqueueThresholdFlush();
         }
       } catch {
         return;


### PR DESCRIPTION
## Problem

On Windows, the desktop client could become unreliable during busy turns or reconnects: requests crossed the 15-second warning threshold, the client displayed repeated reconnect banners, and newly submitted messages could fail.

The trace showed three compounding causes:

- local trace append/rotation used synchronous filesystem calls on the Node.js event loop;
- reconnect hydration spawned repeated Git/favicon work and revalidated every mounted asset URL at once;
- lazy provider/settings PubSub streams left a startup window where a change could be published before the consumer subscribed.

## Fix

- Add serialized asynchronous append and rotation to `RotatingFileSink`, and queue trace flushes without blocking the event loop.
- Cache/coalesce repository identity and favicon discovery, increase bounded cold-snapshot repository resolution from 4 to 16, and cap client asset URL RPC fan-out at 8.
- Acquire managed-provider and settings subscriptions before forking their consumers, then start the consumer fibers immediately.

This keeps the existing event-sourced contracts intact and bounds pressure at the adapter/client edges.

## Validation

Based on upstream `main` at `560d4a456`.

- Focused regression suite: **7 files, 110 tests passed**.
- Changed-file formatting: **16/16 passed**.
- Changed-file lint: **0 warnings, 0 errors**.
- Package-scoped typechecks passed for `t3`, `@t3tools/client-runtime`, and `@t3tools/shared` (only existing suggestions outside this diff).
- The desktop dev runner built and launched the web, server, and Electron surfaces against an isolated T3 home.
- A 100,000-record trace stress run completed in **363 ms** with **0.8 ms maximum timer lag**; all retained NDJSON records were valid and every rotated file stayed within the configured limit.

### Local reconnect E2E

The real Electron dev shell and a paired local renderer ran against the same isolated backend. I submitted a real Codex turn, terminated only that isolated backend process, verified the desktop shell automatically restarted it on the same port in about five seconds, and then submitted both Low and Ultra post-reconnect turns.

| Turn | Result | Duration | Checkpoint |
| --- | --- | ---: | --- |
| Initial | `E2E-CONNECTION-OK` | 5.818 s | ready |
| Post-reconnect | `E2E-RECONNECT-OK` | 7.893 s | ready |
| Post-reconnect Ultra | `E2E-ULTRA-RECONNECT-OK` | 2.878 s | ready |

All **41 orchestration command receipts were accepted**, with **0 error receipts**. The client showed none of `Some requests are slow`, `Failed to connect`, `Reconnecting`, or `disconnected` after the reconnect and Ultra turn.

## Surface notes

- The asset concurrency guard lives in `packages/client-runtime`, so web, desktop, and mobile share it.
- Server-side changes apply to the same WebSocket path used by local, remote/relay, and tunnel connections; local desktop was the integrated path exercised here.
- Managed subscription handling is provider-generic.
- No wire-contract or user-workflow changes were required, so there is no user-facing documentation change.

Implemented and validated with GPT-5.6 Sol in T3 Code through the Codex harness.