### PR TITLE
feat(sidebar): reset width on double-click with viewport-based default

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -26,6 +26,7 @@ import {
 import { useProjects } from "../state/entities";
 import {
   resolveInitialThreadSidebarWidth,
+  resolveThreadSidebarDefaultWidth,
   resolveThreadSidebarMaximumWidth,
   THREAD_MAIN_CONTENT_MIN_WIDTH,
   THREAD_SIDEBAR_MIN_WIDTH,
@@ -147,6 +148,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   // that would otherwise refresh a render-time snapshot.
   const viewportWidth = useSyncExternalStore(subscribeToViewportWidth, readViewportWidth);
   const sidebarMaximumWidth = resolveThreadSidebarMaximumWidth(viewportWidth);
+  const sidebarDefaultWidth = resolveThreadSidebarDefaultWidth(viewportWidth);
   const [isWindowFullscreen, setIsWindowFullscreen] = useState(() => {
     const getWindowFullscreenState = window.desktopBridge?.getWindowFullscreenState;
     return isMacosDesktop && typeof getWindowFullscreenState === "function"
@@ -206,6 +208,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         data-app-sidebar=""
         className="border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
         resizable={{
+          defaultWidth: sidebarDefaultWidth,
           maxWidth: sidebarMaximumWidth,
           minWidth: THREAD_SIDEBAR_MIN_WIDTH,
           shouldAcceptWidth: ({ currentWidth, nextWidth, wrapper }) =>

--- a/apps/web/src/components/threadSidebarWidth.test.ts
+++ b/apps/web/src/components/threadSidebarWidth.test.ts
@@ -7,16 +7,19 @@ import {
   resolveInitialThreadSidebarWidth,
   resolveThreadSidebarDefaultWidth,
   THREAD_MAIN_CONTENT_MIN_WIDTH,
+  THREAD_SIDEBAR_DEFAULT_WIDTH_RATIO,
   THREAD_SIDEBAR_MIN_WIDTH,
 } from "./threadSidebarWidth";
 
 describe("thread sidebar width", () => {
   it("uses a viewport percentage default when no preference is stored", () => {
-    expect(resolveInitialThreadSidebarWidth(null, 1200)).toBe(
-      resolveThreadSidebarDefaultWidth(1200),
+    const viewportWidth = 1200;
+    const expectedDefaultWidth = Math.floor(viewportWidth * THREAD_SIDEBAR_DEFAULT_WIDTH_RATIO);
+
+    expect(resolveInitialThreadSidebarWidth(null, viewportWidth)).toBe(
+      resolveThreadSidebarDefaultWidth(viewportWidth),
     );
-    expect(resolveThreadSidebarDefaultWidth(1200)).toBe(264);
-    expect(resolveThreadSidebarDefaultWidth(1200)).toBeGreaterThan(16 * 16);
+    expect(resolveThreadSidebarDefaultWidth(viewportWidth)).toBe(expectedDefaultWidth);
   });
 
   it("uses a stored width in the initial render", () => {

--- a/apps/web/src/components/threadSidebarWidth.test.ts
+++ b/apps/web/src/components/threadSidebarWidth.test.ts
@@ -5,14 +5,18 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   resolveInitialThreadSidebarWidth,
+  resolveThreadSidebarDefaultWidth,
   THREAD_MAIN_CONTENT_MIN_WIDTH,
-  THREAD_SIDEBAR_DEFAULT_WIDTH,
   THREAD_SIDEBAR_MIN_WIDTH,
 } from "./threadSidebarWidth";
 
 describe("thread sidebar width", () => {
-  it("uses the default width when no preference is stored", () => {
-    expect(resolveInitialThreadSidebarWidth(null, 1200)).toBe(THREAD_SIDEBAR_DEFAULT_WIDTH);
+  it("uses a viewport percentage default when no preference is stored", () => {
+    expect(resolveInitialThreadSidebarWidth(null, 1200)).toBe(
+      resolveThreadSidebarDefaultWidth(1200),
+    );
+    expect(resolveThreadSidebarDefaultWidth(1200)).toBe(264);
+    expect(resolveThreadSidebarDefaultWidth(1200)).toBeGreaterThan(16 * 16);
   });
 
   it("uses a stored width in the initial render", () => {

--- a/apps/web/src/components/threadSidebarWidth.ts
+++ b/apps/web/src/components/threadSidebarWidth.ts
@@ -1,5 +1,6 @@
 export const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
-export const THREAD_SIDEBAR_DEFAULT_WIDTH = 16 * 16;
+/** Default sidebar width as a fraction of viewport width (~20%). */
+export const THREAD_SIDEBAR_DEFAULT_WIDTH_RATIO = 0.2;
 export const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
 export const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 
@@ -10,13 +11,21 @@ export function resolveThreadSidebarMaximumWidth(viewportWidth: number): number 
   );
 }
 
+export function resolveThreadSidebarDefaultWidth(viewportWidth: number): number {
+  const preferredWidth = Math.floor(viewportWidth * THREAD_SIDEBAR_DEFAULT_WIDTH_RATIO);
+  return Math.min(
+    Math.max(preferredWidth, THREAD_SIDEBAR_MIN_WIDTH),
+    resolveThreadSidebarMaximumWidth(viewportWidth),
+  );
+}
+
 export function resolveInitialThreadSidebarWidth(
   storedWidth: number | null,
   viewportWidth: number,
 ): number {
   const preferredWidth =
     storedWidth === null
-      ? THREAD_SIDEBAR_DEFAULT_WIDTH
+      ? resolveThreadSidebarDefaultWidth(viewportWidth)
       : Math.max(THREAD_SIDEBAR_MIN_WIDTH, storedWidth);
   return Math.min(preferredWidth, resolveThreadSidebarMaximumWidth(viewportWidth));
 }

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -28,6 +28,7 @@ const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "calc(100vw - var(--spacing(3)))";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH = 16 * 16;
+const SIDEBAR_RESIZE_DEFAULT_WIDTH = 16 * 16;
 
 type SidebarContextProps = {
   state: ResponsiveSidebarState;
@@ -40,6 +41,7 @@ type SidebarContextProps = {
 };
 
 type SidebarResizableOptions = {
+  defaultWidth?: number;
   maxWidth?: number;
   minWidth?: number;
   onResize?: (width: number) => void;
@@ -55,6 +57,7 @@ type SidebarResizableOptions = {
 };
 
 type SidebarResolvedResizableOptions = {
+  defaultWidth: number;
   maxWidth: number;
   minWidth: number;
   onResize?: (width: number) => void;
@@ -199,6 +202,7 @@ function Sidebar({
 
     const options = typeof resizable === "boolean" ? {} : resizable;
     return {
+      defaultWidth: options.defaultWidth ?? SIDEBAR_RESIZE_DEFAULT_WIDTH,
       maxWidth: options.maxWidth ?? Number.POSITIVE_INFINITY,
       minWidth: options.minWidth ?? SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH,
       storageKey: options.storageKey ?? null,
@@ -350,6 +354,7 @@ function clampSidebarWidth(width: number, options: SidebarResolvedResizableOptio
 function SidebarRail({
   className,
   onClick,
+  onDoubleClick,
   onPointerCancel,
   onPointerDown,
   onPointerMove,
@@ -555,6 +560,29 @@ function SidebarRail({
     [onClick, open, resolvedResizable, toggleSidebar],
   );
 
+  const handleDoubleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onDoubleClick?.(event);
+      if (event.defaultPrevented) return;
+      if (!resolvedResizable || !open) return;
+
+      const wrapper = event.currentTarget.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
+      if (!wrapper) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      suppressClickRef.current = false;
+
+      const nextWidth = clampSidebarWidth(resolvedResizable.defaultWidth, resolvedResizable);
+      wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
+      if (resolvedResizable.storageKey && typeof window !== "undefined") {
+        setLocalStorageItem(resolvedResizable.storageKey, nextWidth, Schema.Finite);
+      }
+      resolvedResizable.onResize?.(nextWidth);
+    },
+    [onDoubleClick, open, resolvedResizable],
+  );
+
   React.useLayoutEffect(() => {
     if (!resolvedResizable?.storageKey || typeof window === "undefined") return;
     const rail = railRef.current;
@@ -610,6 +638,7 @@ function SidebarRail({
             data-sidebar="rail"
             data-slot="sidebar-rail"
             onClick={handleClick}
+            onDoubleClick={handleDoubleClick}
             onPointerCancel={handlePointerCancel}
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -576,7 +576,11 @@ function SidebarRail({
       const nextWidth = clampSidebarWidth(resolvedResizable.defaultWidth, resolvedResizable);
       wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
       if (resolvedResizable.storageKey && typeof window !== "undefined") {
-        setLocalStorageItem(resolvedResizable.storageKey, nextWidth, Schema.Finite);
+        try {
+          setLocalStorageItem(resolvedResizable.storageKey, nextWidth, Schema.Finite);
+        } catch (error) {
+          console.error("Could not persist sidebar width.", error);
+        }
       }
       resolvedResizable.onResize?.(nextWidth);
     },


### PR DESCRIPTION
Double-clicking the resize rail restores the sidebar to 20% of the viewport width and persists the reset preference.

## What Changed

Double-clicking the sidebar resize rail resets the width to 20% of the viewport. The reset is saved to localStorage.

## Why

There was no quick way to get back to a default width after resizing. Double-click-to-reset is a familiar pattern and keeps the sidebar proportional across window sizes.

## UI Changes

Double-click the resize handle between the sidebar and main content to snap the sidebar back to its default width. Video attached.


https://github.com/user-attachments/assets/083496e6-78de-4cdd-aa8c-7130507adb1d


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar sizing and localStorage preference changes; no auth, security, or data-handling impact.
> 
> **Overview**
> Adds **double-click-to-reset** on the sidebar resize rail, snapping width back to a **viewport-scaled default (~20%)** and persisting that preference.
> 
> Replaces the fixed `THREAD_SIDEBAR_DEFAULT_WIDTH` with `THREAD_SIDEBAR_DEFAULT_WIDTH_RATIO` and `resolveThreadSidebarDefaultWidth`, so first-load and reset widths scale with the window (still clamped to min/max). `AppSidebarLayout` passes that live default into the sidebar’s resizable options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b19d6e602e87f8fddd416aefe7acc9d7e33bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset sidebar width on double-click using viewport-based default
> - Replaces the fixed `THREAD_SIDEBAR_DEFAULT_WIDTH` constant with `THREAD_SIDEBAR_DEFAULT_WIDTH_RATIO` (0.2), so the default sidebar width scales with viewport size and is clamped between min and max bounds.
> - Adds `resolveThreadSidebarDefaultWidth(viewportWidth)` in [threadSidebarWidth.ts](https://github.com/pingdotgg/t3code/pull/6287/files#diff-e6fb8629ef2c608b6f1e7a3bfae290cd3eadb1224113622833bce9612dde1f70) to compute this clamped default, and updates `resolveInitialThreadSidebarWidth` to use it as the fallback when no stored preference exists.
> - Extends `SidebarResizableOptions` in [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/6287/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd) with an optional `defaultWidth` prop and wires a double-click handler on `SidebarRail` that resets the sidebar to this default, persists it to localStorage, and calls `onResize`.
> - Behavioral Change: first load or cleared-preference sidebar width is now viewport-relative (~20%) rather than a fixed pixel value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86b19d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->