### PR TITLE
fix: render workspace images in chat markdown

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownBlock.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownBlock.ios.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import { Image, ScrollView, Text, useColorScheme, View } from "react-native";
 import type { MarkdownNode } from "react-native-nitro-markdown/headless";
 
@@ -9,9 +9,13 @@ import { NativeMarkdownSelectableText } from "./NativeMarkdownSelectableText.ios
 import type {
   MarkdownCodeHighlighter,
   MarkdownHighlightedToken,
+  MarkdownImageRenderer,
   NativeMarkdownTextStyle,
   SelectableMarkdownSkill,
 } from "./SelectableMarkdownText.types";
+
+/** Set by SelectableMarkdownText so images anywhere in the block tree can use it. */
+export const MarkdownImageRendererContext = createContext<MarkdownImageRenderer | null>(null);
 
 type HighlightedCode = ReadonlyArray<ReadonlyArray<MarkdownHighlightedToken>>;
 
@@ -379,6 +383,7 @@ function NativeMarkdownImage(props: {
   readonly textStyle: NativeMarkdownTextStyle;
   readonly onLinkPress?: (href: string) => void;
 }) {
+  const renderImage = useContext(MarkdownImageRendererContext);
   const href = props.node.href;
   if (!href) {
     return (
@@ -389,6 +394,17 @@ function NativeMarkdownImage(props: {
         onLinkPress={props.onLinkPress}
       />
     );
+  }
+
+  if (renderImage) {
+    const rendered = renderImage({
+      href,
+      alt: props.node.alt ?? null,
+      title: props.node.title ?? null,
+    });
+    if (rendered != null) {
+      return <>{rendered}</>;
+    }
   }
 
   return (

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
@@ -8,7 +8,7 @@ import {
   nativeMarkdownDocumentRuns,
   nativeMarkdownWithPreservedSoftBreaks,
 } from "./nativeMarkdownText";
-import { NativeMarkdownBlock } from "./NativeMarkdownBlock.ios";
+import { MarkdownImageRendererContext, NativeMarkdownBlock } from "./NativeMarkdownBlock.ios";
 import { NativeMarkdownSelectableText } from "./NativeMarkdownSelectableText.ios";
 import type {
   SelectableMarkdownSkill,
@@ -20,6 +20,8 @@ const EMPTY_SKILLS: ReadonlyArray<SelectableMarkdownSkill> = [];
 export type {
   MarkdownCodeHighlighter,
   MarkdownHighlightedToken,
+  MarkdownImageRenderer,
+  MarkdownImageRequest,
   NativeMarkdownTextStyle,
   SelectableMarkdownSkill,
   SelectableMarkdownTextProps,
@@ -36,6 +38,7 @@ export function SelectableMarkdownText({
   highlightCode,
   preserveSoftBreaks = false,
   onLinkPress,
+  renderImage,
   marginTop = 0,
   marginBottom = 0,
 }: SelectableMarkdownTextProps) {
@@ -59,38 +62,40 @@ export function SelectableMarkdownText({
   }, [markdown, preserveSoftBreaks, skills]);
 
   return (
-    // A percentage width here creates a cyclic intrinsic measurement inside
-    // shrink-to-fit containers such as user-message bubbles. Yoga then gives
-    // the native text node an unbounded second pass and the parent only clips
-    // the resulting single-line width instead of reflowing it.
-    <View style={{ flexShrink: 1, minWidth: 0, marginTop, marginBottom }}>
-      {chunks.map((chunk, index) => {
-        const content =
-          chunk.kind === "rich" ? (
-            <NativeMarkdownBlock
-              node={chunk.node}
-              skills={skills}
-              textStyle={textStyle}
-              highlightCode={highlightCode}
-              onLinkPress={onLinkPress}
-            />
-          ) : (
-            <NativeMarkdownSelectableText
-              runs={chunk.runs}
-              textStyle={textStyle}
-              onLinkPress={onLinkPress}
-            />
-          );
+    <MarkdownImageRendererContext.Provider value={renderImage ?? null}>
+      {/* A percentage width here creates a cyclic intrinsic measurement inside
+          shrink-to-fit containers such as user-message bubbles. Yoga then gives
+          the native text node an unbounded second pass and the parent only clips
+          the resulting single-line width instead of reflowing it. */}
+      <View style={{ flexShrink: 1, minWidth: 0, marginTop, marginBottom }}>
+        {chunks.map((chunk, index) => {
+          const content =
+            chunk.kind === "rich" ? (
+              <NativeMarkdownBlock
+                node={chunk.node}
+                skills={skills}
+                textStyle={textStyle}
+                highlightCode={highlightCode}
+                onLinkPress={onLinkPress}
+              />
+            ) : (
+              <NativeMarkdownSelectableText
+                runs={chunk.runs}
+                textStyle={textStyle}
+                onLinkPress={onLinkPress}
+              />
+            );
 
-        return (
-          <View
-            key={chunk.key}
-            style={{ paddingTop: nativeMarkdownChunkSpacing(chunks[index - 1], chunk) }}
-          >
-            {content}
-          </View>
-        );
-      })}
-    </View>
+          return (
+            <View
+              key={chunk.key}
+              style={{ paddingTop: nativeMarkdownChunkSpacing(chunks[index - 1], chunk) }}
+            >
+              {content}
+            </View>
+          );
+        })}
+      </View>
+    </MarkdownImageRendererContext.Provider>
   );
 }

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.tsx
@@ -3,6 +3,8 @@ import type { SelectableMarkdownTextProps } from "./SelectableMarkdownText.types
 export type {
   MarkdownCodeHighlighter,
   MarkdownHighlightedToken,
+  MarkdownImageRenderer,
+  MarkdownImageRequest,
   NativeMarkdownTextStyle,
   SelectableMarkdownSkill,
   SelectableMarkdownTextProps,

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.types.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.types.ts
@@ -36,6 +36,20 @@ export interface SelectableMarkdownSkill {
   readonly displayName?: string | null;
 }
 
+export interface MarkdownImageRequest {
+  readonly href: string;
+  readonly alt: string | null;
+  readonly title: string | null;
+}
+
+/**
+ * App-supplied renderer for markdown images. The module cannot load
+ * workspace-relative image paths itself — the host app resolves them (for
+ * example through a signed asset URL) and returns the element to show.
+ * Returning null falls back to the module's plain remote-URI rendering.
+ */
+export type MarkdownImageRenderer = (image: MarkdownImageRequest) => import("react").ReactNode;
+
 export interface SelectableMarkdownTextProps {
   readonly markdown: string;
   readonly textStyle: NativeMarkdownTextStyle;
@@ -43,6 +57,7 @@ export interface SelectableMarkdownTextProps {
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
   readonly preserveSoftBreaks?: boolean;
   readonly onLinkPress?: (href: string) => void;
+  readonly renderImage?: MarkdownImageRenderer;
   readonly marginTop?: number;
   readonly marginBottom?: number;
 }

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -2,6 +2,7 @@ import * as Haptics from "expo-haptics";
 import { KeyboardAwareLegendList } from "@legendapp/list/keyboard";
 import { type LegendListRef } from "@legendapp/list/react-native";
 import type { EnvironmentId, MessageId, ThreadId, TurnId } from "@t3tools/contracts";
+import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
 import { CHAT_LIST_ANCHOR_OFFSET, resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
 import { formatElapsed } from "@t3tools/shared/orchestrationTiming";
 import { SymbolView } from "../../components/AppSymbol";
@@ -103,7 +104,7 @@ import {
 } from "./thread-work-log";
 import { useMarkdownCodeHighlight } from "./markdownCodeHighlightState";
 import { useAssetUrl, useAssetUrlState } from "../../state/assets";
-import { resolveWorkspaceFilePath, resolveWorkspaceRelativeFilePath } from "../files/filePath";
+import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
 
 const WIDE_MARKDOWN_BLOCK_OPTIONS = {
   includeOrderedLists: Platform.OS === "android",
@@ -194,58 +195,6 @@ function MessageAttachmentImage(props: {
   );
 }
 
-const REMOTE_IMAGE_SRC_PATTERN = /^https?:\/\//i;
-const NON_FILE_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:/;
-
-/**
- * Absolute filesystem path for a markdown image src, or null when the src is
- * not a workspace file (remote URL, other scheme, or a relative path with no
- * workspace root to resolve against).
- */
-function markdownImageWorkspacePath(href: string, workspaceRoot: string | null): string | null {
-  const isFileUri = /^file:\/\//i.test(href);
-  let path = isFileUri ? href.slice("file://".length) : href;
-  try {
-    path = decodeURIComponent(path);
-  } catch {
-    // Keep the raw path when it is not valid percent-encoding.
-  }
-  if (path.length === 0) {
-    return null;
-  }
-  if (isFileUri) {
-    // file://localhost/... is the historical spelling of file:///... (WHATWG
-    // parsers normalize the localhost authority away), not a UNC host.
-    if (/^localhost\//i.test(path)) {
-      path = path.slice("localhost".length);
-    }
-    if (!path.startsWith("/")) {
-      // file://host/share/... — the authority is a UNC host on the
-      // environment machine, not a path segment under the workspace root.
-      return `\\\\${path.replaceAll("/", "\\")}`;
-    }
-    // URL parsers encode Windows drive paths as /C:/... — drop the slash.
-    if (/^\/[A-Za-z]:[\\/]/.test(path)) {
-      path = path.slice(1);
-    }
-  } else if (path.startsWith("//")) {
-    // Protocol-relative URL (//cdn.example.com/x.png), not a filesystem path.
-    return null;
-  }
-  const isAbsolute =
-    path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\");
-  if (!isAbsolute && NON_FILE_SCHEME_PATTERN.test(path)) {
-    return null;
-  }
-  if (isAbsolute) {
-    return path;
-  }
-  if (workspaceRoot === null) {
-    return null;
-  }
-  return resolveWorkspaceFilePath(workspaceRoot, path);
-}
-
 /** Markdown image whose src is a workspace file — loads through a signed asset URL. */
 function ThreadMarkdownImage(props: {
   readonly environmentId: EnvironmentId;
@@ -304,6 +253,31 @@ function ThreadMarkdownImage(props: {
           />
         </TouchableOpacity>
       )}
+      {props.alt ? (
+        <Text selectable className="text-xs text-foreground-muted">
+          {props.alt}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function ThreadMarkdownImageUnavailable(props: { readonly alt: string | null }) {
+  const codeBackground = useThemeColor("--color-md-code-bg");
+  return (
+    <View style={{ gap: 6 }}>
+      <View
+        style={{
+          width: "100%",
+          aspectRatio: 16 / 9,
+          borderRadius: 10,
+          backgroundColor: codeBackground,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Text className="text-xs text-foreground-muted">Image unavailable</Text>
+      </View>
       {props.alt ? (
         <Text selectable className="text-xs text-foreground-muted">
           {props.alt}
@@ -1553,19 +1527,18 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
   );
   const renderMarkdownImage = useCallback<MarkdownImageRenderer>(
     (image) => {
-      // Remote URIs load fine in a plain RN Image — keep the module fallback.
-      if (REMOTE_IMAGE_SRC_PATTERN.test(image.href)) {
+      const imageSource = classifyMarkdownImageSource(image.href, props.workspaceRoot ?? null);
+      if (imageSource._tag === "Direct") {
         return null;
       }
-      const path = markdownImageWorkspacePath(image.href, props.workspaceRoot ?? null);
-      if (path === null) {
-        return null;
+      if (imageSource._tag === "Blocked") {
+        return <ThreadMarkdownImageUnavailable alt={image.alt} />;
       }
       return (
         <ThreadMarkdownImage
           environmentId={props.environmentId}
           threadId={props.threadId}
-          path={path}
+          path={imageSource.path}
           alt={image.alt}
           onPressImage={(uri) => setExpandedImage({ uri })}
         />

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -54,6 +54,7 @@ import { hasWideMarkdownBlock } from "../../lib/wideMarkdownBlocks";
 import {
   hasNativeSelectableMarkdownText,
   SelectableMarkdownText,
+  type MarkdownImageRenderer,
   type NativeMarkdownTextStyle,
   type SelectableMarkdownSkill,
 } from "../../native/SelectableMarkdownText";
@@ -101,8 +102,8 @@ import {
   WORK_GROUP_TOGGLE_HEIGHT,
 } from "./thread-work-log";
 import { useMarkdownCodeHighlight } from "./markdownCodeHighlightState";
-import { useAssetUrl } from "../../state/assets";
-import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
+import { useAssetUrl, useAssetUrlState } from "../../state/assets";
+import { resolveWorkspaceFilePath, resolveWorkspaceRelativeFilePath } from "../files/filePath";
 
 const WIDE_MARKDOWN_BLOCK_OPTIONS = {
   includeOrderedLists: Platform.OS === "android",
@@ -190,6 +191,125 @@ function MessageAttachmentImage(props: {
     <TouchableOpacity activeOpacity={0.7} onPress={() => props.onPressImage(uri)}>
       <Image source={{ uri }} className={props.className} resizeMode="cover" />
     </TouchableOpacity>
+  );
+}
+
+const REMOTE_IMAGE_SRC_PATTERN = /^https?:\/\//i;
+const NON_FILE_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+
+/**
+ * Absolute filesystem path for a markdown image src, or null when the src is
+ * not a workspace file (remote URL, other scheme, or a relative path with no
+ * workspace root to resolve against).
+ */
+function markdownImageWorkspacePath(href: string, workspaceRoot: string | null): string | null {
+  const isFileUri = /^file:\/\//i.test(href);
+  let path = isFileUri ? href.slice("file://".length) : href;
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    // Keep the raw path when it is not valid percent-encoding.
+  }
+  if (path.length === 0) {
+    return null;
+  }
+  if (isFileUri) {
+    // file://localhost/... is the historical spelling of file:///... (WHATWG
+    // parsers normalize the localhost authority away), not a UNC host.
+    if (/^localhost\//i.test(path)) {
+      path = path.slice("localhost".length);
+    }
+    if (!path.startsWith("/")) {
+      // file://host/share/... — the authority is a UNC host on the
+      // environment machine, not a path segment under the workspace root.
+      return `\\\\${path.replaceAll("/", "\\")}`;
+    }
+    // URL parsers encode Windows drive paths as /C:/... — drop the slash.
+    if (/^\/[A-Za-z]:[\\/]/.test(path)) {
+      path = path.slice(1);
+    }
+  } else if (path.startsWith("//")) {
+    // Protocol-relative URL (//cdn.example.com/x.png), not a filesystem path.
+    return null;
+  }
+  const isAbsolute =
+    path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\");
+  if (!isAbsolute && NON_FILE_SCHEME_PATTERN.test(path)) {
+    return null;
+  }
+  if (isAbsolute) {
+    return path;
+  }
+  if (workspaceRoot === null) {
+    return null;
+  }
+  return resolveWorkspaceFilePath(workspaceRoot, path);
+}
+
+/** Markdown image whose src is a workspace file — loads through a signed asset URL. */
+function ThreadMarkdownImage(props: {
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+  readonly path: string;
+  readonly alt: string | null;
+  readonly onPressImage: (uri: string) => void;
+}) {
+  const codeBackground = useThemeColor("--color-md-code-bg");
+  const [failedUri, setFailedUri] = useState<string | null>(null);
+  const assetUrl = useAssetUrlState(props.environmentId, {
+    _tag: "workspace-file",
+    threadId: props.threadId,
+    path: props.path,
+  });
+  const uri = assetUrl._tag === "Success" ? assetUrl.url : null;
+  const failed = assetUrl._tag === "Failure" || (uri !== null && failedUri === uri);
+
+  return (
+    <View style={{ gap: 6 }}>
+      {uri === null || failed ? (
+        <View
+          style={{
+            width: "100%",
+            aspectRatio: 16 / 9,
+            borderRadius: 10,
+            backgroundColor: codeBackground,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          {failed ? (
+            <Text className="text-xs text-foreground-muted">Image unavailable</Text>
+          ) : (
+            <ActivityIndicator />
+          )}
+        </View>
+      ) : (
+        <TouchableOpacity
+          accessibilityRole="imagebutton"
+          accessibilityLabel={props.alt ?? "Markdown image"}
+          activeOpacity={0.7}
+          onPress={() => props.onPressImage(uri)}
+        >
+          <Image
+            source={{ uri }}
+            resizeMode="contain"
+            accessible={false}
+            onError={() => setFailedUri(uri)}
+            style={{
+              width: "100%",
+              aspectRatio: 16 / 9,
+              borderRadius: 10,
+              backgroundColor: codeBackground,
+            }}
+          />
+        </TouchableOpacity>
+      )}
+      {props.alt ? (
+        <Text selectable className="text-xs text-foreground-muted">
+          {props.alt}
+        </Text>
+      ) : null}
+    </View>
   );
 }
 
@@ -408,7 +528,10 @@ function useReviewCommentColors(): ReviewCommentColors {
   );
 }
 
-function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSets {
+function useMarkdownStyles(
+  onLinkPress: (href: string) => void,
+  renderImage: MarkdownImageRenderer,
+): MarkdownStyleSets {
   const { appearance, themeAppearance } = useAppearancePreferences();
   const markdownFontSizes = useMemo(
     () => resolveMarkdownFontSizes(appearance.baseFontSize),
@@ -613,6 +736,14 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
           })}
         </View>
       ),
+      image: ({ node }) =>
+        node.href
+          ? (renderImage({
+              href: node.href,
+              alt: node.alt ?? null,
+              title: node.title ?? null,
+            }) ?? undefined)
+          : undefined,
       code_inline: ({ content }) => {
         const value = content ?? "";
         return (
@@ -786,6 +917,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
     nativeMarkdownTypography,
     onLinkPress,
     regularFontFamily,
+    renderImage,
     themeMode,
     userBubbleForegroundMuted,
     userBubbleSkillForeground,
@@ -805,6 +937,7 @@ function renderFeedEntry(
     readonly onToggleTurnFold: (turnId: TurnId) => void;
     readonly onPressImage: (uri: string, headers?: Record<string, string>) => void;
     readonly onMarkdownLinkPress: (href: string) => void;
+    readonly renderMarkdownImage: MarkdownImageRenderer;
     readonly iconSubtleColor: string | import("react-native").ColorValue;
     readonly userBubbleColor: string | import("react-native").ColorValue;
     readonly markdownStyles: MarkdownStyleSets;
@@ -903,6 +1036,7 @@ function renderFeedEntry(
                 reviewCommentColors={props.reviewCommentColors}
                 skills={props.skills}
                 onLinkPress={props.onMarkdownLinkPress}
+                renderImage={props.renderMarkdownImage}
               />
             ) : null}
             {attachments.map((attachment) => {
@@ -954,6 +1088,7 @@ function renderFeedEntry(
               skills={props.skills}
               textStyle={styles.nativeTextStyle}
               onLinkPress={props.onMarkdownLinkPress}
+              renderImage={props.renderMarkdownImage}
             />
           ) : (
             <Markdown
@@ -1039,6 +1174,7 @@ function UserMessageContent(props: {
   readonly reviewCommentColors: ReviewCommentColors;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
   readonly onLinkPress: (href: string) => void;
+  readonly renderImage: MarkdownImageRenderer;
 }) {
   const segments = parseReviewCommentMessageSegments(props.text);
   const hasReviewComment = segments.some((segment) => segment.kind === "review-comment");
@@ -1051,6 +1187,7 @@ function UserMessageContent(props: {
           textStyle={props.markdownStyles.nativeTextStyle}
           preserveSoftBreaks
           onLinkPress={props.onLinkPress}
+          renderImage={props.renderImage}
         />
       );
     }
@@ -1092,6 +1229,7 @@ function UserMessageContent(props: {
             textStyle={props.markdownStyles.nativeTextStyle}
             preserveSoftBreaks
             onLinkPress={props.onLinkPress}
+            renderImage={props.renderImage}
           />
         ) : (
           <Markdown
@@ -1413,7 +1551,29 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     },
     [props.environmentId, props.threadId, props.workspaceRoot, navigation],
   );
-  const markdownStyles = useMarkdownStyles(onMarkdownLinkPress);
+  const renderMarkdownImage = useCallback<MarkdownImageRenderer>(
+    (image) => {
+      // Remote URIs load fine in a plain RN Image — keep the module fallback.
+      if (REMOTE_IMAGE_SRC_PATTERN.test(image.href)) {
+        return null;
+      }
+      const path = markdownImageWorkspacePath(image.href, props.workspaceRoot ?? null);
+      if (path === null) {
+        return null;
+      }
+      return (
+        <ThreadMarkdownImage
+          environmentId={props.environmentId}
+          threadId={props.threadId}
+          path={path}
+          alt={image.alt}
+          onPressImage={(uri) => setExpandedImage({ uri })}
+        />
+      );
+    },
+    [props.environmentId, props.threadId, props.workspaceRoot],
+  );
+  const markdownStyles = useMarkdownStyles(onMarkdownLinkPress, renderMarkdownImage);
   const reviewCommentColors = useReviewCommentColors();
   // LegendList does not invalidate visible rows when only the renderItem closure changes.
   // Keep row-local interaction props in extraData so disclosures and copy feedback repaint.
@@ -1804,6 +1964,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
         onToggleTurnFold,
         onPressImage,
         onMarkdownLinkPress,
+        renderMarkdownImage,
         iconSubtleColor,
         userBubbleColor,
         markdownStyles,
@@ -1831,6 +1992,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       onToggleWorkRow,
       props.environmentId,
       props.skills,
+      renderMarkdownImage,
     ],
   );
 

--- a/apps/mobile/src/native/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/src/native/SelectableMarkdownText.ios.tsx
@@ -8,6 +8,8 @@ import { highlightCodeSnippet } from "../features/review/shikiReviewHighlighter"
 type MobileSelectableMarkdownTextProps = Omit<SelectableMarkdownTextProps, "highlightCode">;
 
 export type {
+  MarkdownImageRenderer,
+  MarkdownImageRequest,
   NativeMarkdownTextStyle,
   SelectableMarkdownSkill,
 } from "@t3tools/mobile-markdown-text/types";

--- a/apps/mobile/src/native/SelectableMarkdownText.tsx
+++ b/apps/mobile/src/native/SelectableMarkdownText.tsx
@@ -3,6 +3,8 @@ import type { SelectableMarkdownTextProps } from "@t3tools/mobile-markdown-text/
 type MobileSelectableMarkdownTextProps = Omit<SelectableMarkdownTextProps, "highlightCode">;
 
 export type {
+  MarkdownImageRenderer,
+  MarkdownImageRequest,
   NativeMarkdownTextStyle,
   SelectableMarkdownSkill,
 } from "@t3tools/mobile-markdown-text/types";

--- a/apps/mobile/src/state/assets.ts
+++ b/apps/mobile/src/state/assets.ts
@@ -12,18 +12,35 @@ const EMPTY_ASSET_URL_ATOM = Atom.make(AsyncResult.initial<never, never>(false))
   Atom.withLabel("mobile-asset-url:empty"),
 );
 
-export function useAssetUrl(
+export type AssetUrlState =
+  | { readonly _tag: "Loading" }
+  | { readonly _tag: "Failure" }
+  | { readonly _tag: "Success"; readonly url: string };
+
+export function useAssetUrlState(
   environmentId: EnvironmentId | null,
   resource: AssetResource | null,
-): string | null {
+): AssetUrlState {
   const preparedConnection = usePreparedConnection(environmentId);
   const result = useAtomValue(
     environmentId === null || resource === null
       ? EMPTY_ASSET_URL_ATOM
       : assetEnvironment.createUrl({ environmentId, input: { resource } }),
   );
-  if (preparedConnection._tag === "None" || result._tag !== "Success") {
-    return null;
+  if (result._tag === "Failure") {
+    return { _tag: "Failure" };
   }
-  return resolveAssetUrl(preparedConnection.value.httpBaseUrl, result.value.relativeUrl);
+  if (preparedConnection._tag === "None" || result._tag !== "Success") {
+    return { _tag: "Loading" };
+  }
+  const url = resolveAssetUrl(preparedConnection.value.httpBaseUrl, result.value.relativeUrl);
+  return url === null ? { _tag: "Failure" } : { _tag: "Success", url };
+}
+
+export function useAssetUrl(
+  environmentId: EnvironmentId | null,
+  resource: AssetResource | null,
+): string | null {
+  const state = useAssetUrlState(environmentId, resource);
+  return state._tag === "Success" ? state.url : null;
 }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -983,8 +983,10 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
   );
 });
 
+// block! outranks the unlayered `.chat-markdown img { display: inline-block }`
+// rule, keeping the loaded image on the same block layout as its placeholder.
 const CHAT_MARKDOWN_IMAGE_CLASS_NAME =
-  "my-1 block max-h-96 max-w-full rounded-lg border border-border/40 object-contain";
+  "my-1 block! max-h-96 max-w-full rounded-lg border border-border/40 object-contain";
 
 /** A remote src the browser can fetch on its own — no workspace resolution needed. */
 const DIRECTLY_LOADABLE_IMAGE_SRC_PATTERN = /^(?:https?:|data:|blob:|\/\/)/i;
@@ -1017,6 +1019,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   if (assetUrl._tag !== "Success") {
     return (
       <span
+        role="status"
         aria-label="Loading image"
         className="my-1 block aspect-video w-full max-w-md rounded-lg bg-muted/60"
       />

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -81,6 +81,7 @@ import {
   type MarkdownFileLinkMeta,
 } from "../markdown-links";
 import { readLocalApi } from "../localApi";
+import { useAssetUrlState } from "../assets/assetUrls";
 import { cn } from "../lib/utils";
 import { useRightPanelStore } from "../rightPanelStore";
 import { useActiveEnvironmentId } from "../state/entities";
@@ -186,6 +187,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   protocols: {
     ...defaultSchema.protocols,
     href: [...(defaultSchema.protocols?.href ?? []), "file"],
+    src: [...(defaultSchema.protocols?.src ?? []), "file"],
   },
 } satisfies Parameters<typeof rehypeSanitize>[0];
 
@@ -950,6 +952,57 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
   );
 });
 
+const CHAT_MARKDOWN_IMAGE_CLASS_NAME =
+  "my-1 block max-h-96 max-w-full rounded-lg border border-border/40 object-contain";
+
+/** A remote src the browser can fetch on its own — no workspace resolution needed. */
+const DIRECTLY_LOADABLE_IMAGE_SRC_PATTERN = /^(?:https?:|data:|blob:)/i;
+
+function ChatMarkdownImageFallback(props: { readonly alt: string }) {
+  return (
+    <span className="my-1 inline-flex items-center gap-1.5 rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground">
+      <TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
+      {props.alt.length > 0 ? `Image unavailable · ${props.alt}` : "Image unavailable"}
+    </span>
+  );
+}
+
+/** Markdown images whose src is a workspace file path load through a signed asset URL. */
+const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(props: {
+  readonly threadRef: ScopedThreadRef;
+  readonly path: string;
+  readonly alt: string;
+}) {
+  const assetUrl = useAssetUrlState(props.threadRef.environmentId, {
+    _tag: "workspace-file",
+    threadId: props.threadRef.threadId,
+    path: props.path,
+  });
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+
+  if (assetUrl._tag === "Failure" || (assetUrl._tag === "Success" && failedUrl === assetUrl.url)) {
+    return <ChatMarkdownImageFallback alt={props.alt} />;
+  }
+  if (assetUrl._tag !== "Success") {
+    return (
+      <span
+        aria-label="Loading image"
+        className="my-1 block aspect-video w-full max-w-md animate-pulse rounded-lg bg-muted/60"
+      />
+    );
+  }
+  return (
+    <img
+      src={assetUrl.url}
+      alt={props.alt}
+      loading="lazy"
+      draggable={false}
+      className={CHAT_MARKDOWN_IMAGE_CLASS_NAME}
+      onError={() => setFailedUrl(assetUrl.url)}
+    />
+  );
+});
+
 function leadingExternalLinkTextLength(text: string): number {
   const protocol = /^(?:https?:\/\/)/i.exec(text)?.[0];
   if (protocol) return protocol.length;
@@ -1710,9 +1763,6 @@ function ChatMarkdown({
           props.className,
         );
       },
-      img({ node: _node, title: _title, ...props }) {
-        return <img {...props} />;
-      },
       code({ node, children, className, ...props }) {
         if (node?.properties?.dataInlineCode != null) {
           const codeText = nodeToPlainText(children);
@@ -1728,6 +1778,29 @@ function ChatMarkdown({
             {children}
           </code>
         );
+      },
+      img({ node: _node, title: _title, src, alt, ...props }) {
+        const srcString = typeof src === "string" ? normalizeMarkdownLinkDestination(src) : "";
+        const altText = alt ?? "";
+        if (srcString.length === 0) {
+          return <ChatMarkdownImageFallback alt={altText} />;
+        }
+        if (!DIRECTLY_LOADABLE_IMAGE_SRC_PATTERN.test(srcString)) {
+          // Agents reference screenshots they saved into the workspace by path
+          // (relative, absolute, or file://); those bytes only exist on the
+          // environment host, so they load through a signed asset URL.
+          const fileMeta = resolveMarkdownFileLinkMeta(srcString, cwd);
+          if (fileMeta && threadRef) {
+            return (
+              <ChatMarkdownWorkspaceImage
+                threadRef={threadRef}
+                path={fileMeta.filePath}
+                alt={altText}
+              />
+            );
+          }
+        }
+        return <img {...props} src={srcString} alt={altText} loading="lazy" />;
       },
       table({ node: _node, ...props }) {
         return <MarkdownTable {...props} />;

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -176,6 +176,36 @@ export function orderedListGutterStyle(
   return { "--list-gutter": `${digits + 1}ch` };
 }
 
+type MarkdownHtmlAstNode = {
+  type?: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: MarkdownHtmlAstNode[];
+};
+
+/** Preserve Windows drive paths through the protocol allowlist in rehype-sanitize. */
+function rehypeNormalizeWindowsImageSrc() {
+  return (tree: MarkdownHtmlAstNode) => {
+    const visit = (node: MarkdownHtmlAstNode) => {
+      const src = node.properties?.src;
+      if (
+        node.type === "element" &&
+        node.tagName === "img" &&
+        typeof src === "string" &&
+        /^[A-Za-z]:[\\/]/.test(src)
+      ) {
+        node.properties = {
+          ...node.properties,
+          src: `file:///${src.replaceAll("\\", "/")}`,
+        };
+      }
+      node.children?.forEach(visit);
+    };
+
+    visit(tree);
+  };
+}
+
 const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   ...defaultSchema,
   attributes: {
@@ -210,6 +240,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
 
 const CHAT_MARKDOWN_REHYPE_PLUGINS = [
   rehypeRaw,
+  rehypeNormalizeWindowsImageSrc,
   [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
 ] satisfies NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -19,6 +19,7 @@ import {
   squashAtomCommandFailure,
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
+import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 import React, {
@@ -988,9 +989,6 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
 const CHAT_MARKDOWN_IMAGE_CLASS_NAME =
   "my-1 block! max-h-96 max-w-full rounded-lg border border-border/40 object-contain";
 
-/** A remote src the browser can fetch on its own — no workspace resolution needed. */
-const DIRECTLY_LOADABLE_IMAGE_SRC_PATTERN = /^(?:https?:|data:|blob:|\/\/)/i;
-
 function ChatMarkdownImageFallback(props: { readonly alt: string }) {
   return (
     <span className="my-1 inline-flex items-center gap-1.5 rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground">
@@ -1816,25 +1814,20 @@ function ChatMarkdown({
       img({ node: _node, title: _title, src, alt, ...props }) {
         const srcString = typeof src === "string" ? normalizeMarkdownLinkDestination(src) : "";
         const altText = alt ?? "";
-        if (srcString.length === 0) {
-          return <ChatMarkdownImageFallback alt={altText} />;
+        const imageSource = classifyMarkdownImageSource(srcString, cwd);
+        if (imageSource._tag === "Direct") {
+          return <img {...props} src={imageSource.uri} alt={altText} loading="lazy" />;
         }
-        if (!DIRECTLY_LOADABLE_IMAGE_SRC_PATTERN.test(srcString)) {
-          // Agents reference screenshots they saved into the workspace by path
-          // (relative, absolute, or file://); those bytes only exist on the
-          // environment host, so they load through a signed asset URL.
-          const fileMeta = resolveMarkdownFileLinkMeta(srcString, cwd);
-          if (fileMeta && threadRef) {
-            return (
-              <ChatMarkdownWorkspaceImage
-                threadRef={threadRef}
-                path={fileMeta.filePath}
-                alt={altText}
-              />
-            );
-          }
+        if (imageSource._tag === "WorkspaceFile" && threadRef) {
+          return (
+            <ChatMarkdownWorkspaceImage
+              threadRef={threadRef}
+              path={imageSource.path}
+              alt={altText}
+            />
+          );
         }
-        return <img {...props} src={srcString} alt={altText} loading="lazy" />;
+        return <ChatMarkdownImageFallback alt={altText} />;
       },
       table({ node: _node, ...props }) {
         return <MarkdownTable {...props} />;

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -956,7 +956,7 @@ const CHAT_MARKDOWN_IMAGE_CLASS_NAME =
   "my-1 block max-h-96 max-w-full rounded-lg border border-border/40 object-contain";
 
 /** A remote src the browser can fetch on its own — no workspace resolution needed. */
-const DIRECTLY_LOADABLE_IMAGE_SRC_PATTERN = /^(?:https?:|data:|blob:)/i;
+const DIRECTLY_LOADABLE_IMAGE_SRC_PATTERN = /^(?:https?:|data:|blob:|\/\/)/i;
 
 function ChatMarkdownImageFallback(props: { readonly alt: string }) {
   return (

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -984,10 +984,15 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
   );
 });
 
+const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME =
+  "h-auto w-auto max-h-[30rem] max-w-[min(100%,30rem)] object-contain";
+
 // block! outranks the unlayered `.chat-markdown img { display: inline-block }`
-// rule, keeping the loaded image on the same block layout as its placeholder.
-const CHAT_MARKDOWN_IMAGE_CLASS_NAME =
-  "my-1 block! max-h-96 max-w-full rounded-lg border border-border/40 object-contain";
+// rule, keeping workspace images on the same block layout as their placeholder.
+const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
+  CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
+  "my-1 block! rounded-lg border border-border/40",
+);
 
 function ChatMarkdownImageFallback(props: { readonly alt: string }) {
   return (
@@ -1019,7 +1024,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
       <span
         role="status"
         aria-label="Loading image"
-        className="my-1 block aspect-video w-full max-w-md rounded-lg bg-muted/60"
+        className="my-1 block aspect-video w-full max-w-[30rem] rounded-lg bg-muted/60"
       />
     );
   }
@@ -1029,7 +1034,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
       alt={props.alt}
       loading="lazy"
       draggable={false}
-      className={CHAT_MARKDOWN_IMAGE_CLASS_NAME}
+      className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
       onError={() => setFailedUrl(assetUrl.url)}
     />
   );
@@ -1816,7 +1821,15 @@ function ChatMarkdown({
         const altText = alt ?? "";
         const imageSource = classifyMarkdownImageSource(srcString, cwd);
         if (imageSource._tag === "Direct") {
-          return <img {...props} src={imageSource.uri} alt={altText} loading="lazy" />;
+          return (
+            <img
+              {...props}
+              src={imageSource.uri}
+              alt={altText}
+              loading="lazy"
+              className={cn(props.className, CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME)}
+            />
+          );
         }
         if (imageSource._tag === "WorkspaceFile" && threadRef) {
           return (

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1018,7 +1018,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
     return (
       <span
         aria-label="Loading image"
-        className="my-1 block aspect-video w-full max-w-md animate-pulse rounded-lg bg-muted/60"
+        className="my-1 block aspect-video w-full max-w-md rounded-lg bg-muted/60"
       />
     );
   }

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -4,13 +4,16 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({
   resources: [] as Array<unknown>,
+  assetState: "success" as "success" | "loading",
 }));
 
 vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
 vi.mock("../assets/assetUrls", () => ({
   useAssetUrlState: (_environmentId: unknown, resource: unknown) => {
     testState.resources.push(resource);
-    return { _tag: "Success", url: "https://signed.test/workspace-image.svg" };
+    return testState.assetState === "loading"
+      ? { _tag: "Loading" }
+      : { _tag: "Success", url: "https://signed.test/workspace-image.svg" };
   },
 }));
 vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
@@ -42,6 +45,7 @@ function render(markdown: string): string {
 describe("ChatMarkdown workspace images", () => {
   beforeEach(() => {
     testState.resources = [];
+    testState.assetState = "success";
   });
 
   it("loads every Windows workspace path form through a signed asset URL", () => {
@@ -84,5 +88,14 @@ describe("ChatMarkdown workspace images", () => {
       },
     ]);
     expect(html).toContain("https://signed.test/workspace-image.svg");
+  });
+
+  it("uses a static placeholder while a signed asset URL loads", () => {
+    testState.assetState = "loading";
+
+    const html = render("![loading](.t3/workspace-image.svg)");
+
+    expect(html).toContain('aria-label="Loading image"');
+    expect(html).not.toContain("animate-pulse");
   });
 });

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -51,6 +51,7 @@ describe("ChatMarkdown workspace images", () => {
         "![relative](.t3/workspace-image.svg)",
         `![absolute](${imagePath})`,
         `![file URL](file:///${imagePath})`,
+        "![UNC file URL](file://server/share/workspace-image.svg)",
       ].join("\n\n"),
     );
 
@@ -62,8 +63,13 @@ describe("ChatMarkdown workspace images", () => {
       },
       { _tag: "workspace-file", threadId: threadRef.threadId, path: imagePath },
       { _tag: "workspace-file", threadId: threadRef.threadId, path: imagePath },
+      {
+        _tag: "workspace-file",
+        threadId: threadRef.threadId,
+        path: "\\\\server\\share\\workspace-image.svg",
+      },
     ]);
-    expect(html.match(/https:\/\/signed\.test\/workspace-image\.svg/g)).toHaveLength(3);
+    expect(html.match(/https:\/\/signed\.test\/workspace-image\.svg/g)).toHaveLength(4);
     expect(html).not.toContain("Image unavailable");
   });
 

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -1,0 +1,82 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => ({
+  resources: [] as Array<unknown>,
+}));
+
+vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
+vi.mock("../assets/assetUrls", () => ({
+  useAssetUrlState: (_environmentId: unknown, resource: unknown) => {
+    testState.resources.push(resource);
+    return { _tag: "Success", url: "https://signed.test/workspace-image.svg" };
+  },
+}));
+vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
+vi.mock("../state/use-atom-query-runner", () => ({ useAtomQueryRunner: () => vi.fn() }));
+vi.mock("../state/use-atom-command", () => ({ useAtomCommand: () => vi.fn() }));
+vi.mock("../state/session", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../state/session")>()),
+  usePreparedConnection: () => ({ _tag: "Loading" }),
+}));
+vi.mock("../state/entities", () => ({
+  useActiveEnvironmentId: () => EnvironmentId.make("env-windows"),
+}));
+vi.mock("../editorPreferences", () => ({ useOpenInPreferredEditor: () => vi.fn() }));
+vi.mock("~/lib/openPullRequestLink", () => ({ useOpenChangeRequestLink: () => vi.fn() }));
+
+import ChatMarkdown from "./ChatMarkdown";
+
+const threadRef = {
+  environmentId: EnvironmentId.make("env-windows"),
+  threadId: ThreadId.make("thread-windows"),
+};
+
+function render(markdown: string): string {
+  return renderToStaticMarkup(
+    <ChatMarkdown cwd={"C:\\Users\\shawn\\project"} threadRef={threadRef} text={markdown} />,
+  );
+}
+
+describe("ChatMarkdown workspace images", () => {
+  beforeEach(() => {
+    testState.resources = [];
+  });
+
+  it("loads every Windows workspace path form through a signed asset URL", () => {
+    const imagePath = "C:/Users/shawn/project/.t3/workspace-image.svg";
+    const html = render(
+      [
+        "![relative](.t3/workspace-image.svg)",
+        `![absolute](${imagePath})`,
+        `![file URL](file:///${imagePath})`,
+      ].join("\n\n"),
+    );
+
+    expect(testState.resources).toEqual([
+      {
+        _tag: "workspace-file",
+        threadId: threadRef.threadId,
+        path: "C:\\Users\\shawn\\project\\.t3\\workspace-image.svg",
+      },
+      { _tag: "workspace-file", threadId: threadRef.threadId, path: imagePath },
+      { _tag: "workspace-file", threadId: threadRef.threadId, path: imagePath },
+    ]);
+    expect(html.match(/https:\/\/signed\.test\/workspace-image\.svg/g)).toHaveLength(3);
+    expect(html).not.toContain("Image unavailable");
+  });
+
+  it("normalizes a drive-absolute src in raw image HTML", () => {
+    const html = render(String.raw`<img src="D:\screens\workspace-image.svg" alt="raw">`);
+
+    expect(testState.resources).toEqual([
+      {
+        _tag: "workspace-file",
+        threadId: threadRef.threadId,
+        path: "D:/screens/workspace-image.svg",
+      },
+    ]);
+    expect(html).toContain("https://signed.test/workspace-image.svg");
+  });
+});

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -42,6 +42,10 @@ function render(markdown: string): string {
   );
 }
 
+function renderWithoutThread(markdown: string): string {
+  return renderToStaticMarkup(<ChatMarkdown cwd={"C:\\Users\\shawn\\project"} text={markdown} />);
+}
+
 describe("ChatMarkdown workspace images", () => {
   beforeEach(() => {
     testState.resources = [];
@@ -97,5 +101,31 @@ describe("ChatMarkdown workspace images", () => {
 
     expect(html).toContain('aria-label="Loading image"');
     expect(html).not.toContain("animate-pulse");
+  });
+
+  it("never passes a workspace source to a raw image when thread context is unavailable", () => {
+    const html = renderWithoutThread(
+      "![file URL](file:///C:/Users/shawn/project/workspace-image.svg)",
+    );
+
+    expect(testState.resources).toEqual([]);
+    expect(html).toContain("Image unavailable");
+    expect(html).not.toContain("file://");
+  });
+
+  it("blocks unsupported image schemes instead of passing them to a raw image", () => {
+    const html = render("![unsupported](content://media/image/1)");
+
+    expect(testState.resources).toEqual([]);
+    expect(html).toContain("Image unavailable");
+    expect(html).not.toContain("content://");
+  });
+
+  it("keeps remote images directly loadable", () => {
+    const html = render("![remote](https://example.com/image.png)");
+
+    expect(testState.resources).toEqual([]);
+    expect(html).toContain('src="https://example.com/image.png"');
+    expect(html).not.toContain("Image unavailable");
   });
 });

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -78,6 +78,8 @@ describe("ChatMarkdown workspace images", () => {
       },
     ]);
     expect(html.match(/https:\/\/signed\.test\/workspace-image\.svg/g)).toHaveLength(4);
+    expect(html.match(/max-w-\[min\(100%,30rem\)\]/g)).toHaveLength(4);
+    expect(html.match(/max-h-\[30rem\]/g)).toHaveLength(4);
     expect(html).not.toContain("Image unavailable");
   });
 
@@ -126,6 +128,8 @@ describe("ChatMarkdown workspace images", () => {
 
     expect(testState.resources).toEqual([]);
     expect(html).toContain('src="https://example.com/image.png"');
+    expect(html).toContain("max-w-[min(100%,30rem)]");
+    expect(html).toContain("max-h-[30rem]");
     expect(html).not.toContain("Image unavailable");
   });
 });

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -34,6 +34,12 @@ describe("rewriteMarkdownFileUriHref", () => {
     );
   });
 
+  it("treats a localhost file uri as a local path", () => {
+    expect(rewriteMarkdownFileUriHref("file://localhost/home/me/notes.md")).toBe(
+      "/home/me/notes.md",
+    );
+  });
+
   it("unwraps angle-bracketed file uri hrefs", () => {
     expect(
       rewriteMarkdownFileUriHref(" <file:///D:/Programme/t3code/apps/web/src/markdown-links.ts> "),
@@ -85,6 +91,12 @@ describe("resolveMarkdownFileLinkTarget", () => {
   it("resolves file uri authorities as windows UNC paths", () => {
     expect(resolveMarkdownFileLinkTarget("file://server/share/workspace-image.svg")).toBe(
       "\\\\server\\share\\workspace-image.svg",
+    );
+  });
+
+  it("resolves a localhost file uri as a local path", () => {
+    expect(resolveMarkdownFileLinkTarget("file://localhost/home/me/notes.md")).toBe(
+      "/home/me/notes.md",
     );
   });
 

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -28,6 +28,12 @@ describe("rewriteMarkdownFileUriHref", () => {
     ).toBe("D:/Programme/t3code/apps/web/src/components/chat/OpenInPicker.tsx#L69");
   });
 
+  it("preserves file uri authorities as windows UNC paths", () => {
+    expect(rewriteMarkdownFileUriHref("file://server/share/workspace-image.svg")).toBe(
+      "\\\\server\\share\\workspace-image.svg",
+    );
+  });
+
   it("unwraps angle-bracketed file uri hrefs", () => {
     expect(
       rewriteMarkdownFileUriHref(" <file:///D:/Programme/t3code/apps/web/src/markdown-links.ts> "),
@@ -73,6 +79,12 @@ describe("resolveMarkdownFileLinkTarget", () => {
   it("does not double-decode file URLs", () => {
     expect(resolveMarkdownFileLinkTarget("file:///Users/julius/project/file%2520name.md")).toBe(
       "/Users/julius/project/file%20name.md",
+    );
+  });
+
+  it("resolves file uri authorities as windows UNC paths", () => {
+    expect(resolveMarkdownFileLinkTarget("file://server/share/workspace-image.svg")).toBe(
+      "\\\\server\\share\\workspace-image.svg",
     );
   });
 

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -85,8 +85,9 @@ function parseFileUrlHref(
     const parsed = new URL(href);
     if (parsed.protocol.toLowerCase() !== "file:") return null;
 
-    const rawPath = parsed.hostname
-      ? `\\\\${parsed.hostname}${parsed.pathname.replaceAll("/", "\\")}`
+    const uncHostname = parsed.hostname.toLowerCase() === "localhost" ? "" : parsed.hostname;
+    const rawPath = uncHostname
+      ? `\\\\${uncHostname}${parsed.pathname.replaceAll("/", "\\")}`
       : parsed.pathname;
     if (rawPath.length === 0) return null;
 

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -85,7 +85,9 @@ function parseFileUrlHref(
     const parsed = new URL(href);
     if (parsed.protocol.toLowerCase() !== "file:") return null;
 
-    const rawPath = parsed.pathname;
+    const rawPath = parsed.hostname
+      ? `\\\\${parsed.hostname}${parsed.pathname.replaceAll("/", "\\")}`
+      : parsed.pathname;
     if (rawPath.length === 0) return null;
 
     // Browser URL parser encodes "C:/foo" as "/C:/foo" for file URLs.

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -15,6 +15,10 @@
       "types": "./src/environment/index.ts",
       "default": "./src/environment/index.ts"
     },
+    "./markdown-images": {
+      "types": "./src/markdownImages.ts",
+      "default": "./src/markdownImages.ts"
+    },
     "./errors": {
       "types": "./src/errors/index.ts",
       "default": "./src/errors/index.ts"

--- a/packages/client-runtime/src/markdownImages.test.ts
+++ b/packages/client-runtime/src/markdownImages.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { classifyMarkdownImageSource } from "./markdownImages.js";
+
+describe("classifyMarkdownImageSource", () => {
+  it.each([
+    "https://example.com/image.png",
+    "HTTP://example.com/image.png",
+    "data:image/png;base64,AAAA",
+    "blob:https://app.t3.codes/image-id",
+    "//cdn.example.com/image.png",
+  ])("keeps %s directly loadable", (uri) => {
+    expect(classifyMarkdownImageSource(uri, "/workspace/project")).toEqual({
+      _tag: "Direct",
+      uri,
+    });
+  });
+
+  it.each([
+    ["images/result.png", "/workspace/project", "/workspace/project/images/result.png"],
+    ["./images/result.png", "/workspace/project", "/workspace/project/./images/result.png"],
+    [
+      "images/result.png",
+      "C:\\Users\\dara\\project",
+      "C:\\Users\\dara\\project\\images\\result.png",
+    ],
+    [
+      "images\\result.png",
+      "C:\\Users\\dara\\project",
+      "C:\\Users\\dara\\project\\images\\result.png",
+    ],
+    ["/workspace/project/image.png", null, "/workspace/project/image.png"],
+    ["C:/Users/dara/project/image.png", null, "C:/Users/dara/project/image.png"],
+    ["\\\\server\\share\\image.png", null, "\\\\server\\share\\image.png"],
+    ["file:///workspace/project/image%20one.png", null, "/workspace/project/image one.png"],
+    ["file:///C:/Users/dara/project/image.png", null, "C:/Users/dara/project/image.png"],
+    ["file://localhost/C:/Users/dara/project/image.png", null, "C:/Users/dara/project/image.png"],
+    ["file://server/share/image.png", null, "\\\\server\\share\\image.png"],
+  ])("maps %s to a workspace file", (source, workspaceRoot, path) => {
+    expect(classifyMarkdownImageSource(source, workspaceRoot)).toEqual({
+      _tag: "WorkspaceFile",
+      path,
+    });
+  });
+
+  it.each([
+    null,
+    "",
+    "#image",
+    "?image=1",
+    "image.png",
+    "~/image.png",
+    "javascript:alert(1)",
+    "ftp://example.com/image.png",
+    "content://media/image/1",
+    "custom:image.png",
+    "file://%",
+  ])("blocks unsupported or unresolved source %s", (source) => {
+    expect(classifyMarkdownImageSource(source)).toEqual({ _tag: "Blocked" });
+  });
+});

--- a/packages/client-runtime/src/markdownImages.test.ts
+++ b/packages/client-runtime/src/markdownImages.test.ts
@@ -30,6 +30,7 @@ describe("classifyMarkdownImageSource", () => {
       "C:\\Users\\dara\\project\\images\\result.png",
     ],
     ["/workspace/project/image.png", null, "/workspace/project/image.png"],
+    ["/C:/Users/dara/project/image.png", null, "C:/Users/dara/project/image.png"],
     ["C:/Users/dara/project/image.png", null, "C:/Users/dara/project/image.png"],
     ["\\\\server\\share\\image.png", null, "\\\\server\\share\\image.png"],
     ["file:///workspace/project/image%20one.png", null, "/workspace/project/image one.png"],

--- a/packages/client-runtime/src/markdownImages.ts
+++ b/packages/client-runtime/src/markdownImages.ts
@@ -20,6 +20,10 @@ function normalizeSource(value: string): string {
   return trimmed.startsWith("<") && trimmed.endsWith(">") ? trimmed.slice(1, -1) : trimmed;
 }
 
+function normalizeWindowsDrivePath(value: string): string {
+  return /^\/[A-Za-z]:[\\/]/.test(value) ? value.slice(1) : value;
+}
+
 function parseFileUrl(value: string): string | null {
   try {
     const parsed = new URL(value);
@@ -32,7 +36,7 @@ function parseFileUrl(value: string): string | null {
 
     const pathname = safeDecode(parsed.pathname);
     if (pathname.length === 0) return null;
-    return /^\/[A-Za-z]:[\\/]/.test(pathname) ? pathname.slice(1) : pathname;
+    return normalizeWindowsDrivePath(pathname);
   } catch {
     return null;
   }
@@ -80,7 +84,7 @@ export function classifyMarkdownImageSource(
     return path === null ? { _tag: "Blocked" } : { _tag: "WorkspaceFile", path };
   }
 
-  const path = safeDecode(stripSearchAndHash(source));
+  const path = normalizeWindowsDrivePath(safeDecode(stripSearchAndHash(source)));
   if (path.length === 0) return { _tag: "Blocked" };
   if (path.startsWith("/") || WINDOWS_DRIVE_PATH_PATTERN.test(path) || path.startsWith("\\\\")) {
     return { _tag: "WorkspaceFile", path };

--- a/packages/client-runtime/src/markdownImages.ts
+++ b/packages/client-runtime/src/markdownImages.ts
@@ -1,0 +1,94 @@
+const DIRECT_IMAGE_SOURCE_PATTERN = /^(?:https?:|data:|blob:|\/\/)/i;
+const URI_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
+
+export type MarkdownImageSource =
+  | { readonly _tag: "Direct"; readonly uri: string }
+  | { readonly _tag: "WorkspaceFile"; readonly path: string }
+  | { readonly _tag: "Blocked" };
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeSource(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith("<") && trimmed.endsWith(">") ? trimmed.slice(1, -1) : trimmed;
+}
+
+function parseFileUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol.toLowerCase() !== "file:") return null;
+
+    if (parsed.hostname.length > 0 && parsed.hostname.toLowerCase() !== "localhost") {
+      const pathname = safeDecode(parsed.pathname).replaceAll("/", "\\");
+      return `\\\\${safeDecode(parsed.hostname)}${pathname}`;
+    }
+
+    const pathname = safeDecode(parsed.pathname);
+    if (pathname.length === 0) return null;
+    return /^\/[A-Za-z]:[\\/]/.test(pathname) ? pathname.slice(1) : pathname;
+  } catch {
+    return null;
+  }
+}
+
+function stripSearchAndHash(value: string): string {
+  const searchIndex = value.indexOf("?");
+  const hashIndex = value.indexOf("#");
+  const end = [searchIndex, hashIndex]
+    .filter((index) => index >= 0)
+    .reduce((lowest, index) => Math.min(lowest, index), value.length);
+  return value.slice(0, end);
+}
+
+function joinWorkspacePath(workspaceRoot: string, relativePath: string): string {
+  const windows =
+    WINDOWS_DRIVE_PATH_PATTERN.test(workspaceRoot) || workspaceRoot.startsWith("\\\\");
+  const separator = windows ? "\\" : "/";
+  const root = workspaceRoot.replace(/[\\/]+$/, "");
+  const path = relativePath.replace(/[\\/]/g, separator).replace(/^[\\/]+/, "");
+  return `${root}${separator}${path}`;
+}
+
+/**
+ * Classifies a markdown image source by where its bytes must be loaded from.
+ * Filesystem paths belong to the environment host and must never reach a
+ * browser or native image component without first becoming a signed asset URL.
+ */
+export function classifyMarkdownImageSource(
+  value: string | null | undefined,
+  workspaceRoot?: string | null,
+): MarkdownImageSource {
+  if (value === null || value === undefined) return { _tag: "Blocked" };
+
+  const source = normalizeSource(value);
+  if (source.length === 0 || source.startsWith("#") || source.startsWith("?")) {
+    return { _tag: "Blocked" };
+  }
+  if (DIRECT_IMAGE_SOURCE_PATTERN.test(source)) {
+    return { _tag: "Direct", uri: source };
+  }
+
+  if (/^file:/i.test(source)) {
+    const path = parseFileUrl(source);
+    return path === null ? { _tag: "Blocked" } : { _tag: "WorkspaceFile", path };
+  }
+
+  const path = safeDecode(stripSearchAndHash(source));
+  if (path.length === 0) return { _tag: "Blocked" };
+  if (path.startsWith("/") || WINDOWS_DRIVE_PATH_PATTERN.test(path) || path.startsWith("\\\\")) {
+    return { _tag: "WorkspaceFile", path };
+  }
+  if (URI_SCHEME_PATTERN.test(path) || path.startsWith("~/") || path.startsWith("~\\")) {
+    return { _tag: "Blocked" };
+  }
+  if (!workspaceRoot) return { _tag: "Blocked" };
+
+  return { _tag: "WorkspaceFile", path: joinWorkspacePath(workspaceRoot, path) };
+}


### PR DESCRIPTION
## Summary

Agents reference screenshots they saved into the workspace by path (relative, absolute, or `file://`). Those bytes only exist on the environment host, so chat rendered a broken image on web (macOS/Windows) and an empty grey box on iOS.

- **Web** (`ChatMarkdown.tsx`): custom `img` renderer resolves workspace paths through the signed `workspace-file` asset endpoint (`useAssetUrlState`), with loading/error states. Remote http(s)/data srcs keep their existing inline rendering so badge rows don't reflow. `file:` allowlisted for `src` in the sanitize schema.
- **iOS** (`t3-markdown-text` module + `ThreadFeed`): the module accepts a `renderImage` hook (context-provided so it reaches images anywhere in the block tree). ThreadFeed supplies `ThreadMarkdownImage`, which resolves the src against the workspace root, loads via `useAssetUrl`, exposes an accessible tap target, and expands into the existing full-screen viewer.
- **Android**: the nitro-markdown fallback path registers an `image` custom renderer backed by the same component.

## Testing

- Web/mobile typecheck, unit tests, and lint pass.
- Live web verification: seeded a thread with markdown images by relative and absolute path; both render through signed `/api/assets/...` URLs.
- Full iOS simulator pass (iPhone 17 Pro, iOS 26.5): both images render with alt-text captions, tap-to-expand opens the full-screen viewer, swipe-down dismisses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches markdown sanitization (`file:` on img src) and how filesystem paths become signed asset URLs. Classification blocks unsupported schemes, but mistakes here could leak local paths or load unexpected sources.
> 
> **Overview**
> Chat markdown can now show screenshots and other images that agents save as workspace paths (relative, absolute, `file://`, Windows drive/UNC) instead of broken images.
> 
> A shared `classifyMarkdownImageSource` helper decides whether a src is a remote/data URI, a workspace file, or blocked. Workspace files load through signed `workspace-file` asset URLs with loading and “Image unavailable” states. Remote http(s)/data/blob srcs still render inline.
> 
> On web, `ChatMarkdown` customizes `img`, allowlists `file:` for `src` after normalizing Windows drive paths, and never passes filesystem URLs to a raw `<img>`. On mobile, `SelectableMarkdownText` takes a `renderImage` hook (via context on iOS); `ThreadFeed` resolves workspace images the same way and taps into the existing full-screen viewer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ba6d7efcaff2336e66b7caf6c32b39a75fd03a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render workspace images in chat markdown
> - Adds `classifyMarkdownImageSource` in [markdownImages.ts](https://github.com/pingdotgg/t3code/pull/6433/files#diff-a0e62b9b7ad618117ab7a7e9cc3c2f7e211811ac4cf8b19c864b6714f6bc4b1f) to classify image sources as Direct, WorkspaceFile, or Blocked, with UNC/localhost file URL parsing support.
> - Plumbs this classification into Web ([ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/6433/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05)) and Mobile ([ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/6433/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245)) markdown renderers.
> - Workspace file images resolve to signed asset URLs via `useAssetUrlState`, displaying loading indicators and 'Image unavailable' fallbacks.
> - Risk: `CHAT_MARKDOWN_SANITIZE_SCHEMA` now allows the `file:` protocol on `src` attributes, and unsupported image sources render a fallback placeholder instead of a broken image.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25ba6d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace-file image support in Markdown across mobile and web.
  * Images can resolve through signed asset URLs, open in the existing viewer, and display loading or unavailable states.
  * Added customizable Markdown image rendering for selectable text.
  * Added support for normalized Windows drive paths, UNC paths, and `file://` image sources.
  * Exposed image-rendering types and asset URL loading states.

* **Tests**
  * Added coverage for workspace image path resolution, normalization, and Windows UNC paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->