### PR TITLE
feat(web): a better right panel empty state

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -480,6 +480,14 @@ function shouldTypeToFocusComposer(event: KeyboardEvent): boolean {
   if (eventPathContainsSelector(event, TYPE_TO_FOCUS_INTERACTIVE_SELECTOR)) return false;
   if (document.querySelector(TYPE_TO_FOCUS_FLOATING_LAYER_SELECTOR)) return false;
 
+  // The right-panel surface launcher claims its shortcut letters while it is
+  // visible (data attribute set in RightPanelTabs); those keys open surfaces
+  // instead of typing into the composer.
+  const launcherKeys = document
+    .querySelector("[data-surface-launcher-keys]")
+    ?.getAttribute("data-surface-launcher-keys");
+  if (launcherKeys && launcherKeys.toLowerCase().includes(event.key.toLowerCase())) return false;
+
   return true;
 }
 

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -1,6 +1,8 @@
 import type { ContextMenuItem, PreviewSessionSnapshot, PullRequestState } from "@t3tools/contracts";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import {
+  ArrowDown,
+  ArrowUp,
   Bot,
   FileDiff,
   Files,
@@ -11,6 +13,7 @@ import {
   X,
 } from "lucide-react";
 import {
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactElement,
   type ReactNode,
@@ -25,6 +28,16 @@ import type { RightPanelSurface } from "~/rightPanelStore";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import {
+  Command,
+  CommandCollection,
+  CommandGroup,
+  CommandGroupLabel,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "~/components/ui/command";
+import { Kbd, KbdGroup } from "~/components/ui/kbd";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { faviconUrlForOrigin } from "~/lib/favicon";
@@ -118,6 +131,12 @@ function SurfaceMenuItem(props: {
   return <DisabledReasonTooltip reason={props.disabledReason} trigger={item} />;
 }
 
+/**
+ * Launcher shown when the right panel has no surfaces. Keyboard-first: the
+ * filter input autofocuses, arrows and Enter open the highlighted surface,
+ * and with an empty query a surface's shortcut letter opens it directly.
+ * Unavailable surfaces stay listed with their reason inline.
+ */
 function RightPanelEmptyState(props: {
   onAddBrowser: () => void;
   onAddTerminal: () => void;
@@ -133,11 +152,14 @@ function RightPanelEmptyState(props: {
   agentsAvailable: boolean;
   liveAgentCount: number;
 }) {
+  const [query, setQuery] = useState("");
+
   const actions = [
     {
       label: "Browser",
       description: "Open a local app or URL.",
       icon: Globe2,
+      shortcut: "B",
       available: props.browserAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.browser,
       onClick: props.onAddBrowser,
@@ -147,6 +169,7 @@ function RightPanelEmptyState(props: {
       label: "Terminal",
       description: "Start a shell in this workspace.",
       icon: TerminalSquare,
+      shortcut: "T",
       available: props.terminalAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.terminal,
       onClick: props.onAddTerminal,
@@ -156,6 +179,7 @@ function RightPanelEmptyState(props: {
       label: "Files",
       description: "Browse and read workspace files.",
       icon: Files,
+      shortcut: "F",
       available: props.filesAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.files,
       onClick: props.onAddFiles,
@@ -165,6 +189,7 @@ function RightPanelEmptyState(props: {
       label: "Diff",
       description: "Review changes in this thread.",
       icon: FileDiff,
+      shortcut: "D",
       available: props.diffAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.diff,
       onClick: props.onAddDiff,
@@ -174,6 +199,7 @@ function RightPanelEmptyState(props: {
       label: "Pull request",
       description: "Open the pull request for this thread's branch.",
       icon: GitPullRequest,
+      shortcut: "P",
       available: props.pullRequestAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.pullRequest,
       onClick: props.onAddPullRequest,
@@ -183,6 +209,7 @@ function RightPanelEmptyState(props: {
       label: "Agents",
       description: "Watch subagents and workflows run.",
       icon: Bot,
+      shortcut: "A",
       available: props.agentsAvailable,
       disabledReason: SURFACE_DISABLED_REASONS.agents,
       onClick: props.onAddAgents,
@@ -190,67 +217,129 @@ function RightPanelEmptyState(props: {
     },
   ] as const;
 
+  type SurfaceAction = (typeof actions)[number];
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const matchesQuery = (action: SurfaceAction) =>
+    action.label.toLowerCase().includes(normalizedQuery);
+  const availableActions = actions.filter((action) => action.available && matchesQuery(action));
+  const unavailableActions = actions.filter((action) => !action.available && matchesQuery(action));
+
+  const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape" && query.length > 0) {
+      event.preventDefault();
+      event.stopPropagation();
+      setQuery("");
+      return;
+    }
+    // Shortcut letters only fire on an empty query; once the user is
+    // filtering, every key belongs to the input.
+    if (query.length > 0 || event.metaKey || event.ctrlKey || event.altKey) return;
+    const action = availableActions.find(
+      (candidate) => candidate.shortcut.toLowerCase() === event.key.toLowerCase(),
+    );
+    if (!action) return;
+    event.preventDefault();
+    action.onClick();
+  };
+
+  const actionIcon = (action: SurfaceAction) => {
+    const Icon = action.icon;
+    return (
+      <span className="relative inline-flex shrink-0">
+        <Icon className="size-4 text-muted-foreground" />
+        {action.badgeCount > 0 ? (
+          <span
+            aria-hidden
+            className="absolute -top-1.5 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-info px-1 text-[9px] font-semibold tabular-nums text-white"
+          >
+            {action.badgeCount}
+          </span>
+        ) : null}
+      </span>
+    );
+  };
+
   return (
-    <div className="flex min-h-0 flex-1 items-center justify-center p-6">
-      <div className="w-full max-w-xl">
-        <div className="mb-5 text-center">
-          <h3 className="text-sm font-medium text-foreground">Open a surface</h3>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Choose what to show in the right panel.
-          </p>
-        </div>
-        <div className="grid grid-cols-2 gap-2">
-          {actions.map((action) => {
-            const Icon = action.icon;
-            const content = (
-              <>
-                <span className="relative mb-3 inline-flex">
-                  <Icon className="size-5" />
-                  {action.badgeCount > 0 ? (
-                    <span
-                      aria-hidden
-                      className="absolute -top-1.5 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-info px-1 text-[9px] font-semibold tabular-nums text-white"
+    <div className="flex min-h-0 flex-1 justify-center overflow-y-auto p-4">
+      <div className="mt-6 h-fit w-full max-w-xl overflow-hidden rounded-lg border border-border/80 bg-card sm:mt-16 dark:border-transparent dark:shadow-none dark:inset-ring-1 dark:inset-ring-white/5">
+        <Command aria-label="Open a surface" mode="none" value={query} onValueChange={setQuery}>
+          <CommandInput
+            placeholder="Open a surface"
+            wrapperClassName="border-b border-border/60"
+            onKeyDown={handleInputKeyDown}
+          />
+          <CommandList>
+            {availableActions.length === 0 && unavailableActions.length === 0 ? (
+              <div className="py-8 text-center text-muted-foreground text-sm">
+                No matching surfaces.
+              </div>
+            ) : null}
+            {availableActions.length > 0 ? (
+              <CommandGroup items={availableActions}>
+                <CommandCollection>
+                  {(action: SurfaceAction) => (
+                    <CommandItem
+                      key={action.label}
+                      value={action.label}
+                      className="cursor-pointer gap-3"
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                      }}
+                      onClick={action.onClick}
                     >
-                      {action.badgeCount}
-                    </span>
-                  ) : null}
-                </span>
-                <span className="text-sm font-medium">{action.label}</span>
-                <span className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                  {action.description}
-                </span>
-              </>
-            );
-            if (action.available) {
-              return (
-                <button
-                  key={action.label}
-                  type="button"
-                  onClick={action.onClick}
-                  className="cursor-pointer flex min-h-28 w-full flex-col items-start rounded-lg border border-border/80 bg-card p-4 text-left transition hover:border-border hover:bg-accent/60 dark:border-transparent dark:shadow-none dark:inset-ring-1 dark:inset-ring-white/5"
-                >
-                  {content}
-                </button>
-              );
-            }
-            const disabledCard = (
-              <button
-                type="button"
-                className="flex min-h-28 w-full cursor-not-allowed flex-col items-start rounded-lg border border-border/80 bg-card p-4 text-left opacity-40 dark:border-transparent dark:shadow-none dark:inset-ring-1 dark:inset-ring-white/5"
-                aria-disabled="true"
-              >
-                {content}
-              </button>
-            );
-            return (
-              <DisabledReasonTooltip
-                key={action.label}
-                reason={action.disabledReason}
-                trigger={disabledCard}
-              />
-            );
-          })}
-        </div>
+                      {actionIcon(action)}
+                      <span className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate text-foreground text-sm">{action.label}</span>
+                        <span className="truncate text-muted-foreground/70 text-xs">
+                          {action.description}
+                        </span>
+                      </span>
+                      <Kbd>{action.shortcut}</Kbd>
+                    </CommandItem>
+                  )}
+                </CommandCollection>
+              </CommandGroup>
+            ) : null}
+            {unavailableActions.length > 0 ? (
+              <CommandGroup items={unavailableActions}>
+                <CommandGroupLabel>Unavailable</CommandGroupLabel>
+                <CommandCollection>
+                  {(action: SurfaceAction) => (
+                    <div
+                      key={action.label}
+                      className="flex select-none items-start gap-3 rounded-sm px-2 py-1.5 opacity-64"
+                    >
+                      <span className="mt-0.5">{actionIcon(action)}</span>
+                      <span className="flex min-w-0 flex-1 flex-col">
+                        <span className="text-foreground text-sm">{action.label}</span>
+                        <span className="text-muted-foreground/70 text-xs">
+                          {action.disabledReason}
+                        </span>
+                      </span>
+                    </div>
+                  )}
+                </CommandCollection>
+              </CommandGroup>
+            ) : null}
+          </CommandList>
+          <div className="flex flex-wrap items-center gap-3 border-t border-border/60 px-3 py-2 text-muted-foreground text-xs">
+            <KbdGroup className="items-center gap-1.5">
+              <Kbd>
+                <ArrowUp />
+              </Kbd>
+              <Kbd>
+                <ArrowDown />
+              </Kbd>
+              <span>Navigate</span>
+            </KbdGroup>
+            <KbdGroup className="items-center gap-1.5">
+              <Kbd>Enter</Kbd>
+              <span>Open</span>
+            </KbdGroup>
+            <span>Letter opens directly</span>
+          </div>
+        </Command>
       </div>
     </div>
   );

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -90,6 +90,16 @@ const SURFACE_DISABLED_REASONS = {
   agents: "Agents are only available from a thread.",
 } as const;
 
+/** Overlays that must win over the launcher's letter shortcuts. */
+const LAUNCHER_SHORTCUT_BLOCKING_LAYERS = [
+  '[data-slot="dialog"]',
+  '[data-slot="menu-popup"]',
+  '[data-slot="select-popup"]',
+  '[data-slot="popover-popup"]',
+  '[data-slot="combobox-popup"]',
+  '[data-slot="autocomplete-popup"]',
+].join(",");
+
 /** One-line unavailability hints for the empty-state cards. */
 const SURFACE_UNAVAILABLE_HINTS = {
   browser: "Only available in the desktop app.",
@@ -234,7 +244,9 @@ function RightPanelEmptyState(props: {
   });
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
-      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+      if (event.defaultPrevented || event.isComposing) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (document.querySelector(LAUNCHER_SHORTCUT_BLOCKING_LAYERS)) return;
       const target = event.target;
       if (target instanceof HTMLElement) {
         if (target.closest("input, textarea, select")) return;
@@ -273,6 +285,9 @@ function RightPanelEmptyState(props: {
       return;
     }
     if (event.key === "Enter") {
+      // A focused card button owns its own activation; only open from the
+      // highlight when the container itself has focus.
+      if (event.target instanceof HTMLElement && event.target.closest("button")) return;
       const action = availableActions[highlightIndex];
       if (!action) return;
       event.preventDefault();
@@ -280,9 +295,11 @@ function RightPanelEmptyState(props: {
     }
   };
 
-  const focusOnMount = (node: HTMLDivElement | null) => {
+  // Stable identity so React only runs this callback ref on mount/unmount;
+  // an inline arrow would re-attach and re-focus on every render.
+  const focusOnMount = useCallback((node: HTMLDivElement | null) => {
     node?.focus();
-  };
+  }, []);
 
   const isHighlighted = (action: SurfaceAction) =>
     highlightIndex !== -1 && availableActions[highlightIndex] === action;

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -323,7 +323,7 @@ function RightPanelEmptyState(props: {
               </CommandGroup>
             ) : null}
           </CommandList>
-          <div className="flex flex-wrap items-center gap-3 border-t border-border/60 px-3 py-2 text-muted-foreground text-xs">
+          <div className="flex items-center gap-3 border-t border-border/60 px-3 py-2 text-muted-foreground text-xs">
             <KbdGroup className="items-center gap-1.5">
               <Kbd>
                 <ArrowUp />
@@ -337,7 +337,6 @@ function RightPanelEmptyState(props: {
               <Kbd>Enter</Kbd>
               <span>Open</span>
             </KbdGroup>
-            <span>Letter opens directly</span>
           </div>
         </Command>
       </div>

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -1,8 +1,6 @@
 import type { ContextMenuItem, PreviewSessionSnapshot, PullRequestState } from "@t3tools/contracts";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import {
-  ArrowDown,
-  ArrowUp,
   Bot,
   FileDiff,
   Files,
@@ -28,16 +26,7 @@ import type { RightPanelSurface } from "~/rightPanelStore";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
-import {
-  Command,
-  CommandCollection,
-  CommandGroup,
-  CommandGroupLabel,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "~/components/ui/command";
-import { Kbd, KbdGroup } from "~/components/ui/kbd";
+import { Kbd } from "~/components/ui/kbd";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { faviconUrlForOrigin } from "~/lib/favicon";
@@ -101,6 +90,16 @@ const SURFACE_DISABLED_REASONS = {
   agents: "Agents are only available from a thread.",
 } as const;
 
+/** One-line unavailability hints for the empty-state cards. */
+const SURFACE_UNAVAILABLE_HINTS = {
+  browser: "Only available in the desktop app.",
+  terminal: "Available when a project is open.",
+  files: "Available when a project is open.",
+  diff: "Available for Git repositories.",
+  pullRequest: "No pull request on this branch yet.",
+  agents: "Available from a thread.",
+} as const;
+
 type TabContextMenuAction = "copy-path" | "close" | "close-others" | "close-to-right" | "close-all";
 
 function DisabledReasonTooltip(props: { reason: string; trigger: ReactElement }) {
@@ -132,10 +131,11 @@ function SurfaceMenuItem(props: {
 }
 
 /**
- * Launcher shown when the right panel has no surfaces. Keyboard-first: the
- * filter input autofocuses, arrows and Enter open the highlighted surface,
- * and with an empty query a surface's shortcut letter opens it directly.
- * Unavailable surfaces stay listed with their reason inline.
+ * Card launcher shown when the right panel has no surfaces. Keyboard-first
+ * without palette chrome: a surface's letter opens it directly from anywhere
+ * outside a typing context, and arrows plus Enter work while the launcher is
+ * focused. The highlight only appears on hover or arrow use. Unavailable
+ * surfaces stay visible with a one-line reason.
  */
 function RightPanelEmptyState(props: {
   onAddBrowser: () => void;
@@ -152,7 +152,8 @@ function RightPanelEmptyState(props: {
   agentsAvailable: boolean;
   liveAgentCount: number;
 }) {
-  const [query, setQuery] = useState("");
+  // -1 means no highlight: it only appears on hover or arrow use.
+  const [highlight, setHighlight] = useState(-1);
 
   const actions = [
     {
@@ -161,7 +162,7 @@ function RightPanelEmptyState(props: {
       icon: Globe2,
       shortcut: "B",
       available: props.browserAvailable,
-      disabledReason: SURFACE_DISABLED_REASONS.browser,
+      disabledReason: SURFACE_UNAVAILABLE_HINTS.browser,
       onClick: props.onAddBrowser,
       badgeCount: 0,
     },
@@ -171,7 +172,7 @@ function RightPanelEmptyState(props: {
       icon: TerminalSquare,
       shortcut: "T",
       available: props.terminalAvailable,
-      disabledReason: SURFACE_DISABLED_REASONS.terminal,
+      disabledReason: SURFACE_UNAVAILABLE_HINTS.terminal,
       onClick: props.onAddTerminal,
       badgeCount: 0,
     },
@@ -181,7 +182,7 @@ function RightPanelEmptyState(props: {
       icon: Files,
       shortcut: "F",
       available: props.filesAvailable,
-      disabledReason: SURFACE_DISABLED_REASONS.files,
+      disabledReason: SURFACE_UNAVAILABLE_HINTS.files,
       onClick: props.onAddFiles,
       badgeCount: 0,
     },
@@ -191,27 +192,27 @@ function RightPanelEmptyState(props: {
       icon: FileDiff,
       shortcut: "D",
       available: props.diffAvailable,
-      disabledReason: SURFACE_DISABLED_REASONS.diff,
+      disabledReason: SURFACE_UNAVAILABLE_HINTS.diff,
       onClick: props.onAddDiff,
       badgeCount: 0,
     },
     {
       label: "Pull request",
-      description: "Open the pull request for this thread's branch.",
+      description: "Open this branch's pull request.",
       icon: GitPullRequest,
       shortcut: "P",
       available: props.pullRequestAvailable,
-      disabledReason: SURFACE_DISABLED_REASONS.pullRequest,
+      disabledReason: SURFACE_UNAVAILABLE_HINTS.pullRequest,
       onClick: props.onAddPullRequest,
       badgeCount: 0,
     },
     {
       label: "Agents",
-      description: "Watch subagents and workflows run.",
+      description: "Follow subagents and workflows.",
       icon: Bot,
       shortcut: "A",
       available: props.agentsAvailable,
-      disabledReason: SURFACE_DISABLED_REASONS.agents,
+      disabledReason: SURFACE_UNAVAILABLE_HINTS.agents,
       onClick: props.onAddAgents,
       badgeCount: props.liveAgentCount,
     },
@@ -219,35 +220,78 @@ function RightPanelEmptyState(props: {
 
   type SurfaceAction = (typeof actions)[number];
 
-  const normalizedQuery = query.trim().toLowerCase();
-  const matchesQuery = (action: SurfaceAction) =>
-    action.label.toLowerCase().includes(normalizedQuery);
-  const availableActions = actions.filter((action) => action.available && matchesQuery(action));
-  const unavailableActions = actions.filter((action) => !action.available && matchesQuery(action));
+  const availableActions = actions.filter((action) => action.available);
+  const highlightIndex =
+    availableActions.length === 0 ? -1 : Math.min(highlight, availableActions.length - 1);
 
-  const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Escape" && query.length > 0) {
+  // Letter shortcuts work while the launcher is visible, not only while it
+  // is focused; focus moves around too easily (stray clicks) to carry them.
+  // Capture phase so app-level key handlers cannot swallow the event first;
+  // typing contexts and already-handled events are left alone.
+  const shortcutActionsRef = useRef(availableActions);
+  useEffect(() => {
+    shortcutActionsRef.current = availableActions;
+  });
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        if (target.closest("input, textarea, select")) return;
+        // An empty contenteditable (the chat composer at rest) does not
+        // count as typing; letters only become text once a draft exists.
+        const editable = target.isContentEditable ? target : target.closest("[contenteditable]");
+        if (editable && (editable.textContent ?? "").trim().length > 0) return;
+      }
+      const action = shortcutActionsRef.current.find(
+        (candidate) => candidate.shortcut.toLowerCase() === event.key.toLowerCase(),
+      );
+      if (!action) return;
       event.preventDefault();
       event.stopPropagation();
-      setQuery("");
+      action.onClick();
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, []);
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+    if (availableActions.length === 0) return;
+    if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+      event.preventDefault();
+      setHighlight((highlightIndex + 1) % availableActions.length);
       return;
     }
-    // Shortcut letters only fire while the effective query is empty; once
-    // the user is filtering, every key belongs to the input.
-    if (normalizedQuery.length > 0 || event.metaKey || event.ctrlKey || event.altKey) return;
-    const action = availableActions.find(
-      (candidate) => candidate.shortcut.toLowerCase() === event.key.toLowerCase(),
-    );
-    if (!action) return;
-    event.preventDefault();
-    action.onClick();
+    if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+      event.preventDefault();
+      setHighlight(
+        highlightIndex === -1
+          ? availableActions.length - 1
+          : (highlightIndex - 1 + availableActions.length) % availableActions.length,
+      );
+      return;
+    }
+    if (event.key === "Enter") {
+      const action = availableActions[highlightIndex];
+      if (!action) return;
+      event.preventDefault();
+      action.onClick();
+    }
   };
 
-  const actionIcon = (action: SurfaceAction) => {
+  const focusOnMount = (node: HTMLDivElement | null) => {
+    node?.focus();
+  };
+
+  const isHighlighted = (action: SurfaceAction) =>
+    highlightIndex !== -1 && availableActions[highlightIndex] === action;
+
+  const actionIcon = (action: SurfaceAction, iconClassName = "size-4") => {
     const Icon = action.icon;
     return (
       <span className="relative inline-flex shrink-0">
-        <Icon className="size-4 text-muted-foreground" />
+        <Icon className={iconClassName} />
         {action.badgeCount > 0 ? (
           <span
             aria-hidden
@@ -260,85 +304,79 @@ function RightPanelEmptyState(props: {
     );
   };
 
+  const cardShellClass =
+    "rounded-lg border border-border/80 bg-card dark:border-transparent dark:shadow-none dark:inset-ring-1 dark:inset-ring-white/5";
+  const highlightedCardClass = "bg-accent/60 dark:inset-ring-white/20";
+
   return (
-    <div className="flex min-h-0 flex-1 justify-center overflow-y-auto p-4">
-      <div className="mt-6 h-fit w-full max-w-xl overflow-hidden rounded-lg border border-border/80 bg-card sm:mt-16 dark:border-transparent dark:shadow-none dark:inset-ring-1 dark:inset-ring-white/5">
-        <Command aria-label="Open a surface" mode="none" value={query} onValueChange={setQuery}>
-          <CommandInput
-            placeholder="Open a surface"
-            wrapperClassName="border-b border-border/60"
-            onKeyDown={handleInputKeyDown}
-          />
-          <CommandList>
-            {availableActions.length === 0 && unavailableActions.length === 0 ? (
-              <div className="py-8 text-center text-muted-foreground text-sm">
-                No matching surfaces.
+    <div
+      ref={focusOnMount}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      aria-label="Open a surface"
+      data-surface-launcher-keys={availableActions.map((action) => action.shortcut).join("")}
+      className={cn(
+        "flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-6 pt-6 outline-none",
+        // The panel topbar sits above this container; matching bottom padding
+        // keeps the cards centered against the full panel, not the leftover.
+        "pb-[calc(var(--workspace-topbar-height)+--spacing(6))]",
+      )}
+    >
+      <div className="relative w-full max-w-lg">
+        <div className="absolute inset-x-0 bottom-full mb-5 text-center">
+          <h3 className="font-medium text-foreground text-sm">Open a surface</h3>
+          <p className="mt-1 text-muted-foreground text-xs">
+            Choose what to show in the right panel.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          {actions.map((action) =>
+            action.available ? (
+              <button
+                key={action.label}
+                type="button"
+                onClick={action.onClick}
+                onMouseEnter={() => setHighlight(availableActions.indexOf(action))}
+                onMouseLeave={() =>
+                  setHighlight((current) =>
+                    current === availableActions.indexOf(action) ? -1 : current,
+                  )
+                }
+                className={cn(
+                  "relative flex w-full cursor-pointer flex-col items-start p-4 text-left transition hover:border-border hover:bg-accent/60",
+                  cardShellClass,
+                  isHighlighted(action) && highlightedCardClass,
+                )}
+              >
+                <Kbd className="absolute top-3 right-3">{action.shortcut}</Kbd>
+                <span className="flex items-center gap-2 pe-8">
+                  {actionIcon(action)}
+                  <span className="font-medium text-sm">{action.label}</span>
+                </span>
+                <span className="mt-1.5 text-muted-foreground text-xs leading-relaxed">
+                  {action.description}
+                </span>
+              </button>
+            ) : (
+              <div
+                key={action.label}
+                className={cn(
+                  "relative flex w-full flex-col items-start p-4 opacity-40",
+                  cardShellClass,
+                )}
+              >
+                <Kbd className="absolute top-3 right-3">{action.shortcut}</Kbd>
+                <span className="flex items-center gap-2 pe-8">
+                  {actionIcon(action)}
+                  <span className="font-medium text-sm">{action.label}</span>
+                </span>
+                <span className="mt-1.5 text-muted-foreground text-xs leading-relaxed">
+                  {action.disabledReason}
+                </span>
               </div>
-            ) : null}
-            {availableActions.length > 0 ? (
-              <CommandGroup items={availableActions}>
-                <CommandCollection>
-                  {(action: SurfaceAction) => (
-                    <CommandItem
-                      key={action.label}
-                      value={action.label}
-                      className="cursor-pointer gap-3"
-                      onMouseDown={(event) => {
-                        event.preventDefault();
-                      }}
-                      onClick={action.onClick}
-                    >
-                      {actionIcon(action)}
-                      <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="truncate text-foreground text-sm">{action.label}</span>
-                        <span className="truncate text-muted-foreground/70 text-xs">
-                          {action.description}
-                        </span>
-                      </span>
-                      <Kbd>{action.shortcut}</Kbd>
-                    </CommandItem>
-                  )}
-                </CommandCollection>
-              </CommandGroup>
-            ) : null}
-            {unavailableActions.length > 0 ? (
-              <CommandGroup items={unavailableActions}>
-                <CommandGroupLabel>Unavailable</CommandGroupLabel>
-                <CommandCollection>
-                  {(action: SurfaceAction) => (
-                    <div
-                      key={action.label}
-                      className="flex select-none items-start gap-3 rounded-sm px-2 py-1.5 opacity-64"
-                    >
-                      <span className="mt-0.5">{actionIcon(action)}</span>
-                      <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="text-foreground text-sm">{action.label}</span>
-                        <span className="text-muted-foreground/70 text-xs">
-                          {action.disabledReason}
-                        </span>
-                      </span>
-                    </div>
-                  )}
-                </CommandCollection>
-              </CommandGroup>
-            ) : null}
-          </CommandList>
-          <div className="flex items-center gap-3 border-t border-border/60 px-3 py-2 text-muted-foreground text-xs">
-            <KbdGroup className="items-center gap-1.5">
-              <Kbd>
-                <ArrowUp />
-              </Kbd>
-              <Kbd>
-                <ArrowDown />
-              </Kbd>
-              <span>Navigate</span>
-            </KbdGroup>
-            <KbdGroup className="items-center gap-1.5">
-              <Kbd>Enter</Kbd>
-              <span>Open</span>
-            </KbdGroup>
-          </div>
-        </Command>
+            ),
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -232,9 +232,9 @@ function RightPanelEmptyState(props: {
       setQuery("");
       return;
     }
-    // Shortcut letters only fire on an empty query; once the user is
-    // filtering, every key belongs to the input.
-    if (query.length > 0 || event.metaKey || event.ctrlKey || event.altKey) return;
+    // Shortcut letters only fire while the effective query is empty; once
+    // the user is filtering, every key belongs to the input.
+    if (normalizedQuery.length > 0 || event.metaKey || event.ctrlKey || event.altKey) return;
     const action = availableActions.find(
       (candidate) => candidate.shortcut.toLowerCase() === event.key.toLowerCase(),
     );

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -92,7 +92,9 @@ const SURFACE_DISABLED_REASONS = {
 
 /** Overlays that must win over the launcher's letter shortcuts. */
 const LAUNCHER_SHORTCUT_BLOCKING_LAYERS = [
-  '[data-slot="dialog"]',
+  '[data-slot="dialog-popup"]',
+  '[data-slot="alert-dialog-popup"]',
+  '[data-slot="command-dialog-popup"]',
   '[data-slot="menu-popup"]',
   '[data-slot="select-popup"]',
   '[data-slot="popover-popup"]',


### PR DESCRIPTION
The right panel's "Open a surface" empty state was easy to bounce off: a static grid where disabled cards only explained themselves through a hover tooltip, every option carried identical weight, and the layout sat visibly off-center in the panel.

This reworks the empty state into a cleaner card launcher:

- Cards keep their icon and label on one line with a one-line description, so each card is exactly as tall as its content.
- Unavailable surfaces stay in place, dimmed, with the reason written inline ("Only available in the desktop app.") instead of behind a tooltip.
- Every card shows its shortcut letter; pressing it opens the surface directly. The chat composer's type-to-focus behavior yields those letters only while the launcher is visible and the draft is empty, so typing is never hijacked.
- Arrow keys plus Enter also work; the highlight appears only on hover or arrow use, so nothing looks pre-selected.
- The grid now centers against the full panel (the always-present topbar row previously pushed it down), with the title floating above.

## Before

![before](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/05b71edb-b616-42bb-9ffa-ddc87cf3dc2e/open-surface-before.png)

## After

![after](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/7d486126-3099-4a0e-a3b7-f3a86f807903/open-surface-cards.png)

### Hover highlight

![hover](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/e61253dc-f6b3-4e43-a3d6-70a6dab3b604/open-surface-cards-hover.png)

### Maximized panel

![maximized](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/c748cf35-44d8-4a47-be7d-39e75d91eb46/open-surface-cards-maximized.png)

Verified in a live browser session: shortcut letters fire with the composer focused on an empty draft, letters type normally once a draft has content, hover and arrow highlighting, and Enter opening the highlighted surface. `tsgo --noEmit` and `vp lint` clean on the touched files.

Built by Claude Fable 5 running in Claude Code.
