### PR TITLE
feat(server): run the background service on macOS via launchd

### DIFF
--- a/apps/server/src/cli/connect.ts
+++ b/apps/server/src/cli/connect.ts
@@ -5,6 +5,7 @@ import {
   type RelayClientInstallProgressStage,
 } from "@t3tools/contracts";
 import { RelayOkResponse } from "@t3tools/contracts/relay";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as RelayClient from "@t3tools/shared/relayClient";
 import { withRelayClientTracing } from "@t3tools/shared/relayTracing";
 import * as Cause from "effect/Cause";
@@ -694,8 +695,11 @@ export const connectCommand = Command.make("connect", {
         // fail the command, just tell the user what happened and move on.
         const background = yield* recoverServiceOnboardingOffer(offerServiceDuringOnboarding);
         if (background) {
+          const platform = yield* HostProcessPlatform;
           yield* Console.log(
-            "\n✓ Background service ready\n\nT3 Code will stay reachable after you log out.",
+            platform === "darwin"
+              ? "\n✓ Background service ready\n\nT3 Code will stay reachable while you are logged in to this Mac."
+              : "\n✓ Background service ready\n\nT3 Code will stay reachable after you log out.",
           );
           return;
         }

--- a/apps/server/src/cli/service.test.ts
+++ b/apps/server/src/cli/service.test.ts
@@ -29,9 +29,9 @@ it("gives a direct repair command for a stale service", () => {
   );
 });
 
-it("explains service availability without systemd", () => {
+it("explains where the service is supported", () => {
   assert.include(
     formatServiceStatus({ ...status, supported: false, installed: false }, "0.0.29"),
-    "Supported on: Linux with systemd",
+    "Supported on: Linux with systemd, macOS with launchd",
   );
 });

--- a/apps/server/src/cli/service.ts
+++ b/apps/server/src/cli/service.ts
@@ -1,3 +1,4 @@
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -48,7 +49,7 @@ export function formatServiceStatus(
   cliVersion: string,
 ): string {
   if (!status.supported) {
-    return "T3 Code service\n  Status: unavailable on this machine\n  Supported on: Linux with systemd";
+    return "T3 Code service\n  Status: unavailable on this machine\n  Supported on: Linux with systemd, macOS with launchd";
   }
   if (!status.installed) {
     return "T3 Code service\n  Status: not installed\n  Next: Run `t3 service install`.";
@@ -152,12 +153,18 @@ export const offerServiceDuringOnboarding = Effect.gen(function* () {
     yield* Console.log("T3 Code is already set up to run in the background on this machine.");
     return true;
   }
+  // A LaunchAgent starts at login and dies at logout; there is no
+  // enable-linger equivalent on macOS. Do not promise more than that.
+  const platform = yield* HostProcessPlatform;
   const wanted = yield* Prompt.run(
     Prompt.confirm({
       message: installed
         ? "The installed T3 Code service needs an update or repair. Update it now?"
-        : "Run T3 Code in the background whenever this machine boots? " +
-          "It stays reachable through T3 Connect even after you log out.",
+        : platform === "darwin"
+          ? "Run T3 Code in the background whenever you log in to this Mac? " +
+            "It stays reachable through T3 Connect while you are logged in."
+          : "Run T3 Code in the background whenever this machine boots? " +
+            "It stays reachable through T3 Connect even after you log out.",
       initial: true,
     }),
   );

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -67,8 +67,8 @@ it("keeps launchd pinned to the stable launcher rather than a versioned server",
 it("restarts the launch agent on the systemd cadence", () => {
   const plist = BootService.renderBootServicePlist(macPlan, { homeDir: "/Users/theo" });
 
-  expect(plist).toContain("<key>RunAtLoad</key>");
-  expect(plist).toContain("<key>KeepAlive</key>");
+  expect(plist).toContain("<key>RunAtLoad</key>\n  <true/>");
+  expect(plist).toContain("<key>KeepAlive</key>\n  <true/>");
   expect(plist).toContain("<key>ThrottleInterval</key>\n  <integer>5</integer>");
 });
 
@@ -276,7 +276,7 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       yield* service.install;
       const plistPath = (yield* service.status).unitPath;
       commands.length = 0;
-      control.failCommand = "launchctl kickstart -k gui/501/com.t3tools.t3code.service";
+      control.failCommand = `launchctl bootstrap gui/501 ${plistPath}`;
 
       const error = yield* service.install.pipe(Effect.flip);
       expect(error._tag).toBe("BootServiceCommandError");
@@ -284,9 +284,7 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
         "launchctl bootout gui/501/com.t3tools.t3code.service",
         "launchctl enable gui/501/com.t3tools.t3code.service",
         `launchctl bootstrap gui/501 ${plistPath}`,
-        "launchctl kickstart -k gui/501/com.t3tools.t3code.service",
         `launchctl bootstrap gui/501 ${plistPath}`,
-        "launchctl kickstart -k gui/501/com.t3tools.t3code.service",
       ]);
     }),
   );
@@ -326,7 +324,6 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       expect(commands.filter((command) => command.startsWith("launchctl "))).toEqual([
         "launchctl bootout gui/501/com.t3tools.t3code.service",
         `launchctl bootstrap gui/501 ${plistPath}`,
-        "launchctl kickstart -k gui/501/com.t3tools.t3code.service",
       ]);
     }),
   );

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -7,6 +7,7 @@ import {
   HostProcessUserId,
 } from "@t3tools/shared/hostProcess";
 import * as ConfigProvider from "effect/ConfigProvider";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -70,6 +71,7 @@ it("restarts the launch agent on the systemd cadence", () => {
   expect(plist).toContain("<key>RunAtLoad</key>\n  <true/>");
   expect(plist).toContain("<key>KeepAlive</key>\n  <true/>");
   expect(plist).toContain("<key>ThrottleInterval</key>\n  <integer>5</integer>");
+  expect(plist).toContain("<key>ExitTimeOut</key>\n  <integer>90</integer>");
 });
 
 it("appends both stdio streams to the boot service log", () => {
@@ -113,12 +115,14 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
   yield* fs.writeFileString(runtime.sentinelPath, "1.2.3\n");
 
   const commands: string[] = [];
+  const timeouts = new Map<string, unknown>();
   const control: { failCommand: string | undefined } = { failCommand: undefined };
   const runner = ProcessRunner.ProcessRunner.of({
     run: (input) =>
       Effect.sync(() => {
         const command = `${input.command} ${input.args.join(" ")}`;
         commands.push(command);
+        timeouts.set(command, input.timeout);
         return {
           stdout: input.args[1] === "--version" ? "t3 v1.2.3\n" : "",
           stderr: "",
@@ -151,13 +155,13 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
       ),
     ),
   );
-  return { service, fs, statePath, commands, control };
+  return { service, fs, statePath, commands, timeouts, control };
 });
 
 it.layer(NodeServices.layer)("boot service install", (it) => {
   it.effect("installs, reports current state, and uninstalls", () =>
     Effect.gen(function* () {
-      const { service, fs, statePath, commands } = yield* makeHarness();
+      const { service, fs, statePath, commands, timeouts } = yield* makeHarness();
       const plan = yield* service.install;
 
       expect(parseServiceState(yield* fs.readFileString(statePath))).toEqual({
@@ -183,6 +187,11 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       expect(yield* service.uninstall).toBe(true);
       expect((yield* service.status).installed).toBe(false);
       expect(commands.some((command) => command.startsWith("npm "))).toBe(false);
+      // The stop can block up to systemd's 90s TimeoutStopSec; the runner's
+      // 60s default would cancel it mid-shutdown.
+      expect(timeouts.get("systemctl --user disable --now t3code.service")).toEqual(
+        Duration.seconds(120),
+      );
     }),
   );
 
@@ -251,7 +260,7 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
 
   it.effect("installs, reports current state, and uninstalls on macOS", () =>
     Effect.gen(function* () {
-      const { service, fs, statePath, commands } = yield* makeHarness("darwin");
+      const { service, fs, statePath, commands, timeouts } = yield* makeHarness("darwin");
       const plan = yield* service.install;
 
       expect(plan.unitPath.endsWith("Library/LaunchAgents/com.t3tools.t3code.service.plist")).toBe(
@@ -267,6 +276,11 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       expect((yield* service.status).installed).toBe(false);
       expect(commands.some((command) => command.startsWith("npm "))).toBe(false);
       expect(commands.some((command) => command.startsWith("systemctl "))).toBe(false);
+      // A bootout can block up to the plist's 90s ExitTimeOut; the runner's
+      // 60s default would cancel it and let bootstrap race a loaded job.
+      expect(timeouts.get("launchctl bootout gui/501/com.t3tools.t3code.service")).toEqual(
+        Duration.seconds(120),
+      );
     }),
   );
 

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -4,6 +4,7 @@ import {
   HostProcessArguments,
   HostProcessExecutablePath,
   HostProcessPlatform,
+  HostProcessUserId,
 } from "@t3tools/shared/hostProcess";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
@@ -45,6 +46,50 @@ it("survives the kernel OOM-killing a greedy agent child", () => {
   });
 
   expect(unit).toContain("OOMPolicy=continue");
+});
+
+const macPlan = {
+  nodePath: "/opt/homebrew/bin/node",
+  launcherPath: "/Users/theo/.t3/runtime/service-launcher.mjs",
+  baseDir: "/Users/theo/.t3",
+  logPath: "/Users/theo/.t3/userdata/logs/boot-service.log",
+  unitPath: "/Users/theo/Library/LaunchAgents/com.t3tools.t3code.service.plist",
+};
+
+it("keeps launchd pinned to the stable launcher rather than a versioned server", () => {
+  const plist = BootService.renderBootServicePlist(macPlan, { homeDir: "/Users/theo" });
+
+  expect(plist).toContain("<string>/opt/homebrew/bin/node</string>");
+  expect(plist).toContain("<string>/Users/theo/.t3/runtime/service-launcher.mjs</string>");
+  expect(plist).not.toContain("versions/1.2.3");
+});
+
+it("restarts the launch agent on the systemd cadence", () => {
+  const plist = BootService.renderBootServicePlist(macPlan, { homeDir: "/Users/theo" });
+
+  expect(plist).toContain("<key>RunAtLoad</key>");
+  expect(plist).toContain("<key>KeepAlive</key>");
+  expect(plist).toContain("<key>ThrottleInterval</key>\n  <integer>5</integer>");
+});
+
+it("appends both stdio streams to the boot service log", () => {
+  const plist = BootService.renderBootServicePlist(macPlan, { homeDir: "/Users/theo" });
+
+  expect(plist).toContain(
+    "<key>StandardOutPath</key>\n  <string>/Users/theo/.t3/userdata/logs/boot-service.log</string>",
+  );
+  expect(plist).toContain(
+    "<key>StandardErrorPath</key>\n  <string>/Users/theo/.t3/userdata/logs/boot-service.log</string>",
+  );
+});
+
+it("escapes XML in host paths", () => {
+  const plist = BootService.renderBootServicePlist(
+    { ...macPlan, baseDir: "/Users/theo/T3 & <Co>" },
+    { homeDir: "/Users/theo" },
+  );
+
+  expect(plist).toContain("<string>/Users/theo/T3 &amp; &lt;Co&gt;</string>");
 });
 
 const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
@@ -99,6 +144,7 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
     Effect.provide(
       Layer.mergeAll(
         Layer.succeed(HostProcessPlatform, platform),
+        Layer.succeed(HostProcessUserId, 501),
         Layer.succeed(HostProcessExecutablePath, "/usr/bin/node"),
         Layer.succeed(HostProcessArguments, ["/usr/bin/node", path.join(home, "bin.mjs")]),
         ConfigProvider.layer(ConfigProvider.fromEnv({ env: { HOME: home } })),
@@ -195,11 +241,93 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
     }),
   );
 
-  it.effect("fails closed off Linux", () =>
+  it.effect("fails closed on Windows", () =>
     Effect.gen(function* () {
-      const { service } = yield* makeHarness("darwin");
+      const { service } = yield* makeHarness("win32");
       expect((yield* service.status).supported).toBe(false);
       expect((yield* service.install.pipe(Effect.flip))._tag).toBe("BootServiceUnsupportedError");
+    }),
+  );
+
+  it.effect("installs, reports current state, and uninstalls on macOS", () =>
+    Effect.gen(function* () {
+      const { service, fs, statePath, commands } = yield* makeHarness("darwin");
+      const plan = yield* service.install;
+
+      expect(plan.unitPath.endsWith("Library/LaunchAgents/com.t3tools.t3code.service.plist")).toBe(
+        true,
+      );
+      expect(parseServiceState(yield* fs.readFileString(statePath))).toEqual({
+        protocol: SERVICE_LAUNCHER_PROTOCOL,
+        activeVersion: "1.2.3",
+      });
+      expect(yield* fs.readFileString(plan.launcherPath)).toBe("export {};\n");
+      expect((yield* service.status).current).toBe(true);
+      expect(yield* service.uninstall).toBe(true);
+      expect((yield* service.status).installed).toBe(false);
+      expect(commands.some((command) => command.startsWith("npm "))).toBe(false);
+      expect(commands.some((command) => command.startsWith("systemctl "))).toBe(false);
+    }),
+  );
+
+  it.effect("restarts the launch agent when repair fails", () =>
+    Effect.gen(function* () {
+      const { service, commands, control } = yield* makeHarness("darwin");
+      yield* service.install;
+      const plistPath = (yield* service.status).unitPath;
+      commands.length = 0;
+      control.failCommand = "launchctl kickstart -k gui/501/com.t3tools.t3code.service";
+
+      const error = yield* service.install.pipe(Effect.flip);
+      expect(error._tag).toBe("BootServiceCommandError");
+      expect(commands.filter((command) => command.startsWith("launchctl "))).toEqual([
+        "launchctl bootout gui/501/com.t3tools.t3code.service",
+        "launchctl enable gui/501/com.t3tools.t3code.service",
+        `launchctl bootstrap gui/501 ${plistPath}`,
+        "launchctl kickstart -k gui/501/com.t3tools.t3code.service",
+        `launchctl bootstrap gui/501 ${plistPath}`,
+        "launchctl kickstart -k gui/501/com.t3tools.t3code.service",
+      ]);
+    }),
+  );
+
+  it.effect("ignores a bootout for an agent that is not loaded", () =>
+    Effect.gen(function* () {
+      const { service, control } = yield* makeHarness("darwin");
+      yield* service.install;
+      control.failCommand = "launchctl bootout gui/501/com.t3tools.t3code.service";
+
+      yield* service.install;
+      expect((yield* service.status).current).toBe(true);
+    }),
+  );
+
+  it.effect("restarts without overwriting a pending remote update on macOS", () =>
+    Effect.gen(function* () {
+      const { service, fs, statePath, commands } = yield* makeHarness("darwin");
+      yield* service.install;
+      const plistPath = (yield* service.status).unitPath;
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - fixed launcher-owned test document.
+      const pendingState = JSON.stringify({
+        protocol: SERVICE_LAUNCHER_PROTOCOL - 1,
+        activeVersion: "1.2.3",
+        update: {
+          id: "remote-update",
+          fromVersion: "1.2.3",
+          targetVersion: "1.2.4",
+          status: "pending",
+        },
+      });
+      yield* fs.writeFileString(statePath, pendingState);
+      commands.length = 0;
+
+      expect((yield* service.install.pipe(Effect.flip))._tag).toBe("BootServiceUpdatePendingError");
+      expect(serviceStateHasPendingUpdate(yield* fs.readFileString(statePath))).toBe(true);
+      expect(commands.filter((command) => command.startsWith("launchctl "))).toEqual([
+        "launchctl bootout gui/501/com.t3tools.t3code.service",
+        `launchctl bootstrap gui/501 ${plistPath}`,
+        "launchctl kickstart -k gui/501/com.t3tools.t3code.service",
+      ]);
     }),
   );
 });

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -278,7 +278,7 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       expect(commands.some((command) => command.startsWith("systemctl "))).toBe(false);
       // A bootout can block up to the plist's 90s ExitTimeOut; the runner's
       // 60s default would cancel it and let bootstrap race a loaded job.
-      expect(timeouts.get("launchctl bootout gui/501/com.t3tools.t3code.service")).toEqual(
+      expect(timeouts.get("launchctl bootout --wait gui/501/com.t3tools.t3code.service")).toEqual(
         Duration.seconds(120),
       );
     }),
@@ -295,7 +295,7 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       const error = yield* service.install.pipe(Effect.flip);
       expect(error._tag).toBe("BootServiceCommandError");
       expect(commands.filter((command) => command.startsWith("launchctl "))).toEqual([
-        "launchctl bootout gui/501/com.t3tools.t3code.service",
+        "launchctl bootout --wait gui/501/com.t3tools.t3code.service",
         "launchctl enable gui/501/com.t3tools.t3code.service",
         `launchctl bootstrap gui/501 ${plistPath}`,
         `launchctl bootstrap gui/501 ${plistPath}`,
@@ -307,7 +307,7 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
     Effect.gen(function* () {
       const { service, control } = yield* makeHarness("darwin");
       yield* service.install;
-      control.failCommand = "launchctl bootout gui/501/com.t3tools.t3code.service";
+      control.failCommand = "launchctl bootout --wait gui/501/com.t3tools.t3code.service";
 
       yield* service.install;
       expect((yield* service.status).current).toBe(true);
@@ -336,7 +336,7 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       expect((yield* service.install.pipe(Effect.flip))._tag).toBe("BootServiceUpdatePendingError");
       expect(serviceStateHasPendingUpdate(yield* fs.readFileString(statePath))).toBe(true);
       expect(commands.filter((command) => command.startsWith("launchctl "))).toEqual([
-        "launchctl bootout gui/501/com.t3tools.t3code.service",
+        "launchctl bootout --wait gui/501/com.t3tools.t3code.service",
         `launchctl bootstrap gui/501 ${plistPath}`,
       ]);
     }),

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -106,8 +106,8 @@ export function renderBootServicePlist(
   // ExitTimeOut 90 matches systemd's default TimeoutStopSec. A plain stop
   // completes within the launcher's 5s child grace, but a stop that queues
   // behind an in-flight update transition can take much longer; launchd's
-  // default 20s would SIGKILL the launcher (and, with it, the process group)
-  // mid-handoff.
+  // system-defined default (5s on current macOS) would SIGKILL the launcher
+  // (and, with it, the process group) mid-handoff.
   // ProcessType Interactive opts out of background-job resource throttling.
   // AbandonProcessGroup stays at its default (false): launchd reaps leftover
   // process-group members only when the launcher itself exits — the analog of
@@ -158,9 +158,23 @@ export interface BootServiceStep {
   readonly step: string;
   readonly command: string;
   readonly args: ReadonlyArray<string>;
-  /** Non-zero exit is logged and ignored: idempotent domain operations. */
+  /**
+   * Non-zero exit is logged and ignored. Reserved for steps whose common
+   * failures (not loaded, already enabled) leave a state a later strict step
+   * either tolerates or fails loudly on.
+   */
   readonly optional?: boolean;
+  /** Override the ProcessRunner default (60s) for steps that block longer. */
+  readonly timeout?: Duration.Input;
 }
+
+/**
+ * Stop commands block until the service manager gives up: 90s by default for
+ * systemd's TimeoutStopSec, and ExitTimeOut=90 in the rendered plist. This
+ * must stay above both, or the runner cancels the stop mid-shutdown and the
+ * next step races a still-loaded service.
+ */
+const STOP_STEP_TIMEOUT = Duration.seconds(120);
 
 /**
  * Platform service-manager integration as data: paths, a pure renderer, and
@@ -203,6 +217,7 @@ export function systemdManager(input: {
         step: "stopping the installed service",
         command: "systemctl",
         args: ["--user", "stop", BOOT_SERVICE_UNIT_FILE],
+        timeout: STOP_STEP_TIMEOUT,
       },
     ],
     activate: [
@@ -236,6 +251,7 @@ export function systemdManager(input: {
         step: "stopping the service",
         command: "systemctl",
         args: ["--user", "disable", "--now", BOOT_SERVICE_UNIT_FILE],
+        timeout: STOP_STEP_TIMEOUT,
       },
     ],
     finalize: [
@@ -278,6 +294,7 @@ export function launchdManager(input: {
         command: "launchctl",
         args: ["bootout", serviceTarget],
         optional: true,
+        timeout: STOP_STEP_TIMEOUT,
       },
     ],
     activate: [
@@ -304,12 +321,15 @@ export function launchdManager(input: {
     ],
     // No `launchctl disable` here: a persisted override would sabotage a
     // later reinstall. Removing the plist is what stops the next login load.
+    // A bootout that fails for a reason other than "not loaded" leaves the
+    // job running until logout; the failure is in the boot-service log.
     deactivate: [
       {
         step: "stopping the service",
         command: "launchctl",
         args: ["bootout", serviceTarget],
         optional: true,
+        timeout: STOP_STEP_TIMEOUT,
       },
     ],
     finalize: [],
@@ -492,7 +512,12 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
     Effect.forEach(
       steps,
       (entry) => {
-        const run = runStep(entry.step, entry.command, entry.args);
+        const run = runStep(
+          entry.step,
+          entry.command,
+          entry.args,
+          entry.timeout === undefined ? undefined : { timeout: entry.timeout },
+        );
         // runStep's tapError already appends the failure to the log, so an
         // ignored optional step still leaves a trace.
         return entry.optional === true ? run.pipe(Effect.ignore) : run.pipe(Effect.asVoid);

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -1,4 +1,8 @@
-import { HostProcessExecutablePath, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import {
+  HostProcessExecutablePath,
+  HostProcessPlatform,
+  HostProcessUserId,
+} from "@t3tools/shared/hostProcess";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -27,6 +31,10 @@ import {
 
 const BOOT_SERVICE_NAME = "t3code";
 export const BOOT_SERVICE_UNIT_FILE = `${BOOT_SERVICE_NAME}.service`;
+// `.service` suffix keeps the label distinct from the desktop app's bundle id
+// (com.t3tools.t3code), so launchd and TCC records never collide.
+export const BOOT_SERVICE_LAUNCHD_LABEL = "com.t3tools.t3code.service";
+export const BOOT_SERVICE_PLIST_FILE = `${BOOT_SERVICE_LAUNCHD_LABEL}.plist`;
 export const BOOT_SERVICE_UNIT_ENV = "T3_BOOT_SERVICE_UNIT";
 
 /** systemd expands `%` specifiers, including in unquoted append-log paths. */
@@ -83,12 +91,262 @@ export function renderBootServiceUnit(plan: BootServicePlan): string {
   ].join("\n");
 }
 
+/** Plist values are emitted as XML text nodes; only these three need escaping. */
+export function escapeXmlText(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+/** Pure renderer: launch agents cannot rely on the user's shell or PATH. */
+export function renderBootServicePlist(
+  plan: BootServicePlan,
+  options: { readonly homeDir: string },
+): string {
+  // KeepAlive + ThrottleInterval mirror Restart=always + RestartSec=5. launchd
+  // has no StartLimitBurst analog; a hard crash loop respawns every 5s forever.
+  // ExitTimeOut must exceed the server's graceful shutdown plus the launcher's
+  // 5s child SIGKILL grace, or launchd (default 20s) SIGKILLs mid-shutdown.
+  // ProcessType Interactive opts out of background-job resource throttling.
+  // AbandonProcessGroup stays at its default (false): launchd reaps leftover
+  // process-group members only when the launcher itself exits — the analog of
+  // KillMode=mixed's final cgroup kill — and not when the launcher restarts its
+  // child, so agent children survive server updates.
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">`,
+    `<plist version="1.0">`,
+    `<dict>`,
+    `  <key>Label</key>`,
+    `  <string>${BOOT_SERVICE_LAUNCHD_LABEL}</string>`,
+    `  <key>ProgramArguments</key>`,
+    `  <array>`,
+    `    <string>${escapeXmlText(plan.nodePath)}</string>`,
+    `    <string>${escapeXmlText(plan.launcherPath)}</string>`,
+    `  </array>`,
+    `  <key>EnvironmentVariables</key>`,
+    `  <dict>`,
+    `    <key>T3CODE_HOME</key>`,
+    `    <string>${escapeXmlText(plan.baseDir)}</string>`,
+    `    <key>${BOOT_SERVICE_UNIT_ENV}</key>`,
+    `    <string>${BOOT_SERVICE_PLIST_FILE}</string>`,
+    `  </dict>`,
+    `  <key>WorkingDirectory</key>`,
+    `  <string>${escapeXmlText(options.homeDir)}</string>`,
+    `  <key>RunAtLoad</key>`,
+    `  <true/>`,
+    `  <key>KeepAlive</key>`,
+    `  <true/>`,
+    `  <key>ThrottleInterval</key>`,
+    `  <integer>5</integer>`,
+    `  <key>ExitTimeOut</key>`,
+    `  <integer>30</integer>`,
+    `  <key>ProcessType</key>`,
+    `  <string>Interactive</string>`,
+    `  <key>StandardOutPath</key>`,
+    `  <string>${escapeXmlText(plan.logPath)}</string>`,
+    `  <key>StandardErrorPath</key>`,
+    `  <string>${escapeXmlText(plan.logPath)}</string>`,
+    `</dict>`,
+    `</plist>`,
+    ``,
+  ].join("\n");
+}
+
+export interface BootServiceStep {
+  readonly step: string;
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  /** Non-zero exit is logged and ignored: idempotent domain operations. */
+  readonly optional?: boolean;
+}
+
+/**
+ * Platform service-manager integration as data: paths, a pure renderer, and
+ * the command steps each flow runs. install/uninstall/status consume this and
+ * never branch on platform.
+ */
+export interface BootServiceManager {
+  readonly kind: "systemd" | "launchd";
+  readonly unitPath: string;
+  readonly render: (plan: BootServicePlan) => string;
+  /** Before rewriting files, when a unit is already installed. */
+  readonly stop: ReadonlyArray<BootServiceStep>;
+  /** After files are written. The last entry starts the service. */
+  readonly activate: ReadonlyArray<BootServiceStep>;
+  /** Best-effort recovery after a failed repair of an installed service. */
+  readonly restart: ReadonlyArray<BootServiceStep>;
+  /** Uninstall, before the unit file is removed. */
+  readonly deactivate: ReadonlyArray<BootServiceStep>;
+  /** Uninstall, after the unit file is removed. */
+  readonly finalize: ReadonlyArray<BootServiceStep>;
+}
+
+export function systemdManager(input: {
+  readonly path: Path.Path;
+  readonly homeDir: string;
+}): BootServiceManager {
+  const unitPath = input.path.join(
+    input.homeDir,
+    ".config",
+    "systemd",
+    "user",
+    BOOT_SERVICE_UNIT_FILE,
+  );
+  return {
+    kind: "systemd",
+    unitPath,
+    render: renderBootServiceUnit,
+    stop: [
+      {
+        step: "stopping the installed service",
+        command: "systemctl",
+        args: ["--user", "stop", BOOT_SERVICE_UNIT_FILE],
+      },
+    ],
+    activate: [
+      {
+        step: "reloading systemd user units",
+        command: "systemctl",
+        args: ["--user", "daemon-reload"],
+      },
+      {
+        step: "enabling the service",
+        command: "systemctl",
+        args: ["--user", "enable", BOOT_SERVICE_UNIT_FILE],
+      },
+      { step: "enabling lingering for this user", command: "loginctl", args: ["enable-linger"] },
+      // Start last. No administrative state write occurs after this succeeds.
+      {
+        step: "starting the service",
+        command: "systemctl",
+        args: ["--user", "restart", BOOT_SERVICE_UNIT_FILE],
+      },
+    ],
+    restart: [
+      {
+        step: "restarting the service after a failed update",
+        command: "systemctl",
+        args: ["--user", "restart", BOOT_SERVICE_UNIT_FILE],
+      },
+    ],
+    deactivate: [
+      {
+        step: "stopping the service",
+        command: "systemctl",
+        args: ["--user", "disable", "--now", BOOT_SERVICE_UNIT_FILE],
+      },
+    ],
+    finalize: [
+      {
+        step: "reloading systemd user units",
+        command: "systemctl",
+        args: ["--user", "daemon-reload"],
+      },
+    ],
+  };
+}
+
+export function launchdManager(input: {
+  readonly path: Path.Path;
+  readonly homeDir: string;
+  readonly uid: number;
+}): BootServiceManager {
+  const unitPath = input.path.join(
+    input.homeDir,
+    "Library",
+    "LaunchAgents",
+    BOOT_SERVICE_PLIST_FILE,
+  );
+  const domainTarget = `gui/${input.uid}`;
+  const serviceTarget = `${domainTarget}/${BOOT_SERVICE_LAUNCHD_LABEL}`;
+  // bootout/enable/bootstrap are optional: they fail on not-loaded /
+  // already-loaded states that are fine to proceed from. The strict
+  // `kickstart -k` runs last, so a genuinely broken gui domain (e.g. an SSH
+  // session with nobody logged in at the screen) still fails the flow loudly.
+  return {
+    kind: "launchd",
+    unitPath,
+    render: (plan) => renderBootServicePlist(plan, { homeDir: input.homeDir }),
+    stop: [
+      {
+        step: "stopping the installed launch agent",
+        command: "launchctl",
+        args: ["bootout", serviceTarget],
+        optional: true,
+      },
+    ],
+    activate: [
+      // A persisted `launchctl disable` override refuses bootstrap; clear it.
+      {
+        step: "enabling the launch agent",
+        command: "launchctl",
+        args: ["enable", serviceTarget],
+        optional: true,
+      },
+      {
+        step: "loading the launch agent",
+        command: "launchctl",
+        args: ["bootstrap", domainTarget, unitPath],
+        optional: true,
+      },
+      // Start last. No administrative state write occurs after this succeeds.
+      {
+        step: "starting the service",
+        command: "launchctl",
+        args: ["kickstart", "-k", serviceTarget],
+      },
+    ],
+    restart: [
+      {
+        step: "reloading the launch agent after a failed update",
+        command: "launchctl",
+        args: ["bootstrap", domainTarget, unitPath],
+        optional: true,
+      },
+      {
+        step: "restarting the service after a failed update",
+        command: "launchctl",
+        args: ["kickstart", "-k", serviceTarget],
+      },
+    ],
+    // No `launchctl disable` here: a persisted override would sabotage a
+    // later reinstall. Removing the plist is what stops the next login load.
+    deactivate: [
+      {
+        step: "stopping the service",
+        command: "launchctl",
+        args: ["bootout", serviceTarget],
+        optional: true,
+      },
+    ],
+    finalize: [],
+  };
+}
+
+/** Undefined means this host cannot run the background service. */
+export function selectBootServiceManager(input: {
+  readonly platform: NodeJS.Platform;
+  readonly homeDir: string;
+  readonly uid: number | undefined;
+  readonly path: Path.Path;
+}): BootServiceManager | undefined {
+  if (input.homeDir === "") {
+    return undefined;
+  }
+  if (input.platform === "linux") {
+    return systemdManager({ path: input.path, homeDir: input.homeDir });
+  }
+  if (input.platform === "darwin" && input.uid !== undefined) {
+    return launchdManager({ path: input.path, homeDir: input.homeDir, uid: input.uid });
+  }
+  return undefined;
+}
+
 export class BootServiceUnsupportedError extends Schema.TaggedErrorClass<BootServiceUnsupportedError>()(
   "BootServiceUnsupportedError",
   { platform: Schema.String },
 ) {
   override get message(): string {
-    return `Background setup currently supports Linux with systemd; this machine reports '${this.platform}'.`;
+    return `Background setup supports Linux with systemd and macOS with launchd; this machine reports '${this.platform}'.`;
   }
 }
 
@@ -163,14 +421,15 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
 }) {
   const hostExecPath = yield* HostProcessExecutablePath;
   const platform = yield* HostProcessPlatform;
+  const uid = yield* HostProcessUserId;
   const homeDir = yield* Config.string("HOME").pipe(Config.withDefault(""));
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const runner = yield* ProcessRunner.ProcessRunner;
   const host = input.host ?? { execPath: hostExecPath };
 
-  const unitDir = path.join(homeDir, ".config", "systemd", "user");
-  const unitPath = path.join(unitDir, BOOT_SERVICE_UNIT_FILE);
+  const detectedManager = selectBootServiceManager({ platform, homeDir, uid, path });
+  const unitPath = detectedManager?.unitPath ?? "";
   const logPath = path.join(input.logsDir, "boot-service.log");
   const launcherPath = path.join(input.baseDir, "runtime", SERVICE_LAUNCHER_FILE);
   const statePath = path.join(input.baseDir, "runtime", SERVICE_STATE_FILE);
@@ -198,11 +457,11 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
     unitPath,
   };
 
-  const requireSystemdLinux = Effect.gen(function* () {
-    if (platform !== "linux" || homeDir === "") {
-      return yield* new BootServiceUnsupportedError({ platform });
-    }
-  });
+  const requireManager = Effect.suspend(() =>
+    detectedManager === undefined
+      ? new BootServiceUnsupportedError({ platform })
+      : Effect.succeed(detectedManager),
+  );
 
   const runStep = Effect.fn("cloud.boot_service.run_step")(function* (
     step: string,
@@ -235,8 +494,20 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
     );
   });
 
+  const runSteps = (steps: ReadonlyArray<BootServiceStep>) =>
+    Effect.forEach(
+      steps,
+      (entry) => {
+        const run = runStep(entry.step, entry.command, entry.args);
+        // runStep's tapError already appends the failure to the log, so an
+        // ignored optional step still leaves a trace.
+        return entry.optional === true ? run.pipe(Effect.ignore) : run.pipe(Effect.asVoid);
+      },
+      { discard: true },
+    );
+
   const install: BootService["Service"]["install"] = Effect.gen(function* () {
-    yield* requireSystemdLinux;
+    const manager = yield* requireManager;
     yield* fs
       .makeDirectory(input.logsDir, { recursive: true })
       .pipe(Effect.mapError((cause) => new BootServiceInstallError({ cause })));
@@ -298,11 +569,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
       .exists(unitPath)
       .pipe(Effect.mapError((cause) => new BootServiceInstallError({ cause })));
     if (installed) {
-      yield* runStep("stopping the installed service", "systemctl", [
-        "--user",
-        "stop",
-        BOOT_SERVICE_UNIT_FILE,
-      ]);
+      yield* runSteps(manager.stop);
     }
 
     yield* Effect.gen(function* () {
@@ -316,7 +583,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
         }
       }
       yield* fs
-        .makeDirectory(unitDir, { recursive: true })
+        .makeDirectory(path.dirname(unitPath), { recursive: true })
         .pipe(Effect.mapError((cause) => new BootServiceInstallError({ cause })));
       yield* writeDurably(launcherPath, launcherSource);
       yield* writeDurably(
@@ -331,58 +598,35 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
           2,
         )}\n`,
       );
-      yield* writeDurably(unitPath, renderBootServiceUnit(plan));
+      yield* writeDurably(unitPath, manager.render(plan));
 
-      yield* runStep("reloading systemd user units", "systemctl", ["--user", "daemon-reload"]);
-      yield* runStep("enabling the service", "systemctl", [
-        "--user",
-        "enable",
-        BOOT_SERVICE_UNIT_FILE,
-      ]);
-      yield* runStep("enabling lingering for this user", "loginctl", ["enable-linger"]);
-      // Start last. No administrative state write occurs after this succeeds.
-      yield* runStep("starting the service", "systemctl", [
-        "--user",
-        "restart",
-        BOOT_SERVICE_UNIT_FILE,
-      ]);
+      yield* runSteps(manager.activate);
     }).pipe(
       Effect.tapError(() =>
-        installed
-          ? runStep("restarting the service after a failed update", "systemctl", [
-              "--user",
-              "restart",
-              BOOT_SERVICE_UNIT_FILE,
-            ]).pipe(Effect.ignore)
-          : Effect.void,
+        installed ? runSteps(manager.restart).pipe(Effect.ignore) : Effect.void,
       ),
     );
     return plan;
   }).pipe(Effect.withSpan("cloud.boot_service.install"));
 
   const uninstall: BootService["Service"]["uninstall"] = Effect.gen(function* () {
-    yield* requireSystemdLinux;
+    const manager = yield* requireManager;
     if (
       !(yield* fs
         .exists(unitPath)
         .pipe(Effect.mapError((cause) => new BootServiceInstallError({ cause }))))
     )
       return false;
-    yield* runStep("stopping the service", "systemctl", [
-      "--user",
-      "disable",
-      "--now",
-      BOOT_SERVICE_UNIT_FILE,
-    ]);
+    yield* runSteps(manager.deactivate);
     yield* fs
       .remove(unitPath)
       .pipe(Effect.mapError((cause) => new BootServiceInstallError({ cause })));
-    yield* runStep("reloading systemd user units", "systemctl", ["--user", "daemon-reload"]);
+    yield* runSteps(manager.finalize);
     return true;
   }).pipe(Effect.withSpan("cloud.boot_service.uninstall"));
 
   const status: BootService["Service"]["status"] = Effect.gen(function* () {
-    if (platform !== "linux" || homeDir === "") {
+    if (detectedManager === undefined) {
       return { supported: false, installed: false, current: false, unitPath, logPath };
     }
     if (!(yield* fs.exists(unitPath))) {
@@ -401,7 +645,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
       supported: true,
       installed: true,
       current:
-        unit === renderBootServiceUnit(plan) &&
+        unit === detectedManager.render(plan) &&
         launcherExists &&
         runtimeEntryExists &&
         Option.isSome(runtimeSentinel) &&

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -103,8 +103,11 @@ export function renderBootServicePlist(
 ): string {
   // KeepAlive + ThrottleInterval mirror Restart=always + RestartSec=5. launchd
   // has no StartLimitBurst analog; a hard crash loop respawns every 5s forever.
-  // ExitTimeOut must exceed the server's graceful shutdown plus the launcher's
-  // 5s child SIGKILL grace, or launchd (default 20s) SIGKILLs mid-shutdown.
+  // ExitTimeOut 90 matches systemd's default TimeoutStopSec. A plain stop
+  // completes within the launcher's 5s child grace, but a stop that queues
+  // behind an in-flight update transition can take much longer; launchd's
+  // default 20s would SIGKILL the launcher (and, with it, the process group)
+  // mid-handoff.
   // ProcessType Interactive opts out of background-job resource throttling.
   // AbandonProcessGroup stays at its default (false): launchd reaps leftover
   // process-group members only when the launcher itself exits — the analog of
@@ -138,7 +141,7 @@ export function renderBootServicePlist(
     `  <key>ThrottleInterval</key>`,
     `  <integer>5</integer>`,
     `  <key>ExitTimeOut</key>`,
-    `  <integer>30</integer>`,
+    `  <integer>90</integer>`,
     `  <key>ProcessType</key>`,
     `  <string>Interactive</string>`,
     `  <key>StandardOutPath</key>`,
@@ -258,10 +261,13 @@ export function launchdManager(input: {
   );
   const domainTarget = `gui/${input.uid}`;
   const serviceTarget = `${domainTarget}/${BOOT_SERVICE_LAUNCHD_LABEL}`;
-  // bootout/enable/bootstrap are optional: they fail on not-loaded /
-  // already-loaded states that are fine to proceed from. The strict
-  // `kickstart -k` runs last, so a genuinely broken gui domain (e.g. an SSH
-  // session with nobody logged in at the screen) still fails the flow loudly.
+  // bootout/enable are optional: they fail on not-loaded states that are fine
+  // to proceed from. The strict `bootstrap` runs last and is also the start:
+  // loading a RunAtLoad/KeepAlive plist starts the job, so a separate
+  // kickstart would kill and restart a server it just booted. A lingering job
+  // that survived bootout, or a gui domain with nobody logged in at the
+  // screen (SSH install), makes bootstrap fail the flow loudly rather than
+  // silently keeping a stale server.
   return {
     kind: "launchd",
     unitPath,
@@ -282,30 +288,18 @@ export function launchdManager(input: {
         args: ["enable", serviceTarget],
         optional: true,
       },
-      {
-        step: "loading the launch agent",
-        command: "launchctl",
-        args: ["bootstrap", domainTarget, unitPath],
-        optional: true,
-      },
       // Start last. No administrative state write occurs after this succeeds.
       {
         step: "starting the service",
         command: "launchctl",
-        args: ["kickstart", "-k", serviceTarget],
+        args: ["bootstrap", domainTarget, unitPath],
       },
     ],
     restart: [
       {
-        step: "reloading the launch agent after a failed update",
-        command: "launchctl",
-        args: ["bootstrap", domainTarget, unitPath],
-        optional: true,
-      },
-      {
         step: "restarting the service after a failed update",
         command: "launchctl",
-        args: ["kickstart", "-k", serviceTarget],
+        args: ["bootstrap", domainTarget, unitPath],
       },
     ],
     // No `launchctl disable` here: a persisted override would sabotage a

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -288,11 +288,15 @@ export function launchdManager(input: {
     kind: "launchd",
     unitPath,
     render: (plan) => renderBootServicePlist(plan, { homeDir: input.homeDir }),
+    // Without --wait, bootout returns in milliseconds while the job drains
+    // for up to ExitTimeOut, and a bootstrap during the drain fails EIO.
+    // --wait (present on modern macOS, absent from the man page) blocks until
+    // the job is removed from the domain; STOP_STEP_TIMEOUT outlives it.
     stop: [
       {
         step: "stopping the installed launch agent",
         command: "launchctl",
-        args: ["bootout", serviceTarget],
+        args: ["bootout", "--wait", serviceTarget],
         optional: true,
         timeout: STOP_STEP_TIMEOUT,
       },
@@ -327,7 +331,7 @@ export function launchdManager(input: {
       {
         step: "stopping the service",
         command: "launchctl",
-        args: ["bootout", serviceTarget],
+        args: ["bootout", "--wait", serviceTarget],
         optional: true,
         timeout: STOP_STEP_TIMEOUT,
       },

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -649,7 +649,8 @@ export const pendingServiceUpdateExists = Effect.gen(function* () {
 });
 
 // A pending update alone is not proof a replacement server is coming: an
-// explicit launcher stop (`t3 service uninstall`, `systemctl stop`) during
+// explicit launcher stop (`t3 service uninstall`, `systemctl stop`,
+// `launchctl bootout`) during
 // the pending window also tears this server down. The launcher marks that case
 // just before it signals the child, so pending + no marker is the handoff.
 const pendingUpdateHandoffExists = Effect.gen(function* () {

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -10,8 +10,8 @@ import * as ProcessRunner from "../processRunner.ts";
 
 /**
  * A pinned runtime is an exact `t3@<version>` npm-installed into
- * <baseDir>/runtime/versions/<version>. The boot service points its systemd
- * unit here, and server self-update installs the target version here before
+ * <baseDir>/runtime/versions/<version>. The boot service points its unit or
+ * launch agent here, and server self-update installs the target version here before
  * switching over, never `npx t3`, whose cache is ephemeral and whose
  * registry fetch at boot would make startup depend on the network.
  */

--- a/apps/server/src/serviceLauncher.ts
+++ b/apps/server/src/serviceLauncher.ts
@@ -317,7 +317,9 @@ export class Launcher {
     // This must happen synchronously at signal receipt. A queued update
     // transition may already be terminating the active child, and that child
     // needs to see the marker in its shutdown finalizer. KillMode=mixed also
-    // ensures systemd signals the launcher before the rest of the cgroup.
+    // ensures systemd signals the launcher before the rest of the cgroup, and
+    // launchd signals only the job's main process (this launcher), so the
+    // marker lands before the child sees any signal on both platforms.
     try {
       NodeFS.writeFileSync(stopMarkerPath(this.#baseDir), "", { mode: 0o600 });
     } catch {

--- a/docs/internals/server-updates.md
+++ b/docs/internals/server-updates.md
@@ -2,14 +2,15 @@
 
 > For maintainers. Using T3 Code? See [docs/user](../user/).
 
-Remote server updates use one stable systemd launcher. Foreground CLI processes do not self-update,
-and a running server never edits its systemd unit or durable service state.
+Remote server updates use one stable launcher selected by the platform service manager (systemd on
+Linux, launchd on macOS). Foreground CLI processes do not self-update, and a running server never
+edits its service definition or durable service state.
 
 ## Ownership
 
 The service files under `<baseDir>/runtime` are:
 
-- `service-launcher.mjs`, the stable process selected by systemd;
+- `service-launcher.mjs`, the stable process selected by the service manager;
 - `service-state.json`, the launcher's durable selection state;
 - `versions/<version>`, immutable exact-version npm installs.
 
@@ -22,7 +23,7 @@ The state contains one active version and, at most, one update record:
 - `pending A → B` selects B as a retryable trial;
 - `committed A → B` selects B for ordinary restarts;
 - `rolled-back A → B` or `failed A → B` selects A;
-- invalid state fails closed so systemd cannot guess at a runtime.
+- invalid state fails closed so the service manager cannot guess at a runtime.
 
 Every write uses same-directory replacement plus file and directory fsync.
 
@@ -50,8 +51,8 @@ operations. It only opens prepared gates and publishes prepared lifecycle state.
 The launcher serializes child exits, IPC messages, and timers. A trial must report prepared within
 120 seconds. If the trial exits or times out before prepared, the launcher stops it, restores the
 snapshot, records rollback, and starts A. A durable restore marker makes an interrupted restore
-resume before either version can boot. After commit, B is active and normal systemd restart policy
-applies.
+resume before either version can boot. After commit, B is active and the service manager's normal
+restart policy applies.
 
 ## Database Rollback
 

--- a/docs/user/background-service.md
+++ b/docs/user/background-service.md
@@ -1,7 +1,7 @@
 # Running T3 Code in the Background
 
-On a Linux host, T3 Code can run as a background service for your user. It starts when the machine
-boots and keeps running after you log out.
+On Linux and macOS, T3 Code can run as a background service for your user, so it is ready without
+keeping a terminal open.
 
 ## Manage the Service
 
@@ -32,18 +32,36 @@ npx t3@latest service uninstall
 Updating restarts T3 Code briefly. Let active agent work and terminal commands finish first.
 If a remote update is already in progress, wait for it to finish before retrying a local update.
 
-The systemd unit runs a small stable launcher. Exact T3 Code versions are installed separately, so
-a failed remote candidate can return to the previous version without rewriting the unit. The
-launcher snapshots the database before a remote candidate starts, so database updates roll back
-with the server version. An older launcher may require one local `service update` before this is
-available.
+The service runs a small stable launcher. Exact T3 Code versions are installed separately, so a
+failed remote candidate can return to the previous version without rewriting the service
+definition. The launcher snapshots the database before a remote candidate starts, so database
+updates roll back with the server version. An older launcher may require one local
+`service update` before this is available.
+
+## Platform Support
+
+**Linux** uses a systemd user unit at `~/.config/systemd/user/t3code.service`. The service starts
+when the machine boots and keeps running after you log out (lingering is enabled during install).
+
+**macOS** uses a launch agent at `~/Library/LaunchAgents/com.t3tools.t3code.service.plist`. It
+starts when you log in, not when the Mac boots, and it stops when you log out; macOS has no
+equivalent of Linux lingering for user agents. For a Mac that should stay reachable unattended,
+turn on automatic login (System Settings → Users & Groups) and keep the Mac from sleeping.
+
+Two more macOS notes:
+
+- Installing over SSH only starts the agent immediately when someone is also logged in at the
+  Mac's screen. Otherwise the install completes and the agent starts at the next login.
+- A background agent cannot answer macOS privacy prompts. If agent work fails to read protected
+  folders such as Desktop, Documents, or Downloads, grant Full Disk Access to the node binary
+  listed in the launch agent's `ProgramArguments`.
+
+**Windows** is not supported yet.
 
 ## Using It with T3 Connect
 
-T3 Connect may offer to install the service during setup so the host stays reachable after you log
-out. This is only an onboarding shortcut: the service and T3 Connect are managed separately.
+T3 Connect may offer to install the service during setup so the host stays reachable in the
+background. This is only an onboarding shortcut: the service and T3 Connect are managed separately.
 
 Signing out of T3 Connect does not remove the service. Use `t3 service uninstall` when you no longer
 want T3 Code to start in the background.
-
-The background service currently requires Linux with systemd.

--- a/docs/user/background-service.md
+++ b/docs/user/background-service.md
@@ -58,6 +58,9 @@ Two more macOS notes:
   attributed to a bare `node` process, or deny access without a prompt. If agent work fails to
   read those folders, grant Full Disk Access to the node binary listed in the launch agent's
   `ProgramArguments`.
+- The agent appears under System Settings → General → Login Items. If it was switched off there,
+  or disabled with `launchctl disable`, macOS will not start it at login until you switch it back
+  on.
 
 **Windows** is not supported yet.
 

--- a/docs/user/background-service.md
+++ b/docs/user/background-service.md
@@ -46,15 +46,18 @@ when the machine boots and keeps running after you log out (lingering is enabled
 **macOS** uses a launch agent at `~/Library/LaunchAgents/com.t3tools.t3code.service.plist`. It
 starts when you log in, not when the Mac boots, and it stops when you log out; macOS has no
 equivalent of Linux lingering for user agents. For a Mac that should stay reachable unattended,
-turn on automatic login (System Settings → Users & Groups) and keep the Mac from sleeping.
+turn on automatic login (System Settings → Users & Groups; unavailable while FileVault is on) and
+keep the Mac from sleeping.
 
 Two more macOS notes:
 
-- Installing over SSH only starts the agent immediately when someone is also logged in at the
-  Mac's screen. Otherwise the install completes and the agent starts at the next login.
-- A background agent cannot answer macOS privacy prompts. If agent work fails to read protected
-  folders such as Desktop, Documents, or Downloads, grant Full Disk Access to the node binary
-  listed in the launch agent's `ProgramArguments`.
+- Installing over SSH needs someone logged in at the Mac's screen to start the agent right away.
+  Without that, the install command reports an error at the final start step, but the agent is
+  fully installed and starts at the next login.
+- macOS may show privacy prompts for protected folders such as Desktop, Documents, or Downloads,
+  attributed to a bare `node` process, or deny access without a prompt. If agent work fails to
+  read those folders, grant Full Disk Access to the node binary listed in the launch agent's
+  `ProgramArguments`.
 
 **Windows** is not supported yet.
 

--- a/docs/user/background-service.md
+++ b/docs/user/background-service.md
@@ -49,7 +49,7 @@ equivalent of Linux lingering for user agents. For a Mac that should stay reacha
 turn on automatic login (System Settings → Users & Groups; unavailable while FileVault is on) and
 keep the Mac from sleeping.
 
-Two more macOS notes:
+A few more macOS notes:
 
 - Installing over SSH needs someone logged in at the Mac's screen to start the agent right away.
   Without that, the install command reports an error at the final start step, but the agent is

--- a/packages/shared/src/hostProcess.ts
+++ b/packages/shared/src/hostProcess.ts
@@ -51,4 +51,12 @@ export const HostProcessArguments = Context.Reference<ReadonlyArray<string>>(
   },
 );
 
+/** Undefined on platforms without POSIX uids (Windows). */
+export const HostProcessUserId = Context.Reference<number | undefined>(
+  "@t3tools/shared/hostProcess/HostProcessUserId",
+  {
+    defaultValue: () => process.getuid?.(),
+  },
+);
+
 export const isHostWindows = Effect.map(HostProcessPlatform, (platform) => platform === "win32");


### PR DESCRIPTION
Wanted the T3 Connect/serve daemon running in the background on a Mac, the same way it works on Linux. But \`t3 service install\` was systemd-only and failed closed on darwin.

Now macOS gets a per-user LaunchAgent (\`~/Library/LaunchAgents/com.t3tools.t3code.service.plist\`). The pinned runtime, stable launcher, and remote-update protocol are reused unchanged; only the service-manager layer is new. The platform split is a small data-driven \`BootServiceManager\` (paths, pure renderer, command steps), so install/uninstall/status stay single-flow with no platform branches. launchctl steps that fail on already/not-loaded states are tolerated; the final \`kickstart -k\` stays strict so a broken setup fails loudly.

Honest semantics: a LaunchAgent starts at login and stops at logout (no linger equivalent), so onboarding copy and docs say so instead of promising boot-time behavior.

Verified end to end on an M-series Mac with an isolated \`T3CODE_HOME\`: install pins \`t3@0.0.33\` from npm, the job runs, killing the launcher gets respawned by KeepAlive, the child server carries the launcher IPC context (so remote self-update capability is advertised), and uninstall removes the job and plist cleanly. 28 tests pass across the touched files.

---
Built by Claude Code (Fable 5) with human direction from Theo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches host service installation and long-blocking `launchctl`/`systemctl` orchestration; mistakes could leave a broken or stale agent, though behavior is heavily tested and Linux paths are mostly refactored, not rewritten.
> 
> **Overview**
> **macOS can now install the same pinned-launcher background service** via a per-user LaunchAgent (`~/Library/LaunchAgents/com.t3tools.t3code.service.plist`). Linux systemd behavior is unchanged; Windows still fails closed.
> 
> `bootService` is refactored around a **`BootServiceManager`** abstraction: each platform supplies paths, a pure unit/plist renderer, and declarative `launchctl` / `systemctl` step lists consumed by shared `install` / `uninstall` / `status` flows. macOS uses `bootout --wait`, optional enable/bootout steps, **120s stop timeouts** (above systemd/`ExitTimeOut`), and plist settings aligned with the existing launcher/update model. **`HostProcessUserId`** (`process.getuid()` on POSIX) drives the `gui/<uid>` launchd domain.
> 
> **Onboarding and status copy** no longer promise post-logout reachability on Mac: connect and `service` prompts describe **login-scoped** availability instead of boot/linger behavior. User and internal docs now document Linux vs macOS differences (SSH install, TCC, Login Items).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3db1408e7449eec3555559a021189e176097e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add macOS launchd support for the background boot service
> - Adds a `launchdManager` in [`bootService.ts`](https://github.com/pingdotgg/t3code/pull/6286/files#diff-9ec1426b86c5c9f63a503a0c78a87a5165a6460ca539deb5c365bda9ff0576f0) that installs a launch agent plist, bootstraps it at login, and handles stop/restart/uninstall via `launchctl`.
> - Adds `renderBootServicePlist` to generate a launchd plist with `RunAtLoad`, `KeepAlive`, `ThrottleInterval=5`, `ExitTimeOut=90`, and consolidated stdout/stderr logging.
> - Refactors the boot service factory to select between systemd (Linux) and launchd (macOS) via a new `selectBootServiceManager` abstraction, using a new `HostProcessUserId` context for POSIX uid.
> - Updates CLI messaging and onboarding prompts to reflect macOS login-scoped persistence vs. Linux boot-time/linger persistence.
> - Behavioral Change: on macOS the service runs only while the user is logged in (no linger equivalent); Windows remains unsupported.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3db140.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->