### PR TITLE
fix(server): show Grok usage limit errors

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -20,6 +20,7 @@ const emitGenericToolPlaceholders = process.env.T3_ACP_EMIT_GENERIC_TOOL_PLACEHO
 const emitAskQuestion = process.env.T3_ACP_EMIT_ASK_QUESTION === "1";
 const emitXAiAskUserQuestion = process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION === "1";
 const emitXAiPromptCompleteThenHang = process.env.T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG === "1";
+const emitXAiRateLimitThenHang = process.env.T3_ACP_EMIT_XAI_RATE_LIMIT_THEN_HANG === "1";
 const emitForeignSessionUpdates = process.env.T3_ACP_EMIT_FOREIGN_SESSION_UPDATES === "1";
 const hangPromptForever = process.env.T3_ACP_HANG_PROMPT_FOREVER === "1";
 const hangFirstPromptForever = process.env.T3_ACP_HANG_FIRST_PROMPT_FOREVER === "1";
@@ -519,6 +520,16 @@ const program = Effect.gen(function* () {
       }
 
       if (hangPromptForever || (hangFirstPromptForever && promptCount === 1)) {
+        return yield* Effect.never;
+      }
+
+      if (emitXAiRateLimitThenHang) {
+        writeJsonRpcNotification("_x.ai/session/prompt_complete", {
+          sessionId: requestedSessionId,
+          promptId: promptIdFromRequestMeta(request) ?? "mock-xai-rate-limit-prompt-1",
+          stopReason: "rate_limit",
+          agentResult: null,
+        });
         return yield* Effect.never;
       }
 

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -943,6 +943,64 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("surfaces Grok usage limits without clearing the selected model", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-usage-limit-error");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_XAI_RATE_LIMIT_THEN_HANG: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      });
+
+      const error = yield* Effect.flip(
+        adapter.sendTurn({
+          threadId,
+          input: "hit the usage limit",
+          attachments: [],
+        }),
+      );
+      const readySessions = yield* adapter.listSessions();
+      const readySession = readySessions.find((session) => session.threadId === threadId);
+      const terminalEvents = runtimeEvents.filter(
+        (event) => event.type === "turn.completed" && event.threadId === threadId,
+      );
+
+      assert.equal(error._tag, "ProviderAdapterRequestError");
+      assert.include(error.message, "Grok usage limit reached. Try again later.");
+      assert.equal(readySession?.status, "ready");
+      assert.equal(readySession?.model, "grok-build");
+      assert.isUndefined(readySession?.activeTurnId);
+      assert.lengthOf(terminalEvents, 1);
+      const [terminalEvent] = terminalEvents;
+      assert.equal(terminalEvent?.type, "turn.completed");
+      if (terminalEvent?.type === "turn.completed") {
+        assert.equal(terminalEvent.payload.state, "failed");
+        assert.include(
+          terminalEvent.payload.errorMessage ?? "",
+          "Grok usage limit reached. Try again later.",
+        );
+      }
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("ignores replayed session/load updates when resuming a Grok session", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-load-replay-filter");

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -299,6 +299,27 @@ describe("XAiAcpExtension", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
+  it.effect("fails a hung standard prompt from an xAI rate-limit completion", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makePromptCompletionRuntime({
+        T3_ACP_EMIT_XAI_RATE_LIMIT_THEN_HANG: "1",
+      });
+      yield* runtime.start();
+
+      const error = yield* Effect.flip(
+        runtime.prompt({
+          prompt: [{ type: "text", text: "hi" }],
+        }),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "AcpRequestError",
+        code: -32003,
+        errorMessage: "Grok usage limit reached. Try again later.",
+      });
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("ignores stale xAI completion from an already settled prompt", () =>
     Effect.gen(function* () {
       const runtime = yield* makePromptCompletionRuntime({

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -3,6 +3,7 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
+import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
 import type * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
@@ -19,11 +20,15 @@ type XAiPromptCompleteNotification = typeof XAiPromptCompleteNotification.Type;
 interface PendingXAiPromptCompletion {
   readonly sessionId: string;
   readonly promptId: string;
-  readonly deferred: Deferred.Deferred<EffectAcpSchema.PromptResponse>;
+  readonly deferred: Deferred.Deferred<
+    EffectAcpSchema.PromptResponse,
+    EffectAcpErrors.AcpRequestError
+  >;
 }
 
 const completedXAiPromptIdLimit = 128;
 const xAiStopReasonMissingMetaKey = "xAiStopReasonMissing";
+const xAiRateLimitedErrorCode = -32003;
 
 const XAiAskUserQuestionOption = Schema.Struct({
   label: Schema.String,
@@ -278,7 +283,7 @@ const registerXAiPromptCompletionFallback = (
   sessionId: string,
   promptId: string,
 ) =>
-  Deferred.make<EffectAcpSchema.PromptResponse>().pipe(
+  Deferred.make<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpRequestError>().pipe(
     Effect.tap((deferred) =>
       Ref.update(pendingRef, (pending) => [...pending, { sessionId, promptId, deferred }]),
     ),
@@ -287,7 +292,7 @@ const registerXAiPromptCompletionFallback = (
 
 const unregisterXAiPromptCompletionFallback = (
   pendingRef: Ref.Ref<ReadonlyArray<PendingXAiPromptCompletion>>,
-  deferred: Deferred.Deferred<EffectAcpSchema.PromptResponse>,
+  deferred: Deferred.Deferred<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpRequestError>,
 ) => Ref.update(pendingRef, (pending) => pending.filter((entry) => entry.deferred !== deferred));
 
 const abortPendingPromptCompletions = (
@@ -358,12 +363,47 @@ const resolveXAiPromptCompletionFallback = ({
           return [Effect.void, pending] as const;
         }
         return [
-          Deferred.succeed(entry.deferred, promptResponseFromXAi(notification)).pipe(Effect.asVoid),
+          settleXAiPromptCompletion(entry.deferred, notification),
           [...pending.slice(0, index), ...pending.slice(index + 1)],
         ] as const;
       }).pipe(Effect.flatten);
     }),
   );
+
+const settleXAiPromptCompletion = (
+  deferred: Deferred.Deferred<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpRequestError>,
+  notification: XAiPromptCompleteNotification,
+) => {
+  if (notification.stopReason === "rate_limit") {
+    return Deferred.fail(
+      deferred,
+      new EffectAcpErrors.AcpRequestError({
+        code: xAiRateLimitedErrorCode,
+        errorMessage: "Grok usage limit reached. Try again later.",
+      }),
+    ).pipe(Effect.asVoid);
+  }
+  if (notification.stopReason === "error") {
+    return Deferred.fail(
+      deferred,
+      EffectAcpErrors.AcpRequestError.internalError(
+        xAiAgentResultMessage(notification.agentResult) ?? "Grok prompt failed.",
+      ),
+    ).pipe(Effect.asVoid);
+  }
+  return Deferred.succeed(deferred, promptResponseFromXAi(notification)).pipe(Effect.asVoid);
+};
+
+function xAiAgentResultMessage(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return trimmed(value);
+  }
+  if (value === null || typeof value !== "object") {
+    return undefined;
+  }
+  const message = "message" in value ? value.message : undefined;
+  return typeof message === "string" ? trimmed(message) : undefined;
+}
 
 const rememberCompletedXAiPromptId = (
   completedPromptIdsRef: Ref.Ref<ReadonlyArray<string>>,


### PR DESCRIPTION
## What Changed

- treat xAI `rate_limit` and `error` prompt completions as failed ACP requests instead of successful fallback completions
- emit one failed terminal turn, restore the Grok session to ready, and retain the selected model
- cover the private xAI notification and full Grok adapter flow with a focused ACP mock

## Why

Grok reports usage exhaustion through its private `_x.ai/session/prompt_complete` notification before the standard prompt request settles. T3 raced that notification against the prompt RPC, normalized the unknown `rate_limit` stop reason to `end_turn`, and cancelled the real error path. The thread therefore appeared to complete with no response or visible explanation.

The fallback now preserves failure semantics at the xAI adapter boundary and surfaces a stable, provider-specific message without synthesizing or clearing any model selection.

## UI Changes

Before, a Grok usage limit could leave an empty completed turn with no error. After, the thread fails once with a visible usage-limit message while the selected Grok model remains in the composer.

![Grok usage limit shown in the T3 chat surface](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-grok-usage-limit/dbdcad3f3e0f-grok-usage-limit-after.png)

## Verification

- `vp test run apps/server/src/provider/acp/XAiAcpExtension.test.ts apps/server/src/provider/Layers/GrokAdapter.test.ts` (32 tests passed)
- `vp run --filter ./apps/server typecheck`
- targeted `vp fmt --check` and `vp lint` for all changed files
- full Computer Use verification in Safari against an isolated T3 environment and an exact `rate_limit` ACP mock: the thread entered `Failed`, displayed the error once, returned the session to ready, and kept `Grok Build` selected

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included screenshot evidence for the user-visible behavior
- [x] No animation or timing behavior changed, so a video is not applicable

Implemented with gpt-5.6-sol through the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show Grok usage limit errors when xAI rate limit is reached
> - Adds a `settleXAiPromptCompletion` helper in [`XAiAcpExtension.ts`](https://github.com/pingdotgg/t3code/pull/6396/files#diff-facfffc25c57123d8d9a118e55dc2c9856d28b4ed93f1c10cc9dbf6f6f5c360a) that inspects the `stopReason` from xAI prompt completions and fails the pending `Deferred` with an `AcpRequestError` (code `-32003`, message "Grok usage limit reached. Try again later.") when `stopReason` is `rate_limit`.
> - Previously, all prompt completions resolved successfully regardless of stop reason; now `rate_limit` and `error` stop reasons produce typed failures that propagate to the adapter layer.
> - Adds a mock flag `T3_ACP_EMIT_XAI_RATE_LIMIT_THEN_HANG` to [`acp-mock-agent.ts`](https://github.com/pingdotgg/t3code/pull/6396/files#diff-8a006152e281284d31dee6c6726df790c3c486b6899a0746f334a8d0663fabc7) for local testing of rate-limit behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 360e13f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Grok/xAI prompt settlement semantics for rate_limit and error completions; incorrect handling could mis-report failures or break hung-prompt fallback, but scope is limited to the xAI ACP extension with targeted tests.
> 
> **Overview**
> **Grok usage limits and xAI prompt errors now fail the turn instead of looking like a silent success.**
> 
> When `_x.ai/session/prompt_complete` arrives with `stopReason` `rate_limit` or `error`, `XAiAcpExtension` resolves the pending prompt via new `settleXAiPromptCompletion` by **failing** the deferred with `AcpRequestError` (usage limit uses code `-32003` and *"Grok usage limit reached. Try again later."*; generic errors use `agentResult` when present). Pending completions are typed to allow failure, so this no longer races into a fake successful `end_turn` completion.
> 
> The ACP mock adds `T3_ACP_EMIT_XAI_RATE_LIMIT_THEN_HANG` to simulate rate-limit-then-hang behavior. Tests cover the xAI extension and full Grok adapter path: failed turn, session back to **ready**, and **selected model unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360e13fb05395825e6bf70a6c93ea0611992b113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->