### PR TITLE
fix(mobile): hide inapplicable model settings in the picker

### DIFF
--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -13,6 +13,7 @@ import {
 import * as Haptics from "expo-haptics";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  LayoutAnimation,
   Modal,
   Platform,
   Pressable,
@@ -31,7 +32,11 @@ import type { ModelOption, ProviderGroup } from "../../lib/modelOptions";
 import { applyProviderOptionSelection, providerOptionValueLabels } from "../../lib/providerOptions";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { RUNTIME_MODE_CHOICES, selectableChoices } from "./thread-settings-menu";
-import { pendingModelAfterPress } from "./thread-settings-sheet-state";
+import {
+  pendingModelAfterPress,
+  usesInlineSelectChoices,
+  visibleSheetOptionDescriptors,
+} from "./thread-settings-sheet-state";
 import type { ThreadSettingsSheetCloseReason } from "./use-thread-settings-sheet-presentation";
 
 /**
@@ -40,6 +45,19 @@ import type { ThreadSettingsSheetCloseReason } from "./use-thread-settings-sheet
  * bury the list.
  */
 const PRIMARY_PROVIDER_DRIVERS: ReadonlySet<string> = new Set(["claudeAgent", "codex"]);
+
+const SETTINGS_LAYOUT_ANIMATION = {
+  duration: 180,
+  create: {
+    type: LayoutAnimation.Types.easeInEaseOut,
+    property: LayoutAnimation.Properties.opacity,
+  },
+  update: { type: LayoutAnimation.Types.easeInEaseOut },
+  delete: {
+    type: LayoutAnimation.Types.easeInEaseOut,
+    property: LayoutAnimation.Properties.opacity,
+  },
+} as const;
 
 /**
  * Compact "Fable 5 · Max · Auto" style summary for the composer trigger pill,
@@ -163,19 +181,14 @@ function ProviderHeader(props: {
 function DisclosureRow(props: {
   readonly label: string;
   readonly value: string | undefined;
-  readonly disabled?: boolean;
   readonly onPress: () => void;
 }) {
   const iconSubtle = useThemeColor("--color-icon-subtle");
   return (
     <Pressable
       accessibilityRole="button"
-      disabled={props.disabled}
       onPress={props.onPress}
-      className={cn(
-        "flex-row items-center gap-2 px-5 py-3 active:opacity-70",
-        props.disabled && "opacity-40",
-      )}
+      className="flex-row items-center gap-2 px-5 py-2.5 active:opacity-70"
     >
       <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
       <View className="flex-1" />
@@ -186,6 +199,61 @@ function DisclosureRow(props: {
       ) : null}
       <SymbolView name="chevron.right" size={12} tintColor={iconSubtle} type="monochrome" />
     </Pressable>
+  );
+}
+
+/** Inline mutually-exclusive choices for short catalogs (reasoning, runtime). */
+function ChoiceChipRow(props: {
+  readonly label: string;
+  readonly choices: ReadonlyArray<{
+    readonly id: string;
+    readonly label: string;
+    readonly accessibilityLabel?: string;
+  }>;
+  readonly selectedId: string | undefined;
+  readonly onSelect: (id: string) => void;
+}) {
+  const equalWidth = props.choices.length > 1 && props.choices.length <= 4;
+  return (
+    <View className="gap-2 px-5 py-2.5">
+      <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
+      <View className={cn("flex-row gap-1.5", equalWidth ? undefined : "flex-wrap")}>
+        {props.choices.map((choice) => {
+          const selected = choice.id === props.selectedId;
+          return (
+            <Pressable
+              key={choice.id}
+              accessibilityRole="button"
+              accessibilityState={{ selected }}
+              accessibilityLabel={choice.accessibilityLabel ?? `${props.label}, ${choice.label}`}
+              onPress={() => {
+                if (choice.id === props.selectedId) {
+                  return;
+                }
+                void Haptics.selectionAsync();
+                props.onSelect(choice.id);
+              }}
+              className={cn(
+                "rounded-full px-3 py-1.5 active:opacity-70",
+                selected ? "bg-primary" : "bg-subtle",
+                equalWidth && "min-w-0 flex-1 items-center",
+              )}
+            >
+              <Text
+                className={cn(
+                  "text-xs font-t3-medium",
+                  selected ? "text-primary-foreground" : "text-foreground",
+                  equalWidth && "text-center",
+                )}
+                numberOfLines={1}
+              >
+                {choice.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
   );
 }
 
@@ -225,21 +293,14 @@ function ChoiceRow(props: {
 function SwitchRow(props: {
   readonly label: string;
   readonly value: boolean;
-  readonly disabled?: boolean;
   readonly onValueChange: (value: boolean) => void;
 }) {
   const activeTrack = String(useThemeColor("--color-switch-active"));
   const track = String(useThemeColor("--color-secondary-border"));
   return (
-    <View
-      className={cn(
-        "flex-row items-center justify-between px-5 py-2.5",
-        props.disabled && "opacity-40",
-      )}
-    >
+    <View className="flex-row items-center justify-between px-5 py-2.5">
       <Text className="text-sm font-t3-medium text-foreground">{props.label}</Text>
       <Switch
-        disabled={props.disabled}
         ios_backgroundColor={track}
         onValueChange={props.onValueChange}
         trackColor={{ false: track, true: activeTrack }}
@@ -249,17 +310,16 @@ function SwitchRow(props: {
   );
 }
 
-type SubmenuPage =
-  | { readonly kind: "descriptor"; readonly id: string }
-  | { readonly kind: "runtime" };
+type SubmenuPage = { readonly kind: "descriptor"; readonly id: string };
 
 /**
  * Unified thread settings: the sheet is the provider-grouped model list
  * (primary harnesses expanded, other providers folded, legacy behind the
- * top-right pill) with a Save button, plus compact disclosure rows whose
- * single-choice submenus stack in a small panel over the sheet so it never
- * changes size. Model changes stage until Save — while staged, the settings
- * rows edit the staged model's options and Save applies everything together.
+ * top-right pill) with a Save button. Settings below the list are only the
+ * options the displayed model actually supports — short catalogs (reasoning,
+ * context, runtime) render as chips; longer ones still open a stacked
+ * submenu. Model changes stage until Save — while staged, the settings
+ * edit the staged model's options and Save applies everything together.
  *
  * Callers control which harnesses are offered via providerGroups: an
  * existing thread must pass only its own provider's group, since a session
@@ -345,37 +405,7 @@ export function ThreadSettingsSheet(props: {
   // legacy model is exempted from the filter instead of forcing the whole
   // legacy list visible.
   const showLegacy = showLegacyToggle;
-
-  // Stable settings rows: the union of descriptors across the primary
-  // harnesses' current models (plus whatever the displayed model advertises)
-  // always renders, with unsupported rows disabled instead of vanishing when
-  // the selection changes. Keyed by label, not id — Claude and Codex use
-  // different ids for the same "Reasoning" concept.
-  const descriptorTemplate = (() => {
-    const seen = new Map<string, { type: "select" | "boolean" }>();
-    for (const group of props.providerGroups) {
-      const driver = group.models[0]?.providerDriver;
-      if (driver === undefined || !PRIMARY_PROVIDER_DRIVERS.has(driver)) {
-        continue;
-      }
-      for (const model of group.models) {
-        if (model.isLegacy) {
-          continue;
-        }
-        for (const descriptor of model.capabilities?.optionDescriptors ?? []) {
-          if (!seen.has(descriptor.label)) {
-            seen.set(descriptor.label, { type: descriptor.type });
-          }
-        }
-      }
-    }
-    for (const descriptor of displayedDescriptors) {
-      if (!seen.has(descriptor.label)) {
-        seen.set(descriptor.label, { type: descriptor.type });
-      }
-    }
-    return [...seen.entries()].map(([label, entry]) => ({ label, ...entry }));
-  })();
+  const visibleDescriptors = visibleSheetOptionDescriptors(displayedDescriptors);
 
   const handleSave = () => {
     if (pendingModel) {
@@ -410,43 +440,27 @@ export function ThreadSettingsSheet(props: {
     });
   };
 
-  const activeDescriptor =
-    submenu?.kind === "descriptor"
-      ? displayedDescriptors.find(
-          (descriptor) => descriptor.type === "select" && descriptor.id === submenu.id,
-        )
-      : undefined;
+  const activeDescriptor = displayedDescriptors.find(
+    (descriptor) =>
+      submenu !== null && descriptor.type === "select" && descriptor.id === submenu.id,
+  );
 
   const submenuContent =
-    submenu?.kind === "runtime"
+    activeDescriptor?.type === "select"
       ? {
-          title: "Runtime",
-          rows: RUNTIME_MODE_CHOICES.map((choice) => ({
-            id: choice.mode,
+          title: activeDescriptor.label,
+          rows: selectableChoices(activeDescriptor).map((choice) => ({
+            id: choice.id,
             label: choice.label,
-            selected: choice.mode === props.runtimeMode,
+            selected: choice.id === getProviderOptionCurrentValue(activeDescriptor),
             onPress: () => {
               void Haptics.selectionAsync();
-              props.onUpdateRuntimeMode(choice.mode);
+              handleOptionChange(activeDescriptor.id, choice.id);
               setSubmenu(null);
             },
           })),
         }
-      : activeDescriptor?.type === "select"
-        ? {
-            title: activeDescriptor.label,
-            rows: selectableChoices(activeDescriptor).map((choice) => ({
-              id: choice.id,
-              label: choice.label,
-              selected: choice.id === getProviderOptionCurrentValue(activeDescriptor),
-              onPress: () => {
-                void Haptics.selectionAsync();
-                handleOptionChange(activeDescriptor.id, choice.id);
-                setSubmenu(null);
-              },
-            })),
-          }
-        : null;
+      : null;
 
   return (
     <Modal
@@ -536,6 +550,7 @@ export function ThreadSettingsSheet(props: {
                           selected={isDisplayed(option)}
                           onPress={() => {
                             void Haptics.selectionAsync();
+                            LayoutAnimation.configureNext(SETTINGS_LAYOUT_ANIMATION);
                             // Re-tapping the applied model cancels staging.
                             setPendingModel((current) =>
                               pendingModelAfterPress({
@@ -554,46 +569,56 @@ export function ThreadSettingsSheet(props: {
 
           <View className="mx-5 h-px bg-border" />
 
-          <View style={{ paddingBottom: insets.bottom + 12 }}>
-            {descriptorTemplate.map((entry) => {
-              const live = displayedDescriptors.find(
-                (descriptor) => descriptor.label === entry.label,
-              );
-              if ((live?.type ?? entry.type) === "select") {
+          <View className="pt-1" style={{ paddingBottom: insets.bottom + 12 }}>
+            {visibleDescriptors.map((descriptor) => {
+              if (descriptor.type === "select") {
+                if (usesInlineSelectChoices(descriptor)) {
+                  const currentValue = getProviderOptionCurrentValue(descriptor);
+                  return (
+                    <ChoiceChipRow
+                      key={descriptor.id}
+                      label={descriptor.label}
+                      selectedId={typeof currentValue === "string" ? currentValue : undefined}
+                      choices={selectableChoices(descriptor).map((choice) => ({
+                        id: choice.id,
+                        label: choice.label,
+                      }))}
+                      onSelect={(id) => handleOptionChange(descriptor.id, id)}
+                    />
+                  );
+                }
                 return (
                   <DisclosureRow
-                    key={entry.label}
-                    label={entry.label}
-                    value={live ? getProviderOptionCurrentLabel(live) : undefined}
-                    disabled={!live}
-                    onPress={() => {
-                      if (live) {
-                        setSubmenu({ kind: "descriptor", id: live.id });
-                      }
-                    }}
+                    key={descriptor.id}
+                    label={descriptor.label}
+                    value={getProviderOptionCurrentLabel(descriptor)}
+                    onPress={() => setSubmenu({ kind: "descriptor", id: descriptor.id })}
                   />
                 );
               }
               return (
                 <SwitchRow
-                  key={entry.label}
-                  label={entry.label}
-                  value={live?.type === "boolean" ? (live.currentValue ?? false) : false}
-                  disabled={!live}
-                  onValueChange={(value) => {
-                    if (live) {
-                      handleOptionChange(live.id, value);
-                    }
-                  }}
+                  key={descriptor.id}
+                  label={descriptor.label}
+                  value={descriptor.currentValue ?? false}
+                  onValueChange={(value) => handleOptionChange(descriptor.id, value)}
                 />
               );
             })}
-            <DisclosureRow
+            <ChoiceChipRow
               label="Runtime"
-              value={
-                RUNTIME_MODE_CHOICES.find((choice) => choice.mode === props.runtimeMode)?.label
-              }
-              onPress={() => setSubmenu({ kind: "runtime" })}
+              selectedId={props.runtimeMode}
+              choices={RUNTIME_MODE_CHOICES.map((choice) => ({
+                id: choice.mode,
+                label: choice.shortLabel,
+                accessibilityLabel: `Runtime, ${choice.label}`,
+              }))}
+              onSelect={(id) => {
+                const choice = RUNTIME_MODE_CHOICES.find((candidate) => candidate.mode === id);
+                if (choice) {
+                  props.onUpdateRuntimeMode(choice.mode);
+                }
+              }}
             />
             <Pressable
               accessibilityRole="button"

--- a/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
+++ b/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { ProviderInstanceId, type ProviderOptionSelection } from "@t3tools/contracts";
+import {
+  ProviderInstanceId,
+  type ProviderOptionDescriptor,
+  type ProviderOptionSelection,
+} from "@t3tools/contracts";
 
 import type { ModelOption } from "../../lib/modelOptions";
-import { pendingModelAfterPress } from "./thread-settings-sheet-state";
+import {
+  pendingModelAfterPress,
+  usesInlineSelectChoices,
+  visibleSheetOptionDescriptors,
+} from "./thread-settings-sheet-state";
 
 function modelOption(
   model: string,
@@ -60,5 +68,72 @@ describe("thread settings sheet state", () => {
         pressedIsApplied: false,
       }),
     ).toBe(pressed);
+  });
+});
+
+const reasoning: ProviderOptionDescriptor = {
+  id: "effort",
+  label: "Reasoning",
+  type: "select",
+  options: [
+    { id: "low", label: "Low" },
+    { id: "medium", label: "Medium", isDefault: true },
+    { id: "high", label: "High" },
+    { id: "ultrathink", label: "Ultrathink" },
+    { id: "ultracode", label: "Ultracode" },
+  ],
+  currentValue: "high",
+  promptInjectedValues: ["ultrathink"],
+};
+
+const contextWindow: ProviderOptionDescriptor = {
+  id: "contextWindow",
+  label: "Context Window",
+  type: "select",
+  options: [
+    { id: "200k", label: "200k", isDefault: true },
+    { id: "1m", label: "1M" },
+  ],
+  currentValue: "200k",
+};
+
+const fastMode: ProviderOptionDescriptor = {
+  id: "fastMode",
+  label: "Fast Mode",
+  type: "boolean",
+  currentValue: false,
+};
+
+describe("visible sheet option descriptors", () => {
+  it("keeps only the advertised options, dropping empty select catalogs", () => {
+    const emptySelect: ProviderOptionDescriptor = {
+      id: "serviceTier",
+      label: "Service Tier",
+      type: "select",
+      options: [{ id: "ultracode", label: "Ultracode" }],
+      currentValue: "ultracode",
+    };
+
+    expect(
+      visibleSheetOptionDescriptors([reasoning, fastMode, emptySelect]).map(
+        (descriptor) => descriptor.id,
+      ),
+    ).toEqual(["effort", "fastMode"]);
+  });
+
+  it("uses inline chips for short catalogs and a disclosure for long ones", () => {
+    expect(usesInlineSelectChoices(reasoning)).toBe(true);
+    expect(usesInlineSelectChoices(contextWindow)).toBe(true);
+
+    const longCatalog: Extract<ProviderOptionDescriptor, { type: "select" }> = {
+      id: "modelVariant",
+      label: "Variant",
+      type: "select",
+      options: Array.from({ length: 8 }, (_, index) => ({
+        id: `v${index}`,
+        label: `Variant ${index}`,
+      })),
+    };
+    expect(usesInlineSelectChoices(longCatalog)).toBe(false);
   });
 });

--- a/apps/mobile/src/features/threads/thread-settings-sheet-state.ts
+++ b/apps/mobile/src/features/threads/thread-settings-sheet-state.ts
@@ -1,4 +1,10 @@
+import type { ProviderOptionDescriptor } from "@t3tools/contracts";
+
 import type { ModelOption } from "../../lib/modelOptions";
+import { selectableChoices } from "./thread-settings-menu";
+
+/** Compact chip rows stay scannable; longer catalogs keep a disclosure. */
+export const INLINE_SELECT_CHOICE_LIMIT = 6;
 
 /** Preserve staged provider options when the highlighted model is tapped again. */
 export function pendingModelAfterPress(input: {
@@ -10,4 +16,26 @@ export function pendingModelAfterPress(input: {
     return null;
   }
   return input.current?.key === input.pressed.key ? input.current : input.pressed;
+}
+
+/**
+ * Settings the displayed model actually advertises. Unsupported rows stay
+ * out of the sheet instead of rendering disabled — switching models should
+ * only show controls that can change something.
+ */
+export function visibleSheetOptionDescriptors(
+  descriptors: ReadonlyArray<ProviderOptionDescriptor>,
+): ReadonlyArray<ProviderOptionDescriptor> {
+  return descriptors.filter((descriptor) => {
+    if (descriptor.type === "boolean") {
+      return true;
+    }
+    return selectableChoices(descriptor).length > 0;
+  });
+}
+
+export function usesInlineSelectChoices(
+  descriptor: Extract<ProviderOptionDescriptor, { type: "select" }>,
+): boolean {
+  return selectableChoices(descriptor).length <= INLINE_SELECT_CHOICE_LIMIT;
 }


### PR DESCRIPTION
## What Changed

The mobile model picker sheet no longer keeps a union of every provider setting on screen. It now shows only the options the selected (or staged) model actually supports, and renders short catalogs — reasoning, context window, service tier, optimize-for, and runtime — as inline chips instead of extra disclosure rows.

Unsupported controls are omitted rather than greyed out. Switching models animates the settings cluster so rows appear and disappear without a jump. Catalogs longer than six choices still open the stacked submenu.

This is the same picker cleanup we shipped in T3 Pretty, re-implemented on current `pingdotgg/t3code` main. The iOS composer menu already skipped empty select catalogs; this brings the sheet (Android, new-task draft, and the fallback sheet) in line.

## Why

Greyed-out Reasoning, Context Window, Fast Mode, and Service Tier rows made the sheet feel cluttered, especially on models like Cursor Auto that only expose Optimize For. Hiding inapplicable settings and putting the remaining choices on chips keeps the panel compact without removing any capability.

## UI Changes

**Before:** Every possible setting stayed visible. Unsupported rows were dimmed with a chevron or a dead toggle, so picking Auto still showed Reasoning / Context Window / Fast Mode / Service Tier as disabled chrome. Runtime opened a second panel.

**After:** Only advertised settings render. Reasoning and similar short selects are chip rows on the main sheet (no extra panel). Runtime uses the existing short labels (Approve / Edits / Auto / Full). A model with no extra options shows just Runtime and Done.

Screenshots were not captured in this pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Test plan

- [x] `vp test run` on `apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts` and `thread-settings-menu.test.ts` (16 tests)
- [x] `vp run --filter @t3tools/mobile typecheck`
- [ ] iOS: open the new-task model sheet, pick Cursor Auto, confirm only Optimize For + Runtime chips appear
- [ ] iOS: switch to a Claude/Codex model and confirm reasoning/context chips appear without a layout jump
- [ ] Android: same sheet from an existing thread composer

Model: grok-4.6

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide inapplicable model settings and render short select options as inline chips in thread settings
> - The settings sheet now filters visible options using `visibleSheetOptionDescriptors`, showing only descriptors the selected model advertises; empty select catalogs and unsupported options are hidden.
> - Select descriptors with 6 or fewer choices render as inline `ChoiceChipRow` chips with immediate selection instead of navigating to a submenu; longer catalogs still use `DisclosureRow`.
> - The Runtime setting is converted from a submenu to an inline chip row that applies the change immediately.
> - Switching models triggers a `LayoutAnimation` (180ms easeInEaseOut) so the settings area transitions smoothly.
> - Behavioral Change: `disabled` visual states are removed from `DisclosureRow` and `SwitchRow`; unsupported rows are now suppressed upstream rather than shown as disabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1780a8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->