### PR TITLE
fix(web): reserve sibling column width when resizing the right panel

### DIFF
--- a/apps/web/src/components/preview/PreviewPanelShell.test.ts
+++ b/apps/web/src/components/preview/PreviewPanelShell.test.ts
@@ -20,4 +20,30 @@ describe("getPreviewPanelMaxWidth", () => {
 
     expect(markup).toContain("max-w-full");
   });
+
+  it("reserves the sibling column minimum when the flex row is known", () => {
+    // Fullscreen 14" MacBook: viewport 1512, sidebar ~256 → row of 1256.
+    // The 70% fraction (1058) would leave the chat column only ~198px;
+    // the container clamp caps the panel at 1256 − 360 instead.
+    expect(getPreviewPanelMaxWidth(1_512, 1_256)).toBe(896);
+  });
+
+  it("keeps the fraction cap when the row is wide enough for both columns", () => {
+    expect(getPreviewPanelMaxWidth(3_000, 2_900)).toBe(2_100);
+  });
+
+  it("rounds fractional row widths down", () => {
+    expect(getPreviewPanelMaxWidth(1_512, 1_256.6)).toBe(896);
+  });
+
+  it("never drops below the panel minimum when the row cannot fit both columns", () => {
+    // ~1000px window with an expanded sidebar → row of 700. The sibling
+    // reservation (700 − 360 = 340) would undercut the panel's own 360
+    // minimum and invert the resize clamp, so the floor wins.
+    expect(getPreviewPanelMaxWidth(1_000, 700)).toBe(360);
+  });
+
+  it("stays at the panel minimum even when the row is narrower than the reservation", () => {
+    expect(getPreviewPanelMaxWidth(1_512, 300)).toBe(360);
+  });
 });

