### PR TITLE
fix(web): freeze idle agent elapsed timers

### DIFF
--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -82,9 +82,12 @@ function elapsedBetween(startedAt: string, endIso: string | null): string {
 /**
  * Elapsed time for the current activation. Live agents self-tick via DOM
  * writes (zero React commits per tick); settled agents freeze at completedAt.
- * Idle is resumable and carries no end stamp of its own, so its last update is
- * the closest end signal we have. Without it the label measures against the
- * current time and climbs forever.
+ * Idle is resumable, so nothing stamps completedAt for it and updatedAt is the
+ * closest end signal we have. Deliberate approximation: a trailing usage-only
+ * task.progress row can push updatedAt past the idle transition, so the label
+ * can overshoot by that gap. It stays bounded by real activity — falling back
+ * to the current time instead grew without limit on every render. An exact
+ * value would need the idle transition stamped in the projection.
  */
 function AgentElapsed({ agent }: { agent: RuntimeSubagent }) {
   const textRef = useRef<HTMLSpanElement>(null);

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -82,11 +82,16 @@ function elapsedBetween(startedAt: string, endIso: string | null): string {
 /**
  * Elapsed time for the current activation. Live agents self-tick via DOM
  * writes (zero React commits per tick); settled agents freeze at completedAt.
+ * Idle is resumable and carries no end stamp of its own, so its last update is
+ * the closest end signal we have. Without it the label measures against the
+ * current time and climbs forever.
  */
 function AgentElapsed({ agent }: { agent: RuntimeSubagent }) {
   const textRef = useRef<HTMLSpanElement>(null);
   const live = agent.status === "running" || agent.status === "waiting";
   const startedAt = agent.startedAt;
+  const settledEnd = agent.status === "idle" ? agent.updatedAt : agent.completedAt;
+  const endedAt = live ? null : settledEnd;
 
   useEffect(() => {
     if (!live || !startedAt) {
@@ -107,7 +112,7 @@ function AgentElapsed({ agent }: { agent: RuntimeSubagent }) {
   }
   return (
     <span ref={textRef} className="tabular-nums">
-      {elapsedBetween(startedAt, live ? null : agent.completedAt)}
+      {elapsedBetween(startedAt, endedAt)}
     </span>
   );
 }


### PR DESCRIPTION
## What Changed

- Freeze the elapsed-time label for `idle` agents at the update that ended their activation.

## Why

An idle agent is resumable, so the idle transition never stamps a `completedAt`. `AgentElapsed` read the missing `completedAt` as "no end yet" and measured against the current time, so the label kept climbing on every render. An agent that ran for 30 seconds and went idle read `53m 05s` an hour later.

This is most visible with Codex subagents, where a normal turn end maps to `idle` (`CodexAdapter.ts`), so every resting child lands in this state.

## UI Changes

Same idle agent in both, one that actually ran for 30 seconds.

### Before
<img width="540" height="150" alt="Before-panel" src="https://github.com/user-attachments/assets/544ffae3-64c1-4a7c-8522-11ce54a5467f" />

https://github.com/user-attachments/assets/e655648c-8572-4e70-919d-4928742afe0e

### After
<img width="540" height="150" alt="After-panel" src="https://github.com/user-attachments/assets/8b5c3030-7da7-4f3c-9b50-7e2fc0954a9f" />

https://github.com/user-attachments/assets/18ded1e5-8128-4c54-bc8b-a8141fde8e4d

## Verification

- `vp run --filter @t3tools/web typecheck` — passed
- Targeted lint and formatting on the changed file
- Checked in an isolated T3 web environment against a seeded idle agent whose activation lasted 30 seconds. Before the fix the row read `53m 05s` and grew every time the panel re-rendered. After the fix it reads `30s` and stays there.
- Exercised a real idle to resume lifecycle. The resumed run is labelled `run 2` and its timer measures the new activation, which matches the existing per-activation model rather than accumulating across runs.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Generated with GPT-5.6 Sol (Codex harness) and Claude Opus 5 (Claude Code harness), both in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only fix to elapsed-time display for idle agents; no auth, data, or backend logic changes.
> 
> **Overview**
> **Freezes the elapsed-time label for idle agents** in `AgentElapsed`.
> 
> Idle is resumable, so it never gets a `completedAt`. The timer previously treated that as “still open” and measured against the current time, so labels kept growing on every render. Idle agents now use `updatedAt` as the end timestamp; live agents still tick, and other settled statuses still use `completedAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f91deef884e5b98a5c1c8e542f6c2b0bf017f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix idle agent elapsed timers freezing at `updatedAt` in AgentsPanel
> In [AgentsPanel.tsx](https://github.com/pingdotgg/t3code/pull/6256/files#diff-10464442e3a11a770b2b1a5718e7a452453347c492f6aa0533f267063e2c6494), the `AgentElapsed` component was falling back to the current time for idle agents because `completedAt` is unset, causing the elapsed timer to keep incrementing. The fix uses `agent.updatedAt` as the end timestamp for idle agents, and `agent.completedAt` for other settled statuses. Running and waiting agent behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f91dee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->