### PR TITLE
fix(terminal): prevent project action commands from getting stuck

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -542,6 +542,18 @@ it.layer(
     }),
   );
 
+  it.effect("leaves an initial command unhandled for an existing shell", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const snapshot = yield* manager.open(openInput({ initialCommand: "npm run dev" }));
+
+      expect(ptyAdapter.spawnInputs).toHaveLength(1);
+      expect(ptyAdapter.processes[0]?.writes).toEqual([]);
+      expect(snapshot.initialCommandHandled).toBeUndefined();
+    }),
+  );
+
   it.effect("preserves structured context and causes for PTY I/O failures", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
@@ -724,9 +736,11 @@ it.layer(
     }),
   );
 
-  it.effect("restarts a running session when open is called with a different cwd", () =>
+  it.effect("handles an initial command when open restarts a running session", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter, logsDir, baseDir } = yield* createManager();
+      const { manager, ptyAdapter, logsDir, baseDir } = yield* createManager(5, {
+        shellResolver: () => "/bin/zsh",
+      });
       const path = yield* Path.Path;
       const originalCwd = path.join(baseDir, "original");
       const differentCwd = path.join(baseDir, "different");
@@ -742,12 +756,22 @@ it.layer(
       const logPath = yield* historyLogPath(logsDir);
       yield* waitFor(pathExists(logPath));
 
-      const reopened = yield* manager.open(openInput({ cwd: differentCwd }));
+      const reopened = yield* manager.open(
+        openInput({ cwd: differentCwd, initialCommand: "npm run dev" }),
+      );
 
       expect(ptyAdapter.spawnInputs).toHaveLength(2);
+      expect(ptyAdapter.spawnInputs[1]?.args).toEqual([
+        "-o",
+        "nopromptsp",
+        "-i",
+        "-c",
+        "trap ':' INT\nnpm run dev\nexec '/bin/zsh' '-o' 'nopromptsp'",
+      ]);
       assert.equal(firstProcess.killed, true);
       assert.equal(reopened.cwd, differentCwd);
       assert.equal(reopened.history, "");
+      expect(reopened.initialCommandHandled).toBe(true);
       yield* waitFor(Effect.map(readFileString(logPath), (text) => text === ""));
     }),
   );
@@ -1607,6 +1631,49 @@ it.layer(
       if (!spawnInput) return;
 
       expect(spawnInput.args).toEqual(["-o", "nopromptsp"]);
+    }),
+  );
+
+  it.effect("runs a fresh command and preserves interactive zsh after Ctrl+C", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") return;
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => "/bin/zsh",
+      });
+
+      const snapshot = yield* manager.open(openInput({ initialCommand: "npm run dev" }));
+
+      expect(ptyAdapter.spawnInputs[0]?.args).toEqual([
+        "-o",
+        "nopromptsp",
+        "-i",
+        "-c",
+        "trap ':' INT\nnpm run dev\nexec '/bin/zsh' '-o' 'nopromptsp'",
+      ]);
+      expect(ptyAdapter.processes[0]?.writes).toEqual([]);
+      expect(snapshot.initialCommandHandled).toBe(true);
+    }),
+  );
+
+  it.effect("leaves fresh Windows shell startup unchanged for an initial command", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        env: {
+          PATH: "C:\\Windows\\System32",
+          SystemRoot: "C:\\Windows",
+        },
+      }).pipe(Effect.provide(withHostPlatform("win32")));
+
+      const snapshot = yield* manager.open(openInput({ initialCommand: "npm run dev" }));
+
+      expect(ptyAdapter.spawnInputs[0]).toEqual(
+        expect.objectContaining({
+          shell: "pwsh.exe",
+          args: ["-NoLogo"],
+        }),
+      );
+      expect(ptyAdapter.processes[0]?.writes).toEqual([]);
+      expect(snapshot.initialCommandHandled).toBeUndefined();
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -349,6 +349,16 @@ function snapshot(session: TerminalSessionState): TerminalSessionSnapshot {
   };
 }
 
