### PR TITLE
fix(server): use prebuilt node-pty binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,68 +264,9 @@ jobs:
           echo "clerk_cli_oauth_client_id=$CLERK_CLI_OAUTH_CLIENT_ID" >> "$GITHUB_OUTPUT"
           echo "relay_url=https://$relay_domain" >> "$GITHUB_OUTPUT"
 
-  # node-pty publishes no Linux prebuilt and the WSL backend runs under the
-  # distro's own (Linux) Node, which can't load the Windows/Electron binary. We
-  # build the Linux pty.node here, on Linux, and hand it to the Windows packaging
-  # job — the Windows artifact then ships a ready WSL backend binary with no
-  # cross-compiling and no first-launch compiler/node-gyp/network on the user's
-  # machine. node-pty is N-API, so one binary works across all WSL Node versions.
-  build_wsl_node_pty:
-    name: Build WSL node-pty (linux-x64)
-    needs: [preflight]
-    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.preflight.outputs.ref }}
-          sparse-checkout: |
-            /*
-            !/.repos/
-          sparse-checkout-cone-mode: false
-
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version-file: package.json
-          cache: true
-          run-install: |
-            args:
-              - --filter=t3...
-
-      - name: Build node-pty linux-x64 prebuild
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Resolve node-pty from apps/server (where it's a dependency) and build
-          # its native binary from source for Linux. node-addon-api resolves from
-          # node-pty's own dependency tree, so node-gyp has everything it needs.
-          pty_pkg="$(node -e "console.log(require.resolve('node-pty/package.json', { paths: ['$GITHUB_WORKSPACE/apps/server'] }))")"
-          pty_dir="$(dirname "$pty_pkg")"
-          ( cd "$pty_dir" && npx --yes node-gyp rebuild )
-          mkdir -p wsl-prebuild
-          cp "$pty_dir/build/Release/pty.node" wsl-prebuild/pty.node
-          file wsl-prebuild/pty.node
-
-      - name: Upload node-pty linux-x64 prebuild
-        uses: actions/upload-artifact@v7
-        with:
-          name: wsl-node-pty-x64
-          path: wsl-prebuild/pty.node
-          if-no-files-found: error
-
   build:
     name: Build ${{ matrix.label }}
-    # build_wsl_node_pty stays in `needs` so it runs first and its artifact is
-    # available to download, but only the Windows matrix entry consumes it. We
-    # therefore gate the job on preflight + relay (must succeed) WITHOUT requiring
-    # build_wsl_node_pty, so a failed Linux prebuild doesn't skip the macOS/Linux
-    # builds. `!cancelled()` (not `!failure()`) lets the job run even when
-    # build_wsl_node_pty failed; the Windows-only download step below then fails
-    # that single platform if the prebuild is missing.
-    needs: [preflight, relay_public_config, build_wsl_node_pty]
+    needs: [preflight, relay_public_config]
     if: ${{ !cancelled() && needs.preflight.result == 'success' && needs.relay_public_config.result == 'success' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -413,13 +354,6 @@ jobs:
 
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
-
-      - name: Download WSL node-pty prebuild
-        if: matrix.platform == 'win'
-        uses: actions/download-artifact@v7
-        with:
-          name: wsl-node-pty-x64
-          path: wsl-prebuild
 
       - name: Install Spectre-mitigated MSVC libs
         if: matrix.platform == 'win'
@@ -574,10 +508,6 @@ jobs:
               echo "macOS signing disabled (missing one or more Apple signing secrets)."
             fi
           elif [[ "${{ matrix.platform }}" == "win" ]]; then
-            # Bundle the Linux node-pty binary built by the build_wsl_node_pty job
-            # so the packaged WSL backend ships a ready binary (no first-launch
-            # compile). Required for a working WSL backend on Windows.
-            args+=(--wsl-prebuild "$GITHUB_WORKSPACE/wsl-prebuild/pty.node")
             if has_all \
               "$AZURE_TENANT_ID" \
               "$AZURE_CLIENT_ID" \

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -215,8 +215,7 @@ interface WslPreflightSuccess {
   readonly linuxEntryPath: string;
   // Absolute path to the node binary the preflight validated after the shared
   // remote resolver repaired PATH. The launch must use this exact path so it
-  // doesn't fall through to a different/old node than the one node-pty was
-  // built against.
+  // doesn't fall through to a different/old node than the one validated.
   readonly nodePath: string;
   // PATH captured from the same login shell after the shared resolver loaded
   // version managers. The launch forwards this value directly without a shell.
@@ -240,7 +239,6 @@ const runWslPreflight = Effect.fn("desktop.backendConfiguration.wslPreflight")(f
   readonly distro: string | null;
   readonly windowsEntryPath: string;
   readonly windowsRepoRoot: string;
-  readonly allowBuild: boolean;
 }): Effect.fn.Return<
   WslPreflightSuccess | WslPreflightFailure,
   never,
@@ -309,7 +307,6 @@ const runWslPreflight = Effect.fn("desktop.backendConfiguration.wslPreflight")(f
   }
 
   const nodePtyResult = yield* wslEnv.ensureNodePty(runningDistro, input.windowsRepoRoot, {
-    allowBuild: input.allowBuild,
     nodeEngineRange: serverPackageJson.engines.node,
   });
   if (!nodePtyResult.ok) {
@@ -468,9 +465,9 @@ const resolveWslStartConfig = Effect.fn("desktop.backendConfiguration.resolveWsl
   // archive FILE. The Windows primary reads its entry through
   // ELECTRON_RUN_AS_NODE (asar-aware), but the WSL backend launches plain
   // `wsl.exe -- node`, which can't read inside an asar. electron-builder unpacks
-  // the server bundle + node-pty (see asarUnpack in build-desktop-artifact.ts)
-  // to the app.asar.unpacked sibling, so point WSL there. In dev appRoot is
-  // already a real directory, so this is a no-op.
+  // the server bundle + node_modules (see asarUnpack in
+  // build-desktop-artifact.ts) to the app.asar.unpacked sibling, so point WSL
+  // there. In dev appRoot is already a real directory, so this is a no-op.
   const wslAppRoot = environment.isPackaged
     ? environment.path.join(environment.resourcesPath, "app.asar.unpacked")
     : environment.appRoot;
@@ -480,14 +477,6 @@ const resolveWslStartConfig = Effect.fn("desktop.backendConfiguration.resolveWsl
     distro: input.distro,
     windowsEntryPath: wslEntryPath,
     windowsRepoRoot: wslAppRoot,
-    // Packaged builds ship a prebuilt Linux node-pty (built on Linux in CI and
-    // attached to the Windows artifact — see build-desktop-artifact.ts), so the
-    // WSL backend never needs a compiler, node-gyp, or network on first launch.
-    // Compiling from source is a dev-only convenience: a checkout has no shipped
-    // prebuilt, and developers have the toolchain. In packaged builds we instead
-    // surface a clear diagnostic if the prebuilt can't load (unsupported
-    // arch/distro), rather than silently dropping into a fragile runtime build.
-    allowBuild: !environment.isPackaged,
   });
 
   // Every operation after preflight uses the same concrete distro. In

--- a/apps/desktop/src/wsl/DesktopWslEnvironment.test.ts
+++ b/apps/desktop/src/wsl/DesktopWslEnvironment.test.ts
@@ -10,15 +10,13 @@ import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
+  buildWslNodePtyProbeScript,
   buildWslNodeEnvPreamble,
   DesktopWslDistroListError,
-  formatMissingToolsReason,
-  formatNodePtyProbeFailureReason,
   formatWslShellTransportFailureReason,
   parseNodePath,
   parseNodeVersion,
   parseResolvedPath,
-  parseToolchainReport,
   probeWslDistros,
 } from "./DesktopWslEnvironment.ts";
 
@@ -88,19 +86,6 @@ describe("probeWslDistros", () => {
   });
 });
 
-describe("formatNodePtyProbeFailureReason", () => {
-  it("identifies a packaged build that omitted the Linux node-pty prebuild", () => {
-    const reason = formatNodePtyProbeFailureReason(4);
-
-    expect(reason).toContain("packaged Linux node-pty binary was not included");
-    expect(reason).toContain("--wsl-prebuild");
-  });
-
-  it("leaves other node-pty load failures to the compatibility diagnostic", () => {
-    expect(formatNodePtyProbeFailureReason(1)).toBeNull();
-  });
-});
-
 describe("formatWslShellTransportFailureReason", () => {
   it("distinguishes timeouts and spawn failures from normal shell exit codes", () => {
     expect(formatWslShellTransportFailureReason("timeout")).toContain("timed out");
@@ -125,32 +110,13 @@ describe("buildWslNodeEnvPreamble", () => {
   });
 });
 
-describe("parseToolchainReport", () => {
-  it("returns no missing tools and no node version on empty output", () => {
-    expect(parseToolchainReport("")).toEqual({ missingTools: [], nodeVersion: null });
-  });
+describe("buildWslNodePtyProbeScript", () => {
+  it("loads the prebuilt wrapper instead of compiling or probing the old package", () => {
+    const script = buildWslNodePtyProbeScript("/mnt/c/t3code/apps/server");
 
-  it("collects all missing: lines", () => {
-    const stdout = ["missing:make", "missing:g++", "nodeVersion:24.10.0"].join("\n");
-    expect(parseToolchainReport(stdout)).toEqual({
-      missingTools: ["make", "g++"],
-      nodeVersion: "24.10.0",
-    });
-  });
-
-  it("ignores blank lines and trims whitespace", () => {
-    const stdout = ["  missing:python3  ", "", "  nodeVersion:v22.16.0  "].join("\n");
-    expect(parseToolchainReport(stdout)).toEqual({
-      missingTools: ["python3"],
-      nodeVersion: "v22.16.0",
-    });
-  });
-
-  it("returns null node version when value after prefix is empty", () => {
-    expect(parseToolchainReport("nodeVersion:")).toEqual({
-      missingTools: [],
-      nodeVersion: null,
-    });
+    expect(script).toContain('require("@lydell/node-pty")');
+    expect(script).not.toContain('require("node-pty")');
+    expect(script).not.toContain("node-gyp");
   });
 });
 
@@ -214,48 +180,5 @@ describe("parseResolvedPath", () => {
   it("returns null when the resolved PATH is absent or empty", () => {
     expect(parseResolvedPath("nodePath:/usr/bin/node\n")).toBeNull();
     expect(parseResolvedPath("resolvedPath:\n")).toBeNull();
-  });
-});
-
-describe("formatMissingToolsReason", () => {
-  it("returns null when everything is present and node is in range", () => {
-    expect(
-      formatMissingToolsReason({ missingTools: [], nodeVersion: "24.10.0" }, "^24.10"),
-    ).toBeNull();
-  });
-
-  it("returns null when range is not specified and tools are present", () => {
-    expect(formatMissingToolsReason({ missingTools: [], nodeVersion: "18.0.0" }, null)).toBeNull();
-  });
-
-  it("flags missing node first", () => {
-    const reason = formatMissingToolsReason(
-      { missingTools: ["node", "make"], nodeVersion: null },
-      "^24.10",
-    );
-    expect(reason).toContain("node");
-    expect(reason).toContain("^24.10");
-    expect(reason).toContain("make");
-    expect(reason).toContain("nvm");
-  });
-
-  it("flags an out-of-range node version with the actual version surfaced", () => {
-    const reason = formatMissingToolsReason(
-      { missingTools: [], nodeVersion: "20.0.0" },
-      "^24.10 || ^22.16",
-    );
-    expect(reason).toContain("node 20.0.0");
-    expect(reason).toContain("requires ^24.10 || ^22.16");
-  });
-
-  it("flags missing build tools without node when node is fine", () => {
-    const reason = formatMissingToolsReason(
-      { missingTools: ["g++", "python3"], nodeVersion: "24.10.0" },
-      "^24.10",
-    );
-    expect(reason).toContain("g++");
-    expect(reason).toContain("python3");
-    expect(reason).toContain("build-essential");
-    expect(reason).not.toContain("nvm");
   });
 });

--- a/apps/desktop/src/wsl/DesktopWslEnvironment.ts
+++ b/apps/desktop/src/wsl/DesktopWslEnvironment.ts
@@ -20,14 +20,9 @@ const LIST_TIMEOUT = Duration.seconds(8);
 const PRE_WARM_TIMEOUT = Duration.seconds(10);
 const WSLPATH_TIMEOUT = Duration.seconds(10);
 const PROBE_TIMEOUT = Duration.seconds(10);
-const TOOLCHAIN_TIMEOUT = Duration.seconds(10);
-const BUILD_TIMEOUT = Duration.minutes(5);
 const USER_HOME_TIMEOUT = Duration.seconds(5);
-const TOOLCHAIN_TRANSPORT_RETRY_LIMIT = 12;
-const BUILD_TRANSPORT_RETRY_LIMIT = 2;
 
 export interface EnsureWslNodePtyOptions {
-  readonly allowBuild?: boolean;
   readonly nodeEngineRange?: string | null;
 }
 
@@ -188,7 +183,7 @@ const runWslShell = (
       }
       const handle = spawnResult.handle;
       // Drain stdout and stderr concurrently so neither pipe buffer can fill
-      // and stall the child (node-gyp rebuild emits large output on both).
+      // and stall the child.
       const [stdoutBytes, stderrBytes, exitCode] = yield* Effect.all(
         [Stream.runCollect(handle.stdout), Stream.runCollect(handle.stderr), handle.exitCode],
         { concurrency: "unbounded" },
@@ -216,14 +211,7 @@ const runWslShell = (
 
 const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
 
-const NODE_PTY_PREBUILD_MISSING_EXIT_CODE = 4;
-
-export const formatNodePtyProbeFailureReason = (exitCode: number): string | null =>
-  exitCode === NODE_PTY_PREBUILD_MISSING_EXIT_CODE
-    ? "WSL support is missing from this T3 Code build: the packaged Linux node-pty binary was not included. Rebuild the Windows artifact with `--wsl-prebuild <path-to-linux-pty.node>` or install a build that includes WSL support."
-    : null;
-
-const NODE_PTY_PROBE_SCRIPT = (
+export const buildWslNodePtyProbeScript = (
   linuxServerDir: string,
 ) => `printf 'nodePath:%s\\n' "$(command -v node 2>/dev/null)"
 printf 'nodeVersion:%s\\n' "$(node -p 'process.versions.node' 2>/dev/null)"
@@ -238,76 +226,11 @@ cd ${shellQuote(linuxServerDir)} && node <<'NODE' >/dev/null 2>&1
 // ERR_MODULE_NOT_FOUND at launch (which, in wsl-only mode, would just fail to
 // launch with no fallback).
 try { require.resolve("effect"); } catch (_e) { process.exit(3); }
-const fs = require("node:fs");
-const path = require("node:path");
-const pkgDir = path.dirname(require.resolve("node-pty/package.json"));
-// node-pty 1.x is N-API based, so a single Linux pty.node is ABI-stable across
-// Node versions — require() succeeding IS the real compatibility test. Compare
-// only arch and node-pty version (a stale binary from a different node-pty),
-// NOT process.versions.modules: that would reject a perfectly loadable prebuilt
-// whenever the user's WSL Node ABI differs from the build's, defeating the
-// whole point of shipping one prebuilt for all Node versions.
-const expected = {
-  arch: process.arch,
-  nodePtyVersion: require("node-pty/package.json").version,
-};
-const prebuildDir = path.join(pkgDir, "prebuilds", "linux-" + process.arch);
-const marker = path.join(prebuildDir, "t3code-wsl-node-pty.json");
-const binary = path.join(prebuildDir, "pty.node");
-if (!fs.existsSync(marker) || !fs.existsSync(binary)) process.exit(${NODE_PTY_PREBUILD_MISSING_EXIT_CODE});
-require("node-pty");
-const actual = JSON.parse(fs.readFileSync(marker, "utf8"));
-for (const key of Object.keys(expected)) {
-  if (actual[key] !== expected[key]) process.exit(2);
-}
+// @lydell/node-pty selects @lydell/node-pty-linux-<arch> at runtime.
+// The Windows package install includes the matching Linux optional dependency
+// for WSL, so loading the wrapper is the real end-to-end compatibility check.
+require("@lydell/node-pty");
 NODE`;
-
-const TOOLCHAIN_CHECK_SCRIPT = [
-  "for tool in node make g++ python3; do",
-  '  command -v "$tool" >/dev/null 2>&1 || echo "missing:$tool"',
-  "done",
-  "if command -v node >/dev/null 2>&1; then",
-  `  ver="$(node -p 'process.versions.node' 2>/dev/null)"`,
-  '  if [ -n "$ver" ]; then printf "nodeVersion:%s\\n" "$ver"; fi',
-  "fi",
-].join("\n");
-
-const NODE_PTY_BUILD_SCRIPT = (linuxServerDir: string) =>
-  [
-    "set -e",
-    `cd ${shellQuote(linuxServerDir)}`,
-    `pkg_dir=$(node -p "require('node:path').dirname(require.resolve('node-pty/package.json'))")`,
-    `arch=$(node -p "process.arch")`,
-    `modules=$(node -p "process.versions.modules")`,
-    `node_pty_version=$(node -p "require('node-pty/package.json').version")`,
-    `cd "$pkg_dir"`,
-    "npx --yes node-gyp rebuild",
-    `prebuild_dir="prebuilds/linux-$arch"`,
-    `mkdir -p "$prebuild_dir"`,
-    `cp build/Release/pty.node "$prebuild_dir/pty.node"`,
-    `printf '{"arch":"%s","modules":"%s","nodePtyVersion":"%s"}\\n' "$arch" "$modules" "$node_pty_version" > "$prebuild_dir/t3code-wsl-node-pty.json"`,
-    `node -e 'require("node-pty")'`,
-  ].join("\n");
-
-export interface ToolchainReport {
-  readonly missingTools: ReadonlyArray<string>;
-  readonly nodeVersion: string | null;
-}
-
-export const parseToolchainReport = (stdout: string): ToolchainReport => {
-  const lines = stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-  const missingTools = lines
-    .filter((line) => line.startsWith("missing:"))
-    .map((line) => line.slice("missing:".length));
-  const nodeVersionLine = lines.find((line) => line.startsWith("nodeVersion:"));
-  const nodeVersion = nodeVersionLine
-    ? nodeVersionLine.slice("nodeVersion:".length).trim() || null
-    : null;
-  return { missingTools, nodeVersion };
-};
 
 // Pulls the absolute node path the WSL distro resolved after the shared remote
 // resolver repaired PATH. Returns null when no node was found, which the caller
@@ -344,47 +267,6 @@ export const parseResolvedPath = (stdout: string): string | null => {
   return resolvedPath.length > 0 ? resolvedPath : null;
 };
 
-export const formatMissingToolsReason = (
-  report: ToolchainReport,
-  requiredRange: string | null,
-): string | null => {
-  const nodeMissing = report.missingTools.includes("node");
-  const nodeOutOfRange =
-    !nodeMissing &&
-    requiredRange !== null &&
-    report.nodeVersion !== null &&
-    !satisfiesSemverRange(report.nodeVersion, requiredRange);
-  const buildToolsMissing = report.missingTools.filter((tool) => tool !== "node");
-
-  if (!nodeMissing && !nodeOutOfRange && buildToolsMissing.length === 0) {
-    return null;
-  }
-
-  const issues: string[] = [];
-  const remediations: string[] = [];
-
-  if (nodeMissing) {
-    issues.push("node");
-    remediations.push(
-      `Node.js${requiredRange ? ` satisfying \`${requiredRange}\`` : " 18+"} (e.g. via nvm)`,
-    );
-  } else if (nodeOutOfRange) {
-    issues.push(`node ${report.nodeVersion} (requires ${requiredRange})`);
-    remediations.push(
-      `a newer Node.js satisfying \`${requiredRange}\` (e.g. \`nvm install 24 && nvm alias default 24\`)`,
-    );
-  }
-
-  if (buildToolsMissing.length > 0) {
-    issues.push(...buildToolsMissing);
-    remediations.push(
-      "the build toolchain (e.g. `sudo apt install -y build-essential python3` on Ubuntu/Debian)",
-    );
-  }
-
-  return `WSL distro is missing required tools: ${issues.join(", ")}. Install ${remediations.join(" and ")}, then retry.`;
-};
-
 const ensureNodePtyImpl = (
   distro: string | null,
   windowsRepoRoot: string,
@@ -404,13 +286,14 @@ const ensureNodePtyImpl = (
       } as const;
     }
     const linuxRepoRoot = linuxRepoRootOption.value;
-    // node-pty lives in the apps/server workspace's node_modules; resolve from
-    // there rather than the monorepo root, where Bun's hoist layout omits it.
+    // @lydell/node-pty lives in the apps/server workspace's node_modules;
+    // resolve from there rather than the monorepo root, where the package
+    // manager's hoist layout may omit it.
     const linuxServerDir = `${linuxRepoRoot}/apps/server`;
 
     const probe = yield* runWslShell(
       distro,
-      NODE_PTY_PROBE_SCRIPT(linuxServerDir),
+      buildWslNodePtyProbeScript(linuxServerDir),
       PROBE_TIMEOUT,
       options,
     );
@@ -426,32 +309,15 @@ const ensureNodePtyImpl = (
       } as const;
     }
 
-    // No node at all, even after the shared resolver repaired PATH. Surface
-    // the specific, actionable toolchain message rather than a confusing
-    // node-pty error, and don't try to build.
+    // No node at all, even after the shared resolver repaired PATH. Surface an
+    // actionable runtime message rather than a confusing native-module error.
     if (nodePath === null) {
-      const toolchainCheck = yield* runWslShell(
-        distro,
-        TOOLCHAIN_CHECK_SCRIPT,
-        TOOLCHAIN_TIMEOUT,
-        options,
-      );
-      const toolchainTransportFailure = formatWslShellTransportFailureReason(
-        toolchainCheck.transportFailure,
-      );
-      if (toolchainTransportFailure !== null) {
-        return {
-          ok: false,
-          reason: toolchainTransportFailure,
-          fatal: false,
-          retryLimit: TOOLCHAIN_TRANSPORT_RETRY_LIMIT,
-        } as const;
-      }
-      const report = parseToolchainReport(toolchainCheck.stdout);
-      const reason =
-        formatMissingToolsReason(report, options.nodeEngineRange?.trim() || null) ??
-        "Node.js was not found in the WSL distro. Install it (e.g. via nvm) and restart the desktop app.";
-      return { ok: false, reason, fatal: true } as const;
+      const range = options.nodeEngineRange?.trim();
+      return {
+        ok: false,
+        reason: `Node.js${range ? ` satisfying \`${range}\`` : ""} was not found in the WSL distro. Install it (e.g. via nvm) and restart the desktop app.`,
+        fatal: true,
+      } as const;
     }
 
     if (resolvedPath === null) {
@@ -476,106 +342,26 @@ const ensureNodePtyImpl = (
       } as const;
     }
 
-    if (probe.exitCode === 0) {
-      const rawVersion = parseNodeVersion(probe.stdout);
-      if (
-        rawVersion !== null &&
-        options.nodeEngineRange &&
-        !satisfiesSemverRange(rawVersion, options.nodeEngineRange.trim())
-      ) {
-        const range = options.nodeEngineRange.trim();
-        return {
-          ok: false,
-          reason: `WSL Node.js ${rawVersion} does not satisfy the server's required engine range (${range}). Install a compatible version, and restart the desktop app.`,
-          fatal: true,
-        } as const;
-      }
-      return { ok: true, nodePath, resolvedPath } as const;
-    }
-
-    if (options.allowBuild !== true) {
-      const packagedProbeFailure = formatNodePtyProbeFailureReason(probe.exitCode);
-      if (packagedProbeFailure !== null) {
-        return {
-          ok: false,
-          reason: packagedProbeFailure,
-          fatal: true,
-        } as const;
-      }
-    }
-
-    // node is present but node-pty's native module didn't load.
-    const toolchainCheck = yield* runWslShell(
-      distro,
-      TOOLCHAIN_CHECK_SCRIPT,
-      TOOLCHAIN_TIMEOUT,
-      options,
-    );
-    const toolchainTransportFailure = formatWslShellTransportFailureReason(
-      toolchainCheck.transportFailure,
-    );
-    if (toolchainTransportFailure !== null) {
+    const rawVersion = parseNodeVersion(probe.stdout);
+    if (
+      rawVersion !== null &&
+      options.nodeEngineRange &&
+      !satisfiesSemverRange(rawVersion, options.nodeEngineRange.trim())
+    ) {
+      const range = options.nodeEngineRange.trim();
       return {
         ok: false,
-        reason: toolchainTransportFailure,
-        fatal: false,
-        retryLimit: TOOLCHAIN_TRANSPORT_RETRY_LIMIT,
-      } as const;
-    }
-    const report = parseToolchainReport(toolchainCheck.stdout);
-
-    if (options.allowBuild !== true) {
-      // Packaged builds ship a prebuilt Linux node-pty, so no compiler, node-gyp,
-      // or network is needed — and we must not nag the user to install build
-      // tools they don't need. Still surface a missing/too-old Node (both the
-      // prebuilt and the server require a compatible Node); otherwise reaching
-      // here means the bundled binary itself couldn't load, which is almost
-      // always an unsupported CPU architecture or incompatible system libraries.
-      const nodeOnlyReason = formatMissingToolsReason(
-        {
-          missingTools: report.missingTools.filter((tool) => tool === "node"),
-          nodeVersion: report.nodeVersion,
-        },
-        options.nodeEngineRange?.trim() || null,
-      );
-      return {
-        ok: false,
-        reason:
-          nodeOnlyReason ??
-          "The bundled WSL backend binary (node-pty) could not be loaded in this distro. This usually means an unsupported CPU architecture or incompatible system libraries (glibc). Use a glibc-based x64/arm64 WSL distro such as Ubuntu; if you already are, please report this with your distro and the output of `uname -m`.",
+        reason: `WSL Node.js ${rawVersion} does not satisfy the server's required engine range (${range}). Install a compatible version, and restart the desktop app.`,
         fatal: true,
       } as const;
     }
 
-    // Dev only: no prebuilt is bundled in a checkout, so compile node-pty from
-    // source. Run the toolchain check first so a missing compiler or out-of-range
-    // Node surfaces a specific, actionable message instead of an opaque node-gyp
-    // failure. Developers have the toolchain; end users never reach this path.
-    const missingReason = formatMissingToolsReason(report, options.nodeEngineRange?.trim() || null);
-    if (missingReason !== null) {
-      return { ok: false, reason: missingReason, fatal: true } as const;
-    }
+    if (probe.exitCode === 0) return { ok: true, nodePath, resolvedPath } as const;
 
-    const build = yield* runWslShell(
-      distro,
-      NODE_PTY_BUILD_SCRIPT(linuxServerDir),
-      BUILD_TIMEOUT,
-      options,
-    );
-    const buildTransportFailure = formatWslShellTransportFailureReason(build.transportFailure);
-    if (buildTransportFailure !== null) {
-      return {
-        ok: false,
-        reason: buildTransportFailure,
-        fatal: false,
-        retryLimit: BUILD_TRANSPORT_RETRY_LIMIT,
-      } as const;
-    }
-    if (build.exitCode === 0) return { ok: true, nodePath, resolvedPath } as const;
-    const trimmedTail = `${build.stdout}${build.stderr}`.trim().slice(-500);
     return {
       ok: false,
-      reason: `node-pty Linux build failed (exit ${build.exitCode}): ${trimmedTail || "no stderr captured"}`,
+      reason:
+        "The @lydell/node-pty Linux prebuilt could not be loaded in this distro. T3 Code supports glibc-based x64/arm64 WSL distributions such as Ubuntu; if you already use one, please report this with your distro and the output of `uname -m`.",
       fatal: true,
     } as const;
   });

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,10 +28,10 @@
     "@effect/platform-node-shared": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
     "@ff-labs/fff-node": "0.9.4",
+    "@lydell/node-pty": "^1.1.0",
     "@opencode-ai/sdk": "^1.3.15",
     "@pierre/diffs": "catalog:",
     "effect": "catalog:",
-    "node-pty": "^1.1.0",
     "yaml": "catalog:"
   },
   "devDependencies": {

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -73,9 +73,8 @@ export class PinnedRuntimePreflightBlockedError extends Schema.TaggedErrorClass<
 /**
  * Installs `t3@<version>` into the pinned runtime directory unless a complete
  * install is already there, and returns its paths. The sentinel is written
- * only after npm exits 0; checking the entry file alone is not enough. npm
- * extracts files before running native builds (node-pty), so a killed
- * install leaves a plausible-looking but broken tree behind.
+ * only after npm exits 0; checking the entry file alone is not enough because
+ * an interrupted install can leave a plausible-looking but incomplete tree.
  */
 interface PinnedRuntimeInstallInput {
   readonly baseDir: string;

--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -87,6 +87,40 @@ it.effect("preserves a caller-provided TERM in the spawn env on win32", () =>
   }).pipe(Effect.provide(testLayer)),
 );
 
