### PR TITLE
fix(web): open automation previews in thread browser panel

### DIFF
--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -65,6 +65,7 @@ import {
 } from "./previewNavigationReadiness";
 import { createPreviewAutomationRequestConsumerAtom } from "./previewAutomationRequestConsumer";
 import { createPreviewAutomationClientId } from "./previewAutomationClientId";
+import { reconcilePreviewRightPanelSurfaces } from "./reconcilePreviewRightPanelSurfaces";
 import {
   needsPreviewAutomationSessionSync,
   resolvePreviewAutomationOpenTab,
@@ -320,6 +321,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             return raiseAtomCommandFailure(result);
           }
           reconcilePreviewServerSessions(threadRef, result.value);
+          reconcilePreviewRightPanelSurfaces(threadRef);
           state = readThreadPreviewState(threadRef);
         }
         tabId = request.tabId ?? state.snapshot?.tabId ?? null;
@@ -428,6 +430,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 updatePreviewServerSnapshot(threadRef, resizeResult.value);
               }
             }
+            reconcilePreviewRightPanelSurfaces(threadRef);
             const shouldPresentPreview = shouldOpenPreviewMiniPlayer(input);
             if (shouldPresentPreview) {
               usePreviewMiniPlayerStore.getState().open(threadRef, activeTabId);

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -65,7 +65,10 @@ import {
 } from "./previewNavigationReadiness";
 import { createPreviewAutomationRequestConsumerAtom } from "./previewAutomationRequestConsumer";
 import { createPreviewAutomationClientId } from "./previewAutomationClientId";
-import { reconcilePreviewRightPanelSurfaces } from "./reconcilePreviewRightPanelSurfaces";
+import {
+  openPreviewRightPanelSurface,
+  reconcilePreviewRightPanelSurfaces,
+} from "./reconcilePreviewRightPanelSurfaces";
 import {
   needsPreviewAutomationSessionSync,
   resolvePreviewAutomationOpenTab,
@@ -433,7 +436,10 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             }
             const shouldPresentPreview = shouldOpenPreviewMiniPlayer(input);
             if (shouldPresentPreview) {
-              usePreviewMiniPlayerStore.getState().open(threadRef, activeTabId);
+              usePreviewMiniPlayerStore.getState().close(threadRef);
+              openPreviewRightPanelSurface(threadRef, activeTabId);
+            } else {
+              reconcilePreviewRightPanelSurfaces(threadRef);
             }
             if (activeSnapshot && previewAutomationOpenNeedsOverlay(input, activeSnapshot)) {
               await waitForDesktopOverlay(

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -393,6 +393,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               activeSnapshot = snapshot;
               tabId = activeTabId;
             }
+            reconcilePreviewRightPanelSurfaces(threadRef);
             const activeRuntimeTabId = previewRuntimeTabId(
               threadRef,
               readThreadPreviewState(threadRef).serverEpoch,
@@ -430,7 +431,6 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 updatePreviewServerSnapshot(threadRef, resizeResult.value);
               }
             }
-            reconcilePreviewRightPanelSurfaces(threadRef);
             const shouldPresentPreview = shouldOpenPreviewMiniPlayer(input);
             if (shouldPresentPreview) {
               usePreviewMiniPlayerStore.getState().open(threadRef, activeTabId);

--- a/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.test.ts
+++ b/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import {
   applyPreviewServerSnapshot,
+  readThreadPreviewState,
   reconcilePreviewServerSessions,
   resetPreviewStateForTests,
 } from "~/previewStateStore";
@@ -73,6 +74,7 @@ describe("reconcilePreviewRightPanelSurfaces", () => {
 
     openPreviewRightPanelSurface(threadRef, "tab-3");
 
+    expect(readThreadPreviewState(threadRef).activeTabId).toBe("tab-3");
     expect(
       selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, threadRef),
     ).toEqual({

--- a/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.test.ts
+++ b/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.test.ts
@@ -9,7 +9,10 @@ import {
 } from "~/previewStateStore";
 import { selectThreadRightPanelState, useRightPanelStore } from "~/rightPanelStore";
 
-import { reconcilePreviewRightPanelSurfaces } from "./reconcilePreviewRightPanelSurfaces";
+import {
+  openPreviewRightPanelSurface,
+  reconcilePreviewRightPanelSurfaces,
+} from "./reconcilePreviewRightPanelSurfaces";
 
 const threadRef = scopeThreadRef("env-1" as EnvironmentId, ThreadId.make("thread-1"));
 const serverEpoch = "server-epoch";
@@ -62,5 +65,23 @@ describe("reconcilePreviewRightPanelSurfaces", () => {
     expect(
       selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, threadRef).surfaces,
     ).toEqual([{ id: "browser:tab-3", kind: "preview", resourceId: "tab-3" }]);
+  });
+
+  it("opens and activates the requested automation tab for the user", () => {
+    applyPreviewServerSnapshot(threadRef, snapshot("tab-2"));
+    applyPreviewServerSnapshot(threadRef, snapshot("tab-3"));
+
+    openPreviewRightPanelSurface(threadRef, "tab-3");
+
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, threadRef),
+    ).toEqual({
+      isOpen: true,
+      activeSurfaceId: "browser:tab-3",
+      surfaces: [
+        { id: "browser:tab-2", kind: "preview", resourceId: "tab-2" },
+        { id: "browser:tab-3", kind: "preview", resourceId: "tab-3" },
+      ],
+    });
   });
 });

