### PR TITLE
feat(web): quote reply to pull request comments

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -12,11 +12,12 @@ import {
   HammerIcon,
   MessageSquareIcon,
   PencilIcon,
+  ReplyIcon,
   SendIcon,
   TagIcon,
   UsersIcon,
 } from "lucide-react";
-import { useRef, useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode, type Ref } from "react";
 
 import { useAtomCommand } from "~/state/use-atom-command";
 import { pullRequestEnvironment } from "~/state/pullRequests";
@@ -40,6 +41,7 @@ import { PullRequestActivityUnavailableState } from "./PullRequestActivityUnavai
 import {
   orderPullRequestComments,
   pullRequestFindingKey,
+  quoteReplyDraft,
   type PullRequestFinding,
 } from "./pullRequestDetail.logic";
 import {
@@ -280,43 +282,22 @@ function Section({
 }
 
 function CommentComposer({
-  environmentId,
-  detail,
-  onCommented,
+  body,
+  posting,
+  textareaRef,
+  onBodyChange,
+  onSubmit,
 }: {
-  environmentId: EnvironmentId;
-  detail: PullRequestDetailView;
-  onCommented: () => void;
+  body: string;
+  posting: boolean;
+  textareaRef: Ref<HTMLTextAreaElement>;
+  onBodyChange: (body: string) => void;
+  onSubmit: () => void;
 }) {
-  const [body, setBody] = useState("");
-  const [posting, setPosting] = useState(false);
-  const postComment = useAtomCommand(pullRequestEnvironment.comment, { reportFailure: false });
-
-  const submit = async () => {
-    const trimmed = body.trim();
-    if (trimmed.length === 0 || posting) return;
-    setPosting(true);
-    const result = await postComment({
-      environmentId,
-      input: {
-        projectId: detail.projectId,
-        repository: detail.repository,
-        number: detail.number,
-        body: trimmed,
-      },
-    });
-    setPosting(false);
-    if (result._tag === "Failure") {
-      toastManager.add({ type: "error", title: "Could not post the comment" });
-      return;
-    }
-    setBody("");
-    onCommented();
-  };
-
   return (
     <div className="mt-3 space-y-2">
       <Textarea
+        ref={textareaRef}
         // Locked while posting: the body is cleared on success, which would otherwise throw
         // away a new draft typed while the request was still in flight.
         disabled={posting}
@@ -324,14 +305,14 @@ function CommentComposer({
         rows={3}
         placeholder="Leave a comment"
         aria-label="Comment on this pull request"
-        onChange={(event) => setBody(event.target.value)}
+        onChange={(event) => onBodyChange(event.target.value)}
       />
       <div className="flex justify-end">
         <Button
           size="xs"
           variant="outline"
           disabled={body.trim().length === 0 || posting}
-          onClick={() => void submit()}
+          onClick={onSubmit}
         >
           <SendIcon className="size-3.5" />
           {posting ? "Posting..." : "Comment"}
@@ -381,6 +362,53 @@ export function PullRequestSummaryTab({
   const hiddenCommentCount = detail.comments.length - recentComments.length;
   const [commentOrder, setCommentOrder] = useState<"newest" | "oldest">("newest");
   const visibleComments = orderPullRequestComments(recentComments, commentOrder);
+
+  const canComment = detail.capabilities.comment && detail.viewerPermissions.comment;
+  // The draft is keyed by the pull request the same way the paging window is, so opening another
+  // one starts from an empty box rather than a half-written reply to a different conversation.
+  const [draft, setDraft] = useState({ url: detail.url, body: "" });
+  const draftBody = draft.url === detail.url ? draft.body : "";
+  const setDraftBody = (body: string) => setDraft({ url: detail.url, body });
+  const [posting, setPosting] = useState(false);
+  const composerRef = useRef<HTMLTextAreaElement>(null);
+  const postComment = useAtomCommand(pullRequestEnvironment.comment, { reportFailure: false });
+
+  const submitComment = async () => {
+    const trimmed = draftBody.trim();
+    if (trimmed.length === 0 || posting) return;
+    setPosting(true);
+    const result = await postComment({
+      environmentId,
+      input: {
+        projectId: detail.projectId,
+        repository: detail.repository,
+        number: detail.number,
+        body: trimmed,
+      },
+    });
+    setPosting(false);
+    if (result._tag === "Failure") {
+      toastManager.add({ type: "error", title: "Could not post the comment" });
+      return;
+    }
+    // Cleared only if the draft still belongs to this pull request: by the time the request
+    // lands, the reader may already be drafting on another one.
+    setDraft((value) => (value.url === detail.url ? { url: value.url, body: "" } : value));
+    onRefresh();
+  };
+
+  const quoteReply = (commentBody: string) => {
+    setDraftBody(quoteReplyDraft(draftBody, commentBody));
+    // After React commits the merged draft: the cursor belongs at its end, below the quote,
+    // with the composer in view.
+    requestAnimationFrame(() => {
+      const element = composerRef.current;
+      if (element === null) return;
+      element.focus();
+      element.setSelectionRange(element.value.length, element.value.length);
+      element.scrollIntoView({ block: "nearest" });
+    });
+  };
 
   // A comment that already lives on a review thread is that thread: the thread carries the line
   // and side the bare comment has lost, and a resolved one is finished work nobody should be
@@ -752,6 +780,28 @@ export function PullRequestSummaryTab({
                               : fixFindingLabel}
                           </Button>
                         ) : null}
+                        {/* Only where the composer below exists to receive the quote, and only
+                            for comments with something to quote — a review that is all verdict
+                            and no words would quote as an empty block. */}
+                        {canComment && comment.body.trim().length > 0 ? (
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <Button
+                                  aria-label="Quote reply"
+                                  size="icon-xs"
+                                  variant="ghost"
+                                  className="-mr-1 -mt-1 shrink-0 text-muted-foreground hover:text-foreground"
+                                  disabled={posting}
+                                  onClick={() => quoteReply(comment.body)}
+                                />
+                              }
+                            >
+                              <ReplyIcon className="size-3" />
+                            </TooltipTrigger>
+                            <TooltipPopup>Quote reply</TooltipPopup>
+                          </Tooltip>
+                        ) : null}
                       </div>
                       {comment.path ? (
                         <p
@@ -779,12 +829,13 @@ export function PullRequestSummaryTab({
           </>
         )}
         {/* Posting is a core capability and remains usable even if the activity read failed. */}
-        {detail.capabilities.comment && detail.viewerPermissions.comment ? (
+        {canComment ? (
           <CommentComposer
-            key={`${environmentId}:${detail.projectId}/${detail.repository}#${detail.number}`}
-            environmentId={environmentId}
-            detail={detail}
-            onCommented={onRefresh}
+            body={draftBody}
+            posting={posting}
+            textareaRef={composerRef}
+            onBodyChange={setDraftBody}
+            onSubmit={() => void submitComment()}
           />
         ) : null}
       </Section>

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -98,10 +98,13 @@ interface CommentEditing {
 function CommentBody({
   comment,
   editing,
+  quoteButton,
   className,
 }: {
   comment: PullRequestComment;
   editing: CommentEditing;
+  /** Built by the owner of the composer, so this stays a view over whatever actions it is handed. */
+  quoteButton?: ReactNode;
   className?: string | undefined;
 }) {
   if (editing.editingId === comment.id) {
@@ -120,6 +123,7 @@ function CommentBody({
   return (
     <div className={cn("flex items-start gap-1", className)}>
       <PullRequestMarkdown className="min-w-0 flex-1" text={comment.body} cwd={editing.cwd} />
+      {quoteButton}
       {editing.canEdit(comment) ? (
         <Button
           size="icon-xs"
@@ -140,11 +144,13 @@ function CollapsedComment({
   comment,
   editing,
   label,
+  quoteButton,
   reactionBar,
 }: {
   comment: PullRequestComment;
   editing: CommentEditing;
   label: string;
+  quoteButton?: ReactNode;
   reactionBar: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
@@ -178,7 +184,12 @@ function CollapsedComment({
                   {comment.path}
                 </p>
               ) : null}
-              <CommentBody className="mt-2" comment={comment} editing={editing} />
+              <CommentBody
+                className="mt-2"
+                comment={comment}
+                editing={editing}
+                quoteButton={quoteButton}
+              />
               {reactionBar}
             </div>
           ) : null}
@@ -409,6 +420,31 @@ export function PullRequestSummaryTab({
       element.scrollIntoView({ block: "nearest" });
     });
   };
+
+  // Rides beside the edit pencil on every remark, collapsed conversations included — but only
+  // where the composer below exists to receive the quote, and only for comments with something
+  // to quote: a review that is all verdict and no words would quote as an empty block. Disabled
+  // while posting, when the composer is locked and the success clear would eat the quote.
+  const quoteReplyButton = (comment: PullRequestComment): ReactNode =>
+    canComment && comment.body.trim().length > 0 ? (
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              aria-label="Quote reply"
+              size="icon-xs"
+              variant="ghost"
+              className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100"
+              disabled={posting}
+              onClick={() => quoteReply(comment.body)}
+            />
+          }
+        >
+          <ReplyIcon className="size-3" />
+        </TooltipTrigger>
+        <TooltipPopup>Quote reply</TooltipPopup>
+      </Tooltip>
+    ) : null;
 
   // A comment that already lives on a review thread is that thread: the thread carries the line
   // and side the bare comment has lost, and a resolved one is finished work nobody should be
@@ -727,6 +763,7 @@ export function PullRequestSummaryTab({
                         comment={comment}
                         editing={commentEditing}
                         label={thread?.isResolved ? "Resolved" : "Approval dismissed"}
+                        quoteButton={quoteReplyButton(comment)}
                         reactionBar={
                           <PullRequestReactionBar
                             className="mt-2"
@@ -780,28 +817,6 @@ export function PullRequestSummaryTab({
                               : fixFindingLabel}
                           </Button>
                         ) : null}
-                        {/* Only where the composer below exists to receive the quote, and only
-                            for comments with something to quote — a review that is all verdict
-                            and no words would quote as an empty block. */}
-                        {canComment && comment.body.trim().length > 0 ? (
-                          <Tooltip>
-                            <TooltipTrigger
-                              render={
-                                <Button
-                                  aria-label="Quote reply"
-                                  size="icon-xs"
-                                  variant="ghost"
-                                  className="-mr-1 -mt-1 shrink-0 text-muted-foreground hover:text-foreground"
-                                  disabled={posting}
-                                  onClick={() => quoteReply(comment.body)}
-                                />
-                              }
-                            >
-                              <ReplyIcon className="size-3" />
-                            </TooltipTrigger>
-                            <TooltipPopup>Quote reply</TooltipPopup>
-                          </Tooltip>
-                        ) : null}
                       </div>
                       {comment.path ? (
                         <p
@@ -811,7 +826,12 @@ export function PullRequestSummaryTab({
                           {comment.path}
                         </p>
                       ) : null}
-                      <CommentBody className="mt-2" comment={comment} editing={commentEditing} />
+                      <CommentBody
+                        className="mt-2"
+                        comment={comment}
+                        editing={commentEditing}
+                        quoteButton={quoteReplyButton(comment)}
+                      />
                       <PullRequestReactionBar
                         className="mt-2"
                         reactions={comment.reactions ?? []}

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -423,10 +423,11 @@ export function PullRequestSummaryTab({
 
   // Rides beside the edit pencil on every remark, collapsed conversations included — but only
   // where the composer below exists to receive the quote, and only for comments with something
-  // to quote: a review that is all verdict and no words would quote as an empty block. Disabled
-  // while posting, when the composer is locked and the success clear would eat the quote.
+  // to quote: a review that is all verdict and no words would quote as an empty block. Gone
+  // rather than disabled while posting — the composer is locked and the success clear would eat
+  // the quote, and a disabled button's own opacity would defeat the hover reveal.
   const quoteReplyButton = (comment: PullRequestComment): ReactNode =>
-    canComment && comment.body.trim().length > 0 ? (
+    canComment && !posting && comment.body.trim().length > 0 ? (
       <Tooltip>
         <TooltipTrigger
           render={
@@ -435,7 +436,6 @@ export function PullRequestSummaryTab({
               size="icon-xs"
               variant="ghost"
               className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100"
-              disabled={posting}
               onClick={() => quoteReply(comment.body)}
             />
           }

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -21,6 +21,7 @@ import {
   pullRequestActionNeedsHostRefresh,
   pullRequestFindingKey,
   pullRequestHandoffLabels,
+  quoteReplyDraft,
   readableFailure,
   resolveBaseFreshness,
   buildPullRequestTimeline,
@@ -95,6 +96,28 @@ describe("ordering comments", () => {
     expect(orderPullRequestComments(comments, "oldest")).toEqual(comments);
     // The source array is chronological input, not a mutation target.
     expect(comments).toEqual([{ createdAt: "a" }, { createdAt: "b" }, { createdAt: "c" }]);
+  });
+});
+
+describe("quote replying to a comment", () => {
+  it("prefixes every line and leaves an empty line for the reply to start on", () => {
+    expect(quoteReplyDraft("", "First point.\n\nSecond point.")).toBe(
+      "> First point.\n>\n> Second point.\n\n",
+    );
+  });
+
+  it("lands under an existing draft instead of replacing it", () => {
+    expect(quoteReplyDraft("What I typed so far.\n", "A remark.")).toBe(
+      "What I typed so far.\n\n> A remark.\n\n",
+    );
+  });
+
+  it("normalizes Windows line endings and surrounding whitespace from the host", () => {
+    expect(quoteReplyDraft("", "\r\nline one\r\nline two\r\n")).toBe("> line one\n> line two\n\n");
+  });
+
+  it("treats a whitespace-only draft as empty rather than stacking blank lines", () => {
+    expect(quoteReplyDraft("   \n", "A remark.")).toBe("> A remark.\n\n");
   });
 });
 

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -72,6 +72,21 @@ export function orderPullRequestComments<T extends { readonly createdAt: string 
   return order === "newest" ? comments.toReversed() : comments;
 }
 
+/**
+ * A quote reply the way GitHub writes one: every line of the quoted comment behind "> ", then an
+ * empty line where the reply starts. Lands under whatever the reader already typed — quoting a
+ * second comment, or quoting after drafting, must never cost them the draft.
+ */
+export function quoteReplyDraft(draft: string, quoted: string): string {
+  const quote = quoted
+    .replace(/\r\n/gu, "\n")
+    .trim()
+    .split("\n")
+    .map((line) => (line.length === 0 ? ">" : `> ${line}`))
+    .join("\n");
+  return draft.trim().length === 0 ? `${quote}\n\n` : `${draft.trimEnd()}\n\n${quote}\n\n`;
+}
+
 export interface PullRequestTimelineEvent {
   readonly id: string;
   readonly at: string;


### PR DESCRIPTION
Replying to a specific comment on a pull request means copying it into the composer and hand-prefixing every line with `> `. Each comment in the Summary tab's conversation now carries a quote-reply button that does what GitHub's does: the composer prefills with the comment quoted line by line and focuses with the cursor on the empty line below the quote, ready for the reply. Quoting appends under anything already drafted instead of replacing it, the button only shows when the viewer can comment and the comment has words to quote, and it stays disabled while a comment is posting so the on-success clear cannot eat a quote added mid-flight.

To let the buttons write into the composer, its draft and posting state moved up onto the tab; the draft stays keyed by pull request so switching tabs still starts with a clean box. The quote formatting is a pure helper with unit tests — validated with `vp test run` on the touched test file plus targeted typecheck and lint.

**Demo**

<img width="535" height="100" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/acdc1b2a-7fc4-482b-9037-c19b859182d1" />


Written by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only comment drafting and formatting in the PR summary tab; no auth, API contract, or server changes beyond existing comment posting.
> 
> **Overview**
> Adds **quote reply** on the pull request Summary tab: a hover **Quote reply** control on each comment (when the viewer can comment and the comment has text) inserts a GitHub-style `> ` block into the bottom composer, focuses the textarea, and places the cursor after the quote. Quotes **append** under any existing draft instead of replacing it; the control is hidden while a post is in flight.
> 
> **Comment composer** is now controlled from `PullRequestSummaryTab`: draft text and posting live on the tab and are **keyed by pull request URL** so switching PRs does not leak drafts. Posting still uses the existing comment command and clears the draft only for the PR that was submitted.
> 
> Formatting is centralized in **`quoteReplyDraft`** in `pullRequestDetail.logic.ts` (line prefixes, blank line for the reply, CRLF normalization), with unit tests in `pullRequestDetail.logic.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a97e5217e86c99b895ff16e34f4ac8fb84d465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add quote reply to pull request comments
> - Adds a hover-revealed 'Quote reply' button to each pull request comment (visible when commenting is allowed, not currently posting, and the comment has content).
> - Clicking quote reply inserts a `> `-prefixed block of the comment into the composer, focuses it, and places the cursor at the end, implemented via the new `quoteReplyDraft` function in [pullRequestDetail.logic.ts](https://github.com/pingdotgg/t3code/pull/6407/files#diff-2c5f917dba9decc3bd48ec3231f7b0db073e8b642379cf000265960a03718c18).
> - Refactors `CommentComposer` into a controlled component, lifting draft/posting state into `PullRequestSummaryTab`, with drafts now persisted per pull request URL.
> - Behavioral Change: comment draft state is now keyed by PR URL, so switching between PRs preserves each PR's in-progress draft rather than sharing a single global draft.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11a97e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->