### PR TITLE
fix(desktop): skip slow powershell profile load if node is available

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -87,7 +87,7 @@ function runShellEnvironment(input: {
     ),
   );
 
-  let program = Effect.gen(function* () {
+  const coreProgram = Effect.gen(function* () {
     const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
     yield* shellEnvironment.installIntoProcess;
   }).pipe(
@@ -95,11 +95,14 @@ function runShellEnvironment(input: {
     Effect.provide(Layer.mergeAll(environmentLayer, spawnerLayer)),
   );
 
-  if (input.fs) {
-    program = program.pipe(Effect.provideService(FileSystem.FileSystem, input.fs));
-  }
-  
-  program = program.pipe(Effect.provide(NodeServices.layer));
+  const program = input.fs
+    ? coreProgram.pipe(
+        Effect.provideService(FileSystem.FileSystem, input.fs),
+        Effect.provide(NodeServices.layer)
+      )
+    : coreProgram.pipe(
+        Effect.provide(NodeServices.layer)
+      );
 
   return withProcessEnv(input.env, program);
 }

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -342,6 +342,8 @@ describe("DesktopShellEnvironment", () => {
       ),
       Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
     );
+  });
+
   it.effect("skips PowerShell profile when node is available and fnm is not", () =>
     Effect.gen(function* () {
       const fs = yield* Effect.promise(() => import("node:fs"));

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -349,7 +349,7 @@ describe("DesktopShellEnvironment", () => {
       const fs = yield* Effect.promise(() => import("node:fs"));
       const os = yield* Effect.promise(() => import("node:os"));
       const path = yield* Effect.promise(() => import("node:path"));
-      
+
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
       try {
         fs.writeFileSync(path.join(tempDir, "node.exe"), "");
@@ -379,7 +379,7 @@ describe("DesktopShellEnvironment", () => {
       const fs = yield* Effect.promise(() => import("node:fs"));
       const os = yield* Effect.promise(() => import("node:os"));
       const path = yield* Effect.promise(() => import("node:path"));
-      
+
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
       try {
         fs.writeFileSync(path.join(tempDir, "node.exe"), "");
@@ -403,6 +403,40 @@ describe("DesktopShellEnvironment", () => {
         const profileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && !c.args.includes("-NoProfile"));
         assert.isTrue(noProfileIdx !== -1);
         assert.isTrue(profileIdx !== -1);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }),
+  );
+
+  it.effect("skips PowerShell probes when node is in knownWindowsCliDirs but not on PATH", () =>
+    Effect.gen(function* () {
+      const fs = yield* Effect.promise(() => import("node:fs"));
+      const os = yield* Effect.promise(() => import("node:os"));
+      const path = yield* Effect.promise(() => import("node:path"));
+
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
+      const knownPath = path.join(tempDir, "nodejs");
+      fs.mkdirSync(knownPath, { recursive: true });
+
+      try {
+        fs.writeFileSync(path.join(knownPath, "node.exe"), "");
+
+        // PATH doesn't have node, but knownWindowsCliDirs will (simulated by tempDir inside PROGRAMFILES)
+        const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32", PROGRAMFILES: tempDir };
+        const commands: ChildProcess.Command[] = [];
+
+        yield* runShellEnvironment({
+          env,
+          platform: "win32",
+          handler: (command) => {
+            commands.push(command);
+            return envOutput({ PATH: "C:\\Windows\\System32" });
+          },
+        });
+
+        assert.equal(commands.length, 0);
+        assert.isTrue(env.PATH!.includes("nodejs"));
       } finally {
         fs.rmSync(tempDir, { recursive: true, force: true });
       }

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -360,7 +360,8 @@ describe("DesktopShellEnvironment", () => {
 
       const mockFs = {
         exists: (path: string) => Effect.succeed(path.includes("node.exe")),
-      } as FileSystem.FileSystem;
+        readFileString: () => Effect.fail(PlatformError.systemError({ _tag: "SystemError", reason: "NotFound", module: "FileSystem", method: "readFileString", pathOrDescriptor: "" })),
+      } as unknown as FileSystem.FileSystem;
 
       yield* runShellEnvironment({
         env,
@@ -377,15 +378,47 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
-  it.effect("loads PowerShell probes concurrently when node and fnm.cmd are both available", () =>
+  it.effect("runs PowerShell probes when node is available but profile references fnm", () =>
     Effect.gen(function* () {
       const mockDir = "C:\\mock\\temp";
-      const env: NodeJS.ProcessEnv = { PATH: mockDir };
+      const env: NodeJS.ProcessEnv = { PATH: mockDir, USERPROFILE: "C:\\Users\\test" };
       const commands: ChildProcess.Command[] = [];
 
       const mockFs = {
-        exists: (path: string) => Effect.succeed(path.includes("node.exe") || path.includes("fnm.cmd")),
-      } as FileSystem.FileSystem;
+        exists: (path: string) => Effect.succeed(path.includes("node.exe")),
+        readFileString: (path: string) => Effect.succeed('Invoke-Expression "fnm env"'),
+      } as unknown as FileSystem.FileSystem;
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        fs: mockFs,
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({ PATH: mockDir, FNM_DIR: "C:\\mock\\fnm" });
+        },
+      });
+
+      assert.equal(commands.length, 2);
+      
+      const noProfileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && c.args.includes("-NoProfile"));
+      const profileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && !c.args.includes("-NoProfile"));
+      assert.isTrue(noProfileIdx !== -1);
+      assert.isTrue(profileIdx !== -1);
+      assert.equal(env.FNM_DIR, "C:\\mock\\fnm");
+    }),
+  );
+
+  it.effect("skips ALL PowerShell probes when node is available and profile exists without fnm", () =>
+    Effect.gen(function* () {
+      const mockDir = "C:\\mock\\temp";
+      const env: NodeJS.ProcessEnv = { PATH: mockDir, USERPROFILE: "C:\\Users\\test" };
+      const commands: ChildProcess.Command[] = [];
+
+      const mockFs = {
+        exists: (path: string) => Effect.succeed(path.includes("node.exe")),
+        readFileString: (path: string) => Effect.succeed('Write-Host "Hello World"'),
+      } as unknown as FileSystem.FileSystem;
 
       yield* runShellEnvironment({
         env,
@@ -397,12 +430,7 @@ describe("DesktopShellEnvironment", () => {
         },
       });
 
-      assert.equal(commands.length, 2);
-      
-      const noProfileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && c.args.includes("-NoProfile"));
-      const profileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && !c.args.includes("-NoProfile"));
-      assert.isTrue(noProfileIdx !== -1);
-      assert.isTrue(profileIdx !== -1);
+      assert.equal(commands.length, 0);
     }),
   );
 
@@ -414,7 +442,8 @@ describe("DesktopShellEnvironment", () => {
 
       const mockFs = {
         exists: (path: string) => Effect.succeed(path.includes("node.exe") && path.includes(mockDir)),
-      } as FileSystem.FileSystem;
+        readFileString: () => Effect.fail(PlatformError.systemError({ _tag: "SystemError", reason: "NotFound", module: "FileSystem", method: "readFileString", pathOrDescriptor: "" })),
+      } as unknown as FileSystem.FileSystem;
 
       yield* runShellEnvironment({
         env,

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -374,7 +374,7 @@ describe("DesktopShellEnvironment", () => {
       });
 
       assert.equal(commands.length, 0);
-      assert.equal(env.PATH, `"${mockDir}"`);
+      assert.isTrue(env.PATH!.includes(`"${mockDir}"`));
     }),
   );
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -355,12 +355,12 @@ describe("DesktopShellEnvironment", () => {
   it.effect("skips ALL PowerShell probes when node is available statically with quotes and no fnm", () =>
     Effect.gen(function* () {
       const mockDir = "C:\\mock\\temp";
-      const env: NodeJS.ProcessEnv = { PATH: `"${mockDir}"` };
+      const env: NodeJS.ProcessEnv = { PATH: `"${mockDir}"`, USERPROFILE: "C:\\Users\\test" };
       const commands: ChildProcess.Command[] = [];
 
       const mockFs = {
         exists: (path: string) => Effect.succeed(path.includes("node.exe")),
-        readFileString: () => Effect.fail(PlatformError.systemError({ _tag: "SystemError", reason: "NotFound", module: "FileSystem", method: "readFileString", pathOrDescriptor: "" })),
+        readFile: () => Effect.fail(PlatformError.systemError({ _tag: "NotFound", module: "FileSystem", method: "readFile", pathOrDescriptor: "" })),
       } as unknown as FileSystem.FileSystem;
 
       yield* runShellEnvironment({
@@ -386,7 +386,7 @@ describe("DesktopShellEnvironment", () => {
 
       const mockFs = {
         exists: (path: string) => Effect.succeed(path.includes("node.exe")),
-        readFileString: (path: string) => Effect.succeed('Invoke-Expression "fnm env"'),
+        readFile: () => Effect.succeed(textEncoder.encode('Invoke-Expression "fnm env"')),
       } as unknown as FileSystem.FileSystem;
 
       yield* runShellEnvironment({
@@ -417,7 +417,7 @@ describe("DesktopShellEnvironment", () => {
 
       const mockFs = {
         exists: (path: string) => Effect.succeed(path.includes("node.exe")),
-        readFileString: (path: string) => Effect.succeed('Write-Host "Hello World"'),
+        readFile: () => Effect.succeed(textEncoder.encode('Write-Host "Hello World"')),
       } as unknown as FileSystem.FileSystem;
 
       yield* runShellEnvironment({
@@ -437,12 +437,12 @@ describe("DesktopShellEnvironment", () => {
   it.effect("skips PowerShell probes when node is in knownWindowsCliDirs but not on PATH", () =>
     Effect.gen(function* () {
       const mockDir = "C:\\mock\\temp";
-      const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32", LOCALAPPDATA: mockDir };
+      const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32", LOCALAPPDATA: mockDir, USERPROFILE: "C:\\Users\\test" };
       const commands: ChildProcess.Command[] = [];
 
       const mockFs = {
         exists: (path: string) => Effect.succeed(path.includes("node.exe") && path.includes(mockDir)),
-        readFileString: () => Effect.fail(PlatformError.systemError({ _tag: "SystemError", reason: "NotFound", module: "FileSystem", method: "readFileString", pathOrDescriptor: "" })),
+        readFile: () => Effect.fail(PlatformError.systemError({ _tag: "NotFound", module: "FileSystem", method: "readFile", pathOrDescriptor: "" })),
       } as unknown as FileSystem.FileSystem;
 
       yield* runShellEnvironment({

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -69,6 +69,7 @@ function runShellEnvironment(input: {
   readonly platform: NodeJS.Platform;
   readonly handler: (command: ChildProcess.Command) => string;
   readonly failure?: PlatformError.PlatformError;
+  readonly fs?: FileSystem.FileSystem;
 }) {
   const environmentLayer = Layer.succeed(
     DesktopEnvironment.DesktopEnvironment,
@@ -85,16 +86,19 @@ function runShellEnvironment(input: {
     ),
   );
 
-  const program = Effect.gen(function* () {
+  let program = Effect.gen(function* () {
     const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
     yield* shellEnvironment.installIntoProcess;
   }).pipe(
-    Effect.provide(
-      DesktopShellEnvironment.layer.pipe(
-        Layer.provide(Layer.mergeAll(environmentLayer, NodeServices.layer, spawnerLayer)),
-      ),
-    ),
+    Effect.provide(DesktopShellEnvironment.layer),
+    Effect.provide(Layer.mergeAll(environmentLayer, spawnerLayer)),
   );
+
+  if (input.fs) {
+    program = program.pipe(Effect.provideService(FileSystem.FileSystem, input.fs));
+  }
+  
+  program = program.pipe(Effect.provide(NodeServices.layer));
 
   return withProcessEnv(input.env, program);
 }
@@ -346,100 +350,80 @@ describe("DesktopShellEnvironment", () => {
 
   it.effect("skips ALL PowerShell probes when node is available statically with quotes and no fnm", () =>
     Effect.gen(function* () {
-      const fs = yield* Effect.promise(() => import("node:fs"));
-      const os = yield* Effect.promise(() => import("node:os"));
-      const path = yield* Effect.promise(() => import("node:path"));
+      const mockDir = "C:\\mock\\temp";
+      const env: NodeJS.ProcessEnv = { PATH: `"${mockDir}"` };
+      const commands: ChildProcess.Command[] = [];
 
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
-      try {
-        fs.writeFileSync(path.join(tempDir, "node.exe"), "");
+      const mockFs = {
+        exists: (path: string) => Effect.succeed(path.includes("node.exe")),
+      } as FileSystem.FileSystem;
 
-        const env: NodeJS.ProcessEnv = { PATH: `"${tempDir}"` };
-        const commands: ChildProcess.Command[] = [];
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        fs: mockFs,
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({ PATH: mockDir });
+        },
+      });
 
-        yield* runShellEnvironment({
-          env,
-          platform: "win32",
-          handler: (command) => {
-            commands.push(command);
-            return envOutput({ PATH: tempDir });
-          },
-        });
-
-        assert.equal(commands.length, 0);
-        assert.equal(env.PATH, `"${tempDir}"`);
-      } finally {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
+      assert.equal(commands.length, 0);
+      assert.equal(env.PATH, `"${mockDir}"`);
     }),
   );
 
   it.effect("loads PowerShell probes concurrently when node and fnm.cmd are both available", () =>
     Effect.gen(function* () {
-      const fs = yield* Effect.promise(() => import("node:fs"));
-      const os = yield* Effect.promise(() => import("node:os"));
-      const path = yield* Effect.promise(() => import("node:path"));
+      const mockDir = "C:\\mock\\temp";
+      const env: NodeJS.ProcessEnv = { PATH: mockDir };
+      const commands: ChildProcess.Command[] = [];
 
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
-      try {
-        fs.writeFileSync(path.join(tempDir, "node.exe"), "");
-        fs.writeFileSync(path.join(tempDir, "fnm.cmd"), "");
+      const mockFs = {
+        exists: (path: string) => Effect.succeed(path.includes("node.exe") || path.includes("fnm.cmd")),
+      } as FileSystem.FileSystem;
 
-        const env: NodeJS.ProcessEnv = { PATH: tempDir };
-        const commands: ChildProcess.Command[] = [];
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        fs: mockFs,
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({ PATH: mockDir });
+        },
+      });
 
-        yield* runShellEnvironment({
-          env,
-          platform: "win32",
-          handler: (command) => {
-            commands.push(command);
-            return envOutput({ PATH: tempDir });
-          },
-        });
-
-        assert.equal(commands.length, 2);
-        
-        const noProfileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && c.args.includes("-NoProfile"));
-        const profileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && !c.args.includes("-NoProfile"));
-        assert.isTrue(noProfileIdx !== -1);
-        assert.isTrue(profileIdx !== -1);
-      } finally {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
+      assert.equal(commands.length, 2);
+      
+      const noProfileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && c.args.includes("-NoProfile"));
+      const profileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && !c.args.includes("-NoProfile"));
+      assert.isTrue(noProfileIdx !== -1);
+      assert.isTrue(profileIdx !== -1);
     }),
   );
 
   it.effect("skips PowerShell probes when node is in knownWindowsCliDirs but not on PATH", () =>
     Effect.gen(function* () {
-      const fs = yield* Effect.promise(() => import("node:fs"));
-      const os = yield* Effect.promise(() => import("node:os"));
-      const path = yield* Effect.promise(() => import("node:path"));
+      const mockDir = "C:\\mock\\temp";
+      const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32", LOCALAPPDATA: mockDir };
+      const commands: ChildProcess.Command[] = [];
 
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
-      const knownPath = path.join(tempDir, "Programs", "nodejs");
-      fs.mkdirSync(knownPath, { recursive: true });
+      const mockFs = {
+        exists: (path: string) => Effect.succeed(path.includes("node.exe") && path.includes(mockDir)),
+      } as FileSystem.FileSystem;
 
-      try {
-        fs.writeFileSync(path.join(knownPath, "node.exe"), "");
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        fs: mockFs,
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({ PATH: "C:\\Windows\\System32" });
+        },
+      });
 
-        // PATH doesn't have node, but knownWindowsCliDirs will (simulated by tempDir inside LOCALAPPDATA)
-        const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32", LOCALAPPDATA: tempDir };
-        const commands: ChildProcess.Command[] = [];
-
-        yield* runShellEnvironment({
-          env,
-          platform: "win32",
-          handler: (command) => {
-            commands.push(command);
-            return envOutput({ PATH: "C:\\Windows\\System32" });
-          },
-        });
-
-        assert.equal(commands.length, 0);
-        assert.isTrue(env.PATH!.includes("nodejs"));
-      } finally {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
+      assert.equal(commands.length, 0);
+      assert.isTrue(env.PATH!.includes("nodejs"));
     }),
   );
 });

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -1,4 +1,5 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as FileSystem from "@effect/platform/FileSystem";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -12,6 +13,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopShellEnvironment from "./DesktopShellEnvironment.ts";
+import * as FileSystem from "@effect/platform/FileSystem";
 
 const textEncoder = new TextEncoder();
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -1,7 +1,7 @@
-import * as FileSystem from "@effect/platform/FileSystem";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as PlatformError from "effect/PlatformError";

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -416,14 +416,14 @@ describe("DesktopShellEnvironment", () => {
       const path = yield* Effect.promise(() => import("node:path"));
 
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
-      const knownPath = path.join(tempDir, "nodejs");
+      const knownPath = path.join(tempDir, "Programs", "nodejs");
       fs.mkdirSync(knownPath, { recursive: true });
 
       try {
         fs.writeFileSync(path.join(knownPath, "node.exe"), "");
 
-        // PATH doesn't have node, but knownWindowsCliDirs will (simulated by tempDir inside PROGRAMFILES)
-        const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32", PROGRAMFILES: tempDir };
+        // PATH doesn't have node, but knownWindowsCliDirs will (simulated by tempDir inside LOCALAPPDATA)
+        const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32", LOCALAPPDATA: tempDir };
         const commands: ChildProcess.Command[] = [];
 
         yield* runShellEnvironment({

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -1,5 +1,5 @@
-import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as FileSystem from "@effect/platform/FileSystem";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -13,7 +13,6 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopShellEnvironment from "./DesktopShellEnvironment.ts";
-import * as FileSystem from "@effect/platform/FileSystem";
 
 const textEncoder = new TextEncoder();
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -242,6 +242,7 @@ describe("DesktopShellEnvironment", () => {
           "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
+          "C:\\Users\\testuser\\.cargo\\bin",
           "C:\\Custom\\Bin",
         ].join(";"),
       );

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -367,8 +367,8 @@ describe("DesktopShellEnvironment", () => {
 
       fs.rmSync(tempDir, { recursive: true, force: true });
 
-      assert.equal(commands.length, 1);
-      assert.isTrue(commands[0]!._tag === "StandardCommand" && commands[0].args.includes("-NoProfile"));
+      assert.equal(commands.length, 2);
+      assert.isTrue(commands.some((c) => c._tag === "StandardCommand" && c.args.includes("-NoProfile")));
     }),
   );
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -367,8 +367,8 @@ describe("DesktopShellEnvironment", () => {
 
       fs.rmSync(tempDir, { recursive: true, force: true });
 
-      assert.equal(commands.length, 2);
-      assert.isTrue(commands.some((c) => c._tag === "StandardCommand" && c.args.includes("-NoProfile")));
+      assert.equal(commands.length, 1);
+      assert.isTrue(commands[0]!._tag === "StandardCommand" && commands[0].args.includes("-NoProfile"));
     }),
   );
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -342,5 +342,61 @@ describe("DesktopShellEnvironment", () => {
       ),
       Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
     );
-  });
+  it.effect("skips PowerShell profile when node is available and fnm is not", () =>
+    Effect.gen(function* () {
+      const fs = yield* Effect.promise(() => import("node:fs"));
+      const os = yield* Effect.promise(() => import("node:os"));
+      const path = yield* Effect.promise(() => import("node:path"));
+      
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
+      fs.writeFileSync(path.join(tempDir, "node.exe"), "");
+
+      const env: NodeJS.ProcessEnv = { PATH: tempDir };
+      const commands: ChildProcess.Command[] = [];
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({ PATH: tempDir });
+        },
+      });
+
+      fs.rmSync(tempDir, { recursive: true, force: true });
+
+      assert.equal(commands.length, 1);
+      assert.isTrue(commands[0]!._tag === "StandardCommand" && commands[0].args.includes("-NoProfile"));
+    }),
+  );
+
+  it.effect("loads PowerShell profile when node and fnm are both available", () =>
+    Effect.gen(function* () {
+      const fs = yield* Effect.promise(() => import("node:fs"));
+      const os = yield* Effect.promise(() => import("node:os"));
+      const path = yield* Effect.promise(() => import("node:path"));
+      
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
+      fs.writeFileSync(path.join(tempDir, "node.exe"), "");
+      fs.writeFileSync(path.join(tempDir, "fnm.exe"), "");
+
+      const env: NodeJS.ProcessEnv = { PATH: tempDir };
+      const commands: ChildProcess.Command[] = [];
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({ PATH: tempDir });
+        },
+      });
+
+      fs.rmSync(tempDir, { recursive: true, force: true });
+
+      assert.equal(commands.length, 2);
+      assert.isTrue(commands[0]!._tag === "StandardCommand" && commands[0].args.includes("-NoProfile"));
+      assert.isFalse(commands[1]!._tag === "StandardCommand" && commands[1].args.includes("-NoProfile"));
+    }),
+  );
 });

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -344,61 +344,68 @@ describe("DesktopShellEnvironment", () => {
     );
   });
 
-  it.effect("skips PowerShell profile when node is available and fnm is not", () =>
+  it.effect("skips ALL PowerShell probes when node is available statically with quotes and no fnm", () =>
     Effect.gen(function* () {
       const fs = yield* Effect.promise(() => import("node:fs"));
       const os = yield* Effect.promise(() => import("node:os"));
       const path = yield* Effect.promise(() => import("node:path"));
       
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
-      fs.writeFileSync(path.join(tempDir, "node.exe"), "");
+      try {
+        fs.writeFileSync(path.join(tempDir, "node.exe"), "");
 
-      const env: NodeJS.ProcessEnv = { PATH: tempDir };
-      const commands: ChildProcess.Command[] = [];
+        const env: NodeJS.ProcessEnv = { PATH: `"${tempDir}"` };
+        const commands: ChildProcess.Command[] = [];
 
-      yield* runShellEnvironment({
-        env,
-        platform: "win32",
-        handler: (command) => {
-          commands.push(command);
-          return envOutput({ PATH: tempDir });
-        },
-      });
+        yield* runShellEnvironment({
+          env,
+          platform: "win32",
+          handler: (command) => {
+            commands.push(command);
+            return envOutput({ PATH: tempDir });
+          },
+        });
 
-      fs.rmSync(tempDir, { recursive: true, force: true });
-
-      assert.equal(commands.length, 1);
-      assert.isTrue(commands[0]!._tag === "StandardCommand" && commands[0].args.includes("-NoProfile"));
+        assert.equal(commands.length, 0);
+        assert.equal(env.PATH, `"${tempDir}"`);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
     }),
   );
 
-  it.effect("loads PowerShell profile when node and fnm are both available", () =>
+  it.effect("loads PowerShell probes concurrently when node and fnm.cmd are both available", () =>
     Effect.gen(function* () {
       const fs = yield* Effect.promise(() => import("node:fs"));
       const os = yield* Effect.promise(() => import("node:os"));
       const path = yield* Effect.promise(() => import("node:path"));
       
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-test-"));
-      fs.writeFileSync(path.join(tempDir, "node.exe"), "");
-      fs.writeFileSync(path.join(tempDir, "fnm.exe"), "");
+      try {
+        fs.writeFileSync(path.join(tempDir, "node.exe"), "");
+        fs.writeFileSync(path.join(tempDir, "fnm.cmd"), "");
 
-      const env: NodeJS.ProcessEnv = { PATH: tempDir };
-      const commands: ChildProcess.Command[] = [];
+        const env: NodeJS.ProcessEnv = { PATH: tempDir };
+        const commands: ChildProcess.Command[] = [];
 
-      yield* runShellEnvironment({
-        env,
-        platform: "win32",
-        handler: (command) => {
-          commands.push(command);
-          return envOutput({ PATH: tempDir });
-        },
-      });
+        yield* runShellEnvironment({
+          env,
+          platform: "win32",
+          handler: (command) => {
+            commands.push(command);
+            return envOutput({ PATH: tempDir });
+          },
+        });
 
-      fs.rmSync(tempDir, { recursive: true, force: true });
-
-      assert.equal(commands.length, 2);
-      assert.isTrue(commands[0]!._tag === "StandardCommand" && commands[0].args.includes("-NoProfile"));
-      assert.isFalse(commands[1]!._tag === "StandardCommand" && commands[1].args.includes("-NoProfile"));
+        assert.equal(commands.length, 2);
+        
+        const noProfileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && c.args.includes("-NoProfile"));
+        const profileIdx = commands.findIndex((c) => c._tag === "StandardCommand" && !c.args.includes("-NoProfile"));
+        assert.isTrue(noProfileIdx !== -1);
+        assert.isTrue(profileIdx !== -1);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
     }),
   );
 });

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -410,6 +410,45 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
+  it.effect("runs PowerShell probes when fnm is referenced only in an OneDrive-redirected profile", () =>
+    Effect.gen(function* () {
+      const mockDir = "C:\\mock\\temp";
+      const env: NodeJS.ProcessEnv = {
+        PATH: mockDir,
+        USERPROFILE: "C:\\Users\\test",
+        OneDrive: "C:\\Users\\test\\OneDrive",
+      };
+      const commands: ChildProcess.Command[] = [];
+
+      const mockFs = {
+        exists: (path: string) => Effect.succeed(path.includes("node.exe")),
+        readFile: (path: string) =>
+          path.includes("OneDrive")
+            ? Effect.succeed(textEncoder.encode('Invoke-Expression "fnm env"'))
+            : Effect.fail(
+                PlatformError.systemError({
+                  _tag: "NotFound",
+                  module: "FileSystem",
+                  method: "readFile",
+                  pathOrDescriptor: "",
+                }),
+              ),
+      } as unknown as FileSystem.FileSystem;
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        fs: mockFs,
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({ PATH: mockDir });
+        },
+      });
+
+      assert.equal(commands.length, 2);
+    }),
+  );
+
   it.effect("skips ALL PowerShell probes when node is available and profile exists without fnm", () =>
     Effect.gen(function* () {
       const mockDir = "C:\\mock\\temp";

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -195,19 +195,19 @@ const knownWindowsCliDirs = (env: NodeJS.ProcessEnv): ReadonlyArray<string> => [
   ...trimNonEmpty(env.APPDATA).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}\\npm`],
+      onSome: (value) => [`${value}/npm`],
     }),
   ),
   ...trimNonEmpty(env.LOCALAPPDATA).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}\\Programs\\nodejs`, `${value}\\Volta\\bin`, `${value}\\pnpm`],
+      onSome: (value) => [`${value}/Programs/nodejs`, `${value}/Volta/bin`, `${value}/pnpm`],
     }),
   ),
   ...trimNonEmpty(env.USERPROFILE).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}\\.local\\bin`, `${value}\\.bun\\bin`, `${value}\\scoop\\shims`],
+      onSome: (value) => [`${value}/.local/bin`, `${value}/.bun/bin`, `${value}/scoop/shims`],
     }),
   ),
 ];

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -406,12 +406,17 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
     const checkProfileMentionsFnm = Effect.gen(function* () {
       const userProfile = config.env.USERPROFILE;
       if (!userProfile) return true; // unsafe to skip if we can't find the profile
-      const profilePaths = [
-        `${userProfile}\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1`,
-        `${userProfile}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1`,
-        `${userProfile}\\Documents\\WindowsPowerShell\\profile.ps1`,
-        `${userProfile}\\Documents\\PowerShell\\profile.ps1`,
-      ];
+      const documentsDirs = [`${userProfile}\\Documents`];
+      const oneDrive = trimNonEmpty(config.env.OneDrive);
+      if (Option.isSome(oneDrive)) {
+        documentsDirs.push(`${oneDrive.value}\\Documents`);
+      }
+      const profilePaths = documentsDirs.flatMap((documentsDir) => [
+        `${documentsDir}\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1`,
+        `${documentsDir}\\PowerShell\\Microsoft.PowerShell_profile.ps1`,
+        `${documentsDir}\\WindowsPowerShell\\profile.ps1`,
+        `${documentsDir}\\PowerShell\\profile.ps1`,
+      ]);
       for (const p of profilePaths) {
         const bytes = yield* fileSystem.readFile(p).pipe(
           Effect.catchIf(

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -395,7 +395,11 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
         if (!nodeFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/node.exe`), () => false))) {
           nodeFound = true;
         }
-        if (!fnmFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/fnm.exe`), () => false))) {
+        if (!fnmFound && (
+          (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/fnm.exe`), () => false)) ||
+          (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/fnm.cmd`), () => false)) ||
+          (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/fnm.ps1`), () => false))
+        )) {
           fnmFound = true;
         }
         if (nodeFound && fnmFound) break;
@@ -404,13 +408,19 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
 
     const skipProfile = nodeFound && !fnmFound;
 
+    // If node is found statically and no fnm wrappers exist, we can skip BOTH PowerShell probes entirely!
+    if (skipProfile) {
+      if (Option.isSome(staticPaths)) {
+        config.env.PATH = staticPaths.value;
+      }
+      return; // Exit early, 0ms startup!
+    }
+
     // Run the necessary probes concurrently, bounded by the slowest single probe
     const [noProfile, profile] = yield* Effect.all(
       [
         readWindowsEnvironment(["PATH"], { loadProfile: false }),
-        skipProfile
-          ? Effect.succeed<EnvironmentPatch>({})
-          : readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
+        readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
       ],
       { concurrency: 2 },
     );

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -394,10 +394,11 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
     let fnmFound = false;
     if (Option.isSome(fastMergedPath)) {
       for (const dir of fastMergedPath.value.split(";")) {
-        if (!nodeFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${dir}/node.exe`), () => false))) {
+        const cleanDir = dir.trim().replace(/^"+|"+$/g, "");
+        if (!nodeFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/node.exe`), () => false))) {
           nodeFound = true;
         }
