### PR TITLE
fix(grok): surface autonomous plan mode proposals

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
 
 import * as Effect from "effect/Effect";
 
@@ -815,7 +816,7 @@ const program = Effect.gen(function* () {
       }
 
       if (emitXAiPlanMdWrite) {
-        const planPath = `/tmp/mock-home/.grok/sessions/${requestedSessionId}/plan.md`;
+        const planPath = `${NodeOS.homedir().replace(/\\/g, "/")}/.grok/sessions/${requestedSessionId}/plan.md`;
         const planBody = "# Mock plan\n\n- Write the feature\n- Add a test\n- Ship it\n";
         yield* agent.client.sessionUpdate({
           sessionId: requestedSessionId,
@@ -862,25 +863,42 @@ const program = Effect.gen(function* () {
       }
 
       if (emitXAiExitPlanMode) {
-        const result = yield* agent.client.extRequest("_x.ai/exit_plan_mode", {
-          method: "x.ai/exit_plan_mode",
-          params: {
+        const planCycles = [
+          { id: "1", planContent: "# Exit plan\n\n- Step one\n- Step two\n" },
+          { id: "2", planContent: null },
+        ] as const;
+        for (const cycle of planCycles) {
+          yield* agent.client.sessionUpdate({
             sessionId: requestedSessionId,
-            toolCallId: "exit-plan-mode-tool-call-1",
-            planContent: "# Exit plan\n\n- Step one\n- Step two\n",
-          },
-        });
-        if (typeof result !== "object" || result === null || !("outcome" in result)) {
-          throw new Error("Expected _x.ai/exit_plan_mode response outcome.");
-        }
-        if (
-          result.outcome !== "abandoned" &&
-          result.outcome !== "approved" &&
-          result.outcome !== "request_changes"
-        ) {
-          throw new Error(
-            `Expected exit_plan_mode outcome abandoned|approved|request_changes, got ${String(result.outcome)}`,
-          );
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: `enter-plan-mode-${cycle.id}`,
+              title: "enter_plan_mode",
+              kind: "other",
+              status: "completed",
+              rawInput: { variant: "EnterPlanMode" },
+            },
+          });
+          const result = yield* agent.client.extRequest("_x.ai/exit_plan_mode", {
+            method: "x.ai/exit_plan_mode",
+            params: {
+              sessionId: requestedSessionId,
+              toolCallId: `exit-plan-mode-tool-call-${cycle.id}`,
+              planContent: cycle.planContent,
+            },
+          });
+          if (typeof result !== "object" || result === null || !("outcome" in result)) {
+            throw new Error("Expected _x.ai/exit_plan_mode response outcome.");
+          }
+          if (
+            result.outcome !== "abandoned" &&
+            result.outcome !== "approved" &&
+            result.outcome !== "request_changes"
+          ) {
+            throw new Error(
+              `Expected exit_plan_mode outcome abandoned|approved|request_changes, got ${String(result.outcome)}`,
+            );
+          }
         }
         return { stopReason: "end_turn" };
       }

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -19,6 +19,8 @@ const emitInterleavedAssistantToolCalls =
 const emitGenericToolPlaceholders = process.env.T3_ACP_EMIT_GENERIC_TOOL_PLACEHOLDERS === "1";
 const emitAskQuestion = process.env.T3_ACP_EMIT_ASK_QUESTION === "1";
 const emitXAiAskUserQuestion = process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION === "1";
+const emitXAiExitPlanMode = process.env.T3_ACP_EMIT_XAI_EXIT_PLAN_MODE === "1";
+const emitXAiPlanMdWrite = process.env.T3_ACP_EMIT_XAI_PLAN_MD_WRITE === "1";
 const emitXAiPromptCompleteThenHang = process.env.T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG === "1";
 const emitForeignSessionUpdates = process.env.T3_ACP_EMIT_FOREIGN_SESSION_UPDATES === "1";
 const hangPromptForever = process.env.T3_ACP_HANG_PROMPT_FOREVER === "1";
@@ -78,6 +80,8 @@ function logExit(reason: string): void {
 function writeJsonRpcNotification(method: string, params: unknown): void {
   process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
 }
+
+logExit(`START:${process.pid}`);
 
 process.once("SIGTERM", () => {
   logExit("SIGTERM");
@@ -807,6 +811,77 @@ const program = Effect.gen(function* () {
           throw new Error("Expected accepted _x.ai/ask_user_question response answers.");
         }
 
+        return { stopReason: "end_turn" };
+      }
+
+      if (emitXAiPlanMdWrite) {
+        const planPath = `/tmp/mock-home/.grok/sessions/${requestedSessionId}/plan.md`;
+        const planBody = "# Mock plan\n\n- Write the feature\n- Add a test\n- Ship it\n";
+        yield* agent.client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: "enter-plan-mode-1",
+            title: "enter_plan_mode",
+            kind: "other",
+            status: "completed",
+            rawInput: { variant: "EnterPlanMode" },
+          },
+        });
+        yield* agent.client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: "plan-md-write-1",
+            title: "write",
+            kind: "edit",
+            status: "pending",
+            rawInput: { file_path: planPath, content: planBody },
+          },
+        });
+        yield* agent.client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "plan-md-write-1",
+            kind: "edit",
+            status: "completed",
+            title: `Write \`${planPath}\``,
+            rawInput: { file_path: planPath, content: planBody },
+            content: [
+              {
+                type: "diff",
+                path: planPath,
+                oldText: "",
+                newText: planBody,
+              },
+            ],
+          },
+        });
+        return { stopReason: "end_turn" };
+      }
+
+      if (emitXAiExitPlanMode) {
+        const result = yield* agent.client.extRequest("_x.ai/exit_plan_mode", {
+          method: "x.ai/exit_plan_mode",
+          params: {
+            sessionId: requestedSessionId,
+            toolCallId: "exit-plan-mode-tool-call-1",
+            planContent: "# Exit plan\n\n- Step one\n- Step two\n",
+          },
+        });
+        if (typeof result !== "object" || result === null || !("outcome" in result)) {
+          throw new Error("Expected _x.ai/exit_plan_mode response outcome.");
+        }
+        if (
+          result.outcome !== "abandoned" &&
+          result.outcome !== "approved" &&
+          result.outcome !== "request_changes"
+        ) {
+          throw new Error(
+            `Expected exit_plan_mode outcome abandoned|approved|request_changes, got ${String(result.outcome)}`,
+          );
+        }
         return { stopReason: "end_turn" };
       }
 

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -14,6 +14,7 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import {
   ApprovalRequestId,
@@ -26,26 +27,46 @@ import {
 } from "@t3tools/contracts";
 
 import { ServerConfig } from "../../config.ts";
-import { grokPromptSettlementBelongsToContext, makeGrokAdapter } from "./GrokAdapter.ts";
+import {
+  grokPromptSettlementBelongsToContext,
+  isGrokEnterPlanModeToolCall,
+  makeGrokAdapter,
+} from "./GrokAdapter.ts";
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 
 const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
 const mockAgentPath = NodePath.join(__dirname, "../../../scripts/acp-mock-agent.ts");
 const mockAgentCommand = process.execPath;
 
-async function makeMockGrokWrapper(extraEnv?: Record<string, string>) {
-  const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-mock-"));
-  const wrapperPath = NodePath.join(dir, "fake-grok.sh");
-  const envExports = Object.entries(extraEnv ?? {})
-    .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
-    .join("\n");
-  const script = `#!/bin/sh
+function makeMockGrokWrapper(extraEnv?: Record<string, string>) {
+  return Effect.gen(function* () {
+    const isWindows = (yield* HostProcessPlatform) === "win32";
+    return yield* Effect.promise(async () => {
+      const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-mock-"));
+      const wrapperPath = NodePath.join(dir, isWindows ? "fake-grok.cmd" : "fake-grok.sh");
+      const envExports = Object.entries(extraEnv ?? {})
+        .map(([key, value]) =>
+          isWindows
+            ? `set "${key}=${value.replace(/%/g, "%%")}"`
+            : `export ${key}='${value.replace(/'/g, `'"'"'`)}'`,
+        )
+        .join("\n");
+      const script = isWindows
+        ? `@echo off
 ${envExports}
-exec ${JSON.stringify(mockAgentCommand)} ${JSON.stringify(mockAgentPath)} "$@"
+"${mockAgentCommand}" "${mockAgentPath}" %*
+`
+        : `#!/bin/sh
+${envExports}
+exec '${mockAgentCommand.replace(/'/g, `'"'"'`)}' '${mockAgentPath.replace(/'/g, `'"'"'`)}' "$@"
 `;
