### PR TITLE
feat(web): project favicon and workspace icons in command subtitles

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -264,6 +264,20 @@ describe("buildThreadActionItems", () => {
     expect(item?.description).toBe("T3 Code · #feat/search");
   });
 
+  it("prefers renderDescription when provided", () => {
+    const [item] = buildThreadActionItems({
+      threads: [makeThread({ branch: "feat/search", worktreePath: "/tmp/wt" })],
+      projectTitleById: new Map([[PROJECT_ID, "T3 Code"]]),
+      sortOrder: "updated_at",
+      icon: null,
+      renderDescription: (thread, { projectTitle }) =>
+        `${projectTitle}:${thread.branch}:${thread.worktreePath ? "wt" : "local"}`,
+      runThread: async (_thread) => undefined,
+    });
+
+    expect(item?.description).toBe("T3 Code:feat/search:wt");
+  });
+
   it("filters archived threads out of thread search items", () => {
     const items = buildThreadActionItems({
       threads: [

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -154,7 +154,16 @@ export function buildProjectActionItems(input: {
 
 export type BuildThreadActionItemsThread = Pick<
   SidebarThreadSummary,
-  "archivedAt" | "branch" | "createdAt" | "environmentId" | "id" | "projectId" | "title"
+  | "archivedAt"
+  | "branch"
+  | "createdAt"
+  | "environmentId"
+  | "id"
+  | "modelSelection"
+  | "projectId"
+  | "session"
+  | "title"
+  | "worktreePath"
 > & {
   updatedAt: string;
   latestUserMessageAt?: string | null;
@@ -170,6 +179,8 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
   renderLeadingContent?: (thread: TThread) => ReactNode;
   /** Optional content rendered inline after the title text per-thread. */
   renderTrailingContent?: (thread: TThread) => ReactNode;
+  /** Optional rich description (e.g. favicon + workspace icons). Falls back to text. */
+  renderDescription?: (thread: TThread, meta: { projectTitle: string | undefined }) => ReactNode;
   getContentMatch?: (thread: TThread) => CommandPaletteThreadContentMatch | undefined;
   runThread: (thread: Pick<SidebarThreadSummary, "environmentId" | "id">) => Promise<void>;
   limit?: number;
@@ -198,6 +209,9 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
     const leadingContent = input.renderLeadingContent?.(thread);
     const trailingContent = input.renderTrailingContent?.(thread);
     const contentMatch = input.getContentMatch?.(thread);
+    const description = input.renderDescription
+      ? input.renderDescription(thread, { projectTitle })
+      : descriptionParts.join(` · `);
 
     return Object.assign(
       {
@@ -210,7 +224,7 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
           contentMatch?.snippet ?? ``,
         ],
         title: thread.title,
-        description: descriptionParts.join(` · `),
+        description,
         timestamp: formatRelativeTimeLabel(
           thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt,
         ),

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -130,6 +130,7 @@ import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../sta
 import {
   deriveProviderInstanceEntries,
   resolveDefaultProviderModelSelection,
+  type ProviderInstanceEntry,
 } from "../providerInstances";
 import { resolveShortcutCommand, threadJumpIndexFromCommand } from "../keybindings";
 import { CommandDialog, CommandDialogPopup } from "./ui/command";
@@ -588,15 +589,18 @@ function OpenCommandPaletteDialog(props: {
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const { theme, themeHalves, resolvedTheme } = useTheme();
   const providers = useAtomValue(primaryServerProvidersAtom);
-  const providerEntryByInstanceId = useMemo(
-    () =>
-      new Map(
-        deriveProviderInstanceEntries(providers).map(
-          (entry) => [entry.instanceId as string, entry] as const,
-        ),
-      ),
-    [providers],
-  );
+  const providerEntryByEnvironmentAndInstanceId = useMemo(() => {
+    const map = new Map<string, ProviderInstanceEntry>();
+    for (const environment of environments) {
+      const environmentProviders =
+        environment.serverConfig?.providers ??
+        (environment.environmentId === primaryEnvironmentId ? providers : []);
+      for (const entry of deriveProviderInstanceEntries(environmentProviders)) {
+        map.set(`${environment.environmentId}:${entry.instanceId}`, entry);
+      }
+    }
+    return map;
+  }, [environments, primaryEnvironmentId, providers]);
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
   const currentView = viewStack.at(-1) ?? null;
   const environmentIds = useMemo(
@@ -829,6 +833,10 @@ function OpenCommandPaletteDialog(props: {
       new Map<ProjectId, string>(projects.map((project) => [project.id, project.workspaceRoot])),
     [projects],
   );
+  const projectFaviconPathById = useMemo(
+    () => new Map(projects.map((project) => [project.id, project.faviconPath ?? null] as const)),
+    [projects],
+  );
   const projectTitleById = useMemo(
     () => new Map<ProjectId, string>(projects.map((project) => [project.id, project.title])),
     [projects],
@@ -1016,11 +1024,15 @@ function OpenCommandPaletteDialog(props: {
         renderDescription: (thread, { projectTitle }) => {
           const modelInstanceId =
             thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
-          const providerEntry = providerEntryByInstanceId.get(modelInstanceId) ?? null;
+          const providerEntry =
+            providerEntryByEnvironmentAndInstanceId.get(
+              `${thread.environmentId}:${modelInstanceId}`,
+            ) ?? null;
           return (
             <ThreadCommandSubtitle
               environmentId={thread.environmentId}
               projectCwd={projectCwdById.get(thread.projectId) ?? null}
+              projectFaviconPath={projectFaviconPathById.get(thread.projectId) ?? null}
               projectTitle={projectTitle ?? null}
               branch={thread.branch}
               worktreePath={thread.worktreePath}
@@ -1059,8 +1071,9 @@ function OpenCommandPaletteDialog(props: {
       clientSettings.sidebarThreadSortOrder,
       navigate,
       projectCwdById,
+      projectFaviconPathById,
       projectTitleById,
-      providerEntryByInstanceId,
+      providerEntryByEnvironmentAndInstanceId,
       threadContentMatchByKey,
       threadSearchQuery,
       threads,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -124,9 +124,13 @@ import { ProjectFavicon } from "./ProjectFavicon";
 import { ProjectFilePicker } from "./files/ProjectFilePicker";
 import { ProjectContentSearchDialog } from "./search/ProjectContentSearchDialog";
 import { toggleThemeEditorForTheme } from "./settings/themeEditorStore";
+import { ThreadCommandSubtitle } from "./ThreadCommandSubtitle";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
 import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
-import { resolveDefaultProviderModelSelection } from "../providerInstances";
+import {
+  deriveProviderInstanceEntries,
+  resolveDefaultProviderModelSelection,
+} from "../providerInstances";
 import { resolveShortcutCommand, threadJumpIndexFromCommand } from "../keybindings";
 import { CommandDialog, CommandDialogPopup } from "./ui/command";
 import { Button } from "./ui/button";
@@ -584,6 +588,15 @@ function OpenCommandPaletteDialog(props: {
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const { theme, themeHalves, resolvedTheme } = useTheme();
   const providers = useAtomValue(primaryServerProvidersAtom);
+  const providerEntryByInstanceId = useMemo(
+    () =>
+      new Map(
+        deriveProviderInstanceEntries(providers).map(
+          (entry) => [entry.instanceId as string, entry] as const,
+        ),
+      ),
+    [providers],
+  );
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
   const currentView = viewStack.at(-1) ?? null;
   const environmentIds = useMemo(
@@ -1000,6 +1013,25 @@ function OpenCommandPaletteDialog(props: {
         icon: <MessageSquareIcon className={ITEM_ICON_CLASS} />,
         renderLeadingContent: (thread) => <ThreadRowLeadingStatus thread={thread} />,
         renderTrailingContent: (thread) => <ThreadRowTrailingStatus thread={thread} />,
+        renderDescription: (thread, { projectTitle }) => {
+          const modelInstanceId =
+            thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+          const providerEntry = providerEntryByInstanceId.get(modelInstanceId) ?? null;
+          return (
+            <ThreadCommandSubtitle
+              environmentId={thread.environmentId}
+              projectCwd={projectCwdById.get(thread.projectId) ?? null}
+              projectTitle={projectTitle ?? null}
+              branch={thread.branch}
+              worktreePath={thread.worktreePath}
+              isCurrent={thread.id === activeThreadId}
+              driverKind={providerEntry?.driverKind ?? null}
+              providerDisplayName={
+                thread.session?.providerName ?? providerEntry?.displayName ?? modelInstanceId
+              }
+            />
+          );
+        },
         getContentMatch: (thread) => {
           const match = threadContentMatchByKey.get(
             threadSearchMatchKey({
@@ -1026,7 +1058,9 @@ function OpenCommandPaletteDialog(props: {
       activeThreadId,
       clientSettings.sidebarThreadSortOrder,
       navigate,
+      projectCwdById,
       projectTitleById,
+      providerEntryByInstanceId,
       threadContentMatchByKey,
       threadSearchQuery,
       threads,

--- a/apps/web/src/components/CommandPaletteResults.tsx
+++ b/apps/web/src/components/CommandPaletteResults.tsx
@@ -142,7 +142,7 @@ function DisabledCommandPaletteResultRow(props: {
             <ThreadContentMatch match={props.item.threadContentMatch} />
           ) : null}
           {props.item.description ? (
-            <span className="truncate text-muted-foreground/70 text-xs">
+            <span className="min-w-0 text-muted-foreground/70 text-xs">
               {props.item.description}
             </span>
           ) : null}
@@ -193,7 +193,7 @@ function CommandPaletteResultRow(props: {
             <ThreadContentMatch match={props.item.threadContentMatch} />
           ) : null}
           {props.item.description ? (
-            <span className="truncate text-muted-foreground/70 text-xs">
+            <span className="min-w-0 text-muted-foreground/70 text-xs">
               {props.item.description}
             </span>
           ) : null}

--- a/apps/web/src/components/ThreadCommandSubtitle.tsx
+++ b/apps/web/src/components/ThreadCommandSubtitle.tsx
@@ -37,6 +37,7 @@ function WorkspaceIcon(props: { variant: ThreadCommandSubtitleVariant; isWorktre
 export function ThreadCommandSubtitle(props: {
   environmentId: EnvironmentId;
   projectCwd: string | null;
+  projectFaviconPath?: string | null;
   projectTitle: string | null;
   branch: string | null;
   worktreePath: string | null;
@@ -71,6 +72,7 @@ export function ThreadCommandSubtitle(props: {
             <ProjectFavicon
               environmentId={props.environmentId}
               cwd={props.projectCwd}
+              faviconPath={props.projectFaviconPath}
               className="size-3 shrink-0"
             />
           ) : null}

--- a/apps/web/src/components/ThreadCommandSubtitle.tsx
+++ b/apps/web/src/components/ThreadCommandSubtitle.tsx
@@ -1,0 +1,110 @@
+import type { EnvironmentId, ProviderDriverKind } from "@t3tools/contracts";
+import { FolderGit2Icon, FolderIcon, GitBranchIcon } from "lucide-react";
+import { ProjectFavicon } from "./ProjectFavicon";
+import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
+import { cn } from "~/lib/utils";
+
+/**
+ * Flip this while reviewing command-palette thread subtitles.
+ * - favicon-workspace-harness: favicon + Folder/FolderGit2 + branch + harness (default)
+ * - favicon-workspace: same without harness
+ * - favicon-branch-harness: GitBranch for local, FolderGit2 for worktrees, + harness
+ */
+export type ThreadCommandSubtitleVariant =
+  | "favicon-workspace-harness"
+  | "favicon-workspace"
+  | "favicon-branch-harness";
+
+export const THREAD_COMMAND_SUBTITLE_VARIANT: ThreadCommandSubtitleVariant =
+  "favicon-workspace-harness";
+
+const META_ICON_CLASS = "size-3 shrink-0 text-muted-foreground/70";
+
+function Dot() {
+  return <span className="shrink-0 text-muted-foreground/50">·</span>;
+}
+
+function WorkspaceIcon(props: { variant: ThreadCommandSubtitleVariant; isWorktree: boolean }) {
+  if (props.isWorktree) {
+    return <FolderGit2Icon className={META_ICON_CLASS} aria-hidden />;
+  }
+  if (props.variant === "favicon-branch-harness") {
+    return <GitBranchIcon className={META_ICON_CLASS} aria-hidden />;
+  }
+  return <FolderIcon className={META_ICON_CLASS} aria-hidden />;
+}
+
+export function ThreadCommandSubtitle(props: {
+  environmentId: EnvironmentId;
+  projectCwd: string | null;
+  projectTitle: string | null;
+  branch: string | null;
+  worktreePath: string | null;
+  isCurrent: boolean;
+  driverKind?: ProviderDriverKind | null;
+  providerDisplayName?: string | null;
+  variant?: ThreadCommandSubtitleVariant;
+  className?: string;
+}) {
+  const variant = props.variant ?? THREAD_COMMAND_SUBTITLE_VARIANT;
+  const isWorktree = props.worktreePath != null && props.worktreePath.trim().length > 0;
+  const showHarness =
+    variant !== "favicon-workspace" && props.driverKind != null && props.providerDisplayName;
+
+  const projectLabel = props.projectTitle?.trim() || null;
+  const branchLabel = props.branch?.trim() || null;
+
+  if (!projectLabel && !branchLabel && !props.isCurrent && !showHarness) {
+    return null;
+  }
+
+  return (
+    <span
+      className={cn(
+        "inline-flex min-w-0 max-w-full items-center gap-1 text-xs text-muted-foreground/70",
+        props.className,
+      )}
+    >
+      {projectLabel ? (
+        <span className="inline-flex min-w-0 items-center gap-1">
+          {props.projectCwd ? (
+            <ProjectFavicon
+              environmentId={props.environmentId}
+              cwd={props.projectCwd}
+              className="size-3 shrink-0"
+            />
+          ) : null}
+          <span className="min-w-0 truncate">{projectLabel}</span>
+        </span>
+      ) : null}
+
+      {branchLabel ? (
+        <>
+          {projectLabel ? <Dot /> : null}
+          <span className="inline-flex min-w-0 items-center gap-1">
+            <WorkspaceIcon variant={variant} isWorktree={isWorktree} />
+            <span className="min-w-0 truncate">{branchLabel}</span>
+          </span>
+        </>
+      ) : null}
+
+      {showHarness && props.driverKind ? (
+        <>
+          {projectLabel || branchLabel ? <Dot /> : null}
+          <ProviderInstanceIcon
+            driverKind={props.driverKind}
+            displayName={props.providerDisplayName ?? props.driverKind}
+            iconClassName="size-3 shrink-0 opacity-70"
+          />
+        </>
+      ) : null}
+
+      {props.isCurrent ? (
+        <>
+          {projectLabel || branchLabel || showHarness ? <Dot /> : null}
+          <span className="shrink-0">Current thread</span>
+        </>
+      ) : null}
+    </span>
+  );
+}


### PR DESCRIPTION
Adds project favicon and model icon to threads in the command palette

<img width="1280" height="898" alt="image" src="https://github.com/user-attachments/assets/cb465237-6036-4b57-a6bb-4e1b6c02b351" />

<img width="1388" height="972" alt="image" src="https://github.com/user-attachments/assets/48a5957e-4da6-4ecc-a4be-2f3458c3d5e2" />



## Summary
- Command palette thread rows no longer use plain `project · #branch` text for the subtitle
- Subtitles now show the real project favicon, local vs worktree icons (`Folder` / `FolderGit2`), branch label, and harness/provider icon
- Layout is flipable via `THREAD_COMMAND_SUBTITLE_VARIANT` while iterating (`favicon-workspace-harness` default)

## Test plan
- [ ] Open command palette and confirm recent threads show project favicons
- [ ] Compare a local/`main` thread vs a worktree thread icon
- [ ] Confirm harness icon matches the thread provider
- [ ] Confirm “Current thread” still appears on the active thread
- [ ] Search threads and verify the same subtitle treatment in results


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add project favicons and provider icons to command palette thread subtitles
> - Introduces [`ThreadCommandSubtitle`](https://github.com/pingdotgg/t3code/pull/6330/files#diff-78658b684b5a6b3b36afcaebc956c772f2786ba23a33e69162acd72dc2b92014), a new component that renders thread items in the command palette with project favicon, workspace/branch icon, provider icon, and a 'Current thread' marker.
> - Extends `buildThreadActionItems` in [`CommandPalette.logic.ts`](https://github.com/pingdotgg/t3code/pull/6330/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e) with an optional `renderDescription` callback so callers can supply rich React subtitles instead of plain text.
> - Builds provider instance and favicon maps in [`CommandPalette.tsx`](https://github.com/pingdotgg/t3code/pull/6330/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a) and passes them to `ThreadCommandSubtitle` via the new callback.
> - Changes the description container class in [`CommandPaletteResults.tsx`](https://github.com/pingdotgg/t3code/pull/6330/files#diff-271e40d15b123273a7653fb5cb873d031dd8d9aeda66bdedf6a5cd39dd174e5d) from `truncate` to `min-w-0` so nested rich content can manage its own truncation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c9200d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->