### PR TITLE
fix(web): improve stashed prompt menu controls

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1142,6 +1142,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   );
 
   const isComposerApprovalState = activePendingApproval !== null;
+  const stashControlsAvailable = !composerMenuOpen && !isComposerApprovalState;
+  const isStashMenuVisible = isStashMenuOpen && stashControlsAvailable;
   const activePendingUserInput = pendingUserInputs[0] ?? null;
   const hasComposerHeader =
     isComposerApprovalState ||
@@ -2270,14 +2272,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     setIsStashMenuOpen((open) => !open);
   }, []);
 
-  // Close the stash menu whenever the trigger-driven command menu opens so
-  // the two popovers never stack in the same layer, and when the user
-  // resumes typing (the menu is a transient picker, not a panel).
+  // Close the stash menu when another composer state takes over its layer.
+  // This also prevents a hidden menu from reappearing after approval ends.
   useEffect(() => {
-    if (composerMenuOpen) {
+    if (composerMenuOpen || isComposerApprovalState) {
       setIsStashMenuOpen(false);
     }
-  }, [composerMenuOpen]);
+  }, [composerMenuOpen, isComposerApprovalState]);
+  // The menu is a transient picker, not a panel, so typing dismisses it.
   useEffect(() => {
     setIsStashMenuOpen(false);
   }, [prompt]);
@@ -2881,15 +2883,17 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               isComposerCollapsedMobile && "hidden",
             )}
           >
-            <ComposerStashBadge
-              count={stashQueue.length}
-              pulseKey={stashPulse.key}
-              pulsing={stashPulse.active}
-              menuOpen={isStashMenuOpen}
-              onToggleMenu={toggleStashMenu}
-            />
+            {stashControlsAvailable && (
+              <ComposerStashBadge
+                count={stashQueue.length}
+                pulseKey={stashPulse.key}
+                pulsing={stashPulse.active}
+                menuOpen={isStashMenuVisible}
+                onToggleMenu={toggleStashMenu}
+              />
+            )}
 
-            {isStashMenuOpen && !composerMenuOpen && !isComposerApprovalState && (
+            {isStashMenuVisible && (
               <ComposerCommandMenuLayer anchor={composerMenuAnchor}>
                 <ComposerStashMenu
                   entries={stashQueue}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1981,6 +1981,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }, 1200);
   }, []);
 
+  const closeStashMenu = useCallback(() => {
+    const restoreComposerFocus = focusStashMenuCloseOnOpenRef.current;
+    focusStashMenuCloseOnOpenRef.current = false;
+    setIsStashMenuOpen(false);
+    if (restoreComposerFocus) scheduleComposerFocus();
+  }, [scheduleComposerFocus]);
+
   const restoreStashEntry = useCallback(
     (entry: PromptStashEntry) => {
       // Remove first so a double activation (click + Enter) can't restore twice.
@@ -1995,6 +2002,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           data: { hideCopyButton: true },
         });
       }
+      const restoreComposerFocus = focusStashMenuCloseOnOpenRef.current;
+      focusStashMenuCloseOnOpenRef.current = false;
       setIsStashMenuOpen(false);
 
       const currentPrompt = promptRef.current;
@@ -2078,9 +2087,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         });
       }
 
-      // Only yank the caret to the end when text was actually inserted;
-      // restoring images alone should leave the user where they were typing.
-      if (promptChanged) {
+      // Pointer-opened image restores leave the caret alone. Keyboard-opened
+      // restores return focus to the composer after the menu unmounts.
+      if (promptChanged || restoreComposerFocus) {
         window.requestAnimationFrame(() => {
           composerEditorRef.current?.focusAtEnd();
         });
@@ -2118,8 +2127,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     const prompt = promptRef.current.split(INLINE_TERMINAL_CONTEXT_PLACEHOLDER).join("").trim();
     const images = [...composerImagesRef.current];
     if (prompt.length === 0 && images.length === 0) {
-      focusStashMenuCloseOnOpenRef.current = true;
-      setIsStashMenuOpen((open) => !open);
+      if (isStashMenuOpen) {
+        closeStashMenu();
+        return;
+      }
+      focusStashMenuCloseOnOpenRef.current = false;
+      setIsStashMenuOpen(true);
       return;
     }
     // A repeat ⌘S on the *same* still-unencoded snapshot would stash it
@@ -2262,28 +2275,32 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }
   }, [
     clearComposerDraftPromptAndImages,
+    closeStashMenu,
     composerDraftTarget,
     composerImagesRef,
     finalizeStashEntryImages,
     promptRef,
     pulseStashBadge,
     stashEntryToQueue,
+    isStashMenuOpen,
   ]);
 
