### PR TITLE
fix(web): preserve appearance mode when changing themes

### DIFF
--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -473,6 +473,10 @@ export function useTheme() {
   const setTheme = useCallback((next: Theme): boolean => {
     if (typeof window === "undefined") return false;
     try {
+      // Preserve the current mode before replacing a legacy or inferred theme
+      // preference. Otherwise a fresh System preference is re-inferred from
+      // the new theme's base appearance, which can switch a dark UI to light.
+      writeAppearanceModePreference(readAppearanceModePreference(getStored()));
       // Choosing a whole theme replaces any automatic-mode mix. The mix is
       // captured first so a failed preference write can put it back instead
       // of erasing it or leaving it attached to the new theme.


### PR DESCRIPTION
## What Changed

Keep the current System, Light, or Dark setting when the user selects another theme.

## Why

On a new setup, System mode was used but not saved. When the user selected a theme, the app used that theme's default Light mode. This could change a dark app to light. The app now saves the current mode before it changes the theme.

## UI Changes

No visual UI, motion, or interaction design changes. The existing theme picker now keeps the active appearance mode.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable because no visual UI changed
- [x] A video is not applicable because no animation or interaction design changed

Implemented with GPT-5.6 Sol via Codex in the T3 Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to theme preference writes in `setTheme`; no auth, security, or data-handling impact.
> 
> **Overview**
> Fixes a case where picking a new theme could flip a dark UI to light when **System** (or another mode) was active but not yet stored.
> 
> **`setTheme`** now writes the current appearance mode to `THEME_APPEARANCE_MODE_STORAGE_KEY` (via `readAppearanceModePreference` + `writeAppearanceModePreference`) **before** clearing theme halves and saving the new theme. That stops the app from re-inferring mode from the newly selected theme’s default appearance on the next apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75081d70ea5638cb3c270cfc1eee529df437c926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `useTheme.setTheme` to preserve appearance mode when changing themes
> When changing themes, the previous appearance mode (light/dark) was being discarded and re-inferred from the new theme, causing unexpected switches. The fix reads the current appearance mode from storage and writes it back before applying the new theme preference in [useTheme.ts](https://github.com/pingdotgg/t3code/pull/6343/files#diff-57ecb397fe0e1618fa00c5e68da8f87d74b28fa80bbe3278328f195bc91505c4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75081d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->