### PR TITLE
fix(vcs): give `git worktree add` a longer timeout on large repos

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -39,6 +39,10 @@ import {
 import { ServerConfig } from "../config.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+// `git worktree add` checks out the full tree, so on large repositories it can
+// take well beyond the default 30s (e.g. a 375k-file repo takes ~40s on an idle
+// machine). Give it generous headroom while still bounding a genuinely hung git.
+const WORKTREE_ADD_TIMEOUT_MS = 300_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
 const PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES = 49_000;
@@ -2761,6 +2765,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
 
     yield* executeGit("GitVcsDriver.createWorktree", input.cwd, args, {
       fallbackErrorDetail: "git worktree add failed",
+      timeoutMs: WORKTREE_ADD_TIMEOUT_MS,
     });
 
     if (input.newRefName && input.baseRefName) {


### PR DESCRIPTION
## Problem

Creating a new worktree fails **deterministically** on large repositories with `GitCommandError: Git command timed out`. In T3 Code this surfaces as *every* new-chat worktree spawn erroring out in that project.

Root cause: all git commands run under `DEFAULT_TIMEOUT_MS` (30s), but `git worktree add` checks out the **full tree**, which on a large repo legitimately takes longer. On a real repo with ~375k files it takes ~40s on an idle machine — past the cap, every time.

The cost is the checkout (file count), not anything hung:

```
git worktree add --no-checkout   ~0.05s   (writes no files)
git worktree add  (375k files)   ~37–40s  (writing the tree)
```

So a healthy-but-large checkout is indistinguishable from a hang under the current 30s cap, and always loses.

## Fix

Give `createWorktree` a dedicated 5-minute timeout (`WORKTREE_ADD_TIMEOUT_MS`) instead of inheriting the 30s default. This still bounds a genuinely hung git, while letting large-but-healthy checkouts finish.

```ts
yield* executeGit("GitVcsDriver.createWorktree", input.cwd, args, {
  fallbackErrorDetail: "git worktree add failed",
  timeoutMs: WORKTREE_ADD_TIMEOUT_MS,
});
```

Minimal, localized to the one operation whose runtime scales with repo size. `timeoutMs` is already a supported `ExecuteGitOptions` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized timeout change for one git operation; no auth, data, or API behavior changes. A hung `git worktree add` can now run longer before being killed, but remains bounded.
> 
> **Overview**
> **Raises the `createWorktree` timeout** so `git worktree add` no longer fails on large repositories under the default 30s cap.
> 
> Adds `WORKTREE_ADD_TIMEOUT_MS` (300s) and passes it only to the `executeGit` call for worktree creation. Other git commands keep the existing default timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2187c6f69760f3f459bd4ddc64dda6925e3027f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `git worktree add` timeout to 300s in `createWorktree`
> The default command timeout was too short for `git worktree add` on large repos. Sets a dedicated `WORKTREE_ADD_TIMEOUT_MS` constant (300,000 ms) in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/6326/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) and passes it as `timeoutMs` to the `executeGit` call in `createWorktree`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2187c6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->