### PR TITLE
fix(web): give the Woke pill room next to snooze

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -371,11 +371,11 @@ function SnoozePopoverButton(props: {
             aria-label="Snooze thread"
             onClick={(event) => event.stopPropagation()}
             onDoubleClick={(event) => event.stopPropagation()}
-            className="inline-flex h-full cursor-pointer items-center gap-0.5 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground"
+            className="inline-flex cursor-pointer items-center rounded-md bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground"
           />
         }
       >
-        <ClockIcon className="size-3" />
+        <ClockIcon className="size-3.5" />
       </PopoverTrigger>
       <PopoverPopup side="bottom" align="end" className="w-56" viewportClassName="p-1">
         {presets.map((preset) => (
@@ -1401,7 +1401,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                       // would keep the controls pinned over the status label
                       // once the pointer moves away (e.g. after a failed
                       // settle) instead of cross-fading back.
-                      "pointer-events-none absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity has-[:focus-visible]:pointer-events-auto has-[:focus-visible]:static has-[:focus-visible]:opacity-100 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:static group-hover/sidebar-row:opacity-100",
+                      // items-center (not stretch): Snooze wraps a Popover
+                      // root, and stretch left that wrapper top-aligning the
+                      // clock above Settle's baseline.
+                      "pointer-events-none absolute inset-y-0 right-0 flex items-center gap-0.5 opacity-0 transition-opacity has-[:focus-visible]:pointer-events-auto has-[:focus-visible]:static has-[:focus-visible]:opacity-100 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:static group-hover/sidebar-row:opacity-100",
                       snoozeMenuOpen && "pointer-events-auto static opacity-100",
                     )}
                   >

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1164,7 +1164,12 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               remain visible AND clickable while the row is hovered. Only
               the time/jump label yields to the settle affordance. */}
             {prBadge}
-            <span className="relative ml-auto flex h-6 min-w-8 shrink-0 items-center justify-end">
+            <span
+              className={cn(
+                "relative ml-auto flex h-6 min-w-8 shrink-0 items-center justify-end",
+                isWoke && "gap-1.5",
+              )}
+            >
               <span
                 className={cn(
                   "inline-flex justify-end tabular-nums text-secondary-label transition-opacity",
@@ -1187,7 +1192,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     onClick={handleAcknowledgeWokeClick}
                     className="inline-flex cursor-pointer items-center gap-1 rounded-sm text-xs font-medium text-amber-700 outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring dark:text-amber-300"
                   >
-                    <AlarmClockIcon aria-hidden className="size-3" />
+                    <AlarmClockIcon aria-hidden className="mb-px size-3 shrink-0" />
                     <span role="status">Woke</span>
                   </button>
                 ) : (
@@ -1326,7 +1331,14 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                   actions on hover/keyboard focus or while the popover is open. Keeping
                   the hidden state out of flow lets the project label reclaim
                   space without either state overlapping it. */}
-              <span className="group/sidebar-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
+              <span
+                className={cn(
+                  "group/sidebar-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs",
+                  // Woke stays visible beside snooze/settle; gap keeps the
+                  // alarm from crowding the set-to clock.
+                  isWokeStatus && "gap-1.5",
+                )}
+              >
                 {/* Read-only status labels yield to the hover actions. Woke is
                     itself an action, so it stays pointer-enabled and visible
                     while the other controls appear beside it. */}
@@ -1351,7 +1363,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                           topStatus.className,
                         )}
                       >
-                        <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
+                        <AlarmClockIcon aria-hidden className="mb-px size-3.5 shrink-0" />
                         <span role="status">{topStatus.label}</span>
                       </button>
                     ) : (


### PR DESCRIPTION
## Summary
- On woke sidebar cards, the amber alarm sat flush against the snooze (set-to) clock and read oversized at `size-4`.
- Add `gap-1.5` between the Woke pill and hover actions, shrink the alarm to `size-3.5` (matching Settle), and nudge it with `mb-px` for optical alignment.
- The snooze clock itself sat high because its Popover wrapper lived in an `items-stretch` row; center the actions and match Settle's `size-3.5` icon.

## Before and after

Stacked whole-card hover state (Woke + set-to clock + Settle):

![Before and after](https://files.catbox.moe/4t907w.png)

| Before | After |
| --- | --- |
| ![Before](https://files.catbox.moe/bo7xfy.png) | ![After](https://files.catbox.moe/wjgpew.png) |

Measured: Woke→clock gap **0px → 12px**; snooze/Settle icon midlines **aligned (0px delta)**.

## Test plan
- [ ] Open a woken thread card in the sidebar
- [ ] Hover the row and confirm Woke no longer crowds the snooze clock
- [ ] Confirm the snooze clock lines up vertically with Settle's check
- [ ] Spot-check a compact history woke row for the same spacing

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix spacing between the Woke pill and snooze button in the sidebar
> Adjusts icon sizes and spacing in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/6329/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) so the Woke pill and snooze button don't crowd each other. Adds conditional `gap-1.5` around the Woke pill, shrinks and vertically aligns alarm clock icons, and switches hover action container alignment from `items-stretch` to `items-center` with a small gap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17b95c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->