### PR TITLE
feat(web): step the merge button aside when the host would refuse it

### DIFF
--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -2048,7 +2048,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
       expect(detail.body).toBe("Core body");
       expect(activity.author?.login).toBe("octocat");
       expect(callAt(0).args.at(-1)).toBe(
-        "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup,body,changedFiles,closedAt,headRepositoryOwner,autoMergeRequest",
+        "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup,body,changedFiles,closedAt,headRepositoryOwner,autoMergeRequest,mergeStateStatus",
       );
       expect(callAt(1).args.at(-1)).toBe("author,comments,reviews,commits");
     }),
@@ -2206,7 +2206,12 @@ layer("GitHubPullRequestCli.layer", (it) => {
         // One request, because both answers hang off the same repository object.
         assert.strictEqual(mockedExecute.mock.calls.length, 1);
         expect(callAt(0).args).toContain("number=7");
-        expect(access).toEqual({ canWrite: false, canUpdate: true, didAuthor: true });
+        expect(access).toEqual({
+          canWrite: false,
+          canUpdate: true,
+          didAuthor: true,
+          autoMergeAllowed: false,
+        });
       }),
   );
 

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -101,6 +101,7 @@ describe("gitHubViewerPermissions", () => {
               mergedAt: null,
               closedAt: null,
               checks: [],
+              mergeReadiness: "unknown",
               comments: [],
               commits: [],
             }),
@@ -144,6 +145,7 @@ describe("getViewerPermissions", () => {
     mergedAt: null,
     closedAt: null,
     checks: [],
+    mergeReadiness: "unknown" as const,
     comments: [],
     commits: [],
   };
@@ -237,6 +239,7 @@ describe("getChangeRequest commits", () => {
     mergedAt: null,
     closedAt: null,
     checks: [],
+    mergeReadiness: "unknown" as const,
     comments: [],
   };
 

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -260,6 +260,7 @@ export const make = Effect.gen(function* () {
               avatarUrl: null,
             })),
             mergeCapabilities: repository.mergeCapabilities,
+            autoMergeAllowed: viewerAccess.autoMergeAllowed === true,
             viewerPermissions: gitHubViewerPermissions({
               ...viewerAccess,
               canUpdateBranch: detail.comparison?.viewerCanUpdate === true,

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -15,6 +15,7 @@ import type {
   PullRequestListState,
   PullRequestMergeCapabilities,
   PullRequestMergeMethod,
+  PullRequestMergeReadiness,
   PullRequestMergeability,
   PullRequestOmittedFileStat,
   PullRequestReaction,
@@ -157,6 +158,10 @@ export interface ProviderChangeRequestDetail extends ProviderChangeRequest {
   readonly behindBy?: number;
   /** Absent from a host that does not report whether it is armed to merge this on its own. */
   readonly autoMergeEnabled?: boolean;
+  /** Absent from a host that does not say whether a merge would go through right now. */
+  readonly mergeReadiness?: PullRequestMergeReadiness;
+  /** Absent from a host that does not report the repository's own auto-merge setting. */
+  readonly autoMergeAllowed?: boolean;
 }
 
 /** The conversation-shaped half of a detail, loaded after the core can already render. */

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -1082,6 +1082,12 @@ export const make = Effect.gen(function* () {
               ...(changeRequest.autoMergeEnabled === undefined
                 ? {}
                 : { autoMergeEnabled: changeRequest.autoMergeEnabled }),
+              ...(changeRequest.mergeReadiness === undefined
+                ? {}
+                : { mergeReadiness: changeRequest.mergeReadiness }),
+              ...(changeRequest.autoMergeAllowed === undefined
+                ? {}
+                : { autoMergeAllowed: changeRequest.autoMergeAllowed }),
             }),
           ),
         ),

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
@@ -237,6 +237,22 @@ describe("pull request detail decoding", () => {
     expect(armed({})).toBeUndefined();
   });
 
+  it("reads merge readiness off mergeStateStatus, and silence as unknown", () => {
+    const raw = JSON.parse(detailJson) as Record<string, unknown>;
+    const readiness = (entry: Record<string, unknown>) =>
+      expectSuccess(decodePullRequestDetailJson(JSON.stringify({ ...raw, ...entry })))
+        .mergeReadiness;
+
+    expect(readiness({ mergeStateStatus: "BLOCKED" })).toBe("blocked");
+    // UNSTABLE is a non-required check failing, which GitHub merges past.
+    for (const status of ["CLEAN", "HAS_HOOKS", "UNSTABLE"]) {
+      expect(readiness({ mergeStateStatus: status })).toBe("ready");
+    }
+    // A status this build has never heard of, and gh not answering at all, both change nothing.
+    expect(readiness({ mergeStateStatus: "SOMETHING_NEW" })).toBe("unknown");
+    expect(readiness({})).toBe("unknown");
+  });
+
   it("shows a re-running check once, as the run that is happening now", () => {
     // What `statusCheckRollup` reports while a workflow is being re-run: the same check twice,
     // the finished run and the one that replaced it, with no id to tell them apart.
@@ -757,7 +773,7 @@ describe("viewer permission decoding", () => {
           }),
         ),
       ),
-    ).toEqual({ canWrite: false, canUpdate: true, didAuthor: true });
+    ).toEqual({ canWrite: false, canUpdate: true, didAuthor: true, autoMergeAllowed: false });
   });
 
   it("says no to a passer-by on a repository they can only read", () => {
@@ -770,7 +786,21 @@ describe("viewer permission decoding", () => {
           }),
         ),
       ),
