### PR TITLE
fix(terminal): restore CTRL+V paste on Windows and context menus

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -497,10 +497,16 @@ export const make = Effect.gen(function* () {
         menuTemplate.push({ type: "separator" });
       }
 
+      // The terminal renders on a canvas, but it focuses a hidden textarea so
+      // Electron's Paste role can send clipboard text to that input. Electron
+      // reports the canvas itself as non-editable, so enable Paste for canvases.
       menuTemplate.push(
         { role: "cut", enabled: params.editFlags.canCut },
         { role: "copy", enabled: params.editFlags.canCopy },
-        { role: "paste", enabled: params.editFlags.canPaste },
+        {
+          role: "paste",
+          enabled: params.editFlags.canPaste || params.mediaType === "canvas",
+        },
         { role: "selectAll", enabled: params.editFlags.canSelectAll },
       );
 

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -246,7 +246,12 @@ describe("isTerminalPasteShortcut", () => {
     expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "MacIntel")).toBe(false);
   });
 
-  it("preserves Ctrl+V and uses Ctrl+Shift+V elsewhere", () => {
+  it("uses Ctrl+V and Ctrl+Shift+V on Windows", () => {
+    expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "Win32")).toBe(true);
+    expect(isTerminalPasteShortcut(event({ ctrlKey: true, shiftKey: true }), "Win32")).toBe(true);
+  });
+
+  it("preserves Ctrl+V and uses Ctrl+Shift+V on Linux", () => {
     expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "Linux x86_64")).toBe(false);
     expect(isTerminalPasteShortcut(event({ ctrlKey: true, shiftKey: true }), "Linux x86_64")).toBe(
       true,

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -45,6 +45,15 @@ const TERMINAL_FONT_LOAD_VARIANTS = [
   "italic 700",
 ] as const;
 
+interface TerminalInputStyleSnapshot {
+  readonly left: string;
+  readonly top: string;
+  readonly width: string;
+  readonly height: string;
+  readonly zIndex: string;
+  readonly pointerEvents: string;
+}
+
 /** Requested terminal font; omitted fields fall back to the defaults. */
 export interface GhosttyTerminalFont {
   readonly family?: string;
@@ -540,7 +549,7 @@ export class GhosttyTerminalSurface {
   private readonly reducedMotionMedia = window.matchMedia?.("(prefers-reduced-motion: reduce)");
   private inputLeft = -1;
   private inputTop = -1;
-  private contextMenuInputPositioned = false;
+  private contextMenuInputStyle: TerminalInputStyleSnapshot | null = null;
 
   private constructor(
     mount: HTMLElement,
@@ -1321,12 +1330,18 @@ export class GhosttyTerminalSurface {
     // Native browser and Electron menus enable Paste for the focused editable
     // element. Put the hidden input under the pointer before the menu opens so
     // the terminal gets the platform's normal context-menu Paste action.
+    this.restoreInputAfterContextMenu();
+    this.contextMenuInputStyle = {
+      left: this.input.style.left,
+      top: this.input.style.top,
+      width: this.input.style.width,
+      height: this.input.style.height,
+      zIndex: this.input.style.zIndex,
+      pointerEvents: this.input.style.pointerEvents,
+    };
     const bounds = this.mount.getBoundingClientRect();
     const left = event.clientX - bounds.left - CONTEXT_MENU_INPUT_SIZE / 2;
     const top = event.clientY - bounds.top - CONTEXT_MENU_INPUT_SIZE / 2;
-    this.contextMenuInputPositioned = true;
-    this.inputLeft = left;
-    this.inputTop = top;
     this.input.style.left = `${left}px`;
     this.input.style.top = `${top}px`;
     this.input.style.width = `${CONTEXT_MENU_INPUT_SIZE}px`;
@@ -1595,7 +1610,7 @@ export class GhosttyTerminalSurface {
   }
 
   private positionInput(): void {
-    if (this.contextMenuInputPositioned) return;
+    if (this.contextMenuInputStyle !== null) return;
     const snapshot = this.snapshot;
     if (!snapshot || !snapshot.cursorVisible || snapshot.cursorX < 0 || snapshot.cursorY < 0) {
       return;
@@ -1613,15 +1628,15 @@ export class GhosttyTerminalSurface {
   }
 
   private restoreInputAfterContextMenu(): void {
-    if (!this.contextMenuInputPositioned) return;
-    this.contextMenuInputPositioned = false;
-    this.inputLeft = -1;
-    this.inputTop = -1;
-    this.input.style.width = "1px";
-    this.input.style.height = "1px";
-    this.input.style.zIndex = "";
-    this.input.style.pointerEvents = "none";
-    this.positionInput();
+    const style = this.contextMenuInputStyle;
+    if (style === null) return;
+    this.contextMenuInputStyle = null;
+    this.input.style.left = style.left;
+    this.input.style.top = style.top;
+    this.input.style.width = style.width;
+    this.input.style.height = style.height;
+    this.input.style.zIndex = style.zIndex;
+    this.input.style.pointerEvents = style.pointerEvents;
   }
 
   private cellAt(clientX: number, clientY: number): { x: number; y: number } {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -1,4 +1,4 @@
-import { isMacPlatform } from "../../lib/utils";
+import { isMacPlatform, isWindowsPlatform } from "../../lib/utils";
 import { collectWrappedTerminalLinkLine, extractTerminalLinks } from "../../terminal-links";
 import {
   GhosttyTerminalCore,
@@ -33,6 +33,7 @@ const TERMINAL_GLYPH_FALLBACKS =
 export const DEFAULT_TERMINAL_FONT_FAMILY =
   '"SF Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", ' + TERMINAL_GLYPH_FALLBACKS;
 const CONTENT_PADDING = 4;
+const CONTEXT_MENU_INPUT_SIZE = 20;
 const MIN_SCROLLBAR_THUMB_HEIGHT = 18;
 /** Half a blink cycle: the visible and hidden phases are equally long. */
 const CURSOR_BLINK_INTERVAL_MS = 500;
@@ -341,7 +342,8 @@ export function isTerminalPasteShortcut(
   platform = navigator.platform,
 ) {
   if (event.key.toLowerCase() !== "v") return false;
-  return isMacPlatform(platform) ? event.metaKey : event.ctrlKey && event.shiftKey;
+  if (isMacPlatform(platform)) return event.metaKey;
+  return event.ctrlKey && (isWindowsPlatform(platform) || event.shiftKey);
 }
 
 export function isTerminalCompositionCommitInput(event: Pick<InputEvent, "inputType">): boolean {
@@ -538,6 +540,7 @@ export class GhosttyTerminalSurface {
   private readonly reducedMotionMedia = window.matchMedia?.("(prefers-reduced-motion: reduce)");
   private inputLeft = -1;
   private inputTop = -1;
+  private contextMenuInputPositioned = false;
 
   private constructor(
     mount: HTMLElement,
@@ -796,6 +799,7 @@ export class GhosttyTerminalSurface {
   }
 
   focus(): void {
+    this.restoreInputAfterContextMenu();
     this.input.focus({ preventScroll: true });
   }
 
@@ -990,6 +994,7 @@ export class GhosttyTerminalSurface {
   }
 
   private readonly onPaste = (event: ClipboardEvent) => {
+    this.restoreInputAfterContextMenu();
     // Always suppress the browser's default insertion: content the textarea
     // would receive (for example an html-only clipboard converted to text)
     // leaks through onInput without bracketed-paste encoding.
@@ -1310,7 +1315,28 @@ export class GhosttyTerminalSurface {
   private readonly onContextMenu = (event: MouseEvent) => {
     if (shouldReportTerminalMouse(this.core.isMouseTracking(), event)) {
       event.preventDefault();
+      return;
     }
+
+    // Native browser and Electron menus enable Paste for the focused editable
+    // element. Put the hidden input under the pointer before the menu opens so
+    // the terminal gets the platform's normal context-menu Paste action.
+    const bounds = this.mount.getBoundingClientRect();
+    const left = event.clientX - bounds.left - CONTEXT_MENU_INPUT_SIZE / 2;
+    const top = event.clientY - bounds.top - CONTEXT_MENU_INPUT_SIZE / 2;
+    this.contextMenuInputPositioned = true;
+    this.inputLeft = left;
+    this.inputTop = top;
+    this.input.style.left = `${left}px`;
+    this.input.style.top = `${top}px`;
+    this.input.style.width = `${CONTEXT_MENU_INPUT_SIZE}px`;
+    this.input.style.height = `${CONTEXT_MENU_INPUT_SIZE}px`;
+    this.input.style.zIndex = "1000";
+    this.input.style.pointerEvents = "auto";
+    this.input.focus({ preventScroll: true });
+    window.setTimeout(() => {
+      if (!this.disposed) this.restoreInputAfterContextMenu();
+    }, 0);
   };
 
   private readonly onScrollbarPointerDown = (event: PointerEvent) => {
@@ -1569,6 +1595,7 @@ export class GhosttyTerminalSurface {
   }
 
   private positionInput(): void {
+    if (this.contextMenuInputPositioned) return;
     const snapshot = this.snapshot;
     if (!snapshot || !snapshot.cursorVisible || snapshot.cursorX < 0 || snapshot.cursorY < 0) {
       return;
@@ -1583,6 +1610,18 @@ export class GhosttyTerminalSurface {
     this.input.style.left = `${left}px`;
     this.input.style.top = `${top}px`;
     this.input.style.height = `${this.metrics.height}px`;
+  }
+
+  private restoreInputAfterContextMenu(): void {
+    if (!this.contextMenuInputPositioned) return;
+    this.contextMenuInputPositioned = false;
+    this.inputLeft = -1;
+    this.inputTop = -1;
+    this.input.style.width = "1px";
+    this.input.style.height = "1px";
+    this.input.style.zIndex = "";
+    this.input.style.pointerEvents = "none";
+    this.positionInput();
   }
 
   private cellAt(clientX: number, clientY: number): { x: number; y: number } {


### PR DESCRIPTION
## What Changed

- Enable native Paste for terminals via context menu
- Support Ctrl+V on Windows

## Why

CTRL+Shift+V worked on Windows, but it wasn't surfaced to the user that it was the expected input for pasting. This PR expands the different methods available.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Input/UX paste handling only; no auth, security, or data-path changes.
> 
> **Overview**
> Makes terminal paste work via **Ctrl+V on Windows** and via the **native/Electron context menu**.
> 
> `isTerminalPasteShortcut` now accepts both `Ctrl+V` and `Ctrl+Shift+V` on Windows; Linux stays `Ctrl+Shift+V`-only and macOS stays `Cmd+V`.
> 
> On right-click, the hidden textarea is briefly moved under the cursor and focused so Paste targets the terminal input, then restored. The desktop Electron menu also enables Paste over `canvas` elements, since Electron treats the terminal canvas as non-editable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dae294c8a70cb8f0e73d07fdd1704bb9670baec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CTRL+V paste in the terminal on Windows and in context menus
> - On Windows, `isTerminalPasteShortcut` in [`surface.ts`](https://github.com/pingdotgg/t3code/pull/6272/files#diff-036d64ffe3b3b3d167137e8ea29edae7af74a9e0323fc798c4f291992235d267) now treats both Ctrl+V and Ctrl+Shift+V as paste shortcuts; Linux keeps only Ctrl+Shift+V; macOS keeps Cmd+V.
> - When the context menu opens on the terminal canvas, the hidden textarea is temporarily repositioned under the cursor and focused so that the native/Electron "Paste" menu item correctly targets the terminal. Styles are restored on the next tick.
> - The context-menu Paste item in [`DesktopWindow.ts`](https://github.com/pingdotgg/t3code/pull/6272/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) is now enabled when `params.mediaType` is `"canvas"`, not just when `editFlags.canPaste` is true.
> - When terminal mouse reporting is active, context menu handling stops after `preventDefault` to avoid unintended textarea repositioning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dae294.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->