### PR TITLE
fix(web): authorized-client revoke no longer silently leaves the row

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -2,8 +2,12 @@ import type { AdvertisedEndpoint, DesktopWslState } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   applyWslEnableSelection,
+  excludeHiddenAccessRows,
   isQrShareableEndpoint,
+  reconcileHiddenAccessIds,
   selectQrEndpointOption,
+  withHiddenAccessId,
+  withHiddenAccessIds,
 } from "./ConnectionsSettings.logic";
 
 const baseWslState: DesktopWslState = {
@@ -161,5 +165,30 @@ describe("selectQrEndpointOption", () => {
     const loopbackOnly = options.slice(0, 1);
     expect(selectQrEndpointOption(loopbackOnly, null, null)?.id).toBe("desktop-loopback:4780");
     expect(selectQrEndpointOption([], "anything", "anything")).toBeNull();
+  });
+});
+
+describe("authorized client optimistic hide helpers", () => {
+  it("excludes rows the user already revoked", () => {
+    const rows = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    expect(excludeHiddenAccessRows(rows, new Set(["b"]), (row) => row.id)).toEqual([
+      { id: "a" },
+      { id: "c" },
+    ]);
+  });
+
+  it("keeps hidden ids that are still live and drops ones the stream already removed", () => {
+    const hidden = new Set(["gone", "still-live"]);
+    const next = reconcileHiddenAccessIds(hidden, new Set(["still-live", "other"]));
+    expect([...next]).toEqual(["still-live"]);
+  });
+
+  it("adds newly revoked ids without mutating the previous set", () => {
+    const previous = new Set(["a"]);
+    const single = withHiddenAccessId(previous, "b");
+    const many = withHiddenAccessIds(previous, ["b", "c"]);
+    expect([...previous]).toEqual(["a"]);
+    expect([...single].toSorted()).toEqual(["a", "b"]);
+    expect([...many].toSorted()).toEqual(["a", "b", "c"]);
   });
 });

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -62,3 +62,67 @@ export async function applyWslEnableSelection(input: {
   }
   return await bridge.setWslBackendEnabled(true);
 }
+
+/**
+ * Hides rows the user already revoked while the auth-access stream catches up.
+ * Drops ids that left the live snapshot so the set does not grow forever.
+ */
+export function reconcileHiddenAccessIds(
+  hiddenIds: ReadonlySet<string>,
+  liveIds: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (hiddenIds.size === 0) {
+    return hiddenIds;
+  }
+  let changed = false;
+  const next = new Set<string>();
+  for (const id of hiddenIds) {
+    if (liveIds.has(id)) {
+      next.add(id);
+    } else {
+      changed = true;
+    }
+  }
+  return changed ? next : hiddenIds;
+}
+
+export function excludeHiddenAccessRows<T>(
+  rows: ReadonlyArray<T>,
+  hiddenIds: ReadonlySet<string>,
+  idOf: (row: T) => string,
+): ReadonlyArray<T> {
+  if (hiddenIds.size === 0) {
+    return rows;
+  }
+  return rows.filter((row) => !hiddenIds.has(idOf(row)));
+}
+
+export function withHiddenAccessId(
+  hiddenIds: ReadonlySet<string>,
+  id: string,
+): ReadonlySet<string> {
+  if (hiddenIds.has(id)) {
+    return hiddenIds;
+  }
+  const next = new Set(hiddenIds);
+  next.add(id);
+  return next;
+}
+
+export function withHiddenAccessIds(
+  hiddenIds: ReadonlySet<string>,
+  ids: ReadonlyArray<string>,
+): ReadonlySet<string> {
+  if (ids.length === 0) {
+    return hiddenIds;
+  }
+  const next = new Set(hiddenIds);
+  let changed = false;
+  for (const id of ids) {
+    if (!next.has(id)) {
+      next.add(id);
+      changed = true;
+    }
+  }
+  return changed ? next : hiddenIds;
+}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -6,7 +6,7 @@ import {
   TerminalIcon,
 } from "lucide-react";
 import { useAtomValue } from "@effect/atom-react";
