### PR TITLE
fix(web): hide opencode's plan agent when legacy plan mode is off

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -182,9 +182,7 @@ const AGENT_HEADER_RE = /^(.+)\s+\((\S+)\)\s*$/;
 // Agents that are always hidden in OpenCode but the CLI "agent list" command
 // does not expose the hidden flag. Keep in sync with OpenCode agent
 // definitions (in the OpenCode repo: packages/opencode/src/agent/agent.ts).
-// "plan" is not hidden in OpenCode itself; we hide it because T3's plan mode
-// is a legacy feature and the agent select must not surface it.
-const KNOWN_HIDDEN_AGENTS = new Set(["compaction", "plan", "summary", "title"]);
+const KNOWN_HIDDEN_AGENTS = new Set(["compaction", "summary", "title"]);
 
 /** @internal */
 export function parseModelsCliOutput(stdout: string): {

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -182,6 +182,8 @@ const AGENT_HEADER_RE = /^(.+)\s+\((\S+)\)\s*$/;
 // Agents that are always hidden in OpenCode but the CLI "agent list" command
 // does not expose the hidden flag. Keep in sync with OpenCode agent
 // definitions (in the OpenCode repo: packages/opencode/src/agent/agent.ts).
+// "plan" is not hidden in OpenCode itself; we hide it because T3's plan mode
+// is a legacy feature and the agent select must not surface it.
 const KNOWN_HIDDEN_AGENTS = new Set(["compaction", "plan", "summary", "title"]);
 
 /** @internal */

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -182,7 +182,7 @@ const AGENT_HEADER_RE = /^(.+)\s+\((\S+)\)\s*$/;
 // Agents that are always hidden in OpenCode but the CLI "agent list" command
 // does not expose the hidden flag. Keep in sync with OpenCode agent
 // definitions (in the OpenCode repo: packages/opencode/src/agent/agent.ts).
-const KNOWN_HIDDEN_AGENTS = new Set(["compaction", "summary", "title"]);
+const KNOWN_HIDDEN_AGENTS = new Set(["compaction", "plan", "summary", "title"]);
 
 /** @internal */
 export function parseModelsCliOutput(stdout: string): {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -873,6 +873,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         models: selectedProviderModels,
         promptInjectionState: composerPromptInjectionState,
         modelOptions: composerModelOptions?.[selectedInstanceId],
+        planModeEnabled: settings.planModeEnabled,
       }),
     [
       composerModelOptions,
@@ -881,6 +882,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       selectedModel,
       selectedProvider,
       selectedProviderModels,
+      settings.planModeEnabled,
     ],
   );
 
@@ -1215,6 +1217,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     modelOptions: composerModelOptions?.[selectedInstanceId],
     prompt,
     onPromptChange: setPromptFromTraits,
