### PR TITLE
Fix mobile command popover glass rendering

### DIFF
--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -1,4 +1,3 @@
-import { isLiquidGlassSupported, LiquidGlassView } from "@callstack/liquid-glass";
 import type { ComposerTriggerKind } from "@t3tools/shared/composerTrigger";
 import type { ServerProviderSkill, ServerProviderSlashCommand } from "@t3tools/contracts";
 import { SymbolView } from "../../components/AppSymbol";
@@ -6,6 +5,7 @@ import { memo } from "react";
 import { Pressable, ScrollView, useColorScheme, View, type ViewStyle } from "react-native";
 
 import { AppText as Text } from "../../components/AppText";
+import { GlassSurface } from "../../components/GlassSurface";
 import { PierreEntryIcon } from "../../components/PierreEntryIcon";
 export type ComposerCommandItem =
   | {
@@ -56,33 +56,14 @@ function PopoverSurface(props: {
     ...props.style,
   };
 
-  if (isLiquidGlassSupported) {
-    return (
-      <LiquidGlassView
-        effect="clear"
-        interactive={false}
-        tintColor={props.isDarkMode ? "rgba(30,30,32,0.95)" : "rgba(255,255,255,0.92)"}
-        colorScheme={props.isDarkMode ? "dark" : "light"}
-        style={baseStyle}
-      >
-        {props.children}
-      </LiquidGlassView>
-    );
-  }
-
   return (
-    <View
-      style={[
-        baseStyle,
-        {
-          backgroundColor: props.isDarkMode ? "rgba(44,44,46,0.96)" : "rgba(255,255,255,0.96)",
-          borderWidth: 1,
-          borderColor: props.isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)",
-        },
-      ]}
+    <GlassSurface
+      glassEffectStyle="clear"
+      tintColor={props.isDarkMode ? "rgba(30,30,32,0.95)" : "rgba(255,255,255,0.92)"}
+      style={baseStyle}
     >
       {props.children}
-    </View>
+    </GlassSurface>
   );
 }
 


### PR DESCRIPTION
## What Changed

Updated the mobile composer command popover to use the shared `GlassSurface` component instead of rendering Liquid Glass or a manual fallback surface directly.

## Why

Using the shared glass surface keeps the popover's rendering consistent across supported and unsupported platforms while removing duplicated glass and fallback styling logic.

## UI Changes

The command popover's visual surface implementation changed. Before/after screenshots are not included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI surface swap in the composer popover with no auth, data, or API changes; visual parity may differ slightly where GlassSurface’s platform fallback differs from the old manual styles.
> 
> **Overview**
> **Refactors** the composer command popover surface so it no longer branches on `@callstack/liquid-glass` or hand-rolled `View` fallback styles in `PopoverSurface`.
> 
> `PopoverSurface` now wraps its children in the shared **`GlassSurface`** with `glassEffectStyle="clear"` and the same light/dark **tint** values as before, while keeping the existing border radius and overflow on the outer style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 059d08399ecfff651170ea3afb59b501935e0c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix glass rendering in mobile command popover
> Replaces the conditional `LiquidGlassView`/`View` rendering in [ComposerCommandPopover.tsx](https://github.com/pingdotgg/t3code/pull/6370/files#diff-681e5c79a2edd21eaf6435ea81e7856f7eccd991762e0af8b833676cada5d5b8) with a single `GlassSurface` wrapper using `glassEffectStyle="clear"` and a dark-mode-aware `tintColor`. This removes the `isLiquidGlassSupported` check and the explicit `backgroundColor`/border styling from the fallback path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 059d083.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->