### PR TITLE
fix(grok): expose advertised reasoning levels

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -39,6 +39,8 @@ const failPrompt = process.env.T3_ACP_FAIL_PROMPT === "1";
 const failSetConfigOption = process.env.T3_ACP_FAIL_SET_CONFIG_OPTION === "1";
 const exitOnSetConfigOption = process.env.T3_ACP_EXIT_ON_SET_CONFIG_OPTION === "1";
 const promptResponseText = process.env.T3_ACP_PROMPT_RESPONSE_TEXT;
+const initialGrokReasoningEffort =
+  process.env.T3_ACP_INITIAL_GROK_REASONING_EFFORT?.trim() || undefined;
 const promptDelayMs = Number(process.env.T3_ACP_PROMPT_DELAY_MS ?? "0");
 const permissionOptionIds = {
   allowOnce: process.env.T3_ACP_ALLOW_ONCE_OPTION_ID ?? "allow-once",
@@ -279,7 +281,13 @@ function modeState(): AcpSchema.SessionModeState {
 }
 
 const grokAcpModels: ReadonlyArray<AcpSchema.ModelInfo> = [
-  { modelId: "grok-build", name: "Grok Build" },
+  {
+    modelId: "grok-build",
+    name: "Grok Build",
+    ...(initialGrokReasoningEffort
+      ? { _meta: { reasoningEffort: initialGrokReasoningEffort } }
+      : {}),
+  },
   { modelId: "grok-mock-alt", name: "Grok Mock Alt" },
 ];
 

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -188,6 +188,55 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("does not carry reasoning effort across a start-session model switch", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-start-model-effort-reset");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-start-model-effort-reset-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+          T3_ACP_INITIAL_GROK_REASONING_EFFORT: "high",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-mock-alt",
+        },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "select the new model effort",
+        attachments: [],
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-mock-alt",
+          options: [{ id: "reasoningEffort", value: "high" }],
+        },
+      });
+
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      const setModelRequests = requests.filter((entry) => entry.method === "session/set_model");
+      assert.lengthOf(setModelRequests, 2);
+      const [startSelection, turnSelection] = setModelRequests;
+      assert.nestedPropertyVal(startSelection, "params.modelId", "grok-mock-alt");
+      assert.notNestedProperty(startSelection, "params._meta.reasoningEffort");
+      assert.nestedPropertyVal(turnSelection, "params.modelId", "grok-mock-alt");
+      assert.nestedPropertyVal(turnSelection, "params._meta.reasoningEffort", "high");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("closes the ACP child process when a session stops", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-stop-session-close");

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -273,7 +273,13 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("restores ready without completing an unstarted turn when preparation fails", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-preparation-failure-while-connecting");
-      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-preparation-failure-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLogPath }),
+      );
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
@@ -295,6 +301,11 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         adapter.sendTurn({
           threadId,
           input: "prepare invalid attachment",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("grok"),
+            model: "grok-build",
+            options: [{ id: "reasoningEffort", value: "high" }],
+          },
           attachments: [
             {
               type: "image",
@@ -321,6 +332,8 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       assert.isUndefined(turnCompletedEvent);
       assert.equal(readySession?.status, "ready");
       assert.isUndefined(readySession?.activeTurnId);
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      assert.isFalse(requests.some((entry) => entry.method === "session/set_model"));
 
       yield* Fiber.interrupt(runtimeEventsFiber);
       yield* adapter.stopSession(threadId);
@@ -1018,8 +1031,13 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("rejects sendTurn with empty input and no attachments", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-empty-turn");
-
-      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-empty-turn-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLogPath }),
+      );
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       yield* adapter.startSession({
@@ -1035,10 +1053,17 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
           threadId,
           input: "   ",
           attachments: [],
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("grok"),
+            model: "grok-build",
+            options: [{ id: "reasoningEffort", value: "high" }],
+          },
         }),
       );
 
       assert.equal(error._tag, "ProviderAdapterValidationError");
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      assert.isFalse(requests.some((entry) => entry.method === "session/set_model"));
 
       yield* adapter.stopSession(threadId);
     }),

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -237,6 +237,60 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("clears and reapplies reasoning effort on the same model", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-same-model-effort-clear");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-same-model-effort-clear-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLogPath }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const selection = (effort?: string) => ({
+        instanceId: ProviderInstanceId.make("grok"),
+        model: "grok-build",
+        ...(effort ? { options: [{ id: "reasoningEffort", value: effort }] } : {}),
+      });
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: selection(),
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "use high effort",
+        attachments: [],
+        modelSelection: selection("high"),
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "use the model default",
+        attachments: [],
+        modelSelection: selection(),
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "use high effort again",
+        attachments: [],
+        modelSelection: selection("high"),
+      });
+
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      const setModelRequests = requests.filter((entry) => entry.method === "session/set_model");
+      assert.lengthOf(setModelRequests, 3);
+      assert.nestedPropertyVal(setModelRequests[0], "params._meta.reasoningEffort", "high");
+      assert.notNestedProperty(setModelRequests[1], "params._meta");
+      assert.nestedPropertyVal(setModelRequests[2], "params._meta.reasoningEffort", "high");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("closes the ACP child process when a session stops", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-stop-session-close");

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -12,6 +12,7 @@ import {
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -56,6 +57,7 @@ import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
 import {
   applyGrokAcpModelSelection,
   currentGrokModelIdFromSessionSetup,
+  currentGrokReasoningEffortFromSessionSetup,
   makeGrokAcpRuntime,
   resolveGrokAcpBaseModelId,
 } from "../acp/GrokAcpSupport.ts";
@@ -117,6 +119,7 @@ interface GrokSessionContext {
    * continues it, and only the last remaining prompt settles the turn. */
   promptsInFlight: number;
   currentModelId: string | undefined;
+  currentReasoningEffort: string | undefined;
   stopped: boolean;
 }
 
@@ -738,10 +741,22 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           const requestedStartModelId = grokModelSelection?.model
             ? resolveGrokAcpBaseModelId(grokModelSelection.model)
             : undefined;
+          const currentStartModelId = currentGrokModelIdFromSessionSetup(
+            started.sessionSetupResult,
+          );
+          const currentStartReasoningEffort = currentGrokReasoningEffortFromSessionSetup(
+            started.sessionSetupResult,
+          );
+          const requestedStartReasoningEffort = getModelSelectionStringOptionValue(
+            grokModelSelection,
+            "reasoningEffort",
+          );
           const boundModelId = yield* applyGrokAcpModelSelection({
             runtime: acp,
-            currentModelId: currentGrokModelIdFromSessionSetup(started.sessionSetupResult),
+            currentModelId: currentStartModelId,
+            currentReasoningEffort: currentStartReasoningEffort,
             requestedModelId: requestedStartModelId,
+            requestedReasoningEffort: requestedStartReasoningEffort,
             mapError: (cause) =>
               mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
           });
@@ -778,6 +793,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             interruptedTurnIds: new Set(),
             promptsInFlight: 0,
             currentModelId: boundModelId,
+            currentReasoningEffort: requestedStartReasoningEffort ?? currentStartReasoningEffort,
             stopped: false,
           };
 
@@ -942,10 +958,18 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               const requestedTurnModelId = turnModelSelection?.model
                 ? resolveGrokAcpBaseModelId(turnModelSelection.model)
                 : undefined;
+              const requestedTurnReasoningEffort = getModelSelectionStringOptionValue(
+                turnModelSelection,
+                "reasoningEffort",
+              );
+              const modelChanged =
+                requestedTurnModelId !== undefined && requestedTurnModelId !== ctx.currentModelId;
               const currentModelId = yield* applyGrokAcpModelSelection({
                 runtime: ctx.acp,
                 currentModelId: ctx.currentModelId,
+                currentReasoningEffort: ctx.currentReasoningEffort,
                 requestedModelId: requestedTurnModelId,
+                requestedReasoningEffort: requestedTurnReasoningEffort,
                 mapError: (cause) =>
                   mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
               });
@@ -998,6 +1022,11 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               }
 
               ctx.currentModelId = currentModelId;
