### PR TITLE
fix(desktop): keep release notes visible while downloading

### DIFF
--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -179,11 +179,12 @@ function SidebarUpdateControl() {
     : showUpdateDetails
       ? isDesktopUpdateButtonDisabled(state)
       : !canCheckForUpdate(state);
+  const isInteractionDisabled = disabled || isActionPending;
 
   const handleAction = useCallback(async () => {
     const bridge = window.desktopBridge;
     if (!bridge || !state) return;
-    if (disabled || isActionPending) return;
+    if (isInteractionDisabled) return;
 
     setIsActionPending(true);
 
@@ -293,7 +294,7 @@ function SidebarUpdateControl() {
         );
       })
       .finally(() => setIsActionPending(false));
-  }, [action, disabled, isActionPending, prefersReducedMotion, state]);
+  }, [action, isInteractionDisabled, prefersReducedMotion, state]);
 
   const handleCheckAnimationIteration = useCallback(() => {
     setIsCheckAnimationLatched(
@@ -312,13 +313,20 @@ function SidebarUpdateControl() {
             <button
               type="button"
               aria-label={tooltip}
-              aria-disabled={disabled || isActionPending || undefined}
-              disabled={disabled || isActionPending}
+              aria-disabled={isInteractionDisabled || undefined}
               className={cn(
-                "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors enabled:cursor-pointer focus-visible:ring-2 disabled:cursor-not-allowed",
+                "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors focus-visible:ring-2",
+                isInteractionDisabled ? "cursor-not-allowed" : "cursor-pointer",
                 showUpdateIconState
-                  ? "bg-update-surface text-update-foreground enabled:hover:bg-update/12"
-                  : "text-[var(--sidebar-icon-color)] enabled:hover:bg-sidebar-row-hover enabled:hover:text-sidebar-foreground",
+                  ? cn(
+                      "bg-update-surface text-update-foreground",
+                      !isInteractionDisabled && "hover:bg-update/12",
+                    )
+                  : cn(
+                      "text-[var(--sidebar-icon-color)]",
+                      !isInteractionDisabled &&
+                        "hover:bg-sidebar-row-hover hover:text-sidebar-foreground",
+                    ),
                 disabled && !showUpdateIconState && "opacity-60",
               )}
               onClick={handleAction}


### PR DESCRIPTION
## What Changed

Keep the desktop update pill's release notes popout hoverable and focusable while an update is downloading. The control retains its disabled styling and ARIA state, and its existing action guard still prevents duplicate downloads.

## Why

A native `disabled` button does not receive the pointer or focus events the tooltip needs, so nightly patch notes disappeared for the duration of a download. Using `aria-disabled` with explicit disabled styling preserves the non-actionable state without blocking the popout.

## UI Changes

Before: The downloading button could not reveal the patch-notes popout.

After: Patch notes remain available while the button shows download progress and stays non-actionable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

## Verification

- `vp test run src/components/desktopUpdate.logic.test.ts --project unit`
- `vp run typecheck`
- Targeted lint and formatting checks

Built with GPT-5.6-Sol in the Codex harness via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small desktop UI/a11y tweak to one sidebar button. Actions remain guarded; no auth, data, or update-pipeline logic changes.
> 
> **Overview**
> Keeps nightly release notes hoverable and focusable on the sidebar update pill while a download is in progress.
> 
> A native `disabled` button blocked pointer/focus events the tooltip needs. The control now uses `aria-disabled` plus an `isInteractionDisabled` click guard, with hover/cursor styles applied explicitly instead of Tailwind `disabled:` variants. Clicks still no-op during pending/disabled states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 585d33b71ba13971f5d3d23a7b1c512c8362c916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep `SidebarUpdateControl` focusable and release notes visible while downloading
> - Replaces the HTML `disabled` attribute with an `aria-disabled` guard and an `isInteractionDisabled` early-return in the `onClick` handler so the button stays focusable during pending actions.
> - Moves hover and cursor styles to explicit conditionals on `isInteractionDisabled` instead of Tailwind `disabled:` variants.
> - Keeps `opacity-60` tied only to `disabled`, so the pending download state no longer dims the control.
> - Behavioral Change: the button no longer sets `disabled`; screen readers and keyboard users can focus it while a download is in progress, though clicks are a no-op when `isInteractionDisabled` is true.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 585d33b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->