+it.effect("resolves the spawn helper from the platform package", () =>
+  Effect.gen(function* () {
+    const wrapperPackageJsonPath =
+      "/Applications/T3.app/Contents/Resources/app.asar/node_modules.asar/@lydell/node-pty/package.json";
+    const packedHelperPath =
+      "/Applications/T3.app/Contents/Resources/app.asar/node_modules.asar/@lydell/node-pty-darwin-arm64/spawn-helper";
+    const resolve = vi.fn((request: string) => {
+      if (request === "@lydell/node-pty/package.json") return wrapperPackageJsonPath;
+      if (request === "@lydell/node-pty-darwin-arm64/spawn-helper") return packedHelperPath;
+      throw new Error(`Unexpected module request: ${request}`);
+    });
+    const createRequire = vi.fn((_filename: string | URL) => ({ resolve }));
+
+    const helperPath = yield* NodePtyAdapter.resolveNodePtySpawnHelperPath(createRequire);
+
+    assert.equal(
+      helperPath,
+      "/Applications/T3.app/Contents/Resources/app.asar.unpacked/node_modules.asar.unpacked/@lydell/node-pty-darwin-arm64/spawn-helper",
+    );
+    assert.deepEqual(createRequire.mock.calls[1], [wrapperPackageJsonPath]);
+    assert.deepEqual(resolve.mock.calls, [
+      ["@lydell/node-pty/package.json"],
+      ["@lydell/node-pty-darwin-arm64/spawn-helper"],
+    ]);
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        Layer.succeed(HostProcessPlatform, "darwin"),
+        Layer.succeed(HostProcessArchitecture, "arm64"),
+      ),
+    ),
+  ),
+);
+
 it.effect("reports native module load failures as structured startup defects", () =>
   Effect.gen(function* () {
     const cause = new Error("native binding could not be loaded");

--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -19,7 +19,7 @@ const spawn = vi.fn(() => ({
   onExit: vi.fn(() => ({ dispose: vi.fn() })),
 }));
 
-vi.mock("node-pty", () => ({ spawn }));
+vi.mock("@lydell/node-pty", () => ({ spawn }));
 
 const testLayer = NodePtyAdapter.layer.pipe(
   Layer.provide(

--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -121,6 +121,32 @@ it.effect("resolves the spawn helper from the platform package", () =>
   ),
 );
 
+it.effect("preserves an already-unpacked spawn helper path", () =>
+  Effect.gen(function* () {
+    const wrapperPackageJsonPath =
+      "/Applications/T3.app/Contents/Resources/app.asar.unpacked/node_modules.asar.unpacked/@lydell/node-pty/package.json";
+    const unpackedHelperPath =
+      "/Applications/T3.app/Contents/Resources/app.asar.unpacked/node_modules.asar.unpacked/@lydell/node-pty-darwin-arm64/spawn-helper";
+    const resolve = vi.fn((request: string) => {
+      if (request === "@lydell/node-pty/package.json") return wrapperPackageJsonPath;
+      if (request === "@lydell/node-pty-darwin-arm64/spawn-helper") return unpackedHelperPath;
+      throw new Error(`Unexpected module request: ${request}`);
+    });
+    const createRequire = vi.fn((_filename: string | URL) => ({ resolve }));
+
+    const helperPath = yield* NodePtyAdapter.resolveNodePtySpawnHelperPath(createRequire);
+
+    assert.equal(helperPath, unpackedHelperPath);
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        Layer.succeed(HostProcessPlatform, "darwin"),
+        Layer.succeed(HostProcessArchitecture, "arm64"),
+      ),
+    ),
+  ),
+);
+
 it.effect("reports native module load failures as structured startup defects", () =>
   Effect.gen(function* () {
     const cause = new Error("native binding could not be loaded");

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -3,7 +3,6 @@ import * as NodeModule from "node:module";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
-import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
@@ -23,31 +22,31 @@ export class NodePtyModuleLoadError extends Schema.TaggedErrorClass<NodePtyModul
 }
 
 type NodePtyModuleLoader = () => Promise<typeof import("@lydell/node-pty")>;
+type NodePtyRequireFactory = (filename: string | URL) => {
+  readonly resolve: (request: string) => string;
+};
 
 let didEnsureSpawnHelperExecutable = false;
 
-const resolveNodePtySpawnHelperPath = Effect.gen(function* () {
-  const requireForNodePty = NodeModule.createRequire(import.meta.url);
-  const path = yield* Path.Path;
-  const fs = yield* FileSystem.FileSystem;
+export const resolveNodePtySpawnHelperPath = Effect.fn(
+  "NodePtyAdapter.resolveNodePtySpawnHelperPath",
+)(function* (createRequire: NodePtyRequireFactory = NodeModule.createRequire) {
   const platform = yield* HostProcessPlatform;
   const architecture = yield* HostProcessArchitecture;
 
-  const packageJsonPath = requireForNodePty.resolve("@lydell/node-pty/package.json");
-  const packageDir = path.dirname(packageJsonPath);
-  const candidates = [
-    path.join(packageDir, "build", "Release", "spawn-helper"),
-    path.join(packageDir, "build", "Debug", "spawn-helper"),
-    path.join(packageDir, "prebuilds", `${platform}-${architecture}`, "spawn-helper"),
-  ];
-
-  for (const candidate of candidates) {
-    if (yield* fs.exists(candidate)) {
-      return candidate;
-    }
-  }
-  return null;
-}).pipe(Effect.orElseSucceed(() => null));
+  return yield* Effect.try({
+    try: () => {
+      const requireForAdapter = createRequire(import.meta.url);
+      const packageJsonPath = requireForAdapter.resolve("@lydell/node-pty/package.json");
+      const requireForNodePty = createRequire(packageJsonPath);
+      return requireForNodePty
+        .resolve(`@lydell/node-pty-${platform}-${architecture}/spawn-helper`)
+        .replace("app.asar", "app.asar.unpacked")
+        .replace("node_modules.asar", "node_modules.asar.unpacked");
+    },
+    catch: () => null,
+  }).pipe(Effect.orElseSucceed(() => null));
+});
 
 const ensureNodePtySpawnHelperExecutable = Effect.fn(function* () {
   const fs = yield* FileSystem.FileSystem;
@@ -55,7 +54,7 @@ const ensureNodePtySpawnHelperExecutable = Effect.fn(function* () {
   if (platform === "win32") return;
   if (didEnsureSpawnHelperExecutable) return;
 
-  const helperPath = yield* resolveNodePtySpawnHelperPath;
+  const helperPath = yield* resolveNodePtySpawnHelperPath();
   if (!helperPath) return;
   didEnsureSpawnHelperExecutable = true;
 
@@ -114,7 +113,6 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
   loadNodePtyModule: NodePtyModuleLoader = () => import("@lydell/node-pty"),
 ) {
   const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
   const platform = yield* HostProcessPlatform;
   const architecture = yield* HostProcessArchitecture;
 
@@ -131,7 +129,6 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
   const ensureNodePtySpawnHelperExecutableCached = yield* Effect.cached(
     ensureNodePtySpawnHelperExecutable().pipe(
       Effect.provideService(FileSystem.FileSystem, fs),
-      Effect.provideService(Path.Path, path),
       Effect.provideService(HostProcessPlatform, platform),
       Effect.provideService(HostProcessArchitecture, architecture),
       Effect.orElseSucceed(() => undefined),

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -41,8 +41,8 @@ export const resolveNodePtySpawnHelperPath = Effect.fn(
       const requireForNodePty = createRequire(packageJsonPath);
       return requireForNodePty
         .resolve(`@lydell/node-pty-${platform}-${architecture}/spawn-helper`)
-        .replace("app.asar", "app.asar.unpacked")
-        .replace("node_modules.asar", "node_modules.asar.unpacked");
+        .replace(/(^|[\\/])app\.asar([\\/])/u, "$1app.asar.unpacked$2")
+        .replace(/(^|[\\/])node_modules\.asar([\\/])/u, "$1node_modules.asar.unpacked$2");
     },
     catch: () => null,
   }).pipe(Effect.orElseSucceed(() => null));

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -22,7 +22,7 @@ export class NodePtyModuleLoadError extends Schema.TaggedErrorClass<NodePtyModul
   }
 }
 
-type NodePtyModuleLoader = () => Promise<typeof import("node-pty")>;
+type NodePtyModuleLoader = () => Promise<typeof import("@lydell/node-pty")>;
 
 let didEnsureSpawnHelperExecutable = false;
 
@@ -33,7 +33,7 @@ const resolveNodePtySpawnHelperPath = Effect.gen(function* () {
   const platform = yield* HostProcessPlatform;
   const architecture = yield* HostProcessArchitecture;
 
-  const packageJsonPath = requireForNodePty.resolve("node-pty/package.json");
+  const packageJsonPath = requireForNodePty.resolve("@lydell/node-pty/package.json");
   const packageDir = path.dirname(packageJsonPath);
   const candidates = [
     path.join(packageDir, "build", "Release", "spawn-helper"),
@@ -68,9 +68,9 @@ const ensureNodePtySpawnHelperExecutable = Effect.fn(function* () {
 });
 
 class NodePtyProcess implements PtyAdapter.PtyProcess {
-  private readonly process: import("node-pty").IPty;
+  private readonly process: import("@lydell/node-pty").IPty;
 
-  constructor(process: import("node-pty").IPty) {
+  constructor(process: import("@lydell/node-pty").IPty) {
     this.process = process;
   }
 
@@ -111,7 +111,7 @@ class NodePtyProcess implements PtyAdapter.PtyProcess {
 }
 
 export const make = Effect.fn("NodePtyAdapter.make")(function* (
-  loadNodePtyModule: NodePtyModuleLoader = () => import("node-pty"),
+  loadNodePtyModule: NodePtyModuleLoader = () => import("@lydell/node-pty"),
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,9 @@ importers:
       '@ff-labs/fff-node':
         specifier: 0.9.4
         version: 0.9.4(patch_hash=2b16019ce7ab61aec6478dd02f79ef468cc1d5c51e9d00764f7d2ab8167210c8)
+      '@lydell/node-pty':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@opencode-ai/sdk':
         specifier: ^1.3.15
         version: 1.15.13
@@ -473,9 +476,6 @@ importers:
       effect:
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6)
-      node-pty:
-        specifier: ^1.1.0
-        version: 1.1.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -3111,6 +3111,39 @@ packages:
     resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
     cpu: [x64]
     os: [win32]
+
+  '@lydell/node-pty-darwin-arm64@1.1.0':
+    resolution: {integrity: sha512-7kFD+owAA61qmhJCtoMbqj3Uvff3YHDiU+4on5F2vQdcMI3MuwGi7dM6MkFG/yuzpw8LF2xULpL71tOPUfxs0w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@lydell/node-pty-darwin-x64@1.1.0':
+    resolution: {integrity: sha512-XZdvqj5FjAMjH8bdp0YfaZjur5DrCIDD1VYiE9EkkYVMDQqRUPHYV3U8BVEQVT9hYfjmpr7dNaELF2KyISWSNA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@lydell/node-pty-linux-arm64@1.1.0':
+    resolution: {integrity: sha512-yyDBmalCfHpLiQMT2zyLcqL2Fay4Xy7rIs8GH4dqKLnEviMvPGOK7LADVkKAsbsyXBSISL3Lt1m1MtxhPH6ckg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@lydell/node-pty-linux-x64@1.1.0':
+    resolution: {integrity: sha512-NcNqRTD14QT+vXcEuqSSvmWY+0+WUBn2uRE8EN0zKtDpIEr9d+YiFj16Uqds6QfcLCHfZmC+Ls7YzwTaqDnanA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@lydell/node-pty-win32-arm64@1.1.0':
+    resolution: {integrity: sha512-JOMbCou+0fA7d/m97faIIfIU0jOv8sn2OR7tI45u3AmldKoKoLP8zHY6SAvDDnI3fccO1R2HeR1doVjpS7HM0w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@lydell/node-pty-win32-x64@1.1.0':
+    resolution: {integrity: sha512-3N56BZ+WDFnUMYRtsrr7Ky2mhWGl9xXcyqR6cexfuCqcz9RNWL+KoXRv/nZylY5dYaXkft4JaR1uVu+roiZDAw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@lydell/node-pty@1.1.0':
+    resolution: {integrity: sha512-VDD8LtlMTOrPKWMXUAcB9+LTktzuunqrMwkYR1DMRBkS6LQrCt+0/Ws1o2rMml/n3guePpS7cxhHF7Nm5K4iMw==}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -8336,9 +8369,6 @@ packages:
     resolution: {integrity: sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==}
     engines: {node: '>=22.12.0'}
 
-  node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
-
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -8380,9 +8410,6 @@ packages:
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
-
-  node-pty@1.1.0:
-    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-readfiles@0.2.0:
     resolution: {integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==}
@@ -13240,6 +13267,33 @@ snapshots:
 
   '@libsql/win32-x64-msvc@0.5.29':
     optional: true
+
+  '@lydell/node-pty-darwin-arm64@1.1.0':
+    optional: true
+
+  '@lydell/node-pty-darwin-x64@1.1.0':
+    optional: true
+
+  '@lydell/node-pty-linux-arm64@1.1.0':
+    optional: true
+
+  '@lydell/node-pty-linux-x64@1.1.0':
+    optional: true
+
+  '@lydell/node-pty-win32-arm64@1.1.0':
+    optional: true
+
+  '@lydell/node-pty-win32-x64@1.1.0':
+    optional: true
+
+  '@lydell/node-pty@1.1.0':
+    optionalDependencies:
+      '@lydell/node-pty-darwin-arm64': 1.1.0
+      '@lydell/node-pty-darwin-x64': 1.1.0
+      '@lydell/node-pty-linux-arm64': 1.1.0
+      '@lydell/node-pty-linux-x64': 1.1.0
+      '@lydell/node-pty-win32-arm64': 1.1.0
+      '@lydell/node-pty-win32-x64': 1.1.0
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
@@ -19216,8 +19270,6 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  node-addon-api@7.1.1: {}
-
   node-api-version@0.2.1:
     dependencies:
       semver: 7.8.5
@@ -19258,10 +19310,6 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-mock-http@1.0.4: {}
-
-  node-pty@1.1.0:
-    dependencies:
-      node-addon-api: 7.1.1
 
   node-readfiles@0.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,6 @@ allowBuilds:
   esbuild: true
   msgpackr-extract: true
   msw: false
-  node-pty: true
   sharp: true
   utf-8-validate: false
   workerd: false

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -29,6 +29,7 @@ import {
   resolveMacPasskeySigningConfiguration,
   resolveDesktopRuntimeDependencies,
   resolveFffNativeDependencies,
+  resolveNodePtyNativeDependencies,
   resolveBuildOptions,
   resolveDesktopBuildIconAssets,
   resolveDesktopProductName,
@@ -259,7 +260,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         arch: "x64",
         allowBuilds: {
           electron: true,
-          "node-pty": true,
+          sharp: true,
           "browser-tabs-lock": false,
         },
         patchedDependencies: {
@@ -277,7 +278,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         },
         allowBuilds: {
           electron: true,
-          "node-pty": true,
+          sharp: true,
           "browser-tabs-lock": false,
         },
         patchedDependencies: {
@@ -593,6 +594,19 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     });
   });
 
+  it("promotes target node-pty prebuilds to direct staged dependencies", () => {
+    assert.deepStrictEqual(resolveNodePtyNativeDependencies("mac", "universal", "^1.1.0"), {
+      "@lydell/node-pty-darwin-arm64": "^1.1.0",
+      "@lydell/node-pty-darwin-x64": "^1.1.0",
+    });
+    assert.deepStrictEqual(resolveNodePtyNativeDependencies("win", "x64", "^1.1.0"), {
+      "@lydell/node-pty-win32-x64": "^1.1.0",
+    });
+    assert.deepStrictEqual(resolveNodePtyNativeDependencies("linux", "arm64", "^1.1.0"), {
+      "@lydell/node-pty-linux-arm64": "^1.1.0",
+    });
+  });
+
   it("resolves target Clerk passkey native artifacts", () => {
     assert.deepStrictEqual(resolveClerkPasskeyNativeArtifacts("mac", "universal"), [
       {
@@ -678,7 +692,6 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         verbose: Option.none(),
         mockUpdates: Option.none(),
         mockUpdateServerPort: Option.none(),
-        wslPrebuild: Option.none(),
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
@@ -718,7 +731,6 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
             verbose: Option.none(),
             mockUpdates: Option.none(),
             mockUpdateServerPort: Option.none(),
-            wslPrebuild: Option.none(),
           }),
         );
 
@@ -742,7 +754,6 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         verbose: Option.some(false),
         mockUpdates: Option.some(false),
         mockUpdateServerPort: Option.none(),
-        wslPrebuild: Option.none(),
       }).pipe(
         Effect.provide(
           ConfigProvider.layer(

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -69,9 +69,6 @@ const RepoRoot = Effect.service(Path.Path).pipe(
 );
 const encodeJsonString = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
 const decodeWorkspaceConfig = Schema.decodeEffect(fromYaml(WorkspaceConfig));
-const decodeNodePtyManifest = Schema.decodeUnknownEffect(
-  Schema.fromJsonString(Schema.Struct({ version: Schema.String })),
-);
 const encodeStageWorkspaceConfig = Schema.encodeEffect(fromYaml(StageWorkspaceConfig));
 
 const readWorkspaceConfig = Effect.fn("readWorkspaceConfig")(function* () {
@@ -144,7 +141,6 @@ interface BuildCliInput {
   readonly verbose: Option.Option<boolean>;
   readonly mockUpdates: Option.Option<boolean>;
   readonly mockUpdateServerPort: Option.Option<number>;
-  readonly wslPrebuild: Option.Option<string>;
 }
 
 function detectHostBuildPlatform(hostPlatform: string): typeof BuildPlatform.Type | undefined {
@@ -425,29 +421,6 @@ export class DesktopBuildNoArtifactsProducedError extends Schema.TaggedErrorClas
   }
 }
 
-export class WslNodePtyPrebuildMissingError extends Schema.TaggedErrorClass<WslNodePtyPrebuildMissingError>()(
-  "WslNodePtyPrebuildMissingError",
-  {
-    prebuildPath: Schema.String,
-  },
-) {
-  override get message(): string {
-    return `WSL node-pty prebuild not found at ${this.prebuildPath}.`;
-  }
-}
-
-export class WslNodePtyManifestReadError extends Schema.TaggedErrorClass<WslNodePtyManifestReadError>()(
-  "WslNodePtyManifestReadError",
-  {
-    manifestPath: Schema.String,
-    cause: Schema.Defect(),
-  },
-) {
-  override get message(): string {
-    return `Could not read node-pty version from ${this.manifestPath}.`;
-  }
-}
-
 export class LinuxIconResizeError extends Schema.TaggedErrorClass<LinuxIconResizeError>()(
   "LinuxIconResizeError",
   {
@@ -605,7 +578,6 @@ interface ResolvedBuildOptions {
   readonly verbose: boolean;
   readonly mockUpdates: boolean;
   readonly mockUpdateServerPort: number | undefined;
-  readonly wslPrebuild: string | undefined;
 }
 
 interface StagePackageJson {
@@ -890,6 +862,22 @@ export function resolveFffNativeDependencies(
   );
 }
 
+export function resolveNodePtyNativeDependencies(
+  platform: typeof BuildPlatform.Type,
+  arch: typeof BuildArch.Type,
+  version: string,
+): Record<string, string> {
+  const platformName = platform === "mac" ? "darwin" : platform === "win" ? "win32" : "linux";
+  const architectures = arch === "universal" ? (["arm64", "x64"] as const) : [arch];
+
+  return Object.fromEntries(
+    architectures.map((architecture) => [
+      `@lydell/node-pty-${platformName}-${architecture}`,
+      version,
+    ]),
+  );
+}
+
 export interface ClerkPasskeyNativeArtifact {
   readonly packageName: string;
   readonly binaryFileName: string;
@@ -1035,11 +1023,6 @@ const BuildEnvConfig = Config.all({
   verbose: Config.boolean("T3CODE_DESKTOP_VERBOSE").pipe(Config.withDefault(false)),
   mockUpdates: Config.boolean("T3CODE_DESKTOP_MOCK_UPDATES").pipe(Config.withDefault(false)),
   mockUpdateServerPort: Config.string("T3CODE_DESKTOP_MOCK_UPDATE_SERVER_PORT").pipe(Config.option),
-  // Path to a prebuilt Linux node-pty binary (pty.node) for the target arch,
-  // produced by the Linux CI job and handed to the Windows packaging job. Placed
-  // into the staged node-pty so the WSL backend ships a ready binary and never
-  // compiles on the user's machine.
-  wslPrebuild: Config.string("T3CODE_DESKTOP_WSL_PREBUILD").pipe(Config.option),
 });
 
 const MockUpdateServerPortSchema = Schema.NumberFromString.check(
@@ -1131,9 +1114,6 @@ export const resolveBuildOptions = Effect.fn("resolveBuildOptions")(function* (
           ),
         ));
 
-  const wslPrebuild =
-    Option.getOrUndefined(input.wslPrebuild) ?? Option.getOrUndefined(env.wslPrebuild);
-
   return {
     platform,
     target,
@@ -1146,7 +1126,6 @@ export const resolveBuildOptions = Effect.fn("resolveBuildOptions")(function* (
     verbose,
     mockUpdates,
     mockUpdateServerPort,
-    wslPrebuild,
   } satisfies ResolvedBuildOptions;
 });
 
@@ -1646,76 +1625,6 @@ const assertPlatformBuildResources = Effect.fn("assertPlatformBuildResources")(f
   }
 });
 
-// Stage the prebuilt Linux node-pty binary into the packaged app so the WSL
-// backend never compiles on the user's machine. node-pty publishes no Linux
-// prebuilt and the WSL Linux Node can't load the Windows/Electron binary, so the
-// Linux CI job builds pty.node and hands it here. We drop it into the staged
-// node-pty's prebuilds/linux-<arch>/ with a t3code marker the WSL preflight
-// checks (arch + node-pty version; the binary is N-API, hence ABI-stable across
-// Node versions). A missing prebuild is a warning, not an error, so local and
-// non-Windows builds still succeed — they just won't ship a working WSL backend.
-const stageWslNodePtyPrebuild = Effect.fn("stageWslNodePtyPrebuild")(function* (input: {
-  readonly stageAppDir: string;
-  readonly arch: typeof BuildArch.Type;
-  readonly prebuildPath: string | undefined;
-}) {
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-
-  if (input.prebuildPath === undefined) {
-    yield* Effect.logWarning(
-      "[desktop-artifact] No WSL node-pty prebuild provided (--wsl-prebuild / T3CODE_DESKTOP_WSL_PREBUILD); the packaged WSL backend will not start until a Linux pty.node is bundled.",
-    );
-    return;
-  }
-
-  // WSL runs the same CPU arch as the Windows host; universal is mac-only.
-  const linuxArch = input.arch === "x64" ? "x64" : input.arch === "arm64" ? "arm64" : undefined;
-  if (linuxArch === undefined) {
-    yield* Effect.logWarning(
-      `[desktop-artifact] No WSL node-pty prebuild mapping for arch "${input.arch}"; skipping WSL backend bundling.`,
-    );
-    return;
-  }
-
-  const prebuildExists = yield* fs
-    .exists(input.prebuildPath)
-    .pipe(Effect.orElseSucceed(() => false));
-  if (!prebuildExists) {
-    return yield* new WslNodePtyPrebuildMissingError({
-      prebuildPath: input.prebuildPath,
-    });
-  }
-
-  // Resolve through the (pnpm) symlink so we write into the stage's own node-pty
-  // copy, never a shared content-addressable store.
-  const nodePtyLink = path.join(input.stageAppDir, "node_modules", "node-pty");
-  const nodePtyDir = yield* fs.realPath(nodePtyLink).pipe(Effect.orElseSucceed(() => nodePtyLink));
-
-  const manifestPath = path.join(nodePtyDir, "package.json");
-  const pkgRaw = yield* fs.readFileString(manifestPath);
-  const manifest = yield* decodeNodePtyManifest(pkgRaw).pipe(
-    Effect.mapError(
-      (cause) =>
-        new WslNodePtyManifestReadError({
-          manifestPath,
-          cause,
-        }),
-    ),
-  );
-  const nodePtyVersion = manifest.version;
-
-  const prebuildDir = path.join(nodePtyDir, "prebuilds", `linux-${linuxArch}`);
-  yield* fs.makeDirectory(prebuildDir, { recursive: true });
-  yield* fs.copyFile(input.prebuildPath, path.join(prebuildDir, "pty.node"));
-  const markerJson = yield* encodeJsonString({ arch: linuxArch, nodePtyVersion });
-  yield* fs.writeFileString(path.join(prebuildDir, "t3code-wsl-node-pty.json"), `${markerJson}\n`);
-
-  yield* Effect.log(
-    `[desktop-artifact] Staged WSL node-pty prebuild (linux-${linuxArch}, node-pty ${nodePtyVersion}).`,
-  );
-});
-
 const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   options: ResolvedBuildOptions,
 ) {
@@ -1895,6 +1804,11 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       options.arch,
       serverPackageJson.dependencies["@ff-labs/fff-node"],
     ),
+    ...resolveNodePtyNativeDependencies(
+      options.platform,
+      options.arch,
+      serverPackageJson.dependencies["@lydell/node-pty"],
+    ),
     // Windows artifacts also bundle the same-architecture WSL Linux backend, which loads the
     // fff native binary through ffi-rs. The platform fff binary above is the
     // host's (win32), so promote the matching Linux fff binaries too; without
@@ -1904,6 +1818,16 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
           "linux",
           options.arch,
           serverPackageJson.dependencies["@ff-labs/fff-node"],
+        )
+      : {}),
+    // @lydell/node-pty selects its native package at runtime. Promote the
+    // matching Linux package so electron-builder cannot prune it as an
+    // optional dependency while producing the Windows host artifact.
+    ...(options.platform === "win"
+      ? resolveNodePtyNativeDependencies(
+          "linux",
+          options.arch,
+          serverPackageJson.dependencies["@lydell/node-pty"],
         )
       : {}),
   };
@@ -1970,16 +1894,6 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     { label: "vp install --prod", verbose: options.verbose },
   );
   yield* stageClerkPasskeyNativeBinaries(stageAppDir, options.platform, options.arch);
-
-  // WSL is Windows-only, so only the Windows artifact carries the Linux backend
-  // binary; other platforms ignore the prebuild input.
-  if (options.platform === "win") {
-    yield* stageWslNodePtyPrebuild({
-      stageAppDir,
-      arch: options.arch,
-      prebuildPath: options.wslPrebuild,
-    });
-  }
 
   // electron-builder treats several set-but-empty variables (e.g. CSC_LINK="")
   // as enabled, so copy the host env and scrub empty values instead of relying
@@ -2133,12 +2047,6 @@ const buildDesktopArtifactCli = Command.make("build-desktop-artifact", {
   mockUpdateServerPort: Flag.integer("mock-update-server-port").pipe(
     Flag.withSchema(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65535 }))),
     Flag.withDescription("Mock update server port (env: T3CODE_DESKTOP_MOCK_UPDATE_SERVER_PORT)."),
-    Flag.optional,
-  ),
-  wslPrebuild: Flag.string("wsl-prebuild").pipe(
-    Flag.withDescription(
-      "Path to a prebuilt Linux node-pty (pty.node) for the target arch, staged for the WSL backend (env: T3CODE_DESKTOP_WSL_PREBUILD).",
-    ),
     Flag.optional,
   ),
 }).pipe(


### PR DESCRIPTION
Fixes #5129

## What Changed

- Replace `node-pty` with the API-compatible `@lydell/node-pty` package.
- Update the terminal adapter import and spawn-helper resolution to use the replacement package.
- Include its prebuilt Darwin, Linux, and Windows platform packages in the lockfile.

## Why

The published `node-pty@1.1.0` package does not include Linux prebuilds. Installing T3 on a fresh or immutable Linux SSH host therefore falls back to `node-gyp`, and hosts without a compiler toolchain fail before the remote server can start. Desktop then surfaces the generic `Remote T3 server did not become ready` error.

`@lydell/node-pty` exposes the same API while publishing prebuilt binaries for the supported desktop and Linux architectures. This removes the compiler requirement instead of only improving the diagnostic when compilation fails.

This complements #5132: that PR surfaces a failed install, while this change prevents the native build failure on supported platforms.

## Validation

- `vp test run src/terminal/NodePtyAdapter.test.ts` — 4 tests passed
- `vp run --filter t3 typecheck`
- `vp run --filter t3 build`
- `vp fmt --check apps/server/package.json apps/server/src/terminal/NodePtyAdapter.ts apps/server/src/terminal/NodePtyAdapter.test.ts pnpm-lock.yaml`
- Real native PTY spawn on Windows x64
- Installed the replacement into an isolated prefix and spawned a real PTY on Ubuntu Linux x64 with Node 24
- Launched the remote T3 server over SSH on the original failing host; it became ready as a managed server on port 3773

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable
- [x] Interaction video is not applicable

Generated with Codex (GPT-5) in the Codex desktop harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `node-pty` with `@lydell/node-pty` prebuilt binaries for WSL terminal support
> - Replaces the `node-pty` dependency with `@lydell/node-pty` in the server package, removing the need to compile node-pty from source in WSL.
> - The WSL preflight probe now loads `@lydell/node-pty` directly instead of validating custom Linux prebuild files or invoking `node-gyp`.
> - The desktop build now stages platform-specific `@lydell/node-pty-<platform>-<arch>` native packages (including Linux packages for Windows builds) via a new `resolveNodePtyNativeDependencies` function in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/6350/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d).
> - CI removes the `build_wsl_node_pty` job and the `--wsl-prebuild` CLI flag; the entire custom Linux pty.node build and upload pipeline is eliminated.
> - Behavioral Change: `ensureNodePty` no longer accepts `allowBuild` and never attempts toolchain checks or a WSL-side build; failures now report Node.js version mismatches or a generic incompatibility message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c05b5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native PTY loading, Windows/WSL packaging, and the release workflow; mis-staged or pruned platform packages would break terminals or the WSL backend, though behavior is simpler than the prior compile path.
> 
> **Overview**
> **Replaces `node-pty` with `@lydell/node-pty`** on the server and in the terminal adapter, including spawn-helper resolution from `@lydell/node-pty-<platform>-<arch>` with `.asar` → `.asar.unpacked` rewrites for packaged Electron apps.
> 
> **Release and desktop packaging** no longer run a Linux CI job to build `pty.node` or pass `--wsl-prebuild`; Windows staging instead promotes direct dependencies on the host and matching **Linux** `@lydell/node-pty-*` packages so WSL can load prebuilts without `node-gyp`. `node-pty` is removed from pnpm `allowBuilds`.
> 
> **WSL preflight** drops `allowBuild`, toolchain checks, and in-distro `node-gyp` builds; it now probes `require("@lydell/node-pty")` (plus Node/engine and unpacked `effect` checks) and fails with clearer messages when the Linux prebuilt cannot load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c05b5e3bc31c2631d7d6f1e0c83fcf5d7f5ef6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->