-  const toggleStashMenu = useCallback((focusCloseButton: boolean) => {
+  const openStashMenu = useCallback((focusCloseButton: boolean) => {
     focusStashMenuCloseOnOpenRef.current = focusCloseButton;
-    setIsStashMenuOpen((open) => !open);
+    setIsStashMenuOpen(true);
   }, []);
 
   // Close the stash menu when another composer state takes over its layer.
   // This also prevents a hidden menu from reappearing after approval ends.
   useEffect(() => {
     if (composerMenuOpen || isComposerApprovalState) {
+      focusStashMenuCloseOnOpenRef.current = false;
       setIsStashMenuOpen(false);
     }
   }, [composerMenuOpen, isComposerApprovalState]);
   // The menu is a transient picker, not a panel, so typing dismisses it.
   useEffect(() => {
+    focusStashMenuCloseOnOpenRef.current = false;
     setIsStashMenuOpen(false);
   }, [prompt]);
 
@@ -2891,7 +2908,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 count={stashQueue.length}
                 pulseKey={stashPulse.key}
                 pulsing={stashPulse.active}
-                onToggleMenu={toggleStashMenu}
+                onOpenMenu={openStashMenu}
               />
             )}
 
@@ -2901,7 +2918,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   entries={stashQueue}
                   onRestore={restoreStashEntry}
                   onDelete={deleteStashEntry}
-                  onClose={() => setIsStashMenuOpen(false)}
+                  onClose={closeStashMenu}
                   focusCloseOnMount={focusStashMenuCloseOnOpenRef.current}
                 />
               </ComposerCommandMenuLayer>

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -976,6 +976,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const composerMenuOpenRef = useRef(false);
   const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
   const activeComposerMenuItemRef = useRef<ComposerCommandItem | null>(null);
+  const focusStashMenuCloseOnOpenRef = useRef(false);
   const composerBlurFrameRef = useRef<number | null>(null);
   const mobileComposerExpandFrameRef = useRef<number | null>(null);
   const mobileComposerExpandReleaseFrameRef = useRef<number | null>(null);
@@ -2117,6 +2118,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     const prompt = promptRef.current.split(INLINE_TERMINAL_CONTEXT_PLACEHOLDER).join("").trim();
     const images = [...composerImagesRef.current];
     if (prompt.length === 0 && images.length === 0) {
+      focusStashMenuCloseOnOpenRef.current = true;
       setIsStashMenuOpen((open) => !open);
       return;
     }
@@ -2268,7 +2270,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     stashEntryToQueue,
   ]);
 
-  const toggleStashMenu = useCallback(() => {
+  const toggleStashMenu = useCallback((focusCloseButton: boolean) => {
+    focusStashMenuCloseOnOpenRef.current = focusCloseButton;
     setIsStashMenuOpen((open) => !open);
   }, []);
 
@@ -2883,12 +2886,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               isComposerCollapsedMobile && "hidden",
             )}
           >
-            {stashControlsAvailable && (
+            {stashControlsAvailable && !isStashMenuVisible && (
               <ComposerStashBadge
                 count={stashQueue.length}
                 pulseKey={stashPulse.key}
                 pulsing={stashPulse.active}
-                menuOpen={isStashMenuVisible}
                 onToggleMenu={toggleStashMenu}
               />
             )}
@@ -2900,6 +2902,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   onRestore={restoreStashEntry}
                   onDelete={deleteStashEntry}
                   onClose={() => setIsStashMenuOpen(false)}
+                  focusCloseOnMount={focusStashMenuCloseOnOpenRef.current}
                 />
               </ComposerCommandMenuLayer>
             )}

