### PR TITLE
feat(web): clicking a composer mention chip opens the file

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -78,6 +78,7 @@ import {
   collapseExpandedComposerCursor,
   parseStandaloneComposerSlashCommand,
 } from "../composer-logic";
+import { resolveComposerMentionFileTarget } from "../composerMentionFileTarget";
 import {
   derivePendingApprovals,
   derivePendingUserInputs,
@@ -3267,6 +3268,17 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [activeProject, activeThreadRef],
   );
+  // A mention chip opens its file the same way a rendered chat file link does,
+  // so a reference you just wrote is readable before you send it.
+  const openMentionFileSurface = useCallback(
+    (mentionPath: string) => {
+      if (!activeThreadRef || !activeProject) return;
+      const target = resolveComposerMentionFileTarget(mentionPath, activeWorkspaceRoot);
+      if (!target) return;
+      useRightPanelStore.getState().openFile(activeThreadRef, target.relativePath, target.line);
+    },
+    [activeProject, activeThreadRef, activeWorkspaceRoot],
+  );
   // The thread's own change request, placed against the project it belongs to. Without a
   // project there is nothing to resolve it against, so the caller falls back to the browser.
   const threadRepository = activeProject?.repositoryIdentity?.displayName ?? null;
@@ -6352,6 +6364,7 @@ function ChatViewContent(props: ChatViewProps) {
                             keybindings={keybindings}
                             terminalOpen={Boolean(terminalUiState.terminalOpen)}
                             gitCwd={gitCwd}
+                            onOpenMentionFile={openMentionFileSurface}
                             promptRef={promptRef}
                             composerImagesRef={composerImagesRef}
                             composerTerminalContextsRef={composerTerminalContextsRef}

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -154,7 +154,18 @@ function ComposerMentionDecorator(props: { path: string }) {
       data-composer-mention-chip="true"
       {...(onOpenMentionFile
         ? {
+            role: "button",
+            // Focusable inside the contenteditable so opening the file is not
+            // pointer-only. Enter and Space are stopped before Lexical sees
+            // them, or they would also insert into the prompt.
+            tabIndex: 0,
             onClick: (event: React.MouseEvent<HTMLSpanElement>) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onOpenMentionFile(path);
+            },
+            onKeyDown: (event: React.KeyboardEvent<HTMLSpanElement>) => {
+              if (event.key !== "Enter" && event.key !== " ") return;
               event.preventDefault();
               event.stopPropagation();
               onOpenMentionFile(path);

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -155,10 +155,14 @@ function ComposerMentionDecorator(props: { path: string }) {
       {...(onOpenMentionFile
         ? {
             role: "button",
-            // Focusable inside the contenteditable so opening the file is not
-            // pointer-only. Enter and Space are stopped before Lexical sees
-            // them, or they would also insert into the prompt.
+            // Focusable so opening a file is not pointer-only; Enter and Space
+            // are stopped before Lexical inserts them into the prompt.
             tabIndex: 0,
+            // Focus follows a click on a focusable element, which would blur
+            // the editor and leave typing going nowhere.
+            onMouseDown: (event: React.MouseEvent<HTMLSpanElement>) => {
+              event.preventDefault();
+            },
             onClick: (event: React.MouseEvent<HTMLSpanElement>) => {
               event.preventDefault();
               event.stopPropagation();

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -128,22 +128,41 @@ type SerializedComposerTerminalContextNode = Spread<
   SerializedLexicalNode
 >;
 
-const ComposerTerminalContextActionsContext = createContext<{
+const ComposerChipActionsContext = createContext<{
   onRemoveTerminalContext: (contextId: string) => void;
+  // Only a host that can show the mentioned file (the chat surface, via its
+  // right panel) supplies this; standalone editors like the appearance preview
+  // leave it null and their mention chips stay inert.
+  onOpenMentionFile: ((path: string) => void) | null;
 }>({
   onRemoveTerminalContext: () => {},
+  onOpenMentionFile: null,
 });
 
 function ComposerMentionDecorator(props: { path: string }) {
   const theme = resolvedThemeFromDocument();
+  const { onOpenMentionFile } = use(ComposerChipActionsContext);
+  const path = props.path;
   const chip = (
     <span
-      className={FILE_TAG_CHIP_CLASS_NAME}
+      className={cn(
+        FILE_TAG_CHIP_CLASS_NAME,
+        onOpenMentionFile && "cursor-pointer transition-colors hover:bg-accent/70",
+      )}
       contentEditable={false}
       spellCheck={false}
       data-composer-mention-chip="true"
+      {...(onOpenMentionFile
+        ? {
+            onClick: (event: React.MouseEvent<HTMLSpanElement>) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onOpenMentionFile(path);
+            },
+          }
+        : {})}
     >
-      <FileTagChipContent path={props.path} label={basenameOfPath(props.path)} theme={theme} />
+      <FileTagChipContent path={path} label={basenameOfPath(path)} theme={theme} />
     </span>
   );
 
@@ -151,7 +170,7 @@ function ComposerMentionDecorator(props: { path: string }) {
     <Tooltip>
       <TooltipTrigger render={chip} />
       <TooltipPopup side="top" className="max-w-120 whitespace-normal leading-tight wrap-anywhere">
-        {props.path}
+        {path}
       </TooltipPopup>
     </Tooltip>
   );
@@ -884,6 +903,7 @@ interface ComposerPromptEditorProps {
   disabled: boolean;
   placeholder: string;
   className?: string;
+  onOpenMentionFile?: (path: string) => void;
   onRemoveTerminalContext: (contextId: string) => void;
   onChange: (
     nextValue: string,
@@ -1105,7 +1125,7 @@ function ComposerInlineTokenSelectionNormalizePlugin() {
 
 function ComposerInlineTokenBackspacePlugin() {
   const [editor] = useLexicalComposerContext();
-  const { onRemoveTerminalContext } = use(ComposerTerminalContextActionsContext);
+  const { onRemoveTerminalContext } = use(ComposerChipActionsContext);
 
   useEffect(() => {
     return editor.registerCommand(
@@ -1533,6 +1553,7 @@ function ComposerPromptEditorInner({
   disabled,
   placeholder,
   className,
+  onOpenMentionFile,
   onRemoveTerminalContext,
   onChange,
   onCommandKeyDown,
@@ -1554,9 +1575,9 @@ function ComposerPromptEditorInner({
     terminalContextIds: terminalContexts.map((context) => context.id),
   });
   const isApplyingControlledUpdateRef = useRef(false);
-  const terminalContextActions = useMemo(
-    () => ({ onRemoveTerminalContext }),
-    [onRemoveTerminalContext],
+  const chipActions = useMemo(
+    () => ({ onRemoveTerminalContext, onOpenMentionFile: onOpenMentionFile ?? null }),
+    [onOpenMentionFile, onRemoveTerminalContext],
   );
 
   useEffect(() => {
@@ -1746,7 +1767,7 @@ function ComposerPromptEditorInner({
   }, []);
 
   return (
-    <ComposerTerminalContextActionsContext value={terminalContextActions}>
+    <ComposerChipActionsContext value={chipActions}>
       <div className="composer-editor-surface relative">
         <PlainTextPlugin
           contentEditable={
@@ -1783,7 +1804,7 @@ function ComposerPromptEditorInner({
         <ComposerChipSelectionPlugin />
         <HistoryPlugin />
       </div>
-    </ComposerTerminalContextActionsContext>
+    </ComposerChipActionsContext>
   );
 }
 
@@ -1795,6 +1816,7 @@ export function ComposerPromptEditor({
   disabled,
   placeholder,
   className,
+  onOpenMentionFile,
   onRemoveTerminalContext,
   onChange,
   onCommandKeyDown,
@@ -1836,6 +1858,7 @@ export function ComposerPromptEditor({
         onChange={onChange}
         onPaste={onPaste}
         editorRef={editorRef}
+        {...(onOpenMentionFile ? { onOpenMentionFile } : {})}
         {...(onCommandKeyDown ? { onCommandKeyDown } : {})}
         {...(className ? { className } : {})}
       />

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -557,6 +557,8 @@ export interface ChatComposerProps {
   keybindings: ResolvedKeybindingsConfig;
   terminalOpen: boolean;
   gitCwd: string | null;
+  /** Shows a mention chip's file in the right panel; absent when there is no panel to show it in. */
+  onOpenMentionFile?: (path: string) => void;
 
   // Refs the parent needs kept in sync
   promptRef: React.RefObject<string>;
@@ -643,6 +645,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     keybindings,
     terminalOpen,
     gitCwd,
+    onOpenMentionFile,
     promptRef,
     composerRef,
     composerImagesRef,
@@ -3034,6 +3037,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 }
                 skills={selectedProviderStatus?.skills ?? []}
                 {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
+                {...(onOpenMentionFile ? { onOpenMentionFile } : {})}
                 onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                 onChange={onPromptChange}
                 onCommandKeyDown={onComposerCommandKey}

--- a/apps/web/src/composerMentionFileTarget.test.ts
+++ b/apps/web/src/composerMentionFileTarget.test.ts
@@ -61,6 +61,13 @@ describe("resolveComposerMentionFileTarget", () => {
     expect(resolveComposerMentionFileTarget("/users/dev/t3code/Other.ts", ROOT)).toBeNull();
   });
 
+  // The filesystem behind a drive root does not distinguish these.
+  it("matches a windows root case-insensitively", () => {
+    expect(resolveComposerMentionFileTarget("C:\\Repo\\src\\file.ts", "C:\\repo")).toEqual({
+      relativePath: "src/file.ts",
+    });
+  });
+
   it("still matches a windows root whose drive letter case differs", () => {
     expect(resolveComposerMentionFileTarget("c:\\repo\\apps\\main.tsx", "C:\\repo")).toEqual({
       relativePath: "apps/main.tsx",

--- a/apps/web/src/composerMentionFileTarget.test.ts
+++ b/apps/web/src/composerMentionFileTarget.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveComposerMentionFileTarget } from "./composerMentionFileTarget";
+
+const ROOT = "/Users/dev/t3code";
+
+describe("resolveComposerMentionFileTarget", () => {
+  it("passes workspace-relative mentions straight through", () => {
+    expect(resolveComposerMentionFileTarget("AGENTS.md", ROOT)).toEqual({
+      relativePath: "AGENTS.md",
+    });
+    expect(resolveComposerMentionFileTarget("apps/web/src/main.tsx", ROOT)).toEqual({
+      relativePath: "apps/web/src/main.tsx",
+    });
+  });
+
+  it("relativizes absolute mentions inside the workspace", () => {
+    expect(resolveComposerMentionFileTarget(`${ROOT}/apps/web/src/main.tsx`, ROOT)).toEqual({
+      relativePath: "apps/web/src/main.tsx",
+    });
+  });
+
+  it("keeps extensionless filenames, which markdown link heuristics reject", () => {
+    expect(resolveComposerMentionFileTarget("Makefile", ROOT)).toEqual({
+      relativePath: "Makefile",
+    });
+  });
+
+  it("collapses dot segments", () => {
+    expect(resolveComposerMentionFileTarget("./docs/../AGENTS.md", ROOT)).toEqual({
+      relativePath: "AGENTS.md",
+    });
+  });
+
+  it("carries a :line suffix over as the reveal line", () => {
+    expect(resolveComposerMentionFileTarget("apps/web/src/main.tsx:42", ROOT)).toEqual({
+      relativePath: "apps/web/src/main.tsx",
+      line: 42,
+    });
+    expect(resolveComposerMentionFileTarget("apps/web/src/main.tsx:42:7", ROOT)).toEqual({
+      relativePath: "apps/web/src/main.tsx",
+      line: 42,
+    });
+  });
+
+  it("normalizes windows separators", () => {
+    expect(resolveComposerMentionFileTarget("C:\\repo\\apps\\web\\main.tsx", "C:\\repo")).toEqual({
+      relativePath: "apps/web/main.tsx",
+    });
+  });
+
+  it("works for a workspace rooted at the filesystem root", () => {
+    expect(resolveComposerMentionFileTarget("/srv/app/main.ts", "/")).toEqual({
+      relativePath: "srv/app/main.ts",
+    });
+  });
+
+  // Folding case here would accept a path from outside the workspace on a
+  // case-sensitive filesystem.
+  it("does not accept a root whose case does not match", () => {
+    expect(resolveComposerMentionFileTarget("/users/dev/t3code/Other.ts", ROOT)).toBeNull();
+  });
+
+  it("still matches a windows root whose drive letter case differs", () => {
+    expect(resolveComposerMentionFileTarget("c:\\repo\\apps\\main.tsx", "C:\\repo")).toEqual({
+      relativePath: "apps/main.tsx",
+    });
+  });
+
+  // `/..` is `/`, so climbing past an absolute root cannot leave `..` behind
+  // for the file surface to walk.
+  it("does not let a path climb above the root it resolves against", () => {
+    expect(resolveComposerMentionFileTarget("../a/secret.ts", "/")).toEqual({
+      relativePath: "a/secret.ts",
+    });
+    expect(resolveComposerMentionFileTarget("/x/../../a/secret.ts", "/")).toEqual({
+      relativePath: "a/secret.ts",
+    });
+  });
+
+  it("returns null outside the workspace, and without one", () => {
+    expect(resolveComposerMentionFileTarget("/etc/hosts", ROOT)).toBeNull();
+    expect(resolveComposerMentionFileTarget("../sibling/AGENTS.md", ROOT)).toBeNull();
+    expect(resolveComposerMentionFileTarget("AGENTS.md", undefined)).toBeNull();
+    expect(resolveComposerMentionFileTarget("   ", ROOT)).toBeNull();
+  });
+});

--- a/apps/web/src/composerMentionFileTarget.ts
+++ b/apps/web/src/composerMentionFileTarget.ts
@@ -1,0 +1,77 @@
+import { resolvePathLinkTarget, splitPathAndPosition } from "./terminal-links";
+
+export interface ComposerMentionFileTarget {
+  readonly relativePath: string;
+  readonly line?: number;
+}
+
+function toPosixPath(path: string): string {
+  const normalized = path.replaceAll("\\", "/");
+  // Windows drive paths pick up a leading slash on the way through URL-ish
+  // plumbing (`/C:/repo`); the workspace root never carries one. The drive
+  // letter itself is case-insensitive, so it is folded to make the containment
+  // check below comparable without folding the rest of the path.
+  const withoutLeadingSlash = /^\/[A-Za-z]:\//.test(normalized) ? normalized.slice(1) : normalized;
+  return /^[A-Za-z]:\//.test(withoutLeadingSlash)
+    ? `${withoutLeadingSlash[0]?.toUpperCase() ?? ""}${withoutLeadingSlash.slice(1)}`
+    : withoutLeadingSlash;
+}
+
+function collapseDotSegments(path: string): string {
+  const isAbsolute = path.startsWith("/");
+  const segments: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length > 0 && segments[segments.length - 1] !== "..") {
+        segments.pop();
+        continue;
+      }
+      // `/..` is `/`: an absolute path cannot climb above the root, and a
+      // surviving leading `..` would reach the file surface as a relative path
+      // that walks out of the workspace.
+      if (isAbsolute) continue;
+    }
+    segments.push(segment);
+  }
+  const joined = segments.join("/");
+  return isAbsolute ? `/${joined}` : joined;
+}
+
+/**
+ * Resolve the file a composer mention chip points at, in the form the right
+ * panel wants: a path relative to the workspace root the file preview reads.
+ *
+ * Autocomplete, drag-and-drop, and the file browser all insert
+ * workspace-relative paths, but a hand-typed mention can be absolute, use
+ * `~/`, or carry a `:line` suffix. Anything that lands outside the workspace
+ * has no preview surface, so it resolves to `null` and the chip stays inert.
+ */
+export function resolveComposerMentionFileTarget(
+  mentionPath: string,
+  workspaceRoot: string | undefined,
+): ComposerMentionFileTarget | null {
+  const trimmed = mentionPath.trim();
+  if (!trimmed || !workspaceRoot) return null;
+
+  const { path, line } = splitPathAndPosition(trimmed);
+  if (!path) return null;
+
+  const absolute = collapseDotSegments(toPosixPath(resolvePathLinkTarget(path, workspaceRoot)));
+  const normalizedRoot = collapseDotSegments(toPosixPath(workspaceRoot));
+  // A workspace rooted at `/` strips to nothing, which would leave every
+  // mention inert; the empty prefix is what makes the check below read `/x`
+  // as the relative `x`.
+  const root = normalizedRoot === "/" ? "" : normalizedRoot.replace(/\/+$/, "");
+  if (!root && normalizedRoot !== "/") return null;
+  // Compared exactly: folding case would accept `/users/dev/repo/x.ts` against
+  // a `/Users/dev/repo` root on a case-sensitive filesystem and hand the panel
+  // a path from outside the workspace.
+  if (!absolute.startsWith(`${root}/`)) return null;
+
+  const relativePath = absolute.slice(root.length + 1);
+  if (!relativePath) return null;
+
+  const parsedLine = line ? Number.parseInt(line, 10) : Number.NaN;
+  return Number.isFinite(parsedLine) ? { relativePath, line: parsedLine } : { relativePath };
+}

--- a/apps/web/src/composerMentionFileTarget.ts
+++ b/apps/web/src/composerMentionFileTarget.ts
@@ -24,9 +24,7 @@ function collapseDotSegments(path: string): string {
         segments.pop();
         continue;
       }
-      // `/..` is `/`: an absolute path cannot climb above the root, and a
-      // surviving leading `..` would reach the file surface as a relative path
-      // that walks out of the workspace.
+      // `/..` is `/`; a surviving `..` would walk out of the workspace.
       if (isAbsolute) continue;
     }
     segments.push(segment);
@@ -35,15 +33,7 @@ function collapseDotSegments(path: string): string {
   return isAbsolute ? `/${joined}` : joined;
 }
 
-/**
- * Resolve the file a composer mention chip points at, in the form the right
- * panel wants: a path relative to the workspace root the file preview reads.
- *
- * Autocomplete, drag-and-drop, and the file browser all insert
- * workspace-relative paths, but a hand-typed mention can be absolute, use
- * `~/`, or carry a `:line` suffix. Anything that lands outside the workspace
- * has no preview surface, so it resolves to `null` and the chip stays inert.
- */
+/** Null for anything outside the workspace, which leaves the chip inert. */
 export function resolveComposerMentionFileTarget(
   mentionPath: string,
   workspaceRoot: string | undefined,
@@ -56,16 +46,11 @@ export function resolveComposerMentionFileTarget(
 
   const absolute = collapseDotSegments(toPosixPath(resolvePathLinkTarget(path, workspaceRoot)));
   const normalizedRoot = collapseDotSegments(toPosixPath(workspaceRoot));
-  // A workspace rooted at `/` strips to nothing, which would leave every
-  // mention inert; the empty prefix is what makes the check below read `/x`
-  // as the relative `x`.
+  // A `/` root strips to an empty prefix, which is what makes `/x` read as `x`.
   const root = normalizedRoot === "/" ? "" : normalizedRoot.replace(/\/+$/, "");
   if (!root && normalizedRoot !== "/") return null;
-  // Matched the way the filesystem behind the root would: a POSIX root is
-  // case-sensitive, so folding case there would accept `/users/dev/repo/x.ts`
-  // against a `/Users/dev/repo` root and hand the panel a path from outside
-  // the workspace. A Windows drive root is case-insensitive, so comparing
-  // exactly there would reject `C:/Repo/src/x.ts` against `C:/repo`.
+  // Compared the way the root's filesystem would: exact for POSIX, folded for
+  // a Windows drive.
   const rootIsCaseInsensitive = WINDOWS_DRIVE_ROOT_PATTERN.test(normalizedRoot);
   const comparableAbsolute = rootIsCaseInsensitive ? absolute.toLowerCase() : absolute;
   const comparableRoot = rootIsCaseInsensitive ? root.toLowerCase() : root;

--- a/apps/web/src/composerMentionFileTarget.ts
+++ b/apps/web/src/composerMentionFileTarget.ts
@@ -8,14 +8,11 @@ export interface ComposerMentionFileTarget {
 function toPosixPath(path: string): string {
   const normalized = path.replaceAll("\\", "/");
   // Windows drive paths pick up a leading slash on the way through URL-ish
-  // plumbing (`/C:/repo`); the workspace root never carries one. The drive
-  // letter itself is case-insensitive, so it is folded to make the containment
-  // check below comparable without folding the rest of the path.
-  const withoutLeadingSlash = /^\/[A-Za-z]:\//.test(normalized) ? normalized.slice(1) : normalized;
-  return /^[A-Za-z]:\//.test(withoutLeadingSlash)
-    ? `${withoutLeadingSlash[0]?.toUpperCase() ?? ""}${withoutLeadingSlash.slice(1)}`
-    : withoutLeadingSlash;
+  // plumbing (`/C:/repo`); the workspace root never carries one.
+  return /^\/[A-Za-z]:\//.test(normalized) ? normalized.slice(1) : normalized;
 }
+
+const WINDOWS_DRIVE_ROOT_PATTERN = /^[A-Za-z]:\//;
 
 function collapseDotSegments(path: string): string {
   const isAbsolute = path.startsWith("/");
@@ -64,10 +61,15 @@ export function resolveComposerMentionFileTarget(
   // as the relative `x`.
   const root = normalizedRoot === "/" ? "" : normalizedRoot.replace(/\/+$/, "");
   if (!root && normalizedRoot !== "/") return null;
-  // Compared exactly: folding case would accept `/users/dev/repo/x.ts` against
-  // a `/Users/dev/repo` root on a case-sensitive filesystem and hand the panel
-  // a path from outside the workspace.
-  if (!absolute.startsWith(`${root}/`)) return null;
+  // Matched the way the filesystem behind the root would: a POSIX root is
+  // case-sensitive, so folding case there would accept `/users/dev/repo/x.ts`
+  // against a `/Users/dev/repo` root and hand the panel a path from outside
+  // the workspace. A Windows drive root is case-insensitive, so comparing
+  // exactly there would reject `C:/Repo/src/x.ts` against `C:/repo`.
+  const rootIsCaseInsensitive = WINDOWS_DRIVE_ROOT_PATTERN.test(normalizedRoot);
+  const comparableAbsolute = rootIsCaseInsensitive ? absolute.toLowerCase() : absolute;
+  const comparableRoot = rootIsCaseInsensitive ? root.toLowerCase() : root;
+  if (!comparableAbsolute.startsWith(`${comparableRoot}/`)) return null;
 
   const relativePath = absolute.slice(root.length + 1);
   if (!relativePath) return null;


### PR DESCRIPTION
Fixes #6296.

An `@`-mentioned file shows as a chip in the composer, but you can't look at the file without sending the message first.

The chip opens the file in the right panel on click, where a file link in a rendered message already opens it. A host with no panel to open — the appearance preview in Settings — passes no handler, and its chips stay inert with no pointer cursor.

Mention paths arrive workspace-relative from autocomplete, but can be typed by hand as absolute, with `~/`, or with a `:line` suffix, so they go through a resolver that normalizes those and returns null for anything outside the workspace. The two chip actions (remove a terminal context, open a mention) now share one editor context rather than nesting a second provider, which keeps the diff off the surrounding JSX.

No screenshots: the chip gains a pointer cursor and a hover tint, and clicking it opens the file beside the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI affordance that reuses the existing right-panel openFile path. Path resolution fails closed outside the workspace and is covered by unit tests.
> 
> **Overview**
> **Composer `@`-mention chips can now open the referenced file** in the right panel before you send the message—same surface chat file links already use.
> 
> Click or Enter/Space on a chip calls through a new optional `onOpenMentionFile` handler. Hosts without a panel (e.g. Settings appearance preview) omit it, so those chips stay inert.
> 
> Adds `resolveComposerMentionFileTarget` to normalize relative, absolute, `~/`, Windows, and `:line` mention paths into a workspace-relative target (or `null` outside the workspace). Renames the editor chip context to `ComposerChipActionsContext` so open and remove share one provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a99bf089009062429897eb2894f2827882d88b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make composer mention chips clickable to open the referenced file in the right panel
> - Mention chips in the chat composer are now rendered as interactive buttons; clicking or pressing Enter/Space opens the referenced file in the right panel, optionally scrolling to the specified line.
> - Adds [`resolveComposerMentionFileTarget`](https://github.com/pingdotgg/t3code/pull/6299/files#diff-ea275cf64ec0f7f50f3d9ed819c8caa99c59e1484a7a9576343dd6fb1d580e12) to resolve a mention path against the active workspace root, returning a workspace-relative path and optional line number, or `null` if the path is outside the workspace or invalid.
> - Chips remain inert when no handler is provided or when path resolution fails (e.g. no active thread/project, path escapes workspace root).
> - Renames `ComposerTerminalContextActionsContext` to `ComposerChipActionsContext` in [`ComposerPromptEditor.tsx`](https://github.com/pingdotgg/t3code/pull/6299/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4) to accommodate the new `onOpenMentionFile` handler alongside the existing `onRemoveTerminalContext`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9a99bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

