### PR TITLE
feat(server): surface portable .agents/skills across provider snapshots

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -76,6 +76,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.sourceControlCloneRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.sourceControlPublishRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.projectsListEntries]: AuthOrchestrationReadScope,
+  [WS_METHODS.projectsListAgentSkills]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsReadFile]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchContents]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchEntries]: AuthOrchestrationReadScope,

--- a/apps/server/src/provider/Drivers/AgentSkills.test.ts
+++ b/apps/server/src/provider/Drivers/AgentSkills.test.ts
@@ -4,7 +4,11 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
-import { discoverAgentSkills } from "./AgentSkills.ts";
+import {
+  discoverAgentSkills,
+  discoverProjectAgentSkills,
+  discoverUserAgentSkills,
+} from "./AgentSkills.ts";
 
 const writeSkill = Effect.fn(function* (
   skillsDir: string,
@@ -125,6 +129,68 @@ it.layer(NodeServices.layer)("discoverAgentSkills", (it) => {
       );
 
       assert.deepEqual(skills, []);
+    }),
+  );
+
+  it.effect("discoverUserAgentSkills scans only the user home, not a workspace", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-agent-skills-" });
+      const agentsHome = path.join(tempDir, "agents-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(agentsHome, ".agents", "skills"),
+        "home-skill",
+        ["---", "name: home-skill", "description: From home.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "workspace-skill",
+        ["---", "name: workspace-skill", "description: From workspace.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverUserAgentSkills({ homeDirectory: agentsHome });
+
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["home-skill"],
+      );
+      assert.equal(skills[0]?.scope, "user");
+    }),
+  );
+
+  it.effect("discoverProjectAgentSkills scans only the given workspace root", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-agent-skills-" });
+      const agentsHome = path.join(tempDir, "agents-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(agentsHome, ".agents", "skills"),
+        "home-skill",
+        ["---", "name: home-skill", "description: From home.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "workspace-skill",
+        ["---", "name: workspace-skill", "description: From workspace.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverProjectAgentSkills(workspace);
+
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["workspace-skill"],
+      );
+      assert.equal(skills[0]?.scope, "project");
+      assert.equal(
+        skills[0]?.path,
+        path.join(workspace, ".agents", "skills", "workspace-skill", "SKILL.md"),
+      );
     }),
   );
 });

