### PR TITLE
fix(web): keep turn minimap stable as composer grows

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -610,7 +610,6 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           />
           <TimelineMinimap
             items={minimapItems}
-            bottomInset={contentInsetEndAdjustment}
             hasPersistentGutter={minimapHasPersistentGutter}
             hitStripWidth={minimapHitStripWidth}
             stripMap={minimapStripMap}
@@ -712,14 +711,12 @@ function timelineMinimapEventTargetsPreview(target: EventTarget): boolean {
 }
 
 function TimelineMinimap({
-  bottomInset,
   hasPersistentGutter,
   hitStripWidth,
   items,
   stripMap,
   onSelect,
 }: {
-  bottomInset: number;
   hasPersistentGutter: boolean;
   hitStripWidth: number;
   items: ReadonlyArray<TimelineMinimapItem>;
@@ -779,19 +776,16 @@ function TimelineMinimap({
     return null;
   }
 
-  const safeBottomInset = Math.max(0, Math.ceil(bottomInset));
-
   return (
     <div
       className={cn(
-        "group/minimap pointer-events-none absolute top-0 left-0 z-40 hidden w-18 [@media(pointer:fine)]:block",
+        "group/minimap pointer-events-none absolute inset-y-0 left-0 z-40 hidden w-18 [@media(pointer:fine)]:block",
         hasPersistentGutter
           ? "opacity-100"
           : "opacity-0 transition-opacity duration-150 hover:opacity-100 focus-within:opacity-100",
       )}
       data-testid="timeline-minimap"
       data-persistent-gutter={hasPersistentGutter ? "true" : "false"}
-      style={{ bottom: safeBottomInset }}
     >
       <div className="relative h-full w-full select-none">
         <button


### PR DESCRIPTION
## What Changed

Keep the turn minimap anchored to the full timeline viewport when the composer grows.

## Why

Typing a multiline prompt increased the composer's bottom inset on the minimap itself. That shortened the minimap's positioning area and shifted the centered turn rail upward. The composer inset now remains limited to timeline scrolling and content clearance.

## UI Changes

### Before recording

https://github.com/user-attachments/assets/554c5971-1203-4b17-926b-569ffd59f6a3

### After recording

https://github.com/user-attachments/assets/a785882c-aaa5-4469-829d-6ae5343731e8

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included a video for animation/interaction changes

Implemented with gpt-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to minimap positioning; no auth, data, or API impact.
> 
> **Overview**
> **Fixes the turn minimap jumping upward** when the composer grows (e.g. multiline prompts).
> 
> `TimelineMinimap` no longer receives `contentInsetEndAdjustment` as `bottomInset`. That inset still applies to `LegendList` scrolling and bottom clearance, but the minimap is now **full-height** in the timeline viewport via `inset-y-0` instead of `top-0` plus a dynamic `bottom` offset tied to composer height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e69879ea8fb88899150a21727198f4010dd5759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix turn minimap to remain stable as the composer grows
> The `TimelineMinimap` component was shifting position as the composer grew because it received a dynamic `bottomInset` that adjusted its bottom offset. This removes the `bottomInset` prop entirely and anchors the minimap to both top and bottom of its container using `inset-y-0` instead of `top-0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e69879.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->