### PR TITLE
fix: avoid stale Live Activities when publishing is disabled

### DIFF
--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -20,12 +20,15 @@ import {
   clearAgentAwarenessRegistrationRecord,
   loadAgentAwarenessRegistrationRecord,
   loadOrCreateAgentAwarenessDeviceId,
+  loadPreferences,
   saveAgentAwarenessRegistrationRecord,
 } from "../../persistence/imperative";
+import type { Preferences } from "../../persistence/mobile-preferences";
 import { makeRelayDeviceRegistrationRequest, resolveApsEnvironment } from "./registrationPayload";
 import {
   AgentAwarenessOperationError,
   __resetAgentAwarenessRemoteRegistrationForTest,
+  armAgentAwarenessLiveActivityForLocalWork,
   getAgentAwarenessRegistrationStatus,
   mergeAgentAwarenessRegistrationPreferences,
   refreshActiveLiveActivityRemoteRegistration,
@@ -43,6 +46,13 @@ import * as Notifications from "expo-notifications";
 const secureStore = vi.hoisted(() => new Map<string, string>());
 const widgetMocks = vi.hoisted(() => ({
   getInstances: vi.fn(() => []),
+  start: vi.fn(() => ({})),
+}));
+const environmentConfigsMock = vi.hoisted(() => ({
+  configs: new Map<
+    string,
+    { environment: { capabilities: { agentActivityPublishing?: boolean } } }
+  >(),
 }));
 const backgroundRuntime = vi.hoisted(() => ({
   pending: [] as Array<{
@@ -77,7 +87,20 @@ vi.mock("expo-widgets", () => ({
 vi.mock("../../widgets/AgentActivity", () => ({
   default: {
     getInstances: widgetMocks.getInstances,
+    start: widgetMocks.start,
   },
+}));
+
+// The state modules pull the whole connection stack (and native expo modules)
+// into the import graph; the arming gate only needs the configs map.
+vi.mock("../../state/atom-registry", () => ({
+  appAtomRegistry: {
+    get: () => environmentConfigsMock.configs,
+  },
+}));
+
+vi.mock("../../state/server", () => ({
+  environmentServerConfigsAtom: Symbol("environmentServerConfigsAtom"),
 }));
 
 vi.mock("expo-notifications", () => ({
@@ -227,6 +250,8 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     vi.mocked(loadOrCreateAgentAwarenessDeviceId).mockResolvedValue("device-1");
     widgetMocks.getInstances.mockReset();
     widgetMocks.getInstances.mockReturnValue([]);
+    widgetMocks.start.mockClear();
+    environmentConfigsMock.configs.clear();
   });
 
   it("preserves disabled Live Activity preferences in relay registrations", () => {
@@ -856,4 +881,55 @@ describe("makeRelayDeviceRegistrationRequest", () => {
       }).pipe(Effect.provide(relayTestLayer));
     },
   );
+
+  it("skips the Live Activity seed when the environment reports publishing disabled", async () => {
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+    vi.mocked(loadPreferences).mockResolvedValueOnce({
+      liveActivitiesEnabled: true,
+    } as Preferences);
+    environmentConfigsMock.configs.set("env-1", {
+      environment: { capabilities: { agentActivityPublishing: false } },
+    });
+
+    armAgentAwarenessLiveActivityForLocalWork({
+      environmentId: "env-1" as EnvironmentId,
+      threadTitle: "Fix the flaky test",
+      projectTitle: "t3code",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(widgetMocks.start).not.toHaveBeenCalled();
+  });
+
+  it("seeds the Live Activity for publishing and pre-capability environments", async () => {
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+    environmentConfigsMock.configs.set("env-publishing", {
+      environment: { capabilities: { agentActivityPublishing: true } },
+    });
+
+    vi.mocked(loadPreferences).mockResolvedValueOnce({
+      liveActivitiesEnabled: true,
+    } as Preferences);
+    armAgentAwarenessLiveActivityForLocalWork({
+      environmentId: "env-publishing" as EnvironmentId,
+      threadTitle: "Fix the flaky test",
+      projectTitle: "t3code",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(widgetMocks.start).toHaveBeenCalledTimes(1);
+
+    // An environment without the capability may run an older server that
+    // still publishes; only an explicit false skips the seed.
+    widgetMocks.start.mockClear();
+    vi.mocked(loadPreferences).mockResolvedValueOnce({
+      liveActivitiesEnabled: true,
+    } as Preferences);
+    armAgentAwarenessLiveActivityForLocalWork({
+      environmentId: "env-pre-capability" as EnvironmentId,
+      threadTitle: "Fix the flaky test",
+      projectTitle: "t3code",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(widgetMocks.start).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -20,6 +20,8 @@ import {
 
 import type { SavedRemoteConnection } from "../../lib/connection";
 import { runtime } from "../../lib/runtime";
+import { appAtomRegistry } from "../../state/atom-registry";
+import { environmentServerConfigsAtom } from "../../state/server";
 import type { Preferences } from "../../persistence/mobile-preferences";
 import {
   clearAgentAwarenessRegistrationRecord,
@@ -448,16 +450,36 @@ function unregisterDeviceWithRelay(input: {
   });
 }
 
+// The environment descriptor advertises whether agent-activity publishes
+// currently leave that server (`capabilities.agentActivityPublishing`). Only
+// an explicit false skips the seed card: older servers omit the capability
+// but may still publish.
+function environmentPublishesAgentActivity(environmentId: EnvironmentId): boolean {
+  return (
+    appAtomRegistry.get(environmentServerConfigsAtom).get(environmentId)?.environment.capabilities
+      .agentActivityPublishing !== false
+  );
+}
+
 // Arms the lock-screen card the moment the user starts agent work from this
 // phone, while the app is still foregrounded and the fresh activity's token
 // can be registered immediately. The seeded row is a best-effort placeholder;
 // the relay's registration replay repaints it with the authoritative
-// aggregate within seconds. No-ops when a card is already armed.
+// aggregate within seconds. No-ops when a card is already armed, and skips
+// environments that report publishing disabled — the seed would sit on
+// "Connecting" forever with no update ever arriving to repaint or end it.
 export function armAgentAwarenessLiveActivityForLocalWork(input: {
+  readonly environmentId: EnvironmentId;
   readonly threadTitle: string;
   readonly projectTitle: string;
 }): void {
   if (!canRegisterRemoteLiveActivities() || !relayTokenProvider) {
+    return;
+  }
+  if (!environmentPublishesAgentActivity(input.environmentId)) {
+    logRegistrationDebug("live activity arming skipped; environment does not publish", {
+      environmentId: input.environmentId,
+    });
     return;
   }
   void loadPreferences()

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -859,6 +859,7 @@ export function NewTaskDraftScreen(props: {
     // -only Activity start. If creation fails, the token registration's replay
     // finds no work and ends the card within seconds.
     armAgentAwarenessLiveActivityForLocalWork({
+      environmentId: selectedProject.environmentId,
       threadTitle: deriveThreadTitleFromPrompt(initialMessageText),
       projectTitle: selectedProject.title,
     });

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -525,6 +525,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       // after the send so its preference read and native Activity start don't
       // contend with the queued-message feedback on the tap frame.
       armAgentAwarenessLiveActivityForLocalWork({
+        environmentId: props.environmentId,
         threadTitle: props.selectedThread.title,
         projectTitle: props.environmentLabel ?? "T3 Code",
       });

--- a/apps/server/src/cli/connect.ts
+++ b/apps/server/src/cli/connect.ts
@@ -36,6 +36,7 @@ import * as CliState from "../cloud/CliState.ts";
 import * as CliTokenManager from "../cloud/CliTokenManager.ts";
 import {
   CLOUD_LINKED_USER_ID,
+  isAgentActivityPublishingEnabledValue,
   PUBLISH_AGENT_ACTIVITY_SECRET,
   RELAY_URL_SECRET,
 } from "../cloud/config.ts";
@@ -142,7 +143,7 @@ function stringToBytes(value: string): Uint8Array {
 }
 
 export function isPublishAgentActivityEnabledValue(value: string | null): boolean {
-  return value === "true";
+  return isAgentActivityPublishingEnabledValue(value);
 }
 
 interface CloudCliStatus {

--- a/apps/server/src/cli/connect.ts
+++ b/apps/server/src/cli/connect.ts
@@ -448,7 +448,7 @@ const runCloudCommand = Effect.fn("cloud.cli.run_cloud_command")(function* <A, E
     ),
     RelayClient.layerCloudflared({ baseDir: config.baseDir }),
     EnvironmentAuth.runtimeLayer,
-    ServerEnvironment.layer,
+    ServerEnvironment.layer.pipe(Layer.provide(ServerSecretStore.layer)),
     bootServiceLayer(config),
     headlessRelayClientTracingLayer,
   ).pipe(

--- a/apps/server/src/cloud/config.ts
+++ b/apps/server/src/cloud/config.ts
@@ -1,5 +1,9 @@
 import { RelayManagedEndpointRuntimeConfig } from "@t3tools/contracts/relay";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+
+import type * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 
 export const CLOUD_MINT_PUBLIC_KEY = "cloud-mint-ed25519-public-key";
 export const CLOUD_ENDPOINT_RUNTIME_CONFIG = "cloud-endpoint-runtime-config";
@@ -16,3 +20,35 @@ export const encodeEndpointRuntimeConfigJson = Schema.encodeEffect(
 export const decodeRuntimeConfig = Schema.decodeUnknownOption(
   Schema.fromJsonString(RelayManagedEndpointRuntimeConfig),
 );
+
+export function isAgentActivityPublishingEnabledValue(value: string | null): boolean {
+  return value === "true";
+}
+
+/** Whether agent-activity publishes currently leave this environment: the
+    publish opt-in secret is enabled and the relay link credentials exist.
+    Mirrors the per-publish gate in AgentAwarenessRelay, so the descriptor
+    capability never advertises publishing that the publisher would skip. */
+export const readAgentActivityPublishingActive = (
+  secrets: ServerSecretStore.ServerSecretStore["Service"],
+): Effect.Effect<boolean> =>
+  Effect.gen(function* () {
+    const readSecretString = (name: string) =>
+      secrets
+        .get(name)
+        .pipe(
+          Effect.map((bytes) =>
+            Option.isSome(bytes) ? new TextDecoder().decode(bytes.value) : null,
+          ),
+        );
+    const [enabled, url, environmentCredential] = yield* Effect.all([
+      readSecretString(PUBLISH_AGENT_ACTIVITY_SECRET),
+      readSecretString(RELAY_URL_SECRET),
+      readSecretString(RELAY_ENVIRONMENT_CREDENTIAL_SECRET),
+    ]);
+    return (
+      isAgentActivityPublishingEnabledValue(enabled) &&
+      url !== null &&
+      environmentCredential !== null
+    );
+  }).pipe(Effect.orElseSucceed(() => false));

--- a/apps/server/src/cloud/config.ts
+++ b/apps/server/src/cloud/config.ts
@@ -46,9 +46,13 @@ export const readAgentActivityPublishingActive = (
       readSecretString(RELAY_URL_SECRET),
       readSecretString(RELAY_ENVIRONMENT_CREDENTIAL_SECRET),
     ]);
+    // Empty strings are as unconfigured as missing files: the publisher's
+    // truthiness gate skips them, so the capability must too.
     return (
       isAgentActivityPublishingEnabledValue(enabled) &&
       url !== null &&
-      environmentCredential !== null
+      url !== "" &&
+      environmentCredential !== null &&
+      environmentCredential !== ""
     );
   }).pipe(Effect.orElseSucceed(() => false));

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -6,6 +6,12 @@ import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 
+import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import {
+  PUBLISH_AGENT_ACTIVITY_SECRET,
+  RELAY_ENVIRONMENT_CREDENTIAL_SECRET,
+  RELAY_URL_SECRET,
+} from "../cloud/config.ts";
 import * as ServerConfig from "../config.ts";
 import * as ServerEnvironment from "./ServerEnvironment.ts";
 
@@ -70,6 +76,46 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.repositoryIdentity).toBe(true);
       expect(second.capabilities.connectionProbe).toBe(true);
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
+      expect(second.capabilities.agentActivityPublishing).toBe(false);
+    }),
+  );
+
+  it.effect("reports agent activity publishing from the current secret state", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-environment-publish-test-",
+      });
+      const testLayer = Layer.mergeAll(
+        makeServerEnvironmentLayer(baseDir),
+        ServerSecretStore.layer.pipe(Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir))),
+      );
+
+      yield* Effect.gen(function* () {
+        const secrets = yield* ServerSecretStore.ServerSecretStore;
+        const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
+        const encode = (value: string) => new TextEncoder().encode(value);
+
+        const unlinked = yield* serverEnvironment.getDescriptor;
+        expect(unlinked.capabilities.agentActivityPublishing).toBe(false);
+
+        // The opt-in alone is not enough: without relay link credentials no
+        // publish would leave this environment.
+        yield* secrets.set(PUBLISH_AGENT_ACTIVITY_SECRET, encode("true"));
+        const withoutLink = yield* serverEnvironment.getDescriptor;
+        expect(withoutLink.capabilities.agentActivityPublishing).toBe(false);
+
+        yield* secrets.set(RELAY_URL_SECRET, encode("https://relay.example"));
+        yield* secrets.set(RELAY_ENVIRONMENT_CREDENTIAL_SECRET, encode("credential"));
+        const linked = yield* serverEnvironment.getDescriptor;
+        expect(linked.capabilities.agentActivityPublishing).toBe(true);
+
+        // The toggle changes at runtime, so the same service instance must
+        // reflect a flip without a restart.
+        yield* secrets.set(PUBLISH_AGENT_ACTIVITY_SECRET, encode("false"));
+        const disabled = yield* serverEnvironment.getDescriptor;
+        expect(disabled.capabilities.agentActivityPublishing).toBe(false);
+      }).pipe(Effect.provide(testLayer));
     }),
   );
 
@@ -104,6 +150,11 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
             writeAttempts.push(path);
             return Effect.fail(cause);
           },
+          // The secret store the environment layer builds prepares its
+          // directory on construction; only the environment-id operations
+          // above are meant to fail here.
+          makeDirectory: () => Effect.void,
+          chmod: () => Effect.void,
         });
 
         const error = yield* Effect.gen(function* () {

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 
@@ -20,7 +21,21 @@ const isServerEnvironmentIdPersistenceError = Schema.is(
 );
 
 const makeServerEnvironmentLayer = (baseDir: string) =>
-  ServerEnvironment.layer.pipe(Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir)));
+  ServerEnvironment.layer.pipe(
+    Layer.provide(ServerSecretStore.layer),
+    Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir)),
+  );
+
+const emptySecretStoreLayer = Layer.succeed(
+  ServerSecretStore.ServerSecretStore,
+  ServerSecretStore.ServerSecretStore.of({
+    get: () => Effect.succeed(Option.none()),
+    set: () => Effect.void,
+    create: () => Effect.void,
+    getOrCreateRandom: () => Effect.succeed(new Uint8Array()),
+    remove: () => Effect.void,
+  }),
+);
 
 const makeServerConfig = Effect.fn(function* (baseDir: string) {
   const derivedPaths = yield* ServerConfig.deriveServerPaths(baseDir, undefined);
@@ -87,9 +102,9 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
         prefix: "t3-server-environment-publish-test-",
       });
       const testLayer = Layer.mergeAll(
-        makeServerEnvironmentLayer(baseDir),
-        ServerSecretStore.layer.pipe(Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir))),
-      );
+        ServerEnvironment.layer.pipe(Layer.provide(ServerSecretStore.layer)),
+        ServerSecretStore.layer,
+      ).pipe(Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir)));
 
       yield* Effect.gen(function* () {
         const secrets = yield* ServerSecretStore.ServerSecretStore;
@@ -105,8 +120,15 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
         const withoutLink = yield* serverEnvironment.getDescriptor;
         expect(withoutLink.capabilities.agentActivityPublishing).toBe(false);
 
-        yield* secrets.set(RELAY_URL_SECRET, encode("https://relay.example"));
+        // Empty credentials are as unconfigured as missing ones: the
+        // publisher's truthiness gate skips them, so the capability must not
+        // advertise publishing.
+        yield* secrets.set(RELAY_URL_SECRET, encode(""));
         yield* secrets.set(RELAY_ENVIRONMENT_CREDENTIAL_SECRET, encode("credential"));
+        const emptyUrl = yield* serverEnvironment.getDescriptor;
+        expect(emptyUrl.capabilities.agentActivityPublishing).toBe(false);
+
+        yield* secrets.set(RELAY_URL_SECRET, encode("https://relay.example"));
         const linked = yield* serverEnvironment.getDescriptor;
         expect(linked.capabilities.agentActivityPublishing).toBe(true);
 
@@ -150,11 +172,6 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
             writeAttempts.push(path);
             return Effect.fail(cause);
           },
-          // The secret store the environment layer builds prepares its
-          // directory on construction; only the environment-id operations
-          // above are meant to fail here.
-          makeDirectory: () => Effect.void,
-          chmod: () => Effect.void,
         });
 
         const error = yield* Effect.gen(function* () {
@@ -163,6 +180,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
         }).pipe(
           Effect.provide(
             ServerEnvironment.layer.pipe(
+              Layer.provide(emptySecretStoreLayer),
               Layer.provide(Layer.merge(ServerConfig.layer(serverConfig), failingFileSystemLayer)),
             ),
           ),

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -170,9 +170,7 @@ export const make = Effect.gen(function* () {
 /**
  * ServerEnvironment is acquired from persisted filesystem and host-process
  * state. It intentionally has no fallback Layer.succeed value: callers must
- * provide the external platform services and a ServerConfig.
+ * provide the external platform services, a ServerConfig, and the
+ * ServerSecretStore backing the descriptor's publishing capability.
  */
-export const layer = Layer.effect(ServerEnvironment, make).pipe(
-  Layer.provide(ProcessRunner.layer),
-  Layer.provide(ServerSecretStore.layer),
-);
+export const layer = Layer.effect(ServerEnvironment, make).pipe(Layer.provide(ProcessRunner.layer));

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -9,6 +9,8 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
 import packageJson from "../../package.json" with { type: "json" };
+import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import { readAgentActivityPublishingActive } from "../cloud/config.ts";
 import { resolveServerSelfUpdateCapability } from "../cloud/selfUpdate.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProcessRunner from "../processRunner.ts";
@@ -65,6 +67,7 @@ export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig.ServerConfig;
+  const secrets = yield* ServerSecretStore.ServerSecretStore;
   const crypto = yield* Crypto.Crypto;
   const hostPlatform = yield* HostProcessPlatform;
   const hostArchitecture = yield* HostProcessArchitecture;
@@ -152,7 +155,15 @@ export const make = Effect.gen(function* () {
 
   return ServerEnvironment.of({
     getEnvironmentId: Effect.succeed(environmentId),
-    getDescriptor: Effect.succeed(descriptor),
+    // The publish opt-in and relay link change at runtime (`t3 connect
+    // publish`, the client settings toggle), so the capability is read per
+    // descriptor request rather than baked in at startup.
+    getDescriptor: readAgentActivityPublishingActive(secrets).pipe(
+      Effect.map((agentActivityPublishing) => ({
+        ...descriptor,
+        capabilities: { ...descriptor.capabilities, agentActivityPublishing },
+      })),
+    ),
   });
 });
 
@@ -161,4 +172,7 @@ export const make = Effect.gen(function* () {
  * state. It intentionally has no fallback Layer.succeed value: callers must
  * provide the external platform services and a ServerConfig.
  */
-export const layer = Layer.effect(ServerEnvironment, make).pipe(Layer.provide(ProcessRunner.layer));
+export const layer = Layer.effect(ServerEnvironment, make).pipe(
+  Layer.provide(ProcessRunner.layer),
+  Layer.provide(ServerSecretStore.layer),
+);

--- a/apps/server/src/relay/AgentAwarenessRelay.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.ts
@@ -35,6 +35,7 @@ import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import {
+  isAgentActivityPublishingEnabledValue,
   PUBLISH_AGENT_ACTIVITY_SECRET,
   RELAY_ENVIRONMENT_CREDENTIAL_SECRET,
   RELAY_ISSUER_SECRET,
@@ -101,7 +102,7 @@ export function agentAwarenessPublishIdentity(state: RelayAgentActivityState | n
 }
 
 export function isAgentActivityPublishingEnabled(value: string | null): boolean {
-  return value === "true";
+  return isAgentActivityPublishingEnabledValue(value);
 }
 
 export function resolveAgentActivityPublishingStartupState(input: {

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -57,6 +57,12 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   /** Server can stream self-update progress before acknowledging the
       restart. Clients fall back to server.updateServer when absent. */
   serverSelfUpdateProgress: Schema.optionalKey(Schema.Boolean),
+  /** Agent-activity publishes (push notifications and Live Activities)
+      currently leave this environment: the publish opt-in is enabled and the
+      relay link credentials exist. Clients skip seeding a Live Activity when
+      this is false — no update would ever repaint it. Absent on older
+      servers, which may still publish, so only an explicit false skips. */
+  agentActivityPublishing: Schema.optionalKey(Schema.Boolean),
 });
 export type ExecutionEnvironmentCapabilities = typeof ExecutionEnvironmentCapabilities.Type;
 


### PR DESCRIPTION
## Problem

When agent-activity publishing is disabled on an environment (the `cloud-publish-agent-activity` opt-in was never enabled, e.g. after a plain managed `t3 connect link`), the mobile app still seeds a Live Activity with status **Connecting** when starting work from the phone. No update ever arrives to repaint or end it, so the card sits on Connecting until the relay's freshly-armed grace expires and kills it. Nothing above debug level hints at why.

## Changes

**Expose publishing state as a descriptor capability** so clients can tell whether updates will ever come, on every path the descriptor flows through (`/.well-known/t3/environment`, server config over websocket, relay environment status):

- `packages/contracts`: new optional `capabilities.agentActivityPublishing` on `ExecutionEnvironmentDescriptor`. Optional so newer clients tolerate older servers.
- `apps/server`: `readAgentActivityPublishingActive` in `cloud/config.ts` reports true only when the publish opt-in secret is enabled **and** the relay link credentials exist — mirroring the per-publish gate in `AgentAwarenessRelay`, so the descriptor never advertises publishing the publisher would skip. `ServerEnvironment.getDescriptor` computes the capability per read (the toggle flips at runtime via `t3 connect publish` / the settings toggle, so it must not be baked in at startup). The three identical `value === "true"` predicates are consolidated into one canonical helper.

**Skip the doomed seed on mobile:**

- `armAgentAwarenessLiveActivityForLocalWork` now takes the target `environmentId` and skips seeding when that environment explicitly reports `agentActivityPublishing: false`. Absent capability (older server) still arms — those servers may well be publishing, so only an explicit false skips.

## Tests

- `ServerEnvironment.test.ts`: capability defaults to false; opt-in alone is not enough without link credentials; the same service instance reflects a runtime flip without restart. The noop-filesystem failure test now stubs `makeDirectory`/`chmod` for the secret store the layer builds.
- `remoteRegistration.test.ts`: arming is skipped for explicitly non-publishing environments and preserved for publishing/pre-capability ones. The new state-module imports are mocked to keep expo-native code out of the node test graph.

## Notes

- The phone evaluates the capability from its cached server config (refreshed on reconnect). Toggling publishing off while an app holds a config can still seed one card; the relay's existing 2-minute grace ends it, same as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is gated on an explicit false capability; older servers and publishing-enabled environments are unchanged, with focused tests on descriptor and arming logic.
> 
> **Overview**
> Adds optional **`capabilities.agentActivityPublishing`** on the environment descriptor so clients know whether agent-activity updates will actually leave the server. The server sets it **per descriptor read** via `readAgentActivityPublishingActive` (publish opt-in secret **and** relay link credentials, matching `AgentAwarenessRelay`); duplicate `value === "true"` checks are centralized in `isAgentActivityPublishingEnabledValue`.
> 
> **Mobile** `armAgentAwarenessLiveActivityForLocalWork` now takes `environmentId` and **does not seed** a lock-screen Live Activity when the cached config has **`agentActivityPublishing: false`**—avoiding a stuck **Connecting** card when nothing will repaint it. Missing capability (older servers) still arms; only explicit `false` skips. Call sites in thread composer and new-task draft pass the environment id.
> 
> Tests cover descriptor capability from secret state, arming skip/allow behavior, and CLI layers that now wire `ServerSecretStore` into `ServerEnvironment`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3094ad5cf8c0841565d2c77382d6211d9a87f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip Live Activity arming when agent-activity publishing is disabled for an environment
> - Adds an optional `agentActivityPublishing` boolean to the `ExecutionEnvironmentCapabilities` schema; absent means enabled, only explicit `false` disables client behavior.
> - `ServerEnvironment` now computes `agentActivityPublishing` dynamically per descriptor request by checking `PUBLISH_AGENT_ACTIVITY_SECRET` and relay credentials via `ServerSecretStore`.
> - Adds `environmentPublishesAgentActivity` helper in [`remoteRegistration.ts`](https://github.com/pingdotgg/t3code/pull/6325/files#diff-ac13745728627647bf60cf50ea2b1d61f0b216df0229029b70f9e6be23887f47) and gates `armAgentAwarenessLiveActivityForLocalWork` on it, skipping arming when the capability is explicitly false.
> - Call sites in [`NewTaskDraftScreen.tsx`](https://github.com/pingdotgg/t3code/pull/6325/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2) and [`ThreadComposer.tsx`](https://github.com/pingdotgg/t3code/pull/6325/files#diff-4c62d895b68dd46f4d2858321c8942fde0d3ddd37c5e4253cba04c18c21a6024) are updated to pass `environmentId` to satisfy the new signature.
> - Behavioral Change: Live Activities will no longer be armed for environments where the server advertises `agentActivityPublishing: false`; previously arming was always attempted when preferences allowed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c3094a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->