### PR TITLE
fix(gitlab): submit review comments on context lines

### DIFF
--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -776,7 +776,13 @@ layer("BitbucketPullRequestApi.layer", (it) => {
         number: 7,
         verdict: "request-changes",
         body: "Two things.",
-        comments: [{ path: "src/a.ts", line: 12, side: "left", body: "why remove?" }],
+        comments: [
+          {
+            path: "src/a.ts",
+            position: { kind: "deleted", oldLine: 12 },
+            body: "why remove?",
+          },
+        ],
       });
 
       expect(callAt(0).url).toContain("/pullrequests/7/comments");

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -12,6 +12,7 @@ import type {
   PullRequestMergeMethod,
   PullRequestMergeability,
   PullRequestReviewCommentDraft,
+  PullRequestReviewPosition,
   PullRequestReviewThread,
   PullRequestReviewVerdict,
   PullRequestReviewerCandidateList,
@@ -351,6 +352,19 @@ function mergeStrategy(method: PullRequestMergeMethod | undefined): string {
       return "rebase_fast_forward";
     default:
       return "merge_commit";
+  }
+}
+
+function bitbucketReviewPosition(
+  position: PullRequestReviewPosition,
+): { readonly from: number } | { readonly to: number } {
+  switch (position.kind) {
+    case "added":
+      return { to: position.newLine };
+    case "deleted":
+      return { from: position.oldLine };
+    case "context":
+      return position.side === "left" ? { from: position.oldLine } : { to: position.newLine };
   }
 }
 
@@ -777,7 +791,7 @@ export const make = Effect.gen(function* () {
                   content: { raw: comment.body },
                   inline: {
                     path: comment.path,
-                    ...(comment.side === "left" ? { from: comment.line } : { to: comment.line }),
+                    ...bitbucketReviewPosition(comment.position),
                   },
                 }),
               }),

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -1624,7 +1624,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
         number: 7,
         verdict: "approve",
         body: "Looks right.",
