### PR TITLE
fix(web): mod-w closes focused right panel tabs

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -164,7 +164,7 @@ import {
   GitBranchIcon,
   WifiOffIcon,
 } from "lucide-react";
-import { cn, randomHex } from "~/lib/utils";
+import { cn, isMacPlatform, randomHex } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
@@ -189,6 +189,7 @@ import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
 import { preventRepeatedTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
+import { isPreviewFocused } from "../lib/previewFocus";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
 import {
   derivePhysicalProjectKey,
@@ -4662,6 +4663,27 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
       const terminalFocusOwner = getTerminalFocusOwner();
+      const modKey = isMacPlatform(navigator.platform)
+        ? event.metaKey && !event.ctrlKey
+        : event.ctrlKey && !event.metaKey;
+      if (
+        activeRightPanelSurface &&
+        event.key.toLowerCase() === "w" &&
+        modKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        isPreviewFocused()
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!event.repeat) {
+          document
+            .querySelector<HTMLElement>("[data-right-panel-surface-content]")
+            ?.focus({ preventScroll: true });
+          closeRightPanelSurface(activeRightPanelSurface);
+        }
+        return;
+      }
       if (event.defaultPrevented && terminalFocusOwner === null) {
         return;
       }
@@ -4789,6 +4811,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeThreadId,
     closeTerminal,
     closePanelTerminal,
+    closeRightPanelSurface,
     createNewTerminal,
     setTerminalOpen,
     runProjectScript,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4666,13 +4666,15 @@ function ChatViewContent(props: ChatViewProps) {
       const modKey = isMacPlatform(navigator.platform)
         ? event.metaKey && !event.ctrlKey
         : event.ctrlKey && !event.metaKey;
+      const activeBrowserTabId =
+        activeRightPanelSurface?.kind === "preview" ? activeRightPanelSurface.resourceId : null;
       if (
         activeRightPanelSurface &&
         event.key.toLowerCase() === "w" &&
         modKey &&
         !event.altKey &&
         !event.shiftKey &&
-        isPreviewFocused()
+        isPreviewFocused(activeBrowserTabId)
       ) {
         event.preventDefault();
         event.stopPropagation();

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -729,7 +729,11 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
         </ScrollArea>
         {props.layoutControls}
       </div>
-      <div className="flex min-h-0 flex-1 flex-col" data-right-panel-surface-content>
+      <div
+        tabIndex={-1}
+        className="flex min-h-0 flex-1 flex-col outline-none"
+        data-right-panel-surface-content
+      >
         {props.activeSurfaceId === null ? (
           <RightPanelEmptyState
             onAddBrowser={props.onAddBrowser}

--- a/apps/web/src/lib/previewFocus.test.ts
+++ b/apps/web/src/lib/previewFocus.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { isPreviewFocused } from "./previewFocus";
+
+class MockHTMLElement {
+  isConnected = true;
+  tagName = "WEBVIEW";
+  previewTabId = "mini-player-tab";
+
+  closest(): null {
+    return null;
+  }
+
+  getAttribute(name: string): string | null {
+    return name === "data-preview-server-tab" ? this.previewTabId : null;
+  }
+}
+
+const originalDocument = globalThis.document;
+const originalHTMLElement = globalThis.HTMLElement;
+
+afterEach(() => {
+  if (originalDocument === undefined) {
+    delete (globalThis as { document?: Document }).document;
+  } else {
+    globalThis.document = originalDocument;
+  }
+  if (originalHTMLElement === undefined) {
+    delete (globalThis as { HTMLElement?: typeof HTMLElement }).HTMLElement;
+  } else {
+    globalThis.HTMLElement = originalHTMLElement;
+  }
+});
+
+describe("isPreviewFocused", () => {
+  it("only accepts a webview that matches the requested browser tab", () => {
+    const webview = new MockHTMLElement();
+    globalThis.HTMLElement = MockHTMLElement as unknown as typeof HTMLElement;
+    globalThis.document = { activeElement: webview } as unknown as Document;
+
+    expect(isPreviewFocused("right-panel-tab")).toBe(false);
+    expect(isPreviewFocused("mini-player-tab")).toBe(true);
+  });
+});

--- a/apps/web/src/lib/previewFocus.ts
+++ b/apps/web/src/lib/previewFocus.ts
@@ -4,12 +4,20 @@
  * `<webview>` focus events — the embedded page).
  *
  * Used by the global keybinding handler to gate `preview.refresh` and
- * `preview.focusUrl` to only fire while the preview owns focus.
+ * `preview.focusUrl` to only fire while the preview owns focus. When a tab id
+ * is provided, focused webviews must belong to that tab; panel DOM still
+ * counts regardless of the active surface kind.
  */
-export function isPreviewFocused(): boolean {
+export function isPreviewFocused(activeBrowserTabId?: string | null): boolean {
   const activeElement = document.activeElement;
   if (!(activeElement instanceof HTMLElement)) return false;
   if (!activeElement.isConnected) return false;
-  if (activeElement.tagName.toLowerCase() === "webview") return true;
+  if (activeElement.tagName.toLowerCase() === "webview") {
+    return (
+      activeBrowserTabId === undefined ||
+      (activeBrowserTabId !== null &&
+        activeElement.getAttribute("data-preview-server-tab") === activeBrowserTabId)
+    );
+  }
   return activeElement.closest("[data-preview-panel-mode]") !== null;
 }


### PR DESCRIPTION
When keyboard focus was inside the right panel, Mod+W fell through to Electron and closed the T3 Code window instead of the active panel tab. After the first tab closed, focus also left the panel, so a second press still closed the window.

Handle the platform-aware Mod+W shortcut while the right panel owns focus, close the active surface through the existing cleanup path, and move focus to the persistent panel container before removing the tab so consecutive presses keep closing tabs. Held-key repeats are consumed without closing multiple tabs. Focused webviews are matched against the active right-panel browser tab so the floating mini-player cannot close an unrelated panel surface.

Visual evidence: not applicable; this changes keyboard behavior without a static visual change.

Tests: ./node_modules/.bin/vp test run apps/web/src/lib/previewFocus.test.ts apps/web/src/keybindings.test.ts apps/web/src/lib/terminalCloseShortcut.test.ts apps/web/src/rightPanelStore.test.ts apps/desktop/src/window/DesktopWindow.test.ts

Model: GPT-5.6-sol via the Codex harness in T3 Code.