### PR TITLE
fix(web): keep the typed prompt when a draft changes repo

### DIFF
--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -115,8 +115,11 @@ export function DraftHeroHeadline({
               return;
             }
             const project = entry.targetProject;
+            // Changing the repo of a draft moves the typed content along:
+            // the user started writing in the wrong project, not a new task.
             void handleNewThread(scopeProjectRef(project.environmentId, project.id), {
               replace: true,
+              carryComposerContent: true,
             });
           }}
         >

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -289,6 +289,62 @@ describe("composerDraftStore clearComposerContent", () => {
   });
 });
 
+describe("composerDraftStore moveComposerPromptAndImages", () => {
+  const sourceDraftId = DraftId.make("draft-move-source");
+  const destinationDraftId = DraftId.make("draft-move-destination");
+  let originalRevokeObjectUrl: typeof URL.revokeObjectURL;
+  let revokeSpy: ReturnType<typeof vi.fn<(url: string) => void>>;
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+    originalRevokeObjectUrl = URL.revokeObjectURL;
+    revokeSpy = vi.fn();
+    URL.revokeObjectURL = revokeSpy;
+  });
+
+  afterEach(() => {
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  });
+
+  it("moves prompt and images to the destination without revoking preview URLs", () => {
+    const store = useComposerDraftStore.getState();
+    store.setPrompt(sourceDraftId, "fix the login redirect");
+    store.addImages(sourceDraftId, [makeImage({ id: "img-move", previewUrl: "blob:move" })]);
+
+    store.moveComposerPromptAndImages(sourceDraftId, destinationDraftId);
+
+    expect(draftByKey(sourceDraftId)).toBeUndefined();
+    const destination = draftByKey(destinationDraftId);
+    expect(destination?.prompt).toBe("fix the login redirect");
+    expect(destination?.images.map((image) => image.id)).toEqual(["img-move"]);
+    expect(revokeSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps session-bound contexts on the source and strips their placeholders from the moved prompt", () => {
+    const sourceThreadId = ThreadId.make("thread-move-source");
+    const sourceThreadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, sourceThreadId);
+    const store = useComposerDraftStore.getState();
+    store.addTerminalContext(sourceThreadRef, makeTerminalContext({ id: "ctx-stay" }));
+    store.setPrompt(sourceThreadRef, `${INLINE_TERMINAL_CONTEXT_PLACEHOLDER} explain this error`);
+
+    store.moveComposerPromptAndImages(sourceThreadRef, destinationDraftId);
+
+    const source = draftFor(sourceThreadId, TEST_ENVIRONMENT_ID);
+    expect(source?.terminalContexts.map((context) => context.id)).toEqual(["ctx-stay"]);
+    expect(source?.prompt).toBe(INLINE_TERMINAL_CONTEXT_PLACEHOLDER);
+    expect(draftByKey(destinationDraftId)?.prompt).toBe(" explain this error");
+  });
+
+  it("is a no-op when source and destination are the same target", () => {
+    const store = useComposerDraftStore.getState();
+    store.setPrompt(sourceDraftId, "keep me");
+
+    store.moveComposerPromptAndImages(sourceDraftId, sourceDraftId);
+
+    expect(draftByKey(sourceDraftId)?.prompt).toBe("keep me");
+  });
+});
+
 describe("composerDraftStore syncPersistedAttachments", () => {
   const threadId = ThreadId.make("thread-sync-persisted");
   const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -38,6 +38,7 @@ import {
   type TerminalContextDraft,
   ensureInlineTerminalContextPlaceholders,
   normalizeTerminalContextText,
+  stripInlineTerminalContextPlaceholders,
 } from "./lib/terminalContext";
 import {
   type ElementContextDraft,
@@ -527,6 +528,15 @@ interface ComposerDraftStoreState {
    * session-bound contexts would destroy state nothing can restore.
    */
   clearComposerPromptAndImages: (threadRef: ComposerThreadTarget) => void;
+  /**
+   * Moves the prompt text and image attachments from one composer target to
+   * another. Used when a draft changes project: the new project gets its own
+   * draft session and the typed content follows it. Session-bound extras
+   * (terminal / element contexts, preview annotations, review comments) stay
+   * on the source — they reference sessions of the source thread that the
+   * destination cannot use.
+   */
+  moveComposerPromptAndImages: (from: ComposerThreadTarget, to: ComposerThreadTarget) => void;
 }
 
 export interface EffectiveComposerModelState {
@@ -3470,6 +3480,62 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               delete nextDraftsByThreadKey[threadKey];
             } else {
               nextDraftsByThreadKey[threadKey] = nextDraft;
+            }
+            return { draftsByThreadKey: nextDraftsByThreadKey };
+          });
+        },
+        moveComposerPromptAndImages: (from, to) => {
+          const fromKey = resolveComposerDraftKey(get(), from) ?? "";
+          const toKey = resolveComposerDraftKey(get(), to) ?? "";
+          if (fromKey.length === 0 || toKey.length === 0 || fromKey === toKey) {
+            return;
+          }
+          set((state) => {
+            const source = state.draftsByThreadKey[fromKey];
+            if (!source) {
+              return state;
+            }
+            const destination = state.draftsByThreadKey[toKey] ?? createEmptyThreadDraft();
+            // Inline placeholders reference the source's terminal contexts,
+            // which stay behind; re-anchor the moved prompt to whatever
+            // contexts the destination already holds.
+            const movedPrompt = ensureInlineTerminalContextPlaceholders(
+              stripInlineTerminalContextPlaceholders(source.prompt),
+              destination.terminalContexts.length,
+            );
+            const nextDestination: ComposerThreadDraftState = {
+              ...destination,
+              prompt: movedPrompt,
+              images: [...destination.images, ...source.images],
+              nonPersistedImageIds: [
+                ...destination.nonPersistedImageIds,
+                ...source.nonPersistedImageIds,
+              ],
+              persistedAttachments: [
+                ...destination.persistedAttachments,
+                ...source.persistedAttachments,
+              ],
+            };
+            // Same clearing shape as clearComposerPromptAndImages, but the
+            // preview URLs are NOT revoked: the images moved and their blobs
+            // are still referenced from the destination.
+            const nextSource: ComposerThreadDraftState = {
+              ...source,
+              prompt: ensureInlineTerminalContextPlaceholders("", source.terminalContexts.length),
+              images: [],
+              nonPersistedImageIds: [],
+              persistedAttachments: [],
+            };
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            if (shouldRemoveDraft(nextSource)) {
+              delete nextDraftsByThreadKey[fromKey];
+            } else {
+              nextDraftsByThreadKey[fromKey] = nextSource;
+            }
+            if (shouldRemoveDraft(nextDestination)) {
+              delete nextDraftsByThreadKey[toKey];
+            } else {
+              nextDraftsByThreadKey[toKey] = nextDestination;
             }
             return { draftsByThreadKey: nextDraftsByThreadKey };
           });

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -147,6 +147,10 @@ export function useNewThreadHandler() {
         if (
           carryContentSourceDraftId &&
           carryContentSourceDraftId !== destinationDraftId &&
+          // Never clobber a destination the user already invested in — the
+          // move overwrites the destination prompt, so a concurrent repo
+          // change that carried content first must win.
+          !composerDraftHasUserContent(getComposerDraft(destinationDraftId)) &&
           composerDraftHasUserContent(getComposerDraft(carryContentSourceDraftId))
         ) {
           moveComposerPromptAndImages(carryContentSourceDraftId, destinationDraftId);

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -74,6 +74,14 @@ export function useNewThreadHandler() {
         envMode?: DraftThreadEnvMode;
         startFromOrigin?: boolean;
         replace?: boolean;
+        /**
+         * Move the viewed draft's typed content (prompt + images) into the
+         * draft this request lands on. Set by the draft repo picker: the
+         * user started writing in the wrong project and the text should
+         * follow them. Explicit new-thread surfaces leave this unset and
+         * keep mint-fresh semantics.
+         */
+        carryComposerContent?: boolean;
       },
       // Which draft the thread ended up in, so a caller that has something to put in it — a
       // prepared checkout, a task to write — addresses that one rather than looking the project
@@ -85,6 +93,7 @@ export function useNewThreadHandler() {
         getDraftSession,
         getDraftThread,
         applyStickyState,
+        moveComposerPromptAndImages,
         setDraftThreadContext,
         setLogicalProjectDraftThreadId,
         setModelSelection,
@@ -126,6 +135,21 @@ export function useNewThreadHandler() {
         carrySourceShell?.interactionMode ??
         carrySourceDraft?.interactionMode ??
         null;
+      // Content only moves when the caller opted in, the user is looking at
+      // a draft, and that draft has real typed content to move. The move
+      // reads the store at call time, so text typed during the awaits below
+      // still comes along.
+      const carryContentSourceDraftId =
+        options?.carryComposerContent === true &&
+        currentRouteTarget?.kind === "draft" &&
+        composerDraftHasUserContent(carrySourceComposer)
+          ? currentRouteTarget.draftId
+          : null;
+      const carryComposerContentTo = (destinationDraftId: DraftId) => {
+        if (carryContentSourceDraftId && carryContentSourceDraftId !== destinationDraftId) {
+          moveComposerPromptAndImages(carryContentSourceDraftId, destinationDraftId);
+        }
+      };
       const project = projects.find(
         (candidate) =>
           candidate.id === projectRef.projectId &&
@@ -267,6 +291,7 @@ export function useNewThreadHandler() {
               ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
             },
           );
+          carryComposerContentTo(emptyStoredDraftThread.draftId);
           const opened = {
             draftId: emptyStoredDraftThread.draftId,
             threadId: emptyStoredDraftThread.threadId,
@@ -354,6 +379,7 @@ export function useNewThreadHandler() {
             interactionMode: racedDraft.interactionMode,
             ...pickExplicitWorkspaceOptions(options),
           });
+          carryComposerContentTo(racedDraft.draftId);
           await router.navigate({
             to: "/draft/$draftId",
             params: { draftId: racedDraft.draftId },
@@ -385,6 +411,7 @@ export function useNewThreadHandler() {
           // whatever sticky state just wrote".
           setModelSelection(draftId, carryModelSelection, { replaceOptions: true });
         }
+        carryComposerContentTo(draftId);
 
         await router.navigate({
           to: "/draft/$draftId",

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -135,18 +135,20 @@ export function useNewThreadHandler() {
         carrySourceShell?.interactionMode ??
         carrySourceDraft?.interactionMode ??
         null;
-      // Content only moves when the caller opted in, the user is looking at
-      // a draft, and that draft has real typed content to move. The move
-      // reads the store at call time, so text typed during the awaits below
-      // still comes along.
+      // Content only moves when the caller opted in and the user is looking
+      // at a draft. The content check happens at move time, not here: the
+      // paths below await, and text typed during those awaits must still
+      // come along.
       const carryContentSourceDraftId =
-        options?.carryComposerContent === true &&
-        currentRouteTarget?.kind === "draft" &&
-        composerDraftHasUserContent(carrySourceComposer)
+        options?.carryComposerContent === true && currentRouteTarget?.kind === "draft"
           ? currentRouteTarget.draftId
           : null;
       const carryComposerContentTo = (destinationDraftId: DraftId) => {
-        if (carryContentSourceDraftId && carryContentSourceDraftId !== destinationDraftId) {
+        if (
+          carryContentSourceDraftId &&
+          carryContentSourceDraftId !== destinationDraftId &&
+          composerDraftHasUserContent(getComposerDraft(carryContentSourceDraftId))
+        ) {
           moveComposerPromptAndImages(carryContentSourceDraftId, destinationDraftId);
         }
       };


### PR DESCRIPTION
Reported by dominicroy0: start writing a prompt, notice you are in the wrong repo, switch repos in the draft hero — and your text is gone. The switch minted a fresh empty draft and the typed prompt stayed behind on the old project.

Now the prompt and image attachments move with you to the new project's draft. Session-bound extras (terminal/element contexts, preview annotations, review comments) stay on the source draft because they reference the old thread's sessions; if nothing else remains there, the old draft empties out and drops its sidebar row.

Only the draft repo picker opts into the carry (`carryComposerContent`). Explicit new-thread surfaces (button, hotkeys, palette, sidebar) keep their mint-fresh behavior.

Store tests cover the move, placeholder stripping, and that blob preview URLs are not revoked.

---
Written by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized draft/composer state changes with guards against clobbering invested destination drafts; no auth, API, or persistence schema changes.
> 
> **Overview**
> Fixes losing composer text when switching projects from the draft hero: **prompt and image attachments now move** to the new project's draft instead of staying on the old one.
> 
> Adds **`moveComposerPromptAndImages`** on the composer draft store to transfer prompt + images between draft targets without revoking blob preview URLs. Session-bound extras (terminal/element contexts, preview annotations, review comments) **stay on the source**; inline terminal placeholders are stripped from the moved text and re-applied for the destination's contexts.
> 
> **`useHandleNewThread`** gains optional **`carryComposerContent`**: when set and the user is on a draft route, it moves content after the destination draft is resolved (including async paths), and skips the move if the destination already has user content. Only **`DraftHeroHeadline`**'s project picker passes this flag; other new-thread entry points stay mint-fresh.
> 
> Store tests cover the move, placeholder handling, same-target no-op, and non-revocation of preview URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e3f33949c4f51a0517131a545adf74789ae240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep typed prompt and images when changing a draft's repo in the chat composer
> - When a user changes the selected project on a draft via the project picker, the current prompt text and image attachments are moved to the new draft instead of being discarded.
> - Adds `moveComposerPromptAndImages` to [`composerDraftStore`](https://github.com/pingdotgg/t3code/pull/6393/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a), which re-anchors inline terminal context placeholders for the destination and clears the source without revoking image preview URLs.
> - Extends `useHandleNewThread` in [`useHandleNewThread.ts`](https://github.com/pingdotgg/t3code/pull/6393/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef) with a `carryComposerContent` option that triggers the move after the destination draft is resolved, skipping it if the destination already has user content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41e3f33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->