--- a/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.test.ts
+++ b/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.test.ts
@@ -1,0 +1,66 @@
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { type EnvironmentId, type PreviewSessionSnapshot, ThreadId } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  applyPreviewServerSnapshot,
+  reconcilePreviewServerSessions,
+  resetPreviewStateForTests,
+} from "~/previewStateStore";
+import { selectThreadRightPanelState, useRightPanelStore } from "~/rightPanelStore";
+
+import { reconcilePreviewRightPanelSurfaces } from "./reconcilePreviewRightPanelSurfaces";
+
+const threadRef = scopeThreadRef("env-1" as EnvironmentId, ThreadId.make("thread-1"));
+const serverEpoch = "server-epoch";
+
+const snapshot = (tabId: string): PreviewSessionSnapshot => ({
+  threadId: threadRef.threadId,
+  tabId,
+  navStatus: { _tag: "Idle" },
+  canGoBack: false,
+  canGoForward: false,
+  updatedAt: `2026-08-10T00:00:0${tabId.at(-1) ?? "0"}.000Z`,
+});
+
+beforeEach(() => {
+  resetPreviewStateForTests();
+  useRightPanelStore.setState({ byThreadKey: {} });
+});
+
+describe("reconcilePreviewRightPanelSurfaces", () => {
+  it("registers automation tabs without forcing the panel open", () => {
+    applyPreviewServerSnapshot(threadRef, snapshot("tab-2"));
+    applyPreviewServerSnapshot(threadRef, snapshot("tab-3"));
+
+    reconcilePreviewRightPanelSurfaces(threadRef);
+
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, threadRef),
+    ).toEqual({
+      isOpen: false,
+      activeSurfaceId: "browser:tab-2",
+      surfaces: [
+        { id: "browser:tab-2", kind: "preview", resourceId: "tab-2" },
+        { id: "browser:tab-3", kind: "preview", resourceId: "tab-3" },
+      ],
+    });
+  });
+
+  it("removes stale automation tabs after an authoritative session sync", () => {
+    applyPreviewServerSnapshot(threadRef, snapshot("tab-2"));
+    applyPreviewServerSnapshot(threadRef, snapshot("tab-3"));
+    reconcilePreviewRightPanelSurfaces(threadRef);
+
+    reconcilePreviewServerSessions(threadRef, {
+      sessions: [snapshot("tab-3")],
+      serverEpoch,
+      revision: 1,
+    });
+    reconcilePreviewRightPanelSurfaces(threadRef);
+
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, threadRef).surfaces,
+    ).toEqual([{ id: "browser:tab-3", kind: "preview", resourceId: "tab-3" }]);
+  });
+});

--- a/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.ts
+++ b/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.ts
@@ -1,6 +1,6 @@
 import type { ScopedThreadRef } from "@t3tools/contracts";
 
-import { readThreadPreviewState } from "~/previewStateStore";
+import { readThreadPreviewState, setActivePreviewTab } from "~/previewStateStore";
 import { useRightPanelStore } from "~/rightPanelStore";
 
 /** Keep automation-owned preview tabs recoverable from the thread's Browser surface. */
@@ -12,5 +12,6 @@ export function reconcilePreviewRightPanelSurfaces(threadRef: ScopedThreadRef): 
 /** Reveal an automation-owned tab in the thread's Browser panel. */
 export function openPreviewRightPanelSurface(threadRef: ScopedThreadRef, tabId: string): void {
   reconcilePreviewRightPanelSurfaces(threadRef);
+  setActivePreviewTab(threadRef, tabId);
   useRightPanelStore.getState().openBrowser(threadRef, tabId);
 }

