### PR TITLE
perf(server): stop Windows port discovery thrashing WMI

### DIFF
--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -122,6 +122,101 @@ effectIt.layer(TestPortDiscoveryLive)("PortDiscovery integration (TCP probe fall
   );
 });
 
+effectIt("Windows listener probe builds the process-name map once", () =>
+  Effect.gen(function* () {
+    let seenCommand: string | undefined;
+    const layer = PortScanner.layer.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          Layer.succeed(ProcessRunner.ProcessRunner, {
+            run: (input) => {
+              seenCommand = input.args.at(-1);
+              return Effect.succeed({
+                stdout: "127.0.0.1|5173|4242|node\n",
+                stderr: "",
+                code: 0,
+                timedOut: false,
+                stdoutTruncated: false,
+                stderrTruncated: false,
+                stdoutInvalidUtf8: false,
+                stderrInvalidUtf8: false,
+              });
+            },
+          }),
+          Layer.succeed(Net.NetService, {
+            canListenOnHost: () => Effect.succeed(true),
+            isPortAvailableOnLoopback: () => Effect.succeed(true),
+            reserveLoopbackPort: () => Effect.succeed(40_000),
+            findAvailablePort: (preferred) => Effect.succeed(preferred),
+          }),
+          Layer.succeed(HostProcessPlatform, "win32"),
+        ),
+      ),
+    );
+
+    const servers = yield* Effect.gen(function* () {
+      const scanner = yield* PortScanner.PortDiscovery;
+      return yield* scanner.scan();
+    }).pipe(Effect.provide(layer), Effect.scoped);
+
+    expect(seenCommand).toBe(PortScanner.WINDOWS_LISTENER_COMMAND);
+    // Regression for #5900: never call Get-Process -Id per listener.
+    expect(seenCommand).toContain("$m = @{}");
+    expect(seenCommand).not.toMatch(/Get-Process\s+-Id/);
+    expect(servers).toEqual([
+      {
+        host: "localhost",
+        port: 5173,
+        url: "http://localhost:5173",
+        processName: "node",
+        pid: 4242,
+        terminal: null,
+      },
+    ]);
+  }),
+);
+
+effectIt("Windows listener probe cools down after a timeout", () =>
+  Effect.gen(function* () {
+    let probeRuns = 0;
+    const layer = PortScanner.layer.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          Layer.succeed(ProcessRunner.ProcessRunner, {
+            run: () => {
+              probeRuns += 1;
+              return Effect.fail(
+                new ProcessRunner.ProcessTimeoutError({
+                  command: "powershell.exe",
+                  argumentCount: 4,
+                  timeoutMs: 5_000,
+                }),
+              );
+            },
+          }),
+          Layer.succeed(Net.NetService, {
+            canListenOnHost: () => Effect.succeed(true),
+            isPortAvailableOnLoopback: () => Effect.succeed(true),
+            reserveLoopbackPort: () => Effect.succeed(40_000),
+            findAvailablePort: (preferred) => Effect.succeed(preferred),
+          }),
+          Layer.succeed(HostProcessPlatform, "win32"),
+        ),
+      ),
+    );
+
+    yield* Effect.gen(function* () {
+      const scanner = yield* PortScanner.PortDiscovery;
+      // First scan hits the probe and records a cooldown.
+      yield* scanner.scan();
+      expect(probeRuns).toBe(1);
+      // Immediate re-scan must use the common-port fallback, not re-spawn PowerShell.
+      yield* scanner.scan();
+      expect(probeRuns).toBe(1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  }),
+);
+
 effectIt("does not swallow process probe defects", () =>
   Effect.gen(function* () {
     const defect = new Error("unexpected process probe defect");

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -207,11 +207,77 @@ effectIt("Windows listener probe cools down after a timeout", () =>
 
     yield* Effect.gen(function* () {
       const scanner = yield* PortScanner.PortDiscovery;
-      // First scan hits the probe and records a cooldown.
+      // First scan hits the probe and records a wall-clock cooldown.
       yield* scanner.scan();
       expect(probeRuns).toBe(1);
-      // Immediate re-scan must use the common-port fallback, not re-spawn PowerShell.
+      // Immediate re-scans (retain, subscribe, poll) must not re-spawn PowerShell.
       yield* scanner.scan();
+      yield* scanner.scan();
+      expect(probeRuns).toBe(1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  }),
+);
+
+effectIt("Windows listener probe is single-flight under concurrent scan()", () =>
+  Effect.gen(function* () {
+    let probeRuns = 0;
+    let releaseProbe: (() => void) | undefined;
+    const probeGate = new Promise<void>((resolve) => {
+      releaseProbe = resolve;
+    });
+    const layer = PortScanner.layer.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          Layer.succeed(ProcessRunner.ProcessRunner, {
+            run: () => {
+              probeRuns += 1;
+              return Effect.tryPromise({
+                try: async () => {
+                  await probeGate;
+                  return {
+                    stdout: "127.0.0.1|5173|4242|node\n",
+                    stderr: "",
+                    code: 0,
+                    timedOut: false,
+                    stdoutTruncated: false,
+                    stderrTruncated: false,
+                    stdoutInvalidUtf8: false,
+                    stderrInvalidUtf8: false,
+                  };
+                },
+                catch: (cause) =>
+                  new ProcessRunner.ProcessReadError({
+                    command: "powershell.exe",
+                    argumentCount: 4,
+                    stream: "stdout",
+                    cause,
+                  }),
+              });
+            },
+          }),
+          Layer.succeed(Net.NetService, {
+            canListenOnHost: () => Effect.succeed(true),
+            isPortAvailableOnLoopback: () => Effect.succeed(true),
+            reserveLoopbackPort: () => Effect.succeed(40_000),
+            findAvailablePort: (preferred) => Effect.succeed(preferred),
+          }),
+          Layer.succeed(HostProcessPlatform, "win32"),
+        ),
+      ),
+    );
+
+    yield* Effect.gen(function* () {
+      const scanner = yield* PortScanner.PortDiscovery;
+      const first = scanner.scan().pipe(Effect.forkChild);
+      // Second claim must skip while the first probe is in flight.
+      yield* Effect.yieldNow();
+      const second = yield* scanner.scan();
+      expect(probeRuns).toBe(1);
+      // Common-port fallback while the expensive probe is busy.
+      expect(second.every((server) => server.processName === null)).toBe(true);
+
+      releaseProbe?.();
+      yield* first;
       expect(probeRuns).toBe(1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   }),

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -316,3 +316,62 @@ effectIt("does not swallow process probe interruption", () =>
     }
   }),
 );
+
+effectIt("clears Windows listener probe in-flight flag after interruption", () =>
+  Effect.gen(function* () {
+    let probeRuns = 0;
+    const layer = PortScanner.layer.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          Layer.succeed(ProcessRunner.ProcessRunner, {
+            run: () => {
+              probeRuns += 1;
+              if (probeRuns === 1) {
+                return Effect.interrupt;
+              }
+              return Effect.succeed({
+                stdout: "127.0.0.1|5173|4242|node\n",
+                stderr: "",
+                code: 0,
+                timedOut: false,
+                stdoutTruncated: false,
+                stderrTruncated: false,
+                stdoutInvalidUtf8: false,
+                stderrInvalidUtf8: false,
+              });
+            },
+          }),
+          Layer.succeed(Net.NetService, {
+            canListenOnHost: () => Effect.succeed(true),
+            isPortAvailableOnLoopback: () => Effect.succeed(true),
+            reserveLoopbackPort: () => Effect.succeed(40_000),
+            findAvailablePort: (preferred) => Effect.succeed(preferred),
+          }),
+          Layer.succeed(HostProcessPlatform, "win32"),
+        ),
+      ),
+    );
+
+    yield* Effect.gen(function* () {
+      const scanner = yield* PortScanner.PortDiscovery;
+      const first = yield* scanner.scan().pipe(Effect.exit);
+      expect(Exit.isFailure(first)).toBe(true);
+      if (Exit.isFailure(first)) {
+        expect(Cause.hasInterruptsOnly(first.cause)).toBe(true);
+      }
+      // Release must clear inFlight; otherwise every later scan would skip.
+      const second = yield* scanner.scan();
+      expect(probeRuns).toBe(2);
+      expect(second).toEqual([
+        {
+          host: "localhost",
+          port: 5173,
+          url: "http://localhost:5173",
+          processName: "node",
+          pid: 4242,
+          terminal: null,
+        },
+      ]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  }),
+);

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -5,8 +5,12 @@
  * stable line-prefixed field format; this is the only `lsof` flag set we rely
  * on).
  *
- * Windows / lsof missing: checks a curated list of common dev ports through
- * the shared Net service.
+ * Windows: PowerShell lists listening sockets (one PID→name map per probe).
+ * On timeout, fall back to the curated common-port list and cool the probe
+ * briefly so a doomed WMI query is not re-spawned every poll (#5900).
+ *
+ * lsof missing / probe failed: checks a curated list of common dev ports
+ * through the shared Net service.
  *
  * Polling is reference-counted via scoped `retain`. A single layer-scoped fiber
  * polls forever, but each tick is a no-op when the retain count is zero.
@@ -53,6 +57,15 @@ export const COMMON_DEV_PORTS: ReadonlyArray<number> = Object.freeze([
 const POLL_INTERVAL = Duration.seconds(3);
 const LSOF_TIMEOUT_MS = 5_000;
 const WINDOWS_LISTENER_TIMEOUT_MS = 5_000;
+/** After a timeout, skip the expensive probe for this many poll ticks (~60s). */
+const WINDOWS_LISTENER_TIMEOUT_COOLDOWN_TICKS = 20;
+
+/**
+ * Windows listener probe command. Builds the process-name map once; per-listener
+ * `Get-Process -Id` was the cost that made this miss its 5s timeout (#5900).
+ */
+export const WINDOWS_LISTENER_COMMAND =
+  '$m = @{}; Get-Process | ForEach-Object { $m[$_.Id] = $_.ProcessName }; Get-NetTCPConnection -State Listen -ErrorAction Stop | ForEach-Object { Write-Output "$($_.LocalAddress)|$($_.LocalPort)|$($_.OwningProcess)|$($m[[int]$_.OwningProcess])" }';
 
 type Listener = (servers: ReadonlyArray<DiscoveredLocalServer>) => Effect.Effect<void>;
 
@@ -67,6 +80,8 @@ interface ScannerState {
     }
   >;
   readonly retainCount: number;
+  /** Poll ticks remaining before the Windows listener probe is tried again. */
+  readonly windowsListenerCooldownTicks: number;
 }
 
 interface TerminalProcessOwner {
@@ -195,6 +210,7 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     listeners: new Set(),
     terminalProcesses: new Map(),
     retainCount: 0,
+    windowsListenerCooldownTicks: 0,
   });
 
   const probeCommonPorts = Effect.fn("PortDiscovery.probeCommonPorts")(function* () {
@@ -238,13 +254,21 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
       }
     }
     if (hostPlatform === "win32") {
+      // A probe that just timed out will time out again until the machine
+      // cools off; skip it for a while and use the cheap common-port path.
+      if (state.windowsListenerCooldownTicks > 0) {
+        yield* Ref.update(stateRef, (current) => ({
+          ...current,
+          windowsListenerCooldownTicks: Math.max(0, current.windowsListenerCooldownTicks - 1),
+        }));
+        return yield* probeCommonPorts();
+      }
+
       const recoverWindowsProbeFailure = recoverProcessProbeFailure("windows-listeners");
-      const command =
-        'Get-NetTCPConnection -State Listen -ErrorAction Stop | ForEach-Object { $processName = (Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue).ProcessName; Write-Output "$($_.LocalAddress)|$($_.LocalPort)|$($_.OwningProcess)|$processName" }';
       const listeners = yield* processRunner
         .run({
           command: "powershell.exe",
-          args: ["-NoProfile", "-NonInteractive", "-Command", command],
+          args: ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_LISTENER_COMMAND],
           timeout: Duration.millis(WINDOWS_LISTENER_TIMEOUT_MS),
           maxOutputBytes: 1024 * 1024,
           outputMode: "truncate",
@@ -256,7 +280,11 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
             ProcessStdinError: recoverWindowsProbeFailure,
             ProcessOutputLimitError: recoverWindowsProbeFailure,
             ProcessReadError: recoverWindowsProbeFailure,
-            ProcessTimeoutError: recoverWindowsProbeFailure,
+            ProcessTimeoutError: (error) =>
+              Ref.update(stateRef, (current) => ({
+                ...current,
+                windowsListenerCooldownTicks: WINDOWS_LISTENER_TIMEOUT_COOLDOWN_TICKS,
+              })).pipe(Effect.zipRight(recoverWindowsProbeFailure(error))),
           }),
         );
       if (listeners !== null) return listeners;

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -6,8 +6,9 @@
  * on).
  *
  * Windows: PowerShell lists listening sockets (one PID→name map per probe).
