### PR TITLE
feat(web): drag reorder right-panel tabs

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3434,6 +3434,13 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [activeThreadRef, diffOpen, onDiffPanelOpen],
   );
+  const reorderRightPanelSurface = useCallback(
+    (surfaceId: string, targetSurfaceId: string) => {
+      if (!activeThreadRef) return;
+      useRightPanelStore.getState().reorderSurface(activeThreadRef, surfaceId, targetSurfaceId);
+    },
+    [activeThreadRef],
+  );
   const toggleRightPanel = useCallback(() => {
     if (!activeThreadRef) return;
     if (rightPanelOpen) {
@@ -6548,6 +6555,7 @@ function ChatViewContent(props: ChatViewProps) {
           onCloseOtherSurfaces={closeOtherRightPanelSurfaces}
           onCloseSurfacesToRight={closeRightPanelSurfacesToRight}
           onCloseAllSurfaces={closeAllRightPanelSurfaces}
+          onReorderSurface={reorderRightPanelSurface}
           onCopyFilePath={copyRightPanelFilePath}
           onAddBrowser={createBrowserSurface}
           onAddTerminal={addTerminalSurface}
@@ -6582,6 +6590,7 @@ function ChatViewContent(props: ChatViewProps) {
             onCloseOtherSurfaces={closeOtherRightPanelSurfaces}
             onCloseSurfacesToRight={closeRightPanelSurfacesToRight}
             onCloseAllSurfaces={closeAllRightPanelSurfaces}
+            onReorderSurface={reorderRightPanelSurface}
             onCopyFilePath={copyRightPanelFilePath}
             onAddBrowser={createBrowserSurface}
             onAddTerminal={addTerminalSurface}

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -547,7 +547,7 @@ function SortableSurfaceTab(props: {
       onAuxClick={(event) => props.onAuxClick(event, props.surface)}
       onContextMenu={(event) => props.onContextMenu(event, props.surface)}
       className={cn(
-        "cursor-grab group/tab flex h-6 max-w-36 shrink-0 items-center gap-0.5 rounded-md pr-2 pl-1.5 text-xs [-webkit-app-region:no-drag]",
+        "cursor-pointer group/tab flex h-6 max-w-36 shrink-0 items-center gap-0.5 rounded-md pr-2 pl-1.5 text-xs [-webkit-app-region:no-drag]",
         props.active
           ? "bg-accent text-foreground"
           : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
@@ -582,7 +582,7 @@ function SortableSurfaceTab(props: {
           render={
             <button
               type="button"
-              className="cursor-grab flex min-w-0 items-center active:cursor-grabbing"
+              className="cursor-pointer flex min-w-0 items-center"
               onClick={() => props.onActivate(props.surface)}
             >
               <span className="truncate">{props.title}</span>

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -518,6 +518,7 @@ function SurfaceIcon({
 function SortableSurfaceTab(props: {
   surface: RightPanelSurface;
   active: boolean;
+  tabDragActive: boolean;
   pending: boolean;
   title: string;
   sessions: Readonly<Record<string, PreviewSessionSnapshot>>;
@@ -547,16 +548,20 @@ function SortableSurfaceTab(props: {
       onAuxClick={(event) => props.onAuxClick(event, props.surface)}
       onContextMenu={(event) => props.onContextMenu(event, props.surface)}
       className={cn(
-        "cursor-pointer group/tab flex h-6 max-w-36 shrink-0 items-center gap-0.5 rounded-md pr-2 pl-1.5 text-xs [-webkit-app-region:no-drag]",
+        "group/tab flex h-6 max-w-36 shrink-0 items-center gap-0.5 rounded-md pr-2 pl-1.5 text-xs [-webkit-app-region:no-drag]",
+        props.tabDragActive ? "cursor-grabbing" : "cursor-pointer",
         props.active
           ? "bg-accent text-foreground"
           : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
-        isDragging && "z-10 cursor-grabbing opacity-70",
+        isDragging && "z-10 opacity-70",
       )}
     >
       <button
         type="button"
-        className="cursor-pointer group/close relative flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted"
+        className={cn(
+          "group/close relative flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted",
+          props.tabDragActive ? "cursor-grabbing" : "cursor-pointer",
+        )}
         aria-label={`Close ${props.title}`}
         onPointerDown={(event) => event.stopPropagation()}
         onClick={() => props.onClose(props.surface)}
@@ -582,7 +587,10 @@ function SortableSurfaceTab(props: {
           render={
             <button
               type="button"
-              className="cursor-pointer flex min-w-0 items-center"
+              className={cn(
+                "flex min-w-0 items-center",
+                props.tabDragActive ? "cursor-grabbing" : "cursor-pointer",
+              )}
               onClick={() => props.onActivate(props.surface)}
             >
               <span className="truncate">{props.title}</span>
@@ -599,6 +607,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
   const ownsDesktopTitleBar = isElectron && props.mode === "inline";
   const { resolvedTheme } = useTheme();
   const tabListRef = useRef<HTMLDivElement>(null);
+  const [tabDragActive, setTabDragActive] = useState(false);
   const tabSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   );
@@ -675,6 +684,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
   );
   const handleTabDragEnd = useCallback(
     (event: DragEndEvent) => {
+      setTabDragActive(false);
       const targetSurfaceId = event.over?.id;
       if (targetSurfaceId === undefined || event.active.id === targetSurfaceId) return;
       props.onReorderSurface(String(event.active.id), String(targetSurfaceId));
@@ -683,12 +693,14 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
   );
   const handleTabDragStart = useCallback(
     (event: DragStartEvent) => {
+      setTabDragActive(true);
       const surface = props.surfaces.find((entry) => entry.id === String(event.active.id));
       if (!surface || surface.id === props.activeSurfaceId) return;
       props.onActivate(surface);
     },
     [props],
   );
+  const handleTabDragCancel = useCallback(() => setTabDragActive(false), []);
 
   useEffect(() => {
     const activeTab = tabListRef.current?.querySelector<HTMLElement>("[data-active-tab='true']");
@@ -724,18 +736,25 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
             collisionDetection={closestCenter}
             modifiers={[restrictToHorizontalAxis, restrictToFirstScrollableAncestor]}
             onDragStart={handleTabDragStart}
+            onDragCancel={handleTabDragCancel}
             onDragEnd={handleTabDragEnd}
           >
             <SortableContext
               items={props.surfaces.map((surface) => surface.id)}
               strategy={horizontalListSortingStrategy}
             >
-              <div className="flex h-full w-max min-w-full items-center gap-1">
+              <div
+                className={cn(
+                  "flex h-full w-max min-w-full items-center gap-1",
+                  tabDragActive && "cursor-grabbing",
+                )}
+              >
                 {props.surfaces.map((surface) => (
                   <SortableSurfaceTab
                     key={surface.id}
                     surface={surface}
                     active={surface.id === props.activeSurfaceId}
+                    tabDragActive={tabDragActive}
                     pending={props.pendingSurfaceIds.has(surface.id)}
                     title={surfaceTitle(surface, props.previewSessions, props.terminalLabelsById)}
                     sessions={props.previewSessions}
@@ -751,7 +770,10 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
                 {props.surfaces.length > 0 ? (
                   <Menu>
                     <MenuTrigger
-                      className="cursor-pointer relative inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                      className={cn(
+                        "relative inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground",
+                        tabDragActive ? "cursor-grabbing" : "cursor-pointer",
+                      )}
                       aria-label="Add panel surface"
                     >
                       <Plus className="size-3.5" />

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -1,3 +1,15 @@
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  type DragEndEvent,
+  type DragStartEvent,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { restrictToFirstScrollableAncestor, restrictToHorizontalAxis } from "@dnd-kit/modifiers";
+import { SortableContext, horizontalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import type { ContextMenuItem, PreviewSessionSnapshot, PullRequestState } from "@t3tools/contracts";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import {
@@ -54,6 +66,7 @@ interface RightPanelTabsProps {
   onCloseOtherSurfaces: (surface: RightPanelSurface) => void;
   onCloseSurfacesToRight: (surface: RightPanelSurface) => void;
   onCloseAllSurfaces: () => void;
+  onReorderSurface: (surfaceId: string, targetSurfaceId: string) => void;
   onCopyFilePath: (relativePath: string) => void;
   onAddBrowser: () => void;
   onAddTerminal: () => void;
@@ -502,10 +515,93 @@ function SurfaceIcon({
   }
 }
 
+function SortableSurfaceTab(props: {
+  surface: RightPanelSurface;
+  active: boolean;
+  pending: boolean;
+  title: string;
+  sessions: Readonly<Record<string, PreviewSessionSnapshot>>;
+  theme: "light" | "dark";
+  pullRequestStatuses: Readonly<Record<string, PullRequestTabStatus>> | undefined;
+  onActivate: (surface: RightPanelSurface) => void;
+  onClose: (surface: RightPanelSurface) => void;
+  onMouseDown: (event: ReactMouseEvent) => void;
+  onAuxClick: (event: ReactMouseEvent, surface: RightPanelSurface) => void;
+  onContextMenu: (event: ReactMouseEvent, surface: RightPanelSurface) => void;
+}) {
+  const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: props.surface.id,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        transition,
+      }}
+      {...listeners}
+      data-active-tab={props.active}
+      data-dragging-tab={isDragging || undefined}
+      onMouseDown={props.onMouseDown}
+      onAuxClick={(event) => props.onAuxClick(event, props.surface)}
+      onContextMenu={(event) => props.onContextMenu(event, props.surface)}
+      className={cn(
+        "cursor-pointer group/tab flex h-6 max-w-36 shrink-0 items-center gap-0.5 rounded-md pr-2 pl-1.5 text-xs [-webkit-app-region:no-drag]",
+        props.active
+          ? "bg-accent text-foreground"
+          : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+        isDragging && "z-10 opacity-70",
+      )}
+    >
+      <button
+        type="button"
+        className="cursor-pointer group/close relative flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted"
+        aria-label={`Close ${props.title}`}
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={() => props.onClose(props.surface)}
+      >
+        <span className="relative flex size-3 items-center justify-center group-hover/tab:hidden group-focus-visible/close:hidden">
+          <SurfaceIcon
+            surface={props.surface}
+            sessions={props.sessions}
+            theme={props.theme}
+            pullRequestStatuses={props.pullRequestStatuses}
+          />
+          {props.pending ? (
+            <span
+              className="absolute -right-0.5 -bottom-0.5 size-1.5 rounded-full bg-current"
+              aria-hidden
+            />
+          ) : null}
+        </span>
+        <X className="hidden size-3 group-hover/tab:block group-focus-visible/close:block" />
+      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              className="cursor-pointer flex min-w-0 items-center"
+              onClick={() => props.onActivate(props.surface)}
+            >
+              <span className="truncate">{props.title}</span>
+            </button>
+          }
+        />
+        <TooltipPopup>{props.title}</TooltipPopup>
+      </Tooltip>
+    </div>
+  );
+}
+
 export function RightPanelTabs(props: RightPanelTabsProps) {
   const ownsDesktopTitleBar = isElectron && props.mode === "inline";
   const { resolvedTheme } = useTheme();
   const tabListRef = useRef<HTMLDivElement>(null);
+  const tabSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
 
   const handleTabContextMenu = useCallback(
     async (event: ReactMouseEvent, surface: RightPanelSurface) => {
@@ -577,6 +673,22 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
     },
     [props],
   );
+  const handleTabDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const targetSurfaceId = event.over?.id;
+      if (targetSurfaceId === undefined || event.active.id === targetSurfaceId) return;
+      props.onReorderSurface(String(event.active.id), String(targetSurfaceId));
+    },
+    [props],
+  );
+  const handleTabDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const surface = props.surfaces.find((entry) => entry.id === String(event.active.id));
+      if (!surface || surface.id === props.activeSurfaceId) return;
+      props.onActivate(surface);
+    },
+    [props],
+  );
 
   useEffect(() => {
     const activeTab = tabListRef.current?.querySelector<HTMLElement>("[data-active-tab='true']");
@@ -607,125 +719,98 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
           className={cn("min-w-0 flex-1 rounded-none", ownsDesktopTitleBar && "drag-region")}
           data-right-panel-tab-list
         >
-          <div className="flex h-full w-max min-w-full items-center gap-1">
-            {props.surfaces.map((surface) => {
-              const active = surface.id === props.activeSurfaceId;
-              const pending = props.pendingSurfaceIds.has(surface.id);
-              const title = surfaceTitle(surface, props.previewSessions, props.terminalLabelsById);
-              return (
-                <div
-                  key={surface.id}
-                  data-active-tab={active}
-                  onMouseDown={handleTabMouseDown}
-                  onAuxClick={(event) => handleTabAuxClick(event, surface)}
-                  onContextMenu={(event) => void handleTabContextMenu(event, surface)}
-                  className={cn(
-                    "cursor-pointer group/tab flex h-6 max-w-36 shrink-0 items-center gap-0.5 rounded-md pr-2 pl-1.5 text-xs",
-                    active
-                      ? "bg-accent text-foreground"
-                      : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
-                  )}
-                >
-                  <button
-                    type="button"
-                    className="cursor-pointer group/close relative flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted"
-                    aria-label={`Close ${title}`}
-                    onClick={() => props.onCloseSurface(surface)}
-                  >
-                    <span className="relative flex size-3 items-center justify-center group-hover/tab:hidden group-focus-visible/close:hidden">
-                      <SurfaceIcon
-                        surface={surface}
-                        sessions={props.previewSessions}
-                        theme={resolvedTheme}
-                        pullRequestStatuses={props.pullRequestStatuses}
-                      />
-                      {pending ? (
-                        <span
-                          className="absolute -right-0.5 -bottom-0.5 size-1.5 rounded-full bg-current"
-                          aria-hidden
-                        />
-                      ) : null}
-                    </span>
-                    <X className="hidden size-3 group-hover/tab:block group-focus-visible/close:block" />
-                  </button>
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <button
-                          type="button"
-                          className="cursor-pointer flex min-w-0 items-center"
-                          onClick={() => props.onActivate(surface)}
-                        >
-                          <span className="truncate">{title}</span>
-                        </button>
-                      }
-                    />
-                    <TooltipPopup>{title}</TooltipPopup>
-                  </Tooltip>
-                </div>
-              );
-            })}
-            {props.surfaces.length > 0 ? (
-              <Menu>
-                <MenuTrigger
-                  className="cursor-pointer relative inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-                  aria-label="Add panel surface"
-                >
-                  <Plus className="size-3.5" />
-                </MenuTrigger>
-                <MenuPopup align="start" side="bottom" sideOffset={6} className="min-w-44">
-                  <SurfaceMenuItem
-                    available={props.browserAvailable}
-                    disabledReason={SURFACE_DISABLED_REASONS.browser}
-                    onClick={props.onAddBrowser}
-                  >
-                    <Globe2 />
-                    Browser
-                  </SurfaceMenuItem>
-                  <SurfaceMenuItem
-                    available={props.terminalAvailable}
-                    disabledReason={SURFACE_DISABLED_REASONS.terminal}
-                    onClick={props.onAddTerminal}
-                  >
-                    <TerminalSquare />
-                    Terminal
-                  </SurfaceMenuItem>
-                  <SurfaceMenuItem
-                    available={props.filesAvailable}
-                    disabledReason={SURFACE_DISABLED_REASONS.files}
-                    onClick={props.onAddFiles}
-                  >
-                    <Files />
-                    Files
-                  </SurfaceMenuItem>
-                  <SurfaceMenuItem
-                    available={props.diffAvailable}
-                    disabledReason={SURFACE_DISABLED_REASONS.diff}
-                    onClick={props.onAddDiff}
-                  >
-                    <FileDiff />
-                    Diff
-                  </SurfaceMenuItem>
-                  <SurfaceMenuItem
-                    available={props.pullRequestAvailable}
-                    disabledReason={SURFACE_DISABLED_REASONS.pullRequest}
-                    onClick={props.onAddPullRequest}
-                  >
-                    <GitPullRequest />
-                    Pull request
-                  </SurfaceMenuItem>
-                  <SurfaceMenuItem
-                    available={props.agentsAvailable}
-                    disabledReason={SURFACE_DISABLED_REASONS.agents}
-                    onClick={props.onAddAgents}
-                  >
-                    <Bot />
-                    Agents
-                  </SurfaceMenuItem>
-                </MenuPopup>
-              </Menu>
-            ) : null}
-          </div>
+          <DndContext
+            sensors={tabSensors}
+            collisionDetection={closestCenter}
+            modifiers={[restrictToHorizontalAxis, restrictToFirstScrollableAncestor]}
+            onDragStart={handleTabDragStart}
+            onDragEnd={handleTabDragEnd}
+          >
+            <SortableContext
+              items={props.surfaces.map((surface) => surface.id)}
+              strategy={horizontalListSortingStrategy}
+            >
+              <div className="flex h-full w-max min-w-full items-center gap-1">
+                {props.surfaces.map((surface) => (
+                  <SortableSurfaceTab
+                    key={surface.id}
+                    surface={surface}
+                    active={surface.id === props.activeSurfaceId}
+                    pending={props.pendingSurfaceIds.has(surface.id)}
+                    title={surfaceTitle(surface, props.previewSessions, props.terminalLabelsById)}
+                    sessions={props.previewSessions}
+                    theme={resolvedTheme}
+                    pullRequestStatuses={props.pullRequestStatuses}
+                    onActivate={props.onActivate}
+                    onClose={props.onCloseSurface}
+                    onMouseDown={handleTabMouseDown}
+                    onAuxClick={handleTabAuxClick}
+                    onContextMenu={(event, entry) => void handleTabContextMenu(event, entry)}
+                  />
+                ))}
+                {props.surfaces.length > 0 ? (
+                  <Menu>
+                    <MenuTrigger
+                      className="cursor-pointer relative inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                      aria-label="Add panel surface"
+                    >
+                      <Plus className="size-3.5" />
+                    </MenuTrigger>
+                    <MenuPopup align="start" side="bottom" sideOffset={6} className="min-w-44">
+                      <SurfaceMenuItem
+                        available={props.browserAvailable}
+                        disabledReason={SURFACE_DISABLED_REASONS.browser}
+                        onClick={props.onAddBrowser}
+                      >
+                        <Globe2 />
+                        Browser
+                      </SurfaceMenuItem>
+                      <SurfaceMenuItem
+                        available={props.terminalAvailable}
+                        disabledReason={SURFACE_DISABLED_REASONS.terminal}
+                        onClick={props.onAddTerminal}
+                      >
+                        <TerminalSquare />
+                        Terminal
+                      </SurfaceMenuItem>
+                      <SurfaceMenuItem
+                        available={props.filesAvailable}
+                        disabledReason={SURFACE_DISABLED_REASONS.files}
+                        onClick={props.onAddFiles}
+                      >
+                        <Files />
+                        Files
+                      </SurfaceMenuItem>
+                      <SurfaceMenuItem
+                        available={props.diffAvailable}
+                        disabledReason={SURFACE_DISABLED_REASONS.diff}
+                        onClick={props.onAddDiff}
+                      >
+                        <FileDiff />
+                        Diff
+                      </SurfaceMenuItem>
+                      <SurfaceMenuItem
+                        available={props.pullRequestAvailable}
+                        disabledReason={SURFACE_DISABLED_REASONS.pullRequest}
+                        onClick={props.onAddPullRequest}
+                      >
+                        <GitPullRequest />
+                        Pull request
+                      </SurfaceMenuItem>
+                      <SurfaceMenuItem
+                        available={props.agentsAvailable}
+                        disabledReason={SURFACE_DISABLED_REASONS.agents}
+                        onClick={props.onAddAgents}
+                      >
+                        <Bot />
+                        Agents
+                      </SurfaceMenuItem>
+                    </MenuPopup>
+                  </Menu>
+                ) : null}
+              </div>
+            </SortableContext>
+          </DndContext>
         </ScrollArea>
         {props.layoutControls}
       </div>

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -47,6 +47,7 @@ import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 
 import { PreviewPanelShell, type PreviewPanelMode } from "./preview/PreviewPanelShell";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
+import { scrollActiveRightPanelTabIntoView } from "./rightPanelTabs.logic";
 
 interface RightPanelTabsProps {
   mode: PreviewPanelMode;
@@ -704,8 +705,8 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
 
   useEffect(() => {
     const activeTab = tabListRef.current?.querySelector<HTMLElement>("[data-active-tab='true']");
-    activeTab?.scrollIntoView({ block: "nearest", inline: "nearest" });
-  }, [props.activeSurfaceId]);
+    scrollActiveRightPanelTabIntoView(activeTab ?? null, tabDragActive);
+  }, [props.activeSurfaceId, tabDragActive]);
 
   return (
     <PreviewPanelShell

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -547,11 +547,11 @@ function SortableSurfaceTab(props: {
       onAuxClick={(event) => props.onAuxClick(event, props.surface)}
       onContextMenu={(event) => props.onContextMenu(event, props.surface)}
       className={cn(
-        "cursor-pointer group/tab flex h-6 max-w-36 shrink-0 items-center gap-0.5 rounded-md pr-2 pl-1.5 text-xs [-webkit-app-region:no-drag]",
+        "cursor-grab group/tab flex h-6 max-w-36 shrink-0 items-center gap-0.5 rounded-md pr-2 pl-1.5 text-xs [-webkit-app-region:no-drag]",
         props.active
           ? "bg-accent text-foreground"
           : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
-        isDragging && "z-10 opacity-70",
+        isDragging && "z-10 cursor-grabbing opacity-70",
       )}
     >
       <button
@@ -582,7 +582,7 @@ function SortableSurfaceTab(props: {
           render={
             <button
               type="button"
-              className="cursor-pointer flex min-w-0 items-center"
+              className="cursor-grab flex min-w-0 items-center active:cursor-grabbing"
               onClick={() => props.onActivate(props.surface)}
             >
               <span className="truncate">{props.title}</span>

--- a/apps/web/src/components/rightPanelTabs.logic.test.ts
+++ b/apps/web/src/components/rightPanelTabs.logic.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { scrollActiveRightPanelTabIntoView } from "./rightPanelTabs.logic";
+
+describe("scrollActiveRightPanelTabIntoView", () => {
+  it("does not scroll the active tab into view during a tab drag", () => {
+    const scrollIntoView = vi.fn();
+
+    scrollActiveRightPanelTabIntoView({ scrollIntoView }, true);
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("scrolls the active tab into view outside a tab drag", () => {
+    const scrollIntoView = vi.fn();
+
+    scrollActiveRightPanelTabIntoView({ scrollIntoView }, false);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
+  });
+});

--- a/apps/web/src/components/rightPanelTabs.logic.ts
+++ b/apps/web/src/components/rightPanelTabs.logic.ts
@@ -1,0 +1,11 @@
+interface ScrollableTab {
+  scrollIntoView: (options: ScrollIntoViewOptions) => void;
+}
+
+export function scrollActiveRightPanelTabIntoView(
+  activeTab: ScrollableTab | null,
+  tabDragActive: boolean,
+): void {
+  if (tabDragActive) return;
+  activeTab?.scrollIntoView({ block: "nearest", inline: "nearest" });
+}

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -683,6 +683,37 @@ describe("rightPanelStore", () => {
     });
   });
 
+  it("reorders surfaces without changing the active surface", () => {
+    useRightPanelStore.getState().openBrowser(refA, "tab-a");
+    useRightPanelStore.getState().openTerminal(refA, "term-1");
+    useRightPanelStore.getState().openFile(refA, "src/index.ts");
+
+    useRightPanelStore.getState().reorderSurface(refA, "file:src/index.ts", "browser:tab-a");
+
+    const state = selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA);
+    expect(state.surfaces.map((surface) => surface.id)).toEqual([
+      "file:src/index.ts",
+      "browser:tab-a",
+      "terminal:term-1",
+    ]);
+    expect(state.activeSurfaceId).toBe("file:src/index.ts");
+  });
+
+  it("keeps a custom surface order while reconciling browser sessions", () => {
+    useRightPanelStore.getState().openTerminal(refA, "term-1");
+    useRightPanelStore.getState().openBrowser(refA, "tab-a");
+    useRightPanelStore.getState().openBrowser(refA, "tab-b");
+    useRightPanelStore.getState().reorderSurface(refA, "browser:tab-b", "terminal:term-1");
+
+    useRightPanelStore.getState().reconcileBrowserSurfaces(refA, ["tab-a", "tab-b", "tab-c"]);
+
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA).surfaces.map(
+        (surface) => surface.id,
+      ),
+    ).toEqual(["browser:tab-b", "terminal:term-1", "browser:tab-a", "browser:tab-c"]);
+  });
+
   it("reconciles browser surfaces without deleting other surface kinds", () => {
     useRightPanelStore.getState().openTerminal(refA, "term-1");
     useRightPanelStore.getState().openBrowser(refA, "tab-a");

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -108,6 +108,7 @@ interface RightPanelStoreState {
   closeOtherSurfaces: (ref: ScopedThreadRef, surfaceId: string) => void;
   closeSurfacesToRight: (ref: ScopedThreadRef, surfaceId: string) => void;
   closeAllSurfaces: (ref: ScopedThreadRef) => void;
+  reorderSurface: (ref: ScopedThreadRef, surfaceId: string, targetSurfaceId: string) => void;
   reconcileBrowserSurfaces: (ref: ScopedThreadRef, tabIds: readonly string[]) => void;
   reconcileFileSurfaces: (ref: ScopedThreadRef, workspaceAvailable: boolean) => void;
   show: (ref: ScopedThreadRef) => void;
@@ -559,22 +560,33 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               : { ...current, isOpen: false, surfaces: [], activeSurfaceId: null },
           ),
         })),
+      reorderSurface: (ref, surfaceId, targetSurfaceId) =>
+        set((state) => ({
+          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+            const fromIndex = current.surfaces.findIndex((surface) => surface.id === surfaceId);
+            const toIndex = current.surfaces.findIndex((surface) => surface.id === targetSurfaceId);
+            if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) return current;
+            const surfaces = [...current.surfaces];
+            const [surface] = surfaces.splice(fromIndex, 1);
+            if (!surface) return current;
+            surfaces.splice(toIndex, 0, surface);
+            return { ...current, surfaces };
+          }),
+        })),
       reconcileBrowserSurfaces: (ref, tabIds) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
             const validIds = new Set(tabIds.map((tabId) => `browser:${tabId}`));
-            const nonBrowser = current.surfaces.filter((surface) => surface.kind !== "preview");
-            const existingBrowser = current.surfaces.filter(
-              (surface): surface is Extract<RightPanelSurface, { kind: "preview" }> =>
-                surface.kind === "preview" &&
-                surface.id !== "browser:new" &&
-                validIds.has(surface.id),
+            const existing = current.surfaces.filter(
+              (surface) =>
+                surface.kind !== "preview" ||
+                (surface.id !== "browser:new" && validIds.has(surface.id)),
             );
-            const knownIds = new Set(existingBrowser.map((surface) => surface.id));
+            const knownIds = new Set(existing.map((surface) => surface.id));
             const added = tabIds
               .filter((tabId) => !knownIds.has(`browser:${tabId}`))
               .map((tabId) => browserSurface(tabId));
-            const surfaces = [...nonBrowser, ...existingBrowser, ...added];
+            const surfaces = [...existing, ...added];
             const activeStillExists = surfaces.some(
               (surface) => surface.id === current.activeSurfaceId,
             );

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1511,6 +1511,10 @@ function PullRequestsRouteView() {
     useRightPanelStore.getState().closeAllSurfaces(rightPanelRef);
     selectSurfaceInUrl(null);
   };
+  const reorderSurface = (surfaceId: string, targetSurfaceId: string) => {
+    if (rightPanelRef === null) return;
+    useRightPanelStore.getState().reorderSurface(rightPanelRef, surfaceId, targetSurfaceId);
+  };
 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
@@ -1544,6 +1548,7 @@ function PullRequestsRouteView() {
               if (surface.kind === "pull-request") closeSurfacesToRight(surface);
             }}
             onCloseAllSurfaces={closeAllSurfaces}
+            onReorderSurface={reorderSurface}
             onCopyFilePath={() => undefined}
             onAddBrowser={() => undefined}
             onAddTerminal={() => undefined}

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -41,6 +41,7 @@ T3 Code works with the platforms your team already uses:
 - Open several reviews from the **Pull requests** page as tabs in the right panel
 - While working in a thread, open linked reviews in the same compact right-panel tabs without
   leaving the conversation
+- Drag right-panel tabs to arrange them in the order that works for you
 - Open the review directly in your browser with one click
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally


### PR DESCRIPTION
## What Changed

- Makes every right-panel tab reorderable in the shared web/desktop tab strip, including chat sheets and pull request tabs.
- Activates an inactive tab as soon as it is picked up, matching browser tab behavior.
- Persists the new order per thread and preserves custom interleaving when browser surfaces reconcile.

## Why

Right-panel surfaces currently stay in creation order, which makes it harder to organize several files, terminals, previews, and pull requests. Drag-to-reorder gives users the familiar browser-tab interaction while keeping the existing active surface and close-to-the-right behavior coherent with the visible order.

## UI Changes

- Before: Right-panel tabs stayed in creation order.
- After: Tabs can be dragged horizontally; picking up an inactive tab activates it immediately.

## Interaction video:

https://github.com/user-attachments/assets/4575b6ef-cb89-4c25-8782-d2882b5dffeb

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included a video for animation/interaction changes

Generated with GPT-5.6-sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only panel tab ordering with unit tests; reconcile change is localized to browser surface sync behavior.
> 
> **Overview**
> **Adds horizontal drag-to-reorder for right-panel tabs** (chat, desktop, and pull-requests), using `@dnd-kit` sortable tabs with a 6px drag threshold and horizontal-only movement.
> 
> Dropping a tab on another calls **`reorderSurface`** on the per-thread right panel store, which moves surfaces in the list **without changing the active tab**. Picking up an inactive tab **activates it immediately** (browser-style). **`reconcileBrowserSurfaces`** no longer groups non-browser tabs ahead of browsers—it keeps the current order and only appends new browser tabs.
> 
> Active-tab auto-scroll is **skipped while dragging** via `scrollActiveRightPanelTabIntoView`; user docs mention drag reorder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29537f172853a18a50397a8ceecfefc0b216caa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drag-to-reorder support for right-panel tabs
> - Implements drag-and-drop tab reordering in [RightPanelTabs.tsx](https://github.com/pingdotgg/t3code/pull/6404/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91) using `@dnd-kit`, with a new `SortableSurfaceTab` component that handles drag listeners and styles.
> - Adds `reorderSurface` to the right panel store in [rightPanelStore.ts](https://github.com/pingdotgg/t3code/pull/6404/files#diff-c23667fc6a40049fa00d6fba14ae4a097ed3561fcdfb9ec172bc8216cd9f82eb), which moves a surface to a target index and preserves custom ordering during browser tab reconciliation.
> - Suppresses auto-scroll of the active tab while a drag is in progress via a new `scrollActiveRightPanelTabIntoView` helper in [rightPanelTabs.logic.ts](https://github.com/pingdotgg/t3code/pull/6404/files#diff-c3f195e098390f0ca4521476b8ed85d7e9681c64bac94a3744350ce59bf53412).
> - Wires the `onReorderSurface` prop through `ChatView` and the pull requests route to connect UI events to the store.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29537f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->