### PR TITLE
feat(web): open skill mentions in file panel

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -106,13 +106,15 @@ interface ChatMarkdownProps {
   threadRef?: ScopedThreadRef | undefined;
   onTaskListChange?: ((input: { markerOffset: number; checked: boolean }) => void) | undefined;
   isStreaming?: boolean;
-  skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
+  skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName" | "path">>;
   className?: string;
   /** Treat single newlines as hard breaks — chat-style user input. */
   lineBreaks?: boolean;
 }
 
-const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<
+  Pick<ServerProviderSkill, "name" | "displayName" | "path">
+> = [];
 
 const CODE_FENCE_LANGUAGE_REGEX = /(?:^|\s)language-([^\s]+)/;
 const MAX_HIGHLIGHT_CACHE_ENTRIES = 500;
@@ -1481,7 +1483,7 @@ function ChatMarkdown({
 
     return {
       p({ node: _node, children, ...props }) {
-        return <p {...props}>{renderSkillInlineMarkdownChildren(children, skills)}</p>;
+        return <p {...props}>{renderSkillInlineMarkdownChildren(children, skills, threadRef)}</p>;
       },
       blockquote({ node: _node, children, ...props }) {
         const alert =
@@ -1509,7 +1511,7 @@ function ChatMarkdown({
           typeof listItemStart === "number" ? findTaskListMarkerOffset(text, listItemStart) : null;
         return (
           <li {...props} data-task-marker-offset={markerOffset ?? undefined}>
-            {renderSkillInlineMarkdownChildren(children, skills)}
+            {renderSkillInlineMarkdownChildren(children, skills, threadRef)}
           </li>
         );
       },

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -131,6 +131,10 @@ import {
   useRightPanelStore,
 } from "../rightPanelStore";
 import {
+  fileSurfacePathForLocation,
+  resolveRightPanelFileLocation,
+} from "../rightPanelFileLocation";
+import {
   isPreviewSupportedInRuntime,
   setActivePreviewTab,
   useThreadPreviewState,
@@ -1721,11 +1725,10 @@ function ChatViewContent(props: ChatViewProps) {
     ? (pendingFileSurfaceIdsByProject.get(activeProjectKey) ?? EMPTY_PENDING_FILE_SURFACE_IDS)
     : EMPTY_PENDING_FILE_SURFACE_IDS;
   const handleFilePendingChange = useCallback(
-    (relativePath: string, pending: boolean) => {
+    (surfaceId: string, pending: boolean) => {
       if (!activeProjectKey) return;
       setPendingFileSurfaceIdsByProject((currentByProject) => {
         const current = currentByProject.get(activeProjectKey) ?? EMPTY_PENDING_FILE_SURFACE_IDS;
-        const surfaceId = `file:${relativePath}`;
         if (current.has(surfaceId) === pending) return currentByProject;
         const next = new Set(current);
         if (pending) next.add(surfaceId);
@@ -6019,6 +6022,10 @@ function ChatViewContent(props: ChatViewProps) {
       {panelToggleControls}
     </div>
   );
+  const activeFileLocation =
+    activeFileSurface && activeWorkspaceRoot
+      ? resolveRightPanelFileLocation(activeWorkspaceRoot, activeFileSurface.relativePath)
+      : null;
   const rightPanelContent = activeThreadRef ? (
     activeRightPanelSurface?.kind === "preview" ? (
       <Suspense fallback={null}>
@@ -6100,21 +6107,32 @@ function ChatViewContent(props: ChatViewProps) {
       activeWorkspaceRoot ? (
       <Suspense fallback={null}>
         <FilePreviewPanel
-          key={`${activeProject.environmentId}:${activeWorkspaceRoot}`}
+          key={`${activeProject.environmentId}:${activeFileLocation?.cwd ?? activeWorkspaceRoot}`}
           environmentId={activeProject.environmentId}
-          cwd={activeWorkspaceRoot}
-          projectName={activeProject.title}
+          cwd={activeFileLocation?.cwd ?? activeWorkspaceRoot}
+          projectName={activeFileLocation?.rootLabel ?? activeProject.title}
           threadRef={activeThreadRef}
           composerDraftTarget={composerDraftTarget}
           keybindings={keybindings}
           availableEditors={availableEditors}
           relativePath={
-            activeRightPanelSurface.kind === "file" ? activeRightPanelSurface.relativePath : null
+            activeRightPanelSurface.kind === "file"
+              ? (activeFileLocation?.relativePath ?? activeRightPanelSurface.relativePath)
+              : null
           }
           revealLine={activeFileSurface?.revealLine ?? null}
           revealRequestId={activeFileSurface?.revealRequestId ?? 0}
-          onOpenFile={openFileSurface}
-          onPendingChange={handleFilePendingChange}
+          onOpenFile={(relativePath) => {
+            openFileSurface(
+              activeFileLocation
+                ? fileSurfacePathForLocation(activeFileLocation, relativePath)
+                : relativePath,
+            );
+          }}
+          onPendingChange={(_relativePath, pending) => {
+            if (activeRightPanelSurface.kind !== "file") return;
+            handleFilePendingChange(activeRightPanelSurface.id, pending);
+          }}
         />
       </Suspense>
     ) : null

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -411,8 +411,13 @@ function surfaceTitle(
       return "Diff";
     case "files":
       return "Files";
-    case "file":
-      return surface.relativePath.slice(surface.relativePath.lastIndexOf("/") + 1);
+    case "file": {
+      const separatorIndex = Math.max(
+        surface.relativePath.lastIndexOf("/"),
+        surface.relativePath.lastIndexOf("\\"),
+      );
+      return surface.relativePath.slice(separatorIndex + 1);
+    }
     case "terminal":
       return (
         terminalLabelsById.get(surface.activeTerminalId) ??

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -135,7 +135,7 @@ interface TimelineRowSharedState {
   markdownCwd: string | undefined;
   resolvedTheme: "light" | "dark";
   workspaceRoot: string | undefined;
-  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
+  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName" | "path">>;
   activeThreadEnvironmentId: EnvironmentId;
   onRevertUserMessage: (messageId: MessageId) => void;
   onImageExpand: (preview: ExpandedImagePreview) => void;
@@ -187,7 +187,9 @@ function TimelineLoadEarlierHeader({
   );
 }
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
-const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const EMPTY_TIMELINE_SKILLS: ReadonlyArray<
+  Pick<ServerProviderSkill, "name" | "displayName" | "path">
+> = [];
 const TIMELINE_MAINTAIN_SCROLL_AT_END = {
   animated: false,
   on: {
@@ -224,7 +226,7 @@ interface MessagesTimelineProps {
   resolvedTheme: "light" | "dark";
   timestampFormat: TimestampFormat;
   workspaceRoot: string | undefined;
-  skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
+  skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName" | "path">>;
   anchorMessageId: MessageId | null;
   onAnchorReady: (messageId: MessageId, anchorIndex: number) => void;
   contentInsetEndAdjustment: number;
@@ -1604,7 +1606,7 @@ function shouldCollapseUserMessage(text: string): boolean {
 const CollapsibleUserMessageBody = memo(function CollapsibleUserMessageBody(props: {
   text: string;
   terminalContexts: ParsedTerminalContextEntry[];
-  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
+  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName" | "path">>;
   markdownCwd: string | undefined;
   footer?: ReactNode;
 }) {
@@ -1672,7 +1674,7 @@ const CollapsibleUserMessageBody = memo(function CollapsibleUserMessageBody(prop
 const UserMessageBody = memo(function UserMessageBody(props: {
   text: string;
   terminalContexts: ParsedTerminalContextEntry[];
-  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
+  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName" | "path">>;
   markdownCwd: string | undefined;
 }) {
   const ctx = use(TimelineRowCtx);
@@ -1855,7 +1857,11 @@ function UserMessageReviewCommentCard({ comment }: { comment: ReviewCommentConte
       </div>
       {comment.text.length > 0 && (
         <div className="whitespace-pre-wrap wrap-break-word text-sm">
-          <SkillInlineText text={comment.text} skills={ctx.skills} />
+          <SkillInlineText
+            text={comment.text}
+            skills={ctx.skills}
+            threadRef={ctx.threadRef ?? undefined}
+          />
         </div>
       )}
       {fenceLanguage !== "diff" && comment.diff.trim().length > 0 && (

--- a/apps/web/src/components/chat/SkillInlineText.tsx
+++ b/apps/web/src/components/chat/SkillInlineText.tsx
@@ -1,5 +1,5 @@
 import { Children, cloneElement, isValidElement, type ReactNode } from "react";
-import type { ServerProviderSkill } from "@t3tools/contracts";
+import type { ScopedThreadRef, ServerProviderSkill } from "@t3tools/contracts";
 
 import { formatProviderSkillDisplayName } from "../../providerSkillPresentation";
 import {
@@ -9,12 +9,17 @@ import {
   SKILL_CHIP_ICON_SVG,
 } from "../composerInlineChip";
 import { cn } from "~/lib/utils";
+import { useRightPanelStore } from "~/rightPanelStore";
 
 const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s|$)/g;
 
-type InlineSkill = Pick<ServerProviderSkill, "name" | "displayName">;
+type InlineSkill = Pick<ServerProviderSkill, "name" | "displayName" | "path">;
 
-export function SkillInlineText(props: { text: string; skills: ReadonlyArray<InlineSkill> }) {
+export function SkillInlineText(props: {
+  text: string;
+  skills: ReadonlyArray<InlineSkill>;
+  threadRef?: ScopedThreadRef | undefined;
+}) {
   const nodes: ReactNode[] = [];
   let cursor = 0;
 
@@ -31,7 +36,14 @@ export function SkillInlineText(props: { text: string; skills: ReadonlyArray<Inl
     if (start > cursor) {
       nodes.push(props.text.slice(cursor, start));
     }
-    nodes.push(<SkillChip key={`${start}:${name}`} skill={skill} rawText={rawText} />);
+    nodes.push(
+      <SkillChip
+        key={`${start}:${name}`}
+        skill={skill}
+        rawText={rawText}
+        threadRef={props.threadRef}
+      />,
+    );
     cursor = start + rawText.length;
   }
 
@@ -47,10 +59,11 @@ export function SkillInlineText(props: { text: string; skills: ReadonlyArray<Inl
 export function renderSkillInlineMarkdownChildren(
   children: ReactNode,
   skills: ReadonlyArray<InlineSkill>,
+  threadRef?: ScopedThreadRef | undefined,
 ): ReactNode {
   return Children.map(children, (child) => {
     if (typeof child === "string") {
-      return <SkillInlineText text={child} skills={skills} />;
+      return <SkillInlineText text={child} skills={skills} threadRef={threadRef} />;
     }
     if (!isValidElement<{ children?: ReactNode; node?: { tagName?: string } }>(child)) {
       return child;
@@ -67,29 +80,53 @@ export function renderSkillInlineMarkdownChildren(
     return cloneElement(
       child,
       undefined,
-      renderSkillInlineMarkdownChildren(child.props.children, skills),
+      renderSkillInlineMarkdownChildren(child.props.children, skills, threadRef),
     );
   });
 }
 
-function SkillChip(props: { skill: InlineSkill; rawText: string }) {
+function SkillChip(props: {
+  skill: InlineSkill;
+  rawText: string;
+  threadRef?: ScopedThreadRef | undefined;
+}) {
+  const threadRef = props.threadRef;
+  const chipContents = (
+    <>
+      <span
+        aria-hidden="true"
+        className={COMPOSER_INLINE_CHIP_ICON_CLASS_NAME}
+        dangerouslySetInnerHTML={{ __html: SKILL_CHIP_ICON_SVG }}
+      />
+      <span className={CHAT_INLINE_CHIP_LABEL_CLASS_NAME}>
+        {formatProviderSkillDisplayName(props.skill)}
+      </span>
+    </>
+  );
+  const className = cn(
+    CHAT_INLINE_CHIP_CLASS_NAME,
+    "border-fuchsia-500/25 bg-fuchsia-500/12 text-fuchsia-700 dark:text-fuchsia-300",
+  );
+
   return (
     <span className="inline-flex align-middle leading-none" data-markdown-copy={props.rawText}>
-      <span
-        className={cn(
-          CHAT_INLINE_CHIP_CLASS_NAME,
-          "border-fuchsia-500/25 bg-fuchsia-500/12 text-fuchsia-700 dark:text-fuchsia-300",
-        )}
-      >
-        <span
-          aria-hidden="true"
-          className={COMPOSER_INLINE_CHIP_ICON_CLASS_NAME}
-          dangerouslySetInnerHTML={{ __html: SKILL_CHIP_ICON_SVG }}
-        />
-        <span className={CHAT_INLINE_CHIP_LABEL_CLASS_NAME}>
-          {formatProviderSkillDisplayName(props.skill)}
-        </span>
-      </span>
+      {threadRef ? (
+        <button
+          type="button"
+          className={cn(
+            className,
+            "cursor-pointer hover:brightness-95 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:hover:brightness-110",
+          )}
+          aria-label={`Open ${formatProviderSkillDisplayName(props.skill)} skill`}
+          onClick={() => {
+            useRightPanelStore.getState().openFile(threadRef, props.skill.path);
+          }}
+        >
+          {chipContents}
+        </button>
+      ) : (
+        <span className={className}>{chipContents}</span>
+      )}
     </span>
   );
 }

--- a/apps/web/src/rightPanelFileLocation.test.ts
+++ b/apps/web/src/rightPanelFileLocation.test.ts
@@ -50,4 +50,18 @@ describe("resolveRightPanelFileLocation", () => {
       "C:\\Users\\test\\.codex\\skills\\review-follow-up\\references\\checklist.md",
     );
   });
+
+  it("matches UNC workspace paths without case sensitivity", () => {
+    expect(
+      resolveRightPanelFileLocation(
+        "\\\\server\\share\\project",
+        "\\\\Server\\Share\\project\\.codex\\skills\\review-follow-up\\SKILL.md",
+      ),
+    ).toEqual({
+      cwd: "\\\\server\\share\\project",
+      relativePath: ".codex/skills/review-follow-up/SKILL.md",
+      rootLabel: null,
+      workspaceRelative: true,
+    });
+  });
 });

--- a/apps/web/src/rightPanelFileLocation.test.ts
+++ b/apps/web/src/rightPanelFileLocation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  fileSurfacePathForLocation,
+  resolveRightPanelFileLocation,
+} from "./rightPanelFileLocation";
+
+describe("resolveRightPanelFileLocation", () => {
+  it("makes absolute workspace files relative to the project", () => {
+    expect(
+      resolveRightPanelFileLocation("/workspace/t3code", "/workspace/t3code/docs/guide.md"),
+    ).toEqual({
+      cwd: "/workspace/t3code",
+      relativePath: "docs/guide.md",
+      rootLabel: null,
+      workspaceRelative: true,
+    });
+  });
+
+  it("roots a personal skill preview at its skill directory", () => {
+    const location = resolveRightPanelFileLocation(
+      "/workspace/t3code",
+      "/Users/test/.codex/skills/review-follow-up/SKILL.md",
+    );
+
+    expect(location).toEqual({
+      cwd: "/Users/test/.codex/skills/review-follow-up",
+      relativePath: "SKILL.md",
+      rootLabel: "review-follow-up",
+      workspaceRelative: false,
+    });
+    expect(fileSurfacePathForLocation(location, "references/checklist.md")).toBe(
+      "/Users/test/.codex/skills/review-follow-up/references/checklist.md",
+    );
+  });
+
+  it("preserves Windows path semantics for a remote environment", () => {
+    const location = resolveRightPanelFileLocation(
+      "C:\\work\\t3code",
+      "C:\\Users\\test\\.codex\\skills\\review-follow-up\\SKILL.md",
+    );
+
+    expect(location).toEqual({
+      cwd: "C:\\Users\\test\\.codex\\skills\\review-follow-up",
+      relativePath: "SKILL.md",
+      rootLabel: "review-follow-up",
+      workspaceRelative: false,
+    });
+    expect(fileSurfacePathForLocation(location, "references/checklist.md")).toBe(
+      "C:\\Users\\test\\.codex\\skills\\review-follow-up\\references\\checklist.md",
+    );
+  });
+});

--- a/apps/web/src/rightPanelFileLocation.test.ts
+++ b/apps/web/src/rightPanelFileLocation.test.ts
@@ -64,4 +64,26 @@ describe("resolveRightPanelFileLocation", () => {
       workspaceRelative: true,
     });
   });
+
+  it("collapses repeated separators in workspace file paths", () => {
+    expect(
+      resolveRightPanelFileLocation("/workspace/t3code", "/workspace/t3code//docs/guide.md"),
+    ).toEqual({
+      cwd: "/workspace/t3code",
+      relativePath: "docs/guide.md",
+      rootLabel: null,
+      workspaceRelative: true,
+    });
+  });
+
+  it("does not treat paths that escape the workspace as workspace files", () => {
+    expect(
+      resolveRightPanelFileLocation("/workspace/t3code", "/workspace/t3code/../personal/SKILL.md"),
+    ).toEqual({
+      cwd: "/workspace/personal",
+      relativePath: "SKILL.md",
+      rootLabel: "personal",
+      workspaceRelative: false,
+    });
+  });
 });

--- a/apps/web/src/rightPanelFileLocation.ts
+++ b/apps/web/src/rightPanelFileLocation.ts
@@ -1,0 +1,87 @@
+export interface RightPanelFileLocation {
+  cwd: string;
+  relativePath: string;
+  rootLabel: string | null;
+  workspaceRelative: boolean;
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+function isWindowsAbsolutePath(path: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\");
+}
+
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith("/") || isWindowsAbsolutePath(path);
+}
+
+function workspaceRelativePath(path: string, workspaceRoot: string): string | null {
+  const normalizedPath = normalizePath(path);
+  const normalizedRoot = normalizePath(workspaceRoot);
+  const caseInsensitive =
+    /^[A-Za-z]:\//.test(normalizedPath) || /^[A-Za-z]:\//.test(normalizedRoot);
+  const comparablePath = caseInsensitive ? normalizedPath.toLowerCase() : normalizedPath;
+  const comparableRoot = caseInsensitive ? normalizedRoot.toLowerCase() : normalizedRoot;
+  if (!comparablePath.startsWith(`${comparableRoot}/`)) return null;
+  return normalizedPath.slice(normalizedRoot.length + 1);
+}
+
+function absolutePathParent(path: string): string {
+  const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  if (separatorIndex === 0) return path.slice(0, 1);
+  if (separatorIndex === 2 && /^[A-Za-z]:[\\/]/.test(path)) {
+    return path.slice(0, 3);
+  }
+  return path.slice(0, separatorIndex);
+}
+
+function basename(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const separatorIndex = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return separatorIndex >= 0 ? trimmed.slice(separatorIndex + 1) : trimmed;
+}
+
+export function resolveRightPanelFileLocation(
+  workspaceRoot: string,
+  filePath: string,
+): RightPanelFileLocation {
+  if (!isAbsolutePath(filePath)) {
+    return {
+      cwd: workspaceRoot,
+      relativePath: filePath,
+      rootLabel: null,
+      workspaceRelative: true,
+    };
+  }
+
+  const relativePath = workspaceRelativePath(filePath, workspaceRoot);
+  if (relativePath) {
+    return {
+      cwd: workspaceRoot,
+      relativePath,
+      rootLabel: null,
+      workspaceRelative: true,
+    };
+  }
+
+  const cwd = absolutePathParent(filePath);
+  return {
+    cwd,
+    relativePath: basename(filePath),
+    rootLabel: basename(cwd) || cwd,
+    workspaceRelative: false,
+  };
+}
+
+export function fileSurfacePathForLocation(
+  location: RightPanelFileLocation,
+  relativePath: string,
+): string {
+  if (location.workspaceRelative) return relativePath;
+  const separator = location.cwd.includes("\\") ? "\\" : "/";
+  const cwd = location.cwd.replace(/[\\/]+$/, "");
+  const path = separator === "\\" ? relativePath.replaceAll("/", "\\") : relativePath;
+  return `${cwd}${separator}${path}`;
+}

--- a/apps/web/src/rightPanelFileLocation.ts
+++ b/apps/web/src/rightPanelFileLocation.ts
@@ -6,11 +6,31 @@ export interface RightPanelFileLocation {
 }
 
 function normalizePath(path: string): string {
-  return path.replaceAll("\\", "/").replace(/\/+$/, "");
+  const slashPath = path.replaceAll("\\", "/");
+  const isUnc = slashPath.startsWith("//");
+  const driveRoot = slashPath.match(/^[A-Za-z]:\//)?.[0];
+  const root = isUnc ? "//" : driveRoot ? driveRoot : slashPath.startsWith("/") ? "/" : "";
+  const protectedSegments = isUnc ? 2 : 0;
+  const segments: string[] = [];
+
+  for (const segment of slashPath.slice(root.length).split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length > protectedSegments && segments.at(-1) !== "..") {
+        segments.pop();
+      } else if (!root) {
+        segments.push(segment);
+      }
+      continue;
+    }
+    segments.push(segment);
+  }
+
+  return `${root}${segments.join("/")}`;
 }
 
 function isWindowsAbsolutePath(path: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\");
+  return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\") || path.startsWith("//");
 }
 
 function isAbsolutePath(path: string): boolean {
@@ -56,7 +76,7 @@ export function resolveRightPanelFileLocation(
   }
 
   const relativePath = workspaceRelativePath(filePath, workspaceRoot);
-  if (relativePath) {
+  if (relativePath !== null) {
     return {
       cwd: workspaceRoot,
       relativePath,
@@ -65,10 +85,14 @@ export function resolveRightPanelFileLocation(
     };
   }
 
-  const cwd = absolutePathParent(filePath);
+  const normalizedFilePath = normalizePath(filePath);
+  const filePathWithOriginalSeparators = filePath.includes("\\")
+    ? normalizedFilePath.replaceAll("/", "\\")
+    : normalizedFilePath;
+  const cwd = absolutePathParent(filePathWithOriginalSeparators);
   return {
     cwd,
-    relativePath: basename(filePath),
+    relativePath: basename(filePathWithOriginalSeparators),
     rootLabel: basename(cwd) || cwd,
     workspaceRelative: false,
   };

--- a/apps/web/src/rightPanelFileLocation.ts
+++ b/apps/web/src/rightPanelFileLocation.ts
@@ -20,8 +20,7 @@ function isAbsolutePath(path: string): boolean {
 function workspaceRelativePath(path: string, workspaceRoot: string): string | null {
   const normalizedPath = normalizePath(path);
   const normalizedRoot = normalizePath(workspaceRoot);
-  const caseInsensitive =
-    /^[A-Za-z]:\//.test(normalizedPath) || /^[A-Za-z]:\//.test(normalizedRoot);
+  const caseInsensitive = isWindowsAbsolutePath(path) || isWindowsAbsolutePath(workspaceRoot);
   const comparablePath = caseInsensitive ? normalizedPath.toLowerCase() : normalizedPath;
   const comparableRoot = caseInsensitive ? normalizedRoot.toLowerCase() : normalizedRoot;
   if (!comparablePath.startsWith(`${comparableRoot}/`)) return null;


### PR DESCRIPTION
## What Changed

- Make sent `$skill` mentions clickable on Web and Electron.
- Open the skill's `SKILL.md` in the existing right-side file panel.
- Resolve project, personal/system, and Windows skill paths while keeping file reads scoped to the thread's environment.

## Why

Skill mentions represent Markdown files but were only visual chips after a message was sent. This makes them behave like file mentions.

## UI Changes

Before: `$skill` mentions were non-interactive chips.

After: selecting a `$skill` mention opens its `SKILL.md` in the right panel.

**Screenshot**

<img width="1041" height="467" alt="image" src="https://github.com/user-attachments/assets/c83a8b73-ccda-4807-bbdf-5ec359de6fb8" />

## Verification

- Tested the local Web flow manually.
- Tested the remote environment flow manually.
- Ran 48 focused Web tests.
- Ran the Web typecheck.
- Ran targeted lint, formatting, and diff checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included screenshots for any UI changes

Implemented with gpt-5.6-sol through the Codex harness in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open skill file in right panel when clicking skill mention chips
> - `$skill` tokens in chat messages, review comments, and markdown now render as clickable buttons (via `SkillChip`) that open the referenced skill file in the right panel when a `threadRef` is available; without one, they remain non-interactive spans.
> - `resolveRightPanelFileLocation` and `fileSurfacePathForLocation` utilities in [rightPanelFileLocation.ts](https://github.com/pingdotgg/t3code/pull/6336/files#diff-f06087fce62358642bd4a30b570e30bdda510b18c592f413e1a44002d7e5deac) handle path resolution for both workspace-relative and absolute (including Windows-style) paths.
> - The file preview panel in `ChatView` now correctly roots externally-located files (e.g. personal skills) at their own directory, updating the displayed project title, `cwd`, and tab keys accordingly.
> - `surfaceTitle` in [RightPanelTabs.tsx](https://github.com/pingdotgg/t3code/pull/6336/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91) is fixed to extract the basename from both POSIX and Windows-style paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 21d6e5e. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->