-        comments: [{ path: "src/a.ts", line: 4, side: "right", body: "nit" }],
+        comments: [{ path: "src/a.ts", position: { kind: "added", newLine: 4 }, body: "nit" }],
       });
 
       expect(callAt(0).args).toEqual([

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -1018,7 +1018,12 @@ layer("GitLabPullRequestCli.layer", (it) => {
         verdict: "approve",
         body: "Looks right.",
         comments: [
-          { path: "src/b.ts", oldPath: "src/a.ts", line: 4, side: "left", body: "why remove?" },
+          {
+            path: "src/b.ts",
+            oldPath: "src/a.ts",
+            position: { kind: "deleted", oldLine: 4 },
+            body: "why remove?",
+          },
         ],
       });
 
@@ -1197,7 +1202,7 @@ layer("GitLabPullRequestCli.layer", (it) => {
           number: 7,
           verdict: "comment",
           body: "",
-          comments: [{ path: "src/a.ts", line: 4, side: "right", body: "nit" }],
+          comments: [{ path: "src/a.ts", position: { kind: "added", newLine: 4 }, body: "nit" }],
         }),
       );
 

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -14,6 +14,7 @@ import type {
   PullRequestReaction,
   PullRequestReactionContent,
   PullRequestReviewCommentDraft,
+  PullRequestReviewPosition,
   PullRequestReviewThread,
   PullRequestReviewVerdict,
   PullRequestReviewerCandidateList,
@@ -398,6 +399,22 @@ export class GitLabPullRequestCli extends Context.Service<
 /** The REST API addresses a project by its URL-encoded full path. */
 function projectPath(repository: string): string {
   return encodeURIComponent(repository.trim());
+}
+
+function gitLabReviewPositionLines(
+  position: PullRequestReviewPosition,
+):
+  | { readonly new_line: number }
+  | { readonly old_line: number }
+  | { readonly old_line: number; readonly new_line: number } {
+  switch (position.kind) {
+    case "added":
+      return { new_line: position.newLine };
+    case "deleted":
+      return { old_line: position.oldLine };
+    case "context":
+      return { old_line: position.oldLine, new_line: position.newLine };
+  }
 }
 
 function stateParam(state: PullRequestListState): string {
@@ -1324,9 +1341,7 @@ export const make = Effect.gen(function* () {
                     // draft carries the name the file had before the change.
                     old_path: comment.oldPath ?? comment.path,
                     new_path: comment.path,
-                    ...(comment.side === "left"
-                      ? { old_line: comment.line }
-                      : { new_line: comment.line }),
+                    ...gitLabReviewPositionLines(comment.position),
                   },
                 }),
               }),

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -1534,7 +1534,7 @@ it.effect("refuses line comments on a host that takes only a summary", () =>
         number: 1,
         verdict: "comment",
         body: "",
-        comments: [{ path: "src/a.ts", line: 1, side: "right", body: "nit" }],
+        comments: [{ path: "src/a.ts", position: { kind: "added", newLine: 1 }, body: "nit" }],
       }),
     );
 

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
@@ -1147,8 +1147,16 @@ describe("review submission payload", () => {
         verdict: "request-changes",
         body: "Two things.",
         comments: [
-          { path: "src/a.ts", line: 12, side: "right", body: "rename this" },
-          { path: "src/b.ts", line: 3, side: "left", body: "why remove?" },
+          {
+            path: "src/a.ts",
+            position: { kind: "added", newLine: 12 },
+            body: "rename this",
+          },
+          {
+            path: "src/b.ts",
+            position: { kind: "deleted", oldLine: 3 },
+            body: "why remove?",
+          },
         ],
       }),
     ) as Record<string, unknown>;

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -17,6 +17,7 @@ import type {
   PullRequestReactionContent,
   PullRequestReviewCommentDraft,
   PullRequestReviewDecision,
+  PullRequestReviewPosition,
   PullRequestReviewThread,
   PullRequestReviewVerdict,
   PullRequestReviewerCandidate,
@@ -933,6 +934,22 @@ export const REVIEW_DISMISSALS_GRAPHQL_QUERY = `query($owner: String!, $name: St
   }
 }`;
 
+function gitHubReviewPosition(position: PullRequestReviewPosition): {
+  readonly line: number;
+  readonly side: "LEFT" | "RIGHT";
+} {
+  switch (position.kind) {
+    case "added":
+      return { line: position.newLine, side: "RIGHT" };
+    case "deleted":
+      return { line: position.oldLine, side: "LEFT" };
+    case "context":
+      return position.side === "left"
+        ? { line: position.oldLine, side: "LEFT" }
+        : { line: position.newLine, side: "RIGHT" };
+  }
+}
+
 /** The whole review as one request body, which is how GitHub keeps it invisible until sent. */
 export function buildReviewSubmissionJson(input: {
   readonly verdict: PullRequestReviewVerdict;
@@ -944,8 +961,7 @@ export function buildReviewSubmissionJson(input: {
     body: input.body,
     comments: input.comments.map((comment) => ({
       path: comment.path,
-      line: comment.line,
-      side: comment.side === "left" ? ("LEFT" as const) : ("RIGHT" as const),
+      ...gitHubReviewPosition(comment.position),
       body: comment.body,
     })),
   });

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -6,6 +6,7 @@ import type {
   PullRequestDiffSide,
   PullRequestOmittedFileStat,
   PullRequestRef,
+  PullRequestReviewPosition,
   PullRequestReviewThread,
 } from "@t3tools/contracts";
 import {
@@ -43,7 +44,11 @@ import {
 } from "~/lib/diffRendering";
 import { cn } from "~/lib/utils";
 import { createPullRequestDiffFileContentsLoader } from "~/lib/diffFileContents";
-import { buildDiffReviewComment, type ReviewCommentContext } from "~/reviewCommentContext";
+import {
+  buildDiffReviewComment,
+  resolveDiffReviewPosition,
+  type ReviewCommentContext,
+} from "~/reviewCommentContext";
 import { pullRequestEnvironment } from "~/state/pullRequests";
 import { useEnvironmentQuery } from "~/state/query";
 import { useAtomCommand } from "~/state/use-atom-command";
@@ -129,8 +134,7 @@ interface DraftAnchor {
   readonly path: string;
   /** What the file was called before the change, for the hosts that resolve a position by both. */
   readonly oldPath: string | null;
-  readonly line: number;
-  readonly side: PullRequestDiffSide;
+  readonly position: PullRequestReviewPosition;
   /** The whole selection, which the comment collapses to one line but a question keeps. */
   readonly range: SelectedLineRange;
 }
@@ -148,8 +152,21 @@ function toViewerSide(side: PullRequestDiffSide) {
   return side === "left" ? ("deletions" as const) : ("additions" as const);
 }
 
-function fromViewerSide(side: string | undefined): PullRequestDiffSide {
-  return side === "deletions" ? "left" : "right";
+function getReviewPositionAnchor(position: PullRequestReviewPosition): {
+  line: number;
+  side: PullRequestDiffSide;
+} {
+  switch (position.kind) {
+    case "added":
+      return { line: position.newLine, side: "right" };
+    case "deleted":
+      return { line: position.oldLine, side: "left" };
+    case "context":
+      return {
+        line: position.side === "left" ? position.oldLine : position.newLine,
+        side: position.side,
+      };
+  }
 }
 
 /**
@@ -442,10 +459,14 @@ export function PullRequestCodeTab({
         if (commit === null) {
           for (const comment of pendingComments) {
             if (comment.path !== path) continue;
-            groupAt(comment.side, comment.line).pending.push(comment);
+            const anchor = getReviewPositionAnchor(comment.position);
+            groupAt(anchor.side, anchor.line).pending.push(comment);
           }
         }
-        if (draft?.fileKey === fileKey) groupAt(draft.side, draft.line).draft = true;
+        if (draft?.fileKey === fileKey) {
+          const anchor = getReviewPositionAnchor(draft.position);
+          groupAt(anchor.side, anchor.line).draft = true;
+        }
 
         const collapsed = isFileDiffCollapsed(fileKey, foldOverride, toggledFiles);
 
@@ -594,12 +615,13 @@ export function PullRequestCodeTab({
       // that silently lost its first line on the other hosts would be worse than one line.
       const path = resolveFileDiffPath(file);
       const previousPath = resolveFileDiffPreviousPath(file);
+      const position = resolveDiffReviewPosition(file, range.end, range.endSide ?? range.side);
+      if (position === null) return;
       setDraft({
         fileKey: item.id,
         path,
         oldPath: previousPath === path ? null : previousPath,
-        line: range.end,
-        side: fromViewerSide(range.endSide ?? range.side),
+        position,
         range,
       });
     },
@@ -843,7 +865,7 @@ export function PullRequestCodeTab({
         {annotation.metadata.draft && draft ? (
           <DiffCommentAnnotation
             kind="draft"
-            rangeLabel={`${draft.path}:${draft.line}`}
+            rangeLabel={`${draft.path}:${getReviewPositionAnchor(draft.position).line}`}
             text=""
             submitLabel="Add to review"
             {...(onAskAboutSelection
@@ -865,8 +887,7 @@ export function PullRequestCodeTab({
                 id: nextPendingReviewCommentId(),
                 path: draft.path,
                 ...(draft.oldPath === null ? {} : { oldPath: draft.oldPath }),
-                line: draft.line,
-                side: draft.side,
+                position: draft.position,
                 body,
               });
               setDraft(null);

--- a/apps/web/src/components/pullRequest/pullRequestReviewStore.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestReviewStore.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { type PendingReviewComment, usePullRequestReviewStore } from "./pullRequestReviewStore";
 
 function comment(id: string, body = id): PendingReviewComment {
-  return { id, body, path: "src/app.ts", line: 1, side: "right" };
+  return { id, body, path: "src/app.ts", position: { kind: "added", newLine: 1 } };
 }
 
 describe("pull request review drafts", () => {

--- a/apps/web/src/components/pullRequest/pullRequestReviewStore.ts
+++ b/apps/web/src/components/pullRequest/pullRequestReviewStore.ts
@@ -6,17 +6,10 @@
  * hosts that have no pending review of their own. That also means a draft lives only as long
  * as the tab does, which is why this is deliberately not persisted.
  */
-import type { ProjectId, PullRequestDiffSide, PullRequestRef } from "@t3tools/contracts";
+import type { ProjectId, PullRequestRef, PullRequestReviewCommentDraft } from "@t3tools/contracts";
 import { create } from "zustand";
 
-export interface PendingReviewComment {
-  readonly id: string;
-  readonly path: string;
-  /** The line in the file the comment's side names: the new file on the right, the old on the left. */
-  readonly line: number;
-  readonly side: PullRequestDiffSide;
-  readonly body: string;
-}
+export type PendingReviewComment = PullRequestReviewCommentDraft & { readonly id: string };
 
 /**
  * A counter rather than anything derived from the comment: two remarks on one line can be the

--- a/apps/web/src/reviewCommentContext.ts
+++ b/apps/web/src/reviewCommentContext.ts
@@ -2,6 +2,14 @@ import type { FileDiffMetadata, SelectedLineRange, SelectionSide } from "@pierre
 import type { PullRequestReviewPosition } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 
+const ReviewCommentSelectionSchema = Schema.Struct({
+  start: Schema.Number,
+  side: Schema.Literals(["additions", "deletions"]),
+  end: Schema.Number,
+  endSide: Schema.Literals(["additions", "deletions"]),
+});
+type ReviewCommentSelection = typeof ReviewCommentSelectionSchema.Type;
+
 export const ReviewCommentContextSchema = Schema.Struct({
   id: Schema.String,
   sectionId: Schema.String,
@@ -13,6 +21,7 @@ export const ReviewCommentContextSchema = Schema.Struct({
   text: Schema.String,
   diff: Schema.String,
   fenceLanguage: Schema.optional(Schema.String),
+  selection: Schema.optional(ReviewCommentSelectionSchema),
 });
 
 export interface ReviewCommentContext {
@@ -26,6 +35,7 @@ export interface ReviewCommentContext {
   readonly text: string;
   readonly diff: string;
   readonly fenceLanguage?: string | undefined;
+  readonly selection?: ReviewCommentSelection | undefined;
 }
 
 interface DiffReviewLine {
@@ -382,6 +392,8 @@ export function restoreDiffReviewCommentRange(
   fileDiff: FileDiffMetadata,
   comment: ReviewCommentContext,
 ): SelectedLineRange | null {
+  if (comment.selection) return comment.selection;
+
   const lines = buildDiffReviewLines(fileDiff);
   const startLine = lines[comment.startIndex];
   const endLine = lines[comment.endIndex];
@@ -511,6 +523,12 @@ export function buildDiffReviewComment(input: {
       ...selectedLines.map((line) => `${getDiffChangeMarker(line.change)}${line.content}`),
     ].join("\n"),
     fenceLanguage: "diff",
+    selection: {
+      start: input.range.start,
+      side: input.range.side ?? "additions",
+      end: input.range.end,
+      endSide: input.range.endSide ?? input.range.side ?? "additions",
+    },
   };
 }
 

--- a/apps/web/src/reviewCommentContext.ts
+++ b/apps/web/src/reviewCommentContext.ts
@@ -371,6 +371,51 @@ function findDiffReviewLineIndex(
   return lines.findIndex((line) => line[fallbackKey] === lineNumber);
 }
 
+/** Resolve a line Pierre hydrated from the unchanged regions outside the host patch's hunks. */
+function resolveExpandedContextPosition(
+  fileDiff: FileDiffMetadata,
+  lineNumber: number,
+  side: SelectionSide | undefined,
+): PullRequestReviewPosition | null {
+  if (fileDiff.isPartial) return null;
+
+  const selectedSide = side === "deletions" ? "left" : "right";
+  let oldContextStart = 1;
+  let newContextStart = 1;
+
+  for (let hunkIndex = 0; hunkIndex <= fileDiff.hunks.length; hunkIndex += 1) {
+    const hunk = fileDiff.hunks[hunkIndex];
+    const oldContextEnd =
+      hunk === undefined
+        ? fileDiff.deletionLines.length + 1
+        : hunk.deletionStart + (hunk.deletionCount === 0 ? 1 : 0);
+    const newContextEnd =
+      hunk === undefined
+        ? fileDiff.additionLines.length + 1
+        : hunk.additionStart + (hunk.additionCount === 0 ? 1 : 0);
+    const selectedStart = selectedSide === "left" ? oldContextStart : newContextStart;
+    const selectedEnd = selectedSide === "left" ? oldContextEnd : newContextEnd;
+    const otherStart = selectedSide === "left" ? newContextStart : oldContextStart;
+    const otherEnd = selectedSide === "left" ? newContextEnd : oldContextEnd;
+    const offset = lineNumber - selectedStart;
+
+    if (offset >= 0 && lineNumber < selectedEnd && otherStart + offset < otherEnd) {
+      return {
+        kind: "context",
+        oldLine: selectedSide === "left" ? lineNumber : otherStart + offset,
+        newLine: selectedSide === "right" ? lineNumber : otherStart + offset,
+        side: selectedSide,
+      };
+    }
+
+    if (hunk === undefined) return null;
+    oldContextStart = oldContextEnd + hunk.deletionCount;
+    newContextStart = newContextEnd + hunk.additionCount;
+  }
+
+  return null;
+}
+
 /** Resolve the host-facing coordinates of a line selected in the diff viewer. */
 export function resolveDiffReviewPosition(
   fileDiff: FileDiffMetadata,
@@ -378,7 +423,15 @@ export function resolveDiffReviewPosition(
   side: SelectionSide | undefined,
 ): PullRequestReviewPosition | null {
   const lines = buildDiffReviewLines(fileDiff);
-  const line = lines[findDiffReviewLineIndex(lines, lineNumber, side)];
+  const preferredKey = side === "deletions" ? "oldLineNumber" : "newLineNumber";
+  const preferredIndex = lines.findIndex((line) => line[preferredKey] === lineNumber);
+  if (preferredIndex < 0) {
+    const expandedPosition = resolveExpandedContextPosition(fileDiff, lineNumber, side);
+    if (expandedPosition !== null) return expandedPosition;
+  }
+
+  const line =
+    lines[preferredIndex >= 0 ? preferredIndex : findDiffReviewLineIndex(lines, lineNumber, side)];
   if (line === undefined) return null;
 
   switch (line.change) {

--- a/apps/web/src/reviewCommentContext.ts
+++ b/apps/web/src/reviewCommentContext.ts
@@ -270,14 +270,17 @@ function stripTrailingNewline(value: string): string {
 
 function buildDiffReviewLines(fileDiff: FileDiffMetadata): ReadonlyArray<DiffReviewLine> {
   const rows: DiffReviewLine[] = [];
+  let oldContextStart = 1;
+  let newContextStart = 1;
 
   for (const hunk of fileDiff.hunks) {
     if (!fileDiff.isPartial) {
       const oldHunkStart = hunk.deletionStart + (hunk.deletionCount === 0 ? 1 : 0);
       const newHunkStart = hunk.additionStart + (hunk.additionCount === 0 ? 1 : 0);
-      for (let offset = hunk.collapsedBefore; offset > 0; offset -= 1) {
-        const oldLineNumber = oldHunkStart - offset;
-        const newLineNumber = newHunkStart - offset;
+      const contextLines = Math.min(oldHunkStart - oldContextStart, newHunkStart - newContextStart);
+      for (let offset = 0; offset < contextLines; offset += 1) {
+        const oldLineNumber = oldContextStart + offset;
+        const newLineNumber = newContextStart + offset;
         rows.push({
           change: "context",
           oldLineNumber,
@@ -335,26 +338,24 @@ function buildDiffReviewLines(fileDiff: FileDiffMetadata): ReadonlyArray<DiffRev
         additionLineIndex += 1;
       }
     }
+
+    oldContextStart = hunk.deletionStart + hunk.deletionCount;
+    newContextStart = hunk.additionStart + hunk.additionCount;
+    if (hunk.deletionCount === 0) oldContextStart += 1;
+    if (hunk.additionCount === 0) newContextStart += 1;
   }
 
   if (!fileDiff.isPartial) {
-    const lastHunk = fileDiff.hunks.at(-1);
-    const oldStart = lastHunk
-      ? lastHunk.deletionStart + lastHunk.deletionCount + (lastHunk.deletionCount === 0 ? 1 : 0)
-      : 1;
-    const newStart = lastHunk
-      ? lastHunk.additionStart + lastHunk.additionCount + (lastHunk.additionCount === 0 ? 1 : 0)
-      : 1;
     const trailingLines = Math.min(
-      fileDiff.deletionLines.length - oldStart + 1,
-      fileDiff.additionLines.length - newStart + 1,
+      fileDiff.deletionLines.length - oldContextStart + 1,
+      fileDiff.additionLines.length - newContextStart + 1,
     );
     for (let offset = 0; offset < trailingLines; offset += 1) {
       rows.push({
         change: "context",
-        oldLineNumber: oldStart + offset,
-        newLineNumber: newStart + offset,
-        content: stripTrailingNewline(fileDiff.additionLines[newStart + offset - 1] ?? ""),
+        oldLineNumber: oldContextStart + offset,
+        newLineNumber: newContextStart + offset,
+        content: stripTrailingNewline(fileDiff.additionLines[newContextStart + offset - 1] ?? ""),
       });
     }
   }

--- a/apps/web/src/reviewCommentContext.ts
+++ b/apps/web/src/reviewCommentContext.ts
@@ -1,4 +1,5 @@
 import type { FileDiffMetadata, SelectedLineRange, SelectionSide } from "@pierre/diffs";
+import type { PullRequestReviewPosition } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 
 export const ReviewCommentContextSchema = Schema.Struct({
@@ -368,6 +369,33 @@ function findDiffReviewLineIndex(
   if (preferredIndex >= 0) return preferredIndex;
   const fallbackKey = preferredKey === "oldLineNumber" ? "newLineNumber" : "oldLineNumber";
   return lines.findIndex((line) => line[fallbackKey] === lineNumber);
+}
+
+/** Resolve the host-facing coordinates of a line selected in the diff viewer. */
+export function resolveDiffReviewPosition(
+  fileDiff: FileDiffMetadata,
+  lineNumber: number,
+  side: SelectionSide | undefined,
+): PullRequestReviewPosition | null {
+  const lines = buildDiffReviewLines(fileDiff);
+  const line = lines[findDiffReviewLineIndex(lines, lineNumber, side)];
+  if (line === undefined) return null;
+
+  switch (line.change) {
+    case "add":
+      return line.newLineNumber === null ? null : { kind: "added", newLine: line.newLineNumber };
+    case "delete":
+      return line.oldLineNumber === null ? null : { kind: "deleted", oldLine: line.oldLineNumber };
+    case "context":
+      return line.oldLineNumber === null || line.newLineNumber === null
+        ? null
+        : {
+            kind: "context",
+            oldLine: line.oldLineNumber,
+            newLine: line.newLineNumber,
+            side: side === "deletions" ? "left" : "right",
+          };
+  }
 }
 
 function getDiffRange(

--- a/apps/web/src/reviewCommentContext.ts
+++ b/apps/web/src/reviewCommentContext.ts
@@ -278,13 +278,16 @@ function stripTrailingNewline(value: string): string {
   return value.endsWith("\n") ? value.slice(0, -1) : value;
 }
 
-function buildDiffReviewLines(fileDiff: FileDiffMetadata): ReadonlyArray<DiffReviewLine> {
+function buildDiffReviewLines(
+  fileDiff: FileDiffMetadata,
+  includeExpandedContext = !fileDiff.isPartial,
+): ReadonlyArray<DiffReviewLine> {
   const rows: DiffReviewLine[] = [];
   let oldContextStart = 1;
   let newContextStart = 1;
 
   for (const hunk of fileDiff.hunks) {
-    if (!fileDiff.isPartial) {
+    if (includeExpandedContext) {
       const oldHunkStart = hunk.deletionStart + (hunk.deletionCount === 0 ? 1 : 0);
       const newHunkStart = hunk.additionStart + (hunk.additionCount === 0 ? 1 : 0);
       const contextLines = Math.min(oldHunkStart - oldContextStart, newHunkStart - newContextStart);
@@ -355,7 +358,7 @@ function buildDiffReviewLines(fileDiff: FileDiffMetadata): ReadonlyArray<DiffRev
     if (hunk.additionCount === 0) newContextStart += 1;
   }
 
-  if (!fileDiff.isPartial) {
+  if (includeExpandedContext) {
     const trailingLines = Math.min(
       fileDiff.deletionLines.length - oldContextStart + 1,
       fileDiff.additionLines.length - newContextStart + 1,
@@ -421,13 +424,54 @@ function findDiffReviewLineIndex(
   return lines.findIndex((line) => line[fallbackKey] === lineNumber);
 }
 
+function resolveExpandedContextPosition(
+  fileDiff: FileDiffMetadata,
+  lineNumber: number,
+  side: SelectionSide | undefined,
+): PullRequestReviewPosition | null {
+  if (fileDiff.isPartial) return null;
+
+  const selectedSide = side === "deletions" ? "left" : "right";
+  let oldContextStart = 1;
+  let newContextStart = 1;
+  const resolveGap = (
+    oldContextEnd: number,
+    newContextEnd: number,
+  ): PullRequestReviewPosition | null => {
+    const contextLines = Math.min(oldContextEnd - oldContextStart, newContextEnd - newContextStart);
+    const selectedStart = selectedSide === "left" ? oldContextStart : newContextStart;
+    const offset = lineNumber - selectedStart;
+    if (offset < 0 || offset >= contextLines) return null;
+    return {
+      kind: "context",
+      oldLine: oldContextStart + offset,
+      newLine: newContextStart + offset,
+      side: selectedSide,
+    };
+  };
+
+  for (const hunk of fileDiff.hunks) {
+    const oldContextEnd = hunk.deletionStart + (hunk.deletionCount === 0 ? 1 : 0);
+    const newContextEnd = hunk.additionStart + (hunk.additionCount === 0 ? 1 : 0);
+    const position = resolveGap(oldContextEnd, newContextEnd);
+    if (position) return position;
+    oldContextStart = oldContextEnd + hunk.deletionCount;
+    newContextStart = newContextEnd + hunk.additionCount;
+  }
+
+  return resolveGap(fileDiff.deletionLines.length + 1, fileDiff.additionLines.length + 1);
+}
+
 /** Resolve the host-facing coordinates of a line selected in the diff viewer. */
 export function resolveDiffReviewPosition(
   fileDiff: FileDiffMetadata,
   lineNumber: number,
   side: SelectionSide | undefined,
 ): PullRequestReviewPosition | null {
-  const lines = buildDiffReviewLines(fileDiff);
+  const expandedPosition = resolveExpandedContextPosition(fileDiff, lineNumber, side);
+  if (expandedPosition) return expandedPosition;
+
+  const lines = buildDiffReviewLines(fileDiff, false);
   const line = lines[findDiffReviewLineIndex(lines, lineNumber, side)];
   if (line === undefined) return null;
 

--- a/apps/web/src/reviewCommentContext.ts
+++ b/apps/web/src/reviewCommentContext.ts
@@ -280,27 +280,40 @@ function stripTrailingNewline(value: string): string {
 
 function buildDiffReviewLines(
   fileDiff: FileDiffMetadata,
-  includeExpandedContext = !fileDiff.isPartial,
+  includeExpandedContext: boolean,
+  slice?: { readonly startIndex: number; readonly endIndex: number },
 ): ReadonlyArray<DiffReviewLine> {
   const rows: DiffReviewLine[] = [];
+  let rowIndex = 0;
   let oldContextStart = 1;
   let newContextStart = 1;
+  const pushRow = (row: DiffReviewLine) => {
+    if (!slice || (rowIndex >= slice.startIndex && rowIndex <= slice.endIndex)) {
+      rows.push(row);
+    }
+    rowIndex += 1;
+  };
+  const pushContextGap = (oldStart: number, newStart: number, lineCount: number) => {
+    const count = Math.max(0, lineCount);
+    const firstOffset = slice ? Math.max(0, slice.startIndex - rowIndex) : 0;
+    const lastOffset = slice ? Math.min(count - 1, slice.endIndex - rowIndex) : count - 1;
+    for (let offset = firstOffset; offset <= lastOffset; offset += 1) {
+      rows.push({
+        change: "context",
+        oldLineNumber: oldStart + offset,
+        newLineNumber: newStart + offset,
+        content: stripTrailingNewline(fileDiff.additionLines[newStart + offset - 1] ?? ""),
+      });
+    }
+    rowIndex += count;
+  };
 
   for (const hunk of fileDiff.hunks) {
     if (includeExpandedContext) {
       const oldHunkStart = hunk.deletionStart + (hunk.deletionCount === 0 ? 1 : 0);
       const newHunkStart = hunk.additionStart + (hunk.additionCount === 0 ? 1 : 0);
       const contextLines = Math.min(oldHunkStart - oldContextStart, newHunkStart - newContextStart);
-      for (let offset = 0; offset < contextLines; offset += 1) {
-        const oldLineNumber = oldContextStart + offset;
-        const newLineNumber = newContextStart + offset;
-        rows.push({
-          change: "context",
-          oldLineNumber,
-          newLineNumber,
-          content: stripTrailingNewline(fileDiff.additionLines[newLineNumber - 1] ?? ""),
-        });
-      }
+      pushContextGap(oldContextStart, newContextStart, contextLines);
     }
 
     let oldLineNumber = hunk.deletionStart;
@@ -311,7 +324,7 @@ function buildDiffReviewLines(
     for (const segment of hunk.hunkContent) {
       if (segment.type === "context") {
         for (let index = 0; index < segment.lines; index += 1) {
-          rows.push({
+          pushRow({
             change: "context",
             oldLineNumber,
             newLineNumber,
@@ -330,7 +343,7 @@ function buildDiffReviewLines(
       }
 
       for (let index = 0; index < segment.deletions; index += 1) {
-        rows.push({
+        pushRow({
           change: "delete",
           oldLineNumber,
           newLineNumber: null,
@@ -341,7 +354,7 @@ function buildDiffReviewLines(
       }
 
       for (let index = 0; index < segment.additions; index += 1) {
-        rows.push({
+        pushRow({
           change: "add",
           oldLineNumber: null,
           newLineNumber,
@@ -363,14 +376,7 @@ function buildDiffReviewLines(
       fileDiff.deletionLines.length - oldContextStart + 1,
       fileDiff.additionLines.length - newContextStart + 1,
     );
-    for (let offset = 0; offset < trailingLines; offset += 1) {
-      rows.push({
-        change: "context",
-        oldLineNumber: oldContextStart + offset,
-        newLineNumber: newContextStart + offset,
-        content: stripTrailingNewline(fileDiff.additionLines[newContextStart + offset - 1] ?? ""),
-      });
-    }
+    pushContextGap(oldContextStart, newContextStart, trailingLines);
   }
 
   return rows;
@@ -397,9 +403,18 @@ export function restoreDiffReviewCommentRange(
 ): SelectedLineRange | null {
   if (comment.selection) return comment.selection;
 
-  const lines = buildDiffReviewLines(fileDiff);
-  const startLine = lines[comment.startIndex];
-  const endLine = lines[comment.endIndex];
+  const includeExpandedContext = !fileDiff.isPartial;
+  const startLine = buildDiffReviewLines(fileDiff, includeExpandedContext, {
+    startIndex: comment.startIndex,
+    endIndex: comment.startIndex,
+  })[0];
+  const endLine =
+    comment.endIndex === comment.startIndex
+      ? startLine
+      : buildDiffReviewLines(fileDiff, includeExpandedContext, {
+          startIndex: comment.endIndex,
+          endIndex: comment.endIndex,
+        })[0];
   if (!startLine || !endLine) return null;
   const start = getDiffReviewSelectionPoint(startLine);
   const end = getDiffReviewSelectionPoint(endLine);
@@ -413,53 +428,87 @@ export function restoreDiffReviewCommentRange(
 }
 
 function findDiffReviewLineIndex(
-  lines: ReadonlyArray<DiffReviewLine>,
-  lineNumber: number,
-  side: SelectionSide | undefined,
-): number {
-  const preferredKey = side === "deletions" ? "oldLineNumber" : "newLineNumber";
-  const preferredIndex = lines.findIndex((line) => line[preferredKey] === lineNumber);
-  if (preferredIndex >= 0) return preferredIndex;
-  const fallbackKey = preferredKey === "oldLineNumber" ? "newLineNumber" : "oldLineNumber";
-  return lines.findIndex((line) => line[fallbackKey] === lineNumber);
-}
-
-function resolveExpandedContextPosition(
   fileDiff: FileDiffMetadata,
   lineNumber: number,
   side: SelectionSide | undefined,
-): PullRequestReviewPosition | null {
-  if (fileDiff.isPartial) return null;
-
-  const selectedSide = side === "deletions" ? "left" : "right";
-  let oldContextStart = 1;
-  let newContextStart = 1;
-  const resolveGap = (
-    oldContextEnd: number,
-    newContextEnd: number,
-  ): PullRequestReviewPosition | null => {
-    const contextLines = Math.min(oldContextEnd - oldContextStart, newContextEnd - newContextStart);
-    const selectedStart = selectedSide === "left" ? oldContextStart : newContextStart;
-    const offset = lineNumber - selectedStart;
-    if (offset < 0 || offset >= contextLines) return null;
-    return {
-      kind: "context",
-      oldLine: oldContextStart + offset,
-      newLine: newContextStart + offset,
-      side: selectedSide,
+  includeExpandedContext = !fileDiff.isPartial,
+): number {
+  const findOnSide = (selectedSide: "left" | "right") => {
+    let rowIndex = 0;
+    let oldContextStart = 1;
+    let newContextStart = 1;
+    const findContextIndex = (oldStart: number, newStart: number, lineCount: number) => {
+      const count = Math.max(0, lineCount);
+      const selectedStart = selectedSide === "left" ? oldStart : newStart;
+      const offset = lineNumber - selectedStart;
+      return offset >= 0 && offset < count ? rowIndex + offset : -1;
     };
+
+    for (const hunk of fileDiff.hunks) {
+      if (includeExpandedContext) {
+        const oldContextEnd = hunk.deletionStart + (hunk.deletionCount === 0 ? 1 : 0);
+        const newContextEnd = hunk.additionStart + (hunk.additionCount === 0 ? 1 : 0);
+        const contextLines = Math.min(
+          oldContextEnd - oldContextStart,
+          newContextEnd - newContextStart,
+        );
+        const contextIndex = findContextIndex(oldContextStart, newContextStart, contextLines);
+        if (contextIndex >= 0) return contextIndex;
+        rowIndex += Math.max(0, contextLines);
+      }
+
+      let oldLineNumber = hunk.deletionStart;
+      let newLineNumber = hunk.additionStart;
+      for (const segment of hunk.hunkContent) {
+        if (segment.type === "context") {
+          const contextIndex = findContextIndex(oldLineNumber, newLineNumber, segment.lines);
+          if (contextIndex >= 0) return contextIndex;
+          rowIndex += segment.lines;
+          oldLineNumber += segment.lines;
+          newLineNumber += segment.lines;
+          continue;
+        }
+
+        if (
+          selectedSide === "left" &&
+          lineNumber >= oldLineNumber &&
+          lineNumber < oldLineNumber + segment.deletions
+        ) {
+          return rowIndex + lineNumber - oldLineNumber;
+        }
+        rowIndex += segment.deletions;
+        oldLineNumber += segment.deletions;
+
+        if (
+          selectedSide === "right" &&
+          lineNumber >= newLineNumber &&
+          lineNumber < newLineNumber + segment.additions
+        ) {
+          return rowIndex + lineNumber - newLineNumber;
+        }
+        rowIndex += segment.additions;
+        newLineNumber += segment.additions;
+      }
+
+      oldContextStart = hunk.deletionStart + hunk.deletionCount;
+      newContextStart = hunk.additionStart + hunk.additionCount;
+      if (hunk.deletionCount === 0) oldContextStart += 1;
+      if (hunk.additionCount === 0) newContextStart += 1;
+    }
+
+    if (!includeExpandedContext) return -1;
+    const trailingLines = Math.min(
+      fileDiff.deletionLines.length - oldContextStart + 1,
+      fileDiff.additionLines.length - newContextStart + 1,
+    );
+    return findContextIndex(oldContextStart, newContextStart, trailingLines);
   };
 
-  for (const hunk of fileDiff.hunks) {
-    const oldContextEnd = hunk.deletionStart + (hunk.deletionCount === 0 ? 1 : 0);
-    const newContextEnd = hunk.additionStart + (hunk.additionCount === 0 ? 1 : 0);
-    const position = resolveGap(oldContextEnd, newContextEnd);
-    if (position) return position;
-    oldContextStart = oldContextEnd + hunk.deletionCount;
-    newContextStart = newContextEnd + hunk.additionCount;
-  }
-
-  return resolveGap(fileDiff.deletionLines.length + 1, fileDiff.additionLines.length + 1);
+  const selectedSide = side === "deletions" ? "left" : "right";
+  const preferredIndex = findOnSide(selectedSide);
+  return preferredIndex >= 0
+    ? preferredIndex
+    : findOnSide(selectedSide === "left" ? "right" : "left");
 }
 
 /** Resolve the host-facing coordinates of a line selected in the diff viewer. */
@@ -468,11 +517,12 @@ export function resolveDiffReviewPosition(
   lineNumber: number,
   side: SelectionSide | undefined,
 ): PullRequestReviewPosition | null {
-  const expandedPosition = resolveExpandedContextPosition(fileDiff, lineNumber, side);
-  if (expandedPosition) return expandedPosition;
-
-  const lines = buildDiffReviewLines(fileDiff, false);
-  const line = lines[findDiffReviewLineIndex(lines, lineNumber, side)];
+  const lineIndex = findDiffReviewLineIndex(fileDiff, lineNumber, side);
+  if (lineIndex < 0) return null;
+  const line = buildDiffReviewLines(fileDiff, !fileDiff.isPartial, {
+    startIndex: lineIndex,
+    endIndex: lineIndex,
+  })[0];
   if (line === undefined) return null;
 
   switch (line.change) {
@@ -538,18 +588,27 @@ export function buildDiffReviewComment(input: {
   range: SelectedLineRange;
   text: string;
 }): ReviewCommentContext | null {
-  const lines = buildDiffReviewLines(input.fileDiff);
-  const startIndex = findDiffReviewLineIndex(lines, input.range.start, input.range.side);
+  const includeExpandedContext = !input.fileDiff.isPartial;
+  const startIndex = findDiffReviewLineIndex(
+    input.fileDiff,
+    input.range.start,
+    input.range.side,
+    includeExpandedContext,
+  );
   const endIndex = findDiffReviewLineIndex(
-    lines,
+    input.fileDiff,
     input.range.end,
     input.range.endSide ?? input.range.side,
+    includeExpandedContext,
   );
   if (startIndex < 0 || endIndex < 0) return null;
 
   const normalizedStartIndex = Math.min(startIndex, endIndex);
   const normalizedEndIndex = Math.max(startIndex, endIndex);
-  const selectedLines = lines.slice(normalizedStartIndex, normalizedEndIndex + 1);
+  const selectedLines = buildDiffReviewLines(input.fileDiff, includeExpandedContext, {
+    startIndex: normalizedStartIndex,
+    endIndex: normalizedEndIndex,
+  });
   const oldRange = getDiffRange(selectedLines, "oldLineNumber");
   const newRange = getDiffRange(selectedLines, "newLineNumber");
 

--- a/apps/web/src/reviewCommentContext.ts
+++ b/apps/web/src/reviewCommentContext.ts
@@ -272,6 +272,21 @@ function buildDiffReviewLines(fileDiff: FileDiffMetadata): ReadonlyArray<DiffRev
   const rows: DiffReviewLine[] = [];
 
   for (const hunk of fileDiff.hunks) {
+    if (!fileDiff.isPartial) {
+      const oldHunkStart = hunk.deletionStart + (hunk.deletionCount === 0 ? 1 : 0);
+      const newHunkStart = hunk.additionStart + (hunk.additionCount === 0 ? 1 : 0);
+      for (let offset = hunk.collapsedBefore; offset > 0; offset -= 1) {
+        const oldLineNumber = oldHunkStart - offset;
+        const newLineNumber = newHunkStart - offset;
+        rows.push({
+          change: "context",
+          oldLineNumber,
+          newLineNumber,
+          content: stripTrailingNewline(fileDiff.additionLines[newLineNumber - 1] ?? ""),
+        });
+      }
+    }
+
     let oldLineNumber = hunk.deletionStart;
     let newLineNumber = hunk.additionStart;
     let deletionLineIndex = hunk.deletionLineIndex;
@@ -319,6 +334,28 @@ function buildDiffReviewLines(fileDiff: FileDiffMetadata): ReadonlyArray<DiffRev
         newLineNumber += 1;
         additionLineIndex += 1;
       }
+    }
+  }
+
+  if (!fileDiff.isPartial) {
+    const lastHunk = fileDiff.hunks.at(-1);
+    const oldStart = lastHunk
+      ? lastHunk.deletionStart + lastHunk.deletionCount + (lastHunk.deletionCount === 0 ? 1 : 0)
+      : 1;
+    const newStart = lastHunk
+      ? lastHunk.additionStart + lastHunk.additionCount + (lastHunk.additionCount === 0 ? 1 : 0)
+      : 1;
+    const trailingLines = Math.min(
+      fileDiff.deletionLines.length - oldStart + 1,
+      fileDiff.additionLines.length - newStart + 1,
+    );
+    for (let offset = 0; offset < trailingLines; offset += 1) {
+      rows.push({
+        change: "context",
+        oldLineNumber: oldStart + offset,
+        newLineNumber: newStart + offset,
+        content: stripTrailingNewline(fileDiff.additionLines[newStart + offset - 1] ?? ""),
+      });
     }
   }
 
@@ -371,51 +408,6 @@ function findDiffReviewLineIndex(
   return lines.findIndex((line) => line[fallbackKey] === lineNumber);
 }
 
-/** Resolve a line Pierre hydrated from the unchanged regions outside the host patch's hunks. */
-function resolveExpandedContextPosition(
-  fileDiff: FileDiffMetadata,
-  lineNumber: number,
-  side: SelectionSide | undefined,
-): PullRequestReviewPosition | null {
-  if (fileDiff.isPartial) return null;
-
-  const selectedSide = side === "deletions" ? "left" : "right";
-  let oldContextStart = 1;
-  let newContextStart = 1;
-
-  for (let hunkIndex = 0; hunkIndex <= fileDiff.hunks.length; hunkIndex += 1) {
-    const hunk = fileDiff.hunks[hunkIndex];
-    const oldContextEnd =
-      hunk === undefined
-        ? fileDiff.deletionLines.length + 1
-        : hunk.deletionStart + (hunk.deletionCount === 0 ? 1 : 0);
-    const newContextEnd =
-      hunk === undefined
-        ? fileDiff.additionLines.length + 1
-        : hunk.additionStart + (hunk.additionCount === 0 ? 1 : 0);
-    const selectedStart = selectedSide === "left" ? oldContextStart : newContextStart;
-    const selectedEnd = selectedSide === "left" ? oldContextEnd : newContextEnd;
-    const otherStart = selectedSide === "left" ? newContextStart : oldContextStart;
-    const otherEnd = selectedSide === "left" ? newContextEnd : oldContextEnd;
-    const offset = lineNumber - selectedStart;
-
-    if (offset >= 0 && lineNumber < selectedEnd && otherStart + offset < otherEnd) {
-      return {
-        kind: "context",
-        oldLine: selectedSide === "left" ? lineNumber : otherStart + offset,
-        newLine: selectedSide === "right" ? lineNumber : otherStart + offset,
-        side: selectedSide,
-      };
-    }
-
-    if (hunk === undefined) return null;
-    oldContextStart = oldContextEnd + hunk.deletionCount;
-    newContextStart = newContextEnd + hunk.additionCount;
-  }
-
-  return null;
-}
-
 /** Resolve the host-facing coordinates of a line selected in the diff viewer. */
 export function resolveDiffReviewPosition(
   fileDiff: FileDiffMetadata,
@@ -423,15 +415,7 @@ export function resolveDiffReviewPosition(
   side: SelectionSide | undefined,
 ): PullRequestReviewPosition | null {
   const lines = buildDiffReviewLines(fileDiff);
-  const preferredKey = side === "deletions" ? "oldLineNumber" : "newLineNumber";
-  const preferredIndex = lines.findIndex((line) => line[preferredKey] === lineNumber);
-  if (preferredIndex < 0) {
-    const expandedPosition = resolveExpandedContextPosition(fileDiff, lineNumber, side);
-    if (expandedPosition !== null) return expandedPosition;
-  }
-
-  const line =
-    lines[preferredIndex >= 0 ? preferredIndex : findDiffReviewLineIndex(lines, lineNumber, side)];
+  const line = lines[findDiffReviewLineIndex(lines, lineNumber, side)];
   if (line === undefined) return null;
 
   switch (line.change) {

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -856,6 +856,26 @@ export const PullRequestCommentUpdateInput = Schema.Struct({
 });
 export type PullRequestCommentUpdateInput = typeof PullRequestCommentUpdateInput.Type;
 
+/** The coordinates of one line in a pull request diff. */
+export const PullRequestReviewPosition = Schema.Union([
+  Schema.Struct({
+    kind: Schema.Literal("added"),
+    newLine: PositiveInt,
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("deleted"),
+    oldLine: PositiveInt,
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("context"),
+    oldLine: PositiveInt,
+    newLine: PositiveInt,
+    /** Which copy of an unchanged line the reviewer selected in a split diff. */
+    side: PullRequestDiffSide,
+  }),
+]);
+export type PullRequestReviewPosition = typeof PullRequestReviewPosition.Type;
+
 /** One remark in a review that has not been sent yet, anchored to a line of the diff. */
 export const PullRequestReviewCommentDraft = Schema.Struct({
   path: TrimmedNonEmptyString,
@@ -865,8 +885,7 @@ export const PullRequestReviewCommentDraft = Schema.Struct({
    * the hosts that address a comment by one path ignore this.
    */
   oldPath: Schema.optional(TrimmedNonEmptyString),
-  line: PositiveInt,
-  side: PullRequestDiffSide,
+  position: PullRequestReviewPosition,
   body: CommentBody,
 });
 export type PullRequestReviewCommentDraft = typeof PullRequestReviewCommentDraft.Type;


### PR DESCRIPTION
## What Changed

Review comments now retain host-facing diff coordinates for added, deleted, and unchanged context lines.

GitLab submissions include both `old_line` and `new_line` for context lines. GitHub and Bitbucket continue receiving their provider-specific line and side coordinates.

## Why

T3 Code previously stored only one line number and side. GitLab requires both old and new line numbers when commenting on an unchanged context line, so submitting those reviews failed.

## UI Changes

Before:

https://github.com/user-attachments/assets/d244ab31-e581-481f-ab6a-a13d45b59da9

After:

https://github.com/user-attachments/assets/8490f7cf-3b8b-454b-ad5f-15f661fa0cc1


## Testing

- Typechecks passed for contracts, server, and web
- Focused lint passed
- 262 relevant existing tests passed
- The full review flow was verified against a GitLab fixture before and after the fix

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after evidence for the behavior change
- [x] I included videos for the interaction change

Built with GPT-5.6 Sol via the Codex harness in T3 Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking contract change: clients still sending `line`/`side` on review drafts will fail validation; diff line-index logic is more complex and affects where comments anchor across hosts.
> 
> **Overview**
> **Fixes GitLab review submission on unchanged (context) diff lines** by replacing the single `line` + `side` on `PullRequestReviewCommentDraft` with a **`PullRequestReviewPosition`** union (`added`, `deleted`, `context` with optional split-diff side).
> 
> Each host adapter maps that shape to its API: GitLab sends **`old_line` / `new_line`** (both for context), GitHub and Bitbucket keep their existing line/side or `from`/`to` inline fields via small helper functions.
> 
> The web diff UI **resolves** a line selection through **`resolveDiffReviewPosition`** (including expanded context between hunks), stores **`position`** on pending/draft comments, and **`ReviewCommentContext`** can carry an optional **`selection`** for restoring ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f554d6749e66e0266b4104aeb084137470cd6a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix review comment positioning on context lines for GitHub, GitLab, and Bitbucket
> - Replaces the flat `line`/`side` fields on `PullRequestReviewCommentDraft` with a structured `PullRequestReviewPosition` union (`added`, `deleted`, or `context`) in [pullRequest.ts](https://github.com/pingdotgg/t3code/pull/6348/files#diff-3698440642964c6a34f717f82a7bcd5991bfa0d1a341e2a84baf11b1acdf0dfe).
> - Adds per-provider helpers (`gitHubReviewPosition`, `gitLabReviewPositionLines`, `bitbucketReviewPosition`) that translate the new position type into each API's expected wire format, correctly populating both sides for unchanged context lines.
> - Introduces `resolveDiffReviewPosition` in [reviewCommentContext.ts](https://github.com/pingdotgg/t3code/pull/6348/files#diff-fe3405f47eb0c057d4c053b7bfe24b1497958cd259432a3c8d5cfbc32c84e86e) to derive a typed position from a viewer line selection, with support for expanded context lines between hunks.
> - Updates the web UI in [PullRequestCodeTab.tsx](https://github.com/pingdotgg/t3code/pull/6348/files#diff-9b2044cf0a11cf3fc9a01b507ffcdb8f5fef43cdbf0c1ee6c00dfedd8ae796a0) to store and display comments using the resolved position rather than raw line/side values.
> - Risk: `PullRequestReviewCommentDraft` no longer accepts `line`/`side`; any client sending the old shape will fail schema validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f554d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->