### PR TITLE
fix(clients): align placeholders with conversation state

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -16,6 +16,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { conversationComposerPlaceholder } from "@t3tools/client-runtime/composer";
 
 import { ComposerEditor, type ComposerEditorHandle } from "../../components/ComposerEditor";
 import {
@@ -896,7 +897,7 @@ export function NewTaskDraftScreen(props: {
       onFocus={() => setIsComposerFocused(true)}
       onBlur={() => setIsComposerFocused(false)}
       onPasteImages={(uris) => void handleNativePasteImages(uris)}
-      placeholder={`Describe a coding task in ${selectedProject.title}`}
+      placeholder={conversationComposerPlaceholder("new")}
       // Same collapsed centering as ThreadComposer: native vertical gravity
       // in a pill-height box.
       singleLineCentered={!isExpanded}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -53,6 +53,7 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { ControlPill } from "../../components/ControlPill";
+import { conversationComposerPlaceholder } from "@t3tools/client-runtime/composer";
 import type { ComposerEditorHandle } from "../../components/ComposerEditor";
 import type { StatusTone } from "../../components/StatusPill";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
@@ -717,7 +718,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                 editorRef={composerEditorRef}
                 draftMessage={props.draftMessage}
                 draftAttachments={props.draftAttachments}
-                placeholder="Ask the repo agent, or run a command…"
+                placeholder={conversationComposerPlaceholder("existing")}
                 contentMaxWidth={contentMaxWidth}
                 connectionState={props.connectionStateLabel}
                 connectionError={props.connectionError}

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -15,6 +15,7 @@ import {
   branchMismatchKey,
   buildExpiredTerminalContextToastCopy,
   buildLoadingThreadFromShell,
+  resolveComposerConversationKind,
   buildThreadTurnInterruptInput,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
@@ -167,6 +168,18 @@ describe("buildLoadingThreadFromShell", () => {
       activities: [],
       checkpoints: [],
     });
+  });
+});
+
+describe("resolveComposerConversationKind", () => {
+  it("preserves existing-thread guidance while message detail is loading", () => {
+    expect(
+      resolveComposerConversationKind({
+        messageCount: 0,
+        threadDetailLoading: true,
+        latestUserMessageAt: now,
+      }),
+    ).toBe("existing");
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -10,6 +10,7 @@ import {
   type ThreadId,
   type TurnId,
 } from "@t3tools/contracts";
+import type { ComposerConversationKind } from "@t3tools/client-runtime/composer";
 import { type ChatMessage, type SessionPhase, type Thread, type ThreadShell } from "../types";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
@@ -117,6 +118,16 @@ export function buildLoadingThreadFromShell(shell: ThreadShell): Thread {
     checkpoints: [],
     deletedAt: null,
   };
+}
+
+export function resolveComposerConversationKind(input: {
+  readonly messageCount: number;
+  readonly threadDetailLoading: boolean;
+  readonly latestUserMessageAt: string | null;
+}): ComposerConversationKind {
+  return input.messageCount > 0 || (input.threadDetailLoading && input.latestUserMessageAt !== null)
+    ? "existing"
+    : "new";
 }
 
 export function shouldWriteThreadErrorToCurrentServerThread(input: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -289,6 +289,7 @@ import {
   buildExpiredTerminalContextToastCopy,
   buildLocalDraftThread,
   buildLoadingThreadFromShell,
+  resolveComposerConversationKind,
   buildThreadTurnInterruptInput,
   collectUserMessageBlobPreviewUrls,
   createLocalDispatchSnapshot,
@@ -2548,6 +2549,11 @@ function ChatViewContent(props: ChatViewProps) {
       ),
     [activeThread?.proposedPlans, timelineMessages, turnPlans, workLogEntries],
   );
+  const composerConversationKind = resolveComposerConversationKind({
+    messageCount: timelineMessages.length,
+    threadDetailLoading,
+    latestUserMessageAt: routeServerThreadShell?.latestUserMessageAt ?? null,
+  });
   const [dockedDraftHeroThreadKey, setDockedDraftHeroThreadKey] = useState<string | null>(null);
   const draftHeroDockRequested =
     activeThreadKey !== null && dockedDraftHeroThreadKey === activeThreadKey;
@@ -6344,7 +6350,7 @@ function ChatViewContent(props: ChatViewProps) {
                             activeThread={activeThread}
                             isServerThread={isServerThread}
                             isLocalDraftThread={isLocalDraftThread}
-                            conversationKind={timelineMessages.length === 0 ? "new" : "existing"}
+                            conversationKind={composerConversationKind}
                             forceExpandedOnMobile={forceExpandedMobileComposer && isDraftHeroState}
                             projectSelectionRequired={isLocalDraftThread && activeProject === null}
                             phase={phase}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6344,6 +6344,7 @@ function ChatViewContent(props: ChatViewProps) {
                             activeThread={activeThread}
                             isServerThread={isServerThread}
                             isLocalDraftThread={isLocalDraftThread}
+                            conversationKind={timelineMessages.length === 0 ? "new" : "existing"}
                             forceExpandedOnMobile={forceExpandedMobileComposer && isDraftHeroState}
                             projectSelectionRequired={isLocalDraftThread && activeProject === null}
                             phase={phase}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -18,6 +18,10 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
+import {
+  conversationComposerPlaceholder,
+  type ComposerConversationKind,
+} from "@t3tools/client-runtime/composer";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import {
@@ -503,6 +507,7 @@ export interface ChatComposerProps {
   activeThread: Thread | undefined;
   isServerThread: boolean;
   isLocalDraftThread: boolean;
+  conversationKind: ComposerConversationKind;
   forceExpandedOnMobile: boolean;
   projectSelectionRequired: boolean;
 
@@ -612,6 +617,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activeThread,
     isServerThread: _isServerThread,
     isLocalDraftThread: _isLocalDraftThread,
+    conversationKind,
     forceExpandedOnMobile,
     projectSelectionRequired,
     phase,
@@ -3049,9 +3055,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                           ? "Choose a project above to start a thread"
                           : noProviderAvailable
                             ? "Enable a provider in Settings to send a message"
-                            : phase === "disconnected"
-                              ? "Ask for follow-up changes or attach images"
-                              : "Ask anything, @tag files/folders, $use skills, or / for commands"
+                            : conversationComposerPlaceholder(conversationKind)
                 }
                 disabled={isConnecting || isComposerApprovalState || projectSelectionRequired}
               />

--- a/apps/web/src/components/settings/SettingsFontPreviews.tsx
+++ b/apps/web/src/components/settings/SettingsFontPreviews.tsx
@@ -44,7 +44,7 @@ export function PromptFontPreview() {
         terminalContexts={EMPTY_TERMINAL_CONTEXTS}
         skills={EMPTY_SKILLS}
         disabled={false}
-        placeholder={conversationComposerPlaceholder("existing")}
+        placeholder={conversationComposerPlaceholder("new")}
         className="max-h-40 min-h-12"
         onRemoveTerminalContext={noop}
         onChange={onChange}

--- a/apps/web/src/components/settings/SettingsFontPreviews.tsx
+++ b/apps/web/src/components/settings/SettingsFontPreviews.tsx
@@ -1,4 +1,5 @@
 import { preloadPatchFile } from "@pierre/diffs/ssr";
+import { conversationComposerPlaceholder } from "@t3tools/client-runtime/composer";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "../ComposerPromptEditor";
 import { terminalThemeFromApp } from "../ThreadTerminalDrawer";
@@ -43,7 +44,7 @@ export function PromptFontPreview() {
         terminalContexts={EMPTY_TERMINAL_CONTEXTS}
         skills={EMPTY_SKILLS}
         disabled={false}
-        placeholder="Ask for follow-up changes or attach images"
+        placeholder={conversationComposerPlaceholder("existing")}
         className="max-h-40 min-h-12"
         onRemoveTerminalContext={noop}
         onChange={onChange}

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./composer": {
+      "types": "./src/composer.ts",
+      "default": "./src/composer.ts"
+    },
     "./connection": {
       "types": "./src/connection/index.ts",
       "default": "./src/connection/index.ts"

--- a/packages/client-runtime/src/composer.ts
+++ b/packages/client-runtime/src/composer.ts
@@ -1,8 +1,8 @@
 export type ComposerConversationKind = "new" | "existing";
 
 const CONVERSATION_PLACEHOLDERS = {
-  new: "Describe what you want to build or change",
-  existing: "Ask for changes, add more context, or attach images",
+  new: "Describe the task, tag @files, use $skills or /commands",
+  existing: "Ask for changes, add context, or attach images",
 } as const satisfies Record<ComposerConversationKind, string>;
 
 /** Returns the ordinary composer guidance shared by web, desktop, and mobile. */

--- a/packages/client-runtime/src/composer.ts
+++ b/packages/client-runtime/src/composer.ts
@@ -1,0 +1,11 @@
+export type ComposerConversationKind = "new" | "existing";
+
+const CONVERSATION_PLACEHOLDERS = {
+  new: "Describe what you want to build or change",
+  existing: "Ask for changes, add more context, or attach images",
+} as const satisfies Record<ComposerConversationKind, string>;
+
+/** Returns the ordinary composer guidance shared by web, desktop, and mobile. */
+export function conversationComposerPlaceholder(kind: ComposerConversationKind) {
+  return CONVERSATION_PLACEHOLDERS[kind];
+}


### PR DESCRIPTION
Input placeholders on desktop/web seemed incoherent with what's going on, and the copy wasn't great too.

Turned out they were following "connected / disconnected" state instead of more obvious "new / existing conversation" state that was already used on mobile. I was annoyed more than I probably should've been, so here we go.
<br />
<table>
  <thead>
    <tr>
      <th></th>
      <th colspan="2">Before</th>
      <th colspan="2">After</th>
    </tr>
    <tr>
      <th>Surface</th>
      <th>New thread</th>
      <th>Existing thread</th>
      <th>New thread</th>
      <th>Existing thread</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Mobile</td>
      <td>“Describe a coding task in {project}”</td>
      <td>“Ask the repo agent, or run a command…”</td>
      <td rowspan="4">"Describe the task, tag @files, use $skills or /commands"</td>
      <td rowspan="3">“Ask for changes, add context, or attach images”</td>
    </tr>
    <tr>
      <td>Web</td>
      <td rowspan="2">"Ask for follow-up changes or attach images" (because state is usually "disconnected")</td>
      <td rowspan="3">“Ask anything, @tag files/folders, $use skills, or / for commands” (because state is usually "connected")</td>
    </tr>
    <tr>
      <td>Desktop</td>
    </tr>
    <tr>
      <td>Font preview</td>
      <td></td>
      <td></td>
    </tr>
  </tbody>
</table>



## What Changed

Now there is canonical copy for new and continuing conversation states that lives in the shared client runtime. Web, desktop, and mobile, all invoke the same copy.

- New conversations show: “Describe the task, tag @files, use $skills or /commands”
- Existing conversations show: “Ask for changes, add context, or attach images”

The new copy:

a. Provides a more meaningful tooltip for native
b. Stylistically more consistent than the old desktop one

Web/desktop selects between the two from the rendered conversation, including optimistic messages; mobile explicitly selects the appropriate copy for its new-task and existing-thread composers.

## Why

Web/desktop previously selected its ordinary placeholder from session phase. A new draft has no session and was treated as disconnected, so it showed follow-up guidance. Once a session existed, continued conversations showed the basic starter instructions – the opposite of the intended behavior.

## UI Changes

The composer placeholder copy changes on web, desktop, and mobile.

## Verification

- `vp run --filter @t3tools/client-runtime typecheck`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/mobile typecheck`
- Targeted lint for every changed TypeScript file
- Full repository test run: 7,405 tests passed; two unrelated root-runner suites failed because a `.cjs` script was collected without tests and the Ghostty ABI suite could not import its vendored `wasm?inline` asset

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for the UI changes
- [x] A video is not applicable because no motion or interaction timing changed

Implemented with GPT-5.6 Sol via Codex in the T3 Code harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize composer placeholder text based on conversation state
> - Adds a `conversationComposerPlaceholder` function in [composer.ts](https://github.com/pingdotgg/t3code/pull/6379/files#diff-e6ad1246e4b3207e1535c40b6668a79b62ff68947413cbab69cf74ea4c6dea48) that maps a `ComposerConversationKind` (`"new"` or `"existing"`) to a shared guidance string.
> - Adds `resolveComposerConversationKind` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/6379/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) to derive the kind from message count, loading state, and `latestUserMessageAt`.
> - Web `ChatComposer` and mobile composers (`NewTaskDraftScreen`, `ThreadDetailScreen`) now use these shared helpers instead of hardcoded or interpolated placeholder strings.
> - Behavioral Change: the web composer no longer shows phase- or state-specific placeholder variants; all clients now show one of two standardized strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c24b879.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and lightweight UI classification only; no auth, data, or send-path changes.
> 
> **Overview**
> Composer placeholders now follow **new vs existing conversation** instead of web/desktop **session connected/disconnected**, with one shared copy path for web, mobile, and settings previews.
> 
> A new `@t3tools/client-runtime/composer` export defines `conversationComposerPlaceholder` for `'new'` and `'existing'` strings. Web derives kind via `resolveComposerConversationKind` (timeline message count, thread detail loading, and shell `latestUserMessageAt` so loading threads still get follow-up copy) and passes `conversationKind` into `ChatComposer`, replacing the old phase-based default placeholder. Mobile new-task and thread composers and the settings font preview call the same helper with explicit `'new'` / `'existing'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c24b879ec402f6c152a1f2e7ad8322c5362d631d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->