-        if (!fnmFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${dir}/fnm.exe`), () => false))) {
+        if (!fnmFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/fnm.exe`), () => false))) {
           fnmFound = true;
         }
         if (nodeFound && fnmFound) break;

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -207,7 +207,7 @@ const knownWindowsCliDirs = (env: NodeJS.ProcessEnv): ReadonlyArray<string> => [
   ...trimNonEmpty(env.USERPROFILE).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}\\.local\\bin`, `${value}\\.bun\\bin`, `${value}\\scoop\\shims`],
+      onSome: (value) => [`${value}\\.local\\bin`, `${value}\\.bun\\bin`, `${value}\\scoop\\shims`, `${value}\\.cargo\\bin`],
     }),
   ),
 ];
@@ -387,28 +387,57 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
       readEnvPath(config.env),
     ]);
 
-    let nodeFound = false;
-    let fnmFound = false;
-    if (Option.isSome(staticPaths)) {
+    const checkNodeStatically = Effect.gen(function* () {
+      if (Option.isNone(staticPaths)) return false;
       for (const dir of staticPaths.value.split(";")) {
         const cleanDir = dir.trim().replace(/^"+|"+$/g, "");
-        if (!nodeFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/node.exe`), () => false))) {
-          nodeFound = true;
-        }
-        if (!fnmFound && (
-          (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/fnm.exe`), () => false)) ||
-          (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/fnm.cmd`), () => false)) ||
-          (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/fnm.ps1`), () => false))
-        )) {
-          fnmFound = true;
-        }
-        if (nodeFound && fnmFound) break;
+        if (cleanDir.length === 0) continue;
+        const hasNode = yield* fileSystem.exists(`${cleanDir}\\node.exe`).pipe(
+          Effect.catchAll(() => Effect.succeed(false))
+        );
+        if (hasNode) return true;
       }
-    }
+      return false;
+    }).pipe(
+      Effect.timeoutOption(Duration.millis(250)),
+      Effect.map(Option.getOrElse(() => false))
+    );
 
-    const skipProfile = nodeFound && !fnmFound;
+    const checkProfileMentionsFnm = Effect.gen(function* () {
+      const userProfile = config.env.USERPROFILE;
+      if (!userProfile) return true; // unsafe to skip if we can't find the profile
+      const profilePaths = [
+        `${userProfile}\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1`,
+        `${userProfile}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1`,
+        `${userProfile}\\Documents\\WindowsPowerShell\\profile.ps1`,
+        `${userProfile}\\Documents\\PowerShell\\profile.ps1`,
+      ];
+      for (const p of profilePaths) {
+        const content = yield* fileSystem.readFileString(p).pipe(
+          Effect.catchIf(
+            (err) => err._tag === "SystemError" && err.reason === "NotFound",
+            () => Effect.succeed("")
+          )
+        );
+        if (content.toLowerCase().includes("fnm")) {
+          return true;
+        }
+      }
+      return false;
+    }).pipe(
+      Effect.catchAll(() => Effect.succeed(true)), // On permission or other errors, assume unsafe to skip
+      Effect.timeoutOption(Duration.millis(250)),
+      Effect.map(Option.getOrElse(() => true))
+    );
 
-    // If node is found statically and no fnm wrappers exist, we can skip BOTH PowerShell probes entirely!
+    const [nodeFound, profileMentionsFnm] = yield* Effect.all([
+      checkNodeStatically,
+      checkProfileMentionsFnm
+    ], { concurrency: 2 });
+
+    const skipProfile = nodeFound && !profileMentionsFnm;
+
+    // If node is found statically and no fnm profile refs exist, we can skip BOTH PowerShell probes entirely!
     if (skipProfile) {
       if (Option.isSome(staticPaths)) {
         config.env.PATH = staticPaths.value;

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -393,7 +393,7 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
         const cleanDir = dir.trim().replace(/^"+|"+$/g, "");
         if (cleanDir.length === 0) continue;
         const hasNode = yield* fileSystem.exists(`${cleanDir}\\node.exe`).pipe(
-          Effect.catchAll(() => Effect.succeed(false))
+          Effect.orElseSucceed(() => false)
         );
         if (hasNode) return true;
       }
@@ -413,19 +413,23 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
         `${userProfile}\\Documents\\PowerShell\\profile.ps1`,
       ];
       for (const p of profilePaths) {
-        const content = yield* fileSystem.readFileString(p).pipe(
+        const bytes = yield* fileSystem.readFile(p).pipe(
           Effect.catchIf(
-            (err) => err._tag === "SystemError" && err.reason === "NotFound",
-            () => Effect.succeed("")
+            (err) => err.reason._tag === "NotFound",
+            () => Effect.succeed(new Uint8Array(0))
           )
         );
-        if (content.toLowerCase().includes("fnm")) {
-          return true;
+        if (bytes.length > 0) {
+          const textUtf8 = new TextDecoder("utf-8").decode(bytes);
+          const textUtf16 = new TextDecoder("utf-16le").decode(bytes);
+          if (textUtf8.toLowerCase().includes("fnm") || textUtf16.toLowerCase().includes("fnm")) {
+            return true;
+          }
         }
       }
       return false;
     }).pipe(
-      Effect.catchAll(() => Effect.succeed(true)), // On permission or other errors, assume unsafe to skip
+      Effect.orElseSucceed(() => true), // On permission or other errors, assume unsafe to skip
       Effect.timeoutOption(Duration.millis(250)),
       Effect.map(Option.getOrElse(() => true))
     );

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -409,7 +409,7 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
       [
         readWindowsEnvironment(["PATH"], { loadProfile: false }),
         skipProfile
-          ? Effect.succeed({})
+          ? Effect.succeed<EnvironmentPatch>({})
           : readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
       ],
       { concurrency: 2 },

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -195,19 +195,19 @@ const knownWindowsCliDirs = (env: NodeJS.ProcessEnv): ReadonlyArray<string> => [
   ...trimNonEmpty(env.APPDATA).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}/npm`],
