### PR TITLE
fix(web): open the file a bare filename reference names

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1447,15 +1447,13 @@ function ChatMarkdown({
     },
     [createAssetUrl, openPreview, preparedConnection, threadRef],
   );
-  // `ChatView.tsx:3301` names a file without saying where it lives, so the link
-  // resolver can only place it at the workspace root and the read fails there.
-  // Ask the workspace index for the real location before opening the surface.
+  // A bare filename resolves to the workspace root, which is rarely where the
+  // file is, so ask the index before opening.
   const openFileInPanel = useCallback(
     (workspaceRelativePath: string, line: number | undefined) => {
       if (!threadRef) return;
-      // Claimed for every open, not just the ones that look something up: a
-      // path that opens synchronously still has to supersede a lookup already
-      // in flight, or that lookup lands afterwards and takes the panel back.
+      // Claimed on every open so a synchronous one supersedes a lookup already
+      // in flight.
       const isLatestLookup = claimWorkspaceBasenameLookup();
       const openAt = (path: string) =>
         useRightPanelStore.getState().openFile(threadRef, path, line);
@@ -1477,7 +1475,6 @@ function ChatMarkdown({
           result._tag === "Success"
             ? pickWorkspaceBasenameMatch(workspaceRelativePath, result.value.entries)
             : null;
-        // A click that landed after this one already owns the panel.
         if (!isLatestLookup()) return;
         openAt(match ?? workspaceRelativePath);
       })();

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -90,6 +90,13 @@ import { usePreparedConnection } from "../state/session";
 import { previewEnvironment } from "../state/preview";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
+import { projectEnvironment } from "../state/projects";
+import {
+  claimWorkspaceBasenameLookup,
+  needsWorkspaceBasenameLookup,
+  pickWorkspaceBasenameMatch,
+  WORKSPACE_BASENAME_LOOKUP_LIMIT,
+} from "../workspaceBasenameLookup";
 import { useOpenChangeRequestLink } from "~/lib/openPullRequestLink";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
@@ -791,6 +798,7 @@ interface MarkdownFileLinkProps {
   theme: "light" | "dark";
   threadRef?: ScopedThreadRef | undefined;
   onOpen: (targetPath: string) => Promise<AtomCommandResult<unknown, unknown>>;
+  onOpenInPanel: (workspaceRelativePath: string, line: number | undefined) => void;
   onOpenInBrowser?: (() => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
   className?: string | undefined;
 }
@@ -1093,6 +1101,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   theme,
   threadRef,
   onOpen,
+  onOpenInPanel,
   onOpenInBrowser,
   className,
 }: MarkdownFileLinkProps) {
@@ -1136,8 +1145,8 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
       handleOpenInEditor();
       return;
     }
-    useRightPanelStore.getState().openFile(threadRef, workspaceRelativePath, line);
-  }, [handleOpenInEditor, line, threadRef, workspaceRelativePath]);
+    onOpenInPanel(workspaceRelativePath, line);
+  }, [handleOpenInEditor, line, onOpenInPanel, threadRef, workspaceRelativePath]);
 
   const handleOpenInBrowser = useCallback(() => {
     if (!onOpenInBrowser) {
@@ -1313,6 +1322,7 @@ function areMarkdownFileLinkPropsEqual(
     previous.theme === next.theme &&
     previous.threadRef === next.threadRef &&
     previous.onOpen === next.onOpen &&
+    previous.onOpenInPanel === next.onOpenInPanel &&
     previous.onOpenInBrowser === next.onOpenInBrowser &&
     previous.className === next.className
   );
@@ -1330,6 +1340,9 @@ function ChatMarkdown({
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
+    reportFailure: false,
+  });
+  const searchProjectEntries = useAtomQueryRunner(projectEnvironment.searchEntries, {
     reportFailure: false,
   });
   const openPreview = useAtomCommand(previewEnvironment.open, {
@@ -1434,6 +1447,40 @@ function ChatMarkdown({
     },
     [createAssetUrl, openPreview, preparedConnection, threadRef],
   );
+  // `ChatView.tsx:3301` names a file without saying where it lives, so the link
+  // resolver can only place it at the workspace root and the read fails there.
+  // Ask the workspace index for the real location before opening the surface.
+  const openFileInPanel = useCallback(
+    (workspaceRelativePath: string, line: number | undefined) => {
+      if (!threadRef) return;
+      const openAt = (path: string) =>
+        useRightPanelStore.getState().openFile(threadRef, path, line);
+      if (!cwd || !needsWorkspaceBasenameLookup(workspaceRelativePath)) {
+        openAt(workspaceRelativePath);
+        return;
+      }
+      const isLatestLookup = claimWorkspaceBasenameLookup();
+      void (async () => {
+        const result = await searchProjectEntries({
+          environmentId: threadRef.environmentId,
+          input: {
+            cwd,
+            query: workspaceRelativePath,
+            limit: WORKSPACE_BASENAME_LOOKUP_LIMIT,
+            kind: "file",
+          },
+        });
+        const match =
+          result._tag === "Success"
+            ? pickWorkspaceBasenameMatch(workspaceRelativePath, result.value.entries)
+            : null;
+        // A click that landed after this one already owns the panel.
+        if (!isLatestLookup()) return;
+        openAt(match ?? workspaceRelativePath);
+      })();
+    },
+    [cwd, searchProjectEntries, threadRef],
+  );
   /* eslint-disable react/no-unstable-nested-components -- ReactMarkdown requires component
    * renderers that close over this message's metadata. useMemo keeps them stable until that
    * metadata changes. */
@@ -1467,6 +1514,7 @@ function ChatMarkdown({
           theme={resolvedTheme}
           threadRef={threadRef}
           onOpen={openInPreferredEditor}
+          onOpenInPanel={openFileInPanel}
           onOpenInBrowser={
             threadRef &&
             isPreviewSupportedInRuntime() &&
@@ -1685,6 +1733,7 @@ function ChatMarkdown({
     isStreaming,
     markdownFileLinkMetaByHref,
     onTaskListChange,
+    openFileInPanel,
     openInPreferredEditor,
     openExternalLinkInPreview,
     openMarkdownFileInPreview,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1453,13 +1453,16 @@ function ChatMarkdown({
   const openFileInPanel = useCallback(
     (workspaceRelativePath: string, line: number | undefined) => {
       if (!threadRef) return;
+      // Claimed for every open, not just the ones that look something up: a
+      // path that opens synchronously still has to supersede a lookup already
+      // in flight, or that lookup lands afterwards and takes the panel back.
+      const isLatestLookup = claimWorkspaceBasenameLookup();
       const openAt = (path: string) =>
         useRightPanelStore.getState().openFile(threadRef, path, line);
       if (!cwd || !needsWorkspaceBasenameLookup(workspaceRelativePath)) {
         openAt(workspaceRelativePath);
         return;
       }
-      const isLatestLookup = claimWorkspaceBasenameLookup();
       void (async () => {
         const result = await searchProjectEntries({
           environmentId: threadRef.environmentId,

--- a/apps/web/src/workspaceBasenameLookup.test.ts
+++ b/apps/web/src/workspaceBasenameLookup.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  claimWorkspaceBasenameLookup,
+  needsWorkspaceBasenameLookup,
+  pickWorkspaceBasenameMatch,
+} from "./workspaceBasenameLookup";
+
+describe("needsWorkspaceBasenameLookup", () => {
+  it("flags bare filenames", () => {
+    expect(needsWorkspaceBasenameLookup("ChatView.tsx")).toBe(true);
+    expect(needsWorkspaceBasenameLookup("Makefile")).toBe(true);
+  });
+
+  it("leaves anything with a directory alone", () => {
+    expect(needsWorkspaceBasenameLookup("apps/web/src/components/ChatView.tsx")).toBe(false);
+    expect(needsWorkspaceBasenameLookup("apps\\web\\ChatView.tsx")).toBe(false);
+    expect(needsWorkspaceBasenameLookup("   ")).toBe(false);
+  });
+});
+
+describe("pickWorkspaceBasenameMatch", () => {
+  const entries = [
+    { path: "apps/web/src/components/ChatView.test.tsx", kind: "file" as const },
+    { path: "apps/web/src/components/ChatView.tsx", kind: "file" as const },
+  ];
+
+  it("takes the first exact filename match, not the closest fuzzy one", () => {
+    expect(pickWorkspaceBasenameMatch("ChatView.tsx", entries)).toBe(
+      "apps/web/src/components/ChatView.tsx",
+    );
+  });
+
+  it("ignores directories", () => {
+    expect(
+      pickWorkspaceBasenameMatch("components", [
+        { path: "apps/web/src/components", kind: "directory" },
+        { path: "apps/web/src/components/components", kind: "file" },
+      ]),
+    ).toBe("apps/web/src/components/components");
+  });
+
+  it("prefers the exactly-cased file over a case-only twin", () => {
+    expect(
+      pickWorkspaceBasenameMatch("foo.ts", [
+        { path: "src/Foo.ts", kind: "file" },
+        { path: "src/foo.ts", kind: "file" },
+      ]),
+    ).toBe("src/foo.ts");
+  });
+
+  it("falls back to case-insensitive when only the casing differs", () => {
+    expect(pickWorkspaceBasenameMatch("chatview.tsx", entries)).toBe(
+      "apps/web/src/components/ChatView.tsx",
+    );
+  });
+
+  it("returns null when nothing matches the name", () => {
+    expect(pickWorkspaceBasenameMatch("ChatView.tsx", [])).toBeNull();
+    expect(
+      pickWorkspaceBasenameMatch("ChatView.tsx", [
+        { path: "apps/web/src/components/ChatHeader.tsx", kind: "file" },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("claimWorkspaceBasenameLookup", () => {
+  it("keeps only the newest claim, whatever order the lookups settle in", () => {
+    const first = claimWorkspaceBasenameLookup();
+    const second = claimWorkspaceBasenameLookup();
+
+    // The older lookup answering last must not reopen the panel behind the
+    // newer one.
+    expect(second()).toBe(true);
+    expect(first()).toBe(false);
+  });
+
+  it("stays valid while it is the only claim", () => {
+    const only = claimWorkspaceBasenameLookup();
+    expect(only()).toBe(true);
+    expect(only()).toBe(true);
+  });
+});

--- a/apps/web/src/workspaceBasenameLookup.test.ts
+++ b/apps/web/src/workspaceBasenameLookup.test.ts
@@ -55,6 +55,15 @@ describe("pickWorkspaceBasenameMatch", () => {
     );
   });
 
+  it("returns null when the case-insensitive fallback is ambiguous", () => {
+    expect(
+      pickWorkspaceBasenameMatch("FOO.ts", [
+        { path: "src/Foo.ts", kind: "file" },
+        { path: "src/foo.ts", kind: "file" },
+      ]),
+    ).toBeNull();
+  });
+
   it("returns null when nothing matches the name", () => {
     expect(pickWorkspaceBasenameMatch("ChatView.tsx", [])).toBeNull();
     expect(

--- a/apps/web/src/workspaceBasenameLookup.ts
+++ b/apps/web/src/workspaceBasenameLookup.ts
@@ -76,6 +76,12 @@ export function pickWorkspaceBasenameMatch(
   // is the common shape on macOS and Windows.
   const exact = files.find((entry) => basenameOfPath(entry.path) === target);
   if (exact) return exact.path;
+  // Only when it is unambiguous: `FOO.ts` against both `Foo.ts` and `foo.ts`
+  // has no right answer, and picking by index rank would open one of them
+  // without saying so.
   const folded = target.toLowerCase();
-  return files.find((entry) => basenameOfPath(entry.path).toLowerCase() === folded)?.path ?? null;
+  const foldedMatches = files.filter(
+    (entry) => basenameOfPath(entry.path).toLowerCase() === folded,
+  );
+  return foldedMatches.length === 1 ? (foldedMatches[0]?.path ?? null) : null;
 }

--- a/apps/web/src/workspaceBasenameLookup.ts
+++ b/apps/web/src/workspaceBasenameLookup.ts
@@ -1,0 +1,81 @@
+/**
+ * Agent output refers to files by name and line — `ChatView.tsx:3301` — far
+ * more often than by full path. The `:line` suffix is what marks the span as a
+ * file reference, but the name alone says nothing about where the file lives,
+ * so the link resolver can only place it at the workspace root, where it
+ * almost never is. Opening one of those links then fails with
+ * "Failed to read workspace file 'ChatView.tsx' in '<workspace>'".
+ *
+ * These helpers let the click path ask the workspace index where that basename
+ * actually lives before opening the file surface.
+ */
+
+/**
+ * Enough index hits to look past same-named neighbours (`ChatView.test.tsx`)
+ * without asking the environment for a full listing on a single click.
+ */
+export const WORKSPACE_BASENAME_LOOKUP_LIMIT = 25;
+
+/**
+ * Sequence for in-flight lookups. Two clicks on bare filenames can be resolving
+ * at once, and nothing guarantees the index answers them in order — so an older
+ * answer landing last would move the panel off the file the user asked for.
+ *
+ * One counter covers every caller on purpose: they all open the same visible
+ * panel, so "newest click wins" is the behaviour regardless of which one
+ * started the lookup.
+ */
+let latestLookupSequence = 0;
+
+/**
+ * Claims the newest lookup. Call the returned predicate once the search
+ * settles: false means a later click has superseded this one and its result
+ * must be dropped.
+ */
+export function claimWorkspaceBasenameLookup(): () => boolean {
+  latestLookupSequence += 1;
+  const claimed = latestLookupSequence;
+  return () => claimed === latestLookupSequence;
+}
+
+export interface WorkspaceEntryCandidate {
+  readonly path: string;
+  readonly kind: "file" | "directory";
+}
+
+function basenameOfPath(path: string): string {
+  const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
+}
+
+/**
+ * True when a workspace-relative path is a bare filename, which is the only
+ * shape that can have come from a reference with no directory in it. Anything
+ * carrying a separator was already resolved against a real location.
+ */
+export function needsWorkspaceBasenameLookup(relativePath: string): boolean {
+  const trimmed = relativePath.trim();
+  return trimmed.length > 0 && !trimmed.includes("/") && !trimmed.includes("\\");
+}
+
+/**
+ * The best index entry for a basename, or null to leave the path alone. Search
+ * results arrive ranked, so the first exact filename match wins; a fuzzy match
+ * on some other file is worse than the honest "not found" error.
+ */
+export function pickWorkspaceBasenameMatch(
+  basename: string,
+  entries: ReadonlyArray<WorkspaceEntryCandidate>,
+): string | null {
+  const target = basename.trim();
+  if (!target) return null;
+  const files = entries.filter((entry) => entry.kind === "file");
+  // Exact first: a workspace holding both `Foo.ts` and `foo.ts` must not open
+  // whichever the index happened to rank higher. The case-insensitive pass
+  // then covers a reference whose casing drifted from the file on disk, which
+  // is the common shape on macOS and Windows.
+  const exact = files.find((entry) => basenameOfPath(entry.path) === target);
+  if (exact) return exact.path;
+  const folded = target.toLowerCase();
+  return files.find((entry) => basenameOfPath(entry.path).toLowerCase() === folded)?.path ?? null;
+}

--- a/apps/web/src/workspaceBasenameLookup.ts
+++ b/apps/web/src/workspaceBasenameLookup.ts
@@ -1,37 +1,12 @@
-/**
- * Agent output refers to files by name and line — `ChatView.tsx:3301` — far
- * more often than by full path. The `:line` suffix is what marks the span as a
- * file reference, but the name alone says nothing about where the file lives,
- * so the link resolver can only place it at the workspace root, where it
- * almost never is. Opening one of those links then fails with
- * "Failed to read workspace file 'ChatView.tsx' in '<workspace>'".
- *
- * These helpers let the click path ask the workspace index where that basename
- * actually lives before opening the file surface.
- */
-
-/**
- * Enough index hits to look past same-named neighbours (`ChatView.test.tsx`)
- * without asking the environment for a full listing on a single click.
- */
+// Enough hits to look past same-named neighbours (`ChatView.test.tsx`) without
+// asking for a full listing on a single click.
 export const WORKSPACE_BASENAME_LOOKUP_LIMIT = 25;
 
-/**
- * Sequence for in-flight lookups. Two clicks on bare filenames can be resolving
- * at once, and nothing guarantees the index answers them in order — so an older
- * answer landing last would move the panel off the file the user asked for.
- *
- * One counter covers every caller on purpose: they all open the same visible
- * panel, so "newest click wins" is the behaviour regardless of which one
- * started the lookup.
- */
+// One counter for every caller: they all open the same panel, so the newest
+// click wins regardless of which one started the lookup.
 let latestLookupSequence = 0;
 
-/**
- * Claims the newest lookup. Call the returned predicate once the search
- * settles: false means a later click has superseded this one and its result
- * must be dropped.
- */
+/** Call the returned predicate when the search settles; false means a later click superseded it. */
 export function claimWorkspaceBasenameLookup(): () => boolean {
   latestLookupSequence += 1;
   const claimed = latestLookupSequence;
@@ -48,21 +23,11 @@ function basenameOfPath(path: string): string {
   return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
 }
 
-/**
- * True when a workspace-relative path is a bare filename, which is the only
- * shape that can have come from a reference with no directory in it. Anything
- * carrying a separator was already resolved against a real location.
- */
 export function needsWorkspaceBasenameLookup(relativePath: string): boolean {
   const trimmed = relativePath.trim();
   return trimmed.length > 0 && !trimmed.includes("/") && !trimmed.includes("\\");
 }
 
-/**
- * The best index entry for a basename, or null to leave the path alone. Search
- * results arrive ranked, so the first exact filename match wins; a fuzzy match
- * on some other file is worse than the honest "not found" error.
- */
 export function pickWorkspaceBasenameMatch(
   basename: string,
   entries: ReadonlyArray<WorkspaceEntryCandidate>,
@@ -70,15 +35,11 @@ export function pickWorkspaceBasenameMatch(
   const target = basename.trim();
   if (!target) return null;
   const files = entries.filter((entry) => entry.kind === "file");
-  // Exact first: a workspace holding both `Foo.ts` and `foo.ts` must not open
-  // whichever the index happened to rank higher. The case-insensitive pass
-  // then covers a reference whose casing drifted from the file on disk, which
-  // is the common shape on macOS and Windows.
   const exact = files.find((entry) => basenameOfPath(entry.path) === target);
   if (exact) return exact.path;
-  // Only when it is unambiguous: `FOO.ts` against both `Foo.ts` and `foo.ts`
-  // has no right answer, and picking by index rank would open one of them
-  // without saying so.
+  // Folded matching covers casing that drifted from disk, but `FOO.ts` against
+  // both `Foo.ts` and `foo.ts` has no right answer, so it resolves to nothing
+  // rather than opening whichever the index ranked first.
   const folded = target.toLowerCase();
   const foldedMatches = files.filter(
     (entry) => basenameOfPath(entry.path).toLowerCase() === folded,


### PR DESCRIPTION
Fixes #6292.

Clicking `ChatView.tsx:3301` fails with "Failed to read workspace file 'ChatView.tsx'". The `:line` suffix is what makes it a link, but the filename alone doesn't say where the file is, so it resolves against the workspace root.

When a path has no directory in it, this asks the workspace index where the file actually is before opening the panel. Only an exact filename match counts — a fuzzy match on some other file would be worse than the error you get today, so anything else keeps the old path and the old message. Paths that already carry a directory skip the lookup entirely and open synchronously, as before.

Two lookups can be in flight at once and the index makes no promise about the order it answers in, so each one claims a sequence and drops its result if a later click superseded it.

No screenshots: the visible change is a chip that used to open an error page now opening the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused UX bugfix for chat file links with conservative exact-match logic and unit tests; no auth, security, or data-handling changes.
> 
> **Overview**
> **Bare filename links in chat markdown now resolve to a real workspace path before opening the right panel**, fixing clicks like `ChatView.tsx:3301` that previously failed against the workspace root.
> 
> When the path has no directory segment, `openFileInPanel` queries `projectEnvironment.searchEntries` and opens only an unambiguous exact (or single case-insensitive) basename match. Paths that already include a directory still open synchronously. Concurrent lookups are sequenced so a later click wins if an earlier search settles out of order.
> 
> `MarkdownFileLink` now takes an `onOpenInPanel` callback instead of calling the right-panel store directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb40ad047fa9c8817ae5dd8af3b72299e9cac2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve bare filename references to project file paths when opening files from chat links
> - When a file link in chat references a bare filename (no directory separator), the new `openFileInPanel` callback in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/6297/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) queries the project index to find a matching file path.
> - Match selection prefers an exact basename match, falls back to a unique case-insensitive match, and uses the original path if ambiguous or unresolved.
> - Concurrent rapid clicks are handled via `claimWorkspaceBasenameLookup` in [workspaceBasenameLookup.ts](https://github.com/pingdotgg/t3code/pull/6297/files#diff-adf774b42de8aeaa6206be1e0b43e93f74c68d60ea3503d6c37e4e99ebb1402f), ensuring only the latest click's lookup result is applied.
> - `MarkdownFileLink` now accepts an `onOpenInPanel` callback instead of calling the right panel store directly, making the open logic configurable by the parent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dcb40ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

