### PR TITLE
feat(web): reset sidebar width on double click

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -10,7 +10,7 @@ import {
 import { useLocation, useNavigate } from "@tanstack/react-router";
 
 import { isElectron } from "../env";
-import { getLocalStorageItem } from "../hooks/useLocalStorage";
+import { getLocalStorageItem, removeLocalStorageItem } from "../hooks/useLocalStorage";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { cn, isMacPlatform } from "../lib/utils";
 import { primaryServerKeybindingsAtom } from "../state/server";
@@ -147,6 +147,14 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   // that would otherwise refresh a render-time snapshot.
   const viewportWidth = useSyncExternalStore(subscribeToViewportWidth, readViewportWidth);
   const sidebarMaximumWidth = resolveThreadSidebarMaximumWidth(viewportWidth);
+  const resetSidebarWidth = () => {
+    try {
+      removeLocalStorageItem(THREAD_SIDEBAR_WIDTH_STORAGE_KEY);
+    } catch (error) {
+      console.error("Could not clear persisted thread sidebar width.", error);
+    }
+    setSidebarWidth(resolveInitialThreadSidebarWidth(null, viewportWidth));
+  };
   const [isWindowFullscreen, setIsWindowFullscreen] = useState(() => {
     const getWindowFullscreenState = window.desktopBridge?.getWindowFullscreenState;
     return isMacosDesktop && typeof getWindowFullscreenState === "function"
@@ -225,7 +233,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         ) : (
           <ThreadSidebar />
         )}
-        <SidebarRail />
+        <SidebarRail onDoubleClick={resetSidebarWidth} />
       </Sidebar>
       {children}
       <SidebarControl />


### PR DESCRIPTION
## What Changed

- Double-clicking the left sidebar resize handle now restores the default width.
- The saved custom width is cleared so the reset persists after reload.

## Why

Users can resize the sidebar but had no quick way to return to the standard layout. This keeps the behavior local to the app sidebar and reuses the existing default-width and persistence helpers. This matches apps like VS Code.

## Interaction video:

https://github.com/user-attachments/assets/c0bcc4a9-95bd-4fcf-9969-df46d5d1fe59

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included a video for animation/interaction changes

Implemented with GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI preference change limited to sidebar width reset and localStorage cleanup; no auth, data, or backend impact.
> 
> **Overview**
> Double-clicking the left sidebar resize rail now restores the default width.
> 
> The handler clears the persisted `THREAD_SIDEBAR_WIDTH_STORAGE_KEY` value and recalculates the default with `resolveInitialThreadSidebarWidth`, so the reset sticks after reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf76ca8e4bac190b0754c8f97c295b4b3383d07b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset sidebar width to default on double-click of the sidebar rail
> Double-clicking the `SidebarRail` in [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/6320/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) now clears the persisted width from local storage and resets the current width to the viewport-derived default via `resolveInitialThreadSidebarWidth`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf76ca8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->