+      onSome: (value) => [`${value}\\npm`],
     }),
   ),
   ...trimNonEmpty(env.LOCALAPPDATA).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}/Programs/nodejs`, `${value}/Volta/bin`, `${value}/pnpm`],
+      onSome: (value) => [`${value}\\Programs\\nodejs`, `${value}\\Volta\\bin`, `${value}\\pnpm`],
     }),
   ),
   ...trimNonEmpty(env.USERPROFILE).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}/.local/bin`, `${value}/.bun/bin`, `${value}/scoop/shims`],
+      onSome: (value) => [`${value}\\.local\\bin`, `${value}\\.bun\\bin`, `${value}\\scoop\\shims`],
     }),
   ),
 ];

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -1,7 +1,6 @@
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
-import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -382,24 +381,16 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
   ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem> {
     const fileSystem = yield* FileSystem.FileSystem;
 
-    // Start the slow profile probe in the background immediately.
-    const profileFiber = yield* Effect.fork(
-      readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true })
-    );
-
-    // Concurrently run the no-profile probe as a fast baseline.
-    const noProfile = yield* readWindowsEnvironment(["PATH"], { loadProfile: false });
-
-    const fastMergedPath = mergePaths("win32", [
+    // Fast pre-check using static paths (no PowerShell required)
+    const staticPaths = mergePaths("win32", [
       trimNonEmpty(knownWindowsCliDirs(config.env).join(";")),
-      trimNonEmpty(noProfile.PATH),
       readEnvPath(config.env),
     ]);
 
     let nodeFound = false;
     let fnmFound = false;
-    if (Option.isSome(fastMergedPath)) {
-      for (const dir of fastMergedPath.value.split(";")) {
+    if (Option.isSome(staticPaths)) {
+      for (const dir of staticPaths.value.split(";")) {
         const cleanDir = dir.trim().replace(/^"+|"+$/g, "");
         if (!nodeFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${cleanDir}/node.exe`), () => false))) {
           nodeFound = true;
@@ -411,14 +402,24 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
       }
     }
 
-    // Only wait for the expensive PowerShell profile if the fast baseline is insufficient,
-    // or if the user actively uses fnm (which requires FNM_DIR from the profile).
-    let profile: EnvironmentPatch = {};
-    if (nodeFound && !fnmFound) {
-      yield* Fiber.interrupt(profileFiber);
-    } else {
-      profile = yield* Fiber.join(profileFiber);
-    }
+    const skipProfile = nodeFound && !fnmFound;
+
+    // Run the necessary probes concurrently, bounded by the slowest single probe
+    const [noProfile, profile] = yield* Effect.all(
+      [
+        readWindowsEnvironment(["PATH"], { loadProfile: false }),
+        skipProfile
+          ? Effect.succeed({})
+          : readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
+      ],
+      { concurrency: 2 },
+    );
+
+    const fastMergedPath = mergePaths("win32", [
+      trimNonEmpty(knownWindowsCliDirs(config.env).join(";")),
+      trimNonEmpty(noProfile.PATH),
+      readEnvPath(config.env),
+    ]);
 
     const mergedPath = mergePaths("win32", [
       trimNonEmpty(profile.PATH),

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -381,7 +382,12 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
   ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem> {
     const fileSystem = yield* FileSystem.FileSystem;
 
-    // Run the no-profile probe first as a fast baseline.
+    // Start the slow profile probe in the background immediately.
+    const profileFiber = yield* Effect.fork(
+      readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true })
+    );
+
+    // Concurrently run the no-profile probe as a fast baseline.
     const noProfile = yield* readWindowsEnvironment(["PATH"], { loadProfile: false });
 
     const fastMergedPath = mergePaths("win32", [
@@ -405,11 +411,14 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
       }
     }
 
-    // Only load the expensive PowerShell profile if the fast baseline is insufficient,
+    // Only wait for the expensive PowerShell profile if the fast baseline is insufficient,
     // or if the user actively uses fnm (which requires FNM_DIR from the profile).
-    const profile: EnvironmentPatch = (nodeFound && !fnmFound)
-      ? {}
-      : yield* readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true });
+    let profile: EnvironmentPatch = {};
+    if (nodeFound && !fnmFound) {
+      yield* Fiber.interrupt(profileFiber);
+    } else {
+      profile = yield* Fiber.join(profileFiber);
+    }
 
     const mergedPath = mergePaths("win32", [
       trimNonEmpty(profile.PATH),

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -391,18 +391,22 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
     ]);
 
     let nodeFound = false;
+    let fnmFound = false;
     if (Option.isSome(fastMergedPath)) {
       for (const dir of fastMergedPath.value.split(";")) {
-        const nodePath = `${dir}\\node.exe`;
-        if (yield* Effect.orElseSucceed(fileSystem.exists(nodePath), () => false)) {
+        if (!nodeFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${dir}\\node.exe`), () => false))) {
           nodeFound = true;
-          break;
         }
+        if (!fnmFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${dir}\\fnm.exe`), () => false))) {
+          fnmFound = true;
+        }
+        if (nodeFound && fnmFound) break;
       }
     }
 
-    // Only load the expensive PowerShell profile if the fast baseline is insufficient.
-    const profile = nodeFound
+    // Only load the expensive PowerShell profile if the fast baseline is insufficient,
+    // or if the user actively uses fnm (which requires FNM_DIR from the profile).
+    const profile: EnvironmentPatch = (nodeFound && !fnmFound)
       ? {}
       : yield* readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true });
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -416,7 +416,12 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
       return; // Exit early, 0ms startup!
     }
 
-    // Run the necessary probes concurrently, bounded by the slowest single probe
+    // Concurrent, not sequential: these two probes are independent (only their
+    // results are combined below) and each spawns its own PowerShell. Run in
+    // series they sit at offset 0 of desktop.startup, before anything else, and
+    // launch traces measured them at 2718ms then 2066ms — the entire 4.8s
+    // startup span, of which desktop.bootstrap is ~30ms. Total cost here is
+    // therefore bounded by the slowest single probe.
     const [noProfile, profile] = yield* Effect.all(
       [
         readWindowsEnvironment(["PATH"], { loadProfile: false }),

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -378,24 +378,37 @@ const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEn
 const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWindowsEnvironment")(
   function* (
     config: ShellEnvironmentConfig,
-  ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner> {
-    // Concurrent, not sequential: these two probes are independent (only their
-    // results are combined below) and each spawns its own PowerShell. Run in
-    // series they sit at offset 0 of desktop.startup, before anything else, and
-    // launch traces measured them at 2718ms then 2066ms — the entire 4.8s
-    // startup span, of which desktop.bootstrap is ~30ms.
-    const [noProfile, profile] = yield* Effect.all(
-      [
-        readWindowsEnvironment(["PATH"], { loadProfile: false }),
-        readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
-      ],
-      { concurrency: 2 },
-    );
-    const mergedPath = mergePaths("win32", [
-      trimNonEmpty(profile.PATH),
+  ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem> {
+    const fileSystem = yield* FileSystem.FileSystem;
+
+    // Run the no-profile probe first as a fast baseline.
+    const noProfile = yield* readWindowsEnvironment(["PATH"], { loadProfile: false });
+
+    const fastMergedPath = mergePaths("win32", [
       trimNonEmpty(knownWindowsCliDirs(config.env).join(";")),
       trimNonEmpty(noProfile.PATH),
       readEnvPath(config.env),
+    ]);
+
+    let nodeFound = false;
+    if (Option.isSome(fastMergedPath)) {
+      for (const dir of fastMergedPath.value.split(";")) {
+        const nodePath = `${dir}\\node.exe`;
+        if (yield* Effect.orElseSucceed(fileSystem.exists(nodePath), () => false)) {
+          nodeFound = true;
+          break;
+        }
+      }
+    }
+
+    // Only load the expensive PowerShell profile if the fast baseline is insufficient.
+    const profile = nodeFound
+      ? {}
+      : yield* readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true });
+
+    const mergedPath = mergePaths("win32", [
+      trimNonEmpty(profile.PATH),
+      fastMergedPath,
     ]);
 
     if (Option.isSome(mergedPath)) {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -394,10 +394,10 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
     let fnmFound = false;
     if (Option.isSome(fastMergedPath)) {
       for (const dir of fastMergedPath.value.split(";")) {
-        if (!nodeFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${dir}\\node.exe`), () => false))) {
+        if (!nodeFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${dir}/node.exe`), () => false))) {
           nodeFound = true;
         }
-        if (!fnmFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${dir}\\fnm.exe`), () => false))) {
+        if (!fnmFound && (yield* Effect.orElseSucceed(fileSystem.exists(`${dir}/fnm.exe`), () => false))) {
           fnmFound = true;
         }
         if (nodeFound && fnmFound) break;


### PR DESCRIPTION
Fixes #4403 by skipping the slow PowerShell profile load if node.exe is already found in the no-profile path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows startup PATH/FNM resolution; conservative fallbacks re-run PowerShell on profile read errors or missing USERPROFILE, but a false negative on fnm detection could omit FNM env vars until probes run.
> 
> **Overview**
> **Windows desktop startup** can skip both PowerShell environment probes when `node.exe` is already discoverable from the current PATH plus `knownWindowsCliDirs`, and no PowerShell profile text mentions `fnm`.
> 
> Before spawning PowerShell, `installWindowsEnvironment` runs parallel **filesystem** checks (250ms caps): scan merged static PATH entries for `node.exe` (including quoted segments) and read standard/OneDrive profile paths for an `fnm` reference (UTF-8/UTF-16). On the fast path it sets `PATH` from that static merge and returns; otherwise it keeps the existing concurrent no-profile + profile probes and still merges `FNM_*` from the profile run.
> 
> Also adds **`~\.cargo\bin`** to known Windows CLI dirs. Tests gain injectable `FileSystem` and cases covering skip vs probe when fnm appears in normal or OneDrive profiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23081bac7379dbab10027e70a4104f0049f968e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip PowerShell profile load on Windows startup when node.exe is found on static paths
> - On Windows, `installWindowsEnvironment` now checks for `node.exe` in known static CLI dirs (PATH + `knownWindowsCliDirs`) and scans PowerShell profiles for `fnm` references before spawning any PowerShell processes.
> - If node is found and no profile references `fnm`, both PowerShell probes are skipped entirely and PATH is set from static sources, avoiding slow profile load on startup.
> - If node is found but a profile references `fnm` (including OneDrive-redirected profiles), the existing PowerShell probes still run to pick up `FNM_DIR`.
> - Adds `~\.cargo\bin` to `knownWindowsCliDirs` so Rust toolchain binaries are included in the merged PATH.
> - `installWindowsEnvironment` now requires a `FileSystem.FileSystem` service in its effect environment for existence checks and profile reads (with 250ms timeouts).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23081ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->