-  await NodeFSP.writeFile(wrapperPath, script, "utf8");
-  await NodeFSP.chmod(wrapperPath, 0o755);
-  return wrapperPath;
+      await NodeFSP.writeFile(wrapperPath, script, "utf8");
+      if (!isWindows) {
+        await NodeFSP.chmod(wrapperPath, 0o755);
+      }
+      return wrapperPath;
+    });
+  });
 }
 
 function waitForFileContent(
@@ -73,6 +94,25 @@ function waitForFileContent(
   return readAttempt(attempts);
 }
 
+function waitForProcessExit(processId: number, attempts = 40): Effect.Effect<void> {
+  const poll = (remainingAttempts: number): Effect.Effect<void> =>
+    Effect.gen(function* () {
+      const isRunning = yield* Effect.try(() => process.kill(processId, 0)).pipe(
+        Effect.as(true),
+        Effect.orElseSucceed(() => false),
+      );
+      if (!isRunning) {
+        return;
+      }
+      if (remainingAttempts <= 0) {
+        return yield* Effect.die(new Error(`Timed out waiting for process ${processId} to exit.`));
+      }
+      yield* Effect.sleep("25 millis");
+      return yield* poll(remainingAttempts - 1);
+    });
+  return poll(attempts);
+}
+
 async function readJsonLines(filePath: string) {
   const raw = await NodeFSP.readFile(filePath, "utf8");
   return raw
@@ -88,6 +128,27 @@ const grokAdapterTestLayer = ServerConfig.layerTest(process.cwd(), {
 
 const makeTestAdapter = (binaryPath: string, options?: Parameters<typeof makeGrokAdapter>[1]) =>
   makeGrokAdapter(decodeGrokSettings({ binaryPath }), options).pipe(Effect.orDie);
+
+it("detects Grok enter_plan_mode tool calls", () => {
+  assert.isTrue(
+    isGrokEnterPlanModeToolCall({
+      title: "enter_plan_mode",
+      data: { toolCallId: "1" },
+    }),
+  );
+  assert.isTrue(
+    isGrokEnterPlanModeToolCall({
+      title: "Enter plan mode",
+      data: { toolCallId: "1", rawInput: { variant: "EnterPlanMode" } },
+    }),
+  );
+  assert.isFalse(
+    isGrokEnterPlanModeToolCall({
+      title: "write",
+      data: { toolCallId: "1", rawInput: { file_path: "/tmp/x", content: "y" } },
+    }),
+  );
+});
 
 it("requires a settlement to match the live Grok turn", () => {
   const staleTurnId = TurnId.make("stale-turn");
@@ -126,7 +187,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("starts a session and maps mock ACP prompt flow to runtime events", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-mock-thread");
-      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const wrapperPath = yield* makeMockGrokWrapper();
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
@@ -196,11 +257,9 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       );
       const exitLogPath = NodePath.join(tempDir, "exit.log");
 
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_EXIT_LOG_PATH: exitLogPath,
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_EXIT_LOG_PATH: exitLogPath,
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       yield* adapter.startSession({
@@ -211,21 +270,26 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
       });
 
+      const startLog = yield* waitForFileContent(exitLogPath, 40, "START:");
+      const processId = Number(/^START:(\d+)$/m.exec(startLog)?.[1]);
+      assert.isTrue(Number.isInteger(processId));
       yield* adapter.stopSession(threadId);
 
-      const exitLog = yield* waitForFileContent(exitLogPath);
-      assert.include(exitLog, "SIGTERM");
+      if ((yield* HostProcessPlatform) === "win32") {
+        yield* waitForProcessExit(processId);
+      } else {
+        const exitLog = yield* waitForFileContent(exitLogPath, 40, "SIGTERM");
+        assert.include(exitLog, "SIGTERM");
+      }
     }),
   );
 
   it.effect("reports a Grok session running only while the prompt is in flight", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-session-ready-after-prompt");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_EMIT_TOOL_CALLS: "1",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_EMIT_TOOL_CALLS: "1",
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
       const requestOpened =
         yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "request.opened" }>>();
@@ -273,7 +337,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("restores ready without completing an unstarted turn when preparation fails", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-preparation-failure-while-connecting");
-      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const wrapperPath = yield* makeMockGrokWrapper();
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
@@ -330,12 +394,10 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("completes a Grok turn from xAI prompt completion when the prompt RPC hangs", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-xai-prompt-complete-fallback");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
-          T3_ACP_EMIT_FOREIGN_SESSION_UPDATES: "1",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
+        T3_ACP_EMIT_FOREIGN_SESSION_UPDATES: "1",
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
@@ -421,11 +483,9 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("retains turn transcript when sendTurn is interrupted after prompt success", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-send-turn-interrupt-after-prompt");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
       const contentDelta = yield* Deferred.make<void>();
       const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
@@ -469,12 +529,10 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("does not report a synthetic stop reason when xAI omits one", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-xai-prompt-complete-missing-stop-reason");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
-          T3_ACP_OMIT_XAI_PROMPT_COMPLETE_STOP_REASON: "1",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
+        T3_ACP_OMIT_XAI_PROMPT_COMPLETE_STOP_REASON: "1",
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
@@ -522,11 +580,9 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("lets Stop unblock a fully silent Grok prompt and accept a follow-up turn", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-stop-after-full-silence");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_HANG_FIRST_PROMPT_FOREVER: "1",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_HANG_FIRST_PROMPT_FOREVER: "1",
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
@@ -601,12 +657,10 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-cancel-race-")),
       );
       const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_HANG_FIRST_PROMPT_FOREVER: "1",
-          T3_ACP_REQUEST_LOG_PATH: requestLogPath,
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_HANG_FIRST_PROMPT_FOREVER: "1",
+        T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
@@ -679,12 +733,10 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("drops late ACP notifications after a turn is cancelled", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-drop-late-cancelled-notifications");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_HANG_PROMPT_FOREVER: "1",
-          T3_ACP_EMIT_LATE_UPDATE_AFTER_CANCEL: "1",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_HANG_PROMPT_FOREVER: "1",
+        T3_ACP_EMIT_LATE_UPDATE_AFTER_CANCEL: "1",
+      });
       const lateNativeUpdate = yield* Deferred.make<void>();
       const adapter = yield* makeTestAdapter(wrapperPath, {
         nativeEventLogger: {
@@ -762,11 +814,9 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("lets Stop cancel during the xAI completion drain window", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-stop-during-completion-drain");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
@@ -832,7 +882,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("settles the in-flight prompt before emitting completion", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-completion-before-next-turn");
-      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const wrapperPath = yield* makeMockGrokWrapper();
       const adapter = yield* makeTestAdapter(wrapperPath);
       const completedCountRef = yield* Ref.make(0);
       const secondTurnCompleted = yield* Deferred.make<void>();
@@ -895,11 +945,9 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("restores a Grok session to ready when the prompt RPC fails", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-prompt-failure-ready");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_FAIL_PROMPT: "1",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_FAIL_PROMPT: "1",
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
       const runtimeEvents: ProviderRuntimeEvent[] = [];
       const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
@@ -946,11 +994,9 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("ignores replayed session/load updates when resuming a Grok session", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-load-replay-filter");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_EMIT_LOAD_REPLAY: "1",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_EMIT_LOAD_REPLAY: "1",
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
       const runtimeEvents: ProviderRuntimeEvent[] = [];
       const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
@@ -997,7 +1043,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
 
   it.effect("rejects startSession when provider mismatches", () =>
     Effect.gen(function* () {
-      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const wrapperPath = yield* makeMockGrokWrapper();
       const adapter = yield* makeTestAdapter(wrapperPath);
       const threadId = ThreadId.make("grok-provider-mismatch");
 
@@ -1019,7 +1065,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-empty-turn");
 
-      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const wrapperPath = yield* makeMockGrokWrapper();
       const adapter = yield* makeTestAdapter(wrapperPath);
 
       yield* adapter.startSession({
@@ -1051,13 +1097,11 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-")),
       );
       const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_REQUEST_LOG_PATH: requestLogPath,
-          T3_ACP_EMIT_TOOL_CALLS: "1",
-          T3_ACP_ALLOW_ONCE_OPTION_ID: "agent-defined-approval-id",
-        }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({
+        T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        T3_ACP_EMIT_TOOL_CALLS: "1",
+        T3_ACP_ALLOW_ONCE_OPTION_ID: "agent-defined-approval-id",
+      });
       const adapter = yield* makeTestAdapter(wrapperPath);
       const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
         event.type === "request.opened"
@@ -1097,12 +1141,123 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("captures xAI exit_plan_mode as a proposed plan and unblocks the turn", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-xai-exit-plan-mode");
+      const wrapperPath = yield* makeMockGrokWrapper({ T3_ACP_EMIT_XAI_EXIT_PLAN_MODE: "1" });
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const proposed =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.proposed.completed" }>>();
+      const turnCompleted = yield* Deferred.make<void>();
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+
+      const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) => {
+        if (String(event.threadId) !== String(threadId)) {
+          return Effect.void;
+        }
+        return Effect.sync(() => runtimeEvents.push(event)).pipe(
+          Effect.andThen(
+            Effect.all(
+              [
+                event.type === "turn.proposed.completed"
+                  ? Deferred.succeed(proposed, event).pipe(Effect.ignore)
+                  : Effect.void,
+                event.type === "turn.completed"
+                  ? Deferred.succeed(turnCompleted, undefined).pipe(Effect.ignore)
+                  : Effect.void,
+              ],
+              { discard: true },
+            ),
+          ),
+        );
+      }).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId, input: "present the plan", attachments: [] });
+
+      const proposedEvent = yield* Deferred.await(proposed);
+      yield* Deferred.await(turnCompleted);
+      assert.equal(proposedEvent.payload.planMarkdown, "# Exit plan\n\n- Step one\n- Step two");
+      assert.equal(proposedEvent.raw?.method, "_x.ai/exit_plan_mode");
+      assert.equal(
+        new Set(runtimeEvents.map((event) => String(event.eventId))).size,
+        runtimeEvents.length,
+      );
+
+      yield* Fiber.interrupt(eventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("surfaces a Grok session plan.md write while plan mode is active", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-xai-plan-md-write");
+      const wrapperPath = yield* makeMockGrokWrapper({ T3_ACP_EMIT_XAI_PLAN_MD_WRITE: "1" });
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const proposed =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.proposed.completed" }>>();
+      const turnCompleted = yield* Deferred.make<void>();
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+
+      const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) => {
+        if (String(event.threadId) !== String(threadId)) {
+          return Effect.void;
+        }
+        return Effect.sync(() => runtimeEvents.push(event)).pipe(
+          Effect.andThen(
+            Effect.all(
+              [
+                event.type === "turn.proposed.completed"
+                  ? Deferred.succeed(proposed, event).pipe(Effect.ignore)
+                  : Effect.void,
+                event.type === "turn.completed"
+                  ? Deferred.succeed(turnCompleted, undefined).pipe(Effect.ignore)
+                  : Effect.void,
+              ],
+              { discard: true },
+            ),
+          ),
+        );
+      }).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId, input: "write the plan", attachments: [] });
+
+      const proposedEvent = yield* Deferred.await(proposed);
+      yield* Deferred.await(turnCompleted);
+      assert.equal(
+        proposedEvent.payload.planMarkdown,
+        "# Mock plan\n\n- Write the feature\n- Add a test\n- Ship it",
+      );
+      assert.equal(proposedEvent.raw?.method, "session/update");
+      assert.equal(
+        runtimeEvents.filter((event) => event.type === "turn.proposed.completed").length,
+        1,
+      );
+      assert.equal(
+        new Set(runtimeEvents.map((event) => String(event.eventId))).size,
+        runtimeEvents.length,
+      );
+
+      yield* Fiber.interrupt(eventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("handles xAI ask_user_question extension requests", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-xai-ask-user-question");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({ T3_ACP_EMIT_XAI_ASK_USER_QUESTION: "1" }),
-      );
+      const wrapperPath = yield* makeMockGrokWrapper({ T3_ACP_EMIT_XAI_ASK_USER_QUESTION: "1" });
       const adapter = yield* makeTestAdapter(wrapperPath);
       const requested =
         yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "user-input.requested" }>>();
@@ -1162,7 +1317,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   it.effect("continues streaming events when native notification logging fails", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-native-log-failure");
-      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const wrapperPath = yield* makeMockGrokWrapper();
       const adapter = yield* makeTestAdapter(wrapperPath, {
         nativeEventLogger: {
           filePath: "memory://grok-native-events",

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -27,6 +27,7 @@ import {
 } from "@t3tools/contracts";
 
 import { ServerConfig } from "../../config.ts";
+import { XAI_EMPTY_PLAN_MARKDOWN } from "../acp/XAiAcpExtension.ts";
 import {
   grokPromptSettlementBelongsToContext,
   isGrokEnterPlanModeToolCall,
@@ -1184,6 +1185,12 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       yield* Deferred.await(turnCompleted);
       assert.equal(proposedEvent.payload.planMarkdown, "# Exit plan\n\n- Step one\n- Step two");
       assert.equal(proposedEvent.raw?.method, "_x.ai/exit_plan_mode");
+      assert.deepStrictEqual(
+        runtimeEvents
+          .filter((event) => event.type === "turn.proposed.completed")
+          .map((event) => event.payload.planMarkdown),
+        ["# Exit plan\n\n- Step one\n- Step two", XAI_EMPTY_PLAN_MARKDOWN],
+      );
       assert.equal(
         new Set(runtimeEvents.map((event) => String(event.eventId))).size,
         runtimeEvents.length,

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -177,6 +177,15 @@ function clearProposedPlanCapture(ctx: GrokSessionContext): void {
   ctx.planModeActive = false;
 }
 
+function beginProposedPlanCapture(ctx: GrokSessionContext): void {
+  if (ctx.planModeActive) {
+    return;
+  }
+  ctx.lastKnownProposedPlanMarkdown = undefined;
+  ctx.lastKnownProposedPlanTurnId = undefined;
+  ctx.planModeActive = true;
+}
+
 export function isGrokEnterPlanModeToolCall(toolCall: {
   readonly title?: string;
   readonly data: Record<string, unknown>;
@@ -964,7 +973,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       }),
                     );
                     if (isGrokEnterPlanModeToolCall(event.toolCall)) {
-                      ctx.planModeActive = true;
+                      beginProposedPlanCapture(ctx);
                     }
                     if (ctx.planModeActive) {
                       const planMarkdown = extractGrokPlanMarkdownFromToolCallData(

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -60,11 +60,15 @@ import {
   resolveGrokAcpBaseModelId,
 } from "../acp/GrokAcpSupport.ts";
 import {
+  extractGrokPlanMarkdownFromToolCallData,
   extractXAiAskUserQuestions,
+  extractXAiExitPlanMarkdown,
   makeXAiAskUserQuestionCancelledResponse,
   makeXAiAskUserQuestionResponse,
+  makeXAiExitPlanModeCapturedResponse,
   promptResponseHasMissingXAiStopReason,
   XAiAskUserQuestionRequest,
+  XAiExitPlanModeRequest,
 } from "../acp/XAiAcpExtension.ts";
 import { type GrokAdapterShape } from "../Services/GrokAdapter.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
@@ -109,6 +113,9 @@ interface GrokSessionContext {
   readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
   turns: Array<{ id: TurnId; items: Array<unknown> }>;
   lastPlanFingerprint: string | undefined;
+  lastKnownProposedPlanMarkdown: string | undefined;
+  lastKnownProposedPlanTurnId: TurnId | undefined;
+  planModeActive: boolean;
   activeTurnId: TurnId | undefined;
   /** Turns already interrupted; late prompt RPCs must not resurrect them. */
   interruptedTurnIds: Set<TurnId>;
@@ -163,6 +170,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 const resolveNotificationTurnId = (ctx: GrokSessionContext): TurnId | undefined => ctx.activeTurnId;
 
 const resolveCallbackTurnId = (ctx: GrokSessionContext): TurnId | undefined => ctx.activeTurnId;
+
+function clearProposedPlanCapture(ctx: GrokSessionContext): void {
+  ctx.lastKnownProposedPlanMarkdown = undefined;
+  ctx.lastKnownProposedPlanTurnId = undefined;
+  ctx.planModeActive = false;
+}
+
+export function isGrokEnterPlanModeToolCall(toolCall: {
+  readonly title?: string;
+  readonly data: Record<string, unknown>;
+}): boolean {
+  const title = toolCall.title?.trim().toLowerCase() ?? "";
+  if (
+    title === "enter_plan_mode" ||
+    title === "enter plan mode" ||
+    title === "plan: enter" ||
+    title === "plan mode entered" ||
+    title.includes("enter_plan_mode")
+  ) {
+    return true;
+  }
+  const rawInput = toolCall.data.rawInput;
+  return isRecord(rawInput) && rawInput.variant === "EnterPlanMode";
+}
 
 const resolveSessionCallbackTurnId = (
   sessions: ReadonlyMap<ThreadId, GrokSessionContext>,
@@ -367,6 +398,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 const updatedAt = yield* nowIso;
                 const { activeTurnId: _activeTurnId, ...readySession } = liveCtx.session;
                 liveCtx.activeTurnId = undefined;
+                clearProposedPlanCapture(liveCtx);
                 liveCtx.session = {
                   ...readySession,
                   status: "ready",
@@ -397,6 +429,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           options?.completedStopReason !== undefined && canEmitTurnCompletion;
         const { activeTurnId: _activeTurnId, ...readySession } = liveCtx.session;
         liveCtx.activeTurnId = undefined;
+        clearProposedPlanCapture(liveCtx);
         liveCtx.session = {
           ...readySession,
           status: "ready",
@@ -493,6 +526,38 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             rawPayload,
           }),
         );
+      });
+
+    const emitProposedPlanCompleted = (
+      ctx: GrokSessionContext,
+      turnId: TurnId | undefined,
+      planMarkdown: string,
+      raw: { readonly method: string; readonly payload: unknown },
+    ) =>
+      Effect.gen(function* () {
+        const trimmed = planMarkdown.trim();
+        if (
+          trimmed.length === 0 ||
+          (ctx.lastKnownProposedPlanMarkdown === trimmed &&
+            ctx.lastKnownProposedPlanTurnId === turnId)
+        ) {
+          return;
+        }
+        ctx.lastKnownProposedPlanMarkdown = trimmed;
+        ctx.lastKnownProposedPlanTurnId = turnId;
+        yield* offerRuntimeEvent({
+          type: "turn.proposed.completed",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          turnId,
+          payload: { planMarkdown: trimmed },
+          raw: {
+            source: "acp.grok.extension",
+            method: raw.method,
+            payload: raw.payload,
+          },
+        });
       });
 
     const requireSession = (
@@ -663,6 +728,46 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 ),
               { discard: true },
             );
+            yield* Effect.forEach(
+              ["x.ai/exit_plan_mode", "_x.ai/exit_plan_mode"] as const,
+              (method) =>
+                acp.handleExtRequest(method, XAiExitPlanModeRequest, (params) =>
+                  mapAcpCallbackFailure(
+                    Effect.gen(function* () {
+                      yield* logNative(input.threadId, method, params);
+                      const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
+                      const ctx = sessions.get(input.threadId);
+                      const planMarkdown = extractXAiExitPlanMarkdown(
+                        params,
+                        ctx?.lastKnownProposedPlanMarkdown,
+                      );
+                      if (ctx) {
+                        yield* emitProposedPlanCompleted(ctx, turnId, planMarkdown, {
+                          method,
+                          payload: params,
+                        });
+                        ctx.planModeActive = false;
+                      } else {
+                        yield* offerRuntimeEvent({
+                          type: "turn.proposed.completed",
+                          ...(yield* makeEventStamp()),
+                          provider: PROVIDER,
+                          threadId: input.threadId,
+                          turnId,
+                          payload: { planMarkdown },
+                          raw: {
+                            source: "acp.grok.extension",
+                            method,
+                            payload: params,
+                          },
+                        });
+                      }
+                      return makeXAiExitPlanModeCapturedResponse();
+                    }),
+                  ),
+                ),
+              { discard: true },
+            );
             yield* acp.handleRequestPermission((params) =>
               mapAcpCallbackFailure(
                 Effect.gen(function* () {
@@ -774,6 +879,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             pendingUserInputs,
             turns: [],
             lastPlanFingerprint: undefined,
+            lastKnownProposedPlanMarkdown: undefined,
+            lastKnownProposedPlanTurnId: undefined,
+            planModeActive: false,
             activeTurnId: undefined,
             interruptedTurnIds: new Set(),
             promptsInFlight: 0,
@@ -844,7 +952,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       "session/update",
                     );
                     return;
-                  case "ToolCallUpdated":
+                  case "ToolCallUpdated": {
                     yield* offerRuntimeEvent(
                       makeAcpToolCallEvent({
                         stamp,
@@ -855,7 +963,22 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         rawPayload: event.rawPayload,
                       }),
                     );
+                    if (isGrokEnterPlanModeToolCall(event.toolCall)) {
+                      ctx.planModeActive = true;
+                    }
+                    if (ctx.planModeActive) {
+                      const planMarkdown = extractGrokPlanMarkdownFromToolCallData(
+                        event.toolCall.data,
+                      );
+                      if (planMarkdown) {
+                        yield* emitProposedPlanCompleted(ctx, notificationTurnId, planMarkdown, {
+                          method: "session/update",
+                          payload: event.rawPayload,
+                        });
+                      }
+                    }
                     return;
+                  }
                   case "ContentDelta":
                     yield* offerRuntimeEvent(
                       makeAcpContentDeltaEvent({
@@ -920,6 +1043,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             // id is reused instead of opening a new turn.
             const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
             const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+            if (steeringTurnId === undefined) {
+              clearProposedPlanCapture(ctx);
+            }
             // Count this prompt immediately so a superseded in-flight prompt
             // resolving from here on does not settle the turn; decremented on
             // preparation failure here, and after the prompt below otherwise.
@@ -1172,6 +1298,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 const completedAt = yield* nowIso;
                 const { activeTurnId: _completedTurnId, ...readySession } = ctx.session;
                 ctx.activeTurnId = undefined;
+                clearProposedPlanCapture(ctx);
                 ctx.session = {
                   ...readySession,
                   status: "ready",
@@ -1344,6 +1471,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               const updatedAt = yield* nowIso;
               ctx.promptsInFlight = 0;
               ctx.activeTurnId = undefined;
+              clearProposedPlanCapture(ctx);
               const { activeTurnId: _activeTurnId, ...readySession } = ctx.session;
               ctx.session = {
                 ...readySession,

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -366,35 +366,70 @@ describe("XAiAcpExtension", () => {
   });
 
   it("extracts Grok session plan writes without matching workspace plan files", () => {
-    expect(isGrokPlanMarkdownPath("/home/x/.grok/sessions/abc/plan.md")).toBe(true);
-    expect(isGrokPlanMarkdownPath("C:\\Users\\x\\.grok\\sessions\\abc\\plan.md")).toBe(true);
-    expect(isGrokPlanMarkdownPath("plan.md")).toBe(false);
-    expect(isGrokPlanMarkdownPath("/repo/docs/plan.md")).toBe(false);
+    expect(isGrokPlanMarkdownPath("/home/x/.grok/sessions/abc/plan.md", "/home/x")).toBe(true);
+    expect(
+      isGrokPlanMarkdownPath("C:\\Users\\x\\.grok\\sessions\\abc\\plan.md", "C:\\Users\\x"),
+    ).toBe(true);
+    expect(isGrokPlanMarkdownPath("plan.md", "/home/x")).toBe(false);
+    expect(isGrokPlanMarkdownPath("/repo/docs/plan.md", "/home/x")).toBe(false);
+    expect(isGrokPlanMarkdownPath("/repo/.grok/sessions/abc/plan.md", "/home/x")).toBe(false);
 
     expect(
-      extractGrokPlanMarkdownFromToolCallData({
-        rawInput: {
-          file_path: "/home/x/.grok/sessions/sess/plan.md",
-          content: "# From rawInput\n\n- a\n",
+      extractGrokPlanMarkdownFromToolCallData(
+        {
+          rawInput: {
+            file_path: "/home/x/.grok/sessions/sess/plan.md",
+            content: "# From rawInput\n\n- a\n",
+          },
         },
-      }),
+        "/home/x",
+      ),
     ).toBe("# From rawInput\n\n- a");
     expect(
-      extractGrokPlanMarkdownFromToolCallData({
-        content: [
-          {
-            type: "diff",
-            path: "/home/x/.grok/sessions/sess/plan.md",
-            oldText: "",
-            newText: "# From diff\n\n- b\n",
-          },
-        ],
-      }),
+      extractGrokPlanMarkdownFromToolCallData(
+        {
+          content: [
+            {
+              type: "diff",
+              path: "/home/x/.grok/sessions/sess/plan.md",
+              oldText: "",
+              newText: "# From diff\n\n- b\n",
+            },
+          ],
+        },
+        "/home/x",
+      ),
     ).toBe("# From diff\n\n- b");
     expect(
-      extractGrokPlanMarkdownFromToolCallData({
-        rawInput: { file_path: "/repo/docs/plan.md", content: "# Project plan\n" },
-      }),
+      extractGrokPlanMarkdownFromToolCallData(
+        {
+          rawInput: { file_path: "/repo/docs/plan.md", content: "# Project plan\n" },
+        },
+        "/home/x",
+      ),
     ).toBeUndefined();
+    expect(
+      extractGrokPlanMarkdownFromToolCallData(
+        {
+          rawInput: { file_path: "/home/x/.grok/sessions/sess/plan.md", content: "  " },
+        },
+        "/home/x",
+      ),
+    ).toBe(XAI_EMPTY_PLAN_MARKDOWN);
+    expect(
+      extractGrokPlanMarkdownFromToolCallData(
+        {
+          content: [
+            {
+              type: "diff",
+              path: "/home/x/.grok/sessions/sess/plan.md",
+              oldText: "# stale plan",
+              newText: "",
+            },
+          ],
+        },
+        "/home/x",
+      ),
+    ).toBe(XAI_EMPTY_PLAN_MARKDOWN);
   });
 });

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -9,11 +9,17 @@ import * as Schema from "effect/Schema";
 import { describe, expect } from "vite-plus/test";
 
 import {
+  extractGrokPlanMarkdownFromToolCallData,
   extractXAiAskUserQuestions,
+  extractXAiExitPlanMarkdown,
+  isGrokPlanMarkdownPath,
   makeXAiAskUserQuestionCancelledResponse,
   makeXAiAskUserQuestionResponse,
+  makeXAiExitPlanModeCapturedResponse,
   makeXAiPromptCompletionRuntime,
+  XAI_EMPTY_PLAN_MARKDOWN,
   XAiAskUserQuestionRequest,
+  XAiExitPlanModeRequest,
 } from "./XAiAcpExtension.ts";
 import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
@@ -329,4 +335,66 @@ describe("XAiAcpExtension", () => {
       });
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
+
+  it("extracts plan markdown from direct and wrapped exit_plan_mode payloads", () => {
+    const decode = Schema.decodeUnknownSync(XAiExitPlanModeRequest);
+    const direct = decode({
+      sessionId: "session-1",
+      toolCallId: "exit-1",
+      planContent: "# Plan\n\n- do the thing\n",
+    });
+    expect(extractXAiExitPlanMarkdown(direct)).toBe("# Plan\n\n- do the thing");
+
+    const wrapped = decode({
+      method: "_x.ai/exit_plan_mode",
+      params: {
+        sessionId: "session-1",
+        toolCallId: "exit-1",
+        planContent: null,
+      },
+    });
+    expect(extractXAiExitPlanMarkdown(wrapped, "  # fallback plan  ")).toBe("# fallback plan");
+    expect(extractXAiExitPlanMarkdown(wrapped)).toBe(XAI_EMPTY_PLAN_MARKDOWN);
+  });
+
+  it("builds a non-approving exit_plan_mode response", () => {
+    expect(makeXAiExitPlanModeCapturedResponse()).toEqual({
+      outcome: "abandoned",
+      feedback:
+        "The client captured your proposed plan. Stop here and wait for the user's feedback or implementation request in a later turn.",
+    });
+  });
+
+  it("extracts Grok session plan writes without matching workspace plan files", () => {
+    expect(isGrokPlanMarkdownPath("/home/x/.grok/sessions/abc/plan.md")).toBe(true);
+    expect(isGrokPlanMarkdownPath("C:\\Users\\x\\.grok\\sessions\\abc\\plan.md")).toBe(true);
+    expect(isGrokPlanMarkdownPath("plan.md")).toBe(false);
+    expect(isGrokPlanMarkdownPath("/repo/docs/plan.md")).toBe(false);
+
+    expect(
+      extractGrokPlanMarkdownFromToolCallData({
+        rawInput: {
+          file_path: "/home/x/.grok/sessions/sess/plan.md",
+          content: "# From rawInput\n\n- a\n",
+        },
+      }),
+    ).toBe("# From rawInput\n\n- a");
+    expect(
+      extractGrokPlanMarkdownFromToolCallData({
+        content: [
+          {
+            type: "diff",
+            path: "/home/x/.grok/sessions/sess/plan.md",
+            oldText: "",
+            newText: "# From diff\n\n- b\n",
+          },
+        ],
+      }),
+    ).toBe("# From diff\n\n- b");
+    expect(
+      extractGrokPlanMarkdownFromToolCallData({
+        rawInput: { file_path: "/repo/docs/plan.md", content: "# Project plan\n" },
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -373,6 +373,10 @@ describe("XAiAcpExtension", () => {
     expect(isGrokPlanMarkdownPath("plan.md", "/home/x")).toBe(false);
     expect(isGrokPlanMarkdownPath("/repo/docs/plan.md", "/home/x")).toBe(false);
     expect(isGrokPlanMarkdownPath("/repo/.grok/sessions/abc/plan.md", "/home/x")).toBe(false);
+    expect(isGrokPlanMarkdownPath("/home/x/.grok/sessions/../plan.md", "/home/x")).toBe(false);
+    expect(
+      isGrokPlanMarkdownPath("C:\\Users\\x\\.grok\\sessions\\..\\plan.md", "C:\\Users\\x"),
+    ).toBe(false);
 
     expect(
       extractGrokPlanMarkdownFromToolCallData(

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -1,3 +1,5 @@
+import * as NodeOS from "node:os";
+
 import type { ProviderUserInputAnswers, UserInputQuestion } from "@t3tools/contracts";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -255,18 +257,35 @@ export function makeXAiExitPlanModeCapturedResponse(feedback?: string): XAiExitP
   };
 }
 
-/** Match only Grok's private session plan, never a workspace plan.md file. */
-export function isGrokPlanMarkdownPath(path: string | undefined | null): boolean {
+function normalizeFilePath(path: string): string {
+  return path.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+/** Match only Grok's private session plan below the environment user's home directory. */
+export function isGrokPlanMarkdownPath(
+  path: string | undefined | null,
+  homeDirectory = NodeOS.homedir(),
+): boolean {
   if (typeof path !== "string") {
     return false;
   }
-  const normalized = path.trim().replace(/\\/g, "/");
-  return normalized.endsWith("/plan.md") && normalized.includes("/.grok/sessions/");
+  const normalized = normalizeFilePath(path);
+  const privateSessionRoot = `${normalizeFilePath(homeDirectory)}/.grok/sessions/`;
+  if (!normalized.startsWith(privateSessionRoot)) {
+    return false;
+  }
+  const sessionPlanSegments = normalized.slice(privateSessionRoot.length).split("/");
+  return (
+    sessionPlanSegments.length === 2 &&
+    sessionPlanSegments[0] !== "" &&
+    sessionPlanSegments[1] === "plan.md"
+  );
 }
 
 /** Extract the latest plan body from Grok's ACP write/edit tool payload. */
 export function extractGrokPlanMarkdownFromToolCallData(
   data: Record<string, unknown> | undefined,
+  homeDirectory = NodeOS.homedir(),
 ): string | undefined {
   if (!data) {
     return undefined;
@@ -277,9 +296,9 @@ export function extractGrokPlanMarkdownFromToolCallData(
     const filePath =
       (typeof rawInput.file_path === "string" ? rawInput.file_path : undefined) ??
       (typeof rawInput.path === "string" ? rawInput.path : undefined);
-    const content = typeof rawInput.content === "string" ? trimmed(rawInput.content) : undefined;
-    if (isGrokPlanMarkdownPath(filePath) && content) {
-      return content;
+    const content = typeof rawInput.content === "string" ? rawInput.content.trim() : undefined;
+    if (isGrokPlanMarkdownPath(filePath, homeDirectory) && content !== undefined) {
+      return content || XAI_EMPTY_PLAN_MARKDOWN;
     }
   }
 
@@ -291,9 +310,10 @@ export function extractGrokPlanMarkdownFromToolCallData(
       continue;
     }
     const path = typeof block.path === "string" ? block.path : undefined;
-    const newText = typeof block.newText === "string" ? trimmed(block.newText) : undefined;
-    if (isGrokPlanMarkdownPath(path) && newText) {
-      return newText;
+    // ACP diff blocks carry the complete file content after the modification.
+    const newText = typeof block.newText === "string" ? block.newText.trim() : undefined;
+    if (isGrokPlanMarkdownPath(path, homeDirectory) && newText !== undefined) {
+      return newText || XAI_EMPTY_PLAN_MARKDOWN;
     }
   }
   return undefined;

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -1,6 +1,7 @@
 import type { ProviderUserInputAnswers, UserInputQuestion } from "@t3tools/contracts";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Predicate from "effect/Predicate";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import type * as EffectAcpSchema from "effect-acp/schema";
@@ -194,6 +195,108 @@ export function makeXAiAskUserQuestionResponse(
 
 export function makeXAiAskUserQuestionCancelledResponse(): XAiAskUserQuestionCancelledResponse {
   return { outcome: "cancelled" };
+}
+
+const XAiExitPlanModeParams = Schema.Struct({
+  sessionId: Schema.String,
+  toolCallId: Schema.String,
+  planContent: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+const XAiWrappedExitPlanModeParams = Schema.Struct({
+  method: Schema.Literals(["x.ai/exit_plan_mode", "_x.ai/exit_plan_mode"]),
+  params: XAiExitPlanModeParams,
+});
+
+export const XAiExitPlanModeRequest = Schema.Union([
+  XAiExitPlanModeParams,
+  XAiWrappedExitPlanModeParams,
+]);
+
+type XAiExitPlanModeRequestParams = typeof XAiExitPlanModeParams.Type;
+type XAiExitPlanModeRequest = typeof XAiExitPlanModeRequest.Type;
+
+function unwrapExitPlanModeParams(params: XAiExitPlanModeRequest): XAiExitPlanModeRequestParams {
+  return "params" in params ? params.params : params;
+}
+
+export const XAI_EMPTY_PLAN_MARKDOWN =
+  "# No plan written yet\n\n(The agent exited plan mode without writing a plan.)";
+
+export function extractXAiExitPlanMarkdown(
+  params: XAiExitPlanModeRequest,
+  fallback?: string | null,
+): string {
+  const content = unwrapExitPlanModeParams(params).planContent;
+  const fromRequest = typeof content === "string" ? trimmed(content) : undefined;
+  if (fromRequest) {
+    return fromRequest;
+  }
+  return trimmed(fallback ?? undefined) ?? XAI_EMPTY_PLAN_MARKDOWN;
+}
+
+export type XAiExitPlanModeOutcome = "approved" | "abandoned" | "request_changes";
+
+export interface XAiExitPlanModeResponse {
+  readonly outcome: XAiExitPlanModeOutcome;
+  readonly feedback?: string;
+}
+
+/**
+ * T3 has captured the plan into its proposed-plan flow. Abandon Grok's native
+ * approval gate so this turn can finish without implicitly approving work.
+ */
+export function makeXAiExitPlanModeCapturedResponse(feedback?: string): XAiExitPlanModeResponse {
+  return {
+    outcome: "abandoned",
+    feedback:
+      feedback ??
+      "The client captured your proposed plan. Stop here and wait for the user's feedback or implementation request in a later turn.",
+  };
+}
+
+/** Match only Grok's private session plan, never a workspace plan.md file. */
+export function isGrokPlanMarkdownPath(path: string | undefined | null): boolean {
+  if (typeof path !== "string") {
+    return false;
+  }
+  const normalized = path.trim().replace(/\\/g, "/");
+  return normalized.endsWith("/plan.md") && normalized.includes("/.grok/sessions/");
+}
+
+/** Extract the latest plan body from Grok's ACP write/edit tool payload. */
+export function extractGrokPlanMarkdownFromToolCallData(
+  data: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!data) {
+    return undefined;
+  }
+
+  const rawInput = data.rawInput;
+  if (Predicate.isObject(rawInput)) {
+    const filePath =
+      (typeof rawInput.file_path === "string" ? rawInput.file_path : undefined) ??
+      (typeof rawInput.path === "string" ? rawInput.path : undefined);
+    const content = typeof rawInput.content === "string" ? trimmed(rawInput.content) : undefined;
+    if (isGrokPlanMarkdownPath(filePath) && content) {
+      return content;
+    }
+  }
+
+  if (!Array.isArray(data.content)) {
+    return undefined;
+  }
+  for (const block of data.content) {
+    if (!Predicate.isObject(block) || block.type !== "diff") {
+      continue;
+    }
+    const path = typeof block.path === "string" ? block.path : undefined;
+    const newText = typeof block.newText === "string" ? trimmed(block.newText) : undefined;
+    if (isGrokPlanMarkdownPath(path) && newText) {
+      return newText;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -257,8 +257,29 @@ export function makeXAiExitPlanModeCapturedResponse(feedback?: string): XAiExitP
   };
 }
 
-function normalizeFilePath(path: string): string {
-  return path.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+function isWindowsStylePath(path: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(path) || path.startsWith("\\\\");
+}
+
+function resolveAbsoluteFilePath(path: string, caseInsensitive: boolean): string | undefined {
+  const normalized = path.trim().replace(/\\/g, "/");
+  const drive = normalized.match(/^([a-zA-Z]:)\//)?.[1];
+  if (drive === undefined && !normalized.startsWith("/")) {
+    return undefined;
+  }
+  const segments: string[] = [];
+  for (const segment of normalized.slice(drive?.length ?? 0).split("/")) {
+    if (segment === "" || segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  const resolved = `${drive ?? ""}/${segments.join("/")}`;
+  return caseInsensitive ? resolved.toLowerCase() : resolved;
 }
 
 /** Match only Grok's private session plan below the environment user's home directory. */
@@ -269,12 +290,17 @@ export function isGrokPlanMarkdownPath(
   if (typeof path !== "string") {
     return false;
   }
-  const normalized = normalizeFilePath(path);
-  const privateSessionRoot = `${normalizeFilePath(homeDirectory)}/.grok/sessions/`;
-  if (!normalized.startsWith(privateSessionRoot)) {
+  const caseInsensitive = isWindowsStylePath(path) || isWindowsStylePath(homeDirectory);
+  const resolvedHome = resolveAbsoluteFilePath(homeDirectory, caseInsensitive);
+  const resolvedPath = resolveAbsoluteFilePath(path, caseInsensitive);
+  if (resolvedHome === undefined || resolvedPath === undefined) {
     return false;
   }
-  const sessionPlanSegments = normalized.slice(privateSessionRoot.length).split("/");
+  const privateSessionRoot = `${resolvedHome.replace(/\/+$/, "")}/.grok/sessions/`;
+  if (!resolvedPath.startsWith(privateSessionRoot)) {
+    return false;
+  }
+  const sessionPlanSegments = resolvedPath.slice(privateSessionRoot.length).split("/");
   return (
     sessionPlanSegments.length === 2 &&
     sessionPlanSegments[0] !== "" &&


### PR DESCRIPTION
## What Changed

Capture Grok's autonomous plan-mode exit requests and private session plan writes as the existing proposed-plan event. Return a non-approving response so Grok stops at the proposal instead of executing it implicitly.

The ACP mock now covers both xAI exit-plan requests and `.grok/sessions/.../plan.md` writes, including event deduplication and turn settlement.

## Why

Grok can enter plan mode without advertising an ACP mode switch. T3 Code previously did not handle the resulting xAI reverse request, so the turn could hang with no plan approval UI or safe exit path.

Handling the provider-specific extension at the Grok adapter boundary preserves the existing orchestration contract and makes the proposal available to web, desktop, and mobile clients over the normal event stream.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implemented with GPT-5.6 in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface Grok autonomous plan mode proposals as `turn.proposed.completed` events
> - Adds `isGrokEnterPlanModeToolCall` to detect when Grok enters plan mode, setting `planModeActive=true` on the session context; subsequent `plan.md` write tool calls are parsed and emitted as `turn.proposed.completed` events.
> - Registers handlers for `x.ai/exit_plan_mode` and `_x.ai/exit_plan_mode` ext requests that extract plan markdown, emit `turn.proposed.completed`, and return an `abandoned` outcome so the turn completes without implicit approval.
> - Adds `clearProposedPlanCapture` to reset plan tracking state at session boundaries (turn settle, turn complete, session stop, new non-steering turn).
> - Adds `extractGrokPlanMarkdownFromToolCallData` and `extractXAiExitPlanMarkdown` helpers in [`XAiAcpExtension.ts`](https://github.com/pingdotgg/t3code/pull/6431/files#diff-facfffc25c57123d8d9a118e55dc2c9856d28b4ed93f1c10cc9dbf6f6f5c360a) to parse plan content from tool call `rawInput` fields or diff blocks.
> - Extends the mock agent in [`acp-mock-agent.ts`](https://github.com/pingdotgg/t3code/pull/6431/files#diff-8a006152e281284d31dee6c6726df790c3c486b6899a0746f334a8d0663fabc7) with two env flags (`T3_ACP_EMIT_XAI_EXIT_PLAN_MODE`, `T3_ACP_EMIT_XAI_PLAN_MD_WRITE`) to drive the new integration tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 18bfdae. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->