### PR TITLE
fix(web): resume interrupted thread creation

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7592,6 +7592,74 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("resumes an unstarted thread left behind by an interrupted bootstrap", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("thread-partial-bootstrap");
+      const dispatchedCommands: Array<OrchestrationCommand> = [];
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            dispatch: (command) =>
+              Effect.sync(() => {
+                dispatchedCommands.push(command);
+                return { sequence: dispatchedCommands.length };
+              }),
+            readEvents: () => Stream.empty,
+          },
+          projectionSnapshotQuery: {
+            getThreadShellById: (candidateThreadId) =>
+              Effect.succeed(
+                candidateThreadId === threadId
+                  ? Option.some(makeDefaultOrchestrationThreadShell({ id: threadId }))
+                  : Option.none(),
+              ),
+          },
+        },
+      });
+
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const response = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.turn.start",
+            commandId: CommandId.make("cmd-resume-partial-bootstrap"),
+            threadId,
+            message: {
+              messageId: MessageId.make("msg-resume-partial-bootstrap"),
+              role: "user",
+              text: "hello again",
+              attachments: [],
+            },
+            modelSelection: defaultModelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            bootstrap: {
+              createThread: {
+                projectId: defaultProjectId,
+                title: "Bootstrap Thread",
+                modelSelection: defaultModelSelection,
+                runtimeMode: "full-access",
+                interactionMode: "default",
+                branch: "main",
+                worktreePath: null,
+                createdAt,
+              },
+            },
+            createdAt,
+          }),
+        ),
+      );
+
+      assert.equal(response.sequence, 1);
+      assert.deepEqual(
+        dispatchedCommands.map((command) => command.type),
+        ["thread.turn.start"],
+      );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("records setup-script failures without aborting bootstrap turn start", () =>
     Effect.gen(function* () {
       const dispatchedCommands: Array<OrchestrationCommand> = [];

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -763,6 +763,25 @@ const makeWsRpcLayer = (
           let targetProjectCwd = bootstrap?.prepareWorktree?.projectCwd;
           let targetWorktreePath = bootstrap?.createThread?.worktreePath ?? null;
 
+          const existingThread = bootstrap?.createThread
+            ? yield* projectionSnapshotQuery.getThreadShellById(command.threadId).pipe(
+                Effect.map(Option.getOrNull),
+                Effect.mapError((cause) =>
+                  toDispatchCommandError(cause, "Failed to inspect bootstrap thread state."),
+                ),
+              )
+            : null;
+          const canResumeInterruptedBootstrap =
+            existingThread !== null &&
+            existingThread.projectId === bootstrap?.createThread?.projectId &&
+            existingThread.latestTurn === null &&
+            existingThread.session === null;
+
+          if (canResumeInterruptedBootstrap) {
+            targetProjectId = existingThread.projectId;
+            targetWorktreePath = existingThread.worktreePath;
+          }
+
           const cleanupCreatedThread = () =>
             createdThread
               ? serverCommandId("bootstrap-thread-delete").pipe(
@@ -893,7 +912,7 @@ const makeWsRpcLayer = (
             });
 
           const bootstrapProgram = Effect.gen(function* () {
-            if (bootstrap?.createThread) {
+            if (bootstrap?.createThread && !canResumeInterruptedBootstrap) {
               yield* orchestrationEngine.dispatch({
                 type: "thread.create",
                 commandId: yield* serverCommandId("bootstrap-thread-create"),
@@ -910,7 +929,7 @@ const makeWsRpcLayer = (
               createdThread = true;
             }
 
-            if (bootstrap?.prepareWorktree) {
+            if (bootstrap?.prepareWorktree && !targetWorktreePath) {
               let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
               // "Start from origin" is a stored default; repos without an
               // origin remote fall back to the local base branch instead of

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5254,7 +5254,18 @@ function ChatViewContent(props: ChatViewProps) {
         },
       });
       if (startResult._tag === "Failure") {
-        failure = startResult;
+        const interruptedDraftStarted =
+          isLocalDraftThread &&
+          isAtomCommandInterrupted(startResult) &&
+          (await waitForStartedServerThread(
+            scopeThreadRef(activeThread.environmentId, threadIdForSend),
+          ));
+        if (interruptedDraftStarted) {
+          turnStartSucceeded = true;
+          acknowledgeActiveThreadWoke();
+        } else {
+          failure = startResult;
+        }
       } else {
         turnStartSucceeded = true;
         acknowledgeActiveThreadWoke();


### PR DESCRIPTION
## What Changed

Updated new-thread bootstrap handling so an interrupted creation request can safely resume without dispatching `thread.create` twice.

The change handles two interruption states:

- If the thread was created but its first turn was not started, the server resumes with `thread.turn.start`.
- If the thread and first turn both started, the client recognizes the server state as successful and does not restore the prompt for another submission.

A regression test covers resuming an unstarted thread left behind by an interrupted bootstrap.

## Why

Creating a new task and immediately navigating away—such as clicking New Chat while it displayed “Working”—could interrupt the client before it processed the server acknowledgement.

The server may already have created the thread, but the client treated the interrupted request as failed and restored the original prompt. Sending the restored prompt retried the bootstrap with the same thread ID, producing:

> Orchestration command invariant failed (thread.create): Thread
> 'f2a4fa5d-d3cf-454e-aa0b-e736e7f08409' already exists and cannot be
> created twice.

### Reproduction

1. Open New Chat for a project.
2. Enter and send a prompt.
3. Immediately click New Chat or navigate away while the task displays “Working.”
4. Return to the draft.
5. Send the restored prompt again.

Before this fix, the retry could reuse the existing thread ID and issue a second `thread.create`.

The fix only resumes an existing thread when it belongs to the same project and has no turn or provider session. Genuine duplicate thread creation still fails through the existing orchestration invariant.

### Verification

- Reproduced and verified manually in the Windows desktop app.
- All 9 focused bootstrap tests pass.
- Server typecheck passes.
- Changed files pass lint and formatting.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [] I included before/after screenshots for any UI changes
- [] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bootstrap orchestration and client send failure handling; resume is gated on empty turn/session and matching project, but wrong detection could skip creation or mis-handle failures.
> 
> **Overview**
> **Fixes duplicate `thread.create` when a new-chat bootstrap is interrupted** (e.g. navigating away while “Working”) and the user sends again with the same draft thread ID.
> 
> On the server, bootstrap `thread.turn.start` now looks up an existing thread shell: if it matches the bootstrap project and has **no turn and no session**, it **skips** `thread.create` and worktree prep when a worktree path is already present, then continues with the normal turn start.
> 
> On the client, a failed/interrupted local-draft turn start is treated as **success** when the scoped thread is already visible on the server (`waitForStartedServerThread`), so the prompt is not restored for a harmful retry.
> 
> Adds a server regression test for resuming an unstarted thread left behind by an interrupted bootstrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35b212f879e8e562badd5c731a6826e9727b7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resume interrupted thread creation when bootstrap is incomplete
> - When a `thread.turn.start` with a `bootstrap.createThread` payload targets an existing thread with no latest turn and no session, the server now skips thread creation and worktree preparation instead of failing.
> - [`ws.ts`](https://github.com/pingdotgg/t3code/pull/6366/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) introduces `canResumeInterruptedBootstrap` to detect this case by querying `projectionSnapshotQuery.getThreadShellById` and short-circuiting the bootstrap program accordingly.
> - [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/6366/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) treats an interrupted atom command as a success (via `acknowledgeActiveThreadWoke`) if the server thread subsequently starts, avoiding a user-visible failure state for local draft threads.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a35b212. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->