### PR TITLE
fix(usage): resolve transcript dirs from providerInstances

### DIFF
--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -1,0 +1,44 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import { ServerSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import { resolveTranscriptDirsForSettings } from "./UsageService.ts";
+
+const decodeSettings = Schema.decodeSync(ServerSettings);
+
+it.layer(NodeServices.layer)("resolveTranscriptDirsForSettings", (it) => {
+  describe("provider instances", () => {
+    it.effect("includes custom Codex homes and deduplicates legacy homes", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const legacyHome = path.resolve("/tmp/t3-legacy-codex-home");
+        const instanceHome = path.resolve("/tmp/t3-instance-codex-home");
+        const settings = decodeSettings({
+          providers: { codex: { homePath: legacyHome } },
+          providerInstances: {
+            codex_work: {
+              driver: "codex",
+              enabled: true,
+              config: { homePath: instanceHome },
+            },
+            codex_legacy_duplicate: {
+              driver: "codex",
+              enabled: true,
+              config: { homePath: legacyHome },
+            },
+          },
+        });
+
+        const dirs = yield* resolveTranscriptDirsForSettings(settings);
+
+        expect(dirs.filter(({ provider }) => provider === "codex")).toEqual([
+          { provider: "codex", dir: path.join(legacyHome, "sessions") },
+          { provider: "codex", dir: path.join(instanceHome, "sessions") },
+        ]);
+      }),
+    );
+  });
+});

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -14,6 +14,9 @@
 import * as NodeOS from "node:os";
 
 import {
+  ClaudeSettings,
+  CodexSettings,
+  type ServerSettings as ServerSettingsConfig,
   USAGE_CONTRACT_VERSION,
   type UsageProviderKind,
   type UsageSource,
@@ -85,6 +88,51 @@ const encodeRatesCache = Schema.encodeEffect(
 const ScanCacheJson = Schema.fromJsonString(Schema.Unknown as unknown as Schema.Codec<unknown>);
 const decodeScanCacheFile = Schema.decodeUnknownEffect(ScanCacheJson);
 const encodeScanCacheFile = Schema.encodeEffect(ScanCacheJson);
+const decodeCodexSettings = Schema.decodeUnknownOption(CodexSettings);
+const decodeClaudeSettings = Schema.decodeUnknownOption(ClaudeSettings);
+
+export const resolveTranscriptDirsForSettings = Effect.fn(
+  "UsageService.resolveTranscriptDirsForSettings",
+)(function* (settings: ServerSettingsConfig) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const codexConfigs = [settings.providers.codex];
+  const claudeConfigs = [settings.providers.claudeAgent];
+
+  for (const instance of Object.values(settings.providerInstances)) {
+    if (instance.enabled === false) continue;
+    if (instance.driver === "codex") {
+      const config = decodeCodexSettings(instance.config ?? {});
+      if (Option.isSome(config) && (instance.enabled ?? config.value.enabled)) {
+        codexConfigs.push(config.value);
+      }
+    } else if (instance.driver === "claudeAgent") {
+      const config = decodeClaudeSettings(instance.config ?? {});
+      if (Option.isSome(config) && (instance.enabled ?? config.value.enabled)) {
+        claudeConfigs.push(config.value);
+      }
+    }
+  }
+
+  const dirs: Array<{ readonly provider: UsageProviderKind; readonly dir: string }> = [];
+  for (const config of claudeConfigs) {
+    const homePath = yield* resolveClaudeHomePath(config);
+    const nested = path.join(homePath, ".claude", "projects");
+    const nestedExists = yield* fileSystem
+      .exists(nested)
+      .pipe(Effect.catchCause(() => Effect.succeed(false)));
+    dirs.push({
+      provider: "claude",
+      dir: nestedExists ? nested : path.join(homePath, "projects"),
+    });
+  }
+  for (const config of codexConfigs) {
+    const layout = yield* resolveCodexHomeLayout(config);
+    dirs.push({ provider: "codex", dir: path.join(layout.sharedHomePath, "sessions") });
+  }
+
+  return [...new Map(dirs.map((entry) => [`${entry.provider}\0${entry.dir}`, entry])).values()];
+});
 
 export class UsageService extends Context.Service<
   UsageService,
@@ -184,19 +232,6 @@ export const make = Effect.gen(function* () {
     );
   });
 
-  /**
-   * Claude's config dir is the home itself when overridden, but a default
-   * install nests transcripts under `~/.claude/projects`. Probe both.
-   */
-  const resolveClaudeTranscriptDir = (homePath: string) =>
-    Effect.gen(function* () {
-      const nested = path.join(homePath, ".claude", "projects");
-      const nestedExists = yield* fileSystem
-        .exists(nested)
-        .pipe(Effect.catchCause(() => Effect.succeed(false)));
-      return nestedExists ? nested : path.join(homePath, "projects");
-    });
-
   /** Resolves the transcript directory for each provider. */
   const resolveTranscriptDirs = Effect.fn("UsageService.resolveTranscriptDirs")(function* () {
     // A settings failure must surface as an error: swallowing it here would
@@ -215,14 +250,9 @@ export const make = Effect.gen(function* () {
       ),
     );
 
-    const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
-    const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
-    const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
-
-    return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
-    ];
+    return yield* resolveTranscriptDirsForSettings(settings).pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+    );
   });
 
   /**


### PR DESCRIPTION
## What changed

`UsageService.resolveTranscriptDirs` only read the legacy `settings.providers.codex` / `settings.providers.claudeAgent` structs to find the Codex/Claude transcript directories to scan. The Settings UI, however, persists provider config to the newer `settings.providerInstances` map (`packages/contracts/src/settings.ts`). As a result, a Codex (or Claude) home configured via Settings was never scanned and usage reported zero.

This decodes enabled Codex/Claude entries from `settings.providerInstances` with the existing `CodexSettings`/`ClaudeSettings` schemas, resolves their transcript dirs with the same existing resolvers (`resolveCodexHomeLayout` / the Claude home probe), and merges the result with the legacy-derived dirs, deduplicating by `(provider, dir)` so a home configured both ways isn't scanned twice.

Fixes #6310.

## Why

Users who configure a custom Codex/Claude home via the newer Settings provider-instances UI got silent zero usage, since the scanner never looked there.

No UI change — this is a server-side scan-directory fix.

## Tests

Added `apps/server/src/usage/UsageService.test.ts` covering a custom Codex-instance home being included in the scan, and dedup when the same home is configured both legacily and via a provider instance. `pnpm vitest run src/usage` (39/39 passing) and `tsgo --noEmit` (clean) verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve transcript dirs from provider instances in `UsageService`
> - Introduces `resolveTranscriptDirsForSettings` in [UsageService.ts](https://github.com/pingdotgg/t3code/pull/6312/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70) that collects transcript directories from both base provider configs and enabled `providerInstances` for `codex` and `claudeAgent`.
> - Deduplicates results by provider+path using a Map, replacing the previous fixed pair of provider dirs.
> - `resolveTranscriptDirs` now delegates to the new helper, explicitly providing the `FileSystem` service.
> - Behavioral Change: transcript dir resolution now returns a variable-length deduplicated list instead of always returning exactly one dir per provider.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b908a84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->