### PR TITLE
fix(server): serve html assets with utf-8 charset

### DIFF
--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -44,4 +44,15 @@ describe("assetResponseHeaders", () => {
       "X-Content-Type-Options": "nosniff",
     });
   });
+
+  it("declares utf-8 for HTML assets so non-ASCII content renders correctly", () => {
+    expect(assetResponseHeaders("/workspace/page.html")).toHaveProperty(
+      "Content-Type",
+      "text/html; charset=utf-8",
+    );
+    expect(assetResponseHeaders("/workspace/PAGE.HTM")).toHaveProperty(
+      "Content-Type",
+      "text/html; charset=utf-8",
+    );
+  });
 });

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -46,10 +46,14 @@ const DESKTOP_RENDERER_ORIGINS = ["t3code://app", "t3code-dev://app"];
 const SVG_CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
 
 export function assetResponseHeaders(filePath: string): Record<string, string> {
+  const lowerPath = filePath.toLowerCase();
   return {
     "Cache-Control": "private, max-age=3600",
     "X-Content-Type-Options": "nosniff",
-    ...(filePath.toLowerCase().endsWith(".svg")
+    ...(lowerPath.endsWith(".html") || lowerPath.endsWith(".htm")
+      ? { "Content-Type": "text/html; charset=utf-8" }
+      : {}),
+    ...(lowerPath.endsWith(".svg")
       ? { "Content-Security-Policy": SVG_CONTENT_SECURITY_POLICY }
       : {}),
   };


### PR DESCRIPTION
## What Changed

The `/api/assets` route served workspace HTML files with a bare `text/html` content type. It now sends `text/html; charset=utf-8` for `.html`/`.htm` files, plus tests for the header.

## Why

Opening an HTML file in the built-in browser garbles any non-ASCII text unless the file declares its own `<meta charset>` (agents often don't). The asset response has no charset and sets `X-Content-Type-Options: nosniff`, so Chromium falls back to windows-1252 and UTF-8 content renders as mojibake (你好 becomes ä½ å¥½).

HTML is the only type that needs this: CSS and module scripts already default to UTF-8, classic scripts inherit the document's encoding, and SVG is XML which is UTF-8 by default.

## UI Changes

Same file served without and with the fix:

Before:

<img width="1380" height="1509" alt="Screenshot 2026-08-13 at 01 41 15" src="https://github.com/user-attachments/assets/bf96e42a-6cba-4c2b-92f1-19cf015607dc" />

After:

<img width="1380" height="1509" alt="Screenshot 2026-08-13 at 01 42 10" src="https://github.com/user-attachments/assets/1aa7d1e1-a4a5-4f35-be42-be24c2ecefbc" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow header change on the asset route with tests; no auth, data, or routing logic changes.
> 
> **Overview**
> Workspace **HTML** files served from `/api/assets` now get **`Content-Type: text/html; charset=utf-8`** for `.html` and `.htm` paths (case-insensitive), instead of a bare `text/html` from the file response.
> 
> That aligns asset responses with the built-in browser expectation so UTF-8 text renders correctly when pages lack their own `<meta charset>`, especially with **`X-Content-Type-Options: nosniff`** already set on these responses.
> 
> Tests cover `.html`/`.htm` and uppercase `.HTM`; SVG sandbox headers and other asset types are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e42ae654977d942ad50649591024f4f684f3a1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serve HTML assets with `Content-Type: text/html; charset=utf-8` in `assetResponseHeaders`
> Updates [`assetResponseHeaders`](https://github.com/pingdotgg/t3code/pull/6409/files#diff-55fb49cf72ecef123d8f2fa7061526dadb37cf93f8e9dd9e7f0d4f8cd4ff9f6d) to set `Content-Type: text/html; charset=utf-8` for `.html` and `.htm` files (case-insensitive). Previously, HTML assets were served without an explicit charset, which could cause encoding issues in browsers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e42ae6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->