+function openSnapshot(
+  session: TerminalSessionState,
+  initialCommandHandled: boolean,
+): TerminalSessionSnapshot {
+  const current = snapshot(session);
+  return initialCommandHandled && session.status === "running"
+    ? { ...current, initialCommandHandled: true }
+    : current;
+}
+
 function summary(session: TerminalSessionState): TerminalSummary {
   return {
     threadId: session.threadId,
@@ -524,6 +534,33 @@ function windowsCmdPath(env: NodeJS.ProcessEnv): string {
 function formatShellCandidate(candidate: ShellCandidate): string {
   if (!candidate.args || candidate.args.length === 0) return candidate.shell;
   return `${candidate.shell} ${candidate.args.join(" ")}`;
+}
+
+function quotePosixShellArgument(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function posixShellCandidateWithInitialCommand(
+  candidate: ShellCandidate,
+  initialCommand: string,
+): ShellCandidate {
+  const baseArgs = candidate.args ?? [];
+  const reenterShell = [candidate.shell, ...baseArgs].map(quotePosixShellArgument).join(" ");
+  return {
+    shell: candidate.shell,
+    args: [...baseArgs, "-i", "-c", `trap ':' INT\n${initialCommand}\nexec ${reenterShell}`],
+  };
+}
+
+function supportsPosixInitialCommand(
+  candidates: ReadonlyArray<ShellCandidate>,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform === "win32") return false;
+  return candidates.every((candidate) => {
+    const shellName = basenameForPlatform(candidate.shell, platform).toLowerCase();
+    return shellName === "zsh" || shellName === "bash" || shellName === "sh";
+  });
 }
 
 function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellCandidate[] {
@@ -1862,12 +1899,28 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
     let ptyProcess: PtyAdapter.PtyProcess | null = null;
     let startedShell: string | null = null;
+    let initialCommandHandled = false;
 
     const startResult = yield* Effect.result(
       increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
         Effect.andThen(
           Effect.gen(function* () {
-            const shellCandidates = resolveShellCandidates(shellResolver, platform, baseEnv);
+            const resolvedShellCandidates = resolveShellCandidates(
+              shellResolver,
+              platform,
+              baseEnv,
+            );
+            const initialCommand = input.initialCommand;
+            let shellCandidates = resolvedShellCandidates;
+            if (
+              initialCommand !== undefined &&
+              supportsPosixInitialCommand(resolvedShellCandidates, platform)
+            ) {
+              initialCommandHandled = true;
+              shellCandidates = resolvedShellCandidates.map((candidate) =>
+                posixShellCandidateWithInitialCommand(candidate, initialCommand),
+              );
+            }
             const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;
@@ -1914,7 +1967,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     );
 
     if (startResult._tag === "Success") {
-      return;
+      return initialCommandHandled;
     }
 
     {
@@ -1957,6 +2010,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         cause: error,
         ...(startedShell ? { shell: startedShell } : {}),
       });
+      return false;
     }
   });
 
@@ -2187,7 +2241,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       });
 
       yield* evictInactiveSessionsIfNeeded();
-      yield* startSession(
+      const initialCommandHandled = yield* startSession(
         session,
         {
           threadId: input.threadId,
@@ -2197,10 +2251,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           cols,
           rows,
           ...(input.env ? { env: input.env } : {}),
+          ...(input.initialCommand ? { initialCommand: input.initialCommand } : {}),
         },
         "started",
       );
-      return snapshot(session);
+      return openSnapshot(session, initialCommandHandled);
     }
 
     const liveSession = existing.value;
@@ -2239,7 +2294,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     }
 
     if (!liveSession.process) {
-      yield* startSession(
+      const initialCommandHandled = yield* startSession(
         liveSession,
         {
           threadId: input.threadId,
@@ -2249,10 +2304,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           cols: targetCols,
           rows: targetRows,
           ...(input.env ? { env: input.env } : {}),
+          ...(input.initialCommand ? { initialCommand: input.initialCommand } : {}),
         },
         "started",
       );
-      return snapshot(liveSession);
+      return openSnapshot(liveSession, initialCommandHandled);
     }
 
     if (liveSession.cols !== targetCols || liveSession.rows !== targetRows) {
@@ -2262,7 +2318,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.updatedAt = yield* nowIso;
     }
 
-    return snapshot(liveSession);
+    return openSnapshot(liveSession, false);
   });
 
   const open: TerminalManager["Service"]["open"] = (input) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3019,6 +3019,7 @@ function ChatViewContent(props: ChatViewProps) {
             env: runtimeEnv,
             cols: SCRIPT_TERMINAL_COLS,
             rows: SCRIPT_TERMINAL_ROWS,
+            initialCommand: script.command,
           }
         : {
             threadId: activeThreadId,
@@ -3026,6 +3027,7 @@ function ChatViewContent(props: ChatViewProps) {
             cwd: targetCwd,
             ...(targetWorktreePath !== null ? { worktreePath: targetWorktreePath } : {}),
             env: runtimeEnv,
+            initialCommand: script.command,
           };
 
       if (shouldCreateNewTerminal) {
@@ -3046,20 +3048,25 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
 
-      const writeResult = await writeTerminal({
-        environmentId,
-        input: {
-          threadId: activeThreadId,
-          terminalId: targetTerminalId,
-          data: `${script.command}\r`,
-        },
-      });
-      if (writeResult._tag === "Failure" && !isAtomCommandInterrupted(writeResult)) {
-        const error = squashAtomCommandFailure(writeResult);
-        setThreadError(
-          activeThreadId,
-          error instanceof Error ? error.message : `Failed to run script "${script.name}".`,
-        );
+      // Older remote servers ignore the optional initialCommand field. Keep
+      // project actions working across version skew, even though only newer
+      // servers can avoid the fresh-shell startup race.
+      if (openResult.value.initialCommandHandled !== true) {
+        const writeResult = await writeTerminal({
+          environmentId,
+          input: {
+            threadId: activeThreadId,
+            terminalId: targetTerminalId,
+            data: `${script.command}\r`,
+          },
+        });
+        if (writeResult._tag === "Failure" && !isAtomCommandInterrupted(writeResult)) {
+          const error = squashAtomCommandFailure(writeResult);
+          setThreadError(
+            activeThreadId,
+            error instanceof Error ? error.message : `Failed to run script "${script.name}".`,
+          );
+        }
       }
     },
     [

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -95,6 +95,17 @@ describe("TerminalOpenInput", () => {
     expect(parsed.worktreePath).toBe("/tmp/project/.t3/worktrees/feature-a");
   });
 
+  it("accepts an initial command", () => {
+    const parsed = decodeSync(TerminalOpenInput, {
+      threadId: "thread-1",
+      terminalId: DEFAULT_TERMINAL_ID,
+      cwd: "/tmp/project",
+      initialCommand: "npm run dev",
+    });
+
+    expect(parsed.initialCommand).toBe("npm run dev");
+  });
+
   it("rejects invalid env keys", () => {
     expect(
       decodes(TerminalOpenInput, {

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -43,6 +43,10 @@ export const TerminalOpenInput = Schema.Struct({
   cols: Schema.optional(TerminalColsSchema),
   rows: Schema.optional(TerminalRowsSchema),
   env: Schema.optional(TerminalEnvSchema),
+  /** Ask the server to run a command during shell startup when supported. */
+  initialCommand: Schema.optional(
+    Schema.String.check(Schema.isNonEmpty()).check(Schema.isMaxLength(65_536)),
+  ),
 });
 export type TerminalOpenInput = Schema.Codec.Encoded<typeof TerminalOpenInput>;
 
@@ -107,6 +111,8 @@ export const TerminalSessionSnapshot = Schema.Struct({
   label: Schema.String.check(Schema.isMaxLength(128)),
   updatedAt: Schema.String,
   sequence: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  /** Present when terminal.open handled the requested initial command. */
+  initialCommandHandled: Schema.optional(Schema.Boolean),
 });
 export type TerminalSessionSnapshot = typeof TerminalSessionSnapshot.Type;
 


### PR DESCRIPTION
## What Changed

- Prevent project-action commands from getting stuck above the prompt when the terminal has not been opened yet.
- On supported POSIX shells, run the initial action command after interactive shell initialization, then return to the normal interactive shell when it exits.
- Keep the terminal open through Ctrl+C so stopping a long-running action returns to a usable prompt instead of closing the terminal.
- Preserve the existing terminal-write path for running terminals, older remote servers, Windows PowerShell/cmd, and unsupported custom shells.

Fixes #6337.

## Why

Project actions previously opened the terminal and immediately sent the command through a separate terminal write. When the terminal had never been opened, interactive shell initialization could race that write, leaving commands such as `npm run dev` stuck above the new prompt without executing.

The fix includes the command in fresh terminal startup where supported and has the server acknowledge whether it handled the command. This removes the race while preserving the existing fallback behavior for Windows, unsupported shells, running terminals, and older servers.

## UI Changes

| Before | After |
| :---: | :---: |
| <img width="1280" height="677" alt="pr-6338-before" src="https://github.com/user-attachments/assets/f600c997-63e7-496a-b95e-61f535e93944" /> | <img width="1280" height="677" alt="pr-6338-after" src="https://github.com/user-attachments/assets/ff889a18-d684-480e-8dde-e8b95714cb5f" /> |

**Before:** With the terminal unopened, the project-action command could get stuck above the initialized prompt without executing.

**After:** The command executes exactly once after shell initialization. Stopping a long-running command with Ctrl+C returns to a usable prompt without closing the terminal.

## Verification

- `vp test run packages/contracts/src/terminal.test.ts apps/server/src/terminal/Manager.test.ts` — 80 tests passed
- Regression coverage confirms a running terminal restarted by a launch-context change handles the action during the new shell startup
- Focused formatting and lint checks for all five changed files
- `@t3tools/contracts`, `t3`, and `@t3tools/web` typechecks
- Web UI pass with the `t3-testing` project: a long-running custom action executed exactly once when launched with the terminal previously unopened
- User-confirmed retest: the action streamed output, Ctrl+C returned to the prompt, and the terminal remained usable
- Exact zsh PTY lifecycle pass: stop a long-running startup command with Ctrl+C, receive the prompt, and run a second command in the same terminal
- Windows fresh-shell arguments are covered by a regression test; Windows runtime behavior was not manually tested

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Prepared with GPT-5.6 Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent project action commands from getting stuck by running them during terminal startup
> - Adds an `initialCommand` field to `TerminalOpenInput` and an `initialCommandHandled` flag to `TerminalSessionSnapshot` in the contract schemas.
> - On supported POSIX shells (zsh, bash, sh), the terminal manager spawns the shell with `-i -c` to run the command, traps `INT` to avoid early exit, then `exec`s back into the interactive shell.
> - The client in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/6338/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) passes `initialCommand` when opening a terminal for a project script and only falls back to writing the command if the server did not set `initialCommandHandled: true`.
> - Windows and unsupported shells skip the startup injection path entirely.
> - Behavioral Change: project script commands now run inside the shell startup sequence rather than being written to stdin after the shell opens, changing how INT signals are handled during execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59b7e5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal spawn arguments and project-action execution paths; POSIX startup uses embedded shell `-c` with user-supplied commands, though existing write fallback and version skew handling limit blast radius.
> 
> **Overview**
> Fixes project actions that could appear above the prompt without running when the terminal had never been opened, by racing shell init against a separate `write`.
> 
> **Contracts** add optional `initialCommand` on `TerminalOpenInput` and `initialCommandHandled` on `TerminalSessionSnapshot` so the client knows whether the server ran the command at spawn.
> 
> **Server** (`Manager.ts`): on fresh POSIX spawns (zsh/bash/sh), rewrites shell args to run the command via interactive `-c`, traps `INT` so Ctrl+C stops the action but keeps an interactive shell (`exec` back into the normal shell). Returns `initialCommandHandled: true` only when that path runs; Windows and an already-running session do not use it.
> 
> **Web** (`ChatView.tsx`): project scripts pass `initialCommand` on `openTerminal` and only fall back to the legacy `writeTerminal` path when `initialCommandHandled !== true` (older servers, Windows, reused terminals).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59b7e5a1cfb11fe9096d6bebb967eae894b72ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->