### PR TITLE
feat(web): file references can name a span of lines

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -132,6 +132,79 @@ it.effect("launches an installed editor with platform-safe arguments", () =>
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 
+// A `path:20-40` span comes from a chat reference to a range of lines. The
+// editor has no span argument, so it opens at the range's first line rather
+// than failing on a path that does not exist.
+it.effect("opens a line span at its first line", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-editors-" });
+    yield* fileSystem.writeFileString(path.join(binDir, "idea"), "#!/bin/sh\n");
+    yield* fileSystem.chmod(path.join(binDir, "idea"), 0o755);
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.launchEditor({ editor: "idea", cwd: "/workspace/src/index.ts:20-40" });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "linux",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.deepEqual(spawned.args, ["--line", "20", "/workspace/src/index.ts"]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+// `--goto` takes `path:line[:column]`, so a span has to be rebuilt rather than
+// passed through; the raw `path:20-40` would be read as part of the filename.
+it.effect("hands goto editors a span as path:line", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-editors-" });
+    yield* fileSystem.writeFileString(path.join(binDir, "code"), "#!/bin/sh\n");
+    yield* fileSystem.chmod(path.join(binDir, "code"), 0o755);
+
+    const launch = (target: string) =>
+      Effect.gen(function* () {
+        let spawned: ChildProcess.StandardCommand | undefined;
+        yield* Effect.gen(function* () {
+          const launcher = yield* ExternalLauncher.ExternalLauncher;
+          yield* launcher.launchEditor({ editor: "vscode", cwd: target });
+        }).pipe(
+          Effect.provide(
+            testLayer({
+              platform: "linux",
+              env: { PATH: binDir },
+              onSpawn: (command) => {
+                spawned = command;
+              },
+            }),
+          ),
+        );
+        return spawned;
+      });
+
+    const spanLaunch = yield* launch("/workspace/src/index.ts:20-40");
+    assert.ok(spanLaunch);
+    assert.deepEqual(spanLaunch.args, ["--goto", "/workspace/src/index.ts:20"]);
+
+    // Every other shape still reaches the editor exactly as before.
+    const columnLaunch = yield* launch("/workspace/src/index.ts:20:5");
+    assert.ok(columnLaunch);
+    assert.deepEqual(columnLaunch.args, ["--goto", "/workspace/src/index.ts:20:5"]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
 it.effect("discovers editors through the service API", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -164,6 +164,37 @@ it.effect("opens a line span at its first line", () =>
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 
+// Zed takes the path as-is, so a span has to be collapsed before it is handed
+// over or it reads as part of the filename.
+it.effect("opens a span at its first line for a direct-path editor", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-editors-" });
+    yield* fileSystem.writeFileString(path.join(binDir, "zed"), "#!/bin/sh\n");
+    yield* fileSystem.chmod(path.join(binDir, "zed"), 0o755);
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.launchEditor({ editor: "zed", cwd: "/workspace/src/index.ts:20-40" });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "linux",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.deepEqual(spawned.args, ["/workspace/src/index.ts:20"]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
 // `--goto` takes `path:line[:column]`, so a span has to be rebuilt rather than
 // passed through; the raw `path:20-40` would be read as part of the filename.
 it.effect("hands goto editors a span as path:line", () =>

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -65,7 +65,9 @@ interface TargetPathAndPosition {
   readonly column: Option.Option<string>;
 }
 
-const TARGET_WITH_POSITION_PATTERN = /^(.*?):(\d+)(?::(\d+))?$/;
+// `path:12`, `path:12:5`, and the span form `path:12-40`. An editor opens at a
+// span's first line, so its end is matched to be stripped, never captured.
+const TARGET_WITH_POSITION_PATTERN = /^(.*?):(\d+)(?::(\d+)|-\d+)?$/;
 const POWERSHELL_ARGUMENTS_PREFIX = [
   "-NoProfile",
   "-NonInteractive",
@@ -133,8 +135,20 @@ function resolveCommandEditorArgs(
   switch (editor.launchStyle) {
     case "direct-path":
       return [target];
+    // Rebuilt from the parse rather than passed through: a `path:20-40` span
+    // is not a form these CLIs accept, and the rebuilt string is identical to
+    // `target` for every other shape.
     case "goto":
-      return Option.isSome(parsedTarget) ? ["--goto", target] : [target];
+      return Option.match(parsedTarget, {
+        onNone: () => [target],
+        onSome: ({ path, line, column }) => [
+          "--goto",
+          `${path}:${line}${Option.match(column, {
+            onNone: () => "",
+            onSome: (value) => `:${value}`,
+          })}`,
+        ],
+      });
     case "line-column":
       return Option.match(parsedTarget, {
         onNone: () => [target],

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -65,8 +65,8 @@ interface TargetPathAndPosition {
   readonly column: Option.Option<string>;
 }
 
-// `path:12`, `path:12:5`, and the span form `path:12-40`. An editor opens at a
-// span's first line, so its end is matched to be stripped, never captured.
+// `path:12`, `path:12:5`, and `path:12-40` — a span's end is matched to strip
+// it, never captured.
 const TARGET_WITH_POSITION_PATTERN = /^(.*?):(\d+)(?::(\d+)|-\d+)?$/;
 const POWERSHELL_ARGUMENTS_PREFIX = [
   "-NoProfile",
@@ -132,9 +132,8 @@ function resolveCommandEditorArgs(
 ): ReadonlyArray<string> {
   const parsedTarget = parseTargetPathAndPosition(target);
 
-  // Every style below opens at a single line: none of these CLIs accept a
-  // `path:20-40` span, and rebuilding from the parse leaves every other shape
-  // byte-identical to the target that came in.
+  // No editor CLI accepts a `path:20-40` span; rebuilding leaves every other
+  // shape unchanged.
   const positionalTarget = Option.match(parsedTarget, {
     onNone: () => target,
     onSome: ({ path, line, column }) =>

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -132,23 +132,23 @@ function resolveCommandEditorArgs(
 ): ReadonlyArray<string> {
   const parsedTarget = parseTargetPathAndPosition(target);
 
+  // Every style below opens at a single line: none of these CLIs accept a
+  // `path:20-40` span, and rebuilding from the parse leaves every other shape
+  // byte-identical to the target that came in.
+  const positionalTarget = Option.match(parsedTarget, {
+    onNone: () => target,
+    onSome: ({ path, line, column }) =>
+      `${path}:${line}${Option.match(column, {
+        onNone: () => "",
+        onSome: (value) => `:${value}`,
+      })}`,
+  });
+
   switch (editor.launchStyle) {
     case "direct-path":
-      return [target];
-    // Rebuilt from the parse rather than passed through: a `path:20-40` span
-    // is not a form these CLIs accept, and the rebuilt string is identical to
-    // `target` for every other shape.
+      return [positionalTarget];
     case "goto":
-      return Option.match(parsedTarget, {
-        onNone: () => [target],
-        onSome: ({ path, line, column }) => [
-          "--goto",
-          `${path}:${line}${Option.match(column, {
-            onNone: () => "",
-            onSome: (value) => `:${value}`,
-          })}`,
-        ],
-      });
+      return Option.isSome(parsedTarget) ? ["--goto", positionalTarget] : [target];
     case "line-column":
       return Option.match(parsedTarget, {
         onNone: () => [target],

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -786,6 +786,7 @@ interface MarkdownFileLinkProps {
   displayPath: string;
   workspaceRelativePath: string | null;
   line?: number | undefined;
+  endLine?: number | undefined;
   label: string;
   copyMarkdown: string;
   theme: "light" | "dark";
@@ -1088,6 +1089,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   displayPath,
   workspaceRelativePath,
   line,
+  endLine,
   label,
   copyMarkdown,
   theme,
@@ -1136,8 +1138,8 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
       handleOpenInEditor();
       return;
     }
-    useRightPanelStore.getState().openFile(threadRef, workspaceRelativePath, line);
-  }, [handleOpenInEditor, line, threadRef, workspaceRelativePath]);
+    useRightPanelStore.getState().openFile(threadRef, workspaceRelativePath, line, endLine);
+  }, [endLine, handleOpenInEditor, line, threadRef, workspaceRelativePath]);
 
   const handleOpenInBrowser = useCallback(() => {
     if (!onOpenInBrowser) {
@@ -1308,6 +1310,7 @@ function areMarkdownFileLinkPropsEqual(
     previous.displayPath === next.displayPath &&
     previous.workspaceRelativePath === next.workspaceRelativePath &&
     previous.line === next.line &&
+    previous.endLine === next.endLine &&
     previous.label === next.label &&
     previous.copyMarkdown === next.copyMarkdown &&
     previous.theme === next.theme &&
@@ -1450,7 +1453,9 @@ function ChatMarkdown({
       }
       if (fileLinkMeta.line) {
         labelParts.push(
-          `L${fileLinkMeta.line}${fileLinkMeta.column ? `:C${fileLinkMeta.column}` : ""}`,
+          fileLinkMeta.endLine
+            ? `L${fileLinkMeta.line}-${fileLinkMeta.endLine}`
+            : `L${fileLinkMeta.line}${fileLinkMeta.column ? `:C${fileLinkMeta.column}` : ""}`,
         );
       }
 
@@ -1462,6 +1467,7 @@ function ChatMarkdown({
           displayPath={fileLinkMeta.displayPath}
           workspaceRelativePath={fileLinkMeta.workspaceRelativePath}
           line={fileLinkMeta.line}
+          endLine={fileLinkMeta.endLine}
           label={labelParts.join(" · ")}
           copyMarkdown={copyMarkdown}
           theme={resolvedTheme}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6104,6 +6104,7 @@ function ChatViewContent(props: ChatViewProps) {
             activeRightPanelSurface.kind === "file" ? activeRightPanelSurface.relativePath : null
           }
           revealLine={activeFileSurface?.revealLine ?? null}
+          revealEndLine={activeFileSurface?.revealEndLine ?? null}
           revealRequestId={activeFileSurface?.revealRequestId ?? 0}
           onOpenFile={openFileSurface}
           onPendingChange={handleFilePendingChange}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -74,6 +74,7 @@ interface FilePreviewPanelProps {
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
   revealLine: number | null;
+  revealEndLine: number | null;
   revealRequestId: number;
   onOpenFile: (relativePath: string) => void;
   onPendingChange: (relativePath: string, pending: boolean) => void;
@@ -178,19 +179,30 @@ function clampFileLine(contents: string, requestedLine: number): number {
   return Math.min(Math.max(1, requestedLine), lineCount);
 }
 
-function updateFileLinkReveal(fileContainer: HTMLElement, line: number | null): void {
+function updateFileLinkReveal(
+  fileContainer: HTMLElement,
+  line: number | null,
+  endLine: number | null,
+): void {
   const root = fileContainer.shadowRoot ?? fileContainer;
   for (const element of root.querySelectorAll<HTMLElement>(`[${FILE_LINK_REVEAL_ATTRIBUTE}]`)) {
     element.removeAttribute(FILE_LINK_REVEAL_ATTRIBUTE);
   }
   if (line === null) return;
+  const lastLine = endLine !== null && endLine > line ? endLine : line;
 
-  root
-    .querySelector<HTMLElement>(`[data-line="${line}"]`)
-    ?.setAttribute(FILE_LINK_REVEAL_ATTRIBUTE, "");
-  root
-    .querySelector<HTMLElement>(`[data-column-number="${line}"]`)
-    ?.setAttribute(FILE_LINK_REVEAL_ATTRIBUTE, "");
+  // Scanning what is mounted rather than querying each number keeps a span of
+  // any size to one pass, and virtualization means the rows outside the
+  // viewport are not there to mark anyway — this runs on every post-render, so
+  // they pick the mark up as they scroll in.
+  for (const element of root.querySelectorAll<HTMLElement>("[data-line], [data-column-number]")) {
+    const rawValue =
+      element.getAttribute("data-line") ?? element.getAttribute("data-column-number");
+    const lineNumber = rawValue === null ? Number.NaN : Number(rawValue);
+    if (Number.isFinite(lineNumber) && lineNumber >= line && lineNumber <= lastLine) {
+      element.setAttribute(FILE_LINK_REVEAL_ATTRIBUTE, "");
+    }
+  }
 }
 
 /**
@@ -217,6 +229,7 @@ interface FileRevealState {
 function useFileLineReveal(
   relativePath: string | null,
   revealLine: number | null,
+  revealEndLine: number | null,
   revealRequestId: number,
 ): FilePostRender {
   const [revealStatesByPath] = useState(() => new Map<string, FileRevealState>());
@@ -250,7 +263,11 @@ function useFileLineReveal(
       const contents = instance.file?.contents;
       const targetLine =
         revealLine === null || contents === undefined ? null : clampFileLine(contents, revealLine);
-      updateFileLinkReveal(fileContainer, targetLine);
+      const targetEndLine =
+        targetLine === null || revealEndLine === null
+          ? null
+          : clampFileLine(contents ?? "", revealEndLine);
+      updateFileLinkReveal(fileContainer, targetLine, targetEndLine);
 
       if (!(instance instanceof VirtualizedFile)) return;
 
@@ -363,11 +380,15 @@ function useFileLineReveal(
           const line =
             currentContents === undefined ? null : clampFileLine(currentContents, revealLine);
           const targetTop = line === null ? null : resolveScrollTarget(line);
-          if (line === null || targetTop === null) {
+          if (currentContents === undefined || line === null || targetTop === null) {
             if (attempt < REVEAL_MAX_ATTEMPTS) scheduleReveal(attempt + 1);
             return;
           }
-          updateFileLinkReveal(fileContainer, line);
+          updateFileLinkReveal(
+            fileContainer,
+            line,
+            revealEndLine === null ? null : clampFileLine(currentContents, revealEndLine),
+          );
 
           scrollContainer.scrollTop = targetTop;
           state.handledRequestId = revealRequestId;
@@ -377,7 +398,7 @@ function useFileLineReveal(
 
       scheduleReveal(0);
     },
-    [revealStatesByPath, relativePath, revealLine, revealRequestId],
+    [revealStatesByPath, relativePath, revealEndLine, revealLine, revealRequestId],
   );
 }
 
@@ -764,6 +785,7 @@ export default function FilePreviewPanel({
   keybindings,
   availableEditors,
   revealLine,
+  revealEndLine,
   revealRequestId,
   onOpenFile,
   onPendingChange,
@@ -809,7 +831,12 @@ export default function FilePreviewPanel({
     () => (relativePath ? fileBreadcrumbs(projectName, relativePath) : []),
     [projectName, relativePath],
   );
-  const onFilePostRender = useFileLineReveal(relativePath, revealLine, revealRequestId);
+  const onFilePostRender = useFileLineReveal(
+    relativePath,
+    revealLine,
+    revealEndLine,
+    revealRequestId,
+  );
 
   useEffect(() => {
     const currentCrumb = breadcrumbRef.current?.querySelector<HTMLElement>(

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -191,10 +191,8 @@ function updateFileLinkReveal(
   if (line === null) return;
   const lastLine = endLine !== null && endLine > line ? endLine : line;
 
-  // Scanning what is mounted rather than querying each number keeps a span of
-  // any size to one pass, and virtualization means the rows outside the
-  // viewport are not there to mark anyway — this runs on every post-render, so
-  // they pick the mark up as they scroll in.
+  // Scanning the mounted rows keeps a span of any size to one pass; this runs
+  // on every post-render, so virtualized rows pick the mark up as they scroll in.
   for (const element of root.querySelectorAll<HTMLElement>("[data-line], [data-column-number]")) {
     const rawValue =
       element.getAttribute("data-line") ?? element.getAttribute("data-column-number");

--- a/apps/web/src/filePathDisplay.ts
+++ b/apps/web/src/filePathDisplay.ts
@@ -1,4 +1,4 @@
-import { splitPathAndPosition } from "./terminal-links";
+import { formatPathPosition, splitPathAndPosition } from "./terminal-links";
 
 function normalizePathSeparators(path: string): string {
   return path.replaceAll("\\", "/");
@@ -25,7 +25,7 @@ export function formatWorkspaceRelativePath(
   pathWithPosition: string,
   workspaceRoot: string | undefined,
 ): string {
-  const { path, line, column } = splitPathAndPosition(pathWithPosition);
+  const { path, line, endLine, column } = splitPathAndPosition(pathWithPosition);
   const normalizedPath = canonicalizeWindowsDrivePath(normalizePathSeparators(path));
 
   let displayPath = normalizedPath;
@@ -52,6 +52,5 @@ export function formatWorkspaceRelativePath(
     }
   }
 
-  if (!line) return displayPath;
-  return `${displayPath}:${line}${column ? `:${column}` : ""}`;
+  return `${displayPath}${formatPathPosition(line, endLine, column)}`;
 }

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -273,3 +273,45 @@ describe("resolveInlineCodeFileLinkMeta", () => {
     expect(resolveInlineCodeFileLinkMeta(".plans/worktree-management-v1.md")).toBeNull();
   });
 });
+
+describe("line span references", () => {
+  const cwd = "/workspace";
+
+  it("reads a :start-end suffix as a span", () => {
+    expect(resolveInlineCodeFileLinkMeta("src/index.ts:20-40", cwd)).toMatchObject({
+      filePath: "/workspace/src/index.ts",
+      line: 20,
+      endLine: 40,
+    });
+  });
+
+  it("reads a span on a bare filename, which needs the suffix to link at all", () => {
+    expect(resolveInlineCodeFileLinkMeta("index.ts:20-40", cwd)).toMatchObject({
+      line: 20,
+      endLine: 40,
+      workspaceRelativePath: "index.ts",
+    });
+  });
+
+  it("reads GitHub's #L20-L40 hash form", () => {
+    expect(resolveMarkdownFileLinkMeta("src/index.ts#L20-L40", cwd)).toMatchObject({
+      line: 20,
+      endLine: 40,
+    });
+  });
+
+  it("ignores a span that does not run forwards", () => {
+    expect(resolveInlineCodeFileLinkMeta("src/index.ts:40-20", cwd)?.endLine).toBeUndefined();
+    expect(resolveInlineCodeFileLinkMeta("src/index.ts:20-20", cwd)?.endLine).toBeUndefined();
+  });
+
+  it("leaves single-line and line:column references alone", () => {
+    expect(resolveInlineCodeFileLinkMeta("src/index.ts:20", cwd)).toMatchObject({ line: 20 });
+    expect(resolveInlineCodeFileLinkMeta("src/index.ts:20", cwd)?.endLine).toBeUndefined();
+    expect(resolveInlineCodeFileLinkMeta("src/index.ts:20:5", cwd)).toMatchObject({
+      line: 20,
+      column: 5,
+    });
+    expect(resolveInlineCodeFileLinkMeta("src/index.ts:20:5", cwd)?.endLine).toBeUndefined();
+  });
+});

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -5,10 +5,16 @@ const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\/;
 const EXTERNAL_SCHEME_PATTERN = /^([A-Za-z][A-Za-z0-9+.-]*):(.*)$/;
 const RELATIVE_PATH_PREFIX_PATTERN = /^(~\/|\.{1,2}\/)/;
-const RELATIVE_FILE_PATH_PATTERN = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}$/;
-const RELATIVE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]+\.[A-Za-z0-9_-]+(?::\d+){0,2}$/;
-const POSITION_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
-const POSITION_ONLY_PATTERN = /^\d+(?::\d+)?$/;
+const POSITION_SUFFIX_SOURCE = "(?::\\d+(?::\\d+|-\\d+)?)?";
+const RELATIVE_FILE_PATH_PATTERN = new RegExp(
+  `^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+${POSITION_SUFFIX_SOURCE}$`,
+);
+const RELATIVE_FILE_NAME_PATTERN = new RegExp(
+  `^[A-Za-z0-9._-]+\\.[A-Za-z0-9_-]+${POSITION_SUFFIX_SOURCE}$`,
+);
+// `:12`, `:12:5`, and the span form `:12-40`.
+const POSITION_SUFFIX_PATTERN = /:\d+(?::\d+|-\d+)?$/;
+const POSITION_ONLY_PATTERN = /^\d+(?::\d+|-\d+)?$/;
 // Standard OS and dev-container roots; deliberately excludes app-route-ish
 // prefixes like /app/ or /chat/ so SPA routes never read as files.
 const POSIX_FILE_ROOT_PREFIXES = [
@@ -45,6 +51,8 @@ export interface MarkdownFileLinkMeta {
   workspaceRelativePath: string | null;
   basename: string;
   line?: number;
+  /** Present when the reference names a span of lines (`Foo.ts:20-40`). */
+  endLine?: number;
   column?: number;
 }
 
@@ -118,6 +126,10 @@ function looksLikePosixFilesystemPath(path: string): boolean {
 
 function appendLineColumnFromHash(path: string, hash: string): string {
   if (!hash || POSITION_SUFFIX_PATTERN.test(path)) return path;
+  const spanMatch = hash.match(/^#L(\d+)-L?(\d+)$/i);
+  if (spanMatch?.[1] && spanMatch[2]) {
+    return `${path}:${spanMatch[1]}-${spanMatch[2]}`;
+  }
   const match = hash.match(/^#L(\d+)(?:C(\d+))?$/i);
   if (!match?.[1]) return path;
   const line = match[1];
@@ -190,7 +202,7 @@ const INLINE_CODE_DISQUALIFIER_PATTERN = /[\s`]/;
 const PATH_SEPARATOR_PATTERN = /[\\/]/;
 const FILE_EXTENSION_PATTERN = /\.[A-Za-z0-9_-]+$/;
 const NUMERIC_DOTTED_PATTERN = /^\d+(?:\.\d+)+$/;
-const BARE_EXTENSIONLESS_POSITION_PATTERN = /^[A-Za-z0-9_-]+(?::\d+){1,2}$/;
+const BARE_EXTENSIONLESS_POSITION_PATTERN = /^[A-Za-z0-9_-]+:\d+(?::\d+|-\d+)?$/;
 // Any `Name:digits` shape also matches `error:1`, `port:3000`, `TODO:12`, so
 // extensionless linking is limited to conventional filenames.
 const EXTENSIONLESS_FILE_NAMES = new Set([
@@ -386,10 +398,16 @@ export function resolveMarkdownFileLinkMeta(
 }
 
 function buildFileLinkMetaFromTarget(targetPath: string, cwd?: string): MarkdownFileLinkMeta {
-  const { path, line, column } = splitPathAndPosition(targetPath);
+  const { path, line, endLine, column } = splitPathAndPosition(targetPath);
   const parsedLine = line ? Number.parseInt(line, 10) : Number.NaN;
+  const parsedEndLine = endLine ? Number.parseInt(endLine, 10) : Number.NaN;
   const parsedColumn = column ? Number.parseInt(column, 10) : Number.NaN;
   const lineNumber = Number.isFinite(parsedLine) ? parsedLine : undefined;
+  // A backwards or degenerate span (`:40-20`, `:20-20`) is just its start line.
+  const endLineNumber =
+    Number.isFinite(parsedEndLine) && lineNumber !== undefined && parsedEndLine > lineNumber
+      ? parsedEndLine
+      : undefined;
   const columnNumber = Number.isFinite(parsedColumn) ? parsedColumn : undefined;
 
   return {
@@ -399,6 +417,7 @@ function buildFileLinkMetaFromTarget(targetPath: string, cwd?: string): Markdown
     workspaceRelativePath: workspaceRelativePath(path, cwd),
     basename: basenameOfPath(path),
     ...(lineNumber !== undefined ? { line: lineNumber } : {}),
+    ...(endLineNumber !== undefined ? { endLine: endLineNumber } : {}),
     ...(columnNumber !== undefined ? { column: columnNumber } : {}),
   };
 }

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -96,6 +96,7 @@ describe("rightPanelStore", () => {
               kind: "file",
               relativePath: "src/index.ts",
               revealLine: null,
+              revealEndLine: null,
               revealRequestId: 0,
             },
           ],
@@ -266,6 +267,7 @@ describe("rightPanelStore", () => {
           kind: "file",
           relativePath: "src/index.ts",
           revealLine: null,
+          revealEndLine: null,
           revealRequestId: 2,
         },
         {
@@ -273,10 +275,33 @@ describe("rightPanelStore", () => {
           kind: "file",
           relativePath: "README.md",
           revealLine: null,
+          revealEndLine: null,
           revealRequestId: 1,
         },
       ],
     });
+  });
+
+  it("keeps a revealed span, and drops one that does not run forwards", () => {
+    useRightPanelStore.getState().openFile(refA, "src/index.ts", 42, 87);
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA).surfaces,
+    ).toEqual([
+      {
+        id: "file:src/index.ts",
+        kind: "file",
+        relativePath: "src/index.ts",
+        revealLine: 42,
+        revealEndLine: 87,
+        revealRequestId: 1,
+      },
+    ]);
+
+    useRightPanelStore.getState().openFile(refA, "src/index.ts", 42, 42);
+    useRightPanelStore.getState().openFile(refA, "src/index.ts", 42, 10);
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA).surfaces[0],
+    ).toMatchObject({ revealLine: 42, revealEndLine: null });
   });
 
   it("updates line reveal requests when reopening a file surface", () => {
@@ -292,6 +317,7 @@ describe("rightPanelStore", () => {
           kind: "file",
           relativePath: "src/index.ts",
           revealLine: 87,
+          revealEndLine: null,
           revealRequestId: 2,
         },
       ],
@@ -308,6 +334,7 @@ describe("rightPanelStore", () => {
           kind: "file",
           relativePath: "src/index.ts",
           revealLine: null,
+          revealEndLine: null,
           revealRequestId: 3,
         },
       ],
@@ -528,6 +555,7 @@ describe("rightPanelStore", () => {
           kind: "file",
           relativePath: "src/index.ts",
           revealLine: null,
+          revealEndLine: null,
           revealRequestId: 1,
         },
       ],

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -43,6 +43,8 @@ export type RightPanelSurface =
       kind: "file";
       relativePath: string;
       revealLine: number | null;
+      /** End of a revealed span; null when the reference named a single line. */
+      revealEndLine: number | null;
       revealRequestId: number;
     }
   | {
@@ -83,7 +85,7 @@ interface RightPanelStoreState {
     kind: Exclude<RightPanelKind, "file" | "terminal" | "pull-request">,
   ) => void;
   openBrowser: (ref: ScopedThreadRef, tabId: string | null) => void;
-  openFile: (ref: ScopedThreadRef, relativePath: string, line?: number) => void;
+  openFile: (ref: ScopedThreadRef, relativePath: string, line?: number, endLine?: number) => void;
   openPullRequest: (
     ref: ScopedThreadRef,
     target: { projectId: string; repository: string; number: number },
@@ -141,12 +143,14 @@ const browserSurface = (tabId: string | null): RightPanelSurface =>
 const fileSurface = (
   relativePath: string,
   revealLine: number | null,
+  revealEndLine: number | null,
   revealRequestId: number,
 ): RightPanelSurface => ({
   id: `file:${relativePath}`,
   kind: "file",
   relativePath,
   revealLine,
+  revealEndLine,
   revealRequestId,
 });
 
@@ -248,7 +252,14 @@ export function migratePersistedRightPanelState(persistedState: unknown): {
                         surface.revealRequestId >= 0
                           ? surface.revealRequestId
                           : 0;
-                      return [{ ...surface, revealLine, revealRequestId }];
+                      const revealEndLine =
+                        typeof surface.revealEndLine === "number" &&
+                        Number.isFinite(surface.revealEndLine) &&
+                        revealLine !== null &&
+                        surface.revealEndLine > revealLine
+                          ? Math.trunc(surface.revealEndLine)
+                          : null;
+                      return [{ ...surface, revealLine, revealEndLine, revealRequestId }];
                     }
                     if (surface.kind === "pull-request") {
                       if (
@@ -353,7 +364,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             return upsertSurface(current, pullRequestSurface(target));
           }),
         })),
-      openFile: (ref, relativePath, line) =>
+      openFile: (ref, relativePath, line, endLine) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
             const withoutStandaloneExplorer = current.surfaces.filter(
@@ -364,9 +375,16 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               (surface): surface is Extract<RightPanelSurface, { kind: "file" }> =>
                 surface.id === surfaceId && surface.kind === "file",
             );
+            const normalizedLine = normalizeRevealLine(line);
+            const normalizedEndLine = normalizeRevealLine(endLine);
             const surface = fileSurface(
               relativePath,
-              normalizeRevealLine(line),
+              normalizedLine,
+              normalizedLine !== null &&
+                normalizedEndLine !== null &&
+                normalizedEndLine > normalizedLine
+                ? normalizedEndLine
+                : null,
               (existing?.revealRequestId ?? 0) + 1,
             );
             return {

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -137,18 +137,42 @@ function inferHomeFromCwd(cwd: string): string | undefined {
   return undefined;
 }
 
+export function formatPathPosition(
+  line: string | undefined,
+  endLine: string | undefined,
+  column: string | undefined,
+): string {
+  if (!line) return "";
+  if (endLine) return `:${line}-${endLine}`;
+  return `:${line}${column ? `:${column}` : ""}`;
+}
+
 export function splitPathAndPosition(value: string): {
   path: string;
   line: string | undefined;
+  /** Set only for a `:start-end` span; a span never carries a column. */
+  endLine: string | undefined;
   column: string | undefined;
 } {
   let path = value;
   let column: string | undefined;
   let line: string | undefined;
 
+  // A span is checked first: its trailing number would otherwise read as a
+  // column and leave `-` stranded on the path.
+  const spanMatch = path.match(/:(\d+)-(\d+)$/);
+  if (spanMatch?.[1] && spanMatch[2]) {
+    return {
+      path: path.slice(0, -spanMatch[0].length),
+      line: spanMatch[1],
+      endLine: spanMatch[2],
+      column: undefined,
+    };
+  }
+
   const columnMatch = path.match(/:(\d+)$/);
   if (!columnMatch?.[1]) {
-    return { path, line: undefined, column: undefined };
+    return { path, line: undefined, endLine: undefined, column: undefined };
   }
 
   column = columnMatch[1];
@@ -163,7 +187,7 @@ export function splitPathAndPosition(value: string): {
     column = undefined;
   }
 
-  return { path, line, column };
+  return { path, line, endLine: undefined, column };
 }
 
 export function extractTerminalLinks(line: string): TerminalLinkMatch[] {
@@ -267,7 +291,7 @@ export function isTerminalLinkActivation(
 }
 
 export function resolvePathLinkTarget(rawPath: string, cwd: string): string {
-  const { path, line, column } = splitPathAndPosition(rawPath);
+  const { path, line, endLine, column } = splitPathAndPosition(rawPath);
 
   let resolvedPath = path;
   if (path.startsWith("~/")) {
@@ -281,6 +305,5 @@ export function resolvePathLinkTarget(rawPath: string, cwd: string): string {
     resolvedPath = joinPath(cwd, path, separator);
   }
 
-  if (!line) return resolvedPath;
-  return `${resolvedPath}:${line}${column ? `:${column}` : ""}`;
+  return `${resolvedPath}${formatPathPosition(line, endLine, column)}`;
 }


### PR DESCRIPTION
Fixes #6295.

`Foo.ts:20-40` and `Foo.ts#L20-L40` weren't links at all. The position pattern only took `:12` and `:12:5`, and the external-scheme guard read `:20-40` as a URI scheme and gave up.

Both parse now. `splitPathAndPosition` checks for a span before anything else, since the trailing number would otherwise read as a column and leave the `-` stranded on the path. The end line travels with the file surface into the preview, which marks every row in the range and centres the first one — the same reveal a single-line reference already used, applied to more than one row. It scans the mounted rows rather than querying each number, so a long span costs one pass and virtualized rows pick the mark up as they scroll in. A span that runs backwards, or names one line twice, is treated as its start line.

The same target also reaches the external editor, and no editor takes a span. `--goto` editors get the argument rebuilt as `path:line`, `--line` editors get the end dropped; both open at the range's first line instead of failing on a filename that doesn't exist. Rebuilding leaves every non-span shape byte-identical to what it was, which the launcher test pins.

No screenshots: a `Foo.ts:20-40` chip opens the file with rows 20 to 40 highlighted in the existing reveal styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared path parsing used by chat links, file preview reveal, and external editor launch; regressions could break existing single-line or column references, though tests pin non-span behavior.
> 
> **Overview**
> File references can now name a **line span** (`Foo.ts:20-40` or GitHub-style `#L20-L40`), which previously failed to link at all.
> 
> Path parsing recognizes spans alongside existing `line` / `line:column` forms. Chat chips show `Lstart-end`, and opening a span reveals the file with every row in the range highlighted while scrolling to the start line. Backwards or degenerate spans collapse to the start line.
> 
> External editor launches also accept spans but collapse them to the first line (`path:line` / `--line`), since no editor CLI takes a range. Non-span targets stay byte-identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 470ea6228b5d10b60e0881903119d6876651753a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add line span support to file references in chat, preview, and editor launch
> - Updates regex patterns in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/6298/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) and [terminal-links.ts](https://github.com/pingdotgg/t3code/pull/6298/files#diff-5f57eb38e8e99e705308a736729815ef1ec005cf2f20cca912a9f7abcf28c110) to parse `:start-end` span suffixes alongside existing `:line` and `:line:column` forms; GitHub-style `#Lstart-Lend` anchors are also converted.
> - Chat file link chips in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/6298/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) now display `Lstart-end` labels and pass span bounds to the file preview.
> - [FilePreviewPanel.tsx](https://github.com/pingdotgg/t3code/pull/6298/files#diff-776fa2f4352bbbf118206cfd39f4cf95c38e47b1629aa20a6c8c028cadf458ea) highlights the full line range by iterating over all matching `data-line` elements instead of selecting a single element.
> - [rightPanelStore.ts](https://github.com/pingdotgg/t3code/pull/6298/files#diff-c23667fc6a40049fa00d6fba14ae4a097ed3561fcdfb9ec172bc8216cd9f82eb) stores `revealEndLine` on file surfaces; non-forward spans (end ≤ start) are collapsed to single-line reveals.
> - [externalLauncher.ts](https://github.com/pingdotgg/t3code/pull/6298/files#diff-be3164f58b42a06eeb894dae2f386e0aed2f3fc32d3d3df602316eb7bcaabdc2) collapses spans to their start line when building editor launch arguments, handling goto, direct-path, and line-column editor styles correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 470ea62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

