### PR TITLE
fix(shared): prefer Windows PowerShell 5.1 over optional pwsh

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -8,6 +8,8 @@ import * as Schema from "effect/Schema";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
+import { WINDOWS_POWERSHELL_CANDIDATES } from "@t3tools/shared/shell";
+
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 
 type EnvironmentPatch = Record<string, string>;
@@ -84,7 +86,7 @@ const LOGIN_SHELL_ENV_NAMES = [
   "WAYLAND_DISPLAY",
 ] as const;
 const WINDOWS_PROFILE_ENV_NAMES = ["PATH", "FNM_DIR", "FNM_MULTISHELL_PATH"] as const;
-const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
+const WINDOWS_SHELL_CANDIDATES = WINDOWS_POWERSHELL_CANDIDATES;
 const LOGIN_SHELL_TIMEOUT = Duration.seconds(5);
 const LAUNCHCTL_TIMEOUT = Duration.seconds(2);
 const PROCESS_TERMINATE_GRACE = Duration.seconds(1);

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -785,7 +785,7 @@ function splitExecutableAndRest(value: string): { executable: string; rest: stri
 
 const SHELL_WRAPPER_SPECS = [
   {
-    executables: ["pwsh", "pwsh.exe", "powershell", "powershell.exe"],
+    executables: ["powershell", "powershell.exe", "pwsh", "pwsh.exe"],
     wrapperFlagPattern: /(?:^|\s)-command\s+/i,
   },
   {

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1298,12 +1298,17 @@ it.layer(
 
       if (platform === "win32") {
         expect(
-          ptyAdapter.spawnInputs.some(
-            (input) =>
-              input.shell === "pwsh.exe" ||
-              input.shell === "powershell.exe" ||
-              input.shell === "cmd.exe",
-          ),
+          ptyAdapter.spawnInputs.some((input) => {
+            const shell = input.shell.toLowerCase();
+            return (
+              shell === "pwsh.exe" ||
+              shell === "powershell.exe" ||
+              shell === "cmd.exe" ||
+              shell.endsWith("\\powershell.exe") ||
+              shell.endsWith("\\pwsh.exe") ||
+              shell.endsWith("\\cmd.exe")
+            );
+          }),
         ).toBe(true);
       } else {
         expect(
@@ -1315,7 +1320,7 @@ it.layer(
     }),
   );
 
-  it.effect("prefers PowerShell over ComSpec for Windows terminals", () =>
+  it.effect("prefers Windows PowerShell 5.1 over ComSpec for Windows terminals", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager(5, {
         env: {
@@ -1329,7 +1334,7 @@ it.layer(
 
       expect(ptyAdapter.spawnInputs[0]).toEqual(
         expect.objectContaining({
-          shell: "pwsh.exe",
+          shell: "powershell.exe",
           args: ["-NoLogo"],
         }),
       );
@@ -1348,20 +1353,15 @@ it.layer(
           SystemRoot: "C:\\Windows",
         },
       }).pipe(Effect.provide(withHostPlatform("win32")));
-      ptyAdapter.spawnFailures.push(
-        new Error("spawn custom-shell.exe ENOENT"),
-        new Error("spawn pwsh.exe ENOENT"),
-      );
+      ptyAdapter.spawnFailures.push(new Error("spawn custom-shell.exe ENOENT"));
 
       yield* manager.open(openInput());
 
       expect(ptyAdapter.spawnInputs.map((input) => input.shell)).toEqual([
         "C:\\missing\\custom-shell.exe",
-        "pwsh.exe",
         "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
       ]);
       expect(ptyAdapter.spawnInputs[1]?.args).toEqual(["-NoLogo"]);
-      expect(ptyAdapter.spawnInputs[2]?.args).toEqual(["-NoLogo"]);
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -438,7 +438,7 @@ function enqueueProcessEvent(
 
 function defaultShellResolver(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
   if (platform === "win32") {
-    return "pwsh.exe";
+    return "powershell.exe";
   }
   return env.SHELL ?? "bash";
 }
@@ -543,9 +543,9 @@ function resolveShellCandidates(
   if (platform === "win32") {
     return uniqueShellCandidates([
       requested,
-      shellCandidateFromCommand("pwsh.exe", platform),
       shellCandidateFromCommand(windowsPowerShellPath(env), platform),
       shellCandidateFromCommand("powershell.exe", platform),
+      shellCandidateFromCommand("pwsh.exe", platform),
       shellCandidateFromCommand(env.ComSpec ?? null, platform),
       shellCandidateFromCommand(windowsCmdPath(env), platform),
       shellCandidateFromCommand("cmd.exe", platform),
@@ -633,9 +633,9 @@ function windowsInspectSubprocess(
   return Effect.gen(function* () {
     const processRunner = yield* ProcessRunner.ProcessRunner;
     return yield* processRunner.run({
-      // powershell.exe is a real executable — never spawn it through cmd.exe
-      // shell mode, which would re-tokenize the `-Command` payload (pipes,
-      // semicolons) before PowerShell ever sees it.
+      // Windows PowerShell 5.1 is a real executable — never spawn it through
+      // cmd.exe shell mode, which would re-tokenize the `-Command` payload
+      // (pipes, semicolons) before PowerShell ever sees it.
       command: "powershell.exe",
       args: ["-NoProfile", "-NonInteractive", "-Command", command],
       timeout: "1500 millis",

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1184,7 +1184,7 @@ function splitExecutableAndRest(value: string): { executable: string; rest: stri
 
 const SHELL_WRAPPER_SPECS = [
   {
-    executables: ["pwsh", "pwsh.exe", "powershell", "powershell.exe"],
+    executables: ["powershell", "powershell.exe", "pwsh", "pwsh.exe"],
     wrapperFlagPattern: /(?:^|\s)-command\s+/i,
   },
   {

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -21,6 +21,7 @@ import {
   resolveSpawnCommand,
   resolveWindowsEnvironment,
   SpawnExecutableResolution,
+  WINDOWS_POWERSHELL_CANDIDATES,
   WindowsShellEnvironment,
   type WindowsShellEnvironmentReader,
 } from "./shell.ts";
@@ -215,6 +216,12 @@ describe("mergePathEntries", () => {
   });
 });
 
+describe("WINDOWS_POWERSHELL_CANDIDATES", () => {
+  it("tries Windows PowerShell 5.1 before pwsh", () => {
+    expect(WINDOWS_POWERSHELL_CANDIDATES).toEqual(["powershell.exe", "pwsh.exe"]);
+  });
+});
+
 describe("readEnvironmentFromWindowsShell", () => {
   it("extracts environment variables from a PowerShell command", () => {
     const execFile = vi.fn<
@@ -232,7 +239,7 @@ describe("readEnvironmentFromWindowsShell", () => {
       PATH: "C:\\Users\\testuser\\AppData\\Roaming\\npm",
     });
     expect(execFile).toHaveBeenCalledWith(
-      "pwsh.exe",
+      "powershell.exe",
       expect.arrayContaining(["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]),
       { encoding: "utf8", timeout: 5000 },
     );
@@ -268,14 +275,14 @@ describe("readEnvironmentFromWindowsShell", () => {
       PATH: "C:\\Tools",
     });
     expect(execFile).toHaveBeenCalledWith(
-      "pwsh.exe",
+      "powershell.exe",
       expect.arrayContaining(["-NoLogo", "-NonInteractive", "-Command"]),
       { encoding: "utf8", timeout: 5000 },
     );
     expect(execFile.mock.calls[0]?.[1]).not.toContain("-NoProfile");
   });
 
-  it("falls back to Windows PowerShell when pwsh.exe is unavailable", () => {
+  it("falls back to PowerShell 7 when Windows PowerShell 5.1 is unavailable", () => {
     const execFile = vi.fn<
       (
         file: string,
@@ -283,8 +290,8 @@ describe("readEnvironmentFromWindowsShell", () => {
         options: { encoding: "utf8"; timeout: number },
       ) => string
     >((file) => {
-      if (file === "pwsh.exe") {
-        throw new Error("spawn pwsh.exe ENOENT");
+      if (file === "powershell.exe") {
+        throw new Error("spawn powershell.exe ENOENT");
       }
       return "__T3CODE_ENV_PATH_START__\nC:\\Tools\n__T3CODE_ENV_PATH_END__\n";
     });
@@ -292,11 +299,11 @@ describe("readEnvironmentFromWindowsShell", () => {
     expect(readEnvironmentFromWindowsShell(["PATH"], execFile)).toEqual({
       PATH: "C:\\Tools",
     });
-    expect(execFile).toHaveBeenNthCalledWith(1, "pwsh.exe", expect.any(Array), {
+    expect(execFile).toHaveBeenNthCalledWith(1, "powershell.exe", expect.any(Array), {
       encoding: "utf8",
       timeout: 5000,
     });
-    expect(execFile).toHaveBeenNthCalledWith(2, "powershell.exe", expect.any(Array), {
+    expect(execFile).toHaveBeenNthCalledWith(2, "pwsh.exe", expect.any(Array), {
       encoding: "utf8",
       timeout: 5000,
     });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -17,7 +17,10 @@ const PATH_CAPTURE_END = "__T3CODE_PATH_END__";
 const SHELL_ENV_NAME_PATTERN = /^[A-Z0-9_]+$/;
 const WINDOWS_PATH_DELIMITER = ";";
 const POSIX_PATH_DELIMITER = ":";
-const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
+
+// Windows PowerShell 5.1 first (always present); pwsh only as fallback.
+// Probe scripts must stay 5.1-compatible either way.
+export const WINDOWS_POWERSHELL_CANDIDATES = ["powershell.exe", "pwsh.exe"] as const;
 
 type ExecFileSyncLike = (
   file: string,
@@ -381,7 +384,7 @@ export function readEnvironmentFromWindowsShell(
     "-Command",
     command,
   ];
-  for (const shell of WINDOWS_SHELL_CANDIDATES) {
+  for (const shell of WINDOWS_POWERSHELL_CANDIDATES) {
     try {
       const output = execFile(shell, args, { encoding: "utf8", timeout: 5000 });
 


### PR DESCRIPTION
## Problem

On Windows, shell env probes preferred `pwsh` first. That skips the PowerShell every Windows install already has (5.1 / `powershell.exe`) and makes tooling depend on an optional install.

## Fix

Try `powershell.exe` first, then `pwsh.exe`. Share one candidate list from `shared/shell` so desktop hydration and terminal fallback follow the same order.

## Verification

In-app T3 Terminal on this branch (not the agent outer shell):

- `System.Collections.Hashtable.PSVersion` → 5.1.26100.8655
- `(Get-Process -Id $PID).Path` → `C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe`

## Test plan

- [x] Focused shared/shell + terminal Manager tests
- [x] Live in-app Terminal on Windows confirms 5.1 / powershell.exe
- [ ] CI

---

Model: Grok 4.5 · Harness: Grok Build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Windows shell used for terminals and environment probing, which can affect Windows startup and shell behavior. Fallback to pwsh/cmd remains, so risk is moderate rather than high.
> 
> **Overview**
> **Prefers built-in Windows PowerShell 5.1 (`powershell.exe`) over optional PowerShell 7 (`pwsh.exe`)** for Windows shell env probes and terminal startup.
> 
> Exports a shared `WINDOWS_POWERSHELL_CANDIDATES` list from `shared/shell` and uses it in desktop env hydration. Terminal fallback order now tries the absolute 5.1 path / `powershell.exe` before `pwsh.exe`, so Windows installs no longer depend on an optional `pwsh` install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99da444ba9cd4955f4fbd1fb3c815710d81e1f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer Windows PowerShell 5.1 (`powershell.exe`) over `pwsh` for shell resolution on Windows
> - Changes the Windows shell candidate order across the server, desktop, mobile, and web apps to try `powershell.exe` before `pwsh.exe`, since PowerShell 5.1 is built-in while `pwsh` is optional.
> - Introduces and exports `WINDOWS_POWERSHELL_CANDIDATES` from [`packages/shared/src/shell.ts`](https://github.com/pingdotgg/t3code/pull/6260/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) and uses it in [`apps/desktop/src/shell/DesktopShellEnvironment.ts`](https://github.com/pingdotgg/t3code/pull/6260/files#diff-ed26aa44c93ddc9fedab8bc7cf7aa64c7b0b8fc0e22a3960d5c02c30c940dabd) to replace local literals.
> - Updates `readEnvironmentFromWindowsShell` to probe `powershell.exe` first, falling back to `pwsh.exe`.
> - Behavioral Change: Windows terminals now default to `powershell.exe` instead of `pwsh.exe`; systems where only `pwsh` is installed will fall back correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99da444.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->