### PR TITLE
fix(server): share Windows terminal process snapshots

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -24,6 +24,7 @@ import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
 import * as TestClock from "effect/testing/TestClock";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { expect } from "vite-plus/test";
 
 import * as ProcessRunner from "../processRunner.ts";
@@ -949,6 +950,56 @@ it.layer(
       yield* waitFor(
         Effect.sync(() => checks > 0),
         "1200 millis",
+      );
+    }),
+  );
+
+  it.effect("shares one Windows process snapshot across terminal checks", () =>
+    Effect.gen(function* () {
+      const runInputs: ProcessRunner.ProcessRunInput[] = [];
+      const processRunner = ProcessRunner.ProcessRunner.of({
+        run: (input) =>
+          Effect.sync(() => {
+            runInputs.push(input);
+            return {
+              stdout: ["9100|9000|node.exe", "9200|9100|worker.exe", "9101|9001|python.exe"].join(
+                "\n",
+              ),
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+              stdoutInvalidUtf8: false,
+              stderrInvalidUtf8: false,
+            };
+          }),
+      });
+      const inspector = yield* TerminalManager.makeDefaultSubprocessInspectorForPlatform(
+        "win32",
+        1_000,
+      ).pipe(Effect.provideService(ProcessRunner.ProcessRunner, processRunner));
+
+      const [first, second] = yield* Effect.all([inspector(9000), inspector(9001)], {
+        concurrency: "unbounded",
+      });
+
+      expect(first).toEqual({
+        hasRunningSubprocess: true,
+        childCommand: "node",
+        processIds: [9000, 9100, 9200],
+      });
+      expect(second).toEqual({
+        hasRunningSubprocess: true,
+        childCommand: "python",
+        processIds: [9001, 9101],
+      });
+      expect(runInputs).toHaveLength(1);
+      expect(runInputs[0]).toEqual(
+        expect.objectContaining({
+          command: "powershell.exe",
+          args: expect.arrayContaining([expect.stringContaining("Get-CimInstance Win32_Process")]),
+        }),
       );
     }),
   );

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Data from "effect/Data";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
@@ -957,10 +958,14 @@ it.layer(
   it.effect("shares one Windows process snapshot across terminal checks", () =>
     Effect.gen(function* () {
       const runInputs: ProcessRunner.ProcessRunInput[] = [];
+      const runStarted = yield* Deferred.make<void>();
+      const releaseRun = yield* Deferred.make<void>();
       const processRunner = ProcessRunner.ProcessRunner.of({
         run: (input) =>
-          Effect.sync(() => {
+          Effect.gen(function* () {
             runInputs.push(input);
+            yield* Deferred.succeed(runStarted, undefined);
+            yield* Deferred.await(releaseRun);
             return {
               stdout: ["9100|9000|node.exe", "9200|9100|worker.exe", "9101|9001|python.exe"].join(
                 "\n",
@@ -980,9 +985,15 @@ it.layer(
         1_000,
       ).pipe(Effect.provideService(ProcessRunner.ProcessRunner, processRunner));
 
-      const [first, second] = yield* Effect.all([inspector(9000), inspector(9001)], {
+      const inspections = yield* Effect.all([inspector(9000), inspector(9001)], {
         concurrency: "unbounded",
-      });
+      }).pipe(Effect.forkChild);
+
+      yield* Deferred.await(runStarted);
+      yield* Effect.yieldNow;
+      expect(runInputs).toHaveLength(1);
+      yield* Deferred.succeed(releaseRun, undefined);
+      const [first, second] = yield* Fiber.join(inspections);
 
       expect(first).toEqual({
         hasRunningSubprocess: true,
@@ -994,7 +1005,6 @@ it.layer(
         childCommand: "python",
         processIds: [9001, 9101],
       });
-      expect(runInputs).toHaveLength(1);
       expect(runInputs[0]).toEqual(
         expect.objectContaining({
           command: "powershell.exe",

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -620,12 +620,14 @@ function parseFirstChildPidFromPgrep(stdout: string): number | null {
   return null;
 }
 
-function windowsInspectSubprocess(
-  terminalPid: number,
-  platform: NodeJS.Platform,
-): Effect.Effect<
-  TerminalSubprocessInspectResult,
-  TerminalSubprocessCheckError,
+interface WindowsProcessSnapshot {
+  readonly processNameById: ReadonlyMap<number, string>;
+  readonly childrenByParent: ReadonlyMap<number, ReadonlyArray<number>>;
+}
+
+function windowsProcessSnapshot(): Effect.Effect<
+  WindowsProcessSnapshot,
+  ProcessRunner.ProcessRunError,
   ProcessRunner.ProcessRunner
 > {
   const command =
@@ -644,12 +646,12 @@ function windowsInspectSubprocess(
       timeoutBehavior: "timedOutResult",
     });
   }).pipe(
-    Effect.map((result) => {
-      if (result.code !== 0) {
-        return { hasRunningSubprocess: false, childCommand: null, processIds: [] } as const;
-      }
+    Effect.map((result): WindowsProcessSnapshot => {
       const processNameById = new Map<number, string>();
       const childrenByParent = new Map<number, number[]>();
+      if (result.code !== 0) {
+        return { processNameById, childrenByParent };
+      }
       for (const line of result.stdout.split(/\r?\n/g)) {
         const [pidRaw, parentPidRaw, nameRaw] = line.trim().split("|", 3);
         const pid = Number(pidRaw);
@@ -660,38 +662,41 @@ function windowsInspectSubprocess(
         children.push(pid);
         childrenByParent.set(parentPid, children);
       }
-      const directChildren = childrenByParent.get(terminalPid) ?? [];
-      const childPid = directChildren[0];
-      if (childPid === undefined) {
-        return { hasRunningSubprocess: false, childCommand: null, processIds: [] } as const;
-      }
-      const processIds = new Set<number>([terminalPid]);
-      const pending = [terminalPid];
-      while (pending.length > 0) {
-        const parentPid = pending.pop();
-        if (parentPid === undefined) continue;
-        for (const pid of childrenByParent.get(parentPid) ?? []) {
-          if (processIds.has(pid)) continue;
-          processIds.add(pid);
-          pending.push(pid);
-        }
-      }
-      const normalized = normalizeChildCommandName(processNameById.get(childPid) ?? "", platform);
-      return {
-        hasRunningSubprocess: true,
-        childCommand: normalized ? truncateTerminalWireLabel(normalized) : null,
-        processIds: [...processIds],
-      } as const;
+      return { processNameById, childrenByParent };
     }),
-    Effect.mapError(
-      (cause) =>
-        new TerminalSubprocessCheckError({
-          cause,
-          terminalPid,
-          command: "powershell",
-        }),
-    ),
   );
+}
+
+function inspectWindowsProcessSnapshot(
+  snapshot: WindowsProcessSnapshot,
+  terminalPid: number,
+  platform: NodeJS.Platform,
+): TerminalSubprocessInspectResult {
+  const directChildren = snapshot.childrenByParent.get(terminalPid) ?? [];
+  const childPid = directChildren[0];
+  if (childPid === undefined) {
+    return { hasRunningSubprocess: false, childCommand: null, processIds: [] };
+  }
+  const processIds = new Set<number>([terminalPid]);
+  const pending = [terminalPid];
+  while (pending.length > 0) {
+    const parentPid = pending.pop();
+    if (parentPid === undefined) continue;
+    for (const pid of snapshot.childrenByParent.get(parentPid) ?? []) {
+      if (processIds.has(pid)) continue;
+      processIds.add(pid);
+      pending.push(pid);
+    }
+  }
+  const normalized = normalizeChildCommandName(
+    snapshot.processNameById.get(childPid) ?? "",
+    platform,
+  );
+  return {
+    hasRunningSubprocess: true,
+    childCommand: normalized ? truncateTerminalWireLabel(normalized) : null,
+    processIds: [...processIds],
+  };
 }
 
 const posixInspectSubprocess = Effect.fn("terminal.posixInspectSubprocess")(function* (
@@ -840,17 +845,50 @@ const posixInspectSubprocess = Effect.fn("terminal.posixInspectSubprocess")(func
   };
 });
 
-function defaultSubprocessInspectorForPlatform(platform: NodeJS.Platform) {
-  return Effect.fn("terminal.defaultSubprocessInspector")(function* (terminalPid: number) {
+export const makeDefaultSubprocessInspectorForPlatform = Effect.fn(
+  "terminal.makeDefaultSubprocessInspector",
+)(function* (
+  platform: NodeJS.Platform,
+  subprocessPollIntervalMs: number,
+): Effect.fn.Return<TerminalSubprocessInspector, never, ProcessRunner.ProcessRunner> {
+  const processRunner = yield* ProcessRunner.ProcessRunner;
+  if (platform === "win32") {
+    // A poll checks every terminal concurrently. Reuse the full Windows process
+    // table for that interval while each terminal derives its own subtree.
+    const cachedSnapshot = yield* windowsProcessSnapshot().pipe(
+      Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
+      Effect.cachedWithTTL(subprocessPollIntervalMs),
+    );
+    return (terminalPid) => {
+      if (!Number.isInteger(terminalPid) || terminalPid <= 0) {
+        return Effect.succeed({
+          hasRunningSubprocess: false,
+          childCommand: null,
+          processIds: [],
+        });
+      }
+      return cachedSnapshot.pipe(
+        Effect.map((snapshot) => inspectWindowsProcessSnapshot(snapshot, terminalPid, platform)),
+        Effect.mapError(
+          (cause) =>
+            new TerminalSubprocessCheckError({
+              cause,
+              terminalPid,
+              command: "powershell",
+            }),
+        ),
+      );
+    };
+  }
+  return (terminalPid) => {
     if (!Number.isInteger(terminalPid) || terminalPid <= 0) {
-      return { hasRunningSubprocess: false, childCommand: null, processIds: [] };
+      return Effect.succeed({ hasRunningSubprocess: false, childCommand: null, processIds: [] });
     }
-    if (platform === "win32") {
-      return yield* windowsInspectSubprocess(terminalPid, platform);
-    }
-    return yield* posixInspectSubprocess(terminalPid, platform);
-  });
-}
+    return posixInspectSubprocess(terminalPid, platform).pipe(
+      Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
+    );
+  };
+});
 
 function capHistory(history: string, maxLines: number): string {
   if (history.length === 0) return history;
@@ -1226,15 +1264,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   // `options.env` is the test seam.
   const baseEnv = options.env ?? process.env;
   const shellResolver = options.shellResolver ?? (() => defaultShellResolver(platform, baseEnv));
-  const processRunner = yield* ProcessRunner.ProcessRunner;
-  const subprocessInspector =
-    options.subprocessInspector ??
-    ((terminalPid) =>
-      defaultSubprocessInspectorForPlatform(platform)(terminalPid).pipe(
-        Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
-      ));
   const subprocessPollIntervalMs =
     options.subprocessPollIntervalMs ?? DEFAULT_SUBPROCESS_POLL_INTERVAL_MS;
+  const subprocessInspector =
+    options.subprocessInspector ??
+    (yield* makeDefaultSubprocessInspectorForPlatform(platform, subprocessPollIntervalMs));
   const processKillGraceMs = options.processKillGraceMs ?? DEFAULT_PROCESS_KILL_GRACE_MS;
   const maxRetainedInactiveSessions =
     options.maxRetainedInactiveSessions ?? DEFAULT_MAX_RETAINED_INACTIVE_SESSIONS;


### PR DESCRIPTION
## Problem

On Windows, terminal subprocess polling launches a new `powershell.exe` and scans the full `Win32_Process` table for every running terminal on every poll. Because terminal checks run concurrently, 14 terminals can start 14 simultaneous PowerShell/CIM scans.

On this Windows machine, one scan took about 1.16 seconds. Fourteen concurrent scans took 3.05 seconds of wall time and about 36.4 CPU-seconds, confirming the Windows amplification noted in #6332.

## Fix

Separate Windows process-table collection from per-terminal tree derivation, then cache the snapshot for the terminal polling interval. Concurrent terminal checks now share one full process-table scan while preserving each terminal's child label and complete descendant PID set.

This reduces 14 PowerShell/CIM scans per poll to 1 without changing wire contracts or client behavior.

## Validation

- `vp run --filter t3 typecheck`
- `vp lint --report-unused-disable-directives apps/server/src/terminal/Manager.ts apps/server/src/terminal/Manager.test.ts`
- `vp fmt --check apps/server/src/terminal/Manager.ts apps/server/src/terminal/Manager.test.ts`
- Added a focused regression test proving two Windows terminal inspections share one snapshot and still derive distinct process trees.
- A direct Effect runtime probe produced one runner call for two concurrent inspections.

Local `vp test run apps/server/src/terminal/Manager.test.ts` is blocked before test collection by an existing Effect/Vitest harness error (`Cannot read properties of undefined (reading 'config')`); an untouched `GitManager.test.ts` fails at its `it.layer` registration with the same error.

Generated with Codex (GPT-5.6-sol) in the T3 Code Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share a single PowerShell process snapshot across concurrent Windows terminal subprocess checks
> - Replaces `windowsInspectSubprocess` with a `windowsProcessSnapshot` Effect that runs one PowerShell `Get-CimInstance Win32_Process` query and builds a cached snapshot (maps of process names by PID and child PIDs by parent).
> - Adds `inspectWindowsProcessSnapshot`, a pure function that derives a `TerminalSubprocessInspectResult` from a cached snapshot, decoupling result derivation from the query itself.
> - Introduces `makeDefaultSubprocessInspectorForPlatform` which wraps the snapshot in `cachedWithTTL` so all concurrent terminal checks within one polling interval share a single PowerShell invocation on Windows.
> - Non-Windows (POSIX) behavior is functionally unchanged, now wired through the same factory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f023629. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows terminal subprocess monitoring by reusing process snapshots during the polling interval.
  * Improved process ancestry and command detection when monitoring multiple terminals concurrently.
  * Reduced redundant system inspections for faster, more consistent subprocess updates.
  * Added clearer handling and reporting when PowerShell-based inspection fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->