### PR TITLE
feat(web): reveal collapsed sidebar on edge hover

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -203,6 +203,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
       <Sidebar
         side="left"
         collapsible="offcanvas"
+        revealOnHover
         data-app-sidebar=""
         className="border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
         resizable={{

--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  Sidebar,
   SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuSubButton,
@@ -37,6 +38,23 @@ describe("sidebar interactive cursors", () => {
     );
 
     expect(html).toContain('data-sidebar-state="collapsed"');
+  });
+
+  it("can reveal a collapsed off-canvas sidebar from a fine-pointer screen edge", () => {
+    const html = renderToStaticMarkup(
+      <SidebarProvider defaultOpen={false}>
+        <Sidebar revealOnHover>
+          <div>Sidebar content</div>
+        </Sidebar>
+      </SidebarProvider>,
+    );
+
+    expect(html).toContain('data-slot="sidebar-hover-edge"');
+    expect(html).toContain("hidden w-1 md:block");
+    expect(html).toContain("[@media(pointer:fine)]:pointer-events-auto");
+    expect(html).toContain("group-data-[collapsible=offcanvas]:group-hover:left-0");
+    expect(html).toContain("group-data-[collapsible=offcanvas]:group-hover:delay-100");
+    expect(html).toContain("group-data-[collapsible=offcanvas]:group-hover:duration-100");
   });
 
   it("keeps the sidebar trigger interactive inside Electron drag regions", () => {

--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -52,7 +52,16 @@ describe("sidebar interactive cursors", () => {
     expect(html).toContain('data-slot="sidebar-hover-edge"');
     expect(html).toContain("hidden w-1 md:block");
     expect(html).toContain("[@media(pointer:fine)]:pointer-events-auto");
+    expect(html).toContain("group-hover:w-(--sidebar-width)");
+    expect(html).toContain("group-focus-within:w-(--sidebar-width)");
+    expect(html).toContain("group-has-[[data-popup-open]]:w-(--sidebar-width)");
+    expect(html).toContain("group-data-[peek-held=true]:w-(--sidebar-width)");
     expect(html).toContain("group-data-[collapsible=offcanvas]:group-hover:left-0");
+    expect(html).toContain("group-data-[collapsible=offcanvas]:group-focus-within:left-0");
+    expect(html).toContain(
+      "group-data-[collapsible=offcanvas]:group-has-[[data-popup-open]]:left-0",
+    );
+    expect(html).toContain("group-data-[collapsible=offcanvas]:group-data-[peek-held=true]:left-0");
     expect(html).toContain("group-data-[collapsible=offcanvas]:group-hover:delay-100");
     expect(html).toContain("group-data-[collapsible=offcanvas]:group-hover:duration-100");
   });

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -181,6 +181,7 @@ function Sidebar({
   side = "left",
   variant = "sidebar",
   collapsible = "offcanvas",
+  revealOnHover = false,
   resizable = false,
   className,
   children,
@@ -189,6 +190,7 @@ function Sidebar({
   side?: "left" | "right";
   variant?: "sidebar" | "floating" | "inset";
   collapsible?: "offcanvas" | "icon" | "none";
+  revealOnHover?: boolean;
   resizable?: boolean | SidebarResizableOptions;
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
@@ -276,6 +278,16 @@ function Sidebar({
         data-state={state}
         data-variant={variant}
       >
+        {revealOnHover && collapsible === "offcanvas" && state === "collapsed" ? (
+          <div
+            aria-hidden="true"
+            className={cn(
+              "pointer-events-none fixed inset-y-0 z-10 hidden w-1 md:block [@media(pointer:fine)]:pointer-events-auto",
+              side === "left" ? "left-0" : "right-0",
+            )}
+            data-slot="sidebar-hover-edge"
+          />
+        ) : null}
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
@@ -294,6 +306,10 @@ function Sidebar({
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+            revealOnHover &&
+              (side === "left"
+                ? "group-data-[collapsible=offcanvas]:group-hover:left-0 group-data-[collapsible=offcanvas]:group-hover:delay-100 group-data-[collapsible=offcanvas]:group-hover:duration-100"
+                : "group-data-[collapsible=offcanvas]:group-hover:right-0 group-data-[collapsible=offcanvas]:group-hover:delay-100 group-data-[collapsible=offcanvas]:group-hover:duration-100"),
             // Adjust the padding for floating and inset variants.
             variant === "floating" || variant === "inset"
               ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -28,6 +28,12 @@ const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "calc(100vw - var(--spacing(3)))";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH = 16 * 16;
+const COLLAPSED_PEEK_HIT_AREA =
+  "group-hover:w-(--sidebar-width) group-focus-within:w-(--sidebar-width) group-has-[[data-popup-open]]:w-(--sidebar-width) group-data-[peek-held=true]:w-(--sidebar-width)";
+const COLLAPSED_PEEK_LEFT =
+  "group-data-[collapsible=offcanvas]:group-hover:left-0 group-data-[collapsible=offcanvas]:group-focus-within:left-0 group-data-[collapsible=offcanvas]:group-has-[[data-popup-open]]:left-0 group-data-[collapsible=offcanvas]:group-data-[peek-held=true]:left-0 group-data-[collapsible=offcanvas]:group-hover:delay-100 group-data-[collapsible=offcanvas]:group-hover:duration-100";
+const COLLAPSED_PEEK_RIGHT =
+  "group-data-[collapsible=offcanvas]:group-hover:right-0 group-data-[collapsible=offcanvas]:group-focus-within:right-0 group-data-[collapsible=offcanvas]:group-has-[[data-popup-open]]:right-0 group-data-[collapsible=offcanvas]:group-data-[peek-held=true]:right-0 group-data-[collapsible=offcanvas]:group-hover:delay-100 group-data-[collapsible=offcanvas]:group-hover:duration-100";
 
 type SidebarContextProps = {
   state: ResponsiveSidebarState;
@@ -212,6 +218,36 @@ function Sidebar({
     () => ({ side, resizable: resolvedResizable }),
     [resolvedResizable, side],
   );
+  const canPeek =
+    !isMobile && revealOnHover && collapsible === "offcanvas" && state === "collapsed";
+  const [peekHeld, setPeekHeld] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!canPeek) {
+      if (peekHeld) {
+        setPeekHeld(false);
+      }
+      return;
+    }
+    if (!peekHeld) {
+      return;
+    }
+
+    const release = () => setPeekHeld(false);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        release();
+      }
+    };
+    document.addEventListener("pointerdown", release, true);
+    document.addEventListener("keydown", onKeyDown);
+    window.addEventListener("blur", release);
+    return () => {
+      document.removeEventListener("pointerdown", release, true);
+      document.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("blur", release);
+    };
+  }, [canPeek, peekHeld]);
 
   if (collapsible === "none") {
     return (
@@ -273,16 +309,27 @@ function Sidebar({
       <div
         className="group peer hidden text-sidebar-foreground md:block"
         data-collapsible={state === "collapsed" ? collapsible : ""}
+        data-peek-held={peekHeld ? "true" : undefined}
         data-side={side}
         data-slot="sidebar"
         data-state={state}
         data-variant={variant}
+        onContextMenu={
+          canPeek
+            ? () => {
+                setPeekHeld(true);
+              }
+            : undefined
+        }
       >
-        {revealOnHover && collapsible === "offcanvas" && state === "collapsed" ? (
+        {canPeek ? (
+          // Expand the edge hit target immediately so the pointer can travel
+          // toward the delayed slide-in without leaving the group hover target.
           <div
             aria-hidden="true"
             className={cn(
               "pointer-events-none fixed inset-y-0 z-10 hidden w-1 md:block [@media(pointer:fine)]:pointer-events-auto",
+              COLLAPSED_PEEK_HIT_AREA,
               side === "left" ? "left-0" : "right-0",
             )}
             data-slot="sidebar-hover-edge"
@@ -306,10 +353,7 @@ function Sidebar({
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
-            revealOnHover &&
-              (side === "left"
-                ? "group-data-[collapsible=offcanvas]:group-hover:left-0 group-data-[collapsible=offcanvas]:group-hover:delay-100 group-data-[collapsible=offcanvas]:group-hover:duration-100"
-                : "group-data-[collapsible=offcanvas]:group-hover:right-0 group-data-[collapsible=offcanvas]:group-hover:delay-100 group-data-[collapsible=offcanvas]:group-hover:duration-100"),
+            revealOnHover && (side === "left" ? COLLAPSED_PEEK_LEFT : COLLAPSED_PEEK_RIGHT),
             // Adjust the padding for floating and inset variants.
             variant === "floating" || variant === "inset"
               ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { getLocalStorageItem, setLocalStorageItem } from "~/hooks/useLocalStorage";
+import { subscribeContextMenuClosed } from "~/contextMenuLifetime";
 import { resolveSidebarState, type ResponsiveSidebarState } from "./sidebarState";
 import * as Schema from "effect/Schema";
 
@@ -234,18 +235,27 @@ function Sidebar({
     }
 
     const release = () => setPeekHeld(false);
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Element && target.closest("[data-slot='context-menu']")) {
+        return;
+      }
+      release();
+    };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         release();
       }
     };
-    document.addEventListener("pointerdown", release, true);
+    document.addEventListener("pointerdown", onPointerDown, true);
     document.addEventListener("keydown", onKeyDown);
     window.addEventListener("blur", release);
+    const unsubscribeContextMenuClosed = subscribeContextMenuClosed(release);
     return () => {
-      document.removeEventListener("pointerdown", release, true);
+      document.removeEventListener("pointerdown", onPointerDown, true);
       document.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("blur", release);
+      unsubscribeContextMenuClosed();
     };
   }, [canPeek, peekHeld]);
 

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -196,6 +196,12 @@ describe("showContextMenuFallback", () => {
     await expect(selectionPromise).resolves.toBe("rename");
   });
 
+  it("marks the fallback menu as a context-menu slot", () => {
+    void showContextMenuFallback([{ id: "rename", label: "Rename" }]);
+    const menu = (document as unknown as FakeDocument).body.children[0];
+    expect(menu?.dataset.slot).toBe("context-menu");
+  });
+
   it("ignores a click from the gesture that opened the menu", async () => {
     let enablePointerSelection: ((time: number) => void) | undefined;
     vi.stubGlobal("requestAnimationFrame", (callback: (time: number) => void) => {

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -172,6 +172,7 @@ export function showContextMenuFallback<T extends string>(
       menu.style.left = `${preferredLeft}px`;
       menu.style.top = `${preferredTop}px`;
       menu.dataset.level = String(level);
+      menu.dataset.slot = "context-menu";
 
       const inner = document.createElement("div");
       inner.className =

--- a/apps/web/src/contextMenuLifetime.test.ts
+++ b/apps/web/src/contextMenuLifetime.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { notifyContextMenuClosed, subscribeContextMenuClosed } from "./contextMenuLifetime";
+
+describe("context menu lifetime", () => {
+  it("notifies subscribers when a context menu closes", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeContextMenuClosed(listener);
+
+    notifyContextMenuClosed();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    notifyContextMenuClosed();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/contextMenuLifetime.ts
+++ b/apps/web/src/contextMenuLifetime.ts
@@ -1,0 +1,16 @@
+type ContextMenuClosedListener = () => void;
+
+const listeners = new Set<ContextMenuClosedListener>();
+
+export function notifyContextMenuClosed() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function subscribeContextMenuClosed(listener: ContextMenuClosedListener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -85,6 +85,36 @@ describe("LocalApi", () => {
     expect(showContextMenuFallbackMock).toHaveBeenCalledWith(items, { x: 4, y: 5 });
   });
 
+  it("notifies when a browser context menu closes", async () => {
+    const listener = vi.fn();
+    const { subscribeContextMenuClosed } = await import("./contextMenuLifetime");
+    const unsubscribe = subscribeContextMenuClosed(listener);
+    showContextMenuFallbackMock.mockResolvedValue("rename");
+    const { createLocalApi } = await import("./localApi");
+
+    await expect(
+      createLocalApi().contextMenu.show([{ id: "rename", label: "Rename" }]),
+    ).resolves.toBe("rename");
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("notifies when a desktop context menu closes", async () => {
+    const listener = vi.fn();
+    const { subscribeContextMenuClosed } = await import("./contextMenuLifetime");
+    const unsubscribe = subscribeContextMenuClosed(listener);
+    testWindow().desktopBridge = {
+      showContextMenu: vi.fn().mockResolvedValue("delete"),
+    } as unknown as DesktopBridge;
+    const { createLocalApi } = await import("./localApi");
+
+    await expect(
+      createLocalApi().contextMenu.show([{ id: "delete", label: "Delete" }]),
+    ).resolves.toBe("delete");
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
   it("uses the themed confirmation host when it is available", async () => {
     requestConfirmDialogMock.mockResolvedValue(true);
     const { createLocalApi } = await import("./localApi");

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -2,6 +2,7 @@ import type { ConfirmDialogOptions, ContextMenuItem, LocalApi } from "@t3tools/c
 
 import { requestConfirmDialog } from "./confirmDialog";
 import { showContextMenuFallback } from "./contextMenuFallback";
+import { notifyContextMenuClosed } from "./contextMenuLifetime";
 import { readBrowserClientSettings, writeBrowserClientSettings } from "./clientPersistenceStorage";
 import { resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
 
@@ -36,10 +37,14 @@ function createBrowserLocalApi(): LocalApi {
         items: readonly ContextMenuItem<T>[],
         position?: { x: number; y: number },
       ): Promise<T | null> => {
-        if (window.desktopBridge) {
-          return window.desktopBridge.showContextMenu(items, position) as Promise<T | null>;
+        try {
+          if (window.desktopBridge) {
+            return (await window.desktopBridge.showContextMenu(items, position)) as T | null;
+          }
+          return await showContextMenuFallback(items, position);
+        } finally {
+          notifyContextMenuClosed();
         }
-        return showContextMenuFallback(items, position);
       },
     },
     persistence: {

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -13,7 +13,8 @@ environment. Older servers can still pin and unpin threads, but do not understan
 their pinned threads keep the default newest-first order below the ones you have arranged.
 
 On web and desktop, pause the pointer briefly at the left edge of the window to temporarily reveal
-a collapsed sidebar. Move away to hide it again, or use the sidebar control to keep it open.
+a collapsed sidebar. It stays open while you use a control or menu inside it. Move away to hide it
+again, or use the sidebar control to keep it open.
 
 ## Environment artwork
 

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -12,6 +12,9 @@ If reordering is unavailable for one environment, update the T3 Code server runn
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.
 
+On web and desktop, pause the pointer briefly at the left edge of the window to temporarily reveal
+a collapsed sidebar. Move away to hide it again, or use the sidebar control to keep it open.
+
 ## Environment artwork
 
 Dev and Nightly environments can identify themselves with artwork at the top of the sidebar and in


### PR DESCRIPTION
## What Changed

On web and desktop, a collapsed sidebar can be peeked from the left window edge. Pause the pointer there and it slides out; move away and it hides again. The existing sidebar control still pins it open.

Touch and mobile are unchanged. Fine pointers only, with a short delay so the edge is not twitchy.

## Why

A collapsed sidebar currently has no way back except the toggle. Peeking from the screen edge is the usual desktop pattern and avoids an extra click when you just need a thread or project.

## UI Changes

https://github.com/user-attachments/assets/88834b48-b3c5-46bc-92e8-d02c5c48583b

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only interaction and layout changes with targeted tests; no auth, data, or API contract changes beyond context-menu close notifications.
> 
> **Overview**
> Adds **edge-hover peek** for a collapsed off-canvas sidebar on desktop/web with fine pointers: `revealOnHover` on `Sidebar` slides the panel in from a narrow screen-edge hit target (short delay), and hides again when the pointer leaves unless the user is interacting inside it.
> 
> **Peek hold** uses right-click on the sidebar group plus `data-peek-held` / expanded hit-area classes so menus and popups stay usable; release happens on Escape, outside pointer down, window blur, or when any context menu closes.
> 
> Wires this through **`AppSidebarLayout`**, documents it in **thread-sidebar** user docs, and adds **`contextMenuLifetime`** + `data-slot="context-menu"` on the browser fallback menu so dismiss logic does not fight open context menus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 935fc33f67605daebea8436eb2407bc4edc671b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reveal collapsed off-canvas sidebar on edge hover in web layout
> - Adds a `revealOnHover` prop to the `Sidebar` component that renders an invisible hit area at the screen edge; hovering it slides the sidebar into view when `collapsible='offcanvas'` and the sidebar is collapsed on non-mobile.
> - Introduces `peekHeld` state to keep the sidebar visible while a context menu triggered inside it is open, releasing on outside pointer down, Escape, window blur, or a context-menu-closed event.
> - Adds a new [`contextMenuLifetime`](https://github.com/pingdotgg/t3code/pull/6354/files#diff-17f9ae1485c92093c5351a4aa72318c099ab58cdfbfd2994a14989b377b06c6c) pub/sub module; `localApi.contextMenu.show` calls `notifyContextMenuClosed` in a `finally` block after any context menu resolves.
> - Marks fallback context menu root elements with `data-slot="context-menu"` so the sidebar peek logic can distinguish inside from outside clicks.
> - Behavioral Change: the off-canvas sidebar in `AppSidebarLayout` now peeks on edge hover by default when collapsed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 935fc33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->