-import { type ReactNode, memo, useCallback, useId, useMemo, useState } from "react";
+import { type ReactNode, memo, useCallback, useEffect, useId, useMemo, useState } from "react";
 import {
   AuthAccessReadScope,
   AuthAccessWriteScope,
@@ -42,8 +42,12 @@ import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestam
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
 import {
   applyWslEnableSelection,
+  excludeHiddenAccessRows,
   isQrShareableEndpoint,
+  reconcileHiddenAccessIds,
   selectQrEndpointOption,
+  withHiddenAccessId,
+  withHiddenAccessIds,
 } from "./ConnectionsSettings.logic";
 import {
   SettingsPageContainer,
@@ -1793,6 +1797,14 @@ export function ConnectionsSettings() {
   const [desktopAccessManagementMutationError, setDesktopAccessManagementMutationError] = useState<
     string | null
   >(null);
+  // Optimistic hides so revoked rows leave the list immediately, even if the
+  // auth-access stream lags or drops the clientRemoved event.
+  const [hiddenDesktopPairingLinkIds, setHiddenDesktopPairingLinkIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [hiddenDesktopClientSessionIds, setHiddenDesktopClientSessionIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const [revokingDesktopPairingLinkId, setRevokingDesktopPairingLinkId] = useState<string | null>(
     null,
   );
@@ -1908,24 +1920,45 @@ export function ConnectionsSettings() {
     desktopAccessManagementMutationError ?? authAccessChanges.error;
   const isLoadingDesktopAccessManagement =
     authAccessChanges.isPending && authAccessChanges.data === null;
+  useEffect(() => {
+    const event = authAccessChanges.data;
+    if (event?.type !== "snapshot") return;
+    const livePairingLinkIds = new Set(event.payload.pairingLinks.map((link) => link.id));
+    const liveClientSessionIds = new Set(
+      event.payload.clientSessions.map((session) => session.sessionId),
+    );
+    setHiddenDesktopPairingLinkIds((current) =>
+      reconcileHiddenAccessIds(current, livePairingLinkIds),
+    );
+    setHiddenDesktopClientSessionIds((current) =>
+      reconcileHiddenAccessIds(current, liveClientSessionIds),
+    );
+  }, [authAccessChanges.data]);
+
   const desktopPairingLinks = useMemo(() => {
     const event = authAccessChanges.data;
     if (event?.type !== "snapshot") return [];
-    return sortDesktopPairingLinks(
+    const links = sortDesktopPairingLinks(
       event.payload.pairingLinks.map((pairingLink: AuthPairingLink) =>
         toDesktopPairingLinkRecord(pairingLink),
       ),
     );
-  }, [authAccessChanges.data]);
+    return excludeHiddenAccessRows(links, hiddenDesktopPairingLinkIds, (link) => link.id);
+  }, [authAccessChanges.data, hiddenDesktopPairingLinkIds]);
   const desktopClientSessions = useMemo(() => {
     const event = authAccessChanges.data;
     if (event?.type !== "snapshot") return [];
-    return sortDesktopClientSessions(
+    const sessions = sortDesktopClientSessions(
       event.payload.clientSessions.map((clientSession: AuthClientSession) =>
         toDesktopClientSessionRecord(clientSession),
       ),
     );
-  }, [authAccessChanges.data]);
+    return excludeHiddenAccessRows(
+      sessions,
+      hiddenDesktopClientSessionIds,
+      (session) => session.sessionId,
+    );
+  }, [authAccessChanges.data, hiddenDesktopClientSessionIds]);
   const isLocalBackendNetworkAccessible = desktopBridge
     ? desktopServerExposureState?.mode === "network-accessible"
     : currentAuthPolicy === "remote-reachable";
@@ -2059,6 +2092,7 @@ export function ConnectionsSettings() {
     setDesktopAccessManagementMutationError(null);
     try {
       await revokeServerPairingLink(id);
+      setHiddenDesktopPairingLinkIds((current) => withHiddenAccessId(current, id));
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to revoke pairing link.";
       setDesktopAccessManagementMutationError(message);
@@ -2080,6 +2114,7 @@ export function ConnectionsSettings() {
       setDesktopAccessManagementMutationError(null);
       try {
         await revokeServerClientSession(sessionId);
+        setHiddenDesktopClientSessionIds((current) => withHiddenAccessId(current, sessionId));
       } catch (error) {
         const message = error instanceof Error ? error.message : "Failed to revoke client access.";
         setDesktopAccessManagementMutationError(message);
@@ -2100,8 +2135,14 @@ export function ConnectionsSettings() {
   const handleRevokeOtherDesktopClients = useCallback(async () => {
     setIsRevokingOtherDesktopClients(true);
     setDesktopAccessManagementMutationError(null);
+    const otherSessionIds = desktopClientSessions
+      .filter((session) => !session.current)
+      .map((session) => session.sessionId);
     try {
       const revokedCount = await revokeOtherServerClientSessions();
+      if (revokedCount > 0) {
+        setHiddenDesktopClientSessionIds((current) => withHiddenAccessIds(current, otherSessionIds));
+      }
       toastManager.add({
         type: "success",
         title: revokedCount === 1 ? "Revoked 1 other client" : `Revoked ${revokedCount} clients`,
@@ -2120,7 +2161,7 @@ export function ConnectionsSettings() {
     } finally {
       setIsRevokingOtherDesktopClients(false);
     }
-  }, []);
+  }, [desktopClientSessions]);
 
   const handleAddSavedBackend = useCallback(async () => {
     if (savedBackendMode === "ssh") {

--- a/apps/web/src/environments/primary/auth.revoke.test.ts
+++ b/apps/web/src/environments/primary/auth.revoke.test.ts
@@ -1,0 +1,39 @@
+import { AuthSessionId } from "@t3tools/contracts";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { __setPrimaryHttpRunnerForTests } from "../../lib/runtime";
+import { revokeServerClientSession, revokeServerPairingLink } from "./auth";
+
+afterEach(() => {
+  __setPrimaryHttpRunnerForTests();
+});
+
+describe("revokeServerClientSession", () => {
+  it("resolves when the server reports the session was revoked", async () => {
+    __setPrimaryHttpRunnerForTests(async () => ({ revoked: true }));
+    await expect(
+      revokeServerClientSession(AuthSessionId.make("session-1")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails when the server returns a successful no-op", async () => {
+    __setPrimaryHttpRunnerForTests(async () => ({ revoked: false }));
+    await expect(revokeServerClientSession(AuthSessionId.make("session-1"))).rejects.toThrow(
+      "That client session is no longer active.",
+    );
+  });
+});
+
+describe("revokeServerPairingLink", () => {
+  it("resolves when the server reports the link was revoked", async () => {
+    __setPrimaryHttpRunnerForTests(async () => ({ revoked: true }));
+    await expect(revokeServerPairingLink("pairing-1")).resolves.toBeUndefined();
+  });
+
+  it("fails when the server returns a successful no-op", async () => {
+    __setPrimaryHttpRunnerForTests(async () => ({ revoked: false }));
+    await expect(revokeServerPairingLink("pairing-1")).rejects.toThrow(
+      "That pairing link is no longer active.",
+    );
+  });
+});

--- a/apps/web/src/environments/primary/auth.ts
+++ b/apps/web/src/environments/primary/auth.ts
@@ -426,8 +426,9 @@ export async function listServerPairingLinks(): Promise<ReadonlyArray<ServerPair
 }
 
 export async function revokeServerPairingLink(id: string): Promise<void> {
+  let result: { readonly revoked: boolean };
   try {
-    await runPrimaryHttp(
+    result = await runPrimaryHttp(
       PrimaryEnvironmentHttpClient.pipe(
         Effect.flatMap((client) => client.auth.revokePairingLink({ headers: {}, payload: { id } })),
       ),
@@ -438,6 +439,11 @@ export async function revokeServerPairingLink(id: string): Promise<void> {
       pairingLinkId: id,
       cause: error,
     });
+  }
+  // Server returns 200 with revoked:false when nothing matched — surface that
+  // so the UI does not treat a no-op as success while the row stays put.
+  if (!result.revoked) {
+    throw new Error("That pairing link is no longer active.");
   }
 }
 
@@ -474,8 +480,9 @@ export async function listServerClientSessions(): Promise<
 }
 
 export async function revokeServerClientSession(sessionId: AuthSessionId): Promise<void> {
+  let result: { readonly revoked: boolean };
   try {
-    await runPrimaryHttp(
+    result = await runPrimaryHttp(
       PrimaryEnvironmentHttpClient.pipe(
         Effect.flatMap((client) =>
           client.auth.revokeClient({ headers: {}, payload: { sessionId } }),
@@ -488,6 +495,11 @@ export async function revokeServerClientSession(sessionId: AuthSessionId): Promi
       sessionId,
       cause: error,
     });
+  }
+  // Server returns 200 with revoked:false when nothing matched — surface that
+  // so the UI does not treat a no-op as success while the row stays put.
+  if (!result.revoked) {
+    throw new Error("That client session is no longer active.");
   }
 }
 


### PR DESCRIPTION
## Problem

One-off **Revoke** on Settings → Connections → Authorized clients could look like a no-op: the button flashed "Revoking…", then the row stayed, with no error. Reported on Windows.

## Cause

Two client gaps stacked:

1. `POST /api/auth/clients/revoke` can return **200** with `{ revoked: false }` when nothing matched. The client ignored that flag and treated any non-throwing response as success.
2. The list only updated from the live auth-access stream (`clientRemoved`). There was no optimistic hide and no local check of the HTTP result, so a no-op or a lagging stream left the row in place.

Windows was where it was noticed; the contract bug is cross-platform (not a Windows-only code path).

## Fix

- Treat `revoked: false` as failure for client-session and pairing-link revoke (clear error toast).
- Hide the row as soon as revoke succeeds, then prune the hide set when the stream catches up.
- Same optimistic hide for "Revoke others" when `revokedCount > 0`.
- Focused unit tests for the revoke contract and hide helpers.

## Verification

- `vp test run apps/web/src/environments/primary/auth.revoke.test.ts apps/web/src/components/settings/ConnectionsSettings.logic.test.ts` — pass
- Manual smoke on Windows: individual revoke removed the row as expected

## Note on confidence

Confirmed as a real product defect in the client/server contract and UI update path. Not proven with a captured Network response of `revoked: false` on the original report; the fix still closes the silent-failure path that matches the reported symptom.

Model: Grok 4.5 (xAI) · harness: Grok Build TUI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side access-management revoke handling and list visibility for authorized clients. Risk is moderate because incorrect optimistic hide or revoke-result checks could briefly misrepresent access state, but server auth itself is unchanged.
> 
> **Overview**
> Fixes Settings → Connections revoke looking like a no-op when the row stayed after “Revoking…”.
> 
> **`revokeServerClientSession`** and **`revokeServerPairingLink`** now treat HTTP 200 with `revoked: false` as failure and surface an error toast, instead of treating any non-throwing response as success.
> 
> Authorized clients/pairing links also **hide optimistically** on successful revoke (including “Revoke others”), then prune the hide set when the auth-access snapshot catches up—so lagging or dropped stream events no longer leave stale rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77a7fd2debe91e5bd35ad15f480ccf890a5cb5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix revoked authorized-client rows silently persisting in the connections settings UI
> - `revokeServerClientSession` and `revokeServerPairingLink` in [`auth.ts`](https://github.com/pingdotgg/t3code/pull/6282/files#diff-890ed82ba4e0838569b58c8c7aff7ce2995879306e5287324879a4a91b33e27c) now throw when the server returns `revoked: false`, preventing a silent no-op from being treated as success.
> - The connections settings UI now optimistically hides revoked pairing links and client sessions immediately after a successful revoke call, using new `withHiddenAccessId` / `excludeHiddenAccessRows` helpers.
> - A `useEffect` in [`ConnectionsSettings.tsx`](https://github.com/pingdotgg/t3code/pull/6282/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) reconciles the hidden-id sets against live snapshots so stale entries are cleaned up when the server data refreshes.
> - Bulk "revoke other sessions" now also optimistically hides all affected rows when the server reports at least one was revoked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c77a7fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->