### PR TITLE
feat(server): let agents save browser screenshots

### DIFF
--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -5,6 +5,7 @@ import type {
   PreviewAutomationRecordingArtifact,
   PreviewAutomationRecordingStatus,
   PreviewAutomationResizeResult,
+  PreviewAutomationScreenshotArtifact,
   PreviewAutomationSetColorSchemeResult,
   PreviewAutomationSnapshot,
   PreviewAutomationStatus,
@@ -85,6 +86,8 @@ const handlers = {
     invokeTargeted<PreviewAutomationRecordingStatus>("recordingStart", input ?? {}),
   preview_recording_stop: (input) =>
     invokeTargeted<PreviewAutomationRecordingArtifact>("recordingStop", input ?? {}),
+  preview_screenshot: (input) =>
+    invokeTargeted<PreviewAutomationScreenshotArtifact>("screenshot", input ?? {}),
 } satisfies Parameters<typeof PreviewToolkit.toLayer>[0];
 
 const { preview_snapshot, ...standardHandlers } = handlers;

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -9,6 +9,7 @@ import {
   PreviewAutomationRecordingStatus,
   PreviewAutomationResizeInput,
   PreviewAutomationResizeResult,
+  PreviewAutomationScreenshotArtifact,
   PreviewAutomationScrollInput,
   PreviewAutomationSetColorSchemeInput,
   PreviewAutomationSetColorSchemeResult,
@@ -200,6 +201,17 @@ export const PreviewRecordingStopTool = safeBrowserTool(
   }).annotate(Tool.Title, "Stop browser recording"),
 );
 
+export const PreviewScreenshotTool = safeBrowserTool(
+  Tool.make("preview_screenshot", {
+    description:
+      "Save a full-resolution PNG of the collaborative browser tab selected by tabId, or this agent session's current tab when omitted, as a local evidence artifact and return its path. Use this to hand the user a still image; use preview_snapshot instead to look at the page yourself.",
+    parameters: PreviewAutomationTabTargetInput,
+    success: PreviewAutomationScreenshotArtifact,
+    failure: PreviewAutomationError,
+    dependencies,
+  }).annotate(Tool.Title, "Save browser screenshot"),
+);
+
 export const PreviewToolkit = Toolkit.make(
   PreviewStatusTool,
   PreviewOpenTool,
@@ -215,6 +227,7 @@ export const PreviewToolkit = Toolkit.make(
   PreviewWaitForTool,
   PreviewRecordingStartTool,
   PreviewRecordingStopTool,
+  PreviewScreenshotTool,
 );
 
 export const PreviewStandardToolkit = Toolkit.make(
@@ -231,6 +244,7 @@ export const PreviewStandardToolkit = Toolkit.make(
   PreviewWaitForTool,
   PreviewRecordingStartTool,
   PreviewRecordingStopTool,
+  PreviewScreenshotTool,
 );
 
 export const PreviewSnapshotToolkit = Toolkit.make(PreviewSnapshotTool);

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -661,6 +661,13 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             }
             return { ...artifact, tabId: stopTabId };
           }
+          case "screenshot": {
+            const ready = await requireReadyTab();
+            const artifact = await ready.bridge.captureScreenshot(ready.runtimeTabId);
+            // The desktop artifact carries the runtime tab id; callers address
+            // tabs by their server id.
+            return { ...artifact, tabId: ready.tabId };
+          }
         }
       } catch (cause) {
         throw PreviewAutomationOperationError.fromCause({

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -43,6 +43,7 @@ export const PREVIEW_AUTOMATION_OPERATIONS = [
   ...PREVIEW_AUTOMATION_V1_OPERATIONS,
   "resize",
   "setColorScheme",
+  "screenshot",
 ] as const;
 
 export const PreviewAutomationOperation = Schema.Literals(PREVIEW_AUTOMATION_OPERATIONS);
@@ -562,6 +563,16 @@ export const PreviewAutomationRecordingArtifact = Schema.Struct({
   createdAt: Schema.String,
 });
 export type PreviewAutomationRecordingArtifact = typeof PreviewAutomationRecordingArtifact.Type;
+
+export const PreviewAutomationScreenshotArtifact = Schema.Struct({
+  id: Schema.String,
+  tabId: PreviewTabId,
+  path: Schema.String,
+  mimeType: Schema.Literal("image/png"),
+  sizeBytes: Schema.Int,
+  createdAt: Schema.String,
+});
+export type PreviewAutomationScreenshotArtifact = typeof PreviewAutomationScreenshotArtifact.Type;
 
 export const PreviewAutomationClientId = TrimmedNonEmptyString.check(Schema.isMaxLength(128));
 export type PreviewAutomationClientId = typeof PreviewAutomationClientId.Type;


### PR DESCRIPTION
Agents can save a recording of a collaborative browser tab, but they have no way to save a still. `preview_snapshot` returns a downscaled PNG inline for the agent to look at, and the desktop camera button writes a file, but that capture was never exposed over MCP — so an agent that just wants to hand the user a still image has to record a video instead.

This adds a `preview_screenshot` tool that reuses the existing desktop capture and returns the saved artifact's path, mirroring `preview_recording_stop`:

```
preview_screenshot { tabId? } → { id, tabId, path, mimeType: "image/png", sizeBytes, createdAt }
```

Artifacts land in the same `browser-artifacts` directory as recordings and the camera button, so reveal and copy-path work unchanged.

The tool returns a path rather than image data on purpose: `preview_snapshot` already covers "let the agent see the page", and re-encoding a full-resolution PNG into the transcript on every capture would be a lot of tokens for an evidence artifact the human is meant to open.

`"screenshot"` joins `PREVIEW_AUTOMATION_OPERATIONS` but not the V1 list, so desktop hosts predating this change are filtered out by the broker and get a capability error rather than an operation they cannot serve.

One inherited constraint worth knowing: capture needs a composited tab. This calls the same `webContents.capturePage()` as `preview_snapshot`, which fails with `UnknownVizError` on a hidden guest — so a tab opened with `open: false`, or one whose thread is not routed in the desktop window, will not produce an artifact.

### Verification

Against a dev desktop build, an agent called `preview_screenshot` after `preview_open` and reported `sizeBytes: 57265`, matching the artifact written to disk byte for byte. The image below is that artifact, unmodified — full resolution, not downscaled the way snapshot captures are.

![Screenshot artifact saved by preview_screenshot](https://pub-76d803937194457aabd6f4fda5dc02c9.r2.dev/6a24c08c-d8e0-42e3-ad88-80b7523867f7.png)

`tsgo --noEmit` is clean for contracts, server, and web; the preview toolkit and automation broker tests pass.

Model: Claude Opus 5, via Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `preview_screenshot` tool to let agents capture browser tab screenshots
> - Adds a new `preview_screenshot` MCP tool to `PreviewToolkit` and `PreviewStandardToolkit` that captures a full-resolution PNG of a targeted browser tab and returns a `PreviewAutomationScreenshotArtifact` with path, size, and timestamp.
> - Extends `PreviewAutomationHost` to handle the `screenshot` automation operation by calling `bridge.captureScreenshot` with the runtime tab id.
> - Adds the `screenshot` operation to `PREVIEW_AUTOMATION_OPERATIONS` and defines the `PreviewAutomationScreenshotArtifact` schema in [previewAutomation.ts](https://github.com/pingdotgg/t3code/pull/6387/files#diff-2ef56f22cedaed8aa5c26215295ac5661980479b1dced68072d9ca5bc81a9602).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63b662c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->