### PR TITLE
fix(web): theme Clerk surfaces

### DIFF
--- a/apps/web/src/components/clerk/clerkAppearance.test.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.test.ts
@@ -28,6 +28,18 @@ function contrastRatio(first: string, second: string): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+function mixThemeColors(first: string, second: string, firstWeight: number): string {
+  const channels = [first, second].map((value) => {
+    const hex = themeColorToHex(value)?.slice(1, 7);
+    if (!hex) throw new Error(`Expected a theme color, received ${value}`);
+    return [0, 1, 2].map((channel) => Number.parseInt(hex.slice(channel * 2, channel * 2 + 2), 16));
+  });
+  const mixed = channels[0]!.map((channel, index) =>
+    Math.round(channel * firstWeight + channels[1]![index]! * (1 - firstWeight)),
+  );
+  return `#${mixed.map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
+}
+
 const builtInThemeModes = [
   T3_CHAT_THEME,
   GROVE_THEME,
@@ -39,29 +51,38 @@ const builtInThemeModes = [
 );
 
 describe("clerkAppearance", () => {
-  it("maps colors without overriding Clerk's component structure", () => {
+  it("maps theme colors without overriding Clerk's component structure", () => {
     expect(clerkAppearance).toEqual({
       variables: {
         colorPrimary: "var(--update-foreground)",
         colorPrimaryForeground: "var(--card)",
-        colorDanger: "var(--error-foreground)",
-        colorSuccess: "var(--success-foreground)",
-        colorWarning: "var(--warning-foreground)",
+        colorDanger: "var(--error)",
+        colorSuccess: "var(--success)",
+        colorWarning: "var(--warning)",
         colorNeutral: "var(--foreground)",
         colorForeground: "var(--foreground)",
-        colorMuted: "var(--muted)",
+        colorMuted: "color-mix(in srgb, var(--card) 98%, var(--foreground))",
         colorMutedForeground: "var(--muted-foreground)",
         colorBackground: "var(--card)",
         colorInputForeground: "var(--foreground)",
         colorInput: "var(--secondary)",
         colorRing: "var(--ring)",
       },
+      elements: {
+        formFieldErrorText: { color: "var(--error-foreground)" },
+        formFieldWarningText: { color: "var(--warning-foreground)" },
+        formFieldSuccessText: { color: "var(--success-foreground)" },
+        otpCodeFieldErrorText: { color: "var(--error-foreground)" },
+        otpCodeFieldSuccessText: { color: "var(--success-foreground)" },
+      },
     });
   });
 
   it.each(builtInThemeModes)("keeps Clerk text readable across a built-in palette", (colors) => {
+    const mutedSurface = mixThemeColors(colors.surface, colors.text, 0.98);
+
     expect(contrastRatio(colors.text, colors.surface)).toBeGreaterThanOrEqual(4.5);
-    expect(contrastRatio(colors.mutedForeground, colors.surface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.mutedForeground, mutedSurface)).toBeGreaterThanOrEqual(4.5);
     expect(contrastRatio(colors.text, colors.secondary)).toBeGreaterThanOrEqual(4.5);
     expect(contrastRatio(colors.updateForeground, colors.surface)).toBeGreaterThanOrEqual(4.5);
     expect(contrastRatio(colors.errorForeground, colors.surface)).toBeGreaterThanOrEqual(4.5);

--- a/apps/web/src/components/clerk/clerkAppearance.test.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.test.ts
@@ -1,13 +1,49 @@
 import { describe, expect, it } from "vite-plus/test";
 
+import {
+  EMBER_THEME,
+  GROVE_THEME,
+  IRIS_THEME,
+  OCEAN_THEME,
+  T3_CHAT_THEME,
+  themeColorToHex,
+  type ThemeColors,
+} from "../../themePalette";
 import { clerkAppearance } from "./clerkAppearance";
+
+function contrastRatio(first: string, second: string): number {
+  const toRgb = (value: string) => {
+    const hex = themeColorToHex(value)?.slice(1, 7);
+    if (!hex) throw new Error(`Expected a theme color, received ${value}`);
+    return [0, 1, 2].map(
+      (channel) => Number.parseInt(hex.slice(channel * 2, channel * 2 + 2), 16) / 255,
+    );
+  };
+  const luminance = (value: string) =>
+    toRgb(value)
+      .map((channel) => (channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4))
+      .reduce((sum, channel, index) => sum + channel * [0.2126, 0.7152, 0.0722][index]!, 0);
+  const lighter = Math.max(luminance(first), luminance(second));
+  const darker = Math.min(luminance(first), luminance(second));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+const builtInThemeModes = [
+  T3_CHAT_THEME,
+  GROVE_THEME,
+  OCEAN_THEME,
+  EMBER_THEME,
+  IRIS_THEME,
+].flatMap((theme) =>
+  [theme.colors, theme.variants?.dark].filter((colors): colors is ThemeColors => !!colors),
+);
 
 describe("clerkAppearance", () => {
   it("maps colors without overriding Clerk's component structure", () => {
     expect(clerkAppearance).toEqual({
       variables: {
-        colorPrimary: "var(--primary)",
-        colorPrimaryForeground: "var(--primary-foreground)",
+        colorPrimary: "var(--update-foreground)",
+        colorPrimaryForeground: "var(--card)",
         colorDanger: "var(--error)",
         colorSuccess: "var(--success)",
         colorWarning: "var(--warning)",
@@ -15,12 +51,18 @@ describe("clerkAppearance", () => {
         colorForeground: "var(--foreground)",
         colorMuted: "var(--muted)",
         colorMutedForeground: "var(--muted-foreground)",
-        colorBackground: "var(--popover)",
+        colorBackground: "var(--card)",
         colorInputForeground: "var(--foreground)",
-        colorInput: "var(--background)",
+        colorInput: "var(--secondary)",
         colorRing: "var(--ring)",
-        colorBorder: "var(--border)",
       },
     });
+  });
+
+  it.each(builtInThemeModes)("keeps Clerk text readable across a built-in palette", (colors) => {
+    expect(contrastRatio(colors.text, colors.surface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.mutedForeground, colors.surface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.text, colors.secondary)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.updateForeground, colors.surface)).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/apps/web/src/components/clerk/clerkAppearance.test.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { clerkAppearance } from "./clerkAppearance";
+
+describe("clerkAppearance", () => {
+  it("maps colors without overriding Clerk's component structure", () => {
+    expect(clerkAppearance).toEqual({
+      variables: {
+        colorPrimary: "var(--primary)",
+        colorPrimaryForeground: "var(--primary-foreground)",
+        colorDanger: "var(--error)",
+        colorSuccess: "var(--success)",
+        colorWarning: "var(--warning)",
+        colorNeutral: "var(--foreground)",
+        colorForeground: "var(--foreground)",
+        colorMuted: "var(--muted)",
+        colorMutedForeground: "var(--muted-foreground)",
+        colorBackground: "var(--popover)",
+        colorInputForeground: "var(--foreground)",
+        colorInput: "var(--background)",
+        colorRing: "var(--ring)",
+        colorBorder: "var(--border)",
+      },
+    });
+  });
+});

--- a/apps/web/src/components/clerk/clerkAppearance.test.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.test.ts
@@ -44,9 +44,9 @@ describe("clerkAppearance", () => {
       variables: {
         colorPrimary: "var(--update-foreground)",
         colorPrimaryForeground: "var(--card)",
-        colorDanger: "var(--error)",
-        colorSuccess: "var(--success)",
-        colorWarning: "var(--warning)",
+        colorDanger: "var(--error-foreground)",
+        colorSuccess: "var(--success-foreground)",
+        colorWarning: "var(--warning-foreground)",
         colorNeutral: "var(--foreground)",
         colorForeground: "var(--foreground)",
         colorMuted: "var(--muted)",
@@ -64,5 +64,7 @@ describe("clerkAppearance", () => {
     expect(contrastRatio(colors.mutedForeground, colors.surface)).toBeGreaterThanOrEqual(4.5);
     expect(contrastRatio(colors.text, colors.secondary)).toBeGreaterThanOrEqual(4.5);
     expect(contrastRatio(colors.updateForeground, colors.surface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.errorForeground, colors.surface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.warningForeground, colors.surface)).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/apps/web/src/components/clerk/clerkAppearance.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.ts
@@ -10,18 +10,25 @@ export const clerkAppearance = {
     // text, while the card surface provides the inverse filled-control pair.
     colorPrimary: "var(--update-foreground)",
     colorPrimaryForeground: "var(--card)",
-    // Clerk also renders status colors as inline text, so use the readable
-    // foreground roles instead of the deeper fills used for icons and tinting.
-    colorDanger: "var(--error-foreground)",
-    colorSuccess: "var(--success-foreground)",
-    colorWarning: "var(--warning-foreground)",
+    colorDanger: "var(--error)",
+    colorSuccess: "var(--success)",
+    colorWarning: "var(--warning)",
     colorNeutral: "var(--foreground)",
     colorForeground: "var(--foreground)",
-    colorMuted: "var(--muted)",
+    // The stock dark theme's muted token is translucent. Clerk uses this as
+    // the footer's background, so derive an opaque muted surface from the card.
+    colorMuted: "color-mix(in srgb, var(--card) 98%, var(--foreground))",
     colorMutedForeground: "var(--muted-foreground)",
     colorBackground: "var(--card)",
     colorInputForeground: "var(--foreground)",
     colorInput: "var(--secondary)",
     colorRing: "var(--ring)",
+  },
+  elements: {
+    formFieldErrorText: { color: "var(--error-foreground)" },
+    formFieldWarningText: { color: "var(--warning-foreground)" },
+    formFieldSuccessText: { color: "var(--success-foreground)" },
+    otpCodeFieldErrorText: { color: "var(--error-foreground)" },
+    otpCodeFieldSuccessText: { color: "var(--success-foreground)" },
   },
 } satisfies NonNullable<ClerkProviderProps["appearance"]>;

--- a/apps/web/src/components/clerk/clerkAppearance.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.ts
@@ -5,8 +5,11 @@ import type { ClerkProviderProps } from "@clerk/react";
  * portaled sign-in and profile surfaces without remounting Clerk. */
 export const clerkAppearance = {
   variables: {
-    colorPrimary: "var(--primary)",
-    colorPrimaryForeground: "var(--primary-foreground)",
+    // Clerk reuses its primary color for filled buttons and bare links. The
+    // app's update foreground is the palette's action hue cast for readable
+    // text, while the card surface provides the inverse filled-control pair.
+    colorPrimary: "var(--update-foreground)",
+    colorPrimaryForeground: "var(--card)",
     colorDanger: "var(--error)",
     colorSuccess: "var(--success)",
     colorWarning: "var(--warning)",
@@ -14,10 +17,9 @@ export const clerkAppearance = {
     colorForeground: "var(--foreground)",
     colorMuted: "var(--muted)",
     colorMutedForeground: "var(--muted-foreground)",
-    colorBackground: "var(--popover)",
+    colorBackground: "var(--card)",
     colorInputForeground: "var(--foreground)",
-    colorInput: "var(--background)",
+    colorInput: "var(--secondary)",
     colorRing: "var(--ring)",
-    colorBorder: "var(--border)",
   },
 } satisfies NonNullable<ClerkProviderProps["appearance"]>;

--- a/apps/web/src/components/clerk/clerkAppearance.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.ts
@@ -1,0 +1,23 @@
+import type { ClerkProviderProps } from "@clerk/react";
+
+/** Keeps Clerk's stock component structure while binding its color system to
+ * the live T3 Code palette. CSS variables make theme changes propagate to
+ * portaled sign-in and profile surfaces without remounting Clerk. */
+export const clerkAppearance = {
+  variables: {
+    colorPrimary: "var(--primary)",
+    colorPrimaryForeground: "var(--primary-foreground)",
+    colorDanger: "var(--error)",
+    colorSuccess: "var(--success)",
+    colorWarning: "var(--warning)",
+    colorNeutral: "var(--foreground)",
+    colorForeground: "var(--foreground)",
+    colorMuted: "var(--muted)",
+    colorMutedForeground: "var(--muted-foreground)",
+    colorBackground: "var(--popover)",
+    colorInputForeground: "var(--foreground)",
+    colorInput: "var(--background)",
+    colorRing: "var(--ring)",
+    colorBorder: "var(--border)",
+  },
+} satisfies NonNullable<ClerkProviderProps["appearance"]>;

--- a/apps/web/src/components/clerk/clerkAppearance.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.ts
@@ -10,9 +10,11 @@ export const clerkAppearance = {
     // text, while the card surface provides the inverse filled-control pair.
     colorPrimary: "var(--update-foreground)",
     colorPrimaryForeground: "var(--card)",
-    colorDanger: "var(--error)",
-    colorSuccess: "var(--success)",
-    colorWarning: "var(--warning)",
+    // Clerk also renders status colors as inline text, so use the readable
+    // foreground roles instead of the deeper fills used for icons and tinting.
+    colorDanger: "var(--error-foreground)",
+    colorSuccess: "var(--success-foreground)",
+    colorWarning: "var(--warning-foreground)",
     colorNeutral: "var(--foreground)",
     colorForeground: "var(--foreground)",
     colorMuted: "var(--muted)",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -16,6 +16,7 @@ import {
   syncDocumentWindowControlsOverlayClass,
 } from "./lib/windowControlsOverlay";
 import { AppRoot } from "./AppRoot";
+import { clerkAppearance } from "./components/clerk/clerkAppearance";
 
 // Electron loads the app from a file-backed shell, so hash history avoids path resolution issues.
 const history = isElectron ? createHashHistory() : createBrowserHistory();
@@ -35,11 +36,15 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     {clerkPublishableKey && hasCloudPublicConfig() ? (
       isElectron ? (
-        <ElectronClerkProvider publishableKey={clerkPublishableKey} passkeys={passkeys}>
+        <ElectronClerkProvider
+          appearance={clerkAppearance}
+          publishableKey={clerkPublishableKey}
+          passkeys={passkeys}
+        >
           <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
         </ElectronClerkProvider>
       ) : (
-        <ClerkProvider publishableKey={clerkPublishableKey}>
+        <ClerkProvider appearance={clerkAppearance} publishableKey={clerkPublishableKey}>
           <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
         </ClerkProvider>
       )


### PR DESCRIPTION
Clerk’s sign-in and account surfaces kept their default palette after selecting a T3 Code theme, which made authentication feel disconnected from the surrounding app.

This passes live semantic color tokens into the shared Clerk provider used by web and desktop. Clerk keeps its existing component structure, spacing, and behavior. Its card and controls now use contrast-safe surface roles, while the shared action color remains readable both as a filled button and as bare link text.

## Before

![Clerk sign-in modal using its default palette alongside T3 Chat](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/c229540a-f5e6-4463-95c7-3f3c22946439/clerk-theme-t3-chat-before.png)

## After

![The same Clerk sign-in modal using the T3 Chat palette with improved contrast](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/58e2073c-a746-46d0-be9c-4f203ad1f00b/clerk-theme-t3-chat-after.png)

## Verification

- `pnpm exec vp test run --passWithNoTests --project unit src/components/clerk/clerkAppearance.test.ts`
- Contrast assertions cover all 10 built-in light and dark palette variants at 4.5:1 or better
- `pnpm exec vp run --filter @t3tools/web typecheck`
- Targeted formatting and lint checks for the changed files
- Playwright comparison against a real Clerk-rendered sign-in modal using T3 Chat dark mode

Made with GPT-5.6-SOL in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Appearance-only change to Clerk theming; no auth logic, session handling, or credential flow is modified.
> 
> **Overview**
> Clerk sign-in and account UI now follow the live T3 Code theme instead of Clerk’s default palette.
> 
> Adds a shared `clerkAppearance` config that maps Clerk color variables (and a few status text elements) to app CSS tokens like `--update-foreground`, `--card`, and `--muted-foreground`, then passes it to both `ClerkProvider` and `ElectronClerkProvider`. Theme switches propagate via CSS variables without remounting Clerk.
> 
> Includes contrast tests covering all built-in light/dark palettes at WCAG 4.5:1 or better.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6b56caed6494dc7830fe8b10397868d06bad1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply app theme CSS variables to Clerk UI surfaces
> - Adds [clerkAppearance.ts](https://github.com/pingdotgg/t3code/pull/6300/files#diff-6071582417608661c1becf50a6e2d3be51a404d1ec7e7a0788c3f110e910e9d5) exporting a `clerkAppearance` object that maps app palette CSS variables to Clerk appearance tokens and element color overrides.
> - Passes `clerkAppearance` as the `appearance` prop to both `ElectronClerkProvider` and `ClerkProvider` in [main.tsx](https://github.com/pingdotgg/t3code/pull/6300/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b).
> - Adds [clerkAppearance.test.ts](https://github.com/pingdotgg/t3code/pull/6300/files#diff-93993cc936aa25bcf708165f6ee08b66110a3b0b01b7a4112a0627bc1d287c83) with WCAG contrast ratio checks across built-in theme palettes to verify readability of foreground/background pairs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b6b56c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->