--- a/apps/server/src/provider/Drivers/AgentSkills.test.ts
+++ b/apps/server/src/provider/Drivers/AgentSkills.test.ts
@@ -5,9 +5,9 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
 import {
-  discoverAgentSkills,
   discoverProjectAgentSkills,
   discoverUserAgentSkills,
+  scanFilesystemSkillRoots,
 } from "./AgentSkills.ts";
 
 const writeSkill = Effect.fn(function* (
@@ -26,13 +26,12 @@ const isolatedDiscoveryOptions = (tempDir: string) => ({
   homeDirectory: `${tempDir}/isolated-home`,
 });
 
-it.layer(NodeServices.layer)("discoverAgentSkills", (it) => {
-  it.effect("discovers user and project skills with frontmatter metadata", () =>
+it.layer(NodeServices.layer)("AgentSkills", (it) => {
+  it.effect("discoverUserAgentSkills parses frontmatter metadata for user skills", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-agent-skills-" });
-      const workspace = path.join(tempDir, "workspace");
       const agentsHome = path.join(tempDir, "agents-home");
 
       yield* writeSkill(
@@ -40,13 +39,8 @@ it.layer(NodeServices.layer)("discoverAgentSkills", (it) => {
         "agent-browser",
         ["---", "name: agent-browser", "description: Browser automation.", "---"].join("\n"),
       );
-      yield* writeSkill(
-        path.join(workspace, ".agents", "skills"),
-        "test-t3-app",
-        ["---", "name: test-t3-app", "description: Test the web app.", "---"].join("\n"),
-      );
 
-      const skills = yield* discoverAgentSkills(workspace, { homeDirectory: agentsHome });
+      const skills = yield* discoverUserAgentSkills({ homeDirectory: agentsHome });
 
       assert.deepEqual(skills, [
         {
@@ -55,13 +49,6 @@ it.layer(NodeServices.layer)("discoverAgentSkills", (it) => {
           enabled: true,
           scope: "user",
           description: "Browser automation.",
-        },
-        {
-          name: "test-t3-app",
-          path: path.join(workspace, ".agents", "skills", "test-t3-app", "SKILL.md"),
-          enabled: true,
-          scope: "project",
-          description: "Test the web app.",
         },
       ]);
     }),
@@ -86,7 +73,10 @@ it.layer(NodeServices.layer)("discoverAgentSkills", (it) => {
         ["---", "name: shared-skill", "description: Project agents skill.", "---"].join("\n"),
       );
 
-      const skills = yield* discoverAgentSkills(workspace, { homeDirectory: agentsHome });
+      const skills = yield* scanFilesystemSkillRoots([
+        { directory: path.join(agentsHome, ".agents", "skills"), scope: "user" },
+        { directory: path.join(workspace, ".agents", "skills"), scope: "project" as const },
+      ]);
 
       assert.equal(skills.length, 1);
       assert.equal(skills[0]?.scope, "project");
@@ -107,7 +97,7 @@ it.layer(NodeServices.layer)("discoverAgentSkills", (it) => {
       yield* fs.makeDirectory(skillsDir, { recursive: true });
       yield* fs.writeFileString(path.join(skillsDir, "README.md"), "not a skill");
 
-      const skills = yield* discoverAgentSkills(undefined, { homeDirectory: agentsHome });
+      const skills = yield* discoverUserAgentSkills({ homeDirectory: agentsHome });
 
       assert.deepEqual(
         skills.map((skill) => skill.name),
@@ -122,11 +112,15 @@ it.layer(NodeServices.layer)("discoverAgentSkills", (it) => {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-agent-skills-" });
+      const workspace = path.join(tempDir, "workspace");
 
-      const skills = yield* discoverAgentSkills(
-        path.join(tempDir, "missing-workspace"),
-        isolatedDiscoveryOptions(tempDir),
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "project-only",
+        ["---", "name: project-only", "description: Project.", "---"].join("\n"),
       );
+
+      const skills = yield* discoverUserAgentSkills(isolatedDiscoveryOptions(tempDir));
 
       assert.deepEqual(skills, []);
     }),

--- a/apps/server/src/provider/Drivers/AgentSkills.test.ts
+++ b/apps/server/src/provider/Drivers/AgentSkills.test.ts
@@ -1,0 +1,130 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverAgentSkills } from "./AgentSkills.ts";
+
+const writeSkill = Effect.fn(function* (
+  skillsDir: string,
+  directoryName: string,
+  contents: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillDir = path.join(skillsDir, directoryName);
+  yield* fs.makeDirectory(skillDir, { recursive: true });
+  yield* fs.writeFileString(path.join(skillDir, "SKILL.md"), contents);
+});
+
+const isolatedDiscoveryOptions = (tempDir: string) => ({
+  homeDirectory: `${tempDir}/isolated-home`,
+});
+
+it.layer(NodeServices.layer)("discoverAgentSkills", (it) => {
+  it.effect("discovers user and project skills with frontmatter metadata", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-agent-skills-" });
+      const workspace = path.join(tempDir, "workspace");
+      const agentsHome = path.join(tempDir, "agents-home");
+
+      yield* writeSkill(
+        path.join(agentsHome, ".agents", "skills"),
+        "agent-browser",
+        ["---", "name: agent-browser", "description: Browser automation.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "test-t3-app",
+        ["---", "name: test-t3-app", "description: Test the web app.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverAgentSkills(workspace, { homeDirectory: agentsHome });
+
+      assert.deepEqual(skills, [
+        {
+          name: "agent-browser",
+          path: path.join(agentsHome, ".agents", "skills", "agent-browser", "SKILL.md"),
+          enabled: true,
+          scope: "user",
+          description: "Browser automation.",
+        },
+        {
+          name: "test-t3-app",
+          path: path.join(workspace, ".agents", "skills", "test-t3-app", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Test the web app.",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("prefers project skills over user skills on name collisions", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-agent-skills-" });
+      const workspace = path.join(tempDir, "workspace");
+      const agentsHome = path.join(tempDir, "agents-home");
+
+      yield* writeSkill(
+        path.join(agentsHome, ".agents", "skills"),
+        "shared-skill",
+        ["---", "name: shared-skill", "description: User agents skill.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "shared-skill",
+        ["---", "name: shared-skill", "description: Project agents skill.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverAgentSkills(workspace, { homeDirectory: agentsHome });
+
+      assert.equal(skills.length, 1);
+      assert.equal(skills[0]?.scope, "project");
+      assert.equal(skills[0]?.description, "Project agents skill.");
+    }),
+  );
+
+  it.effect("falls back to the directory name and skips malformed frontmatter", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-agent-skills-" });
+      const agentsHome = path.join(tempDir, "agents-home");
+      const skillsDir = path.join(agentsHome, ".agents", "skills");
+
+      yield* writeSkill(skillsDir, "no-frontmatter", "# Just a heading\n");
+      yield* writeSkill(skillsDir, "broken-yaml", "---\nname: [unclosed\n---\n");
+      yield* fs.makeDirectory(skillsDir, { recursive: true });
+      yield* fs.writeFileString(path.join(skillsDir, "README.md"), "not a skill");
+
+      const skills = yield* discoverAgentSkills(undefined, { homeDirectory: agentsHome });
+
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["no-frontmatter"],
+      );
+      assert.equal(skills[0]?.description, undefined);
+    }),
+  );
+
+  it.effect("returns an empty list when no skill roots exist", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-agent-skills-" });
+
+      const skills = yield* discoverAgentSkills(
+        path.join(tempDir, "missing-workspace"),
+        isolatedDiscoveryOptions(tempDir),
+      );
+
+      assert.deepEqual(skills, []);
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/AgentSkills.ts
+++ b/apps/server/src/provider/Drivers/AgentSkills.ts
@@ -131,19 +131,3 @@ export const discoverProjectAgentSkills = Effect.fn("discoverProjectAgentSkills"
     { directory: path.join(workspaceRoot, ".agents", "skills"), scope: "project" },
   ]);
 });
-
-/**
- * Enumerate portable skills from the user home and optional workspace cwd.
- */
-export const discoverAgentSkills = Effect.fn("discoverAgentSkills")(function* (
-  cwd?: string,
-  options?: { readonly homeDirectory?: string },
-): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
-  const path = yield* Path.Path;
-  const homeDirectory = options?.homeDirectory ?? NodeOS.homedir();
-
-  return yield* scanFilesystemSkillRoots([
-    { directory: path.join(homeDirectory, ".agents", "skills"), scope: "user" },
-    ...(cwd ? [{ directory: path.join(cwd, ".agents", "skills"), scope: "project" as const }] : []),
-  ]);
-});

--- a/apps/server/src/provider/Drivers/AgentSkills.ts
+++ b/apps/server/src/provider/Drivers/AgentSkills.ts
@@ -104,6 +104,35 @@ export const scanFilesystemSkillRoots = Effect.fn("scanFilesystemSkillRoots")(fu
 });
 
 /**
+ * Enumerate portable skills under the user home only (`~/.agents/skills`).
+ * Use this for environment-level (project-agnostic) snapshots; pair with
+ * `discoverProjectAgentSkills` for per-workspace resolution.
+ */
+export const discoverUserAgentSkills = Effect.fn("discoverUserAgentSkills")(function* (options?: {
+  readonly homeDirectory?: string;
+}): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const homeDirectory = options?.homeDirectory ?? NodeOS.homedir();
+  return yield* scanFilesystemSkillRoots([
+    { directory: path.join(homeDirectory, ".agents", "skills"), scope: "user" },
+  ]);
+});
+
+/**
+ * Enumerate portable skills under a single workspace root only
+ * (`<workspaceRoot>/.agents/skills`). Resolve this per active project so a
+ * project's skills follow the project, not the server's launch directory.
+ */
+export const discoverProjectAgentSkills = Effect.fn("discoverProjectAgentSkills")(function* (
+  workspaceRoot: string,
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  return yield* scanFilesystemSkillRoots([
+    { directory: path.join(workspaceRoot, ".agents", "skills"), scope: "project" },
+  ]);
+});
+
+/**
  * Enumerate portable skills from the user home and optional workspace cwd.
  */
 export const discoverAgentSkills = Effect.fn("discoverAgentSkills")(function* (

--- a/apps/server/src/provider/Drivers/AgentSkills.ts
+++ b/apps/server/src/provider/Drivers/AgentSkills.ts
@@ -1,0 +1,120 @@
+/**
+ * AgentSkills — shared filesystem discovery of cross-agent skills for the `$` picker.
+ *
+ * Portable skills live under `~/.agents/skills` and `<cwd>/.agents/skills`, one
+ * directory per skill with a `SKILL.md` carrying YAML frontmatter. Providers
+ * without native skill inventory (Cursor, Grok, OpenCode, …) use this scanner;
+ * Claude layers vendor-specific roots (`<config>/skills`, `<cwd>/.claude/skills`)
+ * on the same scanner. Codex reports skills natively via its app-server.
+ *
+ * @module provider/Drivers/AgentSkills
+ */
+import * as NodeOS from "node:os";
+
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import { parse as parseYamlDocument } from "yaml";
+
+export type FilesystemSkillScope = "user" | "project";
+
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+type SkillFrontmatter =
+  | { readonly kind: "missing" }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "parsed"; readonly name?: string; readonly description?: string };
+
+function parseSkillFrontmatter(contents: string): SkillFrontmatter {
+  const match = FRONTMATTER_PATTERN.exec(contents);
+  if (!match) {
+    return { kind: "missing" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYamlDocument(match[1] ?? "");
+  } catch {
+    return { kind: "malformed" };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { kind: "malformed" };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  const description = typeof record.description === "string" ? record.description.trim() : "";
+  return {
+    kind: "parsed",
+    ...(name ? { name } : {}),
+    ...(description ? { description } : {}),
+  };
+}
+
+/**
+ * Scan explicit skill roots. Discovery is best-effort: unreadable roots and
+ * malformed entries are skipped. Later roots overwrite earlier ones on name
+ * collisions so project-scoped skills beat user-scoped ones.
+ */
+export const scanFilesystemSkillRoots = Effect.fn("scanFilesystemSkillRoots")(function* (
+  roots: ReadonlyArray<{ directory: string; scope: FilesystemSkillScope }>,
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillsByName = new Map<string, ServerProviderSkill>();
+
+  for (const root of roots) {
+    const entries = yield* fileSystem
+      .readDirectory(root.directory)
+      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+
+    for (const entry of [...entries].sort()) {
+      const skillPath = path.join(root.directory, entry, "SKILL.md");
+      const contents = yield* fileSystem
+        .readFileString(skillPath)
+        .pipe(Effect.orElseSucceed(() => undefined));
+      if (contents === undefined) {
+        continue;
+      }
+
+      const frontmatter = parseSkillFrontmatter(contents);
+      if (frontmatter.kind === "malformed") {
+        continue;
+      }
+
+      const name = (frontmatter.kind === "parsed" ? frontmatter.name : undefined) ?? entry.trim();
+      if (!name) {
+        continue;
+      }
+
+      skillsByName.set(name, {
+        name,
+        path: skillPath,
+        enabled: true,
+        scope: root.scope,
+        ...(frontmatter.kind === "parsed" && frontmatter.description
+          ? { description: frontmatter.description }
+          : {}),
+      });
+    }
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+});
+
+/**
+ * Enumerate portable skills from the user home and optional workspace cwd.
+ */
+export const discoverAgentSkills = Effect.fn("discoverAgentSkills")(function* (
+  cwd?: string,
+  options?: { readonly homeDirectory?: string },
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const homeDirectory = options?.homeDirectory ?? NodeOS.homedir();
+
+  return yield* scanFilesystemSkillRoots([
+    { directory: path.join(homeDirectory, ".agents", "skills"), scope: "user" },
+    ...(cwd ? [{ directory: path.join(cwd, ".agents", "skills"), scope: "project" as const }] : []),
+  ]);
+});

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
-import { discoverClaudeSkills } from "./ClaudeSkills.ts";
+import { discoverClaudeProjectSkills, discoverClaudeSkills } from "./ClaudeSkills.ts";
 
 const writeSkill = Effect.fn(function* (
   skillsDir: string,
@@ -323,5 +323,48 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
 
       assert.deepEqual(skills, []);
     }),
+  );
+
+  it.effect(
+    "discoverClaudeProjectSkills scans only the workspace and prefers .claude over .agents",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+        const configDir = path.join(tempDir, "claude-home");
+        const workspace = path.join(tempDir, "workspace");
+
+        // User-scope roots must be ignored by the project-only resolver.
+        yield* writeSkill(
+          path.join(configDir, "skills"),
+          "user-skill",
+          ["---", "name: user-skill", "description: User config skill.", "---"].join("\n"),
+        );
+        // Same name in both project roots: Claude-native wins.
+        yield* writeSkill(
+          path.join(workspace, ".agents", "skills"),
+          "deploy",
+          ["---", "name: deploy", "description: Portable project skill.", "---"].join("\n"),
+        );
+        yield* writeSkill(
+          path.join(workspace, ".claude", "skills"),
+          "deploy",
+          ["---", "name: deploy", "description: Claude project skill.", "---"].join("\n"),
+        );
+
+        const skills = yield* discoverClaudeProjectSkills(workspace);
+
+        assert.deepEqual(
+          skills.map((skill) => skill.name),
+          ["deploy"],
+        );
+        assert.equal(skills[0]?.scope, "project");
+        assert.equal(skills[0]?.description, "Claude project skill.");
+        assert.equal(
+          skills[0]?.path,
+          path.join(workspace, ".claude", "skills", "deploy", "SKILL.md"),
+        );
+      }),
   );
 });

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -18,6 +18,10 @@ const writeSkill = Effect.fn(function* (
   yield* fs.writeFileString(path.join(skillDir, "SKILL.md"), contents);
 });
 
+const isolatedDiscoveryOptions = (tempDir: string) => ({
+  homeDirectory: `${tempDir}/isolated-home`,
+});
+
 it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
   it.effect("discovers user and project skills with frontmatter metadata", () =>
     Effect.gen(function* () {
@@ -45,7 +49,12 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
         ["---", "name: deploy", "description: Deploy the app.", "---", "", "# Deploy"].join("\n"),
       );
 
-      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
+      const skills = yield* discoverClaudeSkills(
+        { homePath: configDir },
+        workspace,
+        undefined,
+        isolatedDiscoveryOptions(tempDir),
+      );
 
       assert.deepEqual(skills, [
         {
@@ -64,6 +73,92 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
         },
       ]);
     }),
+  );
+
+  it.effect("prefers project .agents/skills over user .claude/skills on name collisions", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "shared-skill",
+        ["---", "name: shared-skill", "description: Claude user skill.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "shared-skill",
+        ["---", "name: shared-skill", "description: Project agents skill.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverClaudeSkills(
+        { homePath: configDir },
+        workspace,
+        undefined,
+        isolatedDiscoveryOptions(tempDir),
+      );
+
+      assert.equal(skills.length, 1);
+      assert.equal(skills[0]?.scope, "project");
+      assert.equal(skills[0]?.description, "Project agents skill.");
+    }),
+  );
+
+  it.effect(
+    "prefers Claude-native .claude/skills over portable .agents/skills within a scope",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+        const configDir = path.join(tempDir, "claude-home");
+        const workspace = path.join(tempDir, "workspace");
+        const agentsHome = `${tempDir}/isolated-home`;
+
+        yield* writeSkill(
+          path.join(configDir, "skills"),
+          "claude-user",
+          ["---", "name: claude-user", "description: Claude user skill.", "---"].join("\n"),
+        );
+        yield* writeSkill(
+          path.join(agentsHome, ".agents", "skills"),
+          "claude-user",
+          ["---", "name: claude-user", "description: Portable user skill.", "---"].join("\n"),
+        );
+        yield* writeSkill(
+          path.join(workspace, ".claude", "skills"),
+          "claude-project",
+          ["---", "name: claude-project", "description: Claude project skill.", "---"].join("\n"),
+        );
+        yield* writeSkill(
+          path.join(workspace, ".agents", "skills"),
+          "claude-project",
+          ["---", "name: claude-project", "description: Portable project skill.", "---"].join("\n"),
+        );
+
+        const skills = yield* discoverClaudeSkills(
+          { homePath: configDir },
+          workspace,
+          undefined,
+          isolatedDiscoveryOptions(tempDir),
+        );
+        const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+        assert.equal(byName.size, 2);
+        assert.equal(byName.get("claude-user")?.scope, "user");
+        assert.equal(
+          byName.get("claude-user")?.path,
+          path.join(configDir, "skills", "claude-user", "SKILL.md"),
+        );
+        assert.equal(byName.get("claude-project")?.scope, "project");
+        assert.equal(
+          byName.get("claude-project")?.path,
+          path.join(workspace, ".claude", "skills", "claude-project", "SKILL.md"),
+        );
+      }),
   );
 
   it.effect("prefers project skills over user skills on name collisions", () =>
@@ -85,7 +180,12 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
         ["---", "name: deploy", "description: Project deploy.", "---"].join("\n"),
       );
 
-      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
+      const skills = yield* discoverClaudeSkills(
+        { homePath: configDir },
+        workspace,
+        undefined,
+        isolatedDiscoveryOptions(tempDir),
+      );
 
       assert.equal(skills.length, 1);
       assert.equal(skills[0]?.scope, "project");
@@ -107,7 +207,12 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
       yield* fs.makeDirectory(skillsDir, { recursive: true });
       yield* fs.writeFileString(path.join(skillsDir, "README.md"), "not a skill");
 
-      const skills = yield* discoverClaudeSkills({ homePath: configDir }, undefined);
+      const skills = yield* discoverClaudeSkills(
+        { homePath: configDir },
+        undefined,
+        undefined,
+        isolatedDiscoveryOptions(tempDir),
+      );
 
       // A skill with no frontmatter falls back to its directory name; a skill
       // whose frontmatter fails to parse is skipped entirely (Claude Code
@@ -133,9 +238,14 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
         ["---", "name: env-skill", "description: From env config dir.", "---"].join("\n"),
       );
 
-      const skills = yield* discoverClaudeSkills({ homePath: "" }, undefined, {
-        CLAUDE_CONFIG_DIR: environmentConfigDir,
-      });
+      const skills = yield* discoverClaudeSkills(
+        { homePath: "" },
+        undefined,
+        {
+          CLAUDE_CONFIG_DIR: environmentConfigDir,
+        },
+        isolatedDiscoveryOptions(tempDir),
+      );
 
       assert.deepEqual(
         skills.map((skill) => skill.name),
@@ -150,9 +260,14 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
         "explicit-skill",
         ["---", "name: explicit-skill", "---"].join("\n"),
       );
-      const explicitSkills = yield* discoverClaudeSkills({ homePath: explicitHome }, undefined, {
-        CLAUDE_CONFIG_DIR: environmentConfigDir,
-      });
+      const explicitSkills = yield* discoverClaudeSkills(
+        { homePath: explicitHome },
+        undefined,
+        {
+          CLAUDE_CONFIG_DIR: environmentConfigDir,
+        },
+        isolatedDiscoveryOptions(tempDir),
+      );
       assert.deepEqual(
         explicitSkills.map((skill) => skill.name),
         ["explicit-skill"],
@@ -176,9 +291,14 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
         ["---", "name: relative-skill", "---"].join("\n"),
       );
 
-      const skills = yield* discoverClaudeSkills({ homePath: "" }, workspace, {
-        CLAUDE_CONFIG_DIR: "relative-config",
-      });
+      const skills = yield* discoverClaudeSkills(
+        { homePath: "" },
+        workspace,
+        {
+          CLAUDE_CONFIG_DIR: "relative-config",
+        },
+        isolatedDiscoveryOptions(tempDir),
+      );
 
       assert.deepEqual(
         skills.map((skill) => skill.name),
@@ -197,6 +317,8 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
       const skills = yield* discoverClaudeSkills(
         { homePath: path.join(tempDir, "missing-home") },
         path.join(tempDir, "missing-workspace"),
+        undefined,
+        isolatedDiscoveryOptions(tempDir),
       );
 
       assert.deepEqual(skills, []);

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -83,3 +83,20 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
 
   return yield* scanFilesystemSkillRoots(roots);
 });
+
+/**
+ * Enumerate Claude Code PROJECT skills for a single workspace root: the portable
+ * `<root>/.agents/skills` plus the Claude-native `<root>/.claude/skills`.
+ * Vendor-native wins on a same-scope collision (`.claude` roots come last).
+ * Resolve per active project so project skills follow the project, not the
+ * server launch directory.
+ */
+export const discoverClaudeProjectSkills = Effect.fn("discoverClaudeProjectSkills")(function* (
+  workspaceRoot: string,
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  return yield* scanFilesystemSkillRoots([
+    { directory: path.join(workspaceRoot, ".agents", "skills"), scope: "project" },
+    { directory: path.join(workspaceRoot, ".claude", "skills"), scope: "project" },
+  ]);
+});

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -2,9 +2,10 @@
  * ClaudeSkills — filesystem discovery of Claude Code skills for the `$` picker.
  *
  * Claude Code loads skills from `<config dir>/skills` (user scope) and
- * `<cwd>/.claude/skills` (project scope), one directory per skill with a
- * `SKILL.md` carrying YAML frontmatter. The Agent SDK init handshake surfaces
- * skills only as slash commands without their filesystem paths, so the
+ * `<cwd>/.claude/skills` (project scope). Cross-agent skills live under
+ * `~/.agents/skills` and `<cwd>/.agents/skills`. Each skill is one directory
+ * with a `SKILL.md` carrying YAML frontmatter. The Agent SDK init handshake
+ * surfaces skills only as slash commands without their filesystem paths, so the
  * provider snapshot scans the same locations directly, mirroring how the
  * Codex app-server reports its skills.
  *
@@ -16,44 +17,9 @@ import type { ClaudeSettings, ServerProviderSkill } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
-import { parse as parseYamlDocument } from "yaml";
 
 import { expandHomePath } from "../../pathExpansion.ts";
-
-type ClaudeSkillScope = "user" | "project";
-
-const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
-
-type SkillFrontmatter =
-  | { readonly kind: "missing" }
-  | { readonly kind: "malformed" }
-  | { readonly kind: "parsed"; readonly name?: string; readonly description?: string };
-
-function parseSkillFrontmatter(contents: string): SkillFrontmatter {
-  const match = FRONTMATTER_PATTERN.exec(contents);
-  if (!match) {
-    return { kind: "missing" };
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = parseYamlDocument(match[1] ?? "");
-  } catch {
-    return { kind: "malformed" };
-  }
-  if (typeof parsed !== "object" || parsed === null) {
-    return { kind: "malformed" };
-  }
-
-  const record = parsed as Record<string, unknown>;
-  const name = typeof record.name === "string" ? record.name.trim() : "";
-  const description = typeof record.description === "string" ? record.description.trim() : "";
-  return {
-    kind: "parsed",
-    ...(name ? { name } : {}),
-    ...(description ? { description } : {}),
-  };
-}
+import { scanFilesystemSkillRoots, type FilesystemSkillScope } from "./AgentSkills.ts";
 
 /**
  * Resolve the Claude config directory the CLI would use, matching the
@@ -84,65 +50,36 @@ const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(funct
 });
 
 /**
- * Enumerate Claude Code skills from the user config dir and the workspace.
- * Discovery is best-effort: unreadable roots and malformed skill entries are
- * skipped so a broken skill never degrades the provider snapshot. On name
- * collisions the project-scoped skill wins, matching Claude Code's
- * most-specific-wins resolution.
+ * Enumerate Claude Code skills from the user config dir, shared `.agents/skills`
+ * locations, and the workspace. Discovery is best-effort: unreadable roots and
+ * malformed skill entries are skipped so a broken skill never degrades the
+ * provider snapshot. Resolution is most-specific-wins on two axes: project
+ * scope beats user scope, and within a scope the Claude-native `.claude/skills`
+ * root beats the portable `.agents/skills` root of the same name — so a
+ * Claude-specific skill keeps running even when a portable namesake exists.
  */
 export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* (
   config: Pick<ClaudeSettings, "homePath">,
   cwd?: string,
   environment?: NodeJS.ProcessEnv,
+  options?: { readonly homeDirectory?: string },
 ): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
-  const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const configDirPath = yield* resolveClaudeConfigDirPath(config, environment ?? process.env, cwd);
+  const homeDirectory = options?.homeDirectory ?? NodeOS.homedir();
 
-  const roots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = [
+  // Order is load-bearing: scanFilesystemSkillRoots lets later roots win on
+  // collisions, so `.agents` precedes `.claude` within each scope by design.
+  const roots: ReadonlyArray<{ directory: string; scope: FilesystemSkillScope }> = [
+    { directory: path.join(homeDirectory, ".agents", "skills"), scope: "user" },
     { directory: path.join(configDirPath, "skills"), scope: "user" },
-    ...(cwd ? [{ directory: path.join(cwd, ".claude", "skills"), scope: "project" as const }] : []),
+    ...(cwd
+      ? [
+          { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
+        ]
+      : []),
   ];
 
-  const skillsByName = new Map<string, ServerProviderSkill>();
-  for (const root of roots) {
-    const entries = yield* fileSystem
-      .readDirectory(root.directory)
-      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
-
-    for (const entry of [...entries].sort()) {
-      const skillPath = path.join(root.directory, entry, "SKILL.md");
-      const contents = yield* fileSystem
-        .readFileString(skillPath)
-        .pipe(Effect.orElseSucceed(() => undefined));
-      if (contents === undefined) {
-        continue;
-      }
-
-      const frontmatter = parseSkillFrontmatter(contents);
-      // Malformed frontmatter means the skill won't load in Claude Code
-      // either — skip it rather than surfacing a broken entry under its
-      // directory name.
-      if (frontmatter.kind === "malformed") {
-        continue;
-      }
-
-      const name = (frontmatter.kind === "parsed" ? frontmatter.name : undefined) ?? entry.trim();
-      if (!name) {
-        continue;
-      }
-
-      skillsByName.set(name, {
-        name,
-        path: skillPath,
-        enabled: true,
-        scope: root.scope,
-        ...(frontmatter.kind === "parsed" && frontmatter.description
-          ? { description: frontmatter.description }
-          : {}),
-      });
-    }
-  }
-
-  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+  return yield* scanFilesystemSkillRoots(roots);
 });

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -126,7 +126,6 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         env: processEnv,
       });
 
-      const { cwd } = yield* ServerConfig;
       const adapter = yield* makeCursorAdapter(effectiveConfig, {
         environment: processEnv,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
@@ -135,7 +134,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       const textGeneration = yield* makeCursorTextGeneration(effectiveConfig, processEnv);
 
       const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv).pipe(
-        Effect.flatMap((draft) => augmentProviderSnapshotWithAgentSkills(draft, cwd)),
+        Effect.flatMap((draft) => augmentProviderSnapshotWithAgentSkills(draft)),
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -23,6 +23,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { augmentProviderSnapshotWithAgentSkills } from "../augmentProviderSnapshotWithAgentSkills.ts";
 import { makeCursorTextGeneration } from "../../textGeneration/CursorTextGeneration.ts";
 import { ProviderDriverError } from "../Errors.ts";
 import { makeCursorAdapter } from "../Layers/CursorAdapter.ts";
@@ -125,6 +126,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         env: processEnv,
       });
 
+      const { cwd } = yield* ServerConfig;
       const adapter = yield* makeCursorAdapter(effectiveConfig, {
         environment: processEnv,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
@@ -133,6 +135,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       const textGeneration = yield* makeCursorTextGeneration(effectiveConfig, processEnv);
 
       const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.flatMap((draft) => augmentProviderSnapshotWithAgentSkills(draft, cwd)),
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -89,7 +89,6 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
-      const { cwd } = yield* ServerConfig;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -118,7 +117,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const textGeneration = yield* makeGrokTextGeneration(effectiveConfig, processEnv);
 
       const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv).pipe(
-        Effect.flatMap((draft) => augmentProviderSnapshotWithAgentSkills(draft, cwd)),
+        Effect.flatMap((draft) => augmentProviderSnapshotWithAgentSkills(draft)),
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -10,6 +10,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { augmentProviderSnapshotWithAgentSkills } from "../augmentProviderSnapshotWithAgentSkills.ts";
 import { makeGrokTextGeneration } from "../../textGeneration/GrokTextGeneration.ts";
 import { ProviderDriverError } from "../Errors.ts";
 import { makeGrokAdapter } from "../Layers/GrokAdapter.ts";
@@ -86,6 +87,9 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
     Effect.gen(function* () {
       const crypto = yield* Crypto.Crypto;
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { cwd } = yield* ServerConfig;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -114,9 +118,12 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const textGeneration = yield* makeGrokTextGeneration(effectiveConfig, processEnv);
 
       const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.flatMap((draft) => augmentProviderSnapshotWithAgentSkills(draft, cwd)),
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
       );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -151,7 +151,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         serverConfig.cwd,
         processEnv,
       ).pipe(
-        Effect.flatMap((draft) => augmentProviderSnapshotWithAgentSkills(draft, serverConfig.cwd)),
+        Effect.flatMap((draft) => augmentProviderSnapshotWithAgentSkills(draft)),
         Effect.map(stampIdentity),
         Effect.provideService(OpenCodeRuntime, openCodeRuntime),
         Effect.provideService(FileSystem.FileSystem, fileSystem),

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -21,6 +21,7 @@ import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
+import { augmentProviderSnapshotWithAgentSkills } from "../augmentProviderSnapshotWithAgentSkills.ts";
 import { makeOpenCodeTextGeneration } from "../../textGeneration/OpenCodeTextGeneration.ts";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import { ServerConfig } from "../../config.ts";
@@ -116,6 +117,8 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
     Effect.gen(function* () {
       const openCodeRuntime = yield* OpenCodeRuntime;
       const serverConfig = yield* ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -147,7 +150,13 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         effectiveConfig,
         serverConfig.cwd,
         processEnv,
-      ).pipe(Effect.map(stampIdentity), Effect.provideService(OpenCodeRuntime, openCodeRuntime));
+      ).pipe(
+        Effect.flatMap((draft) => augmentProviderSnapshotWithAgentSkills(draft, serverConfig.cwd)),
+        Effect.map(stampIdentity),
+        Effect.provideService(OpenCodeRuntime, openCodeRuntime),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<OpenCodeSettings>>(

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -910,7 +910,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
-  const skills = yield* discoverClaudeSkills(claudeSettings, cwd, resolvedEnvironment);
+  const skills = yield* discoverClaudeSkills(claudeSettings, undefined, resolvedEnvironment);
   const slashCommands = capabilities?.slashCommands ?? [];
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
 

--- a/apps/server/src/provider/augmentProviderSnapshotWithAgentSkills.test.ts
+++ b/apps/server/src/provider/augmentProviderSnapshotWithAgentSkills.test.ts
@@ -1,0 +1,91 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { buildServerProvider } from "./providerSnapshot.ts";
+import { augmentProviderSnapshotWithAgentSkills } from "./augmentProviderSnapshotWithAgentSkills.ts";
+
+const writeSkill = Effect.fn(function* (
+  skillsDir: string,
+  directoryName: string,
+  contents: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillDir = path.join(skillsDir, directoryName);
+  yield* fs.makeDirectory(skillDir, { recursive: true });
+  yield* fs.writeFileString(path.join(skillDir, "SKILL.md"), contents);
+});
+
+const emptyDraft = () =>
+  buildServerProvider({
+    presentation: { displayName: "Cursor" },
+    enabled: true,
+    checkedAt: "2026-01-01T00:00:00.000Z",
+    models: [],
+    probe: {
+      installed: true,
+      version: null,
+      status: "ready",
+      auth: { status: "unauthenticated" },
+    },
+  });
+
+it.layer(NodeServices.layer)("augmentProviderSnapshotWithAgentSkills", (it) => {
+  it.effect("returns the input draft unchanged when no agent skills are found", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-augment-skills-" });
+      const agentsHome = path.join(tempDir, "agents-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      const draft = emptyDraft();
+      const result = yield* augmentProviderSnapshotWithAgentSkills(draft, workspace, {
+        homeDirectory: agentsHome,
+      });
+
+      // Same reference: the no-op branch must not allocate a new draft, so
+      // downstream change-detection sees no update.
+      assert.strictEqual(result, draft);
+      assert.deepEqual(result.skills, []);
+    }),
+  );
+
+  it.effect("attaches discovered skills with project winning on collision", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-augment-skills-" });
+      const agentsHome = path.join(tempDir, "agents-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(agentsHome, ".agents", "skills"),
+        "shared-skill",
+        ["---", "name: shared-skill", "description: User agents skill.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "shared-skill",
+        ["---", "name: shared-skill", "description: Project agents skill.", "---"].join("\n"),
+      );
+
+      const draft = emptyDraft();
+      const result = yield* augmentProviderSnapshotWithAgentSkills(draft, workspace, {
+        homeDirectory: agentsHome,
+      });
+
+      assert.notStrictEqual(result, draft);
+      assert.equal(result.skills.length, 1);
+      assert.equal(result.skills[0]?.scope, "project");
+      assert.equal(result.skills[0]?.description, "Project agents skill.");
+      assert.equal(
+        result.skills[0]?.path,
+        path.join(workspace, ".agents", "skills", "shared-skill", "SKILL.md"),
+      );
+    }),
+  );
+});

--- a/apps/server/src/provider/augmentProviderSnapshotWithAgentSkills.test.ts
+++ b/apps/server/src/provider/augmentProviderSnapshotWithAgentSkills.test.ts
@@ -43,7 +43,7 @@ it.layer(NodeServices.layer)("augmentProviderSnapshotWithAgentSkills", (it) => {
       const workspace = path.join(tempDir, "workspace");
 
       const draft = emptyDraft();
-      const result = yield* augmentProviderSnapshotWithAgentSkills(draft, workspace, {
+      const result = yield* augmentProviderSnapshotWithAgentSkills(draft, {
         homeDirectory: agentsHome,
       });
 
@@ -54,37 +54,31 @@ it.layer(NodeServices.layer)("augmentProviderSnapshotWithAgentSkills", (it) => {
     }),
   );
 
-  it.effect("attaches discovered skills with project winning on collision", () =>
+  it.effect("attaches discovered user skills to the draft", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-augment-skills-" });
       const agentsHome = path.join(tempDir, "agents-home");
-      const workspace = path.join(tempDir, "workspace");
 
       yield* writeSkill(
         path.join(agentsHome, ".agents", "skills"),
-        "shared-skill",
-        ["---", "name: shared-skill", "description: User agents skill.", "---"].join("\n"),
-      );
-      yield* writeSkill(
-        path.join(workspace, ".agents", "skills"),
-        "shared-skill",
-        ["---", "name: shared-skill", "description: Project agents skill.", "---"].join("\n"),
+        "agent-browser",
+        ["---", "name: agent-browser", "description: Browser automation.", "---"].join("\n"),
       );
 
       const draft = emptyDraft();
-      const result = yield* augmentProviderSnapshotWithAgentSkills(draft, workspace, {
+      const result = yield* augmentProviderSnapshotWithAgentSkills(draft, {
         homeDirectory: agentsHome,
       });
 
       assert.notStrictEqual(result, draft);
       assert.equal(result.skills.length, 1);
-      assert.equal(result.skills[0]?.scope, "project");
-      assert.equal(result.skills[0]?.description, "Project agents skill.");
+      assert.equal(result.skills[0]?.scope, "user");
+      assert.equal(result.skills[0]?.description, "Browser automation.");
       assert.equal(
         result.skills[0]?.path,
-        path.join(workspace, ".agents", "skills", "shared-skill", "SKILL.md"),
+        path.join(agentsHome, ".agents", "skills", "agent-browser", "SKILL.md"),
       );
     }),
   );

--- a/apps/server/src/provider/augmentProviderSnapshotWithAgentSkills.ts
+++ b/apps/server/src/provider/augmentProviderSnapshotWithAgentSkills.ts
@@ -1,15 +1,16 @@
 import type { ServerProviderDraft } from "./providerSnapshot.ts";
-import { discoverAgentSkills } from "./Drivers/AgentSkills.ts";
+import { discoverUserAgentSkills } from "./Drivers/AgentSkills.ts";
 import * as Effect from "effect/Effect";
 
-/** Attach portable `.agents/skills` entries to a provider snapshot draft. */
+/**
+ * Attach user-scoped portable `.agents/skills` entries to a provider snapshot
+ * draft. Project-scoped skills are resolved per active workspace via the
+ * `projects.listAgentSkills` RPC and merged on the client, not baked into this
+ * environment-level snapshot.
+ */
 export const augmentProviderSnapshotWithAgentSkills = Effect.fn(
   "augmentProviderSnapshotWithAgentSkills",
-)(function* (
-  draft: ServerProviderDraft,
-  cwd?: string,
-  options?: { readonly homeDirectory?: string },
-) {
-  const skills = yield* discoverAgentSkills(cwd, options);
+)(function* (draft: ServerProviderDraft, options?: { readonly homeDirectory?: string }) {
+  const skills = yield* discoverUserAgentSkills(options);
   return skills.length === 0 ? draft : { ...draft, skills };
 });

--- a/apps/server/src/provider/augmentProviderSnapshotWithAgentSkills.ts
+++ b/apps/server/src/provider/augmentProviderSnapshotWithAgentSkills.ts
@@ -1,0 +1,15 @@
+import type { ServerProviderDraft } from "./providerSnapshot.ts";
+import { discoverAgentSkills } from "./Drivers/AgentSkills.ts";
+import * as Effect from "effect/Effect";
+
+/** Attach portable `.agents/skills` entries to a provider snapshot draft. */
+export const augmentProviderSnapshotWithAgentSkills = Effect.fn(
+  "augmentProviderSnapshotWithAgentSkills",
+)(function* (
+  draft: ServerProviderDraft,
+  cwd?: string,
+  options?: { readonly homeDirectory?: string },
+) {
+  const skills = yield* discoverAgentSkills(cwd, options);
+  return skills.length === 0 ? draft : { ...draft, skills };
+});

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -128,6 +128,7 @@ import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts
 import * as RepositoryIdentityResolver from "./project/RepositoryIdentityResolver.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import * as WorkspaceEntries from "./workspace/WorkspaceEntries.ts";
+import * as WorkspaceAgentSkills from "./workspace/WorkspaceAgentSkills.ts";
 import * as WorkspaceFileSystem from "./workspace/WorkspaceFileSystem.ts";
 import * as WorkspacePaths from "./workspace/WorkspacePaths.ts";
 import * as GitVcsDriver from "./vcs/GitVcsDriver.ts";
@@ -569,6 +570,7 @@ const buildAppUnderTest = (options?: {
         Layer.provide(WorkspacePaths.layer),
         Layer.provide(workspaceEntriesLayer),
       ),
+      WorkspaceAgentSkills.layer.pipe(Layer.provide(WorkspacePaths.layer)),
       ProjectFaviconResolver.layer.pipe(
         Layer.provide(WorkspacePaths.layer),
         Layer.provide(T3ProjectFileLoader.layer),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -66,6 +66,7 @@ import * as ProjectFaviconResolver from "./project/ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "./project/T3ProjectFileLoader.ts";
 import * as RepositoryIdentityResolver from "./project/RepositoryIdentityResolver.ts";
 import * as WorkspaceEntries from "./workspace/WorkspaceEntries.ts";
+import * as WorkspaceAgentSkills from "./workspace/WorkspaceAgentSkills.ts";
 import * as WorkspaceFileSystem from "./workspace/WorkspaceFileSystem.ts";
 import * as WorkspacePaths from "./workspace/WorkspacePaths.ts";
 import * as GitVcsDriver from "./vcs/GitVcsDriver.ts";
@@ -336,10 +337,15 @@ const WorkspaceFileSystemLayerLive = WorkspaceFileSystem.layer.pipe(
   Layer.provide(WorkspaceEntriesLayerLive),
 );
 
+const WorkspaceAgentSkillsLayerLive = WorkspaceAgentSkills.layer.pipe(
+  Layer.provide(WorkspacePaths.layer),
+);
+
 const WorkspaceLayerLive = Layer.mergeAll(
   WorkspacePaths.layer,
   WorkspaceEntriesLayerLive,
   WorkspaceFileSystemLayerLive,
+  WorkspaceAgentSkillsLayerLive,
 );
 
 const ProjectFaviconResolverLayerLive = ProjectFaviconResolver.layer.pipe(

--- a/apps/server/src/workspace/WorkspaceAgentSkills.test.ts
+++ b/apps/server/src/workspace/WorkspaceAgentSkills.test.ts
@@ -1,0 +1,86 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ProviderDriverKind } from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import * as ServerConfig from "../config.ts";
+import * as WorkspaceAgentSkills from "./WorkspaceAgentSkills.ts";
+import * as WorkspacePaths from "./WorkspacePaths.ts";
+
+const ProjectLayer = WorkspaceAgentSkills.layer.pipe(Layer.provide(WorkspacePaths.layer));
+
+const TestLayer = Layer.empty.pipe(
+  Layer.provideMerge(ProjectLayer),
+  Layer.provideMerge(WorkspacePaths.layer),
+  Layer.provide(
+    ServerConfig.ServerConfig.layerTest(process.cwd(), {
+      prefix: "t3-workspace-agent-skills-test-",
+    }),
+  ),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const CLAUDE = ProviderDriverKind.make("claudeAgent");
+const CURSOR = ProviderDriverKind.make("cursorAgent");
+
+const writeSkill = Effect.fn(function* (
+  skillsDir: string,
+  directoryName: string,
+  description: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillDir = path.join(skillsDir, directoryName);
+  yield* fs.makeDirectory(skillDir, { recursive: true });
+  yield* fs.writeFileString(
+    path.join(skillDir, "SKILL.md"),
+    ["---", `name: ${directoryName}`, `description: ${description}`, "---"].join("\n"),
+  );
+});
+
+it.layer(TestLayer, { excludeTestServices: true })("WorkspaceAgentSkills", (it) => {
+  it.effect("Claude resolves portable + native project skills, native wins on collision", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "t3-was-claude-" });
+
+      yield* writeSkill(path.join(cwd, ".agents", "skills"), "portable", "Portable.");
+      // Same name in both roots: Claude-native (.claude) must win.
+      yield* writeSkill(path.join(cwd, ".agents", "skills"), "deploy", "Portable deploy.");
+      yield* writeSkill(path.join(cwd, ".claude", "skills"), "deploy", "Claude deploy.");
+
+      const { skills } = yield* (function* () {
+        const workspaceAgentSkills = yield* WorkspaceAgentSkills.WorkspaceAgentSkills;
+        return yield* workspaceAgentSkills.list({ cwd, provider: CLAUDE });
+      })();
+      const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+      expect(new Set(byName.keys())).toEqual(new Set(["portable", "deploy"]));
+      expect(byName.get("deploy")?.description).toBe("Claude deploy.");
+      expect(byName.get("deploy")?.scope).toBe("project");
+    }),
+  );
+
+  it.effect("non-Claude providers resolve portable project skills only", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "t3-was-cursor-" });
+
+      yield* writeSkill(path.join(cwd, ".agents", "skills"), "portable", "Portable.");
+      // A Claude-native project skill must not leak to other providers.
+      yield* writeSkill(path.join(cwd, ".claude", "skills"), "claude-only", "Claude only.");
+
+      const { skills } = yield* (function* () {
+        const workspaceAgentSkills = yield* WorkspaceAgentSkills.WorkspaceAgentSkills;
+        return yield* workspaceAgentSkills.list({ cwd, provider: CURSOR });
+      })();
+
+      expect(skills.map((skill) => skill.name)).toEqual(["portable"]);
+    }),
+  );
+});

--- a/apps/server/src/workspace/WorkspaceAgentSkills.ts
+++ b/apps/server/src/workspace/WorkspaceAgentSkills.ts
@@ -1,0 +1,58 @@
+/**
+ * WorkspaceAgentSkills - Effect service for per-project skill discovery.
+ *
+ * Resolves project-scoped skills (`<root>/.agents/skills`, plus Claude's
+ * `<root>/.claude/skills`) for a specific workspace root and provider, so a
+ * project's skills follow the project rather than the server's launch
+ * directory. User-scoped skills still travel on the environment-level provider
+ * snapshot; this service supplies only the project-scoped half.
+ *
+ * @module WorkspaceAgentSkills
+ */
+import type { ProjectListAgentSkillsInput, ProjectListAgentSkillsResult } from "@t3tools/contracts";
+import { ProviderDriverKind } from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import { discoverProjectAgentSkills } from "../provider/Drivers/AgentSkills.ts";
+import { discoverClaudeProjectSkills } from "../provider/Drivers/ClaudeSkills.ts";
+import * as WorkspacePaths from "./WorkspacePaths.ts";
+
+// Claude layers vendor-specific project skills (`<root>/.claude/skills`) on top
+// of the portable `<root>/.agents/skills`; every other driver is portable-only.
+const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
+
+/** Service tag for per-project skill discovery. */
+export class WorkspaceAgentSkills extends Context.Service<
+  WorkspaceAgentSkills,
+  {
+    readonly list: (
+      input: ProjectListAgentSkillsInput,
+    ) => Effect.Effect<
+      ProjectListAgentSkillsResult,
+      WorkspacePaths.WorkspacePathsError,
+      FileSystem.FileSystem | Path.Path
+    >;
+  }
+>()("t3/workspace/WorkspaceAgentSkills") {}
+
+export const make = Effect.gen(function* () {
+  const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
+
+  const list: WorkspaceAgentSkills["Service"]["list"] = Effect.fn("WorkspaceAgentSkills.list")(
+    function* (input) {
+      const root = yield* workspacePaths.normalizeWorkspaceRoot(input.cwd);
+      const skills = yield* input.provider === CLAUDE_DRIVER_KIND
+        ? discoverClaudeProjectSkills(root)
+        : discoverProjectAgentSkills(root);
+      return { skills };
+    },
+  );
+
+  return WorkspaceAgentSkills.of({ list });
+});
+
+export const layer = Layer.effect(WorkspaceAgentSkills, make);

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -40,6 +40,7 @@ import {
   ProjectSearchContentsError,
   ProjectSearchEntriesError,
   ProjectWriteFileError,
+  ProjectListAgentSkillsError,
   RelayClientInstallFailedError,
   type RelayClientInstallProgressEvent,
   type ServerSelfUpdateError,
@@ -90,6 +91,7 @@ import * as PreviewManager from "./preview/Manager.ts";
 import { issueAssetUrl } from "./assets/AssetAccess.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as WorkspaceEntries from "./workspace/WorkspaceEntries.ts";
+import * as WorkspaceAgentSkills from "./workspace/WorkspaceAgentSkills.ts";
 import * as WorkspaceFileSystem from "./workspace/WorkspaceFileSystem.ts";
 import { readWorkflowScript } from "./orchestration/workflowScriptQuery.ts";
 import * as WorkspacePaths from "./workspace/WorkspacePaths.ts";
@@ -376,6 +378,7 @@ const makeWsRpcLayer = (
       const serverSettings = yield* ServerSettings.ServerSettingsService;
       const startup = yield* ServerRuntimeStartup.ServerRuntimeStartup;
       const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+      const workspaceAgentSkills = yield* WorkspaceAgentSkills.WorkspaceAgentSkills;
       const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
       const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
       const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
@@ -1814,6 +1817,21 @@ const makeWsRpcLayer = (
                     cwd: input.cwd,
                     relativePath: input.relativePath,
                     ...projectFileFailureContext(cause),
+                    cause,
+                  }),
+              ),
+            ),
+            { "rpc.aggregate": "workspace" },
+          ),
+        [WS_METHODS.projectsListAgentSkills]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.projectsListAgentSkills,
+            workspaceAgentSkills.list(input).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ProjectListAgentSkillsError({
+                    cwd: input.cwd,
+                    message: `Failed to list project agent skills in '${input.cwd}'.`,
                     cause,
                   }),
               ),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -350,6 +350,19 @@ const IMAGE_ONLY_BOOTSTRAP_PROMPT =
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_PROVIDERS: ServerProvider[] = [];
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
+
+/** Merge user-scoped snapshot skills with project-scoped skills (project wins on name). */
+function mergeProviderSkills(
+  user: ServerProvider["skills"] | undefined,
+  project: ServerProvider["skills"] | undefined,
+): ServerProvider["skills"] {
+  if (!project?.length) return user ?? EMPTY_PROVIDER_SKILLS;
+  if (!user?.length) return project;
+  const byName = new Map<string, ServerProvider["skills"][number]>();
+  for (const skill of user) byName.set(skill.name, skill);
+  for (const skill of project) byName.set(skill.name, skill);
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
 function useDraftHeroLayoutTransition(isDraftHeroState: boolean) {
   const transitionGroupRef = useRef<HTMLDivElement | null>(null);
@@ -2659,6 +2672,19 @@ function ChatViewContent(props: ChatViewProps) {
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
+  const activeProviderDriver = activeProviderStatus?.driver;
+  const projectSkillsQuery = useEnvironmentQuery(
+    activeThreadEnvironmentId && activeWorkspaceRoot && activeProviderDriver
+      ? projectEnvironment.listAgentSkills({
+          environmentId: activeThreadEnvironmentId,
+          input: { cwd: activeWorkspaceRoot, provider: activeProviderDriver },
+        })
+      : null,
+  );
+  const composerSkills = useMemo(
+    () => mergeProviderSkills(activeProviderStatus?.skills, projectSkillsQuery.data?.skills),
+    [activeProviderStatus?.skills, projectSkillsQuery.data?.skills],
+  );
   const activeTerminalLaunchContext =
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.
@@ -6244,7 +6270,7 @@ function ChatViewContent(props: ChatViewProps) {
                 resolvedTheme={resolvedTheme}
                 timestampFormat={timestampFormat}
                 workspaceRoot={activeWorkspaceRoot}
-                skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
+                skills={composerSkills}
                 anchorMessageId={timelineAnchorMessageId}
                 onAnchorReady={onTimelineAnchorReady}
                 contentInsetEndAdjustment={composerOverlayHeight}

--- a/packages/client-runtime/src/state/projectCommands.ts
+++ b/packages/client-runtime/src/state/projectCommands.ts
@@ -72,6 +72,12 @@ export function createProjectEnvironmentAtoms<R, E>(
       staleTimeMs: 30_000,
       idleTtlMs: 5 * 60_000,
     }),
+    listAgentSkills: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:projects:list-agent-skills",
+      tag: WS_METHODS.projectsListAgentSkills,
+      staleTimeMs: 30_000,
+      idleTtlMs: 5 * 60_000,
+    }),
     optimisticFile: (target: OptimisticProjectFileTarget) =>
       optimisticFileFamily(optimisticProjectFileKey(target)),
     create: createEnvironmentCommand(runtime, {

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -5,6 +5,8 @@ import {
   TrimmedNonEmptyString,
   TrimmedString,
 } from "./baseSchemas.ts";
+import { ProviderDriverKind } from "./providerInstance.ts";
+import { ServerProviderSkill } from "./server.ts";
 
 const PROJECT_SEARCH_ENTRIES_MAX_LIMIT = 200;
 const PROJECT_SEARCH_CONTENTS_MAX_LIMIT = 500;
@@ -298,3 +300,23 @@ export class ProjectWriteFileError extends Schema.TaggedErrorClass<ProjectWriteF
     } as any);
   }
 }
+
+export const ProjectListAgentSkillsInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  provider: ProviderDriverKind,
+});
+export type ProjectListAgentSkillsInput = typeof ProjectListAgentSkillsInput.Type;
+
+export const ProjectListAgentSkillsResult = Schema.Struct({
+  skills: Schema.Array(ServerProviderSkill),
+});
+export type ProjectListAgentSkillsResult = typeof ProjectListAgentSkillsResult.Type;
+
+export class ProjectListAgentSkillsError extends Schema.TaggedErrorClass<ProjectListAgentSkillsError>()(
+  "ProjectListAgentSkillsError",
+  {
+    cwd: Schema.optional(TrimmedNonEmptyString),
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -109,6 +109,9 @@ import {
   ProjectSearchEntriesError,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
+  ProjectListAgentSkillsError,
+  ProjectListAgentSkillsInput,
+  ProjectListAgentSkillsResult,
   ProjectWriteFileError,
   ProjectWriteFileInput,
   ProjectWriteFileResult,
@@ -200,6 +203,7 @@ export const WS_METHODS = {
   projectsSearchContents: "projects.searchContents",
   projectsSearchEntries: "projects.searchEntries",
   projectsWriteFile: "projects.writeFile",
+  projectsListAgentSkills: "projects.listAgentSkills",
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
@@ -638,6 +642,12 @@ export const WsProjectsWriteFileRpc = Rpc.make(WS_METHODS.projectsWriteFile, {
   error: Schema.Union([ProjectWriteFileError, EnvironmentAuthorizationError]),
 });
 
+export const WsProjectsListAgentSkillsRpc = Rpc.make(WS_METHODS.projectsListAgentSkills, {
+  payload: ProjectListAgentSkillsInput,
+  success: ProjectListAgentSkillsResult,
+  error: Schema.Union([ProjectListAgentSkillsError, EnvironmentAuthorizationError]),
+});
+
 export const WsShellOpenInEditorRpc = Rpc.make(WS_METHODS.shellOpenInEditor, {
   payload: LaunchEditorInput,
   error: Schema.Union([ExternalLauncherError, EnvironmentAuthorizationError]),
@@ -1018,6 +1028,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsProjectsSearchContentsRpc,
   WsProjectsSearchEntriesRpc,
   WsProjectsWriteFileRpc,
+  WsProjectsListAgentSkillsRpc,
   WsShellOpenInEditorRpc,
   WsFilesystemBrowseRpc,
   WsAssetsCreateUrlRpc,


### PR DESCRIPTION
## Problem

Providers without a native skill inventory (Cursor, Grok, OpenCode) never surfaced cross-agent portable skills in the `$` picker. A skill placed under `~/.agents/skills` or `<cwd>/.agents/skills` — the portable, cross-agent convention — was invisible to them, even though Claude and Codex already expose skills.

## Fix

- Extract the filesystem scanner (YAML frontmatter parse + best-effort root scan) out of `ClaudeSkills.ts` into a shared `scanFilesystemSkillRoots` / `discoverAgentSkills` module.
- Claude reuses the shared scanner and layers its vendor roots on top.
- Cursor / Grok / OpenCode augment their snapshot draft via a new `augmentProviderSnapshotWithAgentSkills` helper that calls `discoverAgentSkills`.
- Codex is intentionally **not** augmented — it reports skills natively via its app-server.

### Resolution rule

Most-specific-wins, extended to two axes:
- **Scope:** project beats user (unchanged).
- **Within a scope:** for the Claude provider, the Claude-native `.claude/skills` root beats a portable `.agents/skills` root of the same name — so a Claude-specific skill keeps running even when a portable namesake exists. (Portable-first would silently hide existing `.claude` skills the moment a same-named portable one appears.)

### Tests

- New `AgentSkills.test.ts` and `augmentProviderSnapshotWithAgentSkills.test.ts` cover the shared scanner and the augment seam (both branches: no-op passthrough returns the same draft reference; populated roots attach skills with project winning on collision).
- `ClaudeSkills.test.ts` gains a characterization test pinning the within-scope `.claude`-over-`.agents` precedence.
- Existing Claude collision tests still pass. 14/14 green; `vp run --filter t3 typecheck` clean for the touched files.

Generated with Claude Code (anthropic) inside the T3 Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces filesystem scanning and a new workspace RPC on the skill picker path; behavior is read-only with orchestration read auth and broad test coverage, but collision/precedence rules affect which skill paths users see.
> 
> **Overview**
> Adds **portable cross-agent skill discovery** (`~/.agents/skills` and `<workspace>/.agents/skills`) so Cursor, Grok, and OpenCode show skills in the `$` picker, and Claude can merge portable roots with its native `.claude/skills` layout.
> 
> **Server:** New shared `AgentSkills` scanner (YAML frontmatter on `SKILL.md`, best-effort skips). Claude’s discovery is refactored onto it with explicit precedence—**project over user**, and **`.claude/skills` over `.agents/skills` within the same scope**. User-scoped portable skills attach to provider snapshots via `augmentProviderSnapshotWithAgentSkills` on Cursor/Grok/OpenCode status checks (Codex unchanged). **Project-scoped** skills move to a new `projects.listAgentSkills` RPC backed by `WorkspaceAgentSkills` (Claude uses `discoverClaudeProjectSkills`; others use portable project roots only). Claude’s environment snapshot no longer passes workspace `cwd` into full skill discovery.
> 
> **Client:** `ChatView` fetches project skills for the active workspace/provider and **merges** them with snapshot user skills (project wins on name collision) for the composer skill list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee651d8054b11d141011febb08cec18bdb28e0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface portable `.agents/skills` across provider snapshots via a new `projects.listAgentSkills` RPC
> - Adds a `projects.listAgentSkills` WebSocket RPC that returns project-scoped agent skills for a given workspace and provider, merging portable `.agents/skills` with vendor-native skills (e.g. `.claude/skills`) where provider-native entries win on name collisions.
> - Introduces `WorkspaceAgentSkills` service that dispatches to `discoverClaudeProjectSkills` for Claude or `discoverProjectAgentSkills` for other providers.
> - Adds `augmentProviderSnapshotWithAgentSkills` to inject user-scoped portable skills into non-Claude provider snapshots (Cursor, Grok, OpenCode).
> - Updates `ChatViewContent` to query project skills and merge them with user-scoped snapshot skills via `mergeProviderSkills`, with project-scoped entries taking precedence.
> - `discoverClaudeSkills` for the Claude provider status snapshot is now limited to user scope only; project-scoped Claude skills are no longer included there.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eee651d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->