--- a/apps/web/src/components/preview/PreviewPanelShell.tsx
+++ b/apps/web/src/components/preview/PreviewPanelShell.tsx
@@ -1,4 +1,11 @@
-import { type ReactNode, useEffect, useState } from "react";
+import {
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { isElectron } from "~/env";
 import { useResizableWidth } from "~/hooks/useResizableWidth";
@@ -10,12 +17,31 @@ export type PreviewPanelMode = "inline" | "sheet" | "sidebar" | "embedded";
 
 const PREVIEW_PANEL_WIDTH_STORAGE_KEY = "t3code:preview-panel-width";
 const PREVIEW_PANEL_MIN_WIDTH = 360;
-/** Fraction of the viewport allowed, preserving the remaining space for chat. */
+/**
+ * Upper bound as a fraction of the viewport; only binds on wide screens.
+ * On narrow windows the container clamp below is what preserves the
+ * sibling column's space.
+ */
 const PREVIEW_PANEL_MAX_WIDTH_FRACTION = 0.7;
 const PREVIEW_PANEL_DEFAULT_WIDTH = 540;
+/**
+ * Width reserved for the sibling column (chat, pull-request list) sharing the
+ * panel's flex row. The viewport fraction alone is not enough: the app
+ * sidebar sits outside the row, so on narrow windows (any MacBook, even
+ * fullscreen) the remaining 30% of the viewport minus the sidebar left the
+ * sibling below its usable width and the composer overflowed.
+ */
+const SIBLING_COLUMN_MIN_WIDTH = 360;
 
-export function getPreviewPanelMaxWidth(viewportWidth: number): number {
-  return Math.floor(viewportWidth * PREVIEW_PANEL_MAX_WIDTH_FRACTION);
+export function getPreviewPanelMaxWidth(viewportWidth: number, containerWidth?: number): number {
+  const fractionCap = Math.floor(viewportWidth * PREVIEW_PANEL_MAX_WIDTH_FRACTION);
+  const containerCap =
+    containerWidth === undefined ? Infinity : Math.floor(containerWidth) - SIBLING_COLUMN_MIN_WIDTH;
+  // Never below the panel's own minimum: when the row cannot fit both
+  // columns' minimums the sibling yields, and useResizableWidth's clamp
+  // must not see max < min (it would resolve the inversion to min and,
+  // via drag-end persistence, overwrite the user's stored width).
+  return Math.max(PREVIEW_PANEL_MIN_WIDTH, Math.min(fractionCap, containerCap));
 }
 
 /**
@@ -39,7 +65,10 @@ export function PreviewPanelShell(props: {
 }) {
   const useDragRegion = isElectron && props.mode !== "sheet" && props.mode !== "embedded";
   const isInline = props.mode === "inline";
-  const maxWidth = useViewportClampedMaxWidth();
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  // Only inline non-maximized mode applies `width`/`maxWidth`; skip the
+  // container measurement (and its re-renders) everywhere else.
+  const maxWidth = useClampedMaxWidth(hostRef, isInline && !props.maximized);
   const { width, handlers } = useResizableWidth({
     storageKey: props.widthStorageKey ?? PREVIEW_PANEL_WIDTH_STORAGE_KEY,
     defaultWidth: props.defaultWidth ?? PREVIEW_PANEL_DEFAULT_WIDTH,
@@ -50,6 +79,7 @@ export function PreviewPanelShell(props: {
 
   return (
     <div
+      ref={hostRef}
       className={cn(
         "relative flex h-full min-h-0 min-w-0 max-w-full flex-col self-stretch bg-background",
         isInline
@@ -70,12 +100,17 @@ export function PreviewPanelShell(props: {
 }
 
 /**
- * Track viewport width to derive a sensible upper bound for the panel.
- * Resize-aware so dragging the OS window narrower re-clamps the stored
- * width on the next render (the hook's clamp picks this up automatically).
+ * Track viewport and flex-row widths to derive an upper bound for the panel.
+ * Resize-aware so dragging the OS window narrower (or expanding the app
+ * sidebar) re-clamps the stored width on the next render (the hook's clamp
+ * picks this up automatically). The row is observed rather than the panel
+ * itself because the panel competes with its sibling column for row space.
+ * Row measurement only runs when `enabled`; modes without a resize handle
+ * never apply the resulting width, so they skip the observer entirely.
  */
-function useViewportClampedMaxWidth(): number {
+function useClampedMaxWidth(hostRef: RefObject<HTMLDivElement | null>, enabled: boolean): number {
   const [vw, setVw] = useState(() => (typeof window === "undefined" ? 1280 : window.innerWidth));
+  const [containerWidth, setContainerWidth] = useState<number | undefined>(undefined);
   useEffect(() => {
     if (typeof window === "undefined") return;
     let frame = 0;
@@ -93,5 +128,24 @@ function useViewportClampedMaxWidth(): number {
       if (frame !== 0) window.cancelAnimationFrame(frame);
     };
   }, []);
-  return getPreviewPanelMaxWidth(vw);
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    const parent = hostRef.current?.parentElement;
+    if (!parent) return;
+    // Measure before first paint: the persisted width must be clamped
+    // against the row on the initial render, not one observer tick later
+    // (the panel would flash over-wide on every mount). clientWidth is
+    // integral, so sub-pixel resize deltas bail out of re-rendering.
+    const measure = () => {
+      setContainerWidth(parent.clientWidth);
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(parent);
+    return () => {
+      observer.disconnect();
+    };
+  }, [hostRef, enabled]);
+  return getPreviewPanelMaxWidth(vw, containerWidth);
 }


### PR DESCRIPTION
## What Changed

The right panel's (diff/preview) resize clamp now reserves a minimum width for its sibling column (the chat, or the pull-request list) instead of only capping at 70% of `window.innerWidth`.

- `getPreviewPanelMaxWidth` takes the panel's flex-row width and clamps to `rowWidth − 360px`, keeping the viewport fraction as a secondary cap and flooring at the panel's own 360px minimum so a too-narrow row cannot invert the resize clamp.
- The row is measured with a shared `measure` callback (before first paint, then via ResizeObserver), so the clamp reacts to window *and* sidebar resizes and a persisted over-wide width cannot flash on mount. Measurement is skipped in modes that never apply the width (sheet, embedded, maximized).
- Unit tests cover the fraction cap, the row clamp, and both narrow-row edge cases.

+90/−10 in `PreviewPanelShell.tsx` and its test file.

## Why

Fixes #6181.

The clamp was blind to the app sidebar (which sits outside the 70% math) and to the chat composer's minimum content width. Whenever `0.3 × viewport − sidebar` fell below what the composer needs, the composer overflowed the chat panel before the clamp engaged.

That threshold is roughly a 1950px viewport, which is why the issue looked macOS-only: every MacBook — even fullscreen at 1512–1728 logical px — is below it, while typical Windows desktop monitors are above it. Reproduced on Windows 11 at non-maximized window widths and on macOS fullscreen; the drag now hard-stops leaving the sibling column usable on both.

## UI Changes

Before/after screenshots and drag recordings are in [the comment below](https://github.com/pingdotgg/t3code/pull/6279#issuecomment-5262992977) (macOS fullscreen, matching the issue's environment).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reserve sibling column width when resizing the right preview panel
> - Updates `getPreviewPanelMaxWidth` in [PreviewPanelShell.tsx](https://github.com/pingdotgg/t3code/pull/6279/files#diff-2bc30e0009261fedf96201eed47a807896930a736b4d944b9393ec09c4a72396) to accept an optional `containerWidth` and subtract a `SIBLING_COLUMN_MIN_WIDTH` (360px) reservation, so the preview panel cannot grow into the sibling column's space.
> - Replaces the viewport-only `useViewportClampedMaxWidth` hook with `useClampedMaxWidth`, which tracks both viewport width and the parent flex-row container width via `ResizeObserver` and `useLayoutEffect` to avoid over-wide flashes on mount.
> - Measurement is skipped entirely when not in inline non-maximized mode, avoiding unnecessary DOM observation.
> - Behavioral Change: in inline non-maximized mode, the panel's max width is now clamped by available container space rather than viewport width alone; the panel will never shrink below its own 360px minimum.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee21c84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI resize logic in PreviewPanelShell with unit tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes preview/diff panel resize so the chat (or PR list) column keeps at least **360px** on narrow layouts, instead of only limiting the panel to 70% of the viewport.
> 
> **`getPreviewPanelMaxWidth`** now takes an optional flex-row width and caps the panel at `rowWidth − 360`, still bounded by the 70% viewport rule and floored at the panel’s own 360px minimum so `max` never falls below `min` on very tight rows.
> 
> **`PreviewPanelShell`** measures the parent flex row (`useLayoutEffect` + `ResizeObserver`, only in inline non-maximized mode) so the clamp tracks window and sidebar changes and persisted widths don’t flash too wide on mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee21c84f4d5c5e156c17b88a3c0dc38c1427457f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