- * On timeout, fall back to the curated common-port list and cool the probe
- * briefly so a doomed WMI query is not re-spawned every poll (#5900).
+ * On timeout, fall back to common ports for a wall-clock cool-off and only one
+ * PowerShell probe runs at a time so retain/scan/poll cannot stack WMI work
+ * (#5900).
  *
  * lsof missing / probe failed: checks a curated list of common dev ports
  * through the shared Net service.
@@ -57,8 +58,8 @@ export const COMMON_DEV_PORTS: ReadonlyArray<number> = Object.freeze([
 const POLL_INTERVAL = Duration.seconds(3);
 const LSOF_TIMEOUT_MS = 5_000;
 const WINDOWS_LISTENER_TIMEOUT_MS = 5_000;
-/** After a timeout, skip the expensive probe for this many poll ticks (~60s). */
-const WINDOWS_LISTENER_TIMEOUT_COOLDOWN_TICKS = 20;
+/** After a timeout, skip PowerShell and use common ports until this many ms pass. */
+const WINDOWS_LISTENER_COOLDOWN_MS = 60_000;
 
 /**
  * Windows listener probe command. Builds the process-name map once; per-listener
@@ -68,6 +69,8 @@ export const WINDOWS_LISTENER_COMMAND =
   '$m = @{}; Get-Process | ForEach-Object { $m[$_.Id] = $_.ProcessName }; Get-NetTCPConnection -State Listen -ErrorAction Stop | ForEach-Object { Write-Output "$($_.LocalAddress)|$($_.LocalPort)|$($_.OwningProcess)|$($m[[int]$_.OwningProcess])" }';
 
 type Listener = (servers: ReadonlyArray<DiscoveredLocalServer>) => Effect.Effect<void>;
+
+type WindowsListenerProbeGate = "run" | "skip";
 
 interface ScannerState {
   readonly lastSnapshot: ReadonlyArray<DiscoveredLocalServer>;
@@ -80,8 +83,13 @@ interface ScannerState {
     }
   >;
   readonly retainCount: number;
-  /** Poll ticks remaining before the Windows listener probe is tried again. */
-  readonly windowsListenerCooldownTicks: number;
+  /**
+   * Epoch ms. While `Date.now() < this`, skip PowerShell and use common ports.
+   * Wall-clock so retain/scan/poll cannot burn a tick budget early.
+   */
+  readonly windowsListenerCooldownUntilMs: number;
+  /** Single-flight: only one PowerShell listener probe at a time. */
+  readonly windowsListenerProbeInFlight: boolean;
 }
 
 interface TerminalProcessOwner {
@@ -210,7 +218,8 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     listeners: new Set(),
     terminalProcesses: new Map(),
     retainCount: 0,
-    windowsListenerCooldownTicks: 0,
+    windowsListenerCooldownUntilMs: 0,
+    windowsListenerProbeInFlight: false,
   });
 
   const probeCommonPorts = Effect.fn("PortDiscovery.probeCommonPorts")(function* () {
@@ -245,6 +254,28 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
         platform: hostPlatform,
       }).pipe(Effect.as(null));
 
+  const claimWindowsListenerProbe = Ref.modify(stateRef, (current) => {
+    const now = Date.now();
+    if (now < current.windowsListenerCooldownUntilMs || current.windowsListenerProbeInFlight) {
+      return ["skip", current] as const satisfies readonly [WindowsListenerProbeGate, ScannerState];
+    }
+    return [
+      "run",
+      { ...current, windowsListenerProbeInFlight: true },
+    ] as const satisfies readonly [WindowsListenerProbeGate, ScannerState];
+  });
+
+  const releaseWindowsListenerProbe = Ref.update(stateRef, (current) =>
+    current.windowsListenerProbeInFlight
+      ? { ...current, windowsListenerProbeInFlight: false }
+      : current,
+  );
+
+  const armWindowsListenerCooldown = Ref.update(stateRef, (current) => ({
+    ...current,
+    windowsListenerCooldownUntilMs: Date.now() + WINDOWS_LISTENER_COOLDOWN_MS,
+  }));
+
   const scanOnce = Effect.fn("PortDiscovery.scan")(function* () {
     const state = yield* Ref.get(stateRef);
     const terminalByProcessId = new Map<number, TerminalProcessOwner>();
@@ -254,13 +285,10 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
       }
     }
     if (hostPlatform === "win32") {
-      // A probe that just timed out will time out again until the machine
-      // cools off; skip it for a while and use the cheap common-port path.
-      if (state.windowsListenerCooldownTicks > 0) {
-        yield* Ref.update(stateRef, (current) => ({
-          ...current,
-          windowsListenerCooldownTicks: Math.max(0, current.windowsListenerCooldownTicks - 1),
-        }));
+      // Wall-clock cooldown + single-flight so retain/scan/poll cannot burn a
+      // tick budget or spawn overlapping PowerShell/WMI probes (#5900).
+      const gate = yield* claimWindowsListenerProbe;
+      if (gate === "skip") {
         return yield* probeCommonPorts();
       }
 
@@ -281,11 +309,9 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
             ProcessOutputLimitError: recoverWindowsProbeFailure,
             ProcessReadError: recoverWindowsProbeFailure,
             ProcessTimeoutError: (error) =>
-              Ref.update(stateRef, (current) => ({
-                ...current,
-                windowsListenerCooldownTicks: WINDOWS_LISTENER_TIMEOUT_COOLDOWN_TICKS,
-              })).pipe(Effect.zipRight(recoverWindowsProbeFailure(error))),
+              armWindowsListenerCooldown.pipe(Effect.zipRight(recoverWindowsProbeFailure(error))),
           }),
+          Effect.ensuring(releaseWindowsListenerProbe),
         );
       if (listeners !== null) return listeners;
       return yield* probeCommonPorts();

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -287,32 +287,40 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     if (hostPlatform === "win32") {
       // Wall-clock cooldown + single-flight so retain/scan/poll cannot burn a
       // tick budget or spawn overlapping PowerShell/WMI probes (#5900).
-      const gate = yield* claimWindowsListenerProbe;
-      if (gate === "skip") {
-        return yield* probeCommonPorts();
-      }
-
+      // acquireUseRelease (not claim + later ensuring): if the fiber is
+      // interrupted after claim and before ensuring is installed, inFlight
+      // would stick true and every later scan would skip forever.
       const recoverWindowsProbeFailure = recoverProcessProbeFailure("windows-listeners");
-      const listeners = yield* processRunner
-        .run({
-          command: "powershell.exe",
-          args: ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_LISTENER_COMMAND],
-          timeout: Duration.millis(WINDOWS_LISTENER_TIMEOUT_MS),
-          maxOutputBytes: 1024 * 1024,
-          outputMode: "truncate",
-        })
-        .pipe(
-          Effect.map((result) => parseWindowsListenerOutput(result.stdout, terminalByProcessId)),
-          Effect.catchTags({
-            ProcessSpawnError: recoverWindowsProbeFailure,
-            ProcessStdinError: recoverWindowsProbeFailure,
-            ProcessOutputLimitError: recoverWindowsProbeFailure,
-            ProcessReadError: recoverWindowsProbeFailure,
-            ProcessTimeoutError: (error) =>
-              armWindowsListenerCooldown.pipe(Effect.zipRight(recoverWindowsProbeFailure(error))),
-          }),
-          Effect.ensuring(releaseWindowsListenerProbe),
-        );
+      const listeners = yield* Effect.acquireUseRelease(
+        claimWindowsListenerProbe,
+        (gate) => {
+          if (gate === "skip") {
+            return Effect.succeed(null);
+          }
+          return processRunner
+            .run({
+              command: "powershell.exe",
+              args: ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_LISTENER_COMMAND],
+              timeout: Duration.millis(WINDOWS_LISTENER_TIMEOUT_MS),
+              maxOutputBytes: 1024 * 1024,
+              outputMode: "truncate",
+            })
+            .pipe(
+              Effect.map((result) => parseWindowsListenerOutput(result.stdout, terminalByProcessId)),
+              Effect.catchTags({
+                ProcessSpawnError: recoverWindowsProbeFailure,
+                ProcessStdinError: recoverWindowsProbeFailure,
+                ProcessOutputLimitError: recoverWindowsProbeFailure,
+                ProcessReadError: recoverWindowsProbeFailure,
+                ProcessTimeoutError: (error) =>
+                  armWindowsListenerCooldown.pipe(
+                    Effect.zipRight(recoverWindowsProbeFailure(error)),
+                  ),
+              }),
+            );
+        },
+        (gate) => (gate === "run" ? releaseWindowsListenerProbe : Effect.void),
+      );
       if (listeners !== null) return listeners;
       return yield* probeCommonPorts();
     }


