### PR TITLE
feat(web): add environment filter to the sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -3,6 +3,7 @@ import {
   archiveSelectedThreadEntries,
   buildBulkTitleRegenerationContextMenuItem,
   buildMultiSelectThreadContextMenuItems,
+  buildSidebarEnvironmentFilterOptions,
   createThreadJumpHintVisibilityController,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -13,7 +14,10 @@ import {
   hasUnseenCompletion,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
+  filterSidebarProjectsByEnvironmentScope,
   orderItemsByPreferredIds,
+  planPinnedReorder,
+  projectScopeKeptUnderEnvironmentScope,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
@@ -24,10 +28,10 @@ import {
   formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
+  shouldResetEnvironmentScope,
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebar,
   pinOrderKeyBetween,
-  planPinnedReorder,
   sortPinnedThreadsForSidebar,
   sortThreadsForSidebar,
   sortProjectsForSidebar,
@@ -1631,5 +1635,164 @@ describe("sortLogicalProjectsForSidebar", () => {
         (project) => project.projectKey,
       ),
     ).toEqual(["logical-newer", "logical-older"]);
+  });
+});
+
+describe("buildSidebarEnvironmentFilterOptions", () => {
+  it("sorts environments by label and flags the primary one", () => {
+    const primaryEnvironmentId = EnvironmentId.make("environment-local");
+    const options = buildSidebarEnvironmentFilterOptions({
+      environments: [
+        { environmentId: EnvironmentId.make("environment-remote"), label: "Mac Mini" },
+        { environmentId: primaryEnvironmentId, label: "This Mac" },
+        { environmentId: EnvironmentId.make("environment-relay"), label: "Tailscale" },
+      ],
+      primaryEnvironmentId,
+    });
+    expect(options).toEqual([
+      {
+        environmentId: EnvironmentId.make("environment-remote"),
+        label: "Mac Mini",
+        isPrimary: false,
+      },
+      {
+        environmentId: EnvironmentId.make("environment-relay"),
+        label: "Tailscale",
+        isPrimary: false,
+      },
+      { environmentId: primaryEnvironmentId, label: "This Mac", isPrimary: true },
+    ]);
+  });
+
+  it("marks nothing primary when there is no primary environment", () => {
+    const options = buildSidebarEnvironmentFilterOptions({
+      environments: [{ environmentId: EnvironmentId.make("environment-remote"), label: "Remote" }],
+      primaryEnvironmentId: null,
+    });
+    expect(options[0]).toMatchObject({ isPrimary: false });
+  });
+});
+
+describe("projectScopeKeptUnderEnvironmentScope", () => {
+  const localEnvironmentId = EnvironmentId.make("environment-local");
+  const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+  const projectId = ProjectId.make("project-1");
+
+  it("keeps the project filter when no environment is scoped", () => {
+    expect(
+      projectScopeKeptUnderEnvironmentScope({
+        memberProjectRefs: [{ environmentId: remoteEnvironmentId, projectId }],
+        environmentScopeId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the project filter when the group spans the selected environment", () => {
+    expect(
+      projectScopeKeptUnderEnvironmentScope({
+        memberProjectRefs: [
+          { environmentId: localEnvironmentId, projectId },
+          { environmentId: remoteEnvironmentId, projectId },
+        ],
+        environmentScopeId: remoteEnvironmentId,
+      }),
+    ).toBe(true);
+  });
+
+  it("resets the project filter when the group has no member on the selected environment", () => {
+    expect(
+      projectScopeKeptUnderEnvironmentScope({
+        memberProjectRefs: [
+          { environmentId: localEnvironmentId, projectId },
+          { environmentId: remoteEnvironmentId, projectId },
+        ],
+        environmentScopeId: EnvironmentId.make("environment-other"),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("filterSidebarProjectsByEnvironmentScope", () => {
+  const localEnvironmentId = EnvironmentId.make("environment-local");
+  const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+  const projectId = ProjectId.make("project-1");
+  const localGroup = {
+    projectKey: "local-project",
+    memberProjectRefs: [{ environmentId: localEnvironmentId, projectId }],
+  };
+  const remoteGroup = {
+    projectKey: "remote-project",
+    memberProjectRefs: [{ environmentId: remoteEnvironmentId, projectId }],
+  };
+  const spanningGroup = {
+    projectKey: "spanning-project",
+    memberProjectRefs: [
+      { environmentId: localEnvironmentId, projectId },
+      { environmentId: remoteEnvironmentId, projectId },
+    ],
+  };
+
+  it("keeps every group in the menu when no environment is scoped", () => {
+    expect(
+      filterSidebarProjectsByEnvironmentScope([localGroup, remoteGroup, spanningGroup], null),
+    ).toEqual([localGroup, remoteGroup, spanningGroup]);
+  });
+
+  it("keeps only groups with a member on the scoped environment", () => {
+    expect(
+      filterSidebarProjectsByEnvironmentScope(
+        [localGroup, remoteGroup, spanningGroup],
+        remoteEnvironmentId,
+      ),
+    ).toEqual([remoteGroup, spanningGroup]);
+  });
+});
+
+describe("shouldResetEnvironmentScope", () => {
+  const localEnvironmentId = EnvironmentId.make("environment-local");
+  const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+  const environmentLabelById = new Map<string, string>([
+    [localEnvironmentId, "This Mac"],
+    [remoteEnvironmentId, "Mac Mini"],
+  ]);
+
+  it("keeps the scope while several environments are connected", () => {
+    expect(
+      shouldResetEnvironmentScope({
+        environmentScopeId: remoteEnvironmentId,
+        environmentCount: 2,
+        environmentLabelById,
+      }),
+    ).toBe(false);
+  });
+
+  it("resets when the scoped environment leaves the catalog", () => {
+    expect(
+      shouldResetEnvironmentScope({
+        environmentScopeId: EnvironmentId.make("environment-gone"),
+        environmentCount: 2,
+        environmentLabelById,
+      }),
+    ).toBe(true);
+  });
+
+  it("resets when a disconnect hides the filter menu behind a single environment", () => {
+    expect(
+      shouldResetEnvironmentScope({
+        environmentScopeId: remoteEnvironmentId,
+        environmentCount: 1,
+        environmentLabelById,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a null scope", () => {
+    expect(
+      shouldResetEnvironmentScope({
+        environmentScopeId: null,
+        environmentCount: 2,
+        environmentLabelById,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import type { ContextMenuItem } from "@t3tools/contracts";
+import type { ContextMenuItem, EnvironmentId } from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import {
   getThreadSortTimestamp,
@@ -933,4 +933,81 @@ export function sortScopedProjectsForSidebar<
       left.environmentId.localeCompare(right.environmentId) ||
       left.id.localeCompare(right.id),
   );
+}
+
+/** One entry of the sidebar's environment filter menu. */
+export interface SidebarEnvironmentFilterOption {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly isPrimary: boolean;
+}
+
+/**
+ * Builds the sidebar's environment filter options, sorted by label so the
+ * menu order is stable regardless of connection-catalog churn.
+ */
+export function buildSidebarEnvironmentFilterOptions(input: {
+  environments: readonly { readonly environmentId: EnvironmentId; readonly label: string }[];
+  primaryEnvironmentId: EnvironmentId | null;
+}): SidebarEnvironmentFilterOption[] {
+  return input.environments
+    .toSorted((left, right) => left.label.localeCompare(right.label))
+    .map((environment) => ({
+      environmentId: environment.environmentId,
+      label: environment.label,
+      isPrimary: environment.environmentId === input.primaryEnvironmentId,
+    }));
+}
+
+/**
+ * True when the project filter can stay applied under an environment scope:
+ * either no environment is selected, or the group has at least one member on
+ * that environment. When false the project filter must reset, because a group
+ * with no matching member could only ever produce blank rows.
+ */
+export function projectScopeKeptUnderEnvironmentScope(input: {
+  memberProjectRefs: readonly { readonly environmentId: string; readonly projectId: string }[];
+  environmentScopeId: string | null;
+}): boolean {
+  if (input.environmentScopeId === null) return true;
+  return input.memberProjectRefs.some(
+    (projectRef) => projectRef.environmentId === input.environmentScopeId,
+  );
+}
+
+/**
+ * Narrows the project menu to groups that could produce rows under the current
+ * environment scope. A group with no member on the selected environment would
+ * be auto-cleared the moment it got picked, so it is hidden instead of offered.
+ */
+export function filterSidebarProjectsByEnvironmentScope<
+  TProject extends {
+    readonly memberProjectRefs: readonly {
+      readonly environmentId: string;
+      readonly projectId: string;
+    }[];
+  },
+>(projectGroups: readonly TProject[], environmentScopeId: string | null): TProject[] {
+  if (environmentScopeId === null) return projectGroups as TProject[];
+  return projectGroups.filter((group) =>
+    projectScopeKeptUnderEnvironmentScope({
+      memberProjectRefs: group.memberProjectRefs,
+      environmentScopeId,
+    }),
+  );
+}
+
+/**
+ * True when the environment scope must be dropped: the scoped environment left
+ * the catalog, or so few environments remain that the filter menu is hidden.
+ * With a single surviving environment a scope filters nothing but would stick
+ * anyway, with no menu left to reset it from.
+ */
+export function shouldResetEnvironmentScope(input: {
+  environmentScopeId: string | null;
+  environmentCount: number;
+  environmentLabelById: ReadonlyMap<string, unknown>;
+}): boolean {
+  if (input.environmentScopeId === null) return false;
+  return input.environmentCount <= 1 || !input.environmentLabelById.has(input.environmentScopeId);
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -29,7 +29,7 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef, ThreadId } from "@t3tools/contracts";
+import type { EnvironmentId, ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import type { TimestampFormat } from "@t3tools/contracts/settings";
 import {
   AlarmClockIcon,
@@ -40,10 +40,12 @@ import {
   CircleCheckIcon,
   CircleDashedIcon,
   ClockIcon,
+  CloudIcon,
   FolderIcon,
   FolderPlusIcon,
   GitBranchIcon,
   MessageSquareIcon,
+  MonitorIcon,
   PinIcon,
   PlusIcon,
   SearchIcon,
@@ -121,17 +123,21 @@ import { cn } from "~/lib/utils";
 import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
 import {
   buildBulkTitleRegenerationContextMenuItem,
+  buildSidebarEnvironmentFilterOptions,
+  filterSidebarProjectsByEnvironmentScope,
   formatWorkingDurationLabel,
   firstValidTimestampMs,
   hasUnseenCompletion,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   planPinnedReorder,
+  projectScopeKeptUnderEnvironmentScope,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
   searchSidebarThreadsByTitle,
   shouldCreateNewThreadInCurrentProject,
+  shouldResetEnvironmentScope,
   resolveWorkingStartedAt,
   sortLogicalProjectsForSidebar,
   sortPinnedThreadsForSidebar,
@@ -182,6 +188,11 @@ const SETTLED_TAIL_PAGE_COUNT = 25;
 // Keep the v2 key so existing preferences survive the v2-to-default rename.
 const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:settled-expanded";
 const SNOOZED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:snoozed-expanded";
+// MenuRadioGroup wants a string, and entity IDs accept any non-empty trimmed
+// string — so the "everything" radio wears the one value a real ID can never
+// be: empty. A barely-imaginable "all"-named environment must stay selectable.
+const ALL_ENVIRONMENTS_SCOPE_VALUE = "";
+const ALL_PROJECTS_SCOPE_VALUE = "";
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -538,6 +549,7 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
   projectCwdByKey: ReadonlyMap<string, string>;
   projectFaviconPathByKey: ReadonlyMap<string, string | null | undefined>;
   scopedProjectKeys: ReadonlySet<string> | null;
+  scopedEnvironmentId: EnvironmentId | null;
   routeDraftId: string | null;
   onNavigateToDraft: (draftId: DraftId) => void;
 }) {
@@ -583,6 +595,12 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
       ) {
         continue;
       }
+      if (
+        props.scopedEnvironmentId !== null &&
+        session.environmentId !== props.scopedEnvironmentId
+      ) {
+        continue;
+      }
       if (draftKey === props.routeDraftId) {
         // Open draft: render the frozen entry snapshot, or nothing for a
         // draft that has never been left. Gated on the LIVE session above so
@@ -605,6 +623,7 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
     draftsByThreadKey,
     frozenActive,
     props.routeDraftId,
+    props.scopedEnvironmentId,
     props.scopedProjectKeys,
   ]);
   const handleDiscard = useCallback(
@@ -1666,6 +1685,7 @@ export default function Sidebar() {
     },
   });
   const [projectScopeMenuOpen, setProjectScopeMenuOpen] = useState(false);
+  const [environmentScopeMenuOpen, setEnvironmentScopeMenuOpen] = useState(false);
   const newThreadContext = useHandleNewThread();
   const openAddProjectCommandPalette = useCallback(
     () => openCommandPalette({ open: "add-project" }),
@@ -1842,6 +1862,63 @@ export default function Sidebar() {
       setProjectScopeKey(null);
     }
   }, [projectScopeKey, scopedProjectGroup]);
+  // Environment scope: a second menu in the filter row. Squares with the
+  // project scope — selecting an environment narrows the same thread list,
+  // and a later project pick must only reset the project menu, never this one.
+  const [environmentScopeId, setEnvironmentScopeId] = useState<EnvironmentId | null>(null);
+  const environmentFilterOptions = useMemo(
+    () =>
+      buildSidebarEnvironmentFilterOptions({
+        environments,
+        primaryEnvironmentId,
+      }),
+    [environments, primaryEnvironmentId],
+  );
+  const scopedEnvironmentFilterOption = useMemo(
+    () =>
+      environmentScopeId === null
+        ? null
+        : (environmentFilterOptions.find((option) => option.environmentId === environmentScopeId) ??
+          null),
+    [environmentFilterOptions, environmentScopeId],
+  );
+  // A removed environment resets the scope, same contract as project removal.
+  // The menu hides when only one environment remains; a scope then sticks with
+  // no way back to All environments, so the surviving single-env scope (a
+  // no-op filter anyway) is cleared too.
+  useEffect(() => {
+    if (
+      shouldResetEnvironmentScope({
+        environmentScopeId,
+        environmentCount: environments.length,
+        environmentLabelById,
+      })
+    ) {
+      setEnvironmentScopeId(null);
+    }
+  }, [environmentScopeId, environmentLabelById, environments.length]);
+  // The project scope must stay whichever environment the user narrows to:
+  // a group spanning several environments keeps its filter, but one with no
+  // member on the selected environment could only ever produce blank rows.
+  // Reset to All projects instead, matching the single-select reading of the
+  // two menus working together.
+  useEffect(() => {
+    if (environmentScopeId === null || scopedProjectGroup === null) return;
+    if (
+      !projectScopeKeptUnderEnvironmentScope({
+        memberProjectRefs: scopedProjectGroup.memberProjectRefs,
+        environmentScopeId,
+      })
+    ) {
+      setProjectScopeKey(null);
+    }
+  }, [environmentScopeId, scopedProjectGroup]);
+  // The project menu only offers groups with a member on the scoped
+  // environment; any other pick would be auto-cleared right after landing.
+  const projectScopeMenuGroups = useMemo(
+    () => filterSidebarProjectsByEnvironmentScope(projectGroups, environmentScopeId),
+    [environmentScopeId, projectGroups],
+  );
   // Count-only subscription: the parent needs "are there draft rows" for the
   // empty state, while SidebarDraftBlock owns the per-keystroke content
   // subscription. Selecting a number keeps typing in a draft composer from
@@ -1864,6 +1941,9 @@ export default function Sidebar() {
       ) {
         continue;
       }
+      if (environmentScopeId !== null && session.environmentId !== environmentScopeId) {
+        continue;
+      }
       count += 1;
     }
     return count;
@@ -1872,7 +1952,7 @@ export default function Sidebar() {
   // hidden now, and bulk actions must never count or touch invisible rows.
   useEffect(() => {
     clearSelection();
-  }, [clearSelection, projectScopeKey]);
+  }, [clearSelection, environmentScopeId, projectScopeKey]);
 
   const handleProjectSettings = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>, projectGroup: SidebarProjectSnapshot) => {
@@ -1913,6 +1993,7 @@ export default function Sidebar() {
     const visible = threads.filter(
       (thread) =>
         thread.archivedAt === null &&
+        (environmentScopeId === null || thread.environmentId === environmentScopeId) &&
         (scopedProjectKeys === null ||
           scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
     );
@@ -1983,6 +2064,7 @@ export default function Sidebar() {
   }, [
     autoSettleAfterDays,
     changeRequestStateByKey,
+    environmentScopeId,
     nowMinute,
     scopedProjectKeys,
     serverConfigs,
@@ -2040,7 +2122,7 @@ export default function Sidebar() {
   // filter context changes so a scope/search flip never inherits a deep
   // page state.
   const [settledVisibleCount, setSettledVisibleCount] = useState(SETTLED_TAIL_INITIAL_COUNT);
-  const settledResetKey = projectScopeKey ?? "all";
+  const settledResetKey = `${projectScopeKey ?? "all"}:${environmentScopeId ?? "all"}`;
   const lastSettledResetKeyRef = useRef(settledResetKey);
   if (lastSettledResetKeyRef.current !== settledResetKey) {
     lastSettledResetKeyRef.current = settledResetKey;
@@ -3320,81 +3402,147 @@ export default function Sidebar() {
                 </Tooltip>
               </div>
             </div>
-            {projectGroups.length > 0 ? (
+            {projectGroups.length > 0 || environments.length > 1 ? (
               <div className="flex items-center gap-1">
-                <Menu open={projectScopeMenuOpen} onOpenChange={setProjectScopeMenuOpen}>
-                  <MenuTrigger
-                    render={
-                      <SidebarMenuButton
-                        aria-label="Filter threads by project"
-                        className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
-                      />
-                    }
-                  >
-                    {scopedProjectGroup ? (
-                      <ProjectFavicon
-                        environmentId={scopedProjectGroup.environmentId}
-                        cwd={scopedProjectGroup.workspaceRoot}
-                        faviconPath={scopedProjectGroup.faviconPath}
-                        className="size-4 shrink-0"
-                      />
-                    ) : (
-                      <FolderIcon className="size-4 shrink-0" />
-                    )}
-                    <span className="min-w-0 flex-1 truncate">
-                      {scopedProjectGroup?.displayName ?? "All projects"}
-                    </span>
-                    <ChevronDownIcon className="-mr-px size-4 shrink-0" />
-                  </MenuTrigger>
-                  <MenuPopup align="start" className="w-(--anchor-width)">
-                    <MenuRadioGroup
-                      value={projectScopeKey ?? "all"}
-                      onValueChange={(value) =>
-                        setProjectScopeKey(value === "all" ? null : (value as string))
+                {environments.length > 1 ? (
+                  <Menu open={environmentScopeMenuOpen} onOpenChange={setEnvironmentScopeMenuOpen}>
+                    <MenuTrigger
+                      render={
+                        <SidebarMenuButton
+                          aria-label="Filter threads by environment"
+                          className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+                        />
                       }
                     >
-                      <MenuRadioItem
-                        value="all"
-                        closeOnClick
-                        className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                      {scopedEnvironmentFilterOption === null ? (
+                        <ServerIcon className="size-4 shrink-0" />
+                      ) : scopedEnvironmentFilterOption.isPrimary ? (
+                        <MonitorIcon className="size-4 shrink-0" />
+                      ) : (
+                        <CloudIcon className="size-4 shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate">
+                        {scopedEnvironmentFilterOption?.label ?? "All environments"}
+                      </span>
+                      <ChevronDownIcon className="-mr-px size-4 shrink-0" />
+                    </MenuTrigger>
+                    <MenuPopup align="start" className="w-(--anchor-width)">
+                      <MenuRadioGroup
+                        value={environmentScopeId ?? ALL_ENVIRONMENTS_SCOPE_VALUE}
+                        onValueChange={(value) =>
+                          setEnvironmentScopeId(
+                            value === ALL_ENVIRONMENTS_SCOPE_VALUE
+                              ? null
+                              : (value as EnvironmentId),
+                          )
+                        }
                       >
-                        <FolderIcon className="size-4 shrink-0" />
-                        <span className="min-w-0 truncate text-sm">All projects</span>
-                      </MenuRadioItem>
-                      {projectGroups.map((project) => {
-                        const scopeKey = project.projectKey;
-                        return (
+                        <MenuRadioItem
+                          value={ALL_ENVIRONMENTS_SCOPE_VALUE}
+                          closeOnClick
+                          className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                        >
+                          <ServerIcon className="size-4 shrink-0" />
+                          <span className="min-w-0 truncate text-sm">All environments</span>
+                        </MenuRadioItem>
+                        {environmentFilterOptions.map((option) => (
                           <MenuRadioItem
-                            key={scopeKey}
-                            value={scopeKey}
+                            key={option.environmentId}
+                            value={option.environmentId}
                             closeOnClick
                             className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
                           >
-                            <ProjectFavicon
-                              environmentId={project.environmentId}
-                              cwd={project.workspaceRoot}
-                              faviconPath={project.faviconPath}
-                              className="size-4 shrink-0"
-                            />
-                            <span className="min-w-0 truncate text-sm">{project.displayName}</span>
-                            <button
-                              type="button"
-                              aria-label={`Project settings for ${project.displayName}`}
-                              title={`Project settings for ${project.displayName}`}
-                              className="ml-auto inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-icon-muted outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-                              onPointerDown={(event) => event.stopPropagation()}
-                              onClick={(event) => {
-                                void handleProjectSettings(event, project);
-                              }}
-                            >
-                              <SettingsIcon className="size-3.5" />
-                            </button>
+                            {option.isPrimary ? (
+                              <MonitorIcon className="size-4 shrink-0" />
+                            ) : (
+                              <CloudIcon className="size-4 shrink-0" />
+                            )}
+                            <span className="min-w-0 truncate text-sm">{option.label}</span>
                           </MenuRadioItem>
-                        );
-                      })}
-                    </MenuRadioGroup>
-                  </MenuPopup>
-                </Menu>
+                        ))}
+                      </MenuRadioGroup>
+                    </MenuPopup>
+                  </Menu>
+                ) : null}
+                {projectGroups.length > 0 ? (
+                  <Menu open={projectScopeMenuOpen} onOpenChange={setProjectScopeMenuOpen}>
+                    <MenuTrigger
+                      render={
+                        <SidebarMenuButton
+                          aria-label="Filter threads by project"
+                          className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+                        />
+                      }
+                    >
+                      {scopedProjectGroup ? (
+                        <ProjectFavicon
+                          environmentId={scopedProjectGroup.environmentId}
+                          cwd={scopedProjectGroup.workspaceRoot}
+                          faviconPath={scopedProjectGroup.faviconPath}
+                          className="size-4 shrink-0"
+                        />
+                      ) : (
+                        <FolderIcon className="size-4 shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate">
+                        {scopedProjectGroup?.displayName ?? "All projects"}
+                      </span>
+                      <ChevronDownIcon className="-mr-px size-4 shrink-0" />
+                    </MenuTrigger>
+                    <MenuPopup align="start" className="w-(--anchor-width)">
+                      <MenuRadioGroup
+                        value={projectScopeKey ?? ALL_PROJECTS_SCOPE_VALUE}
+                        onValueChange={(value) =>
+                          setProjectScopeKey(
+                            value === ALL_PROJECTS_SCOPE_VALUE ? null : (value as string),
+                          )
+                        }
+                      >
+                        <MenuRadioItem
+                          value={ALL_PROJECTS_SCOPE_VALUE}
+                          closeOnClick
+                          className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                        >
+                          <FolderIcon className="size-4 shrink-0" />
+                          <span className="min-w-0 truncate text-sm">All projects</span>
+                        </MenuRadioItem>
+                        {projectScopeMenuGroups.map((project) => {
+                          const scopeKey = project.projectKey;
+                          return (
+                            <MenuRadioItem
+                              key={scopeKey}
+                              value={scopeKey}
+                              closeOnClick
+                              className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                            >
+                              <ProjectFavicon
+                                environmentId={project.environmentId}
+                                cwd={project.workspaceRoot}
+                                faviconPath={project.faviconPath}
+                                className="size-4 shrink-0"
+                              />
+                              <span className="min-w-0 truncate text-sm">
+                                {project.displayName}
+                              </span>
+                              <button
+                                type="button"
+                                aria-label={`Project settings for ${project.displayName}`}
+                                title={`Project settings for ${project.displayName}`}
+                                className="ml-auto inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-icon-muted outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                                onPointerDown={(event) => event.stopPropagation()}
+                                onClick={(event) => {
+                                  void handleProjectSettings(event, project);
+                                }}
+                              >
+                                <SettingsIcon className="size-3.5" />
+                              </button>
+                            </MenuRadioItem>
+                          );
+                        })}
+                      </MenuRadioGroup>
+                    </MenuPopup>
+                  </Menu>
+                ) : null}
                 <Tooltip>
                   <TooltipTrigger
                     render={
@@ -3600,6 +3748,7 @@ export default function Sidebar() {
                       projectCwdByKey={projectCwdByKey}
                       projectFaviconPathByKey={projectFaviconPathByKey}
                       scopedProjectKeys={scopedProjectKeys}
+                      scopedEnvironmentId={environmentScopeId}
                       routeDraftId={routeDraftIdForRows}
                       onNavigateToDraft={navigateToDraft}
                     />,
@@ -3758,7 +3907,13 @@ export default function Sidebar() {
                   </button>
                 </>
               ) : scopedProjectGroup ? (
-                `No threads in ${scopedProjectGroup.displayName} yet`
+                scopedEnvironmentFilterOption ? (
+                  `No threads in ${scopedProjectGroup.displayName} on ${scopedEnvironmentFilterOption.label} yet`
+                ) : (
+                  `No threads in ${scopedProjectGroup.displayName} yet`
+                )
+              ) : scopedEnvironmentFilterOption ? (
+                `No threads on ${scopedEnvironmentFilterOption.label} yet`
               ) : (
                 "No threads yet"
               )}


### PR DESCRIPTION
Fixes #6229 

## What Changed

Added a single-select **environment filter** to the sidebar alongside the existing project filter in `apps/web/src/components/Sidebar.tsx` (used by desktop).

The new filter lets users narrow the thread list to a single connected environment while keeping all configured environments available.

## Files Changed

- `apps/web/src/components/Sidebar.tsx`
  - Added environment scope state and filter options
  - Added environment partition/filter logic
  - Added draft filtering and draft UI
  - Added environment filter header UI
  - Added empty state handling
  - Added settled-reset key

- `apps/web/src/components/Sidebar.logic.ts`
  - Added `buildSidebarEnvironmentFilterOptions`
  - Added `projectScopeKeptUnderEnvironmentScope` helpers
  - Added tests for the new helpers

- `apps/web/src/components/Sidebar.logic.test.ts`
  - Added 15 test cases covering the two new helpers

## Why

Previously, the thread list could only be narrowed by **project**, not by **environment**.

For users with multiple connected environments, this made it difficult to focus on threads belonging to a specific environment without losing access to the others.

The new environment filter works alongside the existing project filter:

- Both filters can be active simultaneously.
- Switching environments resets the project filter when the selected project has no member in the new environment.
- Removing an environment filter resets it to **All environments**.

## UI Changes

### Before

Only a project filter was available:

- All projects
- Project list

### After

Both filters are available in the same row:

- **Project filter** — existing All projects + project list
- **Environment filter** — new All environments + one entry per configured environment

Environment options are sorted by label, with the primary environment indicated using the existing `MonitorIcon` / `CloudIcon`.

The two filters can be combined in either order:

1. Select an environment, then a project
2. Select a project, then an environment

When switching environments, the project filter is reset if the selected project has no member in the new environment. Removing the environment selection resets the filter to **All environments**.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sidebar filtering and selection-clearing behavior with non-trivial cross-filter reset rules, so incorrect scope handling could hide threads or clear filters unexpectedly.
> 
> **Overview**
> Adds a single-select **environment filter** beside the existing project filter so users with multiple connected environments can narrow threads and drafts to one environment.
> 
> The filter appears only when more than one environment is connected. It filters the thread list, draft rows, and project menu options; selecting an environment that the current project does not span resets the project filter. Scope also clears when the environment disconnects or only one remains.
> 
> Empty-state copy now mentions the active environment when scoped. New helpers in `Sidebar.logic` cover option building, project-menu filtering, and reset rules, with matching unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783ad2c64b55f7489b8bff0f1563f1edbc9cde6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add environment filter to the sidebar to scope threads, drafts, and projects
> - Adds an environment filter menu to the sidebar, shown when more than one environment exists, with icons distinguishing the primary environment from others.
> - Selecting an environment scopes visible threads and draft sessions to that environment, and constrains the project filter menu to projects present on that environment.
> - Introduces logic helpers in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/6294/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) for building sorted filter options, filtering project groups, checking project scope retention, and auto-resetting a stale environment scope.
> - Changing the environment scope clears the current thread selection and resets settled history pagination; the scope auto-resets if the selected environment disappears or only one environment remains.
> - Empty state messages reflect the currently scoped environment label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 783ad2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->