+    planModeEnabled: settings.planModeEnabled,
   });
   const providerTraitsPicker = renderProviderTraitsPicker({
     provider: selectedProvider,
@@ -1226,6 +1229,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     modelOptions: composerModelOptions?.[selectedInstanceId],
     prompt,
     onPromptChange: setPromptFromTraits,
+    planModeEnabled: settings.planModeEnabled,
   });
   const pendingPrimaryAction = useMemo(
     () =>

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -29,7 +29,6 @@ import {
 } from "../ui/menu";
 import { useComposerDraftStore, DraftId } from "../../composerDraftStore";
 import { getProviderModelCapabilities } from "../../providerModels";
-import { useClientSettings } from "~/hooks/useSettings";
 import { cn } from "~/lib/utils";
 import { Badge } from "../ui/badge";
 import { ComposerControl, ComposerControlChevron, ComposerControlIcon } from "./ComposerControl";
@@ -219,6 +218,7 @@ export interface TraitsMenuContentProps {
   onPromptChange: (prompt: string) => void;
   modelOptions?: ProviderOptions | null | undefined;
   allowPromptInjectedEffort?: boolean;
+  planModeEnabled: boolean;
   triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
   triggerClassName?: string;
 }
@@ -232,10 +232,10 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   onPromptChange,
   modelOptions,
   allowPromptInjectedEffort = true,
+  planModeEnabled,
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
-  const planModeEnabled = useClientSettings((settings) => settings.planModeEnabled);
   const updateModelOptions = useCallback(
     (nextOptions: ProviderOptions | undefined) => {
       if ("onModelOptionsChange" in persistence) {
@@ -458,12 +458,12 @@ export const TraitsPicker = memo(function TraitsPicker({
   onPromptChange,
   modelOptions,
   allowPromptInjectedEffort = true,
+  planModeEnabled,
   triggerVariant,
   triggerClassName,
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const planModeEnabled = useClientSettings((settings) => settings.planModeEnabled);
   const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled } =
     getTraitsSectionVisibility({
       provider,
@@ -553,6 +553,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           onPromptChange={onPromptChange}
           modelOptions={modelOptions}
           allowPromptInjectedEffort={allowPromptInjectedEffort}
+          planModeEnabled={planModeEnabled}
           {...persistence}
         />
       </MenuPopup>

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -29,6 +29,7 @@ import {
 } from "../ui/menu";
 import { useComposerDraftStore, DraftId } from "../../composerDraftStore";
 import { getProviderModelCapabilities } from "../../providerModels";
+import { useClientSettings } from "~/hooks/useSettings";
 import { cn } from "~/lib/utils";
 import { Badge } from "../ui/badge";
 import { ComposerControl, ComposerControlChevron, ComposerControlIcon } from "./ComposerControl";
@@ -96,8 +97,9 @@ function getSelectedTraits(
   prompt: string,
   modelOptions: ProviderOptions | null | undefined,
   allowPromptInjectedEffort: boolean,
+  planModeEnabled: boolean,
 ) {
-  const caps = getProviderModelCapabilities(models, model, provider);
+  const caps = getProviderModelCapabilities(models, model, provider, planModeEnabled);
   const descriptors = getProviderOptionDescriptors({
     caps,
     selections: modelOptions,
@@ -167,6 +169,7 @@ function getTraitsSectionVisibility(input: {
   prompt: string;
   modelOptions: ProviderOptions | null | undefined;
   allowPromptInjectedEffort?: boolean;
+  planModeEnabled: boolean;
 }) {
   const selected = getSelectedTraits(
     input.provider,
@@ -175,6 +178,7 @@ function getTraitsSectionVisibility(input: {
     input.prompt,
     input.modelOptions,
     input.allowPromptInjectedEffort ?? true,
+    input.planModeEnabled,
   );
 
   const showEffort = selected.primarySelectDescriptor !== null;
@@ -201,6 +205,7 @@ export function shouldRenderTraitsControls(input: {
   prompt: string;
   modelOptions: ProviderOptions | null | undefined;
   allowPromptInjectedEffort?: boolean;
+  planModeEnabled: boolean;
 }): boolean {
   return getTraitsSectionVisibility(input).hasAnyControls;
 }
@@ -230,6 +235,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
+  const planModeEnabled = useClientSettings((settings) => settings.planModeEnabled);
   const updateModelOptions = useCallback(
     (nextOptions: ProviderOptions | undefined) => {
       if ("onModelOptionsChange" in persistence) {
@@ -263,6 +269,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     prompt,
     modelOptions,
     allowPromptInjectedEffort,
+    planModeEnabled,
   });
   const updateDescriptors = (nextDescriptors: ReadonlyArray<ProviderOptionDescriptor>) => {
     updateModelOptions(buildProviderOptionSelectionsFromDescriptors(nextDescriptors));
@@ -456,6 +463,7 @@ export const TraitsPicker = memo(function TraitsPicker({
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const planModeEnabled = useClientSettings((settings) => settings.planModeEnabled);
   const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled } =
     getTraitsSectionVisibility({
       provider,
@@ -464,6 +472,7 @@ export const TraitsPicker = memo(function TraitsPicker({
       prompt,
       modelOptions,
       allowPromptInjectedEffort,
+      planModeEnabled,
     });
   if (
     !shouldRenderTraitsControls({
@@ -473,6 +482,7 @@ export const TraitsPicker = memo(function TraitsPicker({
       prompt,
       modelOptions,
       allowPromptInjectedEffort,
+      planModeEnabled,
     })
   ) {
     return null;

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -187,6 +187,24 @@ describe("getComposerProviderState", () => {
     expect(state.modelOptionsForDispatch).toEqual(selections(["agent", "build"]));
   });
 
+  it("drops the agent descriptor entirely when plan is the only option and plan mode is disabled", () => {
+    const state = getComposerProviderState({
+      provider: PROVIDER,
+      model: MODEL,
+      models: modelWith([
+        selectDescriptor("agent", [{ id: "plan", label: "Plan", isDefault: true }]),
+      ]),
+      modelOptions: selections(["agent", "plan"]),
+      planModeEnabled: false,
+    });
+
+    expect(state).toEqual({
+      provider: PROVIDER,
+      promptEffort: null,
+      modelOptionsForDispatch: undefined,
+    });
+  });
+
   it("returns undefined dispatch options when the model declares no descriptors", () => {
     const state = getComposerProviderState({
       provider: PROVIDER,

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -80,6 +80,7 @@ describe("getComposerProviderState", () => {
         ]),
       ]),
       modelOptions: undefined,
+      planModeEnabled: true,
     });
 
     expect(state).toEqual({
@@ -101,6 +102,7 @@ describe("getComposerProviderState", () => {
         booleanDescriptor("fastMode"),
       ]),
       modelOptions: selections(["effort", "low"], ["fastMode", true]),
+      planModeEnabled: true,
     });
 
     expect(state).toEqual({
@@ -119,6 +121,7 @@ describe("getComposerProviderState", () => {
         booleanDescriptor("fastMode"),
       ]),
       modelOptions: selections(["effort", "high"], ["fastMode", false]),
+      planModeEnabled: true,
     });
 
     expect(state.modelOptionsForDispatch).toEqual(
@@ -132,6 +135,7 @@ describe("getComposerProviderState", () => {
       model: MODEL,
       models: modelWith([booleanDescriptor("thinking")]),
       modelOptions: selections(["effort", "max"], ["thinking", false]),
+      planModeEnabled: true,
     });
 
     expect(state).toEqual({
@@ -157,6 +161,7 @@ describe("getComposerProviderState", () => {
         ]),
       ]),
       modelOptions: selections(["agent", "plan"]),
+      planModeEnabled: true,
     });
 
     expect(state.promptEffort).toBe("high");
@@ -165,12 +170,30 @@ describe("getComposerProviderState", () => {
     );
   });
 
+  it("drops the plan agent from dispatch when legacy plan mode is disabled", () => {
+    const state = getComposerProviderState({
+      provider: PROVIDER,
+      model: MODEL,
+      models: modelWith([
+        selectDescriptor("agent", [
+          { id: "build", label: "Build", isDefault: true },
+          { id: "plan", label: "Plan" },
+        ]),
+      ]),
+      modelOptions: selections(["agent", "plan"]),
+      planModeEnabled: false,
+    });
+
+    expect(state.modelOptionsForDispatch).toEqual(selections(["agent", "build"]));
+  });
+
   it("returns undefined dispatch options when the model declares no descriptors", () => {
     const state = getComposerProviderState({
       provider: PROVIDER,
       model: MODEL,
       models: modelWith([]),
       modelOptions: selections(["anything", "value"]),
+      planModeEnabled: true,
     });
 
     expect(state).toEqual({
@@ -199,6 +222,7 @@ describe("getComposerProviderState", () => {
         "Ultrathink:\nInvestigate this failure",
       ),
       modelOptions: selections(["effort", "medium"]),
+      planModeEnabled: true,
     });
 
     expect(state).toEqual({
@@ -220,6 +244,7 @@ describe("getComposerProviderState", () => {
         "Ultrathink:\nInvestigate this failure",
       ),
       modelOptions: undefined,
+      planModeEnabled: true,
     });
 
     expect(state).not.toHaveProperty("composerFrameClassName");
@@ -240,6 +265,7 @@ describe("provider traits render guards", () => {
       modelOptions: undefined,
       prompt: "",
       onPromptChange: () => {},
+      planModeEnabled: true,
     };
 
     expect(renderProviderTraitsPicker(args)).toBeNull();

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -205,6 +205,23 @@ describe("getComposerProviderState", () => {
     });
   });
 
+  it("falls back to a surviving agent when plan was the descriptor default and plan mode is disabled", () => {
+    const state = getComposerProviderState({
+      provider: PROVIDER,
+      model: MODEL,
+      models: modelWith([
+        selectDescriptor("agent", [
+          { id: "plan", label: "Plan", isDefault: true },
+          { id: "research", label: "Research" },
+        ]),
+      ]),
+      modelOptions: undefined,
+      planModeEnabled: false,
+    });
+
+    expect(state.modelOptionsForDispatch).toEqual(selections(["agent", "research"]));
+  });
+
   it("returns undefined dispatch options when the model declares no descriptors", () => {
     const state = getComposerProviderState({
       provider: PROVIDER,

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -23,6 +23,7 @@ export type ComposerProviderStateInput = {
   models: ReadonlyArray<ServerProviderModel>;
   promptInjectionState?: ComposerPromptInjectionState;
   modelOptions: ReadonlyArray<ProviderOptionSelection> | null | undefined;
+  planModeEnabled: boolean;
 };
 
 export type ComposerPromptInjectionState = "none" | "ultrathink";
@@ -46,6 +47,7 @@ type TraitsRenderInput = {
   modelOptions: ReadonlyArray<ProviderOptionSelection> | undefined;
   prompt: string;
   onPromptChange: (prompt: string) => void;
+  planModeEnabled: boolean;
 };
 
 export function getComposerPromptInjectionState(prompt: string): ComposerPromptInjectionState {
@@ -53,8 +55,15 @@ export function getComposerPromptInjectionState(prompt: string): ComposerPromptI
 }
 
 export function getComposerProviderState(input: ComposerProviderStateInput): ComposerProviderState {
-  const { provider, model, models, modelOptions, promptInjectionState = "none" } = input;
-  const caps = getProviderModelCapabilities(models, model, provider);
+  const {
+    provider,
+    model,
+    models,
+    modelOptions,
+    promptInjectionState = "none",
+    planModeEnabled,
+  } = input;
+  const caps = getProviderModelCapabilities(models, model, provider, planModeEnabled);
   const descriptors = getProviderOptionDescriptors({ caps, selections: modelOptions });
   const primarySelectDescriptor = descriptors.find(
     (descriptor): descriptor is Extract<(typeof descriptors)[number], { type: "select" }> =>
@@ -94,11 +103,19 @@ function renderTraitsControl(
     modelOptions,
     prompt,
     onPromptChange,
+    planModeEnabled,
   } = input;
   const hasTarget = threadRef !== undefined || draftId !== undefined;
   if (
     !hasTarget ||
-    !shouldRenderTraitsControls({ provider, models, model, modelOptions, prompt })
+    !shouldRenderTraitsControls({
+      provider,
+      models,
+      model,
+      modelOptions,
+      prompt,
+      planModeEnabled,
+    })
   ) {
     return null;
   }

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -130,6 +130,7 @@ function renderTraitsControl(
       modelOptions={modelOptions}
       prompt={prompt}
       onPromptChange={onPromptChange}
+      planModeEnabled={planModeEnabled}
     />
   );
 }

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -849,6 +849,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                     onPromptChange={() => {}}
                     modelOptions={resolvedSelection.options ?? []}
                     allowPromptInjectedEffort={false}
+                    planModeEnabled={settings.planModeEnabled}
                     triggerVariant="outline"
                     triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
                     onModelOptionsChange={(nextOptions) => {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -68,6 +68,7 @@ import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
   getCustomModelOptionsByInstance,
   resolveAppModelSelectionState,
+  withoutPlanAgentSelection,
 } from "../../modelSelection";
 import {
   applyProviderInstanceSettings,
@@ -1710,9 +1711,31 @@ function LegacyFeaturesSection() {
               control={
                 <Switch
                   checked={settings.planModeEnabled}
-                  onCheckedChange={(checked) =>
-                    updateSettings({ planModeEnabled: Boolean(checked) })
-                  }
+                  onCheckedChange={(checked) => {
+                    const planModeEnabled = Boolean(checked);
+                    const textGenerationModelSelection = withoutPlanAgentSelection(
+                      settings.textGenerationModelSelection,
+                    );
+                    const sourceControlWriterModelSelection = withoutPlanAgentSelection(
+                      settings.sourceControlWriterModelSelection,
+                    );
+                    updateSettings({
+                      planModeEnabled,
+                      ...(planModeEnabled
+                        ? {}
+                        : {
+                            ...(textGenerationModelSelection &&
+                            textGenerationModelSelection !== settings.textGenerationModelSelection
+                              ? { textGenerationModelSelection }
+                              : {}),
+                            ...(sourceControlWriterModelSelection &&
+                            sourceControlWriterModelSelection !==
+                              settings.sourceControlWriterModelSelection
+                              ? { sourceControlWriterModelSelection }
+                              : {}),
+                          }),
+                    });
+                  }}
                   aria-label="Plan mode (legacy)"
                 />
               }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2332,6 +2332,7 @@ export function GeneralSettingsPanel() {
                 onPromptChange={() => {}}
                 modelOptions={textGenModelOptions}
                 allowPromptInjectedEffort={false}
+                planModeEnabled={settings.planModeEnabled}
                 triggerVariant="outline"
                 triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
                 onModelOptionsChange={(nextOptions) => {

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -1,11 +1,13 @@
 import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS, type UnifiedSettings } from "@t3tools/contracts/settings";
 import { describe, expect, it } from "vite-plus/test";
+import { createModelSelection } from "@t3tools/shared/model";
 import { deriveProviderInstanceEntries } from "./providerInstances";
 import {
   getAppModelOptionsForInstance,
   resolveAppModelSelectionForInstance,
   resolveAppModelSelectionState,
+  withoutPlanAgentSelection,
 } from "./modelSelection";
 
 function provider(input: {
@@ -319,5 +321,35 @@ describe("instance-scoped model selection", () => {
       instanceId: ProviderInstanceId.make("claude_openrouter"),
       model: "openai/gpt-5.5",
     });
+  });
+});
+
+describe("withoutPlanAgentSelection", () => {
+  const instance = ProviderInstanceId.make("opencode");
+  const model = "opencode/gpt-5.4";
+
+  it("drops a stored plan agent option", () => {
+    const selection = createModelSelection(instance, model, [
+      { id: "variant", value: "high" },
+      { id: "agent", value: "plan" },
+    ]);
+    expect(withoutPlanAgentSelection(selection)).toEqual(
+      createModelSelection(instance, model, [{ id: "variant", value: "high" }]),
+    );
+  });
+
+  it("keeps non-plan agent options", () => {
+    const selection = createModelSelection(instance, model, [{ id: "agent", value: "build" }]);
+    expect(withoutPlanAgentSelection(selection)).toBe(selection);
+  });
+
+  it("omits options entirely when plan was the only stored option", () => {
+    const selection = createModelSelection(instance, model, [{ id: "agent", value: "plan" }]);
+    expect(withoutPlanAgentSelection(selection)).toEqual({ instanceId: instance, model });
+  });
+
+  it("returns null and undefined selections unchanged", () => {
+    expect(withoutPlanAgentSelection(null)).toBeNull();
+    expect(withoutPlanAgentSelection(undefined)).toBeUndefined();
   });
 });

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -7,6 +7,7 @@ import {
   getAppModelOptionsForInstance,
   resolveAppModelSelectionForInstance,
   resolveAppModelSelectionState,
+  resolvePlanAgentHealPatch,
   withoutPlanAgentSelection,
 } from "./modelSelection";
 
@@ -351,5 +352,54 @@ describe("withoutPlanAgentSelection", () => {
   it("returns null and undefined selections unchanged", () => {
     expect(withoutPlanAgentSelection(null)).toBeNull();
     expect(withoutPlanAgentSelection(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolvePlanAgentHealPatch", () => {
+  const instance = ProviderInstanceId.make("opencode");
+  const model = "opencode/gpt-5.4";
+  const healed = createModelSelection(instance, model, [{ id: "variant", value: "high" }]);
+  const storedPlan = createModelSelection(instance, model, [
+    { id: "variant", value: "high" },
+    { id: "agent", value: "plan" },
+  ]);
+  const nullPatch = {
+    planModeEnabled: true,
+    textGenerationModelSelection: storedPlan,
+    sourceControlWriterModelSelection: null,
+  };
+
+  it("returns null when plan mode is on", () => {
+    expect(resolvePlanAgentHealPatch(nullPatch)).toBeNull();
+  });
+
+  it("returns null when nothing needs healing", () => {
+    expect(
+      resolvePlanAgentHealPatch({
+        planModeEnabled: false,
+        textGenerationModelSelection: healed,
+        sourceControlWriterModelSelection: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("patches the stored text generation selection to drop the plan agent", () => {
+    expect(
+      resolvePlanAgentHealPatch({
+        planModeEnabled: false,
+        textGenerationModelSelection: storedPlan,
+        sourceControlWriterModelSelection: null,
+      }),
+    ).toEqual({ textGenerationModelSelection: healed });
+  });
+
+  it("patches a stored source control writer selection that uses the plan agent", () => {
+    expect(
+      resolvePlanAgentHealPatch({
+        planModeEnabled: false,
+        textGenerationModelSelection: healed,
+        sourceControlWriterModelSelection: storedPlan,
+      }),
+    ).toEqual({ sourceControlWriterModelSelection: healed });
   });
 });

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -277,6 +277,26 @@ export function getCustomModelOptionsByInstance(
   return out;
 }
 
+/**
+ * Drop the opencode "plan" agent option from a stored model selection.
+ * Used when legacy plan mode is turned off so server-side text-generation
+ * tasks (title, branch, PR) cannot keep dispatching the plan agent.
+ */
+export function withoutPlanAgentSelection(
+  selection: ModelSelection | null | undefined,
+): ModelSelection | null | undefined {
+  if (!selection?.options) {
+    return selection;
+  }
+  const options = selection.options.filter(
+    (option) => !(option.id === "agent" && option.value === "plan"),
+  );
+  if (options.length === selection.options.length) {
+    return selection;
+  }
+  return createModelSelection(selection.instanceId, selection.model, options);
+}
+
 export function resolveAppModelSelectionState(
   settings: UnifiedSettings,
   providers: ReadonlyArray<ServerProvider>,

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -6,6 +6,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   type ServerProvider,
+  type ServerSettingsPatch,
 } from "@t3tools/contracts";
 import {
   createModelSelection,
@@ -295,6 +296,31 @@ export function withoutPlanAgentSelection(
     return selection;
   }
   return createModelSelection(selection.instanceId, selection.model, options);
+}
+
+// The dropdown hides the opencode "plan" agent while legacy plan mode is off,
+// but the persisted text-generation selections are only healed when the toggle
+// flips. Users who already have plan mode off and a stored "plan" selection
+// never trip the toggle handler, so resolve the heal once per settings load.
+export function resolvePlanAgentHealPatch(input: {
+  readonly planModeEnabled: boolean;
+  readonly textGenerationModelSelection: ModelSelection | null | undefined;
+  readonly sourceControlWriterModelSelection: ModelSelection | null | undefined;
+}): ServerSettingsPatch | null {
+  if (input.planModeEnabled) {
+    return null;
+  }
+  const healedText = withoutPlanAgentSelection(input.textGenerationModelSelection);
+  const healedSourceControl = withoutPlanAgentSelection(input.sourceControlWriterModelSelection);
+  const patch: ServerSettingsPatch = {
+    ...(healedText && healedText !== input.textGenerationModelSelection
+      ? { textGenerationModelSelection: healedText }
+      : {}),
+    ...(healedSourceControl && healedSourceControl !== input.sourceControlWriterModelSelection
+      ? { sourceControlWriterModelSelection: healedSourceControl }
+      : {}),
+  };
+  return Object.keys(patch).length > 0 ? patch : null;
 }
 
 export function resolveAppModelSelectionState(

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -308,6 +308,7 @@ export function resolveAppModelSelectionState(
       model,
       models: entry.models,
       modelOptions: selectedEntry ? selection.options : undefined,
+      planModeEnabled: settings.planModeEnabled,
     });
 
     return createModelSelection(entry.instanceId, model, modelOptionsForDispatch);
@@ -325,6 +326,7 @@ export function resolveAppModelSelectionState(
     model,
     models: getProviderModels(providers, provider),
     modelOptions: keptSelectedProvider ? selection.options : undefined,
+    planModeEnabled: settings.planModeEnabled,
   });
 
   return createModelSelection(defaultInstanceIdForDriver(provider), model, modelOptionsForDispatch);

--- a/apps/web/src/planAgentSelectionHeal.tsx
+++ b/apps/web/src/planAgentSelectionHeal.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "./hooks/useSettings";
+import {
+  useClientSettingsHydrated,
+  usePrimarySettings,
+  useUpdatePrimarySettings,
+} from "./hooks/useSettings";
 import { resolvePlanAgentHealPatch } from "./modelSelection";
 
 /**
@@ -18,9 +22,16 @@ export function PlanAgentSelectionHeal() {
   const sourceControlWriterModelSelection = usePrimarySettings(
     (settings) => settings.sourceControlWriterModelSelection,
   );
+  const settingsHydrated = useClientSettingsHydrated();
   const updateSettings = useUpdatePrimarySettings();
 
   useEffect(() => {
+    // planModeEnabled reads as false until client settings hydrate, so never
+    // heal before then: we would strip a stored plan selection from a user
+    // whose plan mode is actually on.
+    if (!settingsHydrated) {
+      return;
+    }
     const patch = resolvePlanAgentHealPatch({
       planModeEnabled,
       textGenerationModelSelection,
@@ -31,6 +42,7 @@ export function PlanAgentSelectionHeal() {
     }
   }, [
     planModeEnabled,
+    settingsHydrated,
     textGenerationModelSelection,
     sourceControlWriterModelSelection,
     updateSettings,

--- a/apps/web/src/planAgentSelectionHeal.tsx
+++ b/apps/web/src/planAgentSelectionHeal.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+
+import { usePrimarySettings, useUpdatePrimarySettings } from "./hooks/useSettings";
+import { resolvePlanAgentHealPatch } from "./modelSelection";
+
+/**
+ * Heals persisted text-generation model selections that still reference the
+ * opencode "plan" agent. The dropdown hides the option while legacy plan mode
+ * is off, but the toggle handler only runs when the setting flips; users who
+ * already have plan mode off with a stored "plan" selection need this pass
+ * whenever the settings load.
+ */
+export function PlanAgentSelectionHeal() {
+  const planModeEnabled = usePrimarySettings((settings) => settings.planModeEnabled);
+  const textGenerationModelSelection = usePrimarySettings(
+    (settings) => settings.textGenerationModelSelection,
+  );
+  const sourceControlWriterModelSelection = usePrimarySettings(
+    (settings) => settings.sourceControlWriterModelSelection,
+  );
+  const updateSettings = useUpdatePrimarySettings();
+
+  useEffect(() => {
+    const patch = resolvePlanAgentHealPatch({
+      planModeEnabled,
+      textGenerationModelSelection,
+      sourceControlWriterModelSelection,
+    });
+    if (patch) {
+      updateSettings(patch);
+    }
+  }, [
+    planModeEnabled,
+    textGenerationModelSelection,
+    sourceControlWriterModelSelection,
+    updateSettings,
+  ]);
+
+  return null;
+}

--- a/apps/web/src/providerModels.ts
+++ b/apps/web/src/providerModels.ts
@@ -93,15 +93,18 @@ export function getProviderModelCapabilities(
 }
 
 // The opencode "plan" agent is only reachable while legacy plan mode is on.
-// With it off, drop the option so it cannot be selected or dispatched.
+// With it off, drop the option so it cannot be selected or dispatched, and
+// drop the descriptor entirely when nothing remains selectable.
 function withoutPlanAgentOption(caps: ModelCapabilities): ModelCapabilities {
   return {
     ...caps,
-    optionDescriptors: (caps.optionDescriptors ?? []).map((descriptor) =>
-      descriptor.type === "select" && descriptor.id === "agent"
-        ? { ...descriptor, options: descriptor.options.filter((option) => option.id !== "plan") }
-        : descriptor,
-    ),
+    optionDescriptors: (caps.optionDescriptors ?? []).flatMap((descriptor) => {
+      if (descriptor.type !== "select" || descriptor.id !== "agent") {
+        return [descriptor];
+      }
+      const options = descriptor.options.filter((option) => option.id !== "plan");
+      return options.length > 0 ? [{ ...descriptor, options }] : [];
+    }),
   };
 }
 

--- a/apps/web/src/providerModels.ts
+++ b/apps/web/src/providerModels.ts
@@ -94,7 +94,9 @@ export function getProviderModelCapabilities(
 
 // The opencode "plan" agent is only reachable while legacy plan mode is on.
 // With it off, drop the option so it cannot be selected or dispatched, and
-// drop the descriptor entirely when nothing remains selectable.
+// drop the descriptor entirely when nothing remains selectable. currentValue
+// is re-resolved against the surviving options so a stale or defaulted "plan"
+// value cannot leak back into dispatch.
 function withoutPlanAgentOption(caps: ModelCapabilities): ModelCapabilities {
   return {
     ...caps,
@@ -103,7 +105,14 @@ function withoutPlanAgentOption(caps: ModelCapabilities): ModelCapabilities {
         return [descriptor];
       }
       const options = descriptor.options.filter((option) => option.id !== "plan");
-      return options.length > 0 ? [{ ...descriptor, options }] : [];
+      if (options.length === 0) {
+        return [];
+      }
+      const currentValue =
+        descriptor.currentValue && options.some((option) => option.id === descriptor.currentValue)
+          ? descriptor.currentValue
+          : (options.find((option) => option.isDefault)?.id ?? options[0]?.id);
+      return [{ ...descriptor, options, ...(currentValue ? { currentValue } : {}) }];
     }),
   };
 }

--- a/apps/web/src/providerModels.ts
+++ b/apps/web/src/providerModels.ts
@@ -81,9 +81,28 @@ export function getProviderModelCapabilities(
   models: ReadonlyArray<ServerProviderModel>,
   model: string | null | undefined,
   provider: ProviderDriverKind,
+  planModeEnabled = true,
 ): ModelCapabilities {
   const slug = normalizeModelSlug(model, provider);
-  return models.find((candidate) => candidate.slug === slug)?.capabilities ?? EMPTY_CAPABILITIES;
+  const caps =
+    models.find((candidate) => candidate.slug === slug)?.capabilities ?? EMPTY_CAPABILITIES;
+  if (planModeEnabled) {
+    return caps;
+  }
+  return withoutPlanAgentOption(caps);
+}
+
+// The opencode "plan" agent is only reachable while legacy plan mode is on.
+// With it off, drop the option so it cannot be selected or dispatched.
+function withoutPlanAgentOption(caps: ModelCapabilities): ModelCapabilities {
+  return {
+    ...caps,
+    optionDescriptors: (caps.optionDescriptors ?? []).map((descriptor) =>
+      descriptor.type === "select" && descriptor.id === "agent"
+        ? { ...descriptor, options: descriptor.options.filter((option) => option.id !== "plan") }
+        : descriptor,
+    ),
+  };
 }
 
 export function getDefaultServerModel(

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -31,6 +31,7 @@ import {
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { applyAppearanceFontVariables } from "~/appearanceFonts";
 import { useClientSettings } from "../hooks/useSettings";
+import { PlanAgentSelectionHeal } from "../planAgentSelectionHeal";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKeyFromPath,
@@ -140,6 +141,7 @@ function RootRouteView() {
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
+        {primaryEnvironmentAuthenticated ? <PlanAgentSelectionHeal /> : null}
         {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}
         {appShell}
         {/* Above the router: a theme draft is judged by walking the app, so the


### PR DESCRIPTION
## What Changed

The opencode plan agent now only appears in T3's Agent dropdown while legacy plan mode is enabled. With plan mode feature off, the option is removed from the model's capabilities in `getProviderModelCapabilities`, so it can't be selected or dispatched. When plan mode feature is on, it shows as before. Threaded through the composer, model settings, and project settings (all share TraitsPicker), and covered by a test that a stale agent: plan selection self-heals to build.

## Why

T3's plan mode is now a legacy feature and defaults to off, but the opencode plan agent still showed up in the dropdown regardless. Gating the option on the same planModeEnabled client setting keeps the two in sync.

## Screenshots

Before:
Plan mode is an option even when it is disabled in settings
<img width="1293" height="918" alt="image" src="https://github.com/user-attachments/assets/4547d5a3-f811-4165-b04e-cb4532bd3719" />

After:
Plan mode is not an option when disabled in settings
<img width="1345" height="918" alt="image" src="https://github.com/user-attachments/assets/bcdfea4d-c83f-4e79-95cd-930c16446bc1" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide opencode plan agent in model pickers when legacy plan mode is disabled
> - Extends `getProviderModelCapabilities` in [providerModels.ts](https://github.com/pingdotgg/t3code/pull/6420/files#diff-aae3d964ea760fa1047227e41883ae0577a1676fb25c3f549a31c75ef72319c4) with a `planModeEnabled` flag that strips the `plan` agent option (and its descriptor if empty) from returned capabilities.
> - Propagates `planModeEnabled` through `getComposerProviderState`, `TraitsPicker`, and `TraitsMenuContent` so all model selection UIs omit the plan agent when the toggle is off.
> - Adds `withoutPlanAgentSelection` and `resolvePlanAgentHealPatch` utilities in [modelSelection.ts](https://github.com/pingdotgg/t3code/pull/6420/files#diff-3bbcb619a0f4b212f9d0b396a6b561103b0630227331138956971e1e960d86f2) to sanitize persisted selections that reference the plan agent.
> - Introduces [PlanAgentSelectionHeal](https://github.com/pingdotgg/t3code/pull/6420/files#diff-256ded957b39d5d3f8e53ea35642b12e537009a22c06c2a118f4a2eab2d693dc), mounted at the app root, that auto-removes stored plan agent selections on settings hydration when plan mode is disabled.
> - Disabling the plan mode toggle in settings also immediately patches out any persisted plan agent selections for `textGenerationModelSelection` and `sourceControlWriterModelSelection`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8d6048.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and model-option gating tied to an existing beta setting, with tests and hydration guards; no auth or server contract changes beyond sanitized dispatch options.
> 
> **Overview**
> When **legacy plan mode** (`settings.planModeEnabled`) is off, the opencode **plan** agent is no longer exposed in model traits or sent on dispatch.
> 
> `getProviderModelCapabilities` now takes `planModeEnabled` and strips the `plan` option from the `agent` descriptor (or drops the descriptor when it would be empty), re-resolving `currentValue` so stale `plan` defaults cannot leak into dispatch. That flag is threaded through the composer, `TraitsPicker`, and settings/project model pickers via `getComposerProviderState`.
> 
> **Persisted selections** are cleaned up with `withoutPlanAgentSelection` / `resolvePlanAgentHealPatch`: turning the legacy toggle off immediately patches text-generation and source-control writer models, and `PlanAgentSelectionHeal` at the app root heals stored `agent: plan` selections after client settings hydrate (guarded so pre-hydration `false` does not strip plan for users who still have plan mode on).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d6048889b19e25bc794219707259920b6b6367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->