-    ).toEqual({ canWrite: false, canUpdate: false, didAuthor: false });
+    ).toEqual({ canWrite: false, canUpdate: false, didAuthor: false, autoMergeAllowed: false });
+  });
+
+  it("reads the repository's auto-merge setting off the same call, on only when stated", () => {
+    expect(
+      expectSuccess(
+        decodeViewerPermissionsJson(
+          viewerJson({
+            viewerPermission: "WRITE",
+            autoMergeAllowed: true,
+            pullRequest: { viewerCanUpdate: true, viewerDidAuthor: false },
+          }),
+        ),
+      ).autoMergeAllowed,
+    ).toBe(true);
   });
 
   it("reads silence as permission, but not as authorship", () => {
@@ -781,6 +811,7 @@ describe("viewer permission decoding", () => {
       canWrite: false,
       canUpdate: true,
       didAuthor: false,
+      autoMergeAllowed: false,
     });
   });
 });

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -11,6 +11,7 @@ import type {
   PullRequestCommit,
   PullRequestLabel,
   PullRequestMergeCapabilities,
+  PullRequestMergeReadiness,
   PullRequestOmittedFileStat,
   PullRequestMergeability,
   PullRequestReaction,
@@ -369,6 +370,7 @@ const RawDetailSchema = Schema.Struct({
    * the question the page asks is whether one exists.
    */
   autoMergeRequest: Schema.optional(Schema.NullOr(Schema.Unknown)),
+  mergeStateStatus: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 const RawActivitySchema = Schema.Struct({
@@ -598,7 +600,7 @@ export function decodeActorAvatarsJson(
 export const PULL_REQUEST_LIST_JSON_FIELDS =
   "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup";
 
-export const PULL_REQUEST_DETAIL_JSON_FIELDS = `${PULL_REQUEST_LIST_JSON_FIELDS},body,changedFiles,closedAt,headRepositoryOwner,autoMergeRequest`;
+export const PULL_REQUEST_DETAIL_JSON_FIELDS = `${PULL_REQUEST_LIST_JSON_FIELDS},body,changedFiles,closedAt,headRepositoryOwner,autoMergeRequest,mergeStateStatus`;
 export const PULL_REQUEST_ACTIVITY_JSON_FIELDS = "author,comments,reviews,commits";
 
 /** GitHub's own ceiling on a connection page, which is what both thread reads ask for. */
@@ -995,6 +997,7 @@ export interface GitHubPullRequestDetail extends GitHubPullRequestListItem {
   readonly checks: ReadonlyArray<PullRequestCheck>;
   /** Absent where `gh` did not answer for auto-merge at all, which is not the same as off. */
   readonly autoMergeEnabled?: boolean;
+  readonly mergeReadiness: PullRequestMergeReadiness;
 }
 
 export interface GitHubPullRequestActivity {
@@ -1079,6 +1082,30 @@ function toMergeability(value: string | null | undefined): PullRequestMergeabili
       return "mergeable";
     case "CONFLICTING":
       return "conflicting";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Whether GitHub would carry out a merge right now, from `mergeStateStatus`. UNSTABLE counts as
+ * ready — it is a non-required check failing, which GitHub merges past. DIRTY and DRAFT count as
+ * blocked, though `mergeability` and `isDraft` will have said so first and more precisely. BEHIND
+ * only ever appears where the repository requires branches to be current before merging (see
+ * BASE_COMPARISON_GRAPHQL_QUERY), so on the repositories that report it, it does block. A status
+ * this does not know stays unknown, which leaves the page exactly as it was before this field.
+ */
+function toMergeReadiness(value: string | null | undefined): PullRequestMergeReadiness {
+  switch (value?.trim().toUpperCase()) {
+    case "CLEAN":
+    case "HAS_HOOKS":
+    case "UNSTABLE":
+      return "ready";
+    case "BLOCKED":
+    case "BEHIND":
+    case "DIRTY":
+    case "DRAFT":
+      return "blocked";
     default:
       return "unknown";
   }
@@ -1344,6 +1371,7 @@ function toDetail(raw: Schema.Schema.Type<typeof RawDetailSchema>): GitHubPullRe
     ...(raw.autoMergeRequest === undefined
       ? {}
       : { autoMergeEnabled: raw.autoMergeRequest !== null }),
+    mergeReadiness: toMergeReadiness(raw.mergeStateStatus),
   };
 }
 
@@ -2099,6 +2127,12 @@ export interface GitHubViewerAccess {
    * something to update" at once. Absent where the comparison was not read.
    */
   readonly canUpdateBranch?: boolean;
+  /**
+   * The repository's own auto-merge setting, riding this query because `gh repo view --json`
+   * does not export it. Absent or false reads as off, never as on: offering to arm auto-merge
+   * somewhere it cannot be armed ends in a refusal the page invited.
+   */
+  readonly autoMergeAllowed?: boolean;
 }
 
 /**
@@ -2110,6 +2144,7 @@ export interface GitHubViewerAccess {
 export const VIEWER_PERMISSIONS_GRAPHQL_QUERY = `query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     viewerPermission
+    autoMergeAllowed
     pullRequest(number: $number) { viewerCanUpdate viewerDidAuthor }
   }
 }`;
@@ -2118,6 +2153,7 @@ const RawViewerPermissionsSchema = Schema.Struct({
   data: Schema.Struct({
     repository: Schema.Struct({
       viewerPermission: Schema.optional(Schema.NullOr(Schema.String)),
+      autoMergeAllowed: Schema.optional(Schema.NullOr(Schema.Boolean)),
       /** Null for a number that names no pull request the viewer can see. */
       pullRequest: Schema.NullOr(RawViewerFieldsSchema),
     }),
@@ -2136,6 +2172,7 @@ export function decodeViewerPermissionsJson(
   const repository = decoded.success.data.repository;
   return Result.succeed({
     canWrite: toCanWrite(repository.viewerPermission),
+    autoMergeAllowed: repository.autoMergeAllowed === true,
     ...toPullRequestViewerFields(repository.pullRequest),
   });
 }

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -103,6 +103,8 @@ import {
   handoffPrompt,
   handoffReviewComments,
   pullRequestActionNeedsHostRefresh,
+  pullRequestMergeWithheld,
+  resolvePullRequestPrimaryAction,
   pullRequestFindingKey,
   pullRequestHandoffLabels,
   readableFailure,
@@ -172,6 +174,9 @@ const ACTION_FAILURE_HINTS: Record<PullRequestAction, string> = {
   "disable-auto-merge":
     "The host refused it. Check that you have write access, and that the merge has not already happened.",
 };
+
+/** Why there is a Merge button that cannot be pressed, told where the button would be. */
+const MERGE_WITHHELD_REASON = "You need write access on this repository to merge.";
 
 /**
  * Said instead of the update hint when the reader asked for a rebase: it is the one that fails on
@@ -1015,24 +1020,14 @@ export function PullRequestDetailPanel({
   }, [tab, visibleTabs]);
   // Two questions, both of which have to say yes: whether this host can do it at all, and
   // whether this account may. A reader with read access on someone else's project sees the pull
-  // request and none of the buttons that would only ever be refused.
+  // request and none of the buttons that would only ever be refused — except Merge, whose
+  // withheld state is shown with its reason rather than leaving a hole where the button was.
   const can = (action: PullRequestAction) =>
     detail?.capabilities.actions.includes(action) === true &&
     detail.viewerPermissions.actions.includes(action);
-  // One live action holds the slot. A conflicting change cannot be merged now, so the slot goes
-  // to the thing that would help instead of a Merge button that only ever says no.
   const primaryAction =
-    detail === null || detail.state !== "open"
-      ? null
-      : detail.isDraft && can("ready")
-        ? "ready"
-        : !can("merge")
-          ? null
-          : conflicting
-            ? "resolve"
-            : allowedMergeMethods.length > 0
-              ? "merge"
-              : null;
+    detail && resolvePullRequestPrimaryAction(detail, allowedMergeMethods.length);
+  const mergeWithheld = detail !== null && pullRequestMergeWithheld(detail);
   // The pull request number carries this state in the overview and the right-panel tab mirrors
   // it. Conflicts keep their own row below: an open pull request remains green there.
   const statePresentation = detail
@@ -1212,6 +1207,17 @@ export function PullRequestDetailPanel({
                           <GitMergeIcon className="size-3.5" />
                           Disable auto-merge
                         </MenuItem>
+                      ) : primaryAction === "auto-merge" ? (
+                        /* The header offers the arming, so the menu keeps the immediate merge:
+                           an admin can push past the block, and the host refuses anyone else
+                           with its own sentence. */
+                        <MenuItem
+                          disabled={actionPending}
+                          onClick={() => setConfirmAction("merge")}
+                        >
+                          <GitMergeIcon className="size-3.5" />
+                          Merge now
+                        </MenuItem>
                       ) : !autoMergeArmed &&
                         !detail.isDraft &&
                         !conflicting &&
@@ -1373,6 +1379,26 @@ export function PullRequestDetailPanel({
                 >
                   {pendingAction === "merge" ? "Merging..." : "Merge"}
                 </Button>
+              ) : primaryAction === "auto-merge" ? (
+                /* The same arming the menu offers, promoted to the slot the merge cannot hold:
+                   the host has said this merge is blocked, so the button that would only be
+                   refused steps aside for the one that will land. Merge now stays in the menu
+                   for the roles that can push past the block. */
+                <Button
+                  size="xs"
+                  disabled={actionPending}
+                  title="The merge is blocked right now; this merges once everything it requires has passed."
+                  onClick={() => setConfirmAction("enable-auto-merge")}
+                >
+                  {pendingAction === "enable-auto-merge" ? "Arming..." : "Merge when ready"}
+                </Button>
+              ) : mergeWithheld ? (
+                /* The disabled button swallows pointer events, so the reason rides the wrapper. */
+                <span className="flex" title={MERGE_WITHHELD_REASON}>
+                  <Button size="xs" disabled>
+                    Merge
+                  </Button>
+                </span>
               ) : null}
             </>
           ) : null}

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -21,8 +21,10 @@ import {
   pullRequestActionNeedsHostRefresh,
   pullRequestFindingKey,
   pullRequestHandoffLabels,
+  pullRequestMergeWithheld,
   readableFailure,
   resolveBaseFreshness,
+  resolvePullRequestPrimaryAction,
   buildPullRequestTimeline,
   describePullRequestState,
 } from "./pullRequestDetail.logic";
@@ -935,5 +937,153 @@ describe("which actions need the host read again after they run", () => {
     ] as const) {
       expect(pullRequestActionNeedsHostRefresh(action)).toBe(false);
     }
+  });
+});
+
+describe("resolvePullRequestPrimaryAction", () => {
+  const ALL_ACTIONS = [
+    "merge",
+    "enable-auto-merge",
+    "disable-auto-merge",
+    "ready",
+    "draft",
+    "close",
+    "reopen",
+  ] as const;
+  /** A writer on an open, mergeable pull request; each test narrows what it is about. */
+  const facts = (overrides: Record<string, unknown> = {}) => ({
+    state: "open" as const,
+    isDraft: false,
+    mergeability: "mergeable" as const,
+    capabilities: { actions: ALL_ACTIONS },
+    viewerPermissions: { actions: ALL_ACTIONS },
+    ...overrides,
+  });
+
+  it("offers the plain merge while nothing is known to block it", () => {
+    expect(resolvePullRequestPrimaryAction(facts(), 3)).toBe("merge");
+    expect(resolvePullRequestPrimaryAction(facts({ mergeReadiness: "ready" }), 3)).toBe("merge");
+  });
+
+  it("offers merge-when-ready where the merge is blocked and auto-merge could take it", () => {
+    expect(
+      resolvePullRequestPrimaryAction(
+        facts({ mergeReadiness: "blocked", autoMergeAllowed: true }),
+        3,
+      ),
+    ).toBe("auto-merge");
+  });
+
+  it("keeps the plain merge on a blocked pull request auto-merge cannot take", () => {
+    // A repository with the setting off, one the host said nothing about, and one already
+    // armed: an admin can merge past the block, and the host's own refusal explains the rest.
+    expect(resolvePullRequestPrimaryAction(facts({ mergeReadiness: "blocked" }), 3)).toBe("merge");
+    expect(
+      resolvePullRequestPrimaryAction(
+        facts({ mergeReadiness: "blocked", autoMergeAllowed: false }),
+        3,
+      ),
+    ).toBe("merge");
+    expect(
+      resolvePullRequestPrimaryAction(
+        facts({ mergeReadiness: "blocked", autoMergeAllowed: true, autoMergeEnabled: true }),
+        3,
+      ),
+    ).toBe("merge");
+  });
+
+  it("never offers merge-when-ready without the permission to arm it", () => {
+    expect(
+      resolvePullRequestPrimaryAction(
+        facts({
+          mergeReadiness: "blocked",
+          autoMergeAllowed: true,
+          viewerPermissions: { actions: ["merge"] },
+        }),
+        3,
+      ),
+    ).toBe("merge");
+  });
+
+  it("sends a conflicting change to resolution before any kind of merge", () => {
+    expect(
+      resolvePullRequestPrimaryAction(
+        facts({ mergeability: "conflicting", mergeReadiness: "blocked", autoMergeAllowed: true }),
+        3,
+      ),
+    ).toBe("resolve");
+  });
+
+  it("gives a draft its ready action, and never merge-when-ready", () => {
+    expect(resolvePullRequestPrimaryAction(facts({ isDraft: true }), 3)).toBe("ready");
+    // A draft whose viewer cannot ready it keeps the plain Merge this slot has always given
+    // it: GitHub reports a draft's merge as blocked, but refuses to arm auto-merge on one.
+    expect(
+      resolvePullRequestPrimaryAction(
+        facts({
+          isDraft: true,
+          mergeReadiness: "blocked",
+          autoMergeAllowed: true,
+          viewerPermissions: { actions: ["merge", "enable-auto-merge"] },
+        }),
+        3,
+      ),
+    ).toBe("merge");
+  });
+
+  it("offers nothing without the merge permission, and nothing without a method to merge by", () => {
+    expect(
+      resolvePullRequestPrimaryAction(facts({ viewerPermissions: { actions: [] } }), 3),
+    ).toBeNull();
+    expect(resolvePullRequestPrimaryAction(facts(), 0)).toBeNull();
+    expect(resolvePullRequestPrimaryAction(facts({ state: "merged" }), 3)).toBeNull();
+  });
+});
+
+describe("pullRequestMergeWithheld", () => {
+  const base = { state: "open", isDraft: false } as const;
+
+  it("says why only where the host merges and this viewer may not ask it to", () => {
+    expect(
+      pullRequestMergeWithheld({
+        ...base,
+        capabilities: { actions: ["merge"] },
+        viewerPermissions: { actions: [] },
+      }),
+    ).toBe(true);
+    // A host with no merge at all has no button to explain the absence of.
+    expect(
+      pullRequestMergeWithheld({
+        ...base,
+        capabilities: { actions: [] },
+        viewerPermissions: { actions: [] },
+      }),
+    ).toBe(false);
+    expect(
+      pullRequestMergeWithheld({
+        ...base,
+        capabilities: { actions: ["merge"] },
+        viewerPermissions: { actions: ["merge"] },
+      }),
+    ).toBe(false);
+  });
+
+  it("stays quiet on drafts and on anything no longer open", () => {
+    expect(
+      pullRequestMergeWithheld({
+        ...base,
+        isDraft: true,
+        capabilities: { actions: ["merge"] },
+        viewerPermissions: { actions: [] },
+      }),
+    ).toBe(false);
+    expect(
+      pullRequestMergeWithheld({
+        ...base,
+        state: "merged",
+        capabilities: { actions: ["merge"] },
+        viewerPermissions: { actions: [] },
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -5,6 +5,7 @@ import type {
   PullRequestCheck,
   PullRequestComment,
   PullRequestDetailView,
+  PullRequestMergeReadiness,
   PullRequestMergeability,
   PullRequestReaction,
   PullRequestReviewThread,
@@ -739,6 +740,67 @@ export function resolveBaseFreshness(detail: {
     behindBy: detail.behindBy ?? null,
     methods: offered.filter((method) => allowed.includes(method)),
   };
+}
+
+export type PullRequestPrimaryAction = "ready" | "resolve" | "merge" | "auto-merge";
+
+/**
+ * The one live action the header's primary slot holds, or null when the slot stays empty. A
+ * conflicting change cannot be merged now, so the slot goes to the thing that would help instead
+ * of a Merge button that only ever says no — and a merge the host reports as blocked goes to
+ * arming auto-merge, for the same reason. Only where the repository allows auto-merge and it is
+ * not already armed: everywhere else the plain Merge stays, and roles that can merge past the
+ * block keep it in the menu.
+ */
+export function resolvePullRequestPrimaryAction(
+  detail: {
+    readonly state: PullRequestState;
+    readonly isDraft: boolean;
+    readonly mergeability: PullRequestMergeability;
+    readonly mergeReadiness?: PullRequestMergeReadiness | undefined;
+    readonly autoMergeAllowed?: boolean | undefined;
+    readonly autoMergeEnabled?: boolean | undefined;
+    readonly capabilities: { readonly actions: ReadonlyArray<PullRequestAction> };
+    readonly viewerPermissions: { readonly actions: ReadonlyArray<PullRequestAction> };
+  },
+  allowedMergeMethodCount: number,
+): PullRequestPrimaryAction | null {
+  const can = (action: PullRequestAction) =>
+    detail.capabilities.actions.includes(action) &&
+    detail.viewerPermissions.actions.includes(action);
+  if (detail.state !== "open") return null;
+  if (detail.isDraft && can("ready")) return "ready";
+  if (!can("merge")) return null;
+  if (detail.mergeability === "conflicting") return "resolve";
+  if (allowedMergeMethodCount === 0) return null;
+  // GitHub reports a draft's merge as blocked and refuses to arm auto-merge on one, so a draft
+  // whose viewer cannot ready it keeps the plain Merge this slot has always given it.
+  return !detail.isDraft &&
+    detail.mergeReadiness === "blocked" &&
+    detail.autoMergeAllowed === true &&
+    detail.autoMergeEnabled !== true &&
+    can("enable-auto-merge")
+    ? "auto-merge"
+    : "merge";
+}
+
+/**
+ * The host merges pull requests and this viewer may not ask it to: the one case where the header
+ * says why there is no Merge button, rather than leaving a hole where it stood — write access is
+ * the single permission the providers withhold instead of granting when unreported.
+ */
+export function pullRequestMergeWithheld(detail: {
+  readonly state: PullRequestState;
+  readonly isDraft: boolean;
+  readonly capabilities: { readonly actions: ReadonlyArray<PullRequestAction> };
+  readonly viewerPermissions: { readonly actions: ReadonlyArray<PullRequestAction> };
+}): boolean {
+  return (
+    detail.state === "open" &&
+    !detail.isDraft &&
+    detail.capabilities.actions.includes("merge") &&
+    !detail.viewerPermissions.actions.includes("merge")
+  );
 }
 
 /**

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -45,8 +45,8 @@ T3 Code works with the platforms your team already uses:
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally
 - Merge from the review header when you have write access — the button says why when you don't,
-  and on GitHub a merge blocked by required checks or reviews becomes **Merge when ready**,
-  which lands it automatically once everything passes
+  and on GitHub, when auto-merge is available, a merge blocked by required checks or reviews
+  becomes **Merge when ready**, which lands it automatically once everything passes
 
 **Fix what you wrote, in place**
 

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -44,6 +44,9 @@ T3 Code works with the platforms your team already uses:
 - Open the review directly in your browser with one click
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally
+- Merge from the review header when you have write access — the button says why when you don't,
+  and on GitHub a merge blocked by required checks or reviews becomes **Merge when ready**,
+  which lands it automatically once everything passes
 
 **Fix what you wrote, in place**
 

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -73,6 +73,15 @@ export type PullRequestChecksState = typeof PullRequestChecksState.Type;
 export const PullRequestMergeability = Schema.Literals(["mergeable", "conflicting", "unknown"]);
 export type PullRequestMergeability = typeof PullRequestMergeability.Type;
 
+/**
+ * Whether the host would carry out a merge right now, aside from the conflicts `mergeability`
+ * already reports: "blocked" is a required check or review still outstanding. "unknown" changes
+ * nothing on the page — the Merge button stays, and the host's own refusal explains anything
+ * that fails.
+ */
+export const PullRequestMergeReadiness = Schema.Literals(["ready", "blocked", "unknown"]);
+export type PullRequestMergeReadiness = typeof PullRequestMergeReadiness.Type;
+
 export const PullRequestMergeMethod = Schema.Literals(["merge", "squash", "rebase"]);
 export type PullRequestMergeMethod = typeof PullRequestMergeMethod.Type;
 
@@ -686,6 +695,17 @@ export const PullRequestDetail = Schema.Struct({
    * arm something that is already armed, and a second arming is a write nobody asked for.
    */
   autoMergeEnabled: Schema.optional(Schema.Boolean),
+  /**
+   * Whether the host would carry out a merge right now. Absent where the host does not say,
+   * which leaves the Merge button exactly as it was — only "blocked" moves the primary action
+   * from merging now to arming a merge for when the block lifts.
+   */
+  mergeReadiness: Schema.optional(PullRequestMergeReadiness),
+  /**
+   * Whether this repository has auto-merge switched on at all. Absent where the host does not
+   * say; "blocked" without this never offers to arm what the repository would only refuse.
+   */
+  autoMergeAllowed: Schema.optional(Schema.Boolean),
 });
 export type PullRequestDetail = typeof PullRequestDetail.Type;
 


### PR DESCRIPTION
The PR header offers Merge even when the press can only fail: required checks or reviews still pending gets the host's refusal toast, and a viewer without write access gets no button and no reason why.

The detail now carries GitHub's own answer about merging right now (`mergeReadiness`, from `mergeStateStatus`) and whether the repository allows auto-merge (`autoMergeAllowed`, riding the existing viewer-access GraphQL query since `gh repo view --json` does not export it). When the merge is blocked and the repository allows auto-merge, the header's primary slot becomes **Merge when ready** — the same `enable-auto-merge` the ⋯ menu already offers, promoted to the slot the plain merge cannot hold, with **Merge now** kept in the menu for roles that can push past the block. A viewer without write access now sees a disabled Merge whose tooltip says why, instead of a hole where the button stood. Both new contract fields are optional, so GitLab, Bitbucket, and Azure DevOps stay exactly as they are, and a GitHub install that reports nothing keeps today's behavior. The header decision moves to `pullRequestDetail.logic.ts` where it is unit-tested.

Validated with `vp test run` on the touched pull-request suites (server + web detail logic, 314 tests), against the live GitHub API, and exercised end to end in a dev session.

Built with Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge/auto-merge UX and permission messaging on a high-traffic review surface; scope is mostly GitHub-specific optional fields with unit tests, but wrong readiness mapping could mislead users about when they can merge.
> 
> **Overview**
> GitHub pull request detail now surfaces **`mergeReadiness`** (from `mergeStateStatus`) and **`autoMergeAllowed`** (from the existing viewer-access GraphQL query), threaded through contracts, JSON decoding, provider, and service into the web client.
> 
> The review header no longer always shows a doomed **Merge**. **`resolvePullRequestPrimaryAction`** picks the primary action: when the merge is blocked but the repo allows auto-merge and the viewer can arm it, the slot becomes **Merge when ready** (`enable-auto-merge`), with **Merge now** kept in the ⋯ menu. Readers without merge permission see a **disabled Merge** with a tooltip instead of an empty slot (`pullRequestMergeWithheld`). Optional contract fields leave other hosts and missing GitHub data on prior behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 737dada1ca36915f0a9d8f5a2d1de6b316ae15b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show 'Merge when ready' and disable merge button when GitHub blocks merging
> - Adds `mergeReadiness` (derived from `mergeStateStatus`) and `autoMergeAllowed` fields to the pull request detail contract, propagated from GitHub through the provider and service layers.
> - Introduces `resolvePullRequestPrimaryAction` in [pullRequestDetail.logic.ts](https://github.com/pingdotgg/t3code/pull/6422/files#diff-2c5f917dba9decc3bd48ec3231f7b0db073e8b642379cf000265960a03718c18) to centralize primary action selection, returning `'auto-merge'` when the merge is blocked but auto-merge is available and the viewer can enable it.
> - Updates `PullRequestDetailPanel` to render a 'Merge when ready' button for the `auto-merge` case and a disabled 'Merge' button with an explanatory tooltip when the viewer lacks merge permission but the host supports merging.
> - Adds a 'Merge now' menu item in the action menu when the primary action is `auto-merge`, allowing a direct merge despite blocks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 737dada.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->