### PR TITLE
Sort sessions by latest work; surface Grok skills under /

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -416,7 +416,9 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       const builtIn = allBuiltIn.filter((item) => item.command.includes(q));
 
       const providerCommands: ComposerCommandItem[] = [];
+      const slashNames = new Set<string>();
       for (const cmd of selectedProviderStatus?.slashCommands ?? []) {
+        slashNames.add(cmd.name.toLowerCase());
         if (!cmd.name.toLowerCase().includes(q)) continue;
         providerCommands.push({
           id: `pcmd:${cmd.name}`,
@@ -427,7 +429,26 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         });
       }
 
-      return [...builtIn, ...providerCommands];
+      // Skills normally open with `$`, but users look under `/` for agent
+      // skills (e.g. AI Hero grill-me). Surface enabled skills in this menu too.
+      const skillCommands: ComposerCommandItem[] = [];
+      for (const skill of selectedProviderStatus?.skills ?? []) {
+        if (skill.enabled === false) continue;
+        if (slashNames.has(skill.name.toLowerCase())) continue;
+        const label = skill.displayName ?? skill.name;
+        if (q && !skill.name.toLowerCase().includes(q) && !label.toLowerCase().includes(q)) {
+          continue;
+        }
+        skillCommands.push({
+          id: `skill:${skill.name}`,
+          type: "skill" as const,
+          skill,
+          label: `/${skill.name}`,
+          description: skill.shortDescription ?? skill.description ?? "",
+        });
+      }
+
+      return [...builtIn, ...providerCommands, ...skillCommands];
     }
 
     if (composerTrigger.kind === "skill") {

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -252,13 +252,29 @@ describe("resolveThreadListV2SnoozeGateExpiryMs", () => {
 });
 
 describe("sortThreadsForListV2", () => {
-  it("orders by creation time, newest first, ignoring activity", () => {
+  it("orders by latest activity, most recent first", () => {
     const sorted = sortThreadsForListV2([
-      { id: "oldest", createdAt: "2026-06-01T08:00:00.000Z" },
-      { id: "newest", createdAt: "2026-06-01T12:00:00.000Z" },
-      { id: "middle", createdAt: "2026-06-01T10:00:00.000Z" },
+      {
+        id: "old-creation-fresh-work",
+        createdAt: "2026-06-01T08:00:00.000Z",
+        latestUserMessageAt: "2026-06-01T14:00:00.000Z",
+      },
+      {
+        id: "new-creation-stale",
+        createdAt: "2026-06-01T12:00:00.000Z",
+        latestUserMessageAt: "2026-06-01T12:05:00.000Z",
+      },
+      {
+        id: "middle",
+        createdAt: "2026-06-01T10:00:00.000Z",
+        latestUserMessageAt: "2026-06-01T13:00:00.000Z",
+      },
     ]);
-    expect(sorted.map((thread) => thread.id)).toEqual(["newest", "middle", "oldest"]);
+    expect(sorted.map((thread) => thread.id)).toEqual([
+      "old-creation-fresh-work",
+      "middle",
+      "new-creation-stale",
+    ]);
   });
 });
 
@@ -562,19 +578,20 @@ describe("buildThreadListV2Items", () => {
     expect(layout.settledShelfHeaderIndex).toBe(0);
   });
 
-  it("keeps cards in creation order while settled sorts by recency", () => {
+  it("promotes active cards with recent work above newer-but-stale ones", () => {
     const { items } = buildThreadListV2Items({
       threads: [
         makeThread({
           id: ThreadId.make("older-created"),
           title: "Older",
           createdAt: "2026-06-01T08:00:00.000Z",
-          updatedAt: NOW, // recent activity must NOT promote it
+          updatedAt: NOW, // recent activity must promote it
         }),
         makeThread({
           id: ThreadId.make("newer-created"),
           title: "Newer",
           createdAt: "2026-06-01T12:00:00.000Z",
+          updatedAt: "2026-06-01T12:00:00.000Z",
         }),
       ],
       environmentId: null,
@@ -582,7 +599,7 @@ describe("buildThreadListV2Items", () => {
       now: NOW,
     });
 
-    expect(items.map((item) => item.thread.id)).toEqual(["newer-created", "older-created"]);
+    expect(items.map((item) => item.thread.id)).toEqual(["older-created", "newer-created"]);
   });
 
   it("keeps settled threads in the tail and filters by search query", () => {

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -158,20 +158,49 @@ function firstValidTimestampMs(...candidates: ReadonlyArray<string | null | unde
   return 0;
 }
 
+type ActiveThreadActivityInput = {
+  readonly createdAt: string;
+  readonly updatedAt?: string | null;
+  readonly latestUserMessageAt?: string | null;
+  readonly latestTurn?: {
+    readonly requestedAt?: string | null;
+    readonly startedAt?: string | null;
+    readonly completedAt?: string | null;
+  } | null;
+};
+
 /**
- * v2 sort: static creation order, newest thread on top. Activity NEVER
- * reorders the list — a row holds its position from open until settled, so
- * the screen only moves at lifecycle transitions. Mirrors web's
- * sortThreadsForSidebarV2.
+ * Most recent work first (user message / turn / updatedAt / createdAt).
+ * Mirrors web `sortThreadsForSidebar` so finished or newly touched
+ * sessions rise to the top under All projects and single-project filters.
  */
-export function sortThreadsForListV2<T extends { readonly id: string; readonly createdAt: string }>(
+export function resolveActiveThreadActivityMs(thread: ActiveThreadActivityInput): number {
+  let latestMs = Number.NEGATIVE_INFINITY;
+  for (const candidate of [
+    thread.latestUserMessageAt,
+    thread.latestTurn?.requestedAt,
+    thread.latestTurn?.startedAt,
+    thread.latestTurn?.completedAt,
+    thread.updatedAt,
+    thread.createdAt,
+  ]) {
+    if (candidate == null) continue;
+    const parsed = Date.parse(candidate);
+    if (!Number.isNaN(parsed) && parsed > latestMs) {
+      latestMs = parsed;
+    }
+  }
+  return latestMs === Number.NEGATIVE_INFINITY ? parseTimestampMs(thread.createdAt) : latestMs;
+}
+
+export function sortThreadsForListV2<T extends { readonly id: string } & ActiveThreadActivityInput>(
   threads: readonly T[],
 ): T[] {
   // .sort() on a copy, not .toSorted(): Hermes doesn't ship the ES2023
   // change-by-copy array methods.
   return [...threads].sort(
     (left, right) =>
-      parseTimestampMs(right.createdAt) - parseTimestampMs(left.createdAt) ||
+      resolveActiveThreadActivityMs(right) - resolveActiveThreadActivityMs(left) ||
       left.id.localeCompare(right.id),
   );
 }

--- a/apps/server/src/provider/Drivers/AgentFsSkills.ts
+++ b/apps/server/src/provider/Drivers/AgentFsSkills.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared filesystem discovery of SKILL.md skill packs for T3 providers that
+ * mirror Claude Code's layout (`<home>/skills/<name>/SKILL.md`).
+ *
+ * Used by Grok and Hermes so skills installed under `~/.grok/skills` and
+ * `~/.hermes/skills` (and optional project-local roots) surface in the T3
+ * skill picker the same way Claude skills do.
+ *
+ * @module provider/Drivers/AgentFsSkills
+ */
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import { parse as parseYamlDocument } from "yaml";
+
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+type SkillFrontmatter =
+  | { readonly kind: "missing" }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "parsed"; readonly name?: string; readonly description?: string };
+
+function parseSkillFrontmatter(contents: string): SkillFrontmatter {
+  const match = FRONTMATTER_PATTERN.exec(contents);
+  if (!match) {
+    return { kind: "missing" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYamlDocument(match[1] ?? "");
+  } catch {
+    return { kind: "malformed" };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { kind: "malformed" };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  const description = typeof record.description === "string" ? record.description.trim() : "";
+  return {
+    kind: "parsed",
+    ...(name ? { name } : {}),
+    ...(description ? { description } : {}),
+  };
+}
+
+export interface AgentSkillRoot {
+  readonly directory: string;
+  readonly scope: "user" | "project";
+}
+
+/**
+ * Best-effort scan of skill directories. Malformed entries are skipped so a
+ * broken pack never degrades the provider snapshot. Later roots win on name
+ * collisions (project over user when ordered that way).
+ */
+export const discoverSkillsFromRoots = Effect.fn("discoverSkillsFromRoots")(function* (
+  roots: ReadonlyArray<AgentSkillRoot>,
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillsByName = new Map<string, ServerProviderSkill>();
+
+  for (const root of roots) {
+    const entries = yield* fileSystem
+      .readDirectory(root.directory)
+      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+
+    for (const entry of [...entries].sort()) {
+      const skillPath = path.join(root.directory, entry, "SKILL.md");
+      const contents = yield* fileSystem
+        .readFileString(skillPath)
+        .pipe(Effect.orElseSucceed(() => undefined));
+      if (contents === undefined) {
+        continue;
+      }
+
+      const frontmatter = parseSkillFrontmatter(contents);
+      if (frontmatter.kind === "malformed") {
+        continue;
+      }
+
+      const name = (frontmatter.kind === "parsed" ? frontmatter.name : undefined) ?? entry.trim();
+      if (!name) {
+        continue;
+      }
+
+      skillsByName.set(name, {
+        name,
+        path: skillPath,
+        enabled: true,
+        scope: root.scope,
+        ...(frontmatter.kind === "parsed" && frontmatter.description
+          ? { description: frontmatter.description }
+          : {}),
+      });
+    }
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+});

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -86,6 +86,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
     Effect.gen(function* () {
       const crypto = yield* Crypto.Crypto;
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -117,6 +119,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
       );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -6,11 +6,15 @@ import {
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
+import * as NodeOS from "node:os";
+
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Result from "effect/Result";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -30,6 +34,7 @@ import {
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
 import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
+import { discoverSkillsFromRoots } from "../Drivers/AgentFsSkills.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -158,16 +163,27 @@ const runGrokVersionCommand = (
     );
   });
 
+const discoverGrokSkills = Effect.fn("discoverGrokSkills")(function* (cwd?: string) {
+  const path = yield* Path.Path;
+  const homeSkills = path.join(NodeOS.homedir(), ".grok", "skills");
+  return yield* discoverSkillsFromRoots([
+    { directory: homeSkills, scope: "user" },
+    ...(cwd ? [{ directory: path.join(cwd, ".grok", "skills"), scope: "project" as const }] : []),
+  ]);
+});
+
 export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(function* (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
+  cwd?: string,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
-  ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
+  ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto | FileSystem.FileSystem | Path.Path
 > {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const fallbackModels = grokModelsFromSettings(grokSettings.customModels);
+  const skills = yield* discoverGrokSkills(cwd);
 
   if (!grokSettings.enabled) {
     return buildServerProvider({
@@ -302,6 +318,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     enabled: grokSettings.enabled,
     checkedAt,
     models,
+    skills,
     probe: {
       installed: true,
       version,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -734,25 +734,57 @@ describe("searchSidebarThreadsByTitle", () => {
 });
 
 describe("sortThreadsForSidebar", () => {
-  const sortable = (input: { id: string; createdAt: string }) => ({
+  const sortable = (input: {
+    id: string;
+    createdAt: string;
+    updatedAt?: string;
+    latestUserMessageAt?: string;
+  }) => ({
     id: input.id,
     createdAt: input.createdAt,
+    updatedAt: input.updatedAt ?? input.createdAt,
+    latestUserMessageAt: input.latestUserMessageAt ?? null,
+    latestTurn: null,
   });
 
-  it("orders by creation time, newest first, ignoring activity", () => {
+  it("orders by latest activity, most recent first", () => {
     const sorted = sortThreadsForSidebar([
-      sortable({ id: "oldest", createdAt: "2026-03-09T08:00:00.000Z" }),
-      sortable({ id: "newest", createdAt: "2026-03-09T12:00:00.000Z" }),
-      sortable({ id: "middle", createdAt: "2026-03-09T10:00:00.000Z" }),
+      sortable({
+        id: "old-creation-fresh-work",
+        createdAt: "2026-03-09T08:00:00.000Z",
+        latestUserMessageAt: "2026-03-09T14:00:00.000Z",
+      }),
+      sortable({
+        id: "new-creation-stale",
+        createdAt: "2026-03-09T12:00:00.000Z",
+        latestUserMessageAt: "2026-03-09T12:05:00.000Z",
+      }),
+      sortable({
+        id: "middle",
+        createdAt: "2026-03-09T10:00:00.000Z",
+        latestUserMessageAt: "2026-03-09T13:00:00.000Z",
+      }),
     ]);
 
-    expect(sorted.map((thread) => thread.id)).toEqual(["newest", "middle", "oldest"]);
+    expect(sorted.map((thread) => thread.id)).toEqual([
+      "old-creation-fresh-work",
+      "middle",
+      "new-creation-stale",
+    ]);
   });
 
-  it("breaks creation-time ties by id so the order is stable", () => {
+  it("breaks activity-time ties by id so the order is stable", () => {
     const sorted = sortThreadsForSidebar([
-      sortable({ id: "b", createdAt: "2026-03-09T10:00:00.000Z" }),
-      sortable({ id: "a", createdAt: "2026-03-09T10:00:00.000Z" }),
+      sortable({
+        id: "b",
+        createdAt: "2026-03-09T10:00:00.000Z",
+        latestUserMessageAt: "2026-03-09T11:00:00.000Z",
+      }),
+      sortable({
+        id: "a",
+        createdAt: "2026-03-09T09:00:00.000Z",
+        latestUserMessageAt: "2026-03-09T11:00:00.000Z",
+      }),
     ]);
 
     expect(sorted.map((thread) => thread.id)).toEqual(["a", "b"]);

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -513,17 +513,56 @@ export function firstValidTimestamp(
   return null;
 }
 
-// Sidebar sort: static creation order, newest thread on top. Activity NEVER
-// reorders the list — a row holds its position from open until settled, so
-// the screen only moves at lifecycle transitions. Status (including pending
-// approval) is carried by each card's edge strip, not by position.
+type ActiveThreadActivityInput = {
+  readonly createdAt: string;
+  readonly updatedAt?: string | null;
+  readonly latestUserMessageAt?: string | null;
+  readonly latestTurn?: {
+    readonly requestedAt?: string | null;
+    readonly startedAt?: string | null;
+    readonly completedAt?: string | null;
+  } | null;
+};
+
+/**
+ * Most recent work on an active thread: last user message or turn stamp,
+ * then updatedAt, then createdAt. Used so a session that just finished
+ * work jumps above older untouched rows (All projects and per-project).
+ */
+export function resolveActiveThreadActivityTimestamp(thread: ActiveThreadActivityInput): string {
+  let latest: string | null = null;
+  let latestMs = Number.NEGATIVE_INFINITY;
+  for (const candidate of [
+    thread.latestUserMessageAt,
+    thread.latestTurn?.requestedAt,
+    thread.latestTurn?.startedAt,
+    thread.latestTurn?.completedAt,
+    thread.updatedAt,
+    thread.createdAt,
+  ]) {
+    if (candidate == null) continue;
+    const parsed = Date.parse(candidate);
+    if (!Number.isNaN(parsed) && parsed > latestMs) {
+      latest = candidate;
+      latestMs = parsed;
+    }
+  }
+  return latest ?? thread.createdAt;
+}
+
+// Active list sort: most recent activity on top (user message / turn /
+// updatedAt / createdAt). Applies for All projects and when a single project
+// is filtered — both pass through the same activeThreads partition.
 export function sortThreadsForSidebar<
-  T extends { readonly id: string; readonly createdAt: string },
+  T extends { readonly id: string } & ActiveThreadActivityInput,
 >(threads: readonly T[]): T[] {
+  const activityMs = (thread: T) => {
+    const timestamp = resolveActiveThreadActivityTimestamp(thread);
+    const parsed = Date.parse(timestamp);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
   return [...threads].toSorted(
-    (left, right) =>
-      parseTimestampMs(right.createdAt) - parseTimestampMs(left.createdAt) ||
-      left.id.localeCompare(right.id),
+    (left, right) => activityMs(right) - activityMs(left) || left.id.localeCompare(right.id),
   );
 }
 

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1074,12 +1074,56 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           description: command.description ?? command.input?.hint ?? "Run provider command",
         }),
       );
+      // Skills are normally under `$`, but users expect agent skills (e.g. AI Hero
+      // /grill-me) in the `/` command menu. Include enabled skills here so they
+      // appear as commands; selecting still inserts `$name` (T3 skill form).
+      const slashCommandNames = new Set(
+        (selectedProviderStatus?.slashCommands ?? []).map((command) => command.name.toLowerCase()),
+      );
+      const skillCommandItems = (selectedProviderStatus?.skills ?? [])
+        .filter((skill) => skill.enabled !== false)
+        .filter((skill) => !slashCommandNames.has(skill.name.toLowerCase()))
+        .map((skill) => ({
+          id: `skill:${selectedProvider}:${skill.name}`,
+          type: "skill" as const,
+          provider: selectedProvider,
+          skill,
+          label: `/${skill.name}`,
+          description:
+            skill.shortDescription ??
+            skill.description ??
+            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+        }));
       const query = composerTrigger.query.trim().toLowerCase();
-      const slashCommandItems = [...builtInSlashCommandItems, ...providerSlashCommandItems];
+      const slashCommandItems = [
+        ...builtInSlashCommandItems,
+        ...providerSlashCommandItems,
+        ...skillCommandItems,
+      ];
       if (!query) {
         return slashCommandItems;
       }
-      return searchSlashCommandItems(slashCommandItems, query);
+      const matchedSlash = searchSlashCommandItems(
+        [...builtInSlashCommandItems, ...providerSlashCommandItems],
+        query,
+      );
+      const matchedSkills = searchProviderSkills(
+        (selectedProviderStatus?.skills ?? []).filter((skill) => skill.enabled !== false),
+        query,
+      )
+        .filter((skill) => !slashCommandNames.has(skill.name.toLowerCase()))
+        .map((skill) => ({
+          id: `skill:${selectedProvider}:${skill.name}`,
+          type: "skill" as const,
+          provider: selectedProvider,
+          skill,
+          label: `/${skill.name}`,
+          description:
+            skill.shortDescription ??
+            skill.description ??
+            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+        }));
+      return [...matchedSlash, ...matchedSkills];
     }
     if (composerTrigger.kind === "skill") {
       return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -92,6 +92,7 @@ function groupCommandItems(
 
   const builtInItems = items.filter((item) => item.type === "slash-command");
   const providerItems = items.filter((item) => item.type === "provider-slash-command");
+  const skillItems = items.filter((item) => item.type === "skill");
 
   const groups: ComposerCommandGroup[] = [];
   if (builtInItems.length > 0) {
@@ -99,6 +100,9 @@ function groupCommandItems(
   }
   if (providerItems.length > 0) {
     groups.push({ id: "provider", label: "Provider", items: providerItems });
+  }
+  if (skillItems.length > 0) {
+    groups.push({ id: "skills", label: "Skills", items: skillItems });
   }
   return groups;
 }


### PR DESCRIPTION
## What Changed

1. **Session list order** — active sessions sort by most recent work (user message, turn times, then updated/created), newest first. Applies for All projects and a single project, on desktop and mobile.
2. **Grok skills from disk** — discover `SKILL.md` packs under `~/.grok/skills` (and project `.grok/skills`) so installed skills show up in provider status.
3. **Slash menu** — enabled skills also appear under `/` (not only `$`), still insert as `$name` when chosen.

## Why

Finished or just-worked sessions were stuck where they were created, so old untouched rows sat above recent work. Skills installed for agents also only showed under `$`, which made AI Hero / similar packs hard to find.

## UI Changes

- Session sidebar/list reorders when activity changes (no new controls).
- `/` command menu can include skill entries that were previously `$`-only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (happy to add if useful)
- [ ] I included a video for animation/interaction changes

## Tests

- `apps/web/src/components/Sidebar.logic.test.ts`
- `apps/mobile/src/features/threads/threadListV2.test.ts`
- 137 tests passed locally for those files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session-list ordering users rely on for navigation, and adds filesystem skill discovery into Grok provider status. Risk is mostly UX/behavior and best-effort FS scanning, not auth or data integrity.
> 
> **Overview**
> **Active sessions now reorder by latest work** instead of creation time. Finished or newly touched threads rise to the top on web and mobile (All projects and single-project views), using user message / turn / `updatedAt` / `createdAt`.
> 
> **Grok skills are discovered from disk** via a shared `SKILL.md` scanner under `~/.grok/skills` (and project `.grok/skills`), so installed packs show up in provider status like Claude skills.
> 
> **Enabled skills also appear under `/`** in the composer command menu (web and mobile), not only `$`. Selection still inserts `$name`; names that collide with provider slash commands are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdabe8f428c6d99920182d524893d42866114799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort sessions by latest activity and surface Grok skills in the slash-command menu
> - Thread lists in the sidebar (web) and mobile now sort by most recent activity (`latestUserMessageAt`, turn timestamps, `updatedAt`, `createdAt`) instead of creation time, with id as a tie-breaker.
> - Grok provider snapshots now include skills discovered from `~/.grok/skills` and optionally `<cwd>/.grok/skills` via the new `AgentFsSkills` module, which scans for `SKILL.md` files and parses optional YAML frontmatter.
> - The `/` slash-command menu in both web (`ChatComposer`) and mobile (`ThreadComposer`) now surfaces enabled provider skills alongside built-in slash commands, grouped under a distinct 'Skills' section, with duplicates excluded.
> - Behavioral Change: active threads that received recent messages will now rank above newer-but-idle threads in the session list.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fdabe8f. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->