### PR TITLE
fix(server): skip killing completed provider updates

### DIFF
--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -109,12 +109,14 @@ function mockHandle(result: {
   readonly stderr?: string;
   readonly code?: number;
   readonly exitCode?: Effect.Effect<ChildProcessSpawner.ExitCode>;
+  readonly isRunning?: Effect.Effect<boolean>;
+  readonly kill?: () => Effect.Effect<void>;
 }) {
   return ChildProcessSpawner.makeHandle({
     pid: ChildProcessSpawner.ProcessId(1),
     exitCode: result.exitCode ?? Effect.succeed(ChildProcessSpawner.ExitCode(result.code ?? 0)),
-    isRunning: Effect.succeed(false),
-    kill: () => Effect.void,
+    isRunning: result.isRunning ?? Effect.succeed(false),
+    kill: result.kill ?? (() => Effect.void),
     unref: Effect.succeed(Effect.void),
     stdin: Sink.drain,
     stdout: Stream.make(encoder.encode(result.stdout ?? "")),
@@ -134,6 +136,8 @@ function mockSpawnerLayer(
     readonly stderr?: string;
     readonly code?: number;
     readonly exitCode?: Effect.Effect<ChildProcessSpawner.ExitCode>;
+    readonly isRunning?: Effect.Effect<boolean>;
+    readonly kill?: () => Effect.Effect<void>;
   },
 ) {
   return Layer.succeed(
@@ -217,6 +221,33 @@ const makeTestRunner = (registry: ProviderRegistryShape) =>
   );
 
 describe("providerMaintenanceRunner", () => {
+  it.effect("does not kill an updater that already exited", () => {
+    let killCalls = 0;
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry(baseCursorProvider);
+      const updater = yield* makeTestRunner(registry);
+
+      yield* updater.updateProvider(CURSOR_DRIVER);
+
+      assert.strictEqual(killCalls, 0);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.0.0"),
+          mockSpawnerLayer(() => ({
+            stdout: "updated",
+            isRunning: Effect.succeed(false),
+            kill: () =>
+              Effect.sync(() => {
+                killCalls += 1;
+              }),
+          })),
+        ),
+      ),
+    );
+  });
+
   it.effect("runs the allowlisted provider update command and records success", () => {
     const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
     return Effect.gen(function* () {

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -93,7 +93,12 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
                 }),
             ),
           );
-        yield* Effect.addFinalizer(() => child.kill().pipe(Effect.ignore));
+        yield* Effect.addFinalizer(() =>
+          child.isRunning.pipe(
+            Effect.flatMap((isRunning) => (isRunning ? child.kill() : Effect.void)),
+            Effect.ignore,
+          ),
+        );
 
         const [stdout, stderr, exitCode] = yield* Effect.all(
           [

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -95,6 +95,7 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
           );
         yield* Effect.addFinalizer(() =>
           child.isRunning.pipe(
+            Effect.orElseSucceed(() => true),
             Effect.flatMap((isRunning) => (isRunning ? child.kill() : Effect.void)),
             Effect.ignore,
           ),


### PR DESCRIPTION
## What changed

- Check whether a provider update process is still running before killing it during cleanup.
- Add a regression test for completed updates.

## Why

Completed provider updates were still sent a kill request when their scope closed. On Windows this can invoke `taskkill` through `cmd.exe` and briefly flash a console window.

This keeps cleanup for running processes while skipping the redundant kill after a successful exit. Related to #2537.

## Testing

- `vp test run apps/server/src/provider/providerMaintenanceRunner.test.ts` (12 passed)
- `vp lint apps/server/src/provider/providerMaintenanceRunner.ts apps/server/src/provider/providerMaintenanceRunner.test.ts`
- `vp run --filter t3 typecheck`

Model: GPT-5.6 Sol · Harness: Codex


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip killing already-exited processes in provider maintenance runner
> In [`providerMaintenanceRunner.ts`](https://github.com/pingdotgg/t3code/pull/6284/files#diff-53af42bf8411ec1355506cb2396e258735619c36076bec3d8d708d8b697275dc), the finalizer now checks `child.isRunning` before calling `child.kill()`, skipping the kill signal if the process has already exited. If `isRunning` check fails, it still attempts to kill. A regression test is added to verify no kill is sent for already-completed processes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9442413.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small process-cleanup tweak with a safe fallback that still kills when `isRunning` cannot be determined. No auth, data, or API surface changes.
> 
> **Overview**
> Stops the provider update cleanup finalizer from always calling `kill()` on completed child processes.
> 
> In `collectCommandResult`, the scoped finalizer now checks `child.isRunning` first and only kills when the process is still alive (`isRunning` failures still fall back to kill). Adds a regression test covering the already-exited case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94424133ee32f3a44f6b0a55312f0ee6da88fb82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->