### PR TITLE
fix(mobile): preserve keyboard suggestions while typing

### DIFF
--- a/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
+++ b/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
@@ -252,6 +252,9 @@ class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
     val textLength = editor.text?.length ?: 0
     val safeStart = start.coerceIn(0, textLength)
     val safeEnd = end.coerceIn(0, textLength)
+    // Re-applying an unchanged selection resets the keyboard's suggestion
+    // state, so a no-op assignment must be skipped.
+    if (editor.selectionStart == safeStart && editor.selectionEnd == safeEnd) return
     editor.setSelection(safeStart, safeEnd)
   }
 
@@ -281,6 +284,10 @@ class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
     )
 
   private fun emitSelectionChange(start: Int, end: Int) {
+    // Caret moves advance the revision counter like text edits do: a
+    // controlled payload computed before this move is stale and must fail the
+    // revision guard instead of yanking the caret back mid-typing.
+    nativeEventCount += 1
     onComposerSelectionChange(
       mapOf(
         "value" to editor.text.toString(),

--- a/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
+++ b/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
@@ -489,6 +489,12 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate, UITextDro
       return
     }
     restoreBaseTypingAttributes()
+    // UIKit moves the selection before textViewDidChange runs. Emitting here
+    // would pair the post-edit text with a pre-edit revision counter, so let
+    // the change event that follows carry both; only pure caret moves emit.
+    guard self.textView.serializedText() == value else {
+      return
+    }
     emitSelection()
   }
 
@@ -774,8 +780,12 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate, UITextDro
   }
 
   private func emitSelection() {
+    // Caret moves advance the revision counter like text edits do: a
+    // controlled payload computed before this move is stale and must fail the
+    // revision guard instead of yanking the caret back mid-typing.
     let currentValue = textView.serializedText()
     let selection = sourceSelection()
+    nativeEventCount += 1
     onComposerSelectionChange([
       "value": currentValue,
       "selection": ["start": selection.start, "end": selection.end],
@@ -817,10 +827,16 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate, UITextDro
           NSMaxRange(nextRange) <= textView.attributedText.length else {
       return
     }
+    self.requestedSelection = nil
+    // Programmatically assigning selectedRange resets the keyboard's
+    // autocorrect and predictive-text context even when the range is
+    // unchanged, so a no-op assignment must be skipped.
+    guard !NSEqualRanges(nextRange, textView.selectedRange) else {
+      return
+    }
     isApplyingControlledValue = true
     textView.selectedRange = nextRange
     isApplyingControlledValue = false
-    self.requestedSelection = nil
   }
 
   private func updatePlaceholderVisibility() {

--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -102,11 +102,12 @@ export function ComposerEditor({
   const nativeRef = useRef<NativeComposerEditorRef>(null);
   const mostRecentEventCountRef = useRef(0);
   const [mostRecentEventCount, setMostRecentEventCount] = useState(0);
-  const [nativeEventSequence, setNativeEventSequence] = useState(0);
-  const previousRenderedEventSequenceRef = useRef(0);
-  const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([
-    { eventCount: 0, value: props.value, selection: selection ?? null },
-  ]);
+  const [, forceNativeEventRender] = useState(0);
+  // The native editor mounts empty, so the snapshot history starts empty: the
+  // first controlled payload must be a non-echo so a restored draft (or a
+  // recycled native view) is applied rather than skipped.
+  const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([]);
+  const lastDeliveredValueRef = useRef(props.value);
   const confirmedTokensRef = useRef(collectComposerInlineTokens(props.value));
   const bodyText = useScaledTextRole("body");
   const textColor = useThemeColor("--color-foreground");
@@ -154,15 +155,16 @@ export function ComposerEditor({
       })),
     );
   }, [props.value, skillLabels]);
-  const includesNativeEvent = nativeEventSequence !== previousRenderedEventSequenceRef.current;
-  const controlledEventCount = includesNativeEvent
-    ? resolveComposerControlledEventCount(
-        props.value,
-        selection ?? null,
-        mostRecentEventCount,
-        nativeEventSnapshotsRef.current,
-      )
-    : mostRecentEventCount;
+  // Every render resolves against the snapshot history, so a render whose
+  // (value, selection) lags the acknowledged native state is stamped behind
+  // the native revision and rejected by the editor instead of re-applying a
+  // stale caret or stale text mid-typing.
+  const controlledEventCount = resolveComposerControlledEventCount(
+    props.value,
+    selection ?? null,
+    mostRecentEventCount,
+    nativeEventSnapshotsRef.current,
+  );
   const acknowledgesLatestNativeEvent = isComposerNativeEcho(
     props.value,
     selection ?? null,
@@ -170,9 +172,7 @@ export function ComposerEditor({
     nativeEventSnapshotsRef.current,
   );
   const isNativeEcho =
-    includesNativeEvent &&
-    controlledEventCount === mostRecentEventCount &&
-    acknowledgesLatestNativeEvent;
+    controlledEventCount === mostRecentEventCount && acknowledgesLatestNativeEvent;
   const controlledDocumentJson = JSON.stringify({
     value: props.value,
     selection: isNativeEcho ? null : (selection ?? null),
@@ -180,9 +180,6 @@ export function ComposerEditor({
     mostRecentEventCount: controlledEventCount,
     isNativeEcho,
   });
-  useEffect(() => {
-    previousRenderedEventSequenceRef.current = nativeEventSequence;
-  }, [nativeEventSequence]);
   useEffect(() => {
     if (!acknowledgesLatestNativeEvent) return;
     nativeEventSnapshotsRef.current = pruneAcknowledgedComposerNativeEvents(
@@ -254,10 +251,11 @@ export function ComposerEditor({
           event.nativeEvent.selection,
         );
         if (acknowledgedEventCount === false) return;
+        lastDeliveredValueRef.current = event.nativeEvent.value;
         onChangeText(event.nativeEvent.value);
         onSelectionChange?.(event.nativeEvent.selection);
         setMostRecentEventCount(acknowledgedEventCount);
-        setNativeEventSequence((sequence) => sequence + 1);
+        forceNativeEventRender((sequence) => sequence + 1);
       }}
       onComposerSelectionChange={(event) => {
         const acknowledgedEventCount = acceptNativeEvent(
@@ -266,9 +264,17 @@ export function ComposerEditor({
           event.nativeEvent.selection,
         );
         if (acknowledgedEventCount === false) return;
+        // A selection event that carries text the change handler has not
+        // delivered yet (the platform emitted it mid-mutation) must also
+        // deliver the value, or the parent's next render would round-trip
+        // stale text stamped with this acknowledged revision.
+        if (event.nativeEvent.value !== lastDeliveredValueRef.current) {
+          lastDeliveredValueRef.current = event.nativeEvent.value;
+          onChangeText(event.nativeEvent.value);
+        }
         onSelectionChange?.(event.nativeEvent.selection);
         setMostRecentEventCount(acknowledgedEventCount);
-        setNativeEventSequence((sequence) => sequence + 1);
+        forceNativeEventRender((sequence) => sequence + 1);
       }}
       onComposerPasteImages={(event) => onPasteImages?.(event.nativeEvent.uris)}
       onComposerFocus={onFocus}

--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -275,6 +275,13 @@ export function ComposerEditor({
           event.nativeEvent.selection,
         );
         if (acknowledgedEventCount === false) return;
+        // A selection change that raced a text mutation can carry post-edit
+        // text. It must reach the parent alongside the acknowledged revision,
+        // or the next render stamps the stale draft at that revision and can
+        // re-apply it over the newer native text.
+        if (event.nativeEvent.value !== props.value) {
+          onChangeText(event.nativeEvent.value);
+        }
         onSelectionChange?.(event.nativeEvent.selection);
         setMostRecentEventCount(acknowledgedEventCount);
         forceNativeEventRender((sequence) => sequence + 1);

--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -19,6 +19,7 @@ import { useFontFamily } from "../lib/useFontFamily";
 import { useScaledTextRole } from "../features/settings/appearance/useScaledTextRole";
 import {
   acknowledgeComposerNativeEvent,
+  assumeComposerControlledState,
   isComposerNativeEcho,
   pruneAcknowledgedComposerNativeEvents,
   resolveComposerControlledEventCount,
@@ -107,7 +108,6 @@ export function ComposerEditor({
   // first controlled payload must be a non-echo so a restored draft (or a
   // recycled native view) is applied rather than skipped.
   const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([]);
-  const lastDeliveredValueRef = useRef(props.value);
   const confirmedTokensRef = useRef(collectComposerInlineTokens(props.value));
   const bodyText = useScaledTextRole("body");
   const textColor = useThemeColor("--color-foreground");
@@ -187,6 +187,18 @@ export function ComposerEditor({
       mostRecentEventCount,
     );
   }, [acknowledgesLatestNativeEvent, mostRecentEventCount]);
+  const assumedValue = props.value;
+  useEffect(() => {
+    // A native event that arrived after this render was committed moves the
+    // acknowledged revision forward; the editor rejects this payload, so the
+    // snapshot history must not assume it applied.
+    if (isNativeEcho || controlledEventCount !== mostRecentEventCountRef.current) return;
+    nativeEventSnapshotsRef.current = assumeComposerControlledState(
+      nativeEventSnapshotsRef.current,
+      controlledEventCount,
+      assumedValue,
+    );
+  }, [assumedValue, controlledEventCount, isNativeEcho, controlledDocumentJson]);
   const acceptNativeEvent = useCallback(
     (eventCount: number, value: string, nextSelection: ComposerEditorSelection) => {
       const acknowledgedEventCount = acknowledgeComposerNativeEvent(
@@ -251,7 +263,6 @@ export function ComposerEditor({
           event.nativeEvent.selection,
         );
         if (acknowledgedEventCount === false) return;
-        lastDeliveredValueRef.current = event.nativeEvent.value;
         onChangeText(event.nativeEvent.value);
         onSelectionChange?.(event.nativeEvent.selection);
         setMostRecentEventCount(acknowledgedEventCount);
@@ -264,14 +275,6 @@ export function ComposerEditor({
           event.nativeEvent.selection,
         );
         if (acknowledgedEventCount === false) return;
-        // A selection event that carries text the change handler has not
-        // delivered yet (the platform emitted it mid-mutation) must also
-        // deliver the value, or the parent's next render would round-trip
-        // stale text stamped with this acknowledged revision.
-        if (event.nativeEvent.value !== lastDeliveredValueRef.current) {
-          lastDeliveredValueRef.current = event.nativeEvent.value;
-          onChangeText(event.nativeEvent.value);
-        }
         onSelectionChange?.(event.nativeEvent.selection);
         setMostRecentEventCount(acknowledgedEventCount);
         forceNativeEventRender((sequence) => sequence + 1);

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -103,11 +103,12 @@ export function ComposerEditor({
   const nativeRef = useRef<NativeComposerEditorRef>(null);
   const mostRecentEventCountRef = useRef(0);
   const [mostRecentEventCount, setMostRecentEventCount] = useState(0);
-  const [nativeEventSequence, setNativeEventSequence] = useState(0);
-  const previousRenderedEventSequenceRef = useRef(0);
-  const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([
-    { eventCount: 0, value: props.value, selection: selection ?? null },
-  ]);
+  const [, forceNativeEventRender] = useState(0);
+  // The native editor mounts empty, so the snapshot history starts empty: the
+  // first controlled payload must be a non-echo so a restored draft (or a
+  // recycled native view) is applied rather than skipped.
+  const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([]);
+  const lastDeliveredValueRef = useRef(props.value);
   const [initialConfirmedTokens] = useState(() => collectComposerInlineTokens(props.value));
   const confirmedTokensRef = useRef(initialConfirmedTokens);
   const textColor = useThemeColor("--color-foreground");
@@ -155,15 +156,16 @@ export function ComposerEditor({
       })),
     );
   }, [props.value, skillLabels]);
-  const includesNativeEvent = nativeEventSequence !== previousRenderedEventSequenceRef.current;
-  const controlledEventCount = includesNativeEvent
-    ? resolveComposerControlledEventCount(
-        props.value,
-        selection ?? null,
-        mostRecentEventCount,
-        nativeEventSnapshotsRef.current,
-      )
-    : mostRecentEventCount;
+  // Every render resolves against the snapshot history, so a render whose
+  // (value, selection) lags the acknowledged native state is stamped behind
+  // the native revision and rejected by the editor instead of re-applying a
+  // stale caret or stale text mid-typing.
+  const controlledEventCount = resolveComposerControlledEventCount(
+    props.value,
+    selection ?? null,
+    mostRecentEventCount,
+    nativeEventSnapshotsRef.current,
+  );
   const acknowledgesLatestNativeEvent = isComposerNativeEcho(
     props.value,
     selection ?? null,
@@ -171,9 +173,7 @@ export function ComposerEditor({
     nativeEventSnapshotsRef.current,
   );
   const isNativeEcho =
-    includesNativeEvent &&
-    controlledEventCount === mostRecentEventCount &&
-    acknowledgesLatestNativeEvent;
+    controlledEventCount === mostRecentEventCount && acknowledgesLatestNativeEvent;
   const controlledDocumentJson = JSON.stringify({
     value: props.value,
     selection: isNativeEcho ? null : (selection ?? null),
@@ -181,9 +181,6 @@ export function ComposerEditor({
     mostRecentEventCount: controlledEventCount,
     isNativeEcho,
   });
-  useEffect(() => {
-    previousRenderedEventSequenceRef.current = nativeEventSequence;
-  }, [nativeEventSequence]);
   useEffect(() => {
     if (!acknowledgesLatestNativeEvent) return;
     nativeEventSnapshotsRef.current = pruneAcknowledgedComposerNativeEvents(
@@ -260,10 +257,11 @@ export function ComposerEditor({
             event.nativeEvent.selection,
           );
           if (acknowledgedEventCount === false) return;
+          lastDeliveredValueRef.current = event.nativeEvent.value;
           onChangeText(event.nativeEvent.value);
           onSelectionChange?.(event.nativeEvent.selection);
           setMostRecentEventCount(acknowledgedEventCount);
-          setNativeEventSequence((sequence) => sequence + 1);
+          forceNativeEventRender((sequence) => sequence + 1);
         }}
         onComposerSelectionChange={(event) => {
           const acknowledgedEventCount = acceptNativeEvent(
@@ -272,9 +270,17 @@ export function ComposerEditor({
             event.nativeEvent.selection,
           );
           if (acknowledgedEventCount === false) return;
+          // A selection event that carries text the change handler has not
+          // delivered yet (the platform emitted it mid-mutation) must also
+          // deliver the value, or the parent's next render would round-trip
+          // stale text stamped with this acknowledged revision.
+          if (event.nativeEvent.value !== lastDeliveredValueRef.current) {
+            lastDeliveredValueRef.current = event.nativeEvent.value;
+            onChangeText(event.nativeEvent.value);
+          }
           onSelectionChange?.(event.nativeEvent.selection);
           setMostRecentEventCount(acknowledgedEventCount);
-          setNativeEventSequence((sequence) => sequence + 1);
+          forceNativeEventRender((sequence) => sequence + 1);
         }}
         onComposerPasteImages={(event) => onPasteImages?.(event.nativeEvent.uris)}
         onComposerFocus={onFocus}

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -281,6 +281,14 @@ export function ComposerEditor({
             event.nativeEvent.selection,
           );
           if (acknowledgedEventCount === false) return;
+          // Android emits the selection change mid-mutation, before the change
+          // event, so the payload can carry post-edit text. It must reach the
+          // parent alongside the acknowledged revision, or the next render
+          // stamps the stale draft at that revision and can re-apply it over
+          // the newer native text.
+          if (event.nativeEvent.value !== props.value) {
+            onChangeText(event.nativeEvent.value);
+          }
           onSelectionChange?.(event.nativeEvent.selection);
           setMostRecentEventCount(acknowledgedEventCount);
           forceNativeEventRender((sequence) => sequence + 1);

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -21,6 +21,7 @@ import { useFontFamily } from "../lib/useFontFamily";
 import { useThemeColor } from "../lib/useThemeColor";
 import {
   acknowledgeComposerNativeEvent,
+  assumeComposerControlledState,
   isComposerNativeEcho,
   pruneAcknowledgedComposerNativeEvents,
   resolveComposerControlledEventCount,
@@ -108,7 +109,6 @@ export function ComposerEditor({
   // first controlled payload must be a non-echo so a restored draft (or a
   // recycled native view) is applied rather than skipped.
   const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([]);
-  const lastDeliveredValueRef = useRef(props.value);
   const [initialConfirmedTokens] = useState(() => collectComposerInlineTokens(props.value));
   const confirmedTokensRef = useRef(initialConfirmedTokens);
   const textColor = useThemeColor("--color-foreground");
@@ -188,6 +188,18 @@ export function ComposerEditor({
       mostRecentEventCount,
     );
   }, [acknowledgesLatestNativeEvent, mostRecentEventCount]);
+  const assumedValue = props.value;
+  useEffect(() => {
+    // A native event that arrived after this render was committed moves the
+    // acknowledged revision forward; the editor rejects this payload, so the
+    // snapshot history must not assume it applied.
+    if (isNativeEcho || controlledEventCount !== mostRecentEventCountRef.current) return;
+    nativeEventSnapshotsRef.current = assumeComposerControlledState(
+      nativeEventSnapshotsRef.current,
+      controlledEventCount,
+      assumedValue,
+    );
+  }, [assumedValue, controlledEventCount, isNativeEcho, controlledDocumentJson]);
   const acceptNativeEvent = useCallback(
     (eventCount: number, value: string, nextSelection: ComposerEditorSelection) => {
       const acknowledgedEventCount = acknowledgeComposerNativeEvent(
@@ -257,7 +269,6 @@ export function ComposerEditor({
             event.nativeEvent.selection,
           );
           if (acknowledgedEventCount === false) return;
-          lastDeliveredValueRef.current = event.nativeEvent.value;
           onChangeText(event.nativeEvent.value);
           onSelectionChange?.(event.nativeEvent.selection);
           setMostRecentEventCount(acknowledgedEventCount);
@@ -270,14 +281,6 @@ export function ComposerEditor({
             event.nativeEvent.selection,
           );
           if (acknowledgedEventCount === false) return;
-          // A selection event that carries text the change handler has not
-          // delivered yet (the platform emitted it mid-mutation) must also
-          // deliver the value, or the parent's next render would round-trip
-          // stale text stamped with this acknowledged revision.
-          if (event.nativeEvent.value !== lastDeliveredValueRef.current) {
-            lastDeliveredValueRef.current = event.nativeEvent.value;
-            onChangeText(event.nativeEvent.value);
-          }
           onSelectionChange?.(event.nativeEvent.selection);
           setMostRecentEventCount(acknowledgedEventCount);
           forceNativeEventRender((sequence) => sequence + 1);

--- a/apps/mobile/src/native/composerEditorRevision.test.ts
+++ b/apps/mobile/src/native/composerEditorRevision.test.ts
@@ -95,7 +95,7 @@ describe("pruneAcknowledgedComposerNativeEvents", () => {
       selection: { start: eventCount, end: eventCount },
     }));
 
-    expect(pruneAcknowledgedComposerNativeEvents(snapshots, 999)).toEqual([]);
+    expect(pruneAcknowledgedComposerNativeEvents(snapshots, 999)).toEqual([snapshots[999]]);
   });
 
   it("retains native events that arrive after the acknowledged render", () => {
@@ -104,6 +104,27 @@ describe("pruneAcknowledgedComposerNativeEvents", () => {
       { eventCount: 41, value: "ab", selection: { start: 2, end: 2 } },
     ];
 
-    expect(pruneAcknowledgedComposerNativeEvents(snapshots, 40)).toEqual([snapshots[1]]);
+    expect(pruneAcknowledgedComposerNativeEvents(snapshots, 40)).toEqual(snapshots);
+  });
+
+  it("retains the newest acknowledged snapshot so settled re-renders stay echoes", () => {
+    const snapshots = [
+      { eventCount: 40, value: "a", selection: { start: 1, end: 1 } },
+      { eventCount: 41, value: "ab", selection: { start: 2, end: 2 } },
+      { eventCount: 42, value: "abc", selection: { start: 3, end: 3 } },
+    ];
+
+    const pruned = pruneAcknowledgedComposerNativeEvents(snapshots, 42);
+    expect(pruned).toEqual([snapshots[2]]);
+    expect(isComposerNativeEcho("abc", { start: 3, end: 3 }, 42, pruned)).toBe(true);
+  });
+
+  it("keeps the newest of several snapshots sharing the acknowledged revision", () => {
+    const snapshots = [
+      { eventCount: 41, value: "ab", selection: { start: 2, end: 2 } },
+      { eventCount: 41, value: "ab", selection: { start: 1, end: 1 } },
+    ];
+
+    expect(pruneAcknowledgedComposerNativeEvents(snapshots, 41)).toEqual([snapshots[1]]);
   });
 });

--- a/apps/mobile/src/native/composerEditorRevision.test.ts
+++ b/apps/mobile/src/native/composerEditorRevision.test.ts
@@ -44,10 +44,17 @@ describe("isComposerNativeEcho", () => {
     expect(isComposerNativeEcho("native", null, 3, snapshots)).toBe(true);
   });
 
-  it("matches any controlled selection against an assumed state without one", () => {
+  it("does not claim a controlled selection against an assumed state without one", () => {
+    // An echo payload serializes `selection: null`; classifying a controlled
+    // selection as an echo of an assumed state would drop a parent caret move.
     const assumed = [{ eventCount: 3, value: "native", selection: null }];
-    expect(isComposerNativeEcho("native", { start: 0, end: 0 }, 3, assumed)).toBe(true);
+    expect(isComposerNativeEcho("native", { start: 0, end: 0 }, 3, assumed)).toBe(false);
     expect(isComposerNativeEcho("other", { start: 0, end: 0 }, 3, assumed)).toBe(false);
+  });
+
+  it("matches an assumed state when selection is uncontrolled", () => {
+    const assumed = [{ eventCount: 3, value: "native", selection: null }];
+    expect(isComposerNativeEcho("native", null, 3, assumed)).toBe(true);
   });
 });
 
@@ -155,6 +162,17 @@ describe("assumeComposerControlledState", () => {
       { eventCount: 3, value: "", selection: null },
       snapshots[1],
     ]);
+  });
+
+  it("applies a parent caret move on the assumed value at the assumed revision", () => {
+    // Same value, new caret: not an echo (so the selection is serialized) but
+    // still stamped at the assumed revision so the editor accepts it.
+    const snapshots = assumeComposerControlledState([], 3, "typed");
+
+    expect(isComposerNativeEcho("typed", { start: 2, end: 2 }, 3, snapshots)).toBe(false);
+    expect(resolveComposerControlledEventCount("typed", { start: 2, end: 2 }, 3, snapshots)).toBe(
+      3,
+    );
   });
 
   it("re-applies a parent value that round-trips back to an acknowledged state", () => {

--- a/apps/mobile/src/native/composerEditorRevision.test.ts
+++ b/apps/mobile/src/native/composerEditorRevision.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 
 import {
   acknowledgeComposerNativeEvent,
+  assumeComposerControlledState,
   isComposerNativeEcho,
   pruneAcknowledgedComposerNativeEvents,
   resolveComposerControlledEventCount,
@@ -41,6 +42,12 @@ describe("isComposerNativeEcho", () => {
 
   it("matches value and revision when selection is uncontrolled", () => {
     expect(isComposerNativeEcho("native", null, 3, snapshots)).toBe(true);
+  });
+
+  it("matches any controlled selection against an assumed state without one", () => {
+    const assumed = [{ eventCount: 3, value: "native", selection: null }];
+    expect(isComposerNativeEcho("native", { start: 0, end: 0 }, 3, assumed)).toBe(true);
+    expect(isComposerNativeEcho("other", { start: 0, end: 0 }, 3, assumed)).toBe(false);
   });
 });
 
@@ -126,5 +133,44 @@ describe("pruneAcknowledgedComposerNativeEvents", () => {
     ];
 
     expect(pruneAcknowledgedComposerNativeEvents(snapshots, 41)).toEqual([snapshots[1]]);
+  });
+});
+
+describe("assumeComposerControlledState", () => {
+  it("replaces the acknowledged history with the applied controlled state", () => {
+    const snapshots = [{ eventCount: 3, value: "typed", selection: { start: 5, end: 5 } }];
+
+    expect(assumeComposerControlledState(snapshots, 3, "")).toEqual([
+      { eventCount: 3, value: "", selection: null },
+    ]);
+  });
+
+  it("keeps native events that raced past the controlled revision", () => {
+    const snapshots = [
+      { eventCount: 3, value: "typed", selection: { start: 5, end: 5 } },
+      { eventCount: 4, value: "typed!", selection: { start: 6, end: 6 } },
+    ];
+
+    expect(assumeComposerControlledState(snapshots, 3, "")).toEqual([
+      { eventCount: 3, value: "", selection: null },
+      snapshots[1],
+    ]);
+  });
+
+  it("re-applies a parent value that round-trips back to an acknowledged state", () => {
+    // Native acknowledged "typed", the parent then controlled the editor to ""
+    // (a send clearing the draft) and back to "typed" (the send failed and the
+    // draft was restored). The restore must be a fresh non-echo edit stamped at
+    // the current revision, not an echo the editor would drop.
+    const snapshots = assumeComposerControlledState(
+      [{ eventCount: 3, value: "typed", selection: { start: 5, end: 5 } }],
+      3,
+      "",
+    );
+
+    expect(isComposerNativeEcho("typed", { start: 5, end: 5 }, 3, snapshots)).toBe(false);
+    expect(resolveComposerControlledEventCount("typed", { start: 5, end: 5 }, 3, snapshots)).toBe(
+      3,
+    );
   });
 });

--- a/apps/mobile/src/native/composerEditorRevision.ts
+++ b/apps/mobile/src/native/composerEditorRevision.ts
@@ -74,5 +74,20 @@ export function pruneAcknowledgedComposerNativeEvents(
   snapshots: ReadonlyArray<ComposerNativeEventSnapshot>,
   acknowledgedEventCount: number,
 ): ComposerNativeEventSnapshot[] {
-  return snapshots.filter((snapshot) => snapshot.eventCount > acknowledgedEventCount);
+  // The newest acknowledged snapshot must survive pruning: it is what lets a
+  // later, unrelated re-render classify the settled composer state as a native
+  // echo instead of a parent-driven edit that would re-control the caret (and
+  // reset the keyboard's autocorrect context on iOS).
+  let latestAcknowledgedIndex = -1;
+  for (let index = snapshots.length - 1; index >= 0; index -= 1) {
+    const snapshot = snapshots[index];
+    if (snapshot !== undefined && snapshot.eventCount <= acknowledgedEventCount) {
+      latestAcknowledgedIndex = index;
+      break;
+    }
+  }
+  return snapshots.filter(
+    (snapshot, index) =>
+      index === latestAcknowledgedIndex || snapshot.eventCount > acknowledgedEventCount,
+  );
 }

--- a/apps/mobile/src/native/composerEditorRevision.ts
+++ b/apps/mobile/src/native/composerEditorRevision.ts
@@ -48,8 +48,11 @@ export function resolveComposerControlledEventCount(
 
 // A snapshot without a selection describes a state the editor applied itself
 // (an assumed controlled document, where the native side may have bounded the
-// caret). It matches any controlled selection: such matches only ever produce
-// echoes, and echo payloads never control the caret.
+// caret). Revision stamping treats it as matching any controlled selection so
+// a parent caret move on the assumed value stays at the assumed revision and
+// passes the editor's staleness guard. Echo detection must not reuse this
+// wildcard: an echo payload serializes `selection: null`, which would drop
+// that caret move instead of applying it.
 function snapshotSelectionMatches(
   snapshot: ComposerNativeEventSnapshot,
   selection: ComposerEditorSelection,
@@ -70,7 +73,10 @@ export function isComposerNativeEcho(
       snapshot !== undefined &&
       snapshot.eventCount === eventCount &&
       snapshot.value === value &&
-      (selection === null || snapshotSelectionMatches(snapshot, selection))
+      (selection === null ||
+        (snapshot.selection !== null &&
+          snapshot.selection.start === selection.start &&
+          snapshot.selection.end === selection.end))
     ) {
       return true;
     }

--- a/apps/mobile/src/native/composerEditorRevision.ts
+++ b/apps/mobile/src/native/composerEditorRevision.ts
@@ -31,10 +31,7 @@ export function resolveComposerControlledEventCount(
     if (snapshot?.value !== value) continue;
 
     newestValueEventCount ??= snapshot.eventCount;
-    if (
-      selection === null ||
-      (snapshot.selection?.start === selection.start && snapshot.selection.end === selection.end)
-    ) {
+    if (selection === null || snapshotSelectionMatches(snapshot, selection)) {
       return snapshot.eventCount;
     }
   }
@@ -49,6 +46,18 @@ export function resolveComposerControlledEventCount(
   return mostRecentEventCount;
 }
 
+// A snapshot without a selection describes a state the editor applied itself
+// (an assumed controlled document, where the native side may have bounded the
+// caret). It matches any controlled selection: such matches only ever produce
+// echoes, and echo payloads never control the caret.
+function snapshotSelectionMatches(
+  snapshot: ComposerNativeEventSnapshot,
+  selection: ComposerEditorSelection,
+): boolean {
+  if (snapshot.selection === null) return true;
+  return snapshot.selection.start === selection.start && snapshot.selection.end === selection.end;
+}
+
 export function isComposerNativeEcho(
   value: string,
   selection: ComposerEditorSelection | null,
@@ -61,13 +70,31 @@ export function isComposerNativeEcho(
       snapshot !== undefined &&
       snapshot.eventCount === eventCount &&
       snapshot.value === value &&
-      (selection === null ||
-        (snapshot.selection?.start === selection.start && snapshot.selection.end === selection.end))
+      (selection === null || snapshotSelectionMatches(snapshot, selection))
     ) {
       return true;
     }
   }
   return false;
+}
+
+/**
+ * Records that a parent-driven controlled document was handed to the native
+ * editor. From that point the acknowledged snapshot history describes a
+ * superseded native state, so it is replaced with the assumed applied state;
+ * a later parent update back to a previously acknowledged value must classify
+ * as a fresh edit, not as a native echo the editor would drop. Native events
+ * that raced past the controlled revision stay authoritative and are kept.
+ */
+export function assumeComposerControlledState(
+  snapshots: ReadonlyArray<ComposerNativeEventSnapshot>,
+  eventCount: number,
+  value: string,
+): ComposerNativeEventSnapshot[] {
+  return [
+    { eventCount, value, selection: null },
+    ...snapshots.filter((snapshot) => snapshot.eventCount > eventCount),
+  ];
 }
 
 export function pruneAcknowledgedComposerNativeEvents(


### PR DESCRIPTION
## What Changed

Preserve keyboard suggestions and predictive text while typing by skipping no-op selection updates and tracking caret changes through the native editor revision flow. Prevent stale controlled values from reapplying during native edits, and ensure selection events deliver any newer text to the parent.

Also simplify changed-files layout breakpoints in the web client.

## Why

Reapplying an unchanged selection resets keyboard suggestion state on Android and iOS. Stale controlled renders could also move the caret backward or overwrite text mid-typing. The revision and event-handling changes keep native edits authoritative until the parent acknowledges them.

## UI Changes

Changed-files labels and actions now use the standard `sm` breakpoint instead of container queries.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native text-input sync and revision guards on a hot typing path; regressions could cause caret jumps, lost keystrokes, or draft restore issues, though changes are localized and well covered by unit tests.
> 
> **Overview**
> Fixes the mobile composer resetting **keyboard suggestions/autocorrect** and **yanking the caret or overwriting text** during fast typing by tightening how native selection and revision events sync with React.
> 
> **Native (iOS/Android):** Skips programmatic selection updates when the range is already correct (re-applying selection resets the keyboard context). **Caret-only moves** now bump `nativeEventCount` like text edits. iOS defers selection events during text mutations so revision counters stay paired with the right document; Android/iOS selection handlers can forward **newer text** when selection events race ahead of change events.
> 
> **React + `composerEditorRevision`:** Drops the render-sequence gate—every render resolves controlled revision from **snapshot history** (starting empty on mount so restored drafts apply). Adds **`assumeComposerControlledState`** and keeps the **latest acknowledged snapshot** when pruning so settled re-renders stay echoes instead of re-controlling the caret. Echo detection no longer treats a parent caret move as an echo of an assumed document without a stored selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e0b505e90917d6c573faec1f81cbc3804b5fcd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve keyboard autocorrect and predictive text suggestions while typing in the mobile composer
> - Skips no-op `selectedRange`/`setSelection` assignments in the native iOS ([T3ComposerEditorView.swift](https://github.com/pingdotgg/t3code/pull/6323/files#diff-bf020ce11861c51d7a3be2ccf67632f77afe80ff4ecf76a17884c5b040c21749)) and Android ([T3ComposerEditorView.kt](https://github.com/pingdotgg/t3code/pull/6323/files#diff-dbf8b69facaf4bfdba7369705927677e0a538325ec8355999f2a34f3b9d32e30)) views so the keyboard's suggestion context is not reset during programmatic no-op selection updates.
> - Adds `assumeComposerControlledState` in [composerEditorRevision.ts](https://github.com/pingdotgg/t3code/pull/6323/files#diff-13070a989fda29d965af9c14d8b313a24fe0346688e6f55dcde290b5a37b6451) to stamp a parent-applied controlled state into snapshot history, preventing subsequent parent updates from being misclassified as echoes.
> - Refactors both [T3ComposerEditor.ios.tsx](https://github.com/pingdotgg/t3code/pull/6323/files#diff-69d4d5095272f78042959f979b5bdb8cec908152e8d1461903770acd5e76c7df) and [T3ComposerEditor.native.tsx](https://github.com/pingdotgg/t3code/pull/6323/files#diff-713805a2470d470287c4d2a11eafef4c6b9d4d8397caf53923053dd64462f0a7) to resolve `controlledEventCount` from snapshot history and propagate `onChangeText` when a selection-change event carries a post-edit value.
> - Fixes `pruneAcknowledgedComposerNativeEvents` to retain the newest acknowledged snapshot, ensuring settled re-renders can still be classified as native echoes.
> - Risk: echo detection and event count resolution logic has changed; stale controlled renders are now actively rejected by the editor, which may surface edge-case ordering issues in complex typing flows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e0b505.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->