### PR TITLE
fix(scripts): run worktree setup without POSIX shell

### DIFF
--- a/scripts/setup-worktree.test.ts
+++ b/scripts/setup-worktree.test.ts
@@ -91,4 +91,27 @@ describe("setup-worktree", () => {
       NodeFs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("keeps the worktree env file when staging the replacement fails", () => {
+    const root = makeTempDir("setup-worktree-fail-root-");
+    const worktree = makeTempDir("setup-worktree-fail-wt-");
+    try {
+      // Source path exists but is a directory so symlink("file")/copyFile both fail.
+      NodeFs.mkdirSync(NodePath.join(root, ".env"));
+      const destination = NodePath.join(worktree, ".env");
+      NodeFs.writeFileSync(destination, "LOCAL=1\n", "utf8");
+
+      expect(() =>
+        linkOrCopyEnvFile({
+          projectRoot: root,
+          worktree,
+          relativePath: ".env",
+        }),
+      ).toThrow();
+      expect(NodeFs.readFileSync(destination, "utf8")).toBe("LOCAL=1\n");
+    } finally {
+      NodeFs.rmSync(root, { recursive: true, force: true });
+      NodeFs.rmSync(worktree, { recursive: true, force: true });
+    }
+  });
 });

--- a/scripts/setup-worktree.test.ts
+++ b/scripts/setup-worktree.test.ts
@@ -1,0 +1,94 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  linkOrCopyEnvFile,
+  linkProjectEnvFiles,
+  resolveWorktreePaths,
+} from "./setup-worktree.ts";
+
+const makeTempDir = (prefix: string): string =>
+  NodeFs.mkdtempSync(NodePath.join(NodeOs.tmpdir(), prefix));
+
+describe("setup-worktree", () => {
+  it("resolves worktree from env, falling back to cwd", () => {
+    expect(
+      resolveWorktreePaths({
+        T3CODE_PROJECT_ROOT: "C:\\repo",
+        T3CODE_WORKTREE_PATH: "C:\\repo-wt",
+      }),
+    ).toEqual({
+      projectRoot: "C:\\repo",
+      worktree: "C:\\repo-wt",
+    });
+
+    const resolved = resolveWorktreePaths({ T3CODE_PROJECT_ROOT: "/repo" });
+    expect(resolved.projectRoot).toBe("/repo");
+    expect(resolved.worktree).toBe(process.cwd());
+  });
+
+  it("links or copies env files into the worktree", () => {
+    const root = makeTempDir("setup-worktree-root-");
+    const worktree = makeTempDir("setup-worktree-wt-");
+    try {
+      NodeFs.mkdirSync(NodePath.join(root, "infra", "relay"), { recursive: true });
+      NodeFs.writeFileSync(NodePath.join(root, ".env"), "ROOT=1\n", "utf8");
+      NodeFs.writeFileSync(NodePath.join(root, "infra", "relay", ".env"), "RELAY=1\n", "utf8");
+
+      const results = linkProjectEnvFiles({ projectRoot: root, worktree });
+      expect(results).toHaveLength(2);
+      for (const entry of results) {
+        expect(["linked", "copied"]).toContain(entry.result);
+      }
+      // Either linked or copied is fine; content must match.
+      expect(NodeFs.readFileSync(NodePath.join(worktree, ".env"), "utf8")).toBe("ROOT=1\n");
+      expect(NodeFs.readFileSync(NodePath.join(worktree, "infra", "relay", ".env"), "utf8")).toBe(
+        "RELAY=1\n",
+      );
+    } finally {
+      NodeFs.rmSync(root, { recursive: true, force: true });
+      NodeFs.rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+
+  it("does not delete a worktree env file when the source is missing", () => {
+    const root = makeTempDir("setup-worktree-missing-root-");
+    const worktree = makeTempDir("setup-worktree-missing-wt-");
+    try {
+      const destination = NodePath.join(worktree, ".env");
+      NodeFs.writeFileSync(destination, "LOCAL=1\n", "utf8");
+
+      expect(
+        linkOrCopyEnvFile({
+          projectRoot: root,
+          worktree,
+          relativePath: ".env",
+        }),
+      ).toBe("skipped-missing-source");
+      expect(NodeFs.readFileSync(destination, "utf8")).toBe("LOCAL=1\n");
+    } finally {
+      NodeFs.rmSync(root, { recursive: true, force: true });
+      NodeFs.rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+
+  it("skips when project root and worktree are the same path", () => {
+    const root = makeTempDir("setup-worktree-same-");
+    try {
+      NodeFs.writeFileSync(NodePath.join(root, ".env"), "SAME=1\n", "utf8");
+      expect(
+        linkOrCopyEnvFile({
+          projectRoot: root,
+          worktree: root,
+          relativePath: ".env",
+        }),
+      ).toBe("skipped-same-path");
+    } finally {
+      NodeFs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/setup-worktree.test.ts
+++ b/scripts/setup-worktree.test.ts
@@ -92,26 +92,54 @@ describe("setup-worktree", () => {
     }
   });
 
-  it("keeps the worktree env file when staging the replacement fails", () => {
-    const root = makeTempDir("setup-worktree-fail-root-");
-    const worktree = makeTempDir("setup-worktree-fail-wt-");
+  it("skips when worktree is a symlink/junction to the project root", () => {
+    const root = makeTempDir("setup-worktree-alias-root-");
+    const parent = makeTempDir("setup-worktree-alias-parent-");
+    const alias = NodePath.join(parent, "wt-alias");
     try {
-      // Source path exists but is a directory so symlink("file")/copyFile both fail.
+      NodeFs.writeFileSync(NodePath.join(root, ".env"), "ROOT=1\n", "utf8");
+      try {
+        NodeFs.symlinkSync(root, alias, "junction");
+      } catch {
+        // Junction/symlink may be denied; skip this platform-specific case.
+        return;
+      }
+      expect(
+        linkOrCopyEnvFile({
+          projectRoot: root,
+          worktree: alias,
+          relativePath: ".env",
+        }),
+      ).toBe("skipped-same-path");
+      // Must not have replaced root/.env with a self-link/copy mess.
+      expect(NodeFs.readFileSync(NodePath.join(root, ".env"), "utf8")).toBe("ROOT=1\n");
+    } finally {
+      NodeFs.rmSync(alias, { force: true });
+      NodeFs.rmSync(root, { recursive: true, force: true });
+      NodeFs.rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("skips non-file sources without touching the worktree env", () => {
+    const root = makeTempDir("setup-worktree-dir-root-");
+    const worktree = makeTempDir("setup-worktree-dir-wt-");
+    try {
       NodeFs.mkdirSync(NodePath.join(root, ".env"));
       const destination = NodePath.join(worktree, ".env");
       NodeFs.writeFileSync(destination, "LOCAL=1\n", "utf8");
 
-      expect(() =>
+      expect(
         linkOrCopyEnvFile({
           projectRoot: root,
           worktree,
           relativePath: ".env",
         }),
-      ).toThrow();
+      ).toBe("skipped-not-a-file");
       expect(NodeFs.readFileSync(destination, "utf8")).toBe("LOCAL=1\n");
     } finally {
       NodeFs.rmSync(root, { recursive: true, force: true });
       NodeFs.rmSync(worktree, { recursive: true, force: true });
     }
   });
+
 });

--- a/scripts/setup-worktree.ts
+++ b/scripts/setup-worktree.ts
@@ -23,7 +23,8 @@ export type EnvLinkResult =
   | "linked"
   | "copied"
   | "skipped-same-path"
-  | "skipped-missing-source";
+  | "skipped-missing-source"
+  | "skipped-not-a-file";
 
 export const ENV_LINK_RELATIVE_PATHS = [".env", NodePath.join("infra", "relay", ".env")] as const;
 
@@ -35,6 +36,15 @@ export function resolveWorktreePaths(env: NodeJS.ProcessEnv = NodeProcess.env): 
     projectRoot: env.T3CODE_PROJECT_ROOT || undefined,
     worktree: env.T3CODE_WORKTREE_PATH || NodeProcess.cwd(),
   };
+}
+
+/** Resolve through symlinks/junctions when the path exists; else lexical resolve. */
+export function resolvePathIdentity(path: string): string {
+  try {
+    return NodeFs.realpathSync(path);
+  } catch {
+    return NodePath.resolve(path);
+  }
 }
 
 /**
@@ -50,11 +60,18 @@ export function linkOrCopyEnvFile(input: {
 }): EnvLinkResult {
   const source = NodePath.join(input.projectRoot, input.relativePath);
   const destination = NodePath.join(input.worktree, input.relativePath);
-  if (NodePath.resolve(source) === NodePath.resolve(destination)) {
+  // realpath so a worktree that is a symlink/junction to the project root is
+  // treated as the same path (resolve alone does not follow links).
+  if (resolvePathIdentity(source) === resolvePathIdentity(destination)) {
     return "skipped-same-path";
   }
   if (!NodeFs.existsSync(source)) {
     return "skipped-missing-source";
+  }
+  // Directories (or other non-files) must not be linked/copied over a .env —
+  // on POSIX, symlinkSync to a directory would otherwise "succeed".
+  if (!NodeFs.statSync(source).isFile()) {
+    return "skipped-not-a-file";
   }
 
   const destinationDir = NodePath.dirname(destination);

--- a/scripts/setup-worktree.ts
+++ b/scripts/setup-worktree.ts
@@ -1,0 +1,50 @@
+// @effect-diagnostics nodeBuiltinImport:off - setup-script bootstrap, runs before any Effect runtime exists.
+/**
+ * Worktree setup for t3.json, portable across POSIX and Windows shells. The
+ * previous inline command chained `ln -sf` and `$VAR` expansion, which fails
+ * under PowerShell/cmd. Installs dependencies, links the project root's `.env`
+ * files into the worktree, then warms the web dependency cache.
+ *
+ * On Windows, symlink creation needs Developer Mode or elevation; when it is
+ * denied we fall back to copying the file (a copy won't track later edits to
+ * the root `.env`, so re-run this script after changing it).
+ */
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFs from "node:fs";
+import * as NodePath from "node:path";
+
+const projectRoot = process.env.T3CODE_PROJECT_ROOT;
+const worktree = process.env.T3CODE_WORKTREE_PATH ?? process.cwd();
+
+function run(command: string, args: readonly string[]): void {
+  // shell: true so Windows resolves launcher shims like vp.cmd
+  const result = NodeChildProcess.spawnSync(command, [...args], {
+    stdio: "inherit",
+    shell: true,
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function linkEnvFile(relativePath: string): void {
+  if (!projectRoot) return;
+  const source = NodePath.join(projectRoot, relativePath);
+  const destination = NodePath.join(worktree, relativePath);
+  // Running in the project root itself would link the file to itself.
+  if (NodePath.resolve(source) === NodePath.resolve(destination)) return;
+  NodeFs.rmSync(destination, { force: true });
+  try {
+    NodeFs.symlinkSync(source, destination, "file");
+  } catch {
+    if (NodeFs.existsSync(source)) {
+      NodeFs.copyFileSync(source, destination);
+      console.log(`[setup-worktree] copied ${relativePath} (symlink unavailable)`);
+    }
+  }
+}
+
+run("vp", ["i"]);
+linkEnvFile(".env");
+linkEnvFile(NodePath.join("infra", "relay", ".env"));
+run("node", [NodePath.join("apps", "web", "scripts", "warm-dep-cache.ts")]);

--- a/scripts/setup-worktree.ts
+++ b/scripts/setup-worktree.ts
@@ -40,7 +40,8 @@ export function resolveWorktreePaths(env: NodeJS.ProcessEnv = NodeProcess.env): 
 /**
  * Link `projectRoot/relativePath` into the worktree. Never deletes the
  * destination when the source is missing (avoids wiping a local file if the
- * root has no `.env` yet).
+ * root has no `.env` yet). Staging + rename keeps a locally edited worktree
+ * file if symlink/copy fails mid-flight.
  */
 export function linkOrCopyEnvFile(input: {
   readonly projectRoot: string;
@@ -56,15 +57,65 @@ export function linkOrCopyEnvFile(input: {
     return "skipped-missing-source";
   }
 
-  NodeFs.mkdirSync(NodePath.dirname(destination), { recursive: true });
-  NodeFs.rmSync(destination, { force: true });
+  const destinationDir = NodePath.dirname(destination);
+  NodeFs.mkdirSync(destinationDir, { recursive: true });
+
+  // Same directory as destination so rename is same-volume (atomic on POSIX;
+  // on Windows we still only remove the old file after staging succeeds).
+  const staging = NodePath.join(
+    destinationDir,
+    `.${NodePath.basename(destination)}.${NodeProcess.pid}.${Date.now()}.tmp`,
+  );
+  const backup = `${staging}.bak`;
+
+  let result: "linked" | "copied";
   try {
-    NodeFs.symlinkSync(source, destination, "file");
-    return "linked";
-  } catch {
-    NodeFs.copyFileSync(source, destination);
-    console.log(`[setup-worktree] copied ${input.relativePath} (symlink unavailable)`);
-    return "copied";
+    try {
+      NodeFs.symlinkSync(source, staging, "file");
+      result = "linked";
+    } catch {
+      NodeFs.copyFileSync(source, staging);
+      result = "copied";
+      console.log(`[setup-worktree] copied ${input.relativePath} (symlink unavailable)`);
+    }
+
+    let hadDestination = false;
+    try {
+      NodeFs.renameSync(destination, backup);
+      hadDestination = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    try {
+      NodeFs.renameSync(staging, destination);
+    } catch (error) {
+      if (hadDestination) {
+        try {
+          NodeFs.renameSync(backup, destination);
+        } catch {
+          // Leave backup on disk for manual recovery.
+        }
+      }
+      throw error;
+    }
+
+    if (hadDestination) {
+      NodeFs.rmSync(backup, { force: true });
+    }
+    return result;
+  } catch (error) {
+    NodeFs.rmSync(staging, { force: true });
+    if (NodeFs.existsSync(backup) && !NodeFs.existsSync(destination)) {
+      try {
+        NodeFs.renameSync(backup, destination);
+      } catch {
+        // Leave backup on disk for manual recovery.
+      }
+    }
+    throw error;
   }
 }
 

--- a/scripts/setup-worktree.ts
+++ b/scripts/setup-worktree.ts
@@ -1,50 +1,136 @@
 // @effect-diagnostics nodeBuiltinImport:off - setup-script bootstrap, runs before any Effect runtime exists.
 /**
- * Worktree setup for t3.json, portable across POSIX and Windows shells. The
- * previous inline command chained `ln -sf` and `$VAR` expansion, which fails
- * under PowerShell/cmd. Installs dependencies, links the project root's `.env`
- * files into the worktree, then warms the web dependency cache.
+ * Worktree setup for t3.json, portable across POSIX and Windows shells.
+ *
+ * The previous inline command chained `ln -sf` and `$VAR` expansion, which
+ * fails under PowerShell/cmd when T3 types the setup script into a terminal
+ * (see ProjectSetupScriptRunner). This Node entrypoint:
+ *   1. installs deps (`vp i`)
+ *   2. links the project root's `.env` files into the worktree
+ *   3. warms the web dependency cache
  *
  * On Windows, symlink creation needs Developer Mode or elevation; when it is
- * denied we fall back to copying the file (a copy won't track later edits to
- * the root `.env`, so re-run this script after changing it).
+ * denied we fall back to copying (a copy won't track later edits to the root
+ * `.env`, so re-run this script after changing it).
  */
 import * as NodeChildProcess from "node:child_process";
 import * as NodeFs from "node:fs";
 import * as NodePath from "node:path";
+import * as NodeProcess from "node:process";
+import * as NodeURL from "node:url";
 
-const projectRoot = process.env.T3CODE_PROJECT_ROOT;
-const worktree = process.env.T3CODE_WORKTREE_PATH ?? process.cwd();
+export type EnvLinkResult =
+  | "linked"
+  | "copied"
+  | "skipped-same-path"
+  | "skipped-missing-source";
 
-function run(command: string, args: readonly string[]): void {
-  // shell: true so Windows resolves launcher shims like vp.cmd
-  const result = NodeChildProcess.spawnSync(command, [...args], {
-    stdio: "inherit",
-    shell: true,
-  });
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
-  }
+export const ENV_LINK_RELATIVE_PATHS = [".env", NodePath.join("infra", "relay", ".env")] as const;
+
+export function resolveWorktreePaths(env: NodeJS.ProcessEnv = NodeProcess.env): {
+  readonly projectRoot: string | undefined;
+  readonly worktree: string;
+} {
+  return {
+    projectRoot: env.T3CODE_PROJECT_ROOT || undefined,
+    worktree: env.T3CODE_WORKTREE_PATH || NodeProcess.cwd(),
+  };
 }
 
-function linkEnvFile(relativePath: string): void {
-  if (!projectRoot) return;
-  const source = NodePath.join(projectRoot, relativePath);
-  const destination = NodePath.join(worktree, relativePath);
-  // Running in the project root itself would link the file to itself.
-  if (NodePath.resolve(source) === NodePath.resolve(destination)) return;
+/**
+ * Link `projectRoot/relativePath` into the worktree. Never deletes the
+ * destination when the source is missing (avoids wiping a local file if the
+ * root has no `.env` yet).
+ */
+export function linkOrCopyEnvFile(input: {
+  readonly projectRoot: string;
+  readonly worktree: string;
+  readonly relativePath: string;
+}): EnvLinkResult {
+  const source = NodePath.join(input.projectRoot, input.relativePath);
+  const destination = NodePath.join(input.worktree, input.relativePath);
+  if (NodePath.resolve(source) === NodePath.resolve(destination)) {
+    return "skipped-same-path";
+  }
+  if (!NodeFs.existsSync(source)) {
+    return "skipped-missing-source";
+  }
+
+  NodeFs.mkdirSync(NodePath.dirname(destination), { recursive: true });
   NodeFs.rmSync(destination, { force: true });
   try {
     NodeFs.symlinkSync(source, destination, "file");
+    return "linked";
   } catch {
-    if (NodeFs.existsSync(source)) {
-      NodeFs.copyFileSync(source, destination);
-      console.log(`[setup-worktree] copied ${relativePath} (symlink unavailable)`);
-    }
+    NodeFs.copyFileSync(source, destination);
+    console.log(`[setup-worktree] copied ${input.relativePath} (symlink unavailable)`);
+    return "copied";
   }
 }
 
-run("vp", ["i"]);
-linkEnvFile(".env");
-linkEnvFile(NodePath.join("infra", "relay", ".env"));
-run("node", [NodePath.join("apps", "web", "scripts", "warm-dep-cache.ts")]);
+export function linkProjectEnvFiles(input: {
+  readonly projectRoot: string;
+  readonly worktree: string;
+  readonly relativePaths?: readonly string[];
+}): ReadonlyArray<{ readonly relativePath: string; readonly result: EnvLinkResult }> {
+  const relativePaths = input.relativePaths ?? ENV_LINK_RELATIVE_PATHS;
+  return relativePaths.map((relativePath) => ({
+    relativePath,
+    result: linkOrCopyEnvFile({
+      projectRoot: input.projectRoot,
+      worktree: input.worktree,
+      relativePath,
+    }),
+  }));
+}
+
+function run(command: string, args: readonly string[], cwd: string): void {
+  // shell: true so Windows resolves launcher shims (vp.cmd) the same way a
+  // typed terminal command would. Always pin cwd to the worktree — do not
+  // rely on the process already sitting there.
+  const result = NodeChildProcess.spawnSync(command, [...args], {
+    stdio: "inherit",
+    shell: true,
+    cwd,
+    env: NodeProcess.env,
+  });
+  if (result.error) {
+    console.error(`[setup-worktree] failed to spawn ${command}:`, result.error.message);
+    NodeProcess.exit(1);
+  }
+  if (result.status !== 0) {
+    NodeProcess.exit(result.status ?? 1);
+  }
+}
+
+export function runSetupWorktree(env: NodeJS.ProcessEnv = NodeProcess.env): void {
+  const { projectRoot, worktree } = resolveWorktreePaths(env);
+  if (!NodeFs.existsSync(worktree)) {
+    console.error(`[setup-worktree] worktree path does not exist: ${worktree}`);
+    NodeProcess.exit(1);
+  }
+
+  NodeProcess.chdir(worktree);
+
+  run("vp", ["i"], worktree);
+
+  if (projectRoot) {
+    for (const { relativePath, result } of linkProjectEnvFiles({ projectRoot, worktree })) {
+      if (result === "linked" || result === "copied") {
+        console.log(`[setup-worktree] ${result} ${relativePath}`);
+      }
+    }
+  } else {
+    console.warn("[setup-worktree] T3CODE_PROJECT_ROOT unset; skipping .env link");
+  }
+
+  run("node", [NodePath.join("apps", "web", "scripts", "warm-dep-cache.ts")], worktree);
+}
+
+const isExecutedDirectly =
+  typeof NodeProcess.argv[1] === "string" &&
+  NodeURL.pathToFileURL(NodePath.resolve(NodeProcess.argv[1])).href === import.meta.url;
+
+if (isExecutedDirectly) {
+  runSetupWorktree();
+}

--- a/t3.json
+++ b/t3.json
@@ -4,7 +4,7 @@
   "scripts": [
     {
       "name": "Setup Worktree",
-      "command": "vp i && ln -sf $T3CODE_PROJECT_ROOT/.env .env && ln -sf $T3CODE_PROJECT_ROOT/infra/relay/.env infra/relay/.env && node apps/web/scripts/warm-dep-cache.ts",
+      "command": "node scripts/setup-worktree.ts",
       "icon": "configure",
       "runOnWorktreeCreate": true
     }


### PR DESCRIPTION
## Problem

Worktree setup from `t3.json` is typed into a terminal via `ProjectSetupScriptRunner`. The command used `ln -sf`, `&&`, and `` expansion, which fails under Windows PowerShell/cmd — so new worktrees on Windows never get deps, env files, or a warm web cache.

## Fix

Replace the shell one-liner with `node scripts/setup-worktree.ts` that:

1. Runs `vp i` with the worktree as cwd
2. Links project-root `.env` files into the worktree (copy if symlink is denied)
3. Warms the web dep cache

Does not delete a worktree `.env` when the project root has no source yet. Parent dirs are created as needed.

## Test plan

- [x] `vp test run scripts/setup-worktree.test.ts` (link / copy / skip-missing / same-path)
- [ ] Create a worktree on Windows and confirm setup terminal runs without `ln` errors
- [ ] Confirm `.env` appears in the worktree (link or copy) when present on the project root

---

Model: Grok 4.5 · Harness: Grok Build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches worktree bootstrap and `.env` linking/copying with filesystem staging/rollback; a bug could leave worktrees without deps or with wrong env files, especially on Windows.
> 
> **Overview**
> Replaces the POSIX-only worktree setup command in `t3.json` (`vp i && ln -sf ...`) with `node scripts/setup-worktree.ts`, so setup works under PowerShell/cmd on Windows.
> 
> The new script installs deps, links `.env` and `infra/relay/.env` from the project root into the worktree (falling back to copy when symlinks are denied), then warms the web dep cache. Linking uses staging + backup/rename so a failed mid-flight write does not wipe a local worktree `.env`, and missing sources are skipped instead of deleting the destination.
> 
> Adds unit coverage for path resolution, link/copy, same-path/junction skips, missing sources, and non-file sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60918659d093c34beff103bfa0fe1fea2764aaf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace inline shell worktree setup with a Node script in `scripts/setup-worktree.ts`
> - Replaces the inline shell command in [t3.json](https://github.com/pingdotgg/t3code/pull/6268/files#diff-ed2426d5f9a505e4adcba4a25328883302241ea69c3132391a87bc8dc01b80ba) with `node scripts/setup-worktree.ts`, removing the dependency on a POSIX shell.
> - The new script resolves `projectRoot` and `worktree` from environment variables, installs dependencies via `vp i`, links or copies configured `.env` files, and warms the web dep cache.
> - Env file linking uses an atomic staging/rename flow: symlink when possible, copy as fallback, and never deletes an existing worktree env when the source is missing.
> - Behavioral Change: env file handling now skips when source and destination resolve to the same path (symlink/junction-aware), replacing the previous unconditional symlink creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6091865.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->