+              if (requestedTurnReasoningEffort !== undefined) {
+                ctx.currentReasoningEffort = requestedTurnReasoningEffort;
+              } else if (modelChanged) {
+                ctx.currentReasoningEffort = undefined;
+              }
               const displayModel = currentModelId
                 ? resolveGrokAcpBaseModelId(currentModelId)
                 : undefined;

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -751,6 +751,8 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             grokModelSelection,
             "reasoningEffort",
           );
+          const startModelChanged =
+            requestedStartModelId !== undefined && requestedStartModelId !== currentStartModelId;
           const boundModelId = yield* applyGrokAcpModelSelection({
             runtime: acp,
             currentModelId: currentStartModelId,
@@ -793,7 +795,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             interruptedTurnIds: new Set(),
             promptsInFlight: 0,
             currentModelId: boundModelId,
-            currentReasoningEffort: requestedStartReasoningEffort ?? currentStartReasoningEffort,
+            currentReasoningEffort:
+              requestedStartReasoningEffort ??
+              (startModelChanged ? undefined : currentStartReasoningEffort),
             stopped: false,
           };
 

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -964,15 +964,6 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               );
               const modelChanged =
                 requestedTurnModelId !== undefined && requestedTurnModelId !== ctx.currentModelId;
-              const currentModelId = yield* applyGrokAcpModelSelection({
-                runtime: ctx.acp,
-                currentModelId: ctx.currentModelId,
-                currentReasoningEffort: ctx.currentReasoningEffort,
-                requestedModelId: requestedTurnModelId,
-                requestedReasoningEffort: requestedTurnReasoningEffort,
-                mapError: (cause) =>
-                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
-              });
 
               const text = input.input?.trim();
               const imagePromptParts = yield* Effect.forEach(
@@ -1021,6 +1012,15 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 });
               }
 
+              const currentModelId = yield* applyGrokAcpModelSelection({
+                runtime: ctx.acp,
+                currentModelId: ctx.currentModelId,
+                currentReasoningEffort: ctx.currentReasoningEffort,
+                requestedModelId: requestedTurnModelId,
+                requestedReasoningEffort: requestedTurnReasoningEffort,
+                mapError: (cause) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+              });
               ctx.currentModelId = currentModelId;
               if (requestedTurnReasoningEffort !== undefined) {
                 ctx.currentReasoningEffort = requestedTurnReasoningEffort;

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -59,6 +59,7 @@ import {
   currentGrokModelIdFromSessionSetup,
   currentGrokReasoningEffortFromSessionSetup,
   makeGrokAcpRuntime,
+  normalizeGrokReasoningEffort,
   resolveGrokAcpBaseModelId,
 } from "../acp/GrokAcpSupport.ts";
 import {
@@ -751,8 +752,6 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             grokModelSelection,
             "reasoningEffort",
           );
-          const startModelChanged =
-            requestedStartModelId !== undefined && requestedStartModelId !== currentStartModelId;
           const boundModelId = yield* applyGrokAcpModelSelection({
             runtime: acp,
             currentModelId: currentStartModelId,
@@ -796,8 +795,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             promptsInFlight: 0,
             currentModelId: boundModelId,
             currentReasoningEffort:
-              requestedStartReasoningEffort ??
-              (startModelChanged ? undefined : currentStartReasoningEffort),
+              requestedStartModelId !== undefined
+                ? normalizeGrokReasoningEffort(requestedStartReasoningEffort)
+                : currentStartReasoningEffort,
             stopped: false,
           };
 
@@ -966,9 +966,6 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 turnModelSelection,
                 "reasoningEffort",
               );
-              const modelChanged =
-                requestedTurnModelId !== undefined && requestedTurnModelId !== ctx.currentModelId;
-
               const text = input.input?.trim();
               const imagePromptParts = yield* Effect.forEach(
                 input.attachments ?? [],
@@ -1026,10 +1023,10 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
               });
               ctx.currentModelId = currentModelId;
-              if (requestedTurnReasoningEffort !== undefined) {
-                ctx.currentReasoningEffort = requestedTurnReasoningEffort;
-              } else if (modelChanged) {
-                ctx.currentReasoningEffort = undefined;
+              if (requestedTurnModelId !== undefined) {
+                ctx.currentReasoningEffort = normalizeGrokReasoningEffort(
+                  requestedTurnReasoningEffort,
+                );
               }
               const displayModel = currentModelId
                 ? resolveGrokAcpBaseModelId(currentModelId)

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -47,7 +47,7 @@ describe("buildGrokModelCapabilities", () => {
     ]);
   });
 
