### PR TITLE
fix(server): handle files named HEAD in git status

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -950,6 +950,27 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       }),
     );
 
+    it.effect("reports changes to a file named HEAD", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        yield* writeTextFile(cwd, "HEAD", "first line\n");
+        yield* git(cwd, ["add", "HEAD"]);
+        yield* git(cwd, ["commit", "-m", "add HEAD file"]);
+        yield* writeTextFile(cwd, "HEAD", "first line\nsecond line\n");
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
+
+        assert.equal(status.isRepo, true);
+        assert.equal(status.hasWorkingTreeChanges, true);
+        assert.deepInclude(status.workingTree.files, {
+          path: "HEAD",
+          insertions: 1,
+          deletions: 0,
+        });
+      }),
+    );
+
     it.effect("reports default-branch delta separately from upstream delta", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -420,9 +420,10 @@ function isNonRepositoryGitStderr(stderr: string): boolean {
   return stderr.toLowerCase().includes("not a git repository");
 }
 function isUnbornHeadStderr(stderr: string): boolean {
+  const normalized = stderr.toLowerCase();
   return (
-    stderr.toLowerCase().includes("unknown revision") &&
-    stderr.toLowerCase().includes("path not in the working tree")
+    normalized.includes("bad revision 'head'") ||
+    (normalized.includes("unknown revision") && normalized.includes("path not in the working tree"))
   );
 }
 
@@ -1600,7 +1601,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         executeGitWithStableDiagnostics(
           "GitVcsDriver.statusDetails.numstat",
           cwd,
-          ["diff", "HEAD", "--numstat"],
+          ["diff", "HEAD", "--numstat", "--"],
           { allowNonZeroExit: true },
         ).pipe(
           Effect.flatMap((result) => {
@@ -1642,7 +1643,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
                 ...gitCommandContext({
                   operation: "GitVcsDriver.statusDetails.numstat",
                   cwd,
-                  args: ["diff", "HEAD", "--numstat"],
+                  args: ["diff", "HEAD", "--numstat", "--"],
                 }),
                 detail: "git diff HEAD --numstat failed.",
                 exitCode: result.exitCode,


### PR DESCRIPTION
## What Changed

Disambiguate `HEAD` as a Git revision when collecting working-tree numstat data. The status path now terminates revision arguments with `--` and preserves the existing fallback for repositories that do not have an initial commit yet.

A focused integration test creates and modifies a tracked file named `HEAD`, then verifies that `GitVcsDriver.statusDetails()` reports its line counts.

## Why

`git diff HEAD --numstat` treats `HEAD` as ambiguous when the worktree also contains a file with that name, causing Git status collection to fail with exit code 128. The explicit revision/path boundary keeps valid repositories reportable without changing normal status behavior.

## Validation

- `node_modules/.bin/vp test run apps/server/src/vcs/GitVcsDriverCore.test.ts` — 48 passed
- `node_modules/.bin/vp run --filter t3 typecheck`
- Focused lint and format checks for both changed files

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes
- [x] No motion or interaction changes

---

Implemented with OpenAI GPT-5.6 through the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `git diff HEAD --numstat` to handle files named HEAD in git status
> - Adds a pathspec separator `--` to the `git diff HEAD --numstat` invocation in `statusDetails`, preventing Git from misinterpreting path tokens and allowing files literally named `HEAD` to appear in working tree changes.
> - Expands `isUnbornHeadStderr` in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/6397/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) to also match `"bad revision 'head'"` (case-insensitive), covering an additional Git error variant for unborn HEAD detection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdfbeee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow VCS status fix with a regression test; normal repos are unchanged aside from the explicit `--` on the diff invocation.
> 
> **Overview**
> Fixes **Git status collection** when the worktree contains a tracked file named `HEAD`. `statusDetails` now runs `git diff HEAD --numstat` with a trailing `--` so Git treats `HEAD` as the revision, not a pathspec.
> 
> **`isUnbornHeadStderr`** also recognizes `bad revision 'head'`, so the existing unborn-HEAD numstat fallback still applies when appropriate.
> 
> An integration test commits a file named `HEAD`, modifies it, and asserts `statusDetails` reports the path and line counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdfbeee2e410b026a279b445e2fd69811fd4edc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->