### PR TITLE
fix(web): prevent task checkboxes from overwriting large Markdown files

### DIFF
--- a/apps/web/src/components/files/FilePreviewPanel.test.ts
+++ b/apps/web/src/components/files/FilePreviewPanel.test.ts
@@ -5,7 +5,11 @@ import {
   normalizeFileCommentRange,
   remapFileCommentAnnotations,
 } from "./fileCommentAnnotations";
-import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
+import {
+  isMarkdownPreviewFile,
+  resolveMarkdownTaskPreviewUpdate,
+  setMarkdownTaskChecked,
+} from "./filePreviewMode";
 
 describe("file comment annotations", () => {
   it("normalizes and formats selected line ranges", () => {
@@ -78,5 +82,32 @@ describe("setMarkdownTaskChecked", () => {
   it("leaves the document unchanged for a stale or invalid marker offset", () => {
     expect(setMarkdownTaskChecked(markdown, 0, true)).toBe(markdown);
     expect(setMarkdownTaskChecked(markdown, 200, true)).toBe(markdown);
+  });
+
+  it("refuses rendered task-list mutations for a truncated Markdown read", () => {
+    const fullMarkdown = `- [ ] Keep the complete file\n${"x".repeat(1024 * 1024)}`;
+    const truncatedMarkdown = fullMarkdown.slice(0, 1024 * 1024);
+
+    expect(
+      resolveMarkdownTaskPreviewUpdate({
+        markdown: truncatedMarkdown,
+        markerOffset: 2,
+        checked: true,
+        truncated: true,
+      }),
+    ).toBeNull();
+    expect(fullMarkdown.startsWith(truncatedMarkdown)).toBe(true);
+    expect(fullMarkdown.length).toBeGreaterThan(truncatedMarkdown.length);
+  });
+
+  it("returns a task-list update for a complete Markdown read", () => {
+    expect(
+      resolveMarkdownTaskPreviewUpdate({
+        markdown,
+        markerOffset: 2,
+        checked: true,
+        truncated: false,
+      }),
+    ).toBe("- [x] First\n- [x] Second\n");
   });
 });

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -55,7 +55,7 @@ import { resolveCenteredFileLineScrollTop } from "./fileLineReveal";
 import { DiffCommentAnnotation } from "../diffs/DiffCommentAnnotation";
 import { projectFileCacheKey, projectFileEditorCacheKey } from "./fileContentRevision";
 import { fileBreadcrumbs } from "./filePath";
-import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
+import { isMarkdownPreviewFile, resolveMarkdownTaskPreviewUpdate } from "./filePreviewMode";
 import { FileSaveCoordinator } from "./fileSaveCoordinator";
 import {
   confirmProjectFileQueryData,
@@ -704,6 +704,7 @@ function RenderedMarkdownSurface({
   cwd,
   relativePath,
   contents,
+  truncated,
   threadRef,
   onPendingChange,
 }: Omit<
@@ -715,6 +716,7 @@ function RenderedMarkdownSurface({
   | "wordWrap"
   | "onPostRender"
 > & {
+  truncated: boolean;
   threadRef: ScopedThreadRef;
 }) {
   const saveCoordinator = useFileSaveCoordinator({
@@ -731,15 +733,24 @@ function RenderedMarkdownSurface({
         cwd={cwd}
         threadRef={threadRef}
         className="mx-auto max-w-4xl px-6 py-5"
-        onTaskListChange={({ markerOffset, checked }) => {
-          const currentContents =
-            getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??
-            contents;
-          const nextContents = setMarkdownTaskChecked(currentContents, markerOffset, checked);
-          if (nextContents === currentContents) return;
-          setProjectFileQueryData(environmentId, cwd, relativePath, nextContents);
-          saveCoordinator.change(nextContents);
-        }}
+        onTaskListChange={
+          truncated
+            ? undefined
+            : ({ markerOffset, checked }) => {
+                const currentContents =
+                  getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??
+                  contents;
+                const nextContents = resolveMarkdownTaskPreviewUpdate({
+                  markdown: currentContents,
+                  markerOffset,
+                  checked,
+                  truncated,
+                });
+                if (nextContents === null) return;
+                setProjectFileQueryData(environmentId, cwd, relativePath, nextContents);
+                saveCoordinator.change(nextContents);
+              }
+        }
       />
     </ScrollArea>
   );
@@ -970,7 +981,8 @@ export default function FilePreviewPanel({
       ) : null}
       {relativePath && file.data?.truncated ? (
         <div className="shrink-0 border-b border-warning/20 bg-warning-surface px-3 py-1.5 text-[11px] text-warning-foreground">
-          Preview limited to the first 1 MB of a {file.data.byteLength.toLocaleString()} byte file.
+          Read-only preview limited to the first 1 MB of a {file.data.byteLength.toLocaleString()}{" "}
+          byte file.
         </div>
       ) : null}
       <div className="flex min-h-0 flex-1 overflow-hidden">
@@ -1004,6 +1016,7 @@ export default function FilePreviewPanel({
                 relativePath={relativePath}
                 threadRef={threadRef}
                 contents={file.data.contents}
+                truncated={file.data.truncated}
                 onPendingChange={onPendingChange}
               />
             ) : file.data.truncated ? (

--- a/apps/web/src/components/files/filePreviewMode.ts
+++ b/apps/web/src/components/files/filePreviewMode.ts
@@ -16,3 +16,14 @@ export function setMarkdownTaskChecked(
 
   return `${markdown.slice(0, markerOffset + 1)}${checked ? "x" : " "}${markdown.slice(markerOffset + 2)}`;
 }
+
+export function resolveMarkdownTaskPreviewUpdate(input: {
+  readonly markdown: string;
+  readonly markerOffset: number;
+  readonly checked: boolean;
+  readonly truncated: boolean;
+}): string | null {
+  if (input.truncated) return null;
+  const nextMarkdown = setMarkdownTaskChecked(input.markdown, input.markerOffset, input.checked);
+  return nextMarkdown === input.markdown ? null : nextMarkdown;
+}


### PR DESCRIPTION
## What Changed

- Large Markdown files still open as rendered previews, but their task-list checkboxes are now read-only.
- The preview also has a defensive guard that refuses task-list updates whenever the file contents are truncated.
- The existing size warning now says explicitly that the preview is read-only.
- Regression tests cover both a truncated file larger than the 1 MiB preview limit and an ordinary complete Markdown file.

## Why

The file reader intentionally returns only the first 1 MiB of a large text file and marks that result as truncated. The rendered Markdown path was selected before the general read-only truncated-text path, however, so task-list checkboxes still had an active save handler.

Clicking one of those checkboxes could send the truncated prefix to the whole-file writer. That could replace the complete Markdown file with only its first 1 MiB and discard everything after the preview limit.

This change keeps the useful rendered preview while removing its mutation path. Complete Markdown files behave exactly as before.

## UI Changes

The existing warning now begins with “Read-only preview,” and task checkboxes in a truncated Markdown preview no longer accept changes. The layout is unchanged.

### Visual proof

<img width="1084" height="768" alt="T3 Code fixed large Markdown preview showing an explicit read-only banner and a disabled task checkbox" src="https://github.com/user-attachments/assets/572ec78c-4121-4332-8780-b881bd66a969" />

This screenshot is from an isolated desktop build of this PR using a synthetic 1,232,144-byte Markdown file. After clicking the visible checkbox, it remained disabled and unchecked. The file also retained its original SHA-256 (`f96f00c1a67f7aa39888fbdacf85f6075e033ed3e6f6946b80fe1710c076559e`), byte count, and `END-OF-FILE-SENTINEL-MUST-SURVIVE` tail marker.

## Validation

- `pnpm exec vp test run apps/web/src/components/files/FilePreviewPanel.test.ts apps/web/src/components/files/fileSaveCoordinator.test.ts apps/web/src/components/files/projectFilesQueryState.test.ts` — 12 tests passed
- `pnpm --filter @t3tools/web typecheck`
- targeted lint for the three changed files
- targeted format check for the three changed files
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included visual proof for the UI change
- [x] A video is not applicable; this change removes an unsafe interaction and has no animation

Model: GPT-5. Harness: OpenAI Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent task checkboxes from modifying truncated Markdown files in file preview
> - Adds `resolveMarkdownTaskPreviewUpdate` in [filePreviewMode.ts](https://github.com/pingdotgg/t3code/pull/6304/files#diff-3d42bc71d49c181cfe059279ce1523d43b76136616f7c409c50622767f3a66fb) that returns `null` for truncated content or no-op changes, replacing direct use of `setMarkdownTaskChecked`.
> - Disables the `onTaskListChange` handler in `RenderedMarkdownSurface` when the file read is truncated, preventing partial overwrites of large files.
> - Updates the truncated file banner copy to "Read-only preview" to signal non-interactivity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56d80e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Markdown preview save path that writes project files; a missed truncated guard could still cause data loss, though the change itself is a narrow defensive fix.
> 
> **Overview**
> **Prevents truncated Markdown previews from saving partial content** when task-list checkboxes are toggled.
> 
> Rendered Markdown still opens for large files, but `onTaskListChange` is disabled when the read is truncated. A new `resolveMarkdownTaskPreviewUpdate` helper also refuses updates for truncated content as a second guard. The size warning now says **Read-only preview**. Complete Markdown files keep the previous editable checkbox behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d80e6ad6cf833044e8e83a1c89e8ed2c212e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->