### PR TITLE
fix(web): keep diff file lists scrollable past expanded files

### DIFF
--- a/apps/web/src/components/diffs/StyledDiffCodeView.test.tsx
+++ b/apps/web/src/components/diffs/StyledDiffCodeView.test.tsx
@@ -44,7 +44,9 @@ describe("StyledDiffCodeView", () => {
         diffHeaderHeight: 32,
         hunkSeparatorHeight: 24,
         paddingTop: 0,
-        paddingBottom: 0,
+        // Must match the 8px Pierre's stylesheet paints under a file's last code line, or
+        // expanded files run virtually short and the list tail is clipped out of scroll range.
+        paddingBottom: 8,
       },
       layout: { paddingTop: 0, paddingBottom: 0, gap: 0 },
     });

--- a/apps/web/src/components/diffs/StyledDiffCodeView.test.tsx
+++ b/apps/web/src/components/diffs/StyledDiffCodeView.test.tsx
@@ -44,8 +44,6 @@ describe("StyledDiffCodeView", () => {
         diffHeaderHeight: 32,
         hunkSeparatorHeight: 24,
         paddingTop: 0,
-        // Must match the 8px Pierre's stylesheet paints under a file's last code line, or
-        // expanded files run virtually short and the list tail is clipped out of scroll range.
         paddingBottom: 8,
       },
       layout: { paddingTop: 0, paddingBottom: 0, gap: 0 },

--- a/apps/web/src/components/diffs/StyledDiffCodeView.tsx
+++ b/apps/web/src/components/diffs/StyledDiffCodeView.tsx
@@ -296,11 +296,16 @@ export function StyledDiffCodeView<LAnnotation = undefined>({
           diffHeaderHeight: 32,
           hunkSeparatorHeight: 24,
           // Pierre uses its general file spacing as a fallback in expanded-file layout paths.
-          // Keep it zero alongside the explicit paddings or expanding the first file can
+          // Keep it zero alongside the explicit paddingTop or expanding the first file can
           // reintroduce the library's default 8px gap above its header.
           spacing: 0,
           paddingTop: 0,
-          paddingBottom: 0,
+          // Unlike the gap above, the 8px under a file's last line is painted
+          // unconditionally by Pierre's stylesheet (`--diffs-gap-fallback`), so the metric has
+          // to count it: at zero every expanded file's virtual height ran 8px short of its
+          // rendered height, and the end of the list sat past the reachable scroll range —
+          // one clipped file row per expanded file above it.
+          paddingBottom: 8,
         },
         layout: { paddingTop: 0, paddingBottom: 0, gap: 0 },
       }}


### PR DESCRIPTION
In a pull request's Code tab, expanding a file left the file rows after it clipped at the bottom of the scroll area — with a file open mid-list you could scroll until the next file's row peeked in cut off, and the rows past it were unreachable.

Pierre's stylesheet unconditionally paints 8px of padding under a file's last code line (`--diffs-gap-fallback`), but `StyledDiffCodeView` declared `itemMetrics.paddingBottom: 0`, so every expanded file's virtual height ran 8px short of its rendered height and the virtualizer's scroll range came up short by 8px per expanded file. Counting the painted 8px in the metric restores the pairing; `spacing` and `paddingTop` stay zero, so the gap above the first expanded file's header that the zeroing originally fixed does not come back. The thread diff panel shares this adapter and gets the same correction.

Validated in the running app against a live 10-file pull request: with one file or all files expanded (context hydration settled), the scroll range matches the rendered content exactly — the last row lands flush at the viewport bottom, with no new gap above or between files. Web typecheck passes.

BEFORE:

<img width="593" height="273" alt="a0675f9d-7011-4775-9007-e09cdfd801c2-02812817-1b46-4c7f-9526-38e5ea738240" src="https://github.com/user-attachments/assets/b450b5b0-cda6-4334-a09c-2d447a8be803" />

AFTER:

<img width="584" height="191" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/16e9e3b1-6968-4a9e-b299-c0c344af4065" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single geometry constant in the shared diff adapter with no auth, data, or API changes; regression risk is limited to diff list scrolling layout.
> 
> **Overview**
> **Fixes PR Code tab (and shared diff views) clipping file rows below expanded files** by setting `itemMetrics.paddingBottom` to `8` in `StyledDiffCodeView`, matching Pierre’s always-painted `--diffs-gap-fallback` under each file’s last line.
> 
> Previously virtual row height was 8px short per expanded file, so scroll range ended early and later files were unreachable. `spacing` and `paddingTop` stay `0` so the fix for the gap above the first expanded header is unchanged. The unit test expectation for `paddingBottom` is updated to `8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33d5a5928498d5ef4f40862bbce1f39e3fb6fa8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix diff file list scrolling by correcting `itemMetrics.paddingBottom` in `StyledDiffCodeView`
> The virtualized height calculation in `StyledDiffCodeView` was not accounting for the 8px bottom padding painted by the stylesheet, causing the last rows of expanded files to be clipped and the end of the list to be unreachable via scrolling. Sets `itemMetrics.paddingBottom` from `0` to `8` in [StyledDiffCodeView.tsx](https://github.com/pingdotgg/t3code/pull/6423/files#diff-a347b8cf7b7996847506536a031cdbe8205369bbeb948767f3f414833b306507) to match the actual rendered gap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33d5a59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->