--- a/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.ts
+++ b/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.ts
@@ -8,3 +8,9 @@ export function reconcilePreviewRightPanelSurfaces(threadRef: ScopedThreadRef): 
   const tabIds = Object.keys(readThreadPreviewState(threadRef).sessions);
   useRightPanelStore.getState().reconcileBrowserSurfaces(threadRef, tabIds);
 }
+
+/** Reveal an automation-owned tab in the thread's Browser panel. */
+export function openPreviewRightPanelSurface(threadRef: ScopedThreadRef, tabId: string): void {
+  reconcilePreviewRightPanelSurfaces(threadRef);
+  useRightPanelStore.getState().openBrowser(threadRef, tabId);
+}

--- a/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.ts
+++ b/apps/web/src/components/preview/reconcilePreviewRightPanelSurfaces.ts
@@ -1,0 +1,10 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+import { readThreadPreviewState } from "~/previewStateStore";
+import { useRightPanelStore } from "~/rightPanelStore";
+
+/** Keep automation-owned preview tabs recoverable from the thread's Browser surface. */
+export function reconcilePreviewRightPanelSurfaces(threadRef: ScopedThreadRef): void {
+  const tabIds = Object.keys(readThreadPreviewState(threadRef).sessions);
+  useRightPanelStore.getState().reconcileBrowserSurfaces(threadRef, tabIds);
+}


### PR DESCRIPTION
## What Changed

Reconcile automation-owned preview sessions with the thread's Browser surfaces after an authoritative session sync and after automation opens or resizes a preview.

The reconciliation registers live tabs without forcing the right panel open and removes stale Browser surfaces when the server no longer reports their tabs.

## Why

Agent-created preview tabs could exist in the preview session store without being registered as right-panel Browser surfaces. After the mini-player closed, those tabs became unreachable even though their server sessions were still alive.

## UI Changes

<img width="1648" height="320" alt="Before: generic Browser placeholder; after: recovered Example Domain automation tab" src="https://github.com/user-attachments/assets/47de1838-dc89-4af5-ae35-f613fb0d96aa" />

In an isolated authenticated dev client, an automation-owned `Example Domain` preview session was seeded while the right-panel surface registry was empty. Before reconciliation the panel showed only the generic Browser placeholder. After reconciliation it registered and selected `browser:automation-example`, exposing the recoverable `Example Domain` tab.

## Validation

- `vp test run apps/web/src/components/preview` — 21 files, 79 tests passed
- `vp run web#typecheck`
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI behavior
- [x] A video is not applicable because this does not change animation or timing

Written by GPT-5.6 via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how automation presents previews and when the right panel opens, but reuses existing `rightPanelStore` patterns already used from `ChatView` and manual browser open flows.
> 
> **Overview**
> **Automation-owned preview tabs now stay wired to the thread Browser right panel** instead of the preview mini player when the agent asks to show a preview.
> 
> `PreviewAutomationHosts` calls **`reconcilePreviewRightPanelSurfaces`** after listing previews and after open/resize so live server tabs register as Browser surfaces (without opening the panel) and stale surfaces drop when sessions sync away. When presentation is requested, it **closes the mini player** and uses **`openPreviewRightPanelSurface`** to open and focus the tab in the right panel; otherwise it only reconciles.
> 
> New helpers in `reconcilePreviewRightPanelSurfaces.ts` delegate to `reconcileBrowserSurfaces` / `openBrowser` on the existing right-panel store, with unit tests for register-without-open, stale tab removal, and explicit open/activate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c1e5296bd4c0cecd3f30f4dbb6f336d54a513f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open automation previews in the thread browser right panel instead of mini player
> - Adds [`reconcilePreviewRightPanelSurfaces`](https://github.com/pingdotgg/t3code/pull/6261/files#diff-f10e1b676637e6658f5d641bcac7c7e346a4aebfde4d275cbb0637c3b4c57e04) to sync the right panel's browser surfaces with automation-owned preview tabs for a thread.
> - Adds `openPreviewRightPanelSurface` to open and focus a specific tab in the right panel browser while updating preview active-tab state.
> - Updates [`PreviewAutomationHost`](https://github.com/pingdotgg/t3code/pull/6261/files#diff-8244d1ca34cc1e3ae2b642df57ee711f79d00c5a2af9b56bd852e3f093fed097) to call these utilities on list and snapshot events; when a preview should be presented, it now closes the mini player and opens the right panel browser instead.
> - Behavioral Change: automation previews no longer open in the mini player — they open in the thread's right panel browser surface.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c1e529.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->