### PR TITLE
feat(web): show remaining limits beside usage

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -20,7 +20,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "../ui/sidebar";
-import { AccountLimitsHoverCard } from "../usage/AccountLimits";
+import { AccountLimitsHoverCard, AccountLimitsSidebarGauges } from "../usage/AccountLimits";
 import { SidebarProviderUpdatePill } from "./SidebarProviderUpdatePill";
 import { SidebarUpdatePill } from "./SidebarUpdatePill";
 
@@ -132,13 +132,9 @@ export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
       <SidebarUpdatePill />
       <SidebarMenu>
         <SidebarMenuItem>
-          {/* `hidden: false` overrides the sidebar default of only showing
-              menu tooltips while collapsed: availability is worth a hover in
-              either state. */}
           <SidebarMenuButton
             onClick={handleUsageClick}
             tooltip={{
-              hidden: false,
               side: "right",
               align: "end",
               sideOffset: 8,
@@ -147,6 +143,7 @@ export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
           >
             <ChartNoAxesColumnIcon />
             <span>Usage</span>
+            <AccountLimitsSidebarGauges />
           </SidebarMenuButton>
         </SidebarMenuItem>
         <SidebarMenuItem>

--- a/apps/web/src/components/usage/AccountLimits.tsx
+++ b/apps/web/src/components/usage/AccountLimits.tsx
@@ -10,12 +10,17 @@
  *
  * @module AccountLimits
  */
-import type { AccountLimitsSnapshot, AccountLimitsWindow } from "@t3tools/contracts";
+import type {
+  AccountLimitsSnapshot,
+  AccountLimitsWindow,
+  UsageProviderKind,
+} from "@t3tools/contracts";
 import { useEffect, useState } from "react";
 
 import { cn } from "../../lib/utils";
 import { useAccountLimits } from "../../state/accountLimits";
 import { formatAgo, formatResetAt } from "../../usage/limitsFormat";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PROVIDER_COLOR, PROVIDER_LABEL, PROVIDER_MARK, PROVIDER_ORDER } from "./usageProviders";
 
 /** Age past which a snapshot stops being "current" and earns a caption. */
@@ -40,6 +45,33 @@ function usageTone(usedPercent: number): string | undefined {
   return undefined;
 }
 
+function remainingTone(usedPercent: number): string {
+  if (usedPercent >= 95) return "text-red-400";
+  if (usedPercent >= 80) return "text-amber-400";
+  return "text-sidebar-foreground/70";
+}
+
+const sidebarResetFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+function formatSidebarReset(resetsAt: string | null): string {
+  if (resetsAt === null) return "Reset time unavailable";
+  const reset = new Date(resetsAt);
+  if (Number.isNaN(reset.getTime())) return "Reset time unavailable";
+  return `Resets ${sidebarResetFormatter.format(reset)}`;
+}
+
+function compactWindowLabel(window: AccountLimitsWindow): string {
+  if (window.windowMinutes === null) return window.label;
+  if (window.windowMinutes % 1_440 === 0) return `${window.windowMinutes / 1_440}d`;
+  if (window.windowMinutes % 60 === 0) return `${window.windowMinutes / 60}h`;
+  return `${window.windowMinutes}m`;
+}
+
 function LimitMeter({ window, color }: { window: AccountLimitsWindow; color: string }) {
   return (
     <div className="h-1 flex-1 overflow-hidden rounded-full bg-muted">
@@ -60,6 +92,104 @@ function SnapshotAge({ snapshot, nowMs }: { snapshot: AccountLimitsSnapshot; now
   if (!Number.isFinite(ageMs) || ageMs < STALE_AFTER_MS) return null;
   return (
     <span className="text-[10px] text-muted-foreground">{formatAgo(snapshot.asOf, nowMs)}</span>
+  );
+}
+
+/** Always-visible remaining capacity beside the sidebar's Usage label. */
+export function AccountLimitsSidebarGauges() {
+  const { snapshots } = useAccountLimits();
+
+  return (
+    <span className="ml-auto flex shrink-0 items-center gap-1.5 group-data-[collapsible=icon]:hidden">
+      {PROVIDER_ORDER.map((provider) => {
+        const snapshot = snapshots.get(provider);
+        if (snapshot === undefined || snapshot.windows.length === 0) return null;
+        return <AccountLimitsSidebarGauge key={provider} provider={provider} snapshot={snapshot} />;
+      })}
+    </span>
+  );
+}
+
+function AccountLimitsSidebarGauge({
+  provider,
+  snapshot,
+}: {
+  provider: UsageProviderKind;
+  snapshot: AccountLimitsSnapshot;
+}) {
+  const Mark = PROVIDER_MARK[provider];
+  const windows = snapshot.windows.slice(0, 2);
+  const ariaLabel = `${PROVIDER_LABEL[provider]}: ${windows
+    .map(
+      (window) =>
+        `${compactWindowLabel(window)} ${Math.round(100 - window.usedPercent)} percent remaining`,
+    )
+    .join(", ")}`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            aria-label={ariaLabel}
+            className="relative inline-flex size-7 shrink-0 items-center justify-center"
+            role="img"
+          />
+        }
+      >
+        <svg aria-hidden="true" className="absolute inset-0 size-7 -rotate-90" viewBox="0 0 32 32">
+          {windows.map((window, index) => {
+            const radius = index === 0 ? 13.5 : 10;
+            const remainingPercent = Math.min(100, Math.max(0, 100 - window.usedPercent));
+            return (
+              <g key={window.id}>
+                <circle
+                  className="text-sidebar-border/80"
+                  cx="16"
+                  cy="16"
+                  fill="none"
+                  pathLength="100"
+                  r={radius}
+                  stroke="currentColor"
+                  strokeWidth="2"
+                />
+                <circle
+                  className={remainingTone(window.usedPercent)}
+                  cx="16"
+                  cy="16"
+                  fill="none"
+                  pathLength="100"
+                  r={radius}
+                  stroke="currentColor"
+                  strokeDasharray={`${remainingPercent} ${100 - remainingPercent}`}
+                  strokeLinecap="round"
+                  strokeWidth="2"
+                />
+              </g>
+            );
+          })}
+        </svg>
+        <Mark className="relative size-2.5" />
+      </TooltipTrigger>
+      <TooltipPopup align="end" className="min-w-44" side="top" sideOffset={6}>
+        <div className="flex flex-col gap-1.5 py-1">
+          <div className="font-medium text-popover-foreground">{PROVIDER_LABEL[provider]}</div>
+          {windows.map((window, index) => (
+            <div key={window.id} className="grid grid-cols-[1fr_auto] gap-x-3">
+              <span className="text-muted-foreground">
+                {index === 0 ? "Outer" : "Inner"} · {compactWindowLabel(window)}
+              </span>
+              <span className={cn("font-medium tabular-nums", remainingTone(window.usedPercent))}>
+                {Math.round(100 - window.usedPercent)}%
+              </span>
+              <span className="col-span-2 text-[10px] text-muted-foreground/80">
+                {formatSidebarReset(window.resetsAt)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </TooltipPopup>
+    </Tooltip>
   );
 }
 

--- a/apps/web/src/components/usage/AccountLimits.tsx
+++ b/apps/web/src/components/usage/AccountLimits.tsx
@@ -19,7 +19,7 @@ import { useEffect, useState } from "react";
 
 import { cn } from "../../lib/utils";
 import { useAccountLimits } from "../../state/accountLimits";
-import { formatAgo, formatResetAt } from "../../usage/limitsFormat";
+import { formatAgo, formatResetAt, formatSidebarResetAt } from "../../usage/limitsFormat";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PROVIDER_COLOR, PROVIDER_LABEL, PROVIDER_MARK, PROVIDER_ORDER } from "./usageProviders";
 
@@ -49,20 +49,6 @@ function remainingTone(usedPercent: number): string {
   if (usedPercent >= 95) return "text-red-400";
   if (usedPercent >= 80) return "text-amber-400";
   return "text-sidebar-foreground/70";
-}
-
-const sidebarResetFormatter = new Intl.DateTimeFormat(undefined, {
-  month: "short",
-  day: "numeric",
-  hour: "numeric",
-  minute: "2-digit",
-});
-
-function formatSidebarReset(resetsAt: string | null): string {
-  if (resetsAt === null) return "Reset time unavailable";
-  const reset = new Date(resetsAt);
-  if (Number.isNaN(reset.getTime())) return "Reset time unavailable";
-  return `Resets ${sidebarResetFormatter.format(reset)}`;
 }
 
 function compactWindowLabel(window: AccountLimitsWindow): string {
@@ -98,22 +84,32 @@ function SnapshotAge({ snapshot, nowMs }: { snapshot: AccountLimitsSnapshot; now
 /** Always-visible remaining capacity beside the sidebar's Usage label. */
 export function AccountLimitsSidebarGauges() {
   const { snapshots } = useAccountLimits();
+  const nowMs = useNowMs();
 
   return (
     <span className="ml-auto flex shrink-0 items-center gap-1.5 group-data-[collapsible=icon]:hidden">
       {PROVIDER_ORDER.map((provider) => {
         const snapshot = snapshots.get(provider);
         if (snapshot === undefined || snapshot.windows.length === 0) return null;
-        return <AccountLimitsSidebarGauge key={provider} provider={provider} snapshot={snapshot} />;
+        return (
+          <AccountLimitsSidebarGauge
+            key={provider}
+            nowMs={nowMs}
+            provider={provider}
+            snapshot={snapshot}
+          />
+        );
       })}
     </span>
   );
 }
 
 function AccountLimitsSidebarGauge({
+  nowMs,
   provider,
   snapshot,
 }: {
+  nowMs: number;
   provider: UsageProviderKind;
   snapshot: AccountLimitsSnapshot;
 }) {
@@ -153,18 +149,20 @@ function AccountLimitsSidebarGauge({
                   stroke="currentColor"
                   strokeWidth="2"
                 />
-                <circle
-                  className={remainingTone(window.usedPercent)}
-                  cx="16"
-                  cy="16"
-                  fill="none"
-                  pathLength="100"
-                  r={radius}
-                  stroke="currentColor"
-                  strokeDasharray={`${remainingPercent} ${100 - remainingPercent}`}
-                  strokeLinecap="round"
-                  strokeWidth="2"
-                />
+                {remainingPercent > 0 ? (
+                  <circle
+                    className={remainingTone(window.usedPercent)}
+                    cx="16"
+                    cy="16"
+                    fill="none"
+                    pathLength="100"
+                    r={radius}
+                    stroke="currentColor"
+                    strokeDasharray={`${remainingPercent} ${100 - remainingPercent}`}
+                    strokeLinecap="round"
+                    strokeWidth="2"
+                  />
+                ) : null}
               </g>
             );
           })}
@@ -180,10 +178,10 @@ function AccountLimitsSidebarGauge({
                 {index === 0 ? "Outer" : "Inner"} · {compactWindowLabel(window)}
               </span>
               <span className={cn("font-medium tabular-nums", remainingTone(window.usedPercent))}>
-                {Math.round(100 - window.usedPercent)}%
+                {Math.round(100 - window.usedPercent)}% remaining
               </span>
               <span className="col-span-2 text-[10px] text-muted-foreground/80">
-                {formatSidebarReset(window.resetsAt)}
+                {formatSidebarResetAt(window.resetsAt, nowMs)}
               </span>
             </div>
           ))}

--- a/apps/web/src/usage/limitsFormat.test.ts
+++ b/apps/web/src/usage/limitsFormat.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatSidebarResetAt } from "./limitsFormat";
+
+describe("formatSidebarResetAt", () => {
+  const nowMs = Date.parse("2026-08-12T12:00:00.000Z");
+
+  it("labels due and past resets as now", () => {
+    expect(formatSidebarResetAt("2026-08-12T12:00:00.000Z", nowMs)).toBe("Resets now");
+    expect(formatSidebarResetAt("2026-08-12T11:59:59.000Z", nowMs)).toBe("Resets now");
+  });
+
+  it("handles missing and invalid reset times", () => {
+    expect(formatSidebarResetAt(null, nowMs)).toBe("Reset time unavailable");
+    expect(formatSidebarResetAt("not-a-date", nowMs)).toBe("Reset time unavailable");
+  });
+});

--- a/apps/web/src/usage/limitsFormat.ts
+++ b/apps/web/src/usage/limitsFormat.ts
@@ -16,6 +16,12 @@ const DATE_TIME = new Intl.DateTimeFormat("en-US", {
   hour: "2-digit",
   minute: "2-digit",
 });
+const SIDEBAR_DATE_TIME = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
 
 /**
  * When a window resets: `16:00` inside 24 hours, `8/12 16:00` beyond.
@@ -29,6 +35,15 @@ export function formatResetAt(resetsAt: string | null, nowMs: number): string | 
   if (at <= nowMs) return "now";
   if (at - nowMs < 24 * 60 * 60 * 1000) return TIME.format(at);
   return DATE_TIME.format(at).replace(", ", " ");
+}
+
+/** Absolute reset time for the compact gauge tooltip, or `Resets now` once due. */
+export function formatSidebarResetAt(resetsAt: string | null, nowMs: number): string {
+  if (resetsAt === null) return "Reset time unavailable";
+  const at = Date.parse(resetsAt);
+  if (Number.isNaN(at)) return "Reset time unavailable";
+  if (at <= nowMs) return "Resets now";
+  return `Resets ${SIDEBAR_DATE_TIME.format(at)}`;
 }
 
 /** Age of a snapshot: `just now`, `5m ago`, `6h ago`, `3d ago`. */


### PR DESCRIPTION
## What Changed

Adds compact, always-visible remaining-usage gauges beside the sidebar's Usage label. Each provider gets one circular mark; the outer and inner arcs show the remaining capacity in its first two reported limit windows.

Hovering a provider gauge shows which window each ring represents, its remaining percentage, and its reset time. The full account-limits card remains available from the collapsed sidebar.

This is a UI-only commit stacked on #5739. It reuses that PR's account-limit state, provider marks, ordering, and detailed limits view.

## Why

#5739 makes detailed limits available from a sidebar hover card, but the user must interact with the row before seeing whether capacity is running low. These gauges make the same data glanceable, with provider-specific details available on hover.

The arcs are static and add no new polling, RPCs, or continuously repainting animation.

## UI Changes

### Before and after

<img width="498" alt="Before and after: provider remaining-usage gauges beside the Usage label" src="https://github.com/user-attachments/assets/c50c4388-03d1-431e-97e9-967ee86f67f9" />

### Additional states

| Two providers | Two-ring provider hover |
| --- | --- |
| <img width="245" alt="Codex and Claude remaining-usage gauges" src="https://github.com/user-attachments/assets/2ca61020-3729-43af-9729-8f0d77f8dbd5" /> | <img width="271" height="199" alt="Claude gauge hover showing outer and inner limit windows with remaining percentages" src="https://github.com/user-attachments/assets/731f1af2-9d61-4a6c-b115-5edb82a1659d" /> |

## Validation

- `vp test run apps/web/src/usage apps/web/src/components/usage` — 3 files, 20 tests passed
- `vp run --filter @t3tools/web typecheck`
- `vp fmt --check apps/web/src/components/usage/AccountLimits.tsx apps/web/src/components/sidebar/SidebarChrome.tsx apps/web/src/usage/limitsFormat.ts apps/web/src/usage/limitsFormat.test.ts`
- `git diff --check`
- Integrated web pass: two-provider gauges, remaining/used percentage agreement, Usage navigation, and no console or failed-network errors

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] This change has no animation or interaction requiring a video

Implemented with GPT-5.6 in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show remaining capacity gauges beside usage in the sidebar
> - Adds `AccountLimitsSidebarGauges` to the Usage button in [`SidebarChrome.tsx`](https://github.com/pingdotgg/t3code/pull/6264/files#diff-cbdc7d544762cec67fb7c23f9e66e80e1ca2158f0d100a878363a7ae01f77c11), rendering compact circular SVG arcs per provider showing outer and inner window usage.
> - Each gauge (`AccountLimitsSidebarGauge`) includes an accessible `aria-label` and a tooltip with compact window labels, remaining percentages colored by threshold, and reset times via the new `formatSidebarResetAt` formatter.
> - Adds `remainingTone` (colors: red ≥95%, amber ≥80%, muted otherwise) and `compactWindowLabel` (e.g. `2d`, `6h`, `30m`) utilities in [`AccountLimits.tsx`](https://github.com/pingdotgg/t3code/pull/6264/files#diff-0b10e26c0849a7eccc62730d246bfad9ebf9905f99ff4dc02fb00c7c6e9ef1a5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f16e599.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that reuses existing account-limits state with no new polling, RPCs, or auth/data handling.
> 
> **Overview**
> Makes account limit remaining capacity **glanceable** in the expanded sidebar by rendering compact circular gauges beside the Usage label.
> 
> Each provider gets a concentric SVG gauge for its first two limit windows, color-coded when usage is high. Hovering a gauge shows remaining percent and reset time; the existing full hover card still covers the collapsed sidebar. Also adds `formatSidebarResetAt` for those tooltips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16e599f58afeb364581252cc91442b20dfc0f4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
