### PR TITLE
fix(web): let modified clicks on PR links open in the browser

### DIFF
--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   findProjectForChangeRequest,
+  isModifiedClick,
   openPullRequestLink,
   parseChangeRequestUrl,
   PullRequestLinkOpenError,
@@ -132,6 +133,26 @@ describe("parseChangeRequestUrl", () => {
       "not a url",
     ]) {
       expect(parseChangeRequestUrl(link), link).toBeNull();
+    }
+  });
+});
+
+describe("isModifiedClick", () => {
+  const plain = { button: 0, metaKey: false, ctrlKey: false, shiftKey: false, altKey: false };
+
+  it("leaves a plain primary click to the page", () => {
+    expect(isModifiedClick(plain)).toBe(false);
+  });
+
+  it("hands any modified or non-primary click to the browser", () => {
+    for (const click of [
+      { ...plain, metaKey: true },
+      { ...plain, ctrlKey: true },
+      { ...plain, shiftKey: true },
+      { ...plain, altKey: true },
+      { ...plain, button: 1 },
+    ]) {
+      expect(isModifiedClick(click), JSON.stringify(click)).toBe(true);
     }
   });
 });

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -160,9 +160,21 @@ export function findProjectForChangeRequest(
 }
 
 /**
+ * A click whose modifiers spell out a browser destination — cmd/ctrl for a new tab, shift for a
+ * window, alt to download — or that is not the primary button at all. The reader said where the
+ * link should open, so the page never claims it.
+ */
+export function isModifiedClick(
+  event: Pick<MouseEvent<HTMLElement>, "button" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey">,
+): boolean {
+  return event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+}
+
+/**
  * Opens a change request link on the page, and says whether it did. Anything else — another
  * organisation's repository, a host nothing here is checked out from, a link that merely looks
- * like one — is left alone for the caller to handle as the ordinary link it is.
+ * like one, a cmd/ctrl/shift/alt-modified click — is left alone for the caller to handle as the
+ * ordinary link it is.
  *
  * Resolving the project here rather than on the page is what makes recognising a URL safe: a
  * lookalike hostname matches no project and stays a link, and the page is handed the project
@@ -176,7 +188,10 @@ export function findProjectForChangeRequest(
 export function useOpenChangeRequestLink(
   threadRef?: ScopedThreadRef,
 ): (
-  event: Pick<MouseEvent<HTMLElement>, "preventDefault" | "stopPropagation">,
+  event: Pick<
+    MouseEvent<HTMLElement>,
+    "preventDefault" | "stopPropagation" | "button" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey"
+  >,
   targetUrl: string,
   targetThreadRef?: ScopedThreadRef,
 ) => boolean {
@@ -186,6 +201,9 @@ export function useOpenChangeRequestLink(
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   return useCallback(
     (event, targetUrl, targetThreadRef) => {
+      // A modified click already names its destination, so it stays a link: a markdown anchor's
+      // own target opens the tab, and `useOpenPrLink` falls through to the system browser.
+      if (isModifiedClick(event)) return false;
       const resolvedThreadRef = targetThreadRef ?? threadRef;
       const environmentId = resolvedThreadRef?.environmentId ?? primaryEnvironmentId;
       if (


### PR DESCRIPTION
## Summary

Cmd+clicking a pull request link in chat opened the in-app right panel, exactly like a plain click — the modifier was swallowed. This PR makes modified clicks (cmd/ctrl, shift, alt, middle-click) on recognised PR/MR links bypass the interception so they open in the browser, while a plain click keeps opening the side panel.

## Changes

- `useOpenChangeRequestLink` now returns early on a modified click via a new `isModifiedClick` helper, mirroring the modifier guard the markdown fragment handler (`handleMarkdownFragmentClick`) already uses.
- Chat/markdown PR links are real `target="_blank"` anchors, so stepping aside lets the browser's native cmd+click open a new tab.
- Sidebar and branch-toolbar PR badges are buttons routed through `useOpenPrLink`; on a modified click they now fall through to the existing external-open path (`shell.openExternal` / `window.open`).
- Unit tests for `isModifiedClick` covering meta/ctrl/shift/alt/middle-click.

## Testing

- `pnpm test src/lib/openPullRequestLink.test.ts` — 15 passed
- `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small click-handling UX fix with unit tests; no auth, data, or security-sensitive logic changes.
> 
> **Overview**
> **Modified clicks on PR/MR links now fall through to the browser** instead of always opening the in-app panel.
> 
> Adds `isModifiedClick` and early-returns from `useOpenChangeRequestLink` when the click uses cmd/ctrl/shift/alt or a non-primary button. Plain primary clicks still open the side panel; markdown anchors can open a new tab natively, and `useOpenPrLink` callers fall through to the existing external-open path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d2658f4ce5edfc8cf3ebda56656eabe33ad2de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Let modified clicks on PR links fall through to the browser
> Adds an `isModifiedClick` helper in [`openPullRequestLink.ts`](https://github.com/pingdotgg/t3code/pull/6331/files#diff-953140e01f1329a36fe8f5606c9027215b588e76537644ab9819a9a618d000ae) that returns `true` when a click uses a modifier key (meta/ctrl/shift/alt) or a non-primary mouse button. The `useOpenChangeRequestLink` hook now returns `false` immediately for such clicks, allowing the browser to handle them natively (e.g. open in new tab). Unmodified primary clicks continue to be intercepted as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1d2658.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->