### PR TITLE
fix(server): align Codex collaboration prompts

### DIFF
--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -120,7 +120,7 @@ Example:
 plan content
 </proposed_plan>
 
-plan content should be human and agent digestible. The final plan must be plan-only and include:
+plan content should be human and agent digestible. The final plan must be plan-only, concise by default, and include:
 
 * A clear title
 * A brief summary section
@@ -128,9 +128,17 @@ plan content should be human and agent digestible. The final plan must be plan-o
 * Test cases and scenarios
 * Explicit assumptions and defaults chosen where needed
 
+When possible, prefer a compact structure with 3-5 short sections, usually: Summary, Key Changes or Implementation Changes, Test Plan, and Assumptions. Do not include a separate Scope section unless scope boundaries are genuinely important to avoid mistakes.
+
+Prefer grouped implementation bullets by subsystem or behavior over file-by-file inventories. Mention files only when needed to disambiguate a non-obvious change, and avoid naming more than 3 paths unless extra specificity is necessary to prevent mistakes. Prefer behavior-level descriptions over symbol-by-symbol removal lists. For v1 feature-addition plans, do not invent detailed schema, validation, precedence, fallback, or wire-shape policy unless the request establishes it or it is needed to prevent a concrete implementation mistake; prefer the intended capability and minimum interface/behavior changes.
+
+Keep bullets short and avoid explanatory sub-bullets unless they are needed to prevent ambiguity. Prefer the minimum detail needed for implementation safety, not exhaustive coverage. Within each section, compress related changes into a few high-signal bullets and omit branch-by-branch logic, repeated invariants, and long lists of unaffected behavior unless they are necessary to prevent a likely implementation mistake. Avoid repeated repo facts and irrelevant edge-case or rollout detail. For straightforward refactors, keep the plan to a compact summary, key edits, tests, and assumptions. If the user asks for more detail, then expand.
+
 Do not ask "should I proceed?" in the final output. The user can easily switch out of Plan mode and request implementation if you have included a \`<proposed_plan>\` block in your response. Alternatively, they can decide to stay in Plan mode and continue refining the plan.
 
 Only produce at most one \`<proposed_plan>\` block per turn, and only when you are presenting a complete spec.
+
+If the user stays in Plan mode and asks for revisions after a prior \`<proposed_plan>\`, any new \`<proposed_plan>\` must be a complete replacement. If the user indicates that the prior plan is not acceptable but does not provide enough information to produce a complete replacement, address the concern and continue planning without producing a \`<proposed_plan>\` block. If the follow-up neither requires changes nor calls the plan into question (e.g. clarifying question), answer it before the block, then reproduce the prior \`<proposed_plan>\` unchanged.
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
 </collaboration_mode>`;
 
@@ -142,7 +150,7 @@ Your active mode changes only when new developer instructions with a different \
 
 ## request_user_input availability
 
-The \`request_user_input\` tool is unavailable in Default mode. If you call it while in Default mode, it will return an error.
+Use the \`request_user_input\` tool only when it is listed in the available tools for this turn.
 
 In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}


### PR DESCRIPTION
## What Changed

Updated T3's copied collaboration prompts with the substantive changes from Codex 0.147:
- [Plan mode prompt](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/collaboration-mode-templates/templates/plan.md): added the current concise plan and plan-revision guidance.
- [Default mode prompt](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/collaboration-mode-templates/templates/default.md): replaced the outdated claim that `request_user_input` is always unavailable.

## Why

These prompts were originally copied from Codex but had drifted from their upstream versions. This keeps T3's collaboration modes aligned with current Codex behavior while limiting the change to the prompt text itself.

Fixes #5282
Supersedes #5990


## Checklist

- [x] This PR is small and focused
- [x]  I explained what changed and why
- [x] I included before/after screenshots for any UI changes - Not applicable
- [x] I included a video for animation/interaction changes  - Not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only changes to developer instructions; no auth, data, or runtime behavior paths are modified.
> 
> **Overview**
> **Plan mode** developer instructions now tell the model to keep `<proposed_plan>` output **concise by default**, use a compact 3–5 section shape (summary, key changes, tests, assumptions), favor behavior-level bullets over file inventories, and cap detail unless the user wants more. It also adds rules for **plan revisions** in Plan mode: a new block must fully replace the prior plan, or the model should keep planning without a block when there isn’t enough to replace it; clarifying follow-ups can repeat the unchanged plan after answering.
> 
> **Default mode** no longer states that `request_user_input` is unavailable and errors; it now matches tool availability per turn—use that tool **only when it appears in the turn’s tool list**—while keeping the existing bias toward assumptions and direct plain-text questions when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a0d0ed51d5cad05cae1da65893d5787d28dee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align Codex collaboration prompts for concise plans and conditional tool use
> - Updates [CodexDeveloperInstructions.ts](https://github.com/pingdotgg/t3code/pull/6432/files#diff-bfed4010ccd0734199963a19269942f8abbe9e3b025dd0e8e0253dfe8af72c04) to direct the assistant to produce compact plans (3–5 short sections: Summary, Key Changes, Test Plan, Assumptions), grouping bullets by subsystem rather than listing files individually.
> - Adds follow-up revision rules for Plan mode: new `<proposed_plan>` blocks must be complete replacements, and the prior plan is reproduced unchanged after answering clarifying questions.
> - Replaces the assertion that `request_user_input` is unavailable in Default mode with a conditional rule: use the tool only when it appears in the available tools for the current turn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4a0d0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->