### PR TITLE
fix(server): pick up newly installed provider CLIs on Windows refresh

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -229,6 +229,7 @@ describe("DesktopShellEnvironment", () => {
           "C:\\Windows\\System32",
           "C:\\Users\\testuser\\AppData\\Roaming\\npm",
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
+          "C:\\Users\\testuser\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
           "C:\\Users\\testuser\\.local\\bin",

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -201,7 +201,12 @@ const knownWindowsCliDirs = (env: NodeJS.ProcessEnv): ReadonlyArray<string> => [
   ...trimNonEmpty(env.LOCALAPPDATA).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}\\Programs\\nodejs`, `${value}\\Volta\\bin`, `${value}\\pnpm`],
+      onSome: (value) => [
+        `${value}\\Programs\\nodejs`,
+        `${value}\\Programs\\OpenAI\\Codex\\bin`,
+        `${value}\\Volta\\bin`,
+        `${value}\\pnpm`,
+      ],
     }),
   ),
   ...trimNonEmpty(env.USERPROFILE).pipe(
@@ -242,9 +247,21 @@ const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
   [
     "$ErrorActionPreference = 'Stop'",
     ...names.flatMap((name) => {
+      const valueStatements =
+        name === "PATH"
+          ? [
+              "$machine = [Environment]::GetEnvironmentVariable('PATH', 'Machine')",
+              "$user = [Environment]::GetEnvironmentVariable('PATH', 'User')",
+              "$parts = @()",
+              "if ($null -ne $machine -and $machine.Length -gt 0) { $parts += $machine }",
+              "if ($null -ne $user -and $user.Length -gt 0) { $parts += $user }",
+              "$value = $parts -join ';'",
+            ]
+          : [`$value = [Environment]::GetEnvironmentVariable('${name}')`];
+
       return [
         `Write-Output '${startMarker(name)}'`,
-        `$value = [Environment]::GetEnvironmentVariable('${name}')`,
+        ...valueStatements,
         "if ($null -ne $value -and $value.Length -gt 0) { Write-Output $value }",
         `Write-Output '${endMarker(name)}'`,
       ];

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -41,6 +41,7 @@ import * as Stream from "effect/Stream";
 import * as Semaphore from "effect/Semaphore";
 
 import { ServerConfig } from "../../config.ts";
+import { fixPath } from "../../os-jank.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { ProviderRegistry, type ProviderRegistryShape } from "../Services/ProviderRegistry.ts";
 import {
@@ -470,6 +471,7 @@ export const ProviderRegistryLive = Layer.effect(
     });
 
     const refresh = Effect.fn("refresh")(function* (provider?: ProviderDriverKind) {
+      yield* fixPath();
       if (provider === undefined) {
         return yield* refreshAll();
       }
@@ -488,6 +490,7 @@ export const ProviderRegistryLive = Layer.effect(
     const refreshInstance = Effect.fn("refreshInstance")(function* (
       instanceId: ProviderInstanceId,
     ) {
+      yield* fixPath();
       const sources = yield* getLiveSources;
       const providerSource = sources.find((candidate) => candidate.instanceId === instanceId);
       if (!providerSource) {

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -236,6 +236,9 @@ describe("readEnvironmentFromWindowsShell", () => {
       expect.arrayContaining(["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]),
       { encoding: "utf8", timeout: 5000 },
     );
+    const command = execFile.mock.calls[0]?.[1]?.at(-1);
+    expect(command).toContain("[Environment]::GetEnvironmentVariable('PATH', 'Machine')");
+    expect(command).toContain("[Environment]::GetEnvironmentVariable('PATH', 'User')");
   });
 
   it("strips CRLF delimiters from captured PowerShell values", () => {
@@ -334,6 +337,7 @@ describe("resolveKnownWindowsCliDirs", () => {
     ).toEqual([
       "C:\\Users\\testuser\\AppData\\Roaming\\npm",
       "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
+      "C:\\Users\\testuser\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin",
       "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
       "C:\\Users\\testuser\\AppData\\Local\\pnpm",
       "C:\\Users\\testuser\\.local\\bin",
@@ -475,6 +479,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
         PATH: [
           "C:\\Users\\testuser\\AppData\\Roaming\\npm",
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
+          "C:\\Users\\testuser\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
           "C:\\Users\\testuser\\.local\\bin",
@@ -524,6 +529,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
           "C:\\Windows\\System32",
           "C:\\Users\\testuser\\AppData\\Roaming\\npm",
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
+          "C:\\Users\\testuser\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
           "C:\\Users\\testuser\\.local\\bin",

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -269,9 +269,21 @@ function buildWindowsEnvironmentCaptureCommand(names: ReadonlyArray<string>): st
         throw new Error(`Unsupported environment variable name: ${name}`);
       }
 
+      const valueStatements =
+        name === "PATH"
+          ? [
+              "$machine = [Environment]::GetEnvironmentVariable('PATH', 'Machine')",
+              "$user = [Environment]::GetEnvironmentVariable('PATH', 'User')",
+              "$parts = @()",
+              "if ($null -ne $machine -and $machine.Length -gt 0) { $parts += $machine }",
+              "if ($null -ne $user -and $user.Length -gt 0) { $parts += $user }",
+              "$value = $parts -join ';'",
+            ]
+          : [`$value = [Environment]::GetEnvironmentVariable('${name}')`];
+
       return [
         `Write-Output '${envCaptureStart(name)}'`,
-        `$value = [Environment]::GetEnvironmentVariable('${name}')`,
+        ...valueStatements,
         "if ($null -ne $value -and $value.Length -gt 0) { Write-Output $value }",
         `Write-Output '${envCaptureEnd(name)}'`,
       ];
@@ -680,8 +692,14 @@ export function resolveKnownWindowsCliDirs(env: NodeJS.ProcessEnv): ReadonlyArra
 
   return [
     ...(appData ? [`${appData}\\npm`] : []),
-    ...(localAppData ? [`${localAppData}\\Programs\\nodejs`, `${localAppData}\\Volta\\bin`] : []),
-    ...(localAppData ? [`${localAppData}\\pnpm`] : []),
+    ...(localAppData
+      ? [
+          `${localAppData}\\Programs\\nodejs`,
+          `${localAppData}\\Programs\\OpenAI\\Codex\\bin`,
+          `${localAppData}\\Volta\\bin`,
+          `${localAppData}\\pnpm`,
+        ]
+      : []),
     ...(userProfile
       ? [`${userProfile}\\.local\\bin`, `${userProfile}\\.bun\\bin`, `${userProfile}\\scoop\\shims`]
       : []),


### PR DESCRIPTION
Fixes #6352

On Windows, if T3 starts without a provider CLI and you install it mid-session, Refresh still shows Not found until restart. The process PATH was frozen at launch, and the Windows env probe read process PATH instead of User/Machine.

- Call `fixPath()` before provider refresh
- Read Machine + User PATH in the Windows shell probe
- Include `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin` in known Windows CLI dirs

### Demo
Cold start without Codex → red → install → Refresh → green (no restart).


https://github.com/user-attachments/assets/1d83a854-40a9-45ab-95a3-3bc3c07c307b



Model: Grok 4.5
