### PR TITLE
fix(web): keep traits menu open after selection

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -323,9 +323,8 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                     key={option.id}
                     value={option.id}
                     hideIndicator
-                    // Base UI keeps radio menus open by default. Close on pick so
-                    // the traits menu behaves like the model picker.
-                    closeOnClick
+                    // Keep the menu open while the user configures related traits.
+                    closeOnClick={false}
                     disabled={ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id}
                   >
                     <span className="flex w-full min-w-0 items-center justify-between gap-3">
@@ -365,7 +364,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                 }}
               >
                 {(["on", "off"] as const).map((value) => (
-                  <MenuRadioItem key={value} value={value} hideIndicator closeOnClick>
+                  <MenuRadioItem key={value} value={value} hideIndicator closeOnClick={false}>
                     <span className="flex w-full min-w-0 items-center justify-between gap-3">
                       <span>{value === "on" ? "On" : "Off"}</span>
                     </span>


### PR DESCRIPTION
## What Changed

- Keep reasoning effort, context window, service tier, and boolean trait selections open after each choice.
- Preserve the menu’s existing outside-click and Escape dismissal behavior.

## Why

These options are often adjusted together. Closing after every choice forces users to repeatedly reopen the same configuration menu.

## UI Changes

Before: the traits menu closed after each selection.

After: each selection applies immediately while the menu stays open for further changes, then closes when dismissed.

No visual styling changed. Screenshots and video were not captured for this behavior-only change.

## Verification

- `vp test run --project unit src/components/chat/TraitsPicker.test.ts` (7 passed)
- `vp fmt apps/web/src/components/chat/TraitsPicker.tsx --check`
- `vp lint apps/web/src/components/chat/TraitsPicker.tsx`
- `vp run --filter @t3tools/web typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (behavior only; no visual styling change)
- [ ] I included a video for animation/interaction changes (not captured)

Made with `gpt-5.6-sol` in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small interaction-only change in the composer traits menu with no auth, data, or API impact.
> 
> **Overview**
> **Traits picker** no longer closes after each choice. Select traits (reasoning effort, context window, service tier, etc.) and boolean **On/Off** items now use `closeOnClick={false}` on `MenuRadioItem`, so selections apply immediately while the menu stays open for further tweaks.
> 
> Dismissal is unchanged: outside click and Escape still close the menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de383fe8f1048d9f9021d36e210d4ca088716ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep traits menu open after selecting or toggling a trait in `TraitsMenuContent`
> Adds `closeOnClick={false}` to `MenuRadioItem` elements in [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/6346/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45) so the menu stays open when selecting a trait option or toggling a boolean trait on/off. Previously, each selection dismissed the menu, requiring users to reopen it to configure additional traits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de383fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The traits menu now remains open when selecting trait options, making it easier to configure related traits without reopening the menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->