--- a/apps/web/src/components/chat/ComposerStashBadge.tsx
+++ b/apps/web/src/components/chat/ComposerStashBadge.tsx
@@ -18,7 +18,7 @@ export const ComposerStashBadge = memo(function ComposerStashBadge(props: {
   menuOpen: boolean;
   onToggleMenu: () => void;
 }) {
-  if (props.count === 0) return null;
+  if (props.count === 0 || props.menuOpen) return null;
 
   return (
     <button

--- a/apps/web/src/components/chat/ComposerStashBadge.tsx
+++ b/apps/web/src/components/chat/ComposerStashBadge.tsx
@@ -15,21 +15,19 @@ export const ComposerStashBadge = memo(function ComposerStashBadge(props: {
   count: number;
   pulseKey: number;
   pulsing: boolean;
-  menuOpen: boolean;
-  onToggleMenu: () => void;
+  onToggleMenu: (focusCloseButton: boolean) => void;
 }) {
-  if (props.count === 0 || props.menuOpen) return null;
+  if (props.count === 0) return null;
 
   return (
     <button
       type="button"
       data-prompt-stash-badge="true"
       aria-label={`Stashed prompts: ${props.count}. Open stash.`}
-      aria-expanded={props.menuOpen}
       className={cn(
         "absolute -top-3 right-4 z-10 inline-flex cursor-pointer items-center gap-1.5 rounded-full border bg-popover px-2.5 py-0.5 text-xs shadow-sm",
         "transition-[color,border-color,opacity] duration-200",
-        props.menuOpen || props.pulsing
+        props.pulsing
           ? "border-border text-foreground opacity-100"
           : "border-border/70 text-muted-foreground opacity-70 hover:opacity-100 hover:text-foreground",
       )}
@@ -37,7 +35,7 @@ export const ComposerStashBadge = memo(function ComposerStashBadge(props: {
         // Keep composer focus so Escape/typing flows stay intact.
         event.preventDefault();
       }}
-      onClick={props.onToggleMenu}
+      onClick={(event) => props.onToggleMenu(event.detail === 0)}
     >
       <BookmarkIcon className="size-3" aria-hidden="true" />
       Stash

--- a/apps/web/src/components/chat/ComposerStashBadge.tsx
+++ b/apps/web/src/components/chat/ComposerStashBadge.tsx
@@ -15,7 +15,7 @@ export const ComposerStashBadge = memo(function ComposerStashBadge(props: {
   count: number;
   pulseKey: number;
   pulsing: boolean;
-  onToggleMenu: (focusCloseButton: boolean) => void;
+  onOpenMenu: (focusCloseButton: boolean) => void;
 }) {
   if (props.count === 0) return null;
 
@@ -35,7 +35,7 @@ export const ComposerStashBadge = memo(function ComposerStashBadge(props: {
         // Keep composer focus so Escape/typing flows stay intact.
         event.preventDefault();
       }}
-      onClick={(event) => props.onToggleMenu(event.detail === 0)}
+      onClick={(event) => props.onOpenMenu(event.detail === 0)}
     >
       <BookmarkIcon className="size-3" aria-hidden="true" />
       Stash

--- a/apps/web/src/components/chat/ComposerStashControls.test.tsx
+++ b/apps/web/src/components/chat/ComposerStashControls.test.tsx
@@ -12,6 +12,7 @@ describe("ComposerStashMenu", () => {
         onRestore={() => {}}
         onDelete={() => {}}
         onClose={() => {}}
+        focusCloseOnMount={false}
       />,
     );
 
@@ -23,29 +24,17 @@ describe("ComposerStashMenu", () => {
 });
 
 describe("ComposerStashBadge", () => {
-  it("does not render while the stash menu is open", () => {
+  it("does not render without stashed prompts", () => {
     const markup = renderToStaticMarkup(
-      <ComposerStashBadge
-        count={1}
-        pulseKey={0}
-        pulsing={false}
-        menuOpen
-        onToggleMenu={() => {}}
-      />,
+      <ComposerStashBadge count={0} pulseKey={0} pulsing={false} onToggleMenu={() => {}} />,
     );
 
     expect(markup).toBe("");
   });
 
-  it("renders when there are stashed prompts and the menu is closed", () => {
+  it("renders when there are stashed prompts", () => {
     const markup = renderToStaticMarkup(
-      <ComposerStashBadge
-        count={1}
-        pulseKey={0}
-        pulsing={false}
-        menuOpen={false}
-        onToggleMenu={() => {}}
-      />,
+      <ComposerStashBadge count={1} pulseKey={0} pulsing={false} onToggleMenu={() => {}} />,
     );
 
     expect(markup).toContain('data-prompt-stash-badge="true"');

--- a/apps/web/src/components/chat/ComposerStashControls.test.tsx
+++ b/apps/web/src/components/chat/ComposerStashControls.test.tsx
@@ -5,7 +5,7 @@ import { ComposerStashBadge } from "./ComposerStashBadge";
 import { ComposerStashMenu } from "./ComposerStashMenu";
 
 describe("ComposerStashMenu", () => {
-  it("always renders a close control", () => {
+  it("renders the close control outside the scrollable list", () => {
     const markup = renderToStaticMarkup(
       <ComposerStashMenu
         entries={[]}
@@ -16,6 +16,9 @@ describe("ComposerStashMenu", () => {
     );
 
     expect(markup).toContain('aria-label="Close stashed prompts"');
+    expect(markup.indexOf('aria-label="Close stashed prompts"')).toBeLessThan(
+      markup.indexOf('data-slot="command-list"'),
+    );
   });
 });
 

--- a/apps/web/src/components/chat/ComposerStashControls.test.tsx
+++ b/apps/web/src/components/chat/ComposerStashControls.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ComposerStashBadge } from "./ComposerStashBadge";
+import { ComposerStashMenu } from "./ComposerStashMenu";
+
+describe("ComposerStashMenu", () => {
+  it("always renders a close control", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerStashMenu
+        entries={[]}
+        onRestore={() => {}}
+        onDelete={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Close stashed prompts"');
+  });
+});
+
+describe("ComposerStashBadge", () => {
+  it("does not render while the stash menu is open", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerStashBadge
+        count={1}
+        pulseKey={0}
+        pulsing={false}
+        menuOpen
+        onToggleMenu={() => {}}
+      />,
+    );
+
+    expect(markup).toBe("");
+  });
+
+  it("renders when there are stashed prompts and the menu is closed", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerStashBadge
+        count={1}
+        pulseKey={0}
+        pulsing={false}
+        menuOpen={false}
+        onToggleMenu={() => {}}
+      />,
+    );
+
+    expect(markup).toContain('data-prompt-stash-badge="true"');
+  });
+});

--- a/apps/web/src/components/chat/ComposerStashControls.test.tsx
+++ b/apps/web/src/components/chat/ComposerStashControls.test.tsx
@@ -17,6 +17,7 @@ describe("ComposerStashMenu", () => {
     );
 
     expect(markup).toContain('aria-label="Close stashed prompts"');
+    expect(markup).toContain('aria-label="Stashed prompts"');
     expect(markup.indexOf('aria-label="Close stashed prompts"')).toBeLessThan(
       markup.indexOf('data-slot="command-list"'),
     );

--- a/apps/web/src/components/chat/ComposerStashControls.test.tsx
+++ b/apps/web/src/components/chat/ComposerStashControls.test.tsx
@@ -28,7 +28,7 @@ describe("ComposerStashMenu", () => {
 describe("ComposerStashBadge", () => {
   it("does not render without stashed prompts", () => {
     const markup = renderToStaticMarkup(
-      <ComposerStashBadge count={0} pulseKey={0} pulsing={false} onToggleMenu={() => {}} />,
+      <ComposerStashBadge count={0} pulseKey={0} pulsing={false} onOpenMenu={() => {}} />,
     );
 
     expect(markup).toBe("");
@@ -36,7 +36,7 @@ describe("ComposerStashBadge", () => {
 
   it("renders when there are stashed prompts", () => {
     const markup = renderToStaticMarkup(
-      <ComposerStashBadge count={1} pulseKey={0} pulsing={false} onToggleMenu={() => {}} />,
+      <ComposerStashBadge count={1} pulseKey={0} pulsing={false} onOpenMenu={() => {}} />,
     );
 
     expect(markup).toContain('data-prompt-stash-badge="true"');

--- a/apps/web/src/components/chat/ComposerStashControls.test.tsx
+++ b/apps/web/src/components/chat/ComposerStashControls.test.tsx
@@ -18,6 +18,7 @@ describe("ComposerStashMenu", () => {
 
     expect(markup).toContain('aria-label="Close stashed prompts"');
     expect(markup).toContain('aria-label="Stashed prompts"');
+    expect(markup).toMatch(/<div(?=[^>]*data-slot="command-list")(?=[^>]*tabindex="-1")[^>]*>/);
     expect(markup.indexOf('aria-label="Close stashed prompts"')).toBeLessThan(
       markup.indexOf('data-slot="command-list"'),
     );

--- a/apps/web/src/components/chat/ComposerStashMenu.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.tsx
@@ -116,7 +116,7 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
           </Button>
         </div>
         <CommandList className="max-h-72">
-          <CommandGroup>
+          <CommandGroup aria-label="Stashed prompts">
             {entries.length === 0 ? (
               <p className="px-3 pb-3 pt-1 text-secondary-label text-xs">
                 Nothing stashed yet. Press ⌘S with a prompt in the composer to stash it.

--- a/apps/web/src/components/chat/ComposerStashMenu.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.tsx
@@ -4,7 +4,7 @@ import { memo, useEffect, useState } from "react";
 import { formatRelativeTimeLabel } from "../../timestampFormat";
 import { cn } from "~/lib/utils";
 import { type PromptStashEntry } from "../../promptStashStore";
-import { Command, CommandGroup, CommandGroupLabel, CommandItem, CommandList } from "../ui/command";
+import { Command, CommandGroup, CommandItem, CommandList } from "../ui/command";
 import { Button } from "../ui/button";
 
 const SNIPPET_MAX_CHARS = 90;
@@ -91,23 +91,25 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
 
   return (
     <Command autoHighlight={false} mode="none">
-      <div className="dropdown-glass relative w-full overflow-hidden rounded-[20px] shadow-[0_16px_40px_-18px_rgb(0_0_0/55%)] dark:shadow-[0_18px_44px_-18px_rgb(0_0_0/80%)]">
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          className="absolute top-2 right-2 z-10"
-          aria-label="Close stashed prompts"
-          onPointerDown={(event) => event.preventDefault()}
-          onClick={onClose}
-        >
-          <XIcon />
-        </Button>
+      <div className="dropdown-glass w-full overflow-hidden rounded-[20px] shadow-[0_16px_40px_-18px_rgb(0_0_0/55%)] dark:shadow-[0_18px_44px_-18px_rgb(0_0_0/80%)]">
+        <div className="flex min-h-11 items-center gap-1.5 px-3">
+          <BookmarkIcon className="size-3 text-secondary-label" aria-hidden="true" />
+          <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-secondary-label">
+            Stashed prompts
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="ml-auto"
+            aria-label="Close stashed prompts"
+            onPointerDown={(event) => event.preventDefault()}
+            onClick={onClose}
+          >
+            <XIcon />
+          </Button>
+        </div>
         <CommandList className="max-h-72">
           <CommandGroup>
-            <CommandGroupLabel className="flex items-center gap-1.5 pt-2 pr-10 pb-1 pl-3 text-[10px] font-semibold uppercase tracking-[0.08em] text-secondary-label">
-              <BookmarkIcon className="size-3" aria-hidden="true" />
-              Stashed prompts
-            </CommandGroupLabel>
             {entries.length === 0 ? (
               <p className="px-3 pb-3 pt-1 text-secondary-label text-xs">
                 Nothing stashed yet. Press ⌘S with a prompt in the composer to stash it.

--- a/apps/web/src/components/chat/ComposerStashMenu.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.tsx
@@ -1,5 +1,5 @@
 import { BookmarkIcon, XIcon } from "lucide-react";
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 
 import { formatRelativeTimeLabel } from "../../timestampFormat";
 import { cn } from "~/lib/utils";
@@ -34,9 +34,11 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
   onRestore: (entry: PromptStashEntry) => void;
   onDelete: (entry: PromptStashEntry) => void;
   onClose: () => void;
+  focusCloseOnMount: boolean;
 }) {
-  const { entries, onRestore, onDelete, onClose } = props;
+  const { entries, onRestore, onDelete, onClose, focusCloseOnMount } = props;
   const [highlightedId, setHighlightedId] = useState<string | null>(entries[0]?.id ?? null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const highlightedEntry = entries.find((entry) => entry.id === highlightedId) ?? entries[0];
 
@@ -46,6 +48,10 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
       setHighlightedId(entries[0]?.id ?? null);
     }
   }, [entries, highlightedId]);
+
+  useEffect(() => {
+    if (focusCloseOnMount) closeButtonRef.current?.focus();
+  }, [focusCloseOnMount]);
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -98,6 +104,7 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
             Stashed prompts
           </span>
           <Button
+            ref={closeButtonRef}
             variant="ghost"
             size="icon-xs"
             className="ml-auto"

--- a/apps/web/src/components/chat/ComposerStashMenu.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.tsx
@@ -39,6 +39,7 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
   const { entries, onRestore, onDelete, onClose, focusCloseOnMount } = props;
   const [highlightedId, setHighlightedId] = useState<string | null>(entries[0]?.id ?? null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const commandListRef = useRef<HTMLDivElement>(null);
 
   const highlightedEntry = entries.find((entry) => entry.id === highlightedId) ?? entries[0];
 
@@ -65,6 +66,7 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
         if (entries.length === 0) return;
         event.preventDefault();
         event.stopPropagation();
+        if (event.target === closeButtonRef.current) commandListRef.current?.focus();
         const currentIndex = entries.findIndex((entry) => entry.id === highlightedId);
         const offset = event.key === "ArrowDown" ? 1 : -1;
         const normalizedIndex = currentIndex >= 0 ? currentIndex : offset === 1 ? -1 : 0;
@@ -115,7 +117,7 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
             <XIcon />
           </Button>
         </div>
-        <CommandList className="max-h-72">
+        <CommandList ref={commandListRef} tabIndex={-1} className="max-h-72 focus:outline-none">
           <CommandGroup aria-label="Stashed prompts">
             {entries.length === 0 ? (
               <p className="px-3 pb-3 pt-1 text-secondary-label text-xs">

--- a/apps/web/src/components/chat/ComposerStashMenu.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.tsx
@@ -92,9 +92,19 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
   return (
     <Command autoHighlight={false} mode="none">
       <div className="dropdown-glass relative w-full overflow-hidden rounded-[20px] shadow-[0_16px_40px_-18px_rgb(0_0_0/55%)] dark:shadow-[0_18px_44px_-18px_rgb(0_0_0/80%)]">
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          className="absolute top-2 right-2 z-10"
+          aria-label="Close stashed prompts"
+          onPointerDown={(event) => event.preventDefault()}
+          onClick={onClose}
+        >
+          <XIcon />
+        </Button>
         <CommandList className="max-h-72">
           <CommandGroup>
-            <CommandGroupLabel className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-secondary-label">
+            <CommandGroupLabel className="flex items-center gap-1.5 pt-2 pr-10 pb-1 pl-3 text-[10px] font-semibold uppercase tracking-[0.08em] text-secondary-label">
               <BookmarkIcon className="size-3" aria-hidden="true" />
               Stashed prompts
             </CommandGroupLabel>


### PR DESCRIPTION
## What Changed

- Hide the stashed prompt badge while its menu is open.
- Add an explicit close button to the stashed prompt menu and reserve header space for it.
- Add regression coverage for the close control and badge visibility states.

## Why

The badge remained visible after opening the stashed prompt menu, while the menu itself had no explicit close control. Hiding the redundant trigger and adding a dedicated close button makes the open state and exit path clear.

## UI Changes

This changes the stashed prompt menu interaction and header layout. Before/after screenshots and a short interaction video are pending.

### Before

<img width="845" height="325" alt="image" src="https://github.com/user-attachments/assets/e23d10bf-017b-4ffa-89f0-7843166ea4c5" />

### After

<img width="933" height="354" alt="image" src="https://github.com/user-attachments/assets/c9c912f0-2d6f-4833-bc69-878b103c86cf" />


## Testing

- `vp test run apps/web/src/components/chat/ComposerStashControls.test.tsx` (3 tests passed)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI changes
- [ ] I included a video for the interaction changes

Written by GPT-5.6 Sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer UI and focus/keyboard behavior only; no auth, data, or backend changes.
> 
> **Overview**
> Improves the **stashed prompts** popover so the open state is clearer and keyboard/pointer paths behave differently.
> 
> The stash badge is **hidden while the menu is open** (and stash UI is suppressed when the command menu or approval UI is active). Opening is no longer a simple toggle: the badge calls `onOpenMenu` with whether to focus the close control (`event.detail === 0` for keyboard activation). Closing goes through `closeStashMenu`, which can **return focus to the composer** when the menu was opened from the keyboard.
> 
> `ComposerStashMenu` gets a **header with an explicit close button** outside the scrollable list, optional **focus on mount** for that button, and arrow-key handling that moves focus from close into the list. Restore focus behavior is adjusted so keyboard-driven restores refocus the composer after the menu unmounts.
> 
> Adds **`ComposerStashControls.test.tsx`** for close-button placement and badge visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fdfe1be8b7f02f36f5db9df79c9c9a3f9cc3e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve keyboard navigation and focus management in the stashed prompt menu
> - The stash badge (`ComposerStashBadge`) is now an open-only control; it no longer reflects menu open state via `aria-expanded` or active styling, and signals keyboard vs. pointer activation to the parent.
> - `ComposerStashMenu` gains a focusable close button rendered before the list; when opened via keyboard, focus moves to that button, and arrow keys shift focus into the command list.
> - The stash menu closes automatically when the command menu opens or the composer enters approval state, and is dismissed whenever the prompt changes.
> - Restoring a stash entry returns focus to the composer when triggered via keyboard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fdfe1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->