### PR TITLE
docs: mention Bitbucket user read scope needed by auth probe

### DIFF
--- a/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
@@ -195,7 +195,7 @@ export const makeDiscovery = Effect.gen(function* () {
     kind: "bitbucket",
     label: "Bitbucket",
     installHint:
-      "Set T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN on the server (use a Bitbucket API token with pull request and repository scopes).",
+      "Set T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN on the server (use a Bitbucket API token with pull request, repository, and user read scopes).",
     probeAuth: bitbucket.probeAuth,
   } satisfies SourceControlApiDiscoverySpec;
 });

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -94,7 +94,8 @@ export T3CODE_BITBUCKET_ACCESS_TOKEN="your-access-token"
 ```
 
 Or an Atlassian account email plus API token, with read/write access to pull requests and
-repositories:
+repositories, plus read access to your user account (`read:user:bitbucket`, used to verify the
+connection):
 
 ```bash
 export T3CODE_BITBUCKET_EMAIL="you@example.com"


### PR DESCRIPTION
Fixes #6290

The Bitbucket auth probe (`probeAuth`) calls `GET /2.0/user`, which on scoped Atlassian API tokens requires `read:user:bitbucket`. A token created with only the currently documented scopes (pull request + repository read/write) works for every actual PR operation but fails the probe with a 403, so **Settings → Source Control** reports the provider as not authenticated and the toggle stays disabled.

This is a docs-only change (two lines):

- `installHint` in `BitbucketSourceControlProvider.ts` now says "pull request, repository, and user read scopes"
- `docs/user/source-control.md` mentions the `read:user:bitbucket` scope and why it is needed

See the issue for the full 403 response body showing required vs. granted scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording change for Bitbucket token scopes; no runtime or auth logic is modified.
> 
> **Overview**
> Documents that Bitbucket API tokens need the **`read:user:bitbucket`** scope so auth probing can succeed.
> 
> Updates the Bitbucket `installHint` and source-control setup docs to include user read access alongside pull request and repository scopes. Without it, tokens that work for PR operations still fail `probeAuth` (`GET /2.0/user`) and leave the provider disabled in settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edffe14b16c08cc140e850206bfdb976a95334b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `read:user:bitbucket` scope requirement for Bitbucket auth probe
> Adds `read:user:bitbucket` (user read) to the list of required API token scopes in both the [source-control.md](https://github.com/pingdotgg/t3code/pull/6291/files#diff-a171985f6d647c7bc51efc65cf1a0b7261bb1313fe7c275c74f3836f919d1c05) docs and the `installHint` returned by `makeDiscovery` in [BitbucketSourceControlProvider.ts](https://github.com/pingdotgg/t3code/pull/6291/files#diff-7ec660b9e29e0e973bca616351fea4d2a56644856d52bcdf2d4a5f70e9116b7e). This scope is used to verify the Bitbucket connection during the auth probe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edffe14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->