-  it("does not append an Effort suffix when ACP omits option labels", () => {
+  it("uses raw ACP values when option labels are omitted", () => {
     const capabilities = buildGrokModelCapabilities({
       modelId: "grok-4.6",
       name: "Grok 4.6",
@@ -65,11 +65,21 @@ describe("buildGrokModelCapabilities", () => {
         type: "select",
         currentValue: "xhigh",
         options: [
-          { id: "xhigh", label: "Extra High", isDefault: true },
-          { id: "medium", label: "Medium" },
+          { id: "xhigh", label: "xhigh", isDefault: true },
+          { id: "medium", label: "medium" },
         ],
       },
     ]);
+  });
+
+  it("does not synthesize a reasoning menu when ACP omits it", () => {
+    expect(
+      buildGrokModelCapabilities({
+        modelId: "grok-4.6",
+        name: "Grok 4.6",
+        _meta: { supportsReasoningEffort: true, reasoningEffort: "xhigh" },
+      }).optionDescriptors,
+    ).toEqual([]);
   });
 
   it("keeps non-reasoning Grok models free of reasoning controls", () => {

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -6,9 +6,53 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { GrokSettings } from "@t3tools/contracts";
 
-import { buildInitialGrokProviderSnapshot, checkGrokProviderStatus } from "./GrokProvider.ts";
+import {
+  buildGrokModelCapabilities,
+  buildInitialGrokProviderSnapshot,
+  checkGrokProviderStatus,
+} from "./GrokProvider.ts";
 
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
+
+describe("buildGrokModelCapabilities", () => {
+  it("maps model-specific ACP reasoning metadata and its active default", () => {
+    const capabilities = buildGrokModelCapabilities({
+      modelId: "grok-4.6",
+      name: "Grok 4.6",
+      _meta: {
+        supportsReasoningEffort: true,
+        reasoningEffort: "xhigh",
+        reasoningEfforts: [
+          { value: "xhigh", label: "Extra High Effort", default: true },
+          { value: "high", label: "High Effort", default: true },
+          { value: "medium", label: "Medium Effort" },
+          { value: "low", label: "Low Effort" },
+        ],
+      },
+    });
+
+    expect(capabilities.optionDescriptors).toEqual([
+      {
+        id: "reasoningEffort",
+        label: "Reasoning",
+        type: "select",
+        currentValue: "xhigh",
+        options: [
+          { id: "xhigh", label: "Extra High Effort", isDefault: true },
+          { id: "high", label: "High Effort" },
+          { id: "medium", label: "Medium Effort" },
+          { id: "low", label: "Low Effort" },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps non-reasoning Grok models free of reasoning controls", () => {
+    expect(
+      buildGrokModelCapabilities({ modelId: "grok-build", name: "Grok Build" }).optionDescriptors,
+    ).toEqual([]);
+  });
+});
 
 describe("buildInitialGrokProviderSnapshot", () => {
   it.effect("returns a disabled snapshot when settings.enabled is false", () =>

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -65,11 +65,105 @@ describe("buildGrokModelCapabilities", () => {
         type: "select",
         currentValue: "xhigh",
         options: [
-          { id: "xhigh", label: "xhigh", isDefault: true },
+          { id: "xhigh", label: "xhigh" },
           { id: "medium", label: "medium" },
         ],
       },
     ]);
+  });
+
+  it("keeps ACP current effort separate from its collapsed advertised default", () => {
+    const capabilities = buildGrokModelCapabilities({
+      modelId: "grok-4.6",
+      name: "Grok 4.6",
+      _meta: {
+        supportsReasoningEffort: true,
+        reasoningEffort: "medium",
+        reasoningEfforts: [
+          { value: "xhigh", label: "Extra High Effort", default: true },
+          { value: "high", label: "High Effort", default: true },
+          { value: "medium", label: "Medium Effort" },
+        ],
+      },
+    });
+
+    expect(capabilities.optionDescriptors).toEqual([
+      {
+        id: "reasoningEffort",
+        label: "Reasoning",
+        type: "select",
+        currentValue: "medium",
+        options: [
+          { id: "xhigh", label: "Extra High Effort", isDefault: true },
+          { id: "high", label: "High Effort" },
+          { id: "medium", label: "Medium Effort" },
+        ],
+      },
+    ]);
+  });
+
+  it("preserves ACP descriptions and falls back from invalid values to valid ids", () => {
+    const capabilities = buildGrokModelCapabilities({
+      modelId: "grok-4.6",
+      name: "Grok 4.6",
+      _meta: {
+        supportsReasoningEffort: true,
+        reasoningEffort: "high",
+        reasoningEfforts: [
+          {
+            id: "high",
+            value: "not a token",
+            label: "High Effort",
+            description: "Higher implementation quality",
+            default: true,
+          },
+          { id: "bad id", value: "also invalid", label: "Invalid" },
+        ],
+      },
+    });
+
+    expect(capabilities.optionDescriptors).toEqual([
+      {
+        id: "reasoningEffort",
+        label: "Reasoning",
+        type: "select",
+        currentValue: "high",
+        options: [
+          {
+            id: "high",
+            label: "High Effort",
+            description: "Higher implementation quality",
+            isDefault: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("accepts an advertised ACP menu when the support flag is omitted", () => {
+    const capabilities = buildGrokModelCapabilities({
+      modelId: "grok-4.6",
+      name: "Grok 4.6",
+      _meta: {
+        reasoningEffort: "high",
+        reasoningEfforts: [{ value: "high", label: "High Effort", default: true }],
+      },
+    });
+
+    expect(capabilities.optionDescriptors).toHaveLength(1);
+  });
+
+  it("honors an explicit ACP opt-out even when a menu is present", () => {
+    const capabilities = buildGrokModelCapabilities({
+      modelId: "grok-4.6",
+      name: "Grok 4.6",
+      _meta: {
+        supportsReasoningEffort: false,
+        reasoningEfforts: [{ value: "high", label: "High Effort", default: true }],
+      },
+    });
+
+    expect(capabilities.optionDescriptors).toEqual([]);
   });
 
   it("does not synthesize a reasoning menu when ACP omits it", () => {

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -15,7 +15,7 @@ import {
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 
 describe("buildGrokModelCapabilities", () => {
-  it("maps model-specific ACP reasoning metadata and its active default", () => {
+  it("preserves ACP-provided reasoning labels and the active default", () => {
     const capabilities = buildGrokModelCapabilities({
       modelId: "grok-4.6",
       name: "Grok 4.6",
@@ -42,6 +42,31 @@ describe("buildGrokModelCapabilities", () => {
           { id: "high", label: "High Effort" },
           { id: "medium", label: "Medium Effort" },
           { id: "low", label: "Low Effort" },
+        ],
+      },
+    ]);
+  });
+
+  it("does not append an Effort suffix when ACP omits option labels", () => {
+    const capabilities = buildGrokModelCapabilities({
+      modelId: "grok-4.6",
+      name: "Grok 4.6",
+      _meta: {
+        supportsReasoningEffort: true,
+        reasoningEffort: "xhigh",
+        reasoningEfforts: [{ value: "xhigh" }, { value: "medium" }],
+      },
+    });
+
+    expect(capabilities.optionDescriptors).toEqual([
+      {
+        id: "reasoningEffort",
+        label: "Reasoning",
+        type: "select",
+        currentValue: "xhigh",
+        options: [
+          { id: "xhigh", label: "Extra High", isDefault: true },
+          { id: "medium", label: "Medium" },
         ],
       },
     ]);

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -18,6 +18,7 @@ import { createModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
 import {
+  buildSelectOptionDescriptor,
   buildServerProvider,
   isCommandMissingCause,
   parseGenericCliVersion,
@@ -40,6 +41,15 @@ const GROK_PRESENTATION = {
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
+const LEGACY_GROK_REASONING_EFFORTS = ["xhigh", "high", "medium", "low"] as const;
+const GROK_REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
+  none: "None",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+};
 
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
@@ -99,6 +109,72 @@ function grokModelsFromSettings(
   return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
 }
 
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim() || undefined : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function grokReasoningEffortLabel(value: string): string {
+  return GROK_REASONING_EFFORT_LABELS[value] ?? value;
+}
+
+function grokReasoningOptionsFromModel(
+  model: EffectAcpSchema.ModelInfo,
+): ReadonlyArray<{ value: string; label: string; isDefault?: boolean }> {
+  const meta = model._meta;
+  if (!meta || meta.supportsReasoningEffort !== true) {
+    return [];
+  }
+
+  const defaultEffort = nonEmptyString(meta.reasoningEffort);
+  const advertisedOptions = Array.isArray(meta.reasoningEfforts)
+    ? meta.reasoningEfforts
+    : LEGACY_GROK_REASONING_EFFORTS;
+  const seen = new Set<string>();
+  const options: Array<{ value: string; label: string; advertisedDefault: boolean }> = [];
+
+  for (const entry of advertisedOptions) {
+    const value = nonEmptyString(isRecord(entry) ? (entry.value ?? entry.id) : entry);
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    options.push({
+      value,
+      label:
+        nonEmptyString(isRecord(entry) ? entry.label : undefined) ??
+        grokReasoningEffortLabel(value),
+      advertisedDefault: isRecord(entry) && entry.default === true,
+    });
+  }
+
+  const selectedDefault =
+    (defaultEffort && options.some((option) => option.value === defaultEffort)
+      ? defaultEffort
+      : undefined) ?? options.find((option) => option.advertisedDefault)?.value;
+  return options.map(({ value, label }) =>
+    value === selectedDefault ? { value, label, isDefault: true } : { value, label },
+  );
+}
+
+export function buildGrokModelCapabilities(model: EffectAcpSchema.ModelInfo): ModelCapabilities {
+  const reasoningOptions = grokReasoningOptionsFromModel(model);
+  return reasoningOptions.length > 0
+    ? createModelCapabilities({
+        optionDescriptors: [
+          buildSelectOptionDescriptor({
+            id: "reasoningEffort",
+            label: "Reasoning",
+            options: reasoningOptions,
+          }),
+        ],
+      })
+    : EMPTY_CAPABILITIES;
+}
+
 function buildGrokDiscoveredModelsFromSessionModelState(
   modelState: EffectAcpSchema.SessionModelState | null | undefined,
 ): ReadonlyArray<ServerProviderModel> {
@@ -117,7 +193,7 @@ function buildGrokDiscoveredModelsFromSessionModelState(
         slug,
         name: model.name.trim() || slug,
         isCustom: false,
-        capabilities: EMPTY_CAPABILITIES,
+        capabilities: buildGrokModelCapabilities(model),
       };
     })
     .filter((model): model is ServerProviderModel => model !== undefined);

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -41,15 +41,6 @@ const GROK_PRESENTATION = {
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
-const LEGACY_GROK_REASONING_EFFORTS = ["xhigh", "high", "medium", "low"] as const;
-const FALLBACK_GROK_REASONING_LABELS: Readonly<Record<string, string>> = {
-  none: "None",
-  minimal: "Minimal",
-  low: "Low",
-  medium: "Medium",
-  high: "High",
-  xhigh: "Extra High",
-};
 
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
@@ -117,10 +108,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function fallbackGrokReasoningLabel(value: string): string {
-  return FALLBACK_GROK_REASONING_LABELS[value] ?? value;
-}
-
 function grokReasoningOptionsFromModel(
   model: EffectAcpSchema.ModelInfo,
 ): ReadonlyArray<{ value: string; label: string; isDefault?: boolean }> {
@@ -130,9 +117,7 @@ function grokReasoningOptionsFromModel(
   }
 
   const defaultEffort = nonEmptyString(meta.reasoningEffort);
-  const advertisedOptions = Array.isArray(meta.reasoningEfforts)
-    ? meta.reasoningEfforts
-    : LEGACY_GROK_REASONING_EFFORTS;
+  const advertisedOptions = Array.isArray(meta.reasoningEfforts) ? meta.reasoningEfforts : [];
   const seen = new Set<string>();
   const options: Array<{ value: string; label: string; advertisedDefault: boolean }> = [];
 
@@ -144,9 +129,7 @@ function grokReasoningOptionsFromModel(
     seen.add(value);
     options.push({
       value,
-      label:
-        nonEmptyString(isRecord(entry) ? entry.label : undefined) ??
-        fallbackGrokReasoningLabel(value),
+      label: nonEmptyString(isRecord(entry) ? entry.label : undefined) ?? value,
       advertisedDefault: isRecord(entry) && entry.default === true,
     });
   }

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -18,7 +18,6 @@ import { createModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
 import {
-  buildSelectOptionDescriptor,
   buildServerProvider,
   isCommandMissingCause,
   parseGenericCliVersion,
@@ -30,7 +29,11 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
-import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
+import {
+  isValidGrokReasoningEffortToken,
+  makeGrokAcpRuntime,
+  resolveGrokAcpBaseModelId,
+} from "../acp/GrokAcpSupport.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -108,51 +111,91 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function grokReasoningOptionsFromModel(
-  model: EffectAcpSchema.ModelInfo,
-): ReadonlyArray<{ value: string; label: string; isDefault?: boolean }> {
+function grokReasoningOptionsFromModel(model: EffectAcpSchema.ModelInfo): {
+  readonly options: ReadonlyArray<{
+    value: string;
+    label: string;
+    description?: string;
+    isDefault?: boolean;
+  }>;
+  readonly currentValue: string | undefined;
+} {
   const meta = model._meta;
-  if (!meta || meta.supportsReasoningEffort !== true) {
-    return [];
+  if (!meta || meta.supportsReasoningEffort === false) {
+    return { options: [], currentValue: undefined };
   }
 
-  const defaultEffort = nonEmptyString(meta.reasoningEffort);
+  const currentEffort = nonEmptyString(meta.reasoningEffort);
   const advertisedOptions = Array.isArray(meta.reasoningEfforts) ? meta.reasoningEfforts : [];
   const seen = new Set<string>();
-  const options: Array<{ value: string; label: string; advertisedDefault: boolean }> = [];
+  const options: Array<{
+    value: string;
+    label: string;
+    description?: string;
+    advertisedDefault: boolean;
+  }> = [];
 
   for (const entry of advertisedOptions) {
-    const value = nonEmptyString(isRecord(entry) ? (entry.value ?? entry.id) : entry);
-    if (!value || seen.has(value)) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const rawValue = nonEmptyString(entry.value);
+    const rawId = nonEmptyString(entry.id);
+    const value =
+      rawValue && isValidGrokReasoningEffortToken(rawValue)
+        ? rawValue
+        : rawId && isValidGrokReasoningEffortToken(rawId)
+          ? rawId
+          : undefined;
+    if (value === undefined || seen.has(value)) {
       continue;
     }
     seen.add(value);
+    const description = nonEmptyString(entry.description);
     options.push({
       value,
-      label: nonEmptyString(isRecord(entry) ? entry.label : undefined) ?? value,
-      advertisedDefault: isRecord(entry) && entry.default === true,
+      label: nonEmptyString(entry.label) ?? value,
+      ...(description ? { description } : {}),
+      advertisedDefault: entry.default === true || entry.isDefault === true,
     });
   }
 
+  const currentValue =
+    currentEffort && options.some((option) => option.value === currentEffort)
+      ? currentEffort
+      : undefined;
+  const advertisedDefaults = options.filter((option) => option.advertisedDefault);
   const selectedDefault =
-    (defaultEffort && options.some((option) => option.value === defaultEffort)
-      ? defaultEffort
-      : undefined) ?? options.find((option) => option.advertisedDefault)?.value;
-  return options.map(({ value, label }) =>
-    value === selectedDefault ? { value, label, isDefault: true } : { value, label },
-  );
+    advertisedDefaults.find((option) => option.value === currentValue)?.value ??
+    advertisedDefaults[0]?.value;
+  return {
+    options: options.map(({ value, label, description }) => ({
+      value,
+      label,
+      ...(description ? { description } : {}),
+      ...(value === selectedDefault ? { isDefault: true } : {}),
+    })),
+    currentValue: currentValue ?? selectedDefault,
+  };
 }
 
 export function buildGrokModelCapabilities(model: EffectAcpSchema.ModelInfo): ModelCapabilities {
-  const reasoningOptions = grokReasoningOptionsFromModel(model);
-  return reasoningOptions.length > 0
+  const reasoning = grokReasoningOptionsFromModel(model);
+  return reasoning.options.length > 0
     ? createModelCapabilities({
         optionDescriptors: [
-          buildSelectOptionDescriptor({
+          {
             id: "reasoningEffort",
             label: "Reasoning",
-            options: reasoningOptions,
-          }),
+            type: "select",
+            options: reasoning.options.map((option) => ({
+              id: option.value,
+              label: option.label,
+              ...(option.description ? { description: option.description } : {}),
+              ...(option.isDefault ? { isDefault: true } : {}),
+            })),
+            ...(reasoning.currentValue ? { currentValue: reasoning.currentValue } : {}),
+          },
         ],
       })
     : EMPTY_CAPABILITIES;

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -42,7 +42,7 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
 const LEGACY_GROK_REASONING_EFFORTS = ["xhigh", "high", "medium", "low"] as const;
-const GROK_REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
+const FALLBACK_GROK_REASONING_LABELS: Readonly<Record<string, string>> = {
   none: "None",
   minimal: "Minimal",
   low: "Low",
@@ -117,8 +117,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function grokReasoningEffortLabel(value: string): string {
-  return GROK_REASONING_EFFORT_LABELS[value] ?? value;
+function fallbackGrokReasoningLabel(value: string): string {
+  return FALLBACK_GROK_REASONING_LABELS[value] ?? value;
 }
 
 function grokReasoningOptionsFromModel(
@@ -146,7 +146,7 @@ function grokReasoningOptionsFromModel(
       value,
       label:
         nonEmptyString(isRecord(entry) ? entry.label : undefined) ??
-        grokReasoningEffortLabel(value),
+        fallbackGrokReasoningLabel(value),
       advertisedDefault: isRecord(entry) && entry.default === true,
     });
   }

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -226,6 +226,7 @@ export class AcpSessionRuntime extends Context.Service<
      */
     readonly setSessionModel: (
       modelId: string,
+      meta?: EffectAcpSchema.SetSessionModelRequest["_meta"],
     ) => Effect.Effect<EffectAcpSchema.SetSessionModelResponse, EffectAcpErrors.AcpError>;
     /**
      * Sends a generic ACP extension request and records it through the request logger.
@@ -789,12 +790,13 @@ export const make = (
           Effect.flatMap((started) => setConfigOption(started.modelConfigId ?? "model", model)),
           Effect.asVoid,
         ),
-      setSessionModel: (modelId) =>
+      setSessionModel: (modelId, meta) =>
         getStartedState.pipe(
           Effect.flatMap((started) => {
             const requestPayload = {
               sessionId: started.sessionId,
               modelId,
+              ...(meta !== undefined ? { _meta: meta } : {}),
             } satisfies EffectAcpSchema.SetSessionModelRequest;
             return runLoggedRequest(
               "session/set_model",

--- a/apps/server/src/provider/acp/GrokAcpCliProbe.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpCliProbe.test.ts
@@ -66,4 +66,24 @@ describe.runIf(process.env.T3_GROK_ACP_PROBE === "1")("Grok ACP CLI probe", () =
       yield* runtime.setSessionModel(currentModelId);
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
+
+  it.effect("session/set_model accepts advertised reasoning effort metadata", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeProbeRuntime;
+      const started = yield* runtime.start();
+      const modelState = started.sessionSetupResult.models;
+      const currentModelId = modelState?.currentModelId.trim();
+      expect(currentModelId).toBeDefined();
+      if (!currentModelId) return;
+
+      const currentModel = modelState?.availableModels.find(
+        (model) => model.modelId.trim() === currentModelId,
+      );
+      const reasoningEffort = currentModel?._meta?.reasoningEffort;
+      expect(typeof reasoningEffort).toBe("string");
+      if (typeof reasoningEffort !== "string") return;
+
+      yield* runtime.setSessionModel(currentModelId, { reasoningEffort });
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
 });

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -37,11 +37,14 @@ describe("buildGrokAcpSpawnInput", () => {
 
 describe("applyGrokAcpModelSelection", () => {
   const makeRecordingRuntime = (failure?: EffectAcpErrors.AcpError) => {
-    const modelCalls: Array<string> = [];
+    const modelCalls: Array<{
+      modelId: string;
+      meta?: { readonly [key: string]: unknown } | null;
+    }> = [];
     const runtime = {
-      setSessionModel: (modelId: string) =>
+      setSessionModel: (modelId: string, meta?: { readonly [key: string]: unknown } | null) =>
         Effect.gen(function* () {
-          modelCalls.push(modelId);
+          modelCalls.push(meta === undefined ? { modelId } : { modelId, meta });
           if (failure) return yield* failure;
           return {};
         }),
@@ -58,8 +61,24 @@ describe("applyGrokAcpModelSelection", () => {
         requestedModelId: "grok-mock-alt",
         mapError: (cause) => cause.message,
       });
-      expect(modelCalls).toEqual(["grok-mock-alt"]);
+      expect(modelCalls).toEqual([{ modelId: "grok-mock-alt" }]);
       expect(result).toBe("grok-mock-alt");
+    }),
+  );
+
+  it.effect("applies reasoning effort through session/set_model metadata", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyGrokAcpModelSelection({
+        runtime,
+        currentModelId: "grok-4.6",
+        currentReasoningEffort: "high",
+        requestedModelId: "grok-4.6",
+        requestedReasoningEffort: "xhigh",
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([{ modelId: "grok-4.6", meta: { reasoningEffort: "xhigh" } }]);
+      expect(result).toBe("grok-4.6");
     }),
   );
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -5,6 +5,7 @@ import * as EffectAcpErrors from "effect-acp/errors";
 import {
   applyGrokAcpModelSelection,
   buildGrokAcpSpawnInput,
+  isValidGrokReasoningEffortToken,
   resolveGrokAcpBaseModelId,
 } from "./GrokAcpSupport.ts";
 
@@ -32,6 +33,16 @@ describe("buildGrokAcpSpawnInput", () => {
         GROK_OAUTH2_REFERRER: "t3code",
       },
     });
+  });
+});
+
+describe("isValidGrokReasoningEffortToken", () => {
+  it("accepts future ACP tokens and rejects malformed metadata values", () => {
+    expect(isValidGrokReasoningEffortToken("xhigh")).toBe(true);
+    expect(isValidGrokReasoningEffortToken("turbo_v2")).toBe(true);
+    expect(isValidGrokReasoningEffortToken("not a token")).toBe(false);
+    expect(isValidGrokReasoningEffortToken("-leading-dash")).toBe(false);
+    expect(isValidGrokReasoningEffortToken("x".repeat(33))).toBe(false);
   });
 });
 
@@ -79,6 +90,37 @@ describe("applyGrokAcpModelSelection", () => {
       });
       expect(modelCalls).toEqual([{ modelId: "grok-4.6", meta: { reasoningEffort: "xhigh" } }]);
       expect(result).toBe("grok-4.6");
+    }),
+  );
+
+  it.effect("clears reasoning metadata when an explicit same-model selection omits effort", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyGrokAcpModelSelection({
+        runtime,
+        currentModelId: "grok-4.6",
+        currentReasoningEffort: "high",
+        requestedModelId: "grok-4.6",
+        requestedReasoningEffort: undefined,
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([{ modelId: "grok-4.6" }]);
+      expect(result).toBe("grok-4.6");
+    }),
+  );
+
+  it.effect("drops malformed effort metadata instead of sending it", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      yield* applyGrokAcpModelSelection({
+        runtime,
+        currentModelId: "grok-4.6",
+        currentReasoningEffort: "high",
+        requestedModelId: "grok-4.6",
+        requestedReasoningEffort: "not a token",
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([{ modelId: "grok-4.6" }]);
     }),
   );
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -91,18 +91,45 @@ export function currentGrokModelIdFromSessionSetup(
   return sessionSetupResult.models?.currentModelId?.trim() || undefined;
 }
 
+export function currentGrokReasoningEffortFromSessionSetup(
+  sessionSetupResult:
+    | EffectAcpSchema.LoadSessionResponse
+    | EffectAcpSchema.NewSessionResponse
+    | EffectAcpSchema.ResumeSessionResponse,
+): string | undefined {
+  const modelState = sessionSetupResult.models;
+  if (!modelState) {
+    return undefined;
+  }
+  const currentModelId = modelState.currentModelId.trim();
+  if (currentModelId.length === 0) {
+    return undefined;
+  }
+  const currentModel = modelState.availableModels.find(
+    (model) => model.modelId.trim() === currentModelId,
+  );
+  const reasoningEffort = currentModel?._meta?.reasoningEffort;
+  return typeof reasoningEffort === "string" ? reasoningEffort.trim() || undefined : undefined;
+}
+
 export function applyGrokAcpModelSelection<E>(input: {
   readonly runtime: Pick<AcpSessionRuntime.AcpSessionRuntime["Service"], "setSessionModel">;
   readonly currentModelId: string | undefined;
+  readonly currentReasoningEffort?: string | undefined;
   readonly requestedModelId: string | undefined;
+  readonly requestedReasoningEffort?: string | undefined;
   readonly mapError: (cause: EffectAcpErrors.AcpError) => E;
 }): Effect.Effect<string | undefined, E> {
-  const shouldSwitchModel =
+  const modelChanged =
     input.requestedModelId !== undefined && input.requestedModelId !== input.currentModelId;
-  if (!shouldSwitchModel) {
+  const reasoningEffort = input.requestedReasoningEffort?.trim() || undefined;
+  const reasoningEffortChanged =
+    reasoningEffort !== undefined && reasoningEffort !== input.currentReasoningEffort;
+  const targetModelId = input.requestedModelId ?? input.currentModelId;
+  if ((!modelChanged && !reasoningEffortChanged) || targetModelId === undefined) {
     return Effect.succeed(input.currentModelId);
   }
   return input.runtime
-    .setSessionModel(input.requestedModelId)
-    .pipe(Effect.mapError(input.mapError), Effect.as(input.requestedModelId));
+    .setSessionModel(targetModelId, reasoningEffort !== undefined ? { reasoningEffort } : undefined)
+    .pipe(Effect.mapError(input.mapError), Effect.as(targetModelId));
 }

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -82,6 +82,17 @@ export function resolveGrokAcpBaseModelId(model: string | null | undefined): str
   return normalizeModelSlug(base, GROK_DRIVER_KIND) ?? "grok-build";
 }
 
+const GROK_REASONING_EFFORT_TOKEN = /^[a-z0-9][a-z0-9._-]{0,31}$/i;
+
+export function isValidGrokReasoningEffortToken(value: string): boolean {
+  return GROK_REASONING_EFFORT_TOKEN.test(value);
+}
+
+export function normalizeGrokReasoningEffort(value: string | undefined): string | undefined {
+  const effort = value?.trim();
+  return effort && isValidGrokReasoningEffortToken(effort) ? effort : undefined;
+}
+
 export function currentGrokModelIdFromSessionSetup(
   sessionSetupResult:
     | EffectAcpSchema.LoadSessionResponse
@@ -109,7 +120,9 @@ export function currentGrokReasoningEffortFromSessionSetup(
     (model) => model.modelId.trim() === currentModelId,
   );
   const reasoningEffort = currentModel?._meta?.reasoningEffort;
-  return typeof reasoningEffort === "string" ? reasoningEffort.trim() || undefined : undefined;
+  return typeof reasoningEffort === "string"
+    ? normalizeGrokReasoningEffort(reasoningEffort)
+    : undefined;
 }
 
 export function applyGrokAcpModelSelection<E>(input: {
@@ -122,9 +135,9 @@ export function applyGrokAcpModelSelection<E>(input: {
 }): Effect.Effect<string | undefined, E> {
   const modelChanged =
     input.requestedModelId !== undefined && input.requestedModelId !== input.currentModelId;
-  const reasoningEffort = input.requestedReasoningEffort?.trim() || undefined;
+  const reasoningEffort = normalizeGrokReasoningEffort(input.requestedReasoningEffort);
   const reasoningEffortChanged =
-    reasoningEffort !== undefined && reasoningEffort !== input.currentReasoningEffort;
+    input.requestedModelId !== undefined && reasoningEffort !== input.currentReasoningEffort;
   const targetModelId = input.requestedModelId ?? input.currentModelId;
   if ((!modelChanged && !reasoningEffortChanged) || targetModelId === undefined) {
     return Effect.succeed(input.currentModelId);

--- a/apps/server/src/textGeneration/GrokTextGeneration.ts
+++ b/apps/server/src/textGeneration/GrokTextGeneration.ts
@@ -8,6 +8,7 @@ import type * as EffectAcpErrors from "effect-acp/errors";
 
 import { type GrokSettings, type ModelSelection } from "@t3tools/contracts";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import { extractJsonObject } from "@t3tools/shared/schemaJson";
 
 import { TextGenerationError } from "@t3tools/contracts";
@@ -26,6 +27,7 @@ import {
 import {
   applyGrokAcpModelSelection,
   currentGrokModelIdFromSessionSetup,
+  currentGrokReasoningEffortFromSessionSetup,
   makeGrokAcpRuntime,
   resolveGrokAcpBaseModelId,
 } from "../provider/acp/GrokAcpSupport.ts";
@@ -83,10 +85,18 @@ export const makeGrokTextGeneration = Effect.fn("makeGrokTextGeneration")(functi
 
       const promptResult = yield* Effect.gen(function* () {
         const started = yield* runtime.start();
+        const requestedReasoningEffort = getModelSelectionStringOptionValue(
+          modelSelection,
+          "reasoningEffort",
+        );
         yield* applyGrokAcpModelSelection({
           runtime,
           currentModelId: currentGrokModelIdFromSessionSetup(started.sessionSetupResult),
+          currentReasoningEffort: currentGrokReasoningEffortFromSessionSetup(
+            started.sessionSetupResult,
+          ),
           requestedModelId: resolvedModel,
+          requestedReasoningEffort,
           mapError: (cause) =>
             new TextGenerationError({
               operation,

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -57,6 +57,10 @@ to use, then authenticate it.
 Cursor is the one to watch: install Cursor CLI, which provides the `cursor-agent` binary that
 T3 Code looks for, but authenticate with `agent login`, not `cursor-agent login`.
 
+Grok models that support adjustable reasoning show a **Reasoning** control beside the model picker.
+The available levels and default come from the installed Grok Build CLI, so they can vary by model
+and CLI version.
+
 Run the login command on the machine running the T3 Code server, not on the device you browse
 from.
 


### PR DESCRIPTION
## What Changed

- map each Grok model's advertised ACP reasoning menu into the existing model-option contract
- preserve ACP descriptions, reject malformed effort tokens, and keep current selection separate from the advertised default badge
- show those choices in the shared composer on web, desktop, and mobile surfaces
- send the selected effort in `session/set_model` metadata, including same-model changes and explicit clearing back to the model default
- honor the same selection in Grok-backed title, commit, PR, and branch-name generation
- cover the metadata mapping and dispatch path with focused tests and an opt-in real-CLI probe

## Why

Grok 4.6 advertises Extra High, High, Medium, and Low reasoning levels through its ACP model metadata, but T3 discarded Grok model capabilities and only sent model IDs. That left the composer without a reasoning control and made same-model effort changes impossible.

This is a focused reasoning-only fix. It overlaps the reasoning portion of [#6383](https://github.com/pingdotgg/t3code/pull/6383), which appeared after this work started and also bundles Grok auth, rewind, and token-usage changes.

I also compared this implementation with the orchestrator-v2 work in [#5160](https://github.com/pingdotgg/t3code/pull/5160). This PR reuses the portable safeguards from that work: safe ACP token parsing, preserved descriptions, current-vs-default separation, one default badge, and symmetric effort clearing. It intentionally leaves out v2-only lifecycle scaffolding, spawn-bound locks, and fallback catalogs.

## UI Changes

### Before

Grok 4.6 had no reasoning control.

![Grok 4.6 before, without reasoning levels](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-grok-reasoning-levels/f10861b9b276-grok-reasoning-before.jpg)

### After

The composer reads Grok 4.6's live effort menu, and changing the selection updates the visible value.

The `Effort` suffix in this screenshot comes from Grok 4.6's ACP-provided labels. T3 displays only ACP-advertised options, preserving their labels verbatim without synthesizing a fallback menu.

![Grok 4.6 after, with Medium selected from the reasoning menu](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-grok-reasoning-levels/6f2b697fc06e-grok-reasoning-selected.jpg)

## Verification

- `vp test run apps/server/src/provider/acp/GrokAcpSupport.test.ts apps/server/src/provider/Layers/GrokProvider.test.ts apps/server/src/provider/Layers/GrokAdapter.test.ts apps/server/src/textGeneration/GrokTextGeneration.test.ts` (51 tests passed)
- `T3_GROK_ACP_PROBE=1 vp test run apps/server/src/provider/acp/GrokAcpCliProbe.test.ts --reporter=verbose` (4 tests passed against Grok CLI 1.0.3)
- `vp run --filter=t3 typecheck`
- targeted `vp fmt --check` and `vp lint` for all changed files
- full Computer Use verification in Safari against the local T3 app: Grok 4.6 exposed all four advertised levels, accepted a change from Extra High to Medium, and kept the ACP default badge on Extra High

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or timing behavior changed, so a video is not applicable

Implemented with gpt-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Grok session model binding and `session/set_model` behavior (including same-model effort and clearing), which affects live turns and auxiliary Grok prompts; risk is mitigated by validation, deferred `set_model` until after turn validation, and broad tests.
> 
> **Overview**
> **Grok reasoning effort** is now wired end-to-end from ACP model metadata into the composer and runtime.
> 
> **Discovery and UI contract:** `buildGrokModelCapabilities` turns each model’s `_meta.reasoningEffort` / `reasoningEfforts` into a `reasoningEffort` select (labels, descriptions, default badge, token validation). Discovered Grok models use these capabilities instead of empty option lists.
> 
> **ACP dispatch:** `setSessionModel` accepts optional `_meta`; `applyGrokAcpModelSelection` compares current vs requested effort and calls `session/set_model` with `{ reasoningEffort }` when the model or effort changes, or omits `_meta` to clear effort on the same model. **GrokAdapter** tracks `currentReasoningEffort`, applies selection after turn validation (so failed prep/validation does not call `set_model`), and avoids leaking prior-session effort on start when switching models. **Grok text generation** applies the same selection path.
> 
> Tests and the mock ACP agent cover effort metadata; install docs mention the Reasoning control for supported Grok models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0fc12bdb2ce62ec2091ed2ab084d61ea092c1b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose Grok reasoning effort levels from ACP model metadata in model capabilities
> - `buildGrokModelCapabilities` in [GrokProvider.ts](https://github.com/pingdotgg/t3code/pull/6386/files#diff-d88edf38a3399863fd884b8deb4f8eb57539ca15d41ce6ea03cad4baf62acf0f) parses `_meta.reasoningEffort` and `_meta.reasoningEfforts` from ACP model metadata and returns a `reasoningEffort` select option when present; discovered models now use this instead of empty capabilities.
> - `applyGrokAcpModelSelection` in [GrokAcpSupport.ts](https://github.com/pingdotgg/t3code/pull/6386/files#diff-7753f9dffb0a8ad069a7e71c1fae3be3596c6a535c8a6108711f2c575bca5ac4) now tracks current and requested reasoning effort, triggering `session/set_model` with `_meta.reasoningEffort` when effort changes on the same model, and clearing it when omitted.
> - `AcpSessionRuntime.setSessionModel` in [AcpSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/6386/files#diff-947405407dc15b91fd18625aab3132939b58753dce5a014fe17c590f2abfa5d6) accepts an optional `_meta` payload so reasoning effort can be forwarded in set-model requests.
> - The [GrokAdapter](https://github.com/pingdotgg/t3code/pull/6386/files#diff-1a00c5b795ace1b6633f05c6d3b900dc8d4778afd1879ebdbdf3fb41d04ed521) tracks `currentReasoningEffort` in session context and applies it alongside model selection on `sendTurn`; `session/set_model` is no longer issued when `sendTurn` validation fails.
> - A Reasoning control is documented in [install.md](https://github.com/pingdotgg/t3code/pull/6386/files#diff-5445c9485dbf19d6da7ef0ed9335ef230c4eb448b7a58ebc7810d3f1eca744c2) for Grok models that advertise adjustable reasoning levels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0fc12b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->