### PR DESCRIPTION
## Problem

On busy Windows machines, preview port discovery re-spawns a PowerShell listener probe every few seconds. The probe called `Get-Process -Id` once per listening socket, which often exceeded the 5s timeout. Timed-out probes were killed mid-WMI query and retried forever, driving sustained WMI/CPU load (#5900).

## Fix

- Build a single PID→name map with one `Get-Process` per probe instead of per connection.
- After a probe timeout, cool the expensive path off for ~60s and use the existing common-port fallback so a doomed probe is not re-spawned every poll.

## Verification

- `vp test run apps/server/src/preview/PortScanner.test.ts` (6 passed)
- Live on Windows: Preview **Local servers** listed listening ports with process names (map-once path), including an intentional `localhost:3000` listener.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

---
Model: Grok 4.5 · Harness: Grok Build / T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows process probing and port discovery behavior; during cooldown or concurrent scans, results may omit process names via the common-port fallback.
> 
> **Overview**
> Stops Windows preview port discovery from repeatedly spawning expensive PowerShell/WMI probes that were timing out and thrashing CPU (#5900).
> 
> Replaces per-listener `Get-Process -Id` with a single `WINDOWS_LISTENER_COMMAND` that builds the PID→name map once. Adds **single-flight** gating and a **60s wall-clock cooldown** after timeouts so concurrent `scan()` / poll / retain paths fall back to common ports instead of stacking probes. Uses `acquireUseRelease` so the in-flight flag clears even if the probe fiber is interrupted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 920f8251d9c63d0b7e78995ae4bcb3b65f5e6fbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop Windows port discovery from thrashing WMI with per-listener `Get-Process` calls
> - Replaces the per-connection `Get-Process -Id` PowerShell calls with a single PID-to-name map built once per probe via the new `WINDOWS_LISTENER_COMMAND` in [PortScanner.ts](https://github.com/pingdotgg/t3code/pull/6254/files#diff-0f6b3292e660acf982893ba130c26e1ffa8f91ff09032cce9b07d55074e296f4).
> - Adds single-flight enforcement so at most one PowerShell probe runs at a time; concurrent `scan()` calls skip the probe and fall back to common-port results while the probe is in flight.
> - Arms a wall-clock cooldown (`WINDOWS_LISTENER_COOLDOWN_MS`) after a `ProcessTimeoutError` so subsequent scans skip PowerShell until the cooldown expires.
> - The in-flight flag is cleared via `acquireUseRelease` so fiber interruption cannot leave the gate permanently locked.
> - Tests covering all four behaviors (single map build, cooldown, single-flight, interrupted probe) are added in [PortScanner.test.ts](https://github.com/pingdotgg/t3code/pull/6254/files#diff-98bc68e3fec0e5eecd2296d96c5534119745d09603b318b5c1f35045a7325af9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 920f825.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->