### PR TITLE
fix(server): use the correct installer for provider updates

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -22,6 +22,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 
 import { makeClaudeTextGeneration } from "../../textGeneration/ClaudeTextGeneration.ts";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
@@ -46,6 +47,7 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
+  makeProviderMaintenanceCapabilitySources,
   makeProviderMaintenanceResolver,
   normalizeCommandPath,
   resolveProviderMaintenanceCapabilitiesEffect,
@@ -131,7 +133,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const modelManifest = yield* ModelManifest.ModelManifest;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const hostEnvironment = yield* HostProcessEnvironment;
+      const processEnv = mergeProviderInstanceEnvironment(environment, hostEnvironment);
       const fallbackContinuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
         instanceId,
@@ -145,7 +148,12 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         Effect.provideService(FileSystem.FileSystem, fileSystem),
         Effect.provideService(Path.Path, path),
       );
-      const maintenanceCapabilities = yield* resolveMaintenance;
+      const maintenanceSources = yield* makeProviderMaintenanceCapabilitySources(
+        resolveMaintenance,
+        UPDATE.resolve(),
+        { enabled },
+      );
+      const maintenanceCapabilities = yield* maintenanceSources.advisory;
       const continuationGroupKey = yield* makeClaudeContinuationGroupKey(effectiveConfig);
       const stampIdentity = withInstanceIdentity({
         instanceId,
@@ -200,7 +208,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<ClaudeSettings>>({
         maintenanceCapabilities,
-        resolveMaintenance,
+        resolveMaintenance: maintenanceSources.fresh,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -213,7 +221,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
           ),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
-          resolveMaintenance.pipe(
+          maintenanceSources.advisory.pipe(
             Effect.flatMap((maintenanceCapabilities) =>
               enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
                 enableProviderUpdateChecks: settings.enableProviderUpdateChecks,

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -46,7 +46,7 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
-  makePackageManagedProviderMaintenanceResolver,
+  makeProviderMaintenanceResolver,
   normalizeCommandPath,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
@@ -70,9 +70,9 @@ function isClaudeNativeCommandPath(commandPath: string): boolean {
   );
 }
 
-const UPDATE = makePackageManagedProviderMaintenanceResolver({
+const UPDATE = makeProviderMaintenanceResolver({
   provider: DRIVER_KIND,
-  npmPackageName: "@anthropic-ai/claude-code",
+  packageName: "@anthropic-ai/claude-code",
   homebrewFormula: "claude-code",
   nativeUpdate: {
     executable: "claude",
@@ -80,6 +80,9 @@ const UPDATE = makePackageManagedProviderMaintenanceResolver({
     lockKey: "claude-native",
     isCommandPath: isClaudeNativeCommandPath,
   },
+  executableName: "claude",
+  instructionsUrl: "https://docs.anthropic.com/en/docs/claude-code/setup",
+  wingetPackageId: "Anthropic.ClaudeCode",
 });
 
 export type ClaudeDriverEnv =
@@ -134,10 +137,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         instanceId,
       });
       const effectiveConfig = { ...config, enabled } satisfies ClaudeSettings;
-      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+      const resolveMaintenance = resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
-      });
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
+      const maintenanceCapabilities = yield* resolveMaintenance;
       const continuationGroupKey = yield* makeClaudeContinuationGroupKey(effectiveConfig);
       const stampIdentity = withInstanceIdentity({
         instanceId,
@@ -192,6 +200,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<ClaudeSettings>>({
         maintenanceCapabilities,
+        resolveMaintenance,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -204,9 +213,12 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
           ),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
-          enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
-            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
-          }).pipe(
+          resolveMaintenance.pipe(
+            Effect.flatMap((maintenanceCapabilities) =>
+              enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
+                enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+              }),
+            ),
             Effect.provideService(HttpClient.HttpClient, httpClient),
             Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
           ),

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -77,9 +77,7 @@ const UPDATE = makeProviderMaintenanceResolver({
   packageName: "@anthropic-ai/claude-code",
   homebrewFormula: "claude-code",
   nativeUpdate: {
-    executable: "claude",
     args: ["update"],
-    lockKey: "claude-native",
     isCommandPath: isClaudeNativeCommandPath,
   },
   executableName: "claude",

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -151,7 +151,6 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         UPDATE.resolve(),
         { enabled },
       );
-      const maintenanceCapabilities = yield* maintenanceSources.advisory;
       const continuationGroupKey = yield* makeClaudeContinuationGroupKey(effectiveConfig);
       const stampIdentity = withInstanceIdentity({
         instanceId,
@@ -205,7 +204,6 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<ClaudeSettings>>({
-        maintenanceCapabilities,
         resolveMaintenance: maintenanceSources.fresh,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -29,6 +29,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 
 import { makeCodexTextGeneration } from "../../textGeneration/CodexTextGeneration.ts";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
@@ -45,6 +46,7 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
+  makeProviderMaintenanceCapabilitySources,
   makeProviderMaintenanceResolver,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
@@ -127,7 +129,8 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const modelManifest = yield* ModelManifest.ModelManifest;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const hostEnvironment = yield* HostProcessEnvironment;
+      const processEnv = mergeProviderInstanceEnvironment(environment, hostEnvironment);
       const homeLayout = yield* resolveCodexHomeLayout(config);
       const continuationIdentity = codexContinuationIdentity(homeLayout);
       const stampIdentity = withInstanceIdentity({
@@ -160,7 +163,12 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         Effect.provideService(FileSystem.FileSystem, fileSystem),
         Effect.provideService(Path.Path, pathService),
       );
-      const maintenanceCapabilities = yield* resolveMaintenance;
+      const maintenanceSources = yield* makeProviderMaintenanceCapabilitySources(
+        resolveMaintenance,
+        UPDATE.resolve(),
+        { enabled },
+      );
+      const maintenanceCapabilities = yield* maintenanceSources.advisory;
 
       // `makeCodexAdapter` and `makeCodexTextGeneration` have `never` error
       // channels at construction time — their failure modes are all on the
@@ -197,7 +205,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CodexSettings>>({
         maintenanceCapabilities,
-        resolveMaintenance,
+        resolveMaintenance: maintenanceSources.fresh,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -210,7 +218,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
           ),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
-          resolveMaintenance.pipe(
+          maintenanceSources.advisory.pipe(
             Effect.flatMap((maintenanceCapabilities) =>
               enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
                 enableProviderUpdateChecks: settings.enableProviderUpdateChecks,

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -45,7 +45,7 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
-  makePackageManagedProviderMaintenanceResolver,
+  makeProviderMaintenanceResolver,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
@@ -61,11 +61,14 @@ import {
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("codex");
-const UPDATE = makePackageManagedProviderMaintenanceResolver({
+const UPDATE = makeProviderMaintenanceResolver({
   provider: DRIVER_KIND,
-  npmPackageName: "@openai/codex",
+  packageName: "@openai/codex",
   homebrewFormula: "codex",
   nativeUpdate: null,
+  executableName: "codex",
+  instructionsUrl: "https://developers.openai.com/codex/cli/",
+  wingetPackageId: "OpenAI.Codex",
 });
 
 /**
@@ -118,6 +121,8 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
   create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const pathService = yield* Path.Path;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -147,10 +152,15 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         enabled,
         homePath: homeLayout.effectiveHomePath ?? "",
       } satisfies CodexSettings;
-      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+      const resolveMaintenance = resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
-      });
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, pathService),
+      );
+      const maintenanceCapabilities = yield* resolveMaintenance;
 
       // `makeCodexAdapter` and `makeCodexTextGeneration` have `never` error
       // channels at construction time — their failure modes are all on the
@@ -187,6 +197,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CodexSettings>>({
         maintenanceCapabilities,
+        resolveMaintenance,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -199,9 +210,12 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
           ),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
-          enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
-            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
-          }).pipe(
+          resolveMaintenance.pipe(
+            Effect.flatMap((maintenanceCapabilities) =>
+              enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
+                enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+              }),
+            ),
             Effect.provideService(HttpClient.HttpClient, httpClient),
             Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
           ),

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -168,7 +168,6 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         UPDATE.resolve(),
         { enabled },
       );
-      const maintenanceCapabilities = yield* maintenanceSources.advisory;
 
       // `makeCodexAdapter` and `makeCodexTextGeneration` have `never` error
       // channels at construction time — their failure modes are all on the
@@ -204,7 +203,6 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       );
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CodexSettings>>({
-        maintenanceCapabilities,
         resolveMaintenance: maintenanceSources.fresh,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -142,7 +142,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CursorSettings>>({
-        maintenanceCapabilities,
+        resolveMaintenance: Effect.succeed(maintenanceCapabilities),
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -28,8 +28,8 @@ import {
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
-  makeManualOnlyProviderMaintenanceCapabilities,
-  makeStaticProviderMaintenanceResolver,
+  makeProviderMaintenanceResolver,
+  normalizeCommandPath,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
@@ -40,12 +40,27 @@ import {
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("grok");
-const UPDATE = makeStaticProviderMaintenanceResolver(
-  makeManualOnlyProviderMaintenanceCapabilities({
-    provider: DRIVER_KIND,
-    packageName: null,
-  }),
-);
+
+function isGrokNativeCommandPath(commandPath: string): boolean {
+  const normalized = normalizeCommandPath(commandPath);
+  return (
+    normalized.endsWith("/.grok/bin/grok") || normalized.endsWith("/.grok/bin/grok.exe")
+  );
+}
+
+const UPDATE = makeProviderMaintenanceResolver({
+  provider: DRIVER_KIND,
+  packageName: "@xai-official/grok",
+  homebrewFormula: null,
+  nativeUpdate: {
+    executable: "grok",
+    args: ["update"],
+    lockKey: "grok-native",
+    isCommandPath: isGrokNativeCommandPath,
+  },
+  executableName: "grok",
+  instructionsUrl: "https://docs.x.ai/build/overview",
+});
 
 export type GrokDriverEnv =
   | BackgroundPolicy.BackgroundPolicy

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -41,12 +41,12 @@ const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("grok");
 
-function isGrokNativeCommandPath(commandPath: string): boolean {
+function isGrokNativeCommandPath(commandPath: string) {
   const normalized = normalizeCommandPath(commandPath);
   return normalized.endsWith("/.grok/bin/grok") || normalized.endsWith("/.grok/bin/grok.exe");
 }
 
-const UPDATE = makeProviderMaintenanceResolver({
+export const GrokMaintenanceResolver = makeProviderMaintenanceResolver({
   provider: DRIVER_KIND,
   packageName: "@xai-official/grok",
   homebrewFormula: null,
@@ -117,10 +117,13 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       const effectiveConfig = { ...config, enabled } satisfies GrokSettings;
-      const resolveMaintenance = resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
-        binaryPath: effectiveConfig.binaryPath,
-        env: processEnv,
-      }).pipe(
+      const resolveMaintenance = resolveProviderMaintenanceCapabilitiesEffect(
+        GrokMaintenanceResolver,
+        {
+          binaryPath: effectiveConfig.binaryPath,
+          env: processEnv,
+        },
+      ).pipe(
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
         Effect.provideService(FileSystem.FileSystem, fileSystem),
         Effect.provideService(Path.Path, pathService),

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -134,7 +134,6 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         GrokMaintenanceResolver.resolve(),
         { enabled },
       );
-      const maintenanceCapabilities = yield* maintenanceSources.advisory;
 
       const adapter = yield* makeGrokAdapter(effectiveConfig, {
         environment: processEnv,
@@ -151,7 +150,6 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<GrokSettings>>({
-        maintenanceCapabilities,
         resolveMaintenance: maintenanceSources.fresh,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -1,4 +1,5 @@
 import { GrokSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -106,7 +107,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const { cwd } = yield* ServerConfig;
       const eventLoggers = yield* ProviderEventLoggers;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const hostEnvironment = yield* HostProcessEnvironment;
+      const processEnv = mergeProviderInstanceEnvironment(environment, hostEnvironment);
       const continuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
         instanceId,

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -53,9 +53,7 @@ export const GrokMaintenanceResolver = makeProviderMaintenanceResolver({
   packageName: "@xai-official/grok",
   homebrewFormula: null,
   nativeUpdate: {
-    executable: "grok",
     args: ["update"],
-    lockKey: "grok-native",
     isCommandPath: isGrokNativeCommandPath,
   },
   executableName: "grok",

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -28,6 +28,7 @@ import {
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
+  makeProviderMaintenanceCapabilitySources,
   makeProviderMaintenanceResolver,
   normalizeCommandPath,
   resolveProviderMaintenanceCapabilitiesEffect,
@@ -128,7 +129,12 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         Effect.provideService(FileSystem.FileSystem, fileSystem),
         Effect.provideService(Path.Path, pathService),
       );
-      const maintenanceCapabilities = yield* resolveMaintenance;
+      const maintenanceSources = yield* makeProviderMaintenanceCapabilitySources(
+        resolveMaintenance,
+        GrokMaintenanceResolver.resolve(),
+        { enabled },
+      );
+      const maintenanceCapabilities = yield* maintenanceSources.advisory;
 
       const adapter = yield* makeGrokAdapter(effectiveConfig, {
         environment: processEnv,
@@ -146,7 +152,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<GrokSettings>>({
         maintenanceCapabilities,
-        resolveMaintenance,
+        resolveMaintenance: maintenanceSources.fresh,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -154,7 +160,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
           buildInitialGrokProviderSnapshot(settings.provider).pipe(Effect.map(stampIdentity)),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
-          resolveMaintenance.pipe(
+          maintenanceSources.advisory.pipe(
             Effect.flatMap((maintenanceCapabilities) =>
               enrichGrokSnapshot({
                 snapshot: currentSnapshot,

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -43,9 +43,7 @@ const DRIVER_KIND = ProviderDriverKind.make("grok");
 
 function isGrokNativeCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
-  return (
-    normalized.endsWith("/.grok/bin/grok") || normalized.endsWith("/.grok/bin/grok.exe")
-  );
+  return normalized.endsWith("/.grok/bin/grok") || normalized.endsWith("/.grok/bin/grok.exe");
 }
 
 const UPDATE = makeProviderMaintenanceResolver({
@@ -101,6 +99,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
     Effect.gen(function* () {
       const crypto = yield* Crypto.Crypto;
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const pathService = yield* Path.Path;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const { cwd } = yield* ServerConfig;
@@ -117,10 +117,15 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       const effectiveConfig = { ...config, enabled } satisfies GrokSettings;
-      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+      const resolveMaintenance = resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
-      });
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, pathService),
+      );
+      const maintenanceCapabilities = yield* resolveMaintenance;
 
       const adapter = yield* makeGrokAdapter(effectiveConfig, {
         environment: processEnv,
@@ -138,6 +143,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<GrokSettings>>({
         maintenanceCapabilities,
+        resolveMaintenance,
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -145,13 +151,17 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
           buildInitialGrokProviderSnapshot(settings.provider).pipe(Effect.map(stampIdentity)),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
-          enrichGrokSnapshot({
-            snapshot: currentSnapshot,
-            maintenanceCapabilities,
-            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
-            publishSnapshot,
-            httpClient,
-          }),
+          resolveMaintenance.pipe(
+            Effect.flatMap((maintenanceCapabilities) =>
+              enrichGrokSnapshot({
+                snapshot: currentSnapshot,
+                maintenanceCapabilities,
+                enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+                publishSnapshot,
+                httpClient,
+              }),
+            ),
+          ),
       }).pipe(
         Effect.mapError(
           (cause) =>

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -1,3 +1,4 @@
+// @effect-diagnostics nodeBuiltinImport:off
 /**
  * OpenCodeDriver — `ProviderDriver` for the OpenCode runtime.
  *
@@ -12,6 +13,8 @@
  *
  * @module provider/Drivers/OpenCodeDriver
  */
+import * as NodePath from "node:path";
+
 import { OpenCodeSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
@@ -44,7 +47,7 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
-  makePackageManagedProviderMaintenanceResolver,
+  makeProviderMaintenanceResolver,
   normalizeCommandPath,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
@@ -65,16 +68,23 @@ function isOpenCodeNativeCommandPath(commandPath: string): boolean {
   );
 }
 
-const UPDATE = makePackageManagedProviderMaintenanceResolver({
+const UPDATE = makeProviderMaintenanceResolver({
   provider: DRIVER_KIND,
-  npmPackageName: "opencode-ai",
+  packageName: "opencode-ai",
   homebrewFormula: "anomalyco/tap/opencode",
   nativeUpdate: {
     executable: "opencode",
     args: ["upgrade"],
     lockKey: "opencode-native",
     isCommandPath: isOpenCodeNativeCommandPath,
+    environment: (executable, environment) => ({
+      ...environment,
+      OPENCODE_INSTALL_DIR: NodePath.dirname(executable),
+    }),
   },
+  executableName: "opencode",
+  instructionsUrl: "https://opencode.ai/docs/",
+  wingetPackageId: "SST.opencode",
 });
 
 export type OpenCodeDriverEnv =
@@ -115,6 +125,9 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
   defaultConfig: (): OpenCodeSettings => decodeOpenCodeSettings({}),
   create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
     Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const pathService = yield* Path.Path;
       const openCodeRuntime = yield* OpenCodeRuntime;
       const serverConfig = yield* ServerConfig;
       const httpClient = yield* HttpClient.HttpClient;
@@ -132,10 +145,15 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       const effectiveConfig = { ...config, enabled } satisfies OpenCodeSettings;
-      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+      const resolveMaintenance = resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
-      });
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, pathService),
+      );
+      const maintenanceCapabilities = yield* resolveMaintenance;
 
       const adapter = yield* makeOpenCodeAdapter(effectiveConfig, {
         instanceId,
@@ -168,6 +186,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<OpenCodeSettings>>(
         {
           maintenanceCapabilities,
+          resolveMaintenance,
           getSettings: snapshotSettings.getSettings,
           streamSettings: snapshotSettings.streamSettings,
           haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -177,9 +196,12 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
             makePendingOpenCodeProvider(settings.provider).pipe(Effect.map(stampIdentity)),
           checkProvider,
           enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
-            enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
-              enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
-            }).pipe(
+            resolveMaintenance.pipe(
+              Effect.flatMap((maintenanceCapabilities) =>
+                enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
+                  enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+                }),
+              ),
               Effect.provideService(HttpClient.HttpClient, httpClient),
               Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
             ),

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -159,7 +159,6 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         UPDATE.resolve(),
         { enabled },
       );
-      const maintenanceCapabilities = yield* maintenanceSources.advisory;
 
       const adapter = yield* makeOpenCodeAdapter(effectiveConfig, {
         instanceId,
@@ -191,7 +190,6 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<OpenCodeSettings>>(
         {
-          maintenanceCapabilities,
           resolveMaintenance: maintenanceSources.fresh,
           getSettings: snapshotSettings.getSettings,
           streamSettings: snapshotSettings.streamSettings,

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -23,6 +23,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 
 import { makeOpenCodeTextGeneration } from "../../textGeneration/OpenCodeTextGeneration.ts";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
@@ -47,6 +48,7 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
+  makeProviderMaintenanceCapabilitySources,
   makeProviderMaintenanceResolver,
   normalizeCommandPath,
   resolveProviderMaintenanceCapabilitiesEffect,
@@ -133,7 +135,8 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const hostEnvironment = yield* HostProcessEnvironment;
+      const processEnv = mergeProviderInstanceEnvironment(environment, hostEnvironment);
       const continuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
         instanceId,
@@ -153,7 +156,12 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         Effect.provideService(FileSystem.FileSystem, fileSystem),
         Effect.provideService(Path.Path, pathService),
       );
-      const maintenanceCapabilities = yield* resolveMaintenance;
+      const maintenanceSources = yield* makeProviderMaintenanceCapabilitySources(
+        resolveMaintenance,
+        UPDATE.resolve(),
+        { enabled },
+      );
+      const maintenanceCapabilities = yield* maintenanceSources.advisory;
 
       const adapter = yield* makeOpenCodeAdapter(effectiveConfig, {
         instanceId,
@@ -186,7 +194,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<OpenCodeSettings>>(
         {
           maintenanceCapabilities,
-          resolveMaintenance,
+          resolveMaintenance: maintenanceSources.fresh,
           getSettings: snapshotSettings.getSettings,
           streamSettings: snapshotSettings.streamSettings,
           haveSettingsChanged: haveProviderSnapshotSettingsChanged,
@@ -196,7 +204,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
             makePendingOpenCodeProvider(settings.provider).pipe(Effect.map(stampIdentity)),
           checkProvider,
           enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
-            resolveMaintenance.pipe(
+            maintenanceSources.advisory.pipe(
               Effect.flatMap((maintenanceCapabilities) =>
                 enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {
                   enableProviderUpdateChecks: settings.enableProviderUpdateChecks,

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -75,9 +75,7 @@ const UPDATE = makeProviderMaintenanceResolver({
   packageName: "opencode-ai",
   homebrewFormula: "anomalyco/tap/opencode",
   nativeUpdate: {
-    executable: "opencode",
     args: ["upgrade"],
-    lockKey: "opencode-native",
     isCommandPath: isOpenCodeNativeCommandPath,
     environment: (executable, environment) => ({
       ...environment,

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -116,10 +116,12 @@ const makeFakeInstance = (
     displayName: undefined,
     enabled: true,
     snapshot: {
-      maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-        provider: driverKind,
-        packageName: null,
-      }),
+      resolveMaintenance: Effect.succeed(
+        makeManualOnlyProviderMaintenanceCapabilities({
+          provider: driverKind,
+          packageName: null,
+        }),
+      ),
       getSnapshot: Effect.succeed({} as unknown as ServerProvider),
       refresh: Effect.succeed({} as unknown as ServerProvider),
       streamChanges: Stream.empty,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -905,10 +905,12 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             displayName: undefined,
             enabled: true,
             snapshot: {
-              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                provider: codexDriver,
-                packageName: null,
-              }),
+              resolveMaintenance: Effect.succeed(
+                makeManualOnlyProviderMaintenanceCapabilities({
+                  provider: codexDriver,
+                  packageName: null,
+                }),
+              ),
               getSnapshot: Effect.succeed(initialProvider),
               refresh: Ref.update(refreshCalls, (count) => count + 1).pipe(
                 Effect.andThen(Effect.never),
@@ -1176,10 +1178,12 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             displayName: undefined,
             enabled: true,
             snapshot: {
-              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                provider: cursorDriver,
-                packageName: null,
-              }),
+              resolveMaintenance: Effect.succeed(
+                makeManualOnlyProviderMaintenanceCapabilities({
+                  provider: cursorDriver,
+                  packageName: null,
+                }),
+              ),
               getSnapshot: Effect.succeed(initialProvider),
               refresh: Effect.succeed(refreshedProvider),
               streamChanges: Stream.fromPubSub(changes),
@@ -1305,10 +1309,12 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               displayName: undefined,
               enabled: true,
               snapshot: {
-                maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                  provider: openCodeDriver,
-                  packageName: null,
-                }),
+                resolveMaintenance: Effect.succeed(
+                  makeManualOnlyProviderMaintenanceCapabilities({
+                    provider: openCodeDriver,
+                    packageName: null,
+                  }),
+                ),
                 getSnapshot: Effect.succeed(initialProvider),
                 refresh: Effect.succeed(authoritativeProvider),
                 streamChanges: Stream.fromPubSub(changes),
@@ -1412,10 +1418,12 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             displayName: undefined,
             enabled: true,
             snapshot: {
-              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                provider: codexDriver,
-                packageName: null,
-              }),
+              resolveMaintenance: Effect.succeed(
+                makeManualOnlyProviderMaintenanceCapabilities({
+                  provider: codexDriver,
+                  packageName: null,
+                }),
+              ),
               getSnapshot: Effect.succeed(cachedProvider),
               refresh: Effect.die(new Error("simulated refresh failure")),
               streamChanges: Stream.empty,
@@ -1505,10 +1513,12 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             displayName: undefined,
             enabled: true,
             snapshot: {
-              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                provider: provider.driver,
-                packageName: null,
-              }),
+              resolveMaintenance: Effect.succeed(
+                makeManualOnlyProviderMaintenanceCapabilities({
+                  provider: provider.driver,
+                  packageName: null,
+                }),
+              ),
               getSnapshot: Effect.succeed(provider),
               refresh: Effect.succeed(provider),
               streamChanges: Stream.empty,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1026,10 +1026,12 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               displayName: undefined,
               enabled: true,
               snapshot: {
-                maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                  provider: codexDriver,
-                  packageName: null,
-                }),
+                resolveMaintenance: Effect.succeed(
+                  makeManualOnlyProviderMaintenanceCapabilities({
+                    provider: codexDriver,
+                    packageName: null,
+                  }),
+                ),
                 getSnapshot: Effect.succeed(codexProvider),
                 refresh: Ref.update(codexRefreshCalls, (count) => count + 1).pipe(
                   Effect.as(codexProvider),
@@ -1049,10 +1051,12 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               displayName: undefined,
               enabled: true,
               snapshot: {
-                maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                  provider: openCodeDriver,
-                  packageName: null,
-                }),
+                resolveMaintenance: Effect.succeed(
+                  makeManualOnlyProviderMaintenanceCapabilities({
+                    provider: openCodeDriver,
+                    packageName: null,
+                  }),
+                ),
                 getSnapshot: Effect.succeed(failedOpenCodeProvider),
                 refresh: Ref.update(openCodeRefreshCalls, (count) => count + 1).pipe(
                   Effect.andThen(Ref.get(catalogSnapshot)),

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -30,6 +30,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import { deepMerge } from "@t3tools/shared/Struct";
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 
 import { checkCodexProviderStatus, type CodexAppServerProviderSnapshot } from "./CodexProvider.ts";
 import { checkClaudeProviderStatus } from "./ClaudeProvider.ts";
@@ -53,6 +54,10 @@ import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMainte
 const decodeServerSettings = Schema.decodeSync(ServerSettings);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 const encodedDefaultServerSettings = encodeServerSettings(DEFAULT_SERVER_SETTINGS);
+const IsolatedProviderPathLayer = Layer.succeed(HostProcessEnvironment, {
+  ...process.env,
+  PATH: "",
+});
 
 const defaultClaudeSettings: ClaudeSettings = Schema.decodeSync(ClaudeSettings)({});
 const defaultCodexSettings: CodexSettings = Schema.decodeSync(CodexSettings)({});
@@ -1752,6 +1757,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               }),
             ),
             Layer.provideMerge(NodeServices.layer),
+            Layer.provideMerge(IsolatedProviderPathLayer),
             Layer.provideMerge(BackgroundPolicyAlwaysRunLayer),
           );
           const runtimeServices = yield* Layer.build(providerRegistryLayer).pipe(
@@ -1929,6 +1935,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               Layer.provideMerge(ModelManifest.layerTest),
               Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
               Layer.provideMerge(BackgroundPolicyAlwaysRunLayer),
+              Layer.provideMerge(IsolatedProviderPathLayer),
               Layer.provideMerge(
                 mockCommandSpawnerLayer((command, args) => {
                   if (command === "cursor-agent") {

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -517,10 +517,7 @@ export const ProviderRegistryLive = Layer.effect(
       if (!instance || instance.driverKind !== provider) {
         return makeManualProviderMaintenanceCapabilities(provider);
       }
-      return instance.snapshot.resolveMaintenance
-        ? yield* instance.snapshot.resolveMaintenance
-        : (instance.snapshot.maintenanceCapabilities ??
-            makeManualProviderMaintenanceCapabilities(provider));
+      return yield* instance.snapshot.resolveMaintenance;
     });
 
     /**

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -510,16 +510,17 @@ export const ProviderRegistryLive = Layer.effect(
       return yield* refreshOneSource(providerSource);
     });
 
-    const getProviderMaintenanceCapabilitiesForInstance = Effect.fn(
-      "getProviderMaintenanceCapabilitiesForInstance",
+    const resolveProviderMaintenanceCapabilitiesForInstance = Effect.fn(
+      "resolveProviderMaintenanceCapabilitiesForInstance",
     )(function* (instanceId: ProviderInstanceId, provider: ProviderDriverKind) {
-      const instance = Array.from((yield* Ref.get(liveSubsRef)).values()).find(
-        (candidate) => candidate.instanceId === instanceId,
-      );
-      return (
-        instance?.snapshot.maintenanceCapabilities ??
-        makeManualProviderMaintenanceCapabilities(provider)
-      );
+      const instance = yield* instanceRegistry.getInstance(instanceId);
+      if (!instance || instance.driverKind !== provider) {
+        return makeManualProviderMaintenanceCapabilities(provider);
+      }
+      return instance.snapshot.resolveMaintenance
+        ? yield* instance.snapshot.resolveMaintenance
+        : (instance.snapshot.maintenanceCapabilities ??
+            makeManualProviderMaintenanceCapabilities(provider));
     });
 
     /**
@@ -724,7 +725,7 @@ export const ProviderRegistryLive = Layer.effect(
         refresh(provider).pipe(Effect.catchCause(recoverRefreshFailure)),
       refreshInstance: (instanceId: ProviderInstanceId) =>
         refreshInstance(instanceId).pipe(Effect.catchCause(recoverRefreshFailure)),
-      getProviderMaintenanceCapabilitiesForInstance,
+      resolveProviderMaintenanceCapabilitiesForInstance,
       setProviderMaintenanceActionState,
       get streamChanges() {
         return Stream.fromPubSub(changesPubSub);

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -52,7 +52,8 @@ export interface ProviderRegistryShape {
    * Resolve the maintenance capabilities owned by one live provider instance.
    * Falls back to manual-only capabilities when the instance is not live.
    */
-  readonly getProviderMaintenanceCapabilitiesForInstance: (
+  /** Resolve ownership again from the active executable immediately before update. */
+  readonly resolveProviderMaintenanceCapabilitiesForInstance: (
     instanceId: ProviderInstanceId,
     provider: ProviderDriverKind,
   ) => Effect.Effect<ProviderMaintenanceCapabilities>;

--- a/apps/server/src/provider/Services/ServerProvider.ts
+++ b/apps/server/src/provider/Services/ServerProvider.ts
@@ -5,6 +5,7 @@ import type { ProviderMaintenanceCapabilities } from "../providerMaintenance.ts"
 
 export interface ServerProviderShape {
   readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly resolveMaintenance?: Effect.Effect<ProviderMaintenanceCapabilities>;
   readonly getSnapshot: Effect.Effect<ServerProvider>;
   readonly refresh: Effect.Effect<ServerProvider>;
   readonly streamChanges: Stream.Stream<ServerProvider>;

--- a/apps/server/src/provider/Services/ServerProvider.ts
+++ b/apps/server/src/provider/Services/ServerProvider.ts
@@ -4,8 +4,7 @@ import type * as Stream from "effect/Stream";
 import type { ProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
 
 export interface ServerProviderShape {
-  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
-  readonly resolveMaintenance?: Effect.Effect<ProviderMaintenanceCapabilities>;
+  readonly resolveMaintenance: Effect.Effect<ProviderMaintenanceCapabilities>;
   readonly getSnapshot: Effect.Effect<ServerProvider>;
   readonly refresh: Effect.Effect<ServerProvider>;
   readonly streamChanges: Stream.Stream<ServerProvider>;

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -401,7 +401,7 @@ it.effect("proves Bun ownership for its copied Windows global executable", () =>
   );
 });
 
-it.effect("proves Homebrew ownership against the configured formula prefix", () => {
+it.effect("proves Homebrew ownership and fails closed for unresolved shims", () => {
   const brew = "/opt/homebrew/bin/brew";
   const resolve = (version: string) => {
     const formulaPrefix = `/opt/homebrew/Cellar/codex/${version}`;
@@ -446,6 +446,27 @@ it.effect("proves Homebrew ownership against the configured formula prefix", () 
     });
     expect(after.identityKey).toBe(before.identityKey);
     expect(after.lockKey).toBe(before.lockKey);
+
+    const unresolved = yield* resolveInstallation(
+      context({
+        binaryPath: "codex",
+        resolvedCommandPath: "/opt/homebrew/bin/codex",
+        commands: { npm: "/usr/local/bin/npm" },
+        probes: {
+          "/usr/local/bin/npm root -g": {
+            stdout: "/usr/local/lib/node_modules",
+            stderr: "",
+            exitCode: 0,
+          },
+        },
+      }),
+      catalog,
+    );
+    expect(unresolved).toMatchObject({
+      label: "Unknown installation — verification failed",
+      ownershipVerified: false,
+      update: null,
+    });
   });
 });
 

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -1,0 +1,592 @@
+import { expect, it } from "@effect/vitest";
+import { ProviderDriverKind } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import {
+  canonicalPath,
+  type InstallationContext,
+  type MaintenanceProbeResult,
+} from "./definition.ts";
+import {
+  makeProviderInstallationCatalog,
+  parseWingetPortableArp,
+  parseWingetSources,
+} from "./catalogs.ts";
+import { resolveInstallation } from "./resolver.ts";
+
+const provider = ProviderDriverKind.make("codex");
+const catalog = makeProviderInstallationCatalog({
+  provider,
+  packageName: "@openai/codex",
+  executableName: "codex",
+  homebrewFormula: "codex",
+  native: null,
+  instructionsUrl: "https://developers.openai.com/codex/cli/",
+  wingetPackageId: "OpenAI.Codex",
+});
+
+it("preserves valid backslashes in POSIX filenames", () => {
+  expect(canonicalPath("/tmp/provider\\name", "linux")).toBe("/tmp/provider\\name");
+});
+
+function context(input: {
+  readonly binaryPath: string;
+  readonly resolvedCommandPath: string;
+  readonly realCommandPath?: string;
+  readonly platform?: NodeJS.Platform;
+  readonly files?: Readonly<Record<string, string>>;
+  readonly commands?: Readonly<Record<string, string>>;
+  readonly probes?: Readonly<Record<string, MaintenanceProbeResult>>;
+  readonly realPaths?: Readonly<Record<string, string>>;
+}): InstallationContext {
+  const files = new Map(
+    Object.entries(input.files ?? {}).map(([path, value]) => [
+      path.replaceAll("\\", "/").toLowerCase(),
+      value,
+    ]),
+  );
+  return {
+    provider,
+    packageName: "@openai/codex",
+    binaryPath: input.binaryPath,
+    isBareCommand: !input.binaryPath.includes("/") && !input.binaryPath.includes("\\"),
+    resolvedCommandPath: input.resolvedCommandPath,
+    realCommandPath: input.realCommandPath ?? input.resolvedCommandPath,
+    environment: { PATH: "test-path" },
+    platform: input.platform ?? "linux",
+    readTextFile: (path) =>
+      Effect.succeed(files.get(path.replaceAll("\\", "/").toLowerCase()) ?? null),
+    realPath: (path) =>
+      Effect.succeed(input.realPaths?.[path.replaceAll("\\", "/").toLowerCase()] ?? path),
+    resolveCommand: (command) => Effect.succeed(input.commands?.[command] ?? null),
+    run: (executable, args) =>
+      Effect.succeed(input.probes?.[`${executable} ${args.join(" ")}`] ?? null),
+  };
+}
+
+it.effect("keeps native installation identity stable across versioned executable targets", () => {
+  const nativeCatalog = makeProviderInstallationCatalog({
+    provider,
+    packageName: "@openai/codex",
+    executableName: "codex",
+    homebrewFormula: null,
+    native: {
+      label: "Managed by native installer",
+      updateArgs: ["update"],
+      ownsPath: (path) => path.includes("/.local/share/codex/versions/"),
+    },
+    instructionsUrl: "https://developers.openai.com/codex/cli/",
+  });
+  const resolvedCommandPath = "/home/test/.local/bin/codex";
+  return Effect.gen(function* () {
+    const before = yield* resolveInstallation(
+      context({
+        binaryPath: "codex",
+        resolvedCommandPath,
+        realCommandPath: "/home/test/.local/share/codex/versions/1.0.0",
+      }),
+      nativeCatalog,
+    );
+    const after = yield* resolveInstallation(
+      context({
+        binaryPath: "codex",
+        resolvedCommandPath,
+        realCommandPath: "/home/test/.local/share/codex/versions/1.1.0",
+      }),
+      nativeCatalog,
+    );
+
+    expect(before.identityKey).toBe(after.identityKey);
+    expect(before.update?.executable).toBe("/home/test/.local/share/codex/versions/1.0.0");
+    expect(after.update?.executable).toBe("/home/test/.local/share/codex/versions/1.1.0");
+  });
+});
+
+it.effect("proves Scoop ownership from the resolved shim and uses that Scoop and bucket", () => {
+  const root = "C:/Users/test/scoop";
+  const shim = `${root}/shims/codex.exe`;
+  const scoop = `${root}/shims/scoop.ps1`;
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: shim,
+      platform: "win32",
+      commands: { scoop },
+      files: {
+        [`${root}/shims/codex.shim`]: `path = "${root}/apps/codex-nightly/current/codex.exe"`,
+        [`${root}/apps/codex-nightly/current/install.json`]: JSON.stringify({ bucket: "custom" }),
+        [`${root}/apps/codex-nightly/current/manifest.json`]: JSON.stringify({ version: "1.2.3" }),
+        [`${root}/buckets/custom/bucket/codex-nightly.json`]: JSON.stringify({ version: "1.3.0" }),
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by Scoop",
+        ownershipVerified: true,
+        currentVersion: "1.2.3",
+        latestVersion: "1.3.0",
+        update: {
+          executable: scoop,
+          args: ["update", "custom/codex-nightly"],
+        },
+      });
+    }),
+  );
+});
+
+it.effect("uses npm only as the policy for an unknown bare command", () => {
+  const npm = "/usr/local/bin/npm";
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: "/custom/bin/codex",
+      commands: { npm },
+      probes: {
+        [`${npm} root -g`]: { stdout: "/usr/local/lib/node_modules", stderr: "", exitCode: 0 },
+        [`${npm} view @openai/codex@latest version --json`]: {
+          stdout: '"2.0.0"',
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation.label).toBe("Unknown installation — legacy npm fallback");
+      expect(installation.ownershipVerified).toBe(false);
+      expect(installation.update).toMatchObject({
+        executable: npm,
+        args: [
+          "install",
+          "-g",
+          "--allow-scripts=@openai/codex",
+          "@openai/codex@latest",
+        ],
+      });
+    }),
+  );
+});
+
+it.effect("does not fall back to npm when a managed package path has no available owner", () =>
+  resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: "/opt/node/lib/node_modules/@openai/codex/bin/codex.js",
+      commands: { npm: "/usr/local/bin/npm" },
+      probes: {
+        "/usr/local/bin/npm root -g": {
+          stdout: "/usr/local/lib/node_modules",
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Unknown installation — verification failed",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
+  ),
+);
+
+it.effect("proves npm ownership through a Windows global command wrapper", () => {
+  const prefix = "C:/Users/test/AppData/Roaming/npm";
+  const npm = `${prefix}/npm.cmd`;
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: `${prefix}/codex.cmd`,
+      platform: "win32",
+      commands: { npm },
+      files: {
+        [`${prefix}/codex.cmd`]:
+          '@IF EXIST "%~dp0\\node.exe" ("%~dp0\\node.exe" "%~dp0\\node_modules\\@openai\\codex\\bin\\codex.js")',
+        [`${prefix}/node_modules/@openai/codex/package.json`]: JSON.stringify({
+          name: "@openai/codex",
+          version: "1.0.0",
+        }),
+      },
+      probes: {
+        [`${npm} root -g`]: {
+          stdout: `${prefix}/node_modules`,
+          stderr: "",
+          exitCode: 0,
+        },
+        [`${npm} view @openai/codex@latest version --json`]: {
+          stdout: '"1.1.0"',
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by npm",
+        ownershipVerified: true,
+        currentVersion: "1.0.0",
+        latestVersion: "1.1.0",
+        update: { executable: npm },
+      });
+    }),
+  );
+});
+
+it.effect("does not match a wrapper for a package with a shared name prefix", () => {
+  const prefix = "C:/Users/test/AppData/Roaming/npm";
+  const npm = `${prefix}/npm.cmd`;
+  const wrapper = `${prefix}/codex.cmd`;
+  const packageRoot = `${prefix}/node_modules/@openai/codex`;
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: wrapper,
+      platform: "win32",
+      commands: { npm },
+      files: {
+        [wrapper]: `node  "%~dp0\\node_modules\\@openai\\codex-malicious\\bin\\codex.js" %*`,
+        [`${packageRoot}/package.json`]: JSON.stringify({
+          name: "@openai/codex",
+          version: "1.0.0",
+        }),
+      },
+      probes: {
+        [`${npm} root -g`]: { stdout: `${prefix}/node_modules`, stderr: "", exitCode: 0 },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation.update).toBeNull();
+      expect(installation.ownershipVerified).toBe(false);
+    }),
+  );
+});
+
+it.effect("resolves a pnpm Windows wrapper into its versioned global package root", () => {
+  const home = "C:/Users/test/AppData/Local/pnpm";
+  const packageRoot = `${home}/global/v11/hash/node_modules/@openai/codex`;
+  const pnpm = "C:/Users/test/scoop/shims/pnpm.exe";
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: `${home}/bin/codex.CMD`,
+      platform: "win32",
+      commands: { pnpm },
+      files: {
+        [`${home}/bin/codex.CMD`]:
+          '@"%~dp0\\..\\global\\v11\\hash\\node_modules\\@openai\\codex\\bin\\codex.exe" %*',
+        [`${packageRoot}/package.json`]: JSON.stringify({
+          name: "@openai/codex",
+          version: "1.0.0",
+        }),
+      },
+      probes: {
+        [`${pnpm} root -g`]: {
+          stdout: `${home}/global/v11`,
+          stderr: "",
+          exitCode: 0,
+        },
+        [`${pnpm} view @openai/codex@latest version --json`]: {
+          stdout: '"1.1.0"',
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by pnpm",
+        currentVersion: "1.0.0",
+        latestVersion: "1.1.0",
+        update: { executable: pnpm },
+      });
+    }),
+  );
+});
+
+it.effect("proves npm ownership across a Scoop Node persistent-bin junction", () => {
+  const currentBin = "C:/Users/test/scoop/apps/nodejs-lts/current/bin";
+  const persistentBin = "C:/Users/test/scoop/persist/nodejs-lts/bin";
+  const packageRoot = `${persistentBin}/node_modules/@openai/codex`;
+  const npm = "C:/Users/test/scoop/apps/nodejs-lts/current/npm.cmd";
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: `${currentBin}/codex.cmd`,
+      platform: "win32",
+      commands: { npm },
+      realPaths: {
+        [`${currentBin}/node_modules/@openai/codex`.toLowerCase()]: packageRoot,
+      },
+      files: {
+        [`${currentBin}/codex.cmd`]:
+          '@ECHO off\nSET dp0=%~dp0\n"%dp0%\\node_modules\\@openai\\codex\\bin\\codex.exe" %*',
+        [`${packageRoot}/package.json`]: JSON.stringify({
+          name: "@openai/codex",
+          version: "1.0.0",
+        }),
+      },
+      probes: {
+        [`${npm} root -g`]: {
+          stdout: `${persistentBin}/node_modules`,
+          stderr: "",
+          exitCode: 0,
+        },
+        [`${npm} view @openai/codex@latest version --json`]: {
+          stdout: '"1.1.0"',
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by npm",
+        ownershipVerified: true,
+        currentVersion: "1.0.0",
+        latestVersion: "1.1.0",
+        update: { executable: npm },
+      });
+    }),
+  );
+});
+
+it.effect("proves Bun ownership for its copied Windows global executable", () => {
+  const home = "C:/Users/test/.bun";
+  const bun = `${home}/bin/bun.exe`;
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: `${home}/bin/codex.exe`,
+      platform: "win32",
+      commands: { bun },
+      files: {
+        [`${home}/install/global/node_modules/@openai/codex/package.json`]: JSON.stringify({
+          name: "@openai/codex",
+          version: "1.0.0",
+        }),
+      },
+      probes: {
+        [`${bun} pm bin -g`]: { stdout: `${home}/bin`, stderr: "", exitCode: 0 },
+        [`${bun} pm view @openai/codex version`]: {
+          stdout: "1.1.0",
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by Bun",
+        currentVersion: "1.0.0",
+        latestVersion: "1.1.0",
+        update: { executable: bun },
+      });
+    }),
+  );
+});
+
+it.effect("proves Homebrew ownership against the configured formula prefix", () => {
+  const brew = "/opt/homebrew/bin/brew";
+  const resolve = (version: string) => {
+    const formulaPrefix = `/opt/homebrew/Cellar/codex/${version}`;
+    return resolveInstallation(
+      context({
+        binaryPath: "codex",
+        resolvedCommandPath: "/opt/homebrew/bin/codex",
+        realCommandPath: `${formulaPrefix}/bin/codex`,
+        commands: { brew },
+        probes: {
+          [`${brew} --prefix --installed codex`]: {
+            stdout: formulaPrefix,
+            stderr: "",
+            exitCode: 0,
+          },
+          [`${brew} --caskroom codex`]: { stdout: "", stderr: "", exitCode: 1 },
+          [`${brew} info --json=v2 codex`]: {
+            stdout: JSON.stringify({
+              formulae: [
+                {
+                  installed: [{ version }],
+                  versions: { stable: "1.1.0" },
+                },
+              ],
+            }),
+            stderr: "",
+            exitCode: 0,
+          },
+        },
+      }),
+      catalog,
+    );
+  };
+  return Effect.gen(function* () {
+    const before = yield* resolve("1.0.0");
+    const after = yield* resolve("1.1.0");
+    expect(before).toMatchObject({
+      label: "Managed by Homebrew",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      update: { executable: brew, args: ["upgrade", "codex"] },
+    });
+    expect(after.identityKey).toBe(before.identityKey);
+    expect(after.lockKey).toBe(before.lockKey);
+  });
+});
+
+it.effect("keeps an unclassified explicit path manual-only", () =>
+  resolveInstallation(
+    context({
+      binaryPath: "/custom/bin/codex",
+      resolvedCommandPath: "/custom/bin/codex",
+      commands: { npm: "/usr/local/bin/npm" },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Unknown installation",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
+  ),
+);
+
+it.effect("proves WinGet ownership and updates through the mapped source name", () => {
+  const reg = "C:\\Windows\\System32\\reg.exe";
+  const uninstall = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
+  const key = `HKEY_CURRENT_USER\\${uninstall}\\OpenAI.Codex_Microsoft.Winget.Source_8wekyb3d8bbwe`;
+  const link = "C:\\Users\\test\\AppData\\Local\\Microsoft\\WinGet\\Links\\codex.exe";
+  const target =
+    "C:\\Users\\test\\AppData\\Local\\Microsoft\\WinGet\\Packages\\OpenAI.Codex_Microsoft.Winget.Source_8wekyb3d8bbwe\\codex.exe";
+  const winget = "C:\\Users\\test\\AppData\\Local\\Microsoft\\WindowsApps\\winget.exe";
+  const probes: Record<string, MaintenanceProbeResult> = {
+    [`${reg} query HKCU\\${uninstall} /s /f OpenAI.Codex /d /e /reg:64`]: {
+      stdout: key,
+      stderr: "",
+      exitCode: 0,
+    },
+    [`${reg} query HKLM\\${uninstall} /s /f OpenAI.Codex /d /e /reg:64`]: {
+      stdout: "",
+      stderr: "",
+      exitCode: 1,
+    },
+    [`${reg} query HKLM\\${uninstall} /s /f OpenAI.Codex /d /e /reg:32`]: {
+      stdout: "",
+      stderr: "",
+      exitCode: 1,
+    },
+    [`${reg} query ${key} /reg:64`]: {
+      stdout: `${key}\n    DisplayVersion    REG_SZ    1.0.0\n    WinGetPackageIdentifier    REG_SZ    OpenAI.Codex\n    WinGetSourceIdentifier    REG_SZ    Microsoft.Winget.Source_8wekyb3d8bbwe\n    SymlinkFullPath    REG_SZ    ${link}\n    TargetFullPath    REG_SZ    ${target}`,
+      stderr: "",
+      exitCode: 0,
+    },
+    [`${winget} source export --disable-interactivity`]: {
+      stdout:
+        '{"Data":"Microsoft.Winget.Source_8wekyb3d8bbwe","Identifier":"Microsoft.Winget.Source_8wekyb3d8bbwe","Name":"winget"}',
+      stderr: "",
+      exitCode: 0,
+    },
+    [`${winget} show --id OpenAI.Codex --exact --source winget --versions --accept-source-agreements --disable-interactivity`]:
+      {
+        stdout: "Version\n-------\n1.1.0\n1.0.0",
+        stderr: "",
+        exitCode: 0,
+      },
+  };
+  const showKey = `${winget} show --id OpenAI.Codex --exact --source winget --versions --accept-source-agreements --disable-interactivity`;
+  const resolve = (resolvedProbes: Readonly<Record<string, MaintenanceProbeResult>>) =>
+    resolveInstallation(
+      context({
+        binaryPath: "codex",
+        resolvedCommandPath: link,
+        realCommandPath: target,
+        platform: "win32",
+        commands: { winget },
+        probes: resolvedProbes,
+      }),
+      catalog,
+    );
+  return Effect.gen(function* () {
+    const installation = yield* resolve(probes);
+    expect(installation).toMatchObject({
+      label: "Managed by WinGet",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      update: {
+        executable: winget,
+        args: [
+          "upgrade",
+          "--id",
+          "OpenAI.Codex",
+          "--exact",
+          "--source",
+          "winget",
+          "--scope",
+          "user",
+          "--accept-source-agreements",
+          "--disable-interactivity",
+        ],
+      },
+    });
+    const failedShow = yield* resolve({
+      ...probes,
+      [showKey]: { stdout: "Error 1.9.0", stderr: "source unavailable", exitCode: 1 },
+    });
+    expect(failedShow.latestVersion).toBeNull();
+  });
+});
+
+it("parses WinGet portable ownership metadata including the original source", () => {
+  expect(
+    parseWingetPortableArp(`
+HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenAI.Codex
+    DisplayVersion    REG_SZ    1.2.3
+    WinGetPackageIdentifier    REG_SZ    OpenAI.Codex
+    WinGetSourceIdentifier    REG_SZ    private-source
+    SymlinkFullPath    REG_SZ    C:\\Users\\test\\AppData\\Local\\Microsoft\\WinGet\\Links\\codex.exe
+    TargetFullPath    REG_SZ    C:\\Users\\test\\AppData\\Local\\Microsoft\\WinGet\\Packages\\OpenAI.Codex\\codex.exe
+`),
+  ).toEqual([
+    {
+      displayVersion: "1.2.3",
+      packageId: "OpenAI.Codex",
+      sourceId: "private-source",
+      symlinkPath: "C:\\Users\\test\\AppData\\Local\\Microsoft\\WinGet\\Links\\codex.exe",
+      targetPath:
+        "C:\\Users\\test\\AppData\\Local\\Microsoft\\WinGet\\Packages\\OpenAI.Codex\\codex.exe",
+    },
+  ]);
+});
+
+it("maps a WinGet source identifier back to the CLI source name", () => {
+  expect(
+    parseWingetSources(
+      '{"Identifier":"StoreEdgeFD","Name":"msstore"}\n' +
+        '{"Identifier":"Microsoft.Winget.Source_8wekyb3d8bbwe","Name":"winget"}\n',
+    ),
+  ).toEqual([
+    { data: null, identifier: "StoreEdgeFD", name: "msstore" },
+    {
+      data: null,
+      identifier: "Microsoft.Winget.Source_8wekyb3d8bbwe",
+      name: "winget",
+    },
+  ]);
+});

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -51,7 +51,6 @@ function context(input: {
     provider,
     packageName: "@openai/codex",
     binaryPath: input.binaryPath,
-    isBareCommand: !input.binaryPath.includes("/") && !input.binaryPath.includes("\\"),
     resolvedCommandPath: input.resolvedCommandPath,
     realCommandPath: input.realCommandPath ?? input.resolvedCommandPath,
     environment: input.environment ?? { PATH: "test-path" },

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -74,7 +74,12 @@ it.effect("keeps native installation identity stable across versioned executable
     native: {
       label: "Managed by native installer",
       updateArgs: ["update"],
-      ownsPath: (path) => path.includes("/.local/share/codex/versions/"),
+      ownsPath: (path) => path.includes("/.codex/packages/standalone/releases/"),
+      identityRoot: (path) => {
+        const marker = "/.codex/packages/standalone/releases/";
+        const markerIndex = path.indexOf(marker);
+        return markerIndex < 0 ? null : path.slice(0, markerIndex + marker.length - 1);
+      },
     },
     instructionsUrl: "https://developers.openai.com/codex/cli/",
   });
@@ -84,7 +89,8 @@ it.effect("keeps native installation identity stable across versioned executable
       context({
         binaryPath: "codex",
         resolvedCommandPath,
-        realCommandPath: "/home/test/.local/share/codex/versions/1.0.0",
+        realCommandPath:
+          "/home/test/.codex/packages/standalone/releases/1.0.0-x86_64-unknown-linux-musl/bin/codex",
       }),
       nativeCatalog,
     );
@@ -92,14 +98,16 @@ it.effect("keeps native installation identity stable across versioned executable
       context({
         binaryPath: "codex",
         resolvedCommandPath,
-        realCommandPath: "/home/test/.local/share/codex/versions/1.1.0",
+        realCommandPath:
+          "/home/test/.codex/packages/standalone/releases/1.1.0-x86_64-unknown-linux-musl/bin/codex",
       }),
       nativeCatalog,
     );
 
     expect(before.identityKey).toBe(after.identityKey);
-    expect(before.update?.executable).toBe("/home/test/.local/share/codex/versions/1.0.0");
-    expect(after.update?.executable).toBe("/home/test/.local/share/codex/versions/1.1.0");
+    expect(before.lockKey).toBe(after.lockKey);
+    expect(before.update?.executable).toContain("/releases/1.0.0-");
+    expect(after.update?.executable).toContain("/releases/1.1.0-");
   });
 });
 

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -34,6 +34,7 @@ function context(input: {
   readonly resolvedCommandPath: string;
   readonly realCommandPath?: string;
   readonly platform?: NodeJS.Platform;
+  readonly environment?: NodeJS.ProcessEnv;
   readonly files?: Readonly<Record<string, string>>;
   readonly commands?: Readonly<Record<string, string>>;
   readonly probes?: Readonly<Record<string, MaintenanceProbeResult>>;
@@ -52,7 +53,7 @@ function context(input: {
     isBareCommand: !input.binaryPath.includes("/") && !input.binaryPath.includes("\\"),
     resolvedCommandPath: input.resolvedCommandPath,
     realCommandPath: input.realCommandPath ?? input.resolvedCommandPath,
-    environment: { PATH: "test-path" },
+    environment: input.environment ?? { PATH: "test-path" },
     platform: input.platform ?? "linux",
     readTextFile: (path) =>
       Effect.succeed(files.get(path.replaceAll("\\", "/").toLowerCase()) ?? null),
@@ -130,6 +131,46 @@ it.effect("proves Scoop ownership from the resolved shim and uses that Scoop and
         update: {
           executable: scoop,
           args: ["update", "custom/codex-nightly"],
+        },
+      });
+    }),
+  );
+});
+
+it.effect("proves a custom global Scoop root from Scoop configuration", () => {
+  const userRoot = "C:/Users/test/scoop";
+  const globalRoot = "D:/Shared/ScoopGlobal";
+  const shim = `${globalRoot}/shims/codex.exe`;
+  const scoop = `${userRoot}/shims/scoop.ps1`;
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: shim,
+      platform: "win32",
+      commands: { scoop },
+      files: {
+        [`${globalRoot}/shims/codex.shim`]: `path = "${globalRoot}/apps/codex/current/codex.exe"`,
+        [`${globalRoot}/apps/codex/current/install.json`]: JSON.stringify({ bucket: "main" }),
+        [`${globalRoot}/apps/codex/current/manifest.json`]: JSON.stringify({ version: "1.2.3" }),
+        [`${userRoot}/buckets/main/bucket/codex.json`]: JSON.stringify({ version: "1.3.0" }),
+      },
+      probes: {
+        [`${scoop} config global_path`]: {
+          stdout: globalRoot,
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by Scoop",
+        ownershipVerified: true,
+        update: {
+          executable: scoop,
+          args: ["update", "main/codex", "--global"],
         },
       });
     }),
@@ -547,6 +588,41 @@ it.effect("accepts Homebrew cask metadata with a scalar installed version", () =
         currentVersion: "0.149.1",
         latestVersion: "0.150.0",
         update: { executable: brew, args: ["upgrade", "codex"] },
+      });
+    }),
+  );
+});
+
+it.effect("derives a Homebrew alias from the verified Caskroom path", () => {
+  const brew = "/opt/homebrew/bin/brew";
+  const formula = "codex@latest";
+  const caskPrefix = `/opt/homebrew/Caskroom/${formula}`;
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: "/opt/homebrew/bin/codex",
+      realCommandPath: `${caskPrefix}/0.150.0/codex-aarch64-apple-darwin`,
+      commands: { brew },
+      probes: {
+        [`${brew} --prefix --installed ${formula}`]: { stdout: "", stderr: "", exitCode: 1 },
+        [`${brew} --caskroom ${formula}`]: { stdout: caskPrefix, stderr: "", exitCode: 0 },
+        [`${brew} info --json=v2 ${formula}`]: {
+          stdout: JSON.stringify({
+            casks: [{ installed: "0.150.0", version: "0.151.0" }],
+          }),
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by Homebrew",
+        currentVersion: "0.150.0",
+        latestVersion: "0.151.0",
+        update: { executable: brew, args: ["upgrade", formula] },
       });
     }),
   );

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -518,6 +518,40 @@ it.effect("proves Homebrew ownership and fails closed for unresolved shims", () 
   });
 });
 
+it.effect("accepts Homebrew cask metadata with a scalar installed version", () => {
+  const brew = "/opt/homebrew/bin/brew";
+  const caskPrefix = "/opt/homebrew/Caskroom/codex";
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: "/opt/homebrew/bin/codex",
+      realCommandPath: `${caskPrefix}/0.149.1/codex-aarch64-apple-darwin`,
+      commands: { brew },
+      probes: {
+        [`${brew} --prefix --installed codex`]: { stdout: "", stderr: "", exitCode: 1 },
+        [`${brew} --caskroom codex`]: { stdout: caskPrefix, stderr: "", exitCode: 0 },
+        [`${brew} info --json=v2 codex`]: {
+          stdout: JSON.stringify({
+            casks: [{ installed: "0.149.1", version: "0.150.0" }],
+          }),
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by Homebrew",
+        currentVersion: "0.149.1",
+        latestVersion: "0.150.0",
+        update: { executable: brew, args: ["upgrade", "codex"] },
+      });
+    }),
+  );
+});
+
 it.effect("keeps an unclassified explicit path manual-only", () =>
   resolveInstallation(
     context({

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -648,6 +648,11 @@ it.effect("proves WinGet ownership and updates through the mapped source name", 
         ],
       },
     });
+    const ascendingVersions = yield* resolve({
+      ...probes,
+      [showKey]: { stdout: "Version\n-------\n1.0.0\n1.1.0", stderr: "", exitCode: 0 },
+    });
+    expect(ascendingVersions.latestVersion).toBe("1.1.0");
     const failedShow = yield* resolve({
       ...probes,
       [showKey]: { stdout: "Error 1.9.0", stderr: "source unavailable", exitCode: 1 },

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -341,6 +341,30 @@ it.effect("rejects a nested npm package in a Windows global prefix", () => {
   );
 });
 
+it.effect("rejects a nested package inside a pnpm global root", () => {
+  const prefix = "/opt/pnpm";
+  const wrapper = `${prefix}/bin/codex`;
+  const managerRoot = `${prefix}/global/5/node_modules`;
+  const packageRoot = `${managerRoot}/host/node_modules/@openai/codex`;
+  const pnpm = `${prefix}/bin/pnpm`;
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: wrapper,
+    commands: { pnpm },
+    files: {
+      [wrapper]: `exec "$basedir/../global/5/node_modules/host/node_modules/@openai/codex/bin/codex.js" "$@"`,
+      [`${packageRoot}/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${pnpm} root -g`]: probe(managerRoot),
+    },
+  }).pipe(
+    Effect.map((installation) => {
+      expectManualInstallation(installation, true);
+    }),
+  );
+});
+
 it.effect("does not fall back to npm when a managed package path has no available owner", () =>
   resolveCatalog({
     binaryPath: "codex",
@@ -723,6 +747,36 @@ it.effect("does not classify a Linux /usr/local/bin executable as Homebrew", () 
     }),
   ),
 );
+
+it.effect("rejects Homebrew ownership from an unrelated formula", () => {
+  const brew = "/opt/homebrew/bin/brew";
+  const formulaPrefix = "/opt/homebrew/opt/other-tool";
+  const realFormulaPrefix = "/opt/homebrew/Cellar/other-tool/1.2.3";
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: "/opt/homebrew/bin/codex",
+    realCommandPath: `${realFormulaPrefix}/bin/codex`,
+    commands: { brew },
+    realPaths: { [formulaPrefix]: realFormulaPrefix },
+    probes: {
+      [`${brew} --prefix --installed other-tool`]: probe(formulaPrefix),
+      [`${brew} info --json=v2 other-tool`]: probe(
+        JSON.stringify({
+          formulae: [
+            {
+              installed: [{ version: "1.2.3" }],
+              versions: { stable: "1.2.4" },
+            },
+          ],
+        }),
+      ),
+    },
+  }).pipe(
+    Effect.map((installation) => {
+      expectManualInstallation(installation, true);
+    }),
+  );
+});
 
 it.effect("preserves a matching tap-qualified Homebrew formula", () => {
   const brew = "/opt/homebrew/bin/brew";

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -136,17 +136,49 @@ it.effect("proves Scoop ownership from the resolved shim and uses that Scoop and
   );
 });
 
-it.effect("uses npm only as the policy for an unknown bare command", () => {
-  const npm = "/usr/local/bin/npm";
+it.effect("keeps an unknown bare command manual-only", () => {
   return resolveInstallation(
     context({
       binaryPath: "codex",
       resolvedCommandPath: "/custom/bin/codex",
+      commands: { npm: "/usr/local/bin/npm" },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Unknown installation",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
+  );
+});
+
+it.effect("pins npm updates to the verified package prefix", () => {
+  const packagePrefix = "/opt/node-a";
+  const packageRoot = `${packagePrefix}/lib/node_modules/@openai/codex`;
+  const npm = "/opt/node-b/bin/npm";
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: `${packagePrefix}/bin/codex`,
+      realCommandPath: `${packageRoot}/bin/codex.js`,
       commands: { npm },
+      files: {
+        [`${packageRoot}/package.json`]: JSON.stringify({
+          name: "@openai/codex",
+          version: "1.0.0",
+        }),
+      },
       probes: {
-        [`${npm} root -g`]: { stdout: "/usr/local/lib/node_modules", stderr: "", exitCode: 0 },
+        [`${npm} root -g`]: {
+          stdout: "/opt/node-b/lib/node_modules",
+          stderr: "",
+          exitCode: 0,
+        },
         [`${npm} view @openai/codex@latest version --json`]: {
-          stdout: '"2.0.0"',
+          stdout: '"1.1.0"',
           stderr: "",
           exitCode: 0,
         },
@@ -155,16 +187,22 @@ it.effect("uses npm only as the policy for an unknown bare command", () => {
     catalog,
   ).pipe(
     Effect.map((installation) => {
-      expect(installation.label).toBe("Unknown installation — legacy npm fallback");
-      expect(installation.ownershipVerified).toBe(false);
-      expect(installation.update).toMatchObject({
-        executable: npm,
-        args: [
-          "install",
-          "-g",
-          "--allow-scripts=@openai/codex",
-          "@openai/codex@latest",
-        ],
+      expect(installation).toMatchObject({
+        label: "Managed by npm",
+        ownershipVerified: true,
+        currentVersion: "1.0.0",
+        latestVersion: "1.1.0",
+        update: {
+          executable: npm,
+          args: [
+            "install",
+            "-g",
+            "--prefix",
+            packagePrefix,
+            "--allow-scripts=@openai/codex",
+            "@openai/codex@latest",
+          ],
+        },
       });
     }),
   );
@@ -234,7 +272,17 @@ it.effect("proves npm ownership through a Windows global command wrapper", () =>
         ownershipVerified: true,
         currentVersion: "1.0.0",
         latestVersion: "1.1.0",
-        update: { executable: npm },
+        update: {
+          executable: npm,
+          args: [
+            "install",
+            "-g",
+            "--prefix",
+            prefix,
+            "--allow-scripts=@openai/codex",
+            "@openai/codex@latest",
+          ],
+        },
       });
     }),
   );

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -291,6 +291,79 @@ it.effect("pins npm updates to the verified package prefix", () => {
   );
 });
 
+it.effect("rejects an npm package nested under another global package", () => {
+  const prefix = "/opt/node";
+  const packageRoot = `${prefix}/lib/node_modules/host/node_modules/@openai/codex`;
+  const npm = `${prefix}/bin/npm`;
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: `${prefix}/bin/codex`,
+      realCommandPath: `${packageRoot}/bin/codex.js`,
+      commands: { npm },
+      files: {
+        [`${packageRoot}/package.json`]: JSON.stringify({
+          name: "@openai/codex",
+          version: "1.0.0",
+        }),
+      },
+      probes: {
+        [`${npm} root -g`]: {
+          stdout: `${prefix}/lib/node_modules`,
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Unknown installation — verification failed",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
+  );
+});
+
+it.effect("rejects a nested npm package in a Windows global prefix", () => {
+  const prefix = "C:/Users/test/AppData/Roaming/npm";
+  const packageRoot = `${prefix}/node_modules/host/node_modules/@openai/codex`;
+  const npm = `${prefix}/npm.cmd`;
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: `${prefix}/codex.cmd`,
+      realCommandPath: `${packageRoot}/bin/codex.js`,
+      platform: "win32",
+      commands: { npm },
+      files: {
+        [`${packageRoot}/package.json`]: JSON.stringify({
+          name: "@openai/codex",
+          version: "1.0.0",
+        }),
+      },
+      probes: {
+        [`${npm} root -g`]: {
+          stdout: `${prefix}/node_modules`,
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Unknown installation — verification failed",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
+  );
+});
+
 it.effect("does not fall back to npm when a managed package path has no available owner", () =>
   resolveInstallation(
     context({

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -6,6 +6,7 @@ import {
   canonicalPath,
   type InstallationContext,
   type MaintenanceProbeResult,
+  type ResolvedInstallation,
 } from "./definition.ts";
 import {
   makeProviderInstallationCatalog,
@@ -29,7 +30,7 @@ it("preserves valid backslashes in POSIX filenames", () => {
   expect(canonicalPath("/tmp/provider\\name", "linux")).toBe("/tmp/provider\\name");
 });
 
-function context(input: {
+interface TestContextInput {
   readonly binaryPath: string;
   readonly resolvedCommandPath: string;
   readonly realCommandPath?: string;
@@ -40,7 +41,9 @@ function context(input: {
   readonly probes?: Readonly<Record<string, MaintenanceProbeResult>>;
   readonly realPaths?: Readonly<Record<string, string>>;
   readonly textFileReads?: Array<{ readonly path: string; readonly maxBytes?: number }>;
-}): InstallationContext {
+}
+
+function context(input: TestContextInput): InstallationContext {
   const files = new Map(
     Object.entries(input.files ?? {}).map(([path, value]) => [
       path.replaceAll("\\", "/").toLowerCase(),
@@ -70,6 +73,26 @@ function context(input: {
     run: (executable, args) =>
       Effect.succeed(input.probes?.[`${executable} ${args.join(" ")}`] ?? null),
   };
+}
+
+const resolveCatalog = (input: TestContextInput) => resolveInstallation(context(input), catalog);
+
+const probe = (stdout: string, exitCode = 0, stderr = ""): MaintenanceProbeResult => ({
+  stdout,
+  stderr,
+  exitCode,
+});
+
+const packageManifest = (version: string) => JSON.stringify({ name: "@openai/codex", version });
+
+function expectManualInstallation(installation: ResolvedInstallation, verificationFailed = false) {
+  expect(installation).toMatchObject({
+    label: verificationFailed
+      ? "Unknown installation — verification failed"
+      : "Unknown installation",
+    ownershipVerified: false,
+    update: null,
+  });
 }
 
 it.effect("keeps native installation identity stable across versioned executable targets", () => {
@@ -122,21 +145,18 @@ it.effect("proves Scoop ownership from the resolved shim and uses that Scoop and
   const root = "C:/Users/test/scoop";
   const shim = `${root}/shims/codex.exe`;
   const scoop = `${root}/shims/scoop.ps1`;
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: shim,
-      platform: "win32",
-      commands: { scoop },
-      files: {
-        [`${root}/shims/codex.shim`]: `path = "${root}/apps/codex-nightly/current/codex.exe"`,
-        [`${root}/apps/codex-nightly/current/install.json`]: JSON.stringify({ bucket: "custom" }),
-        [`${root}/apps/codex-nightly/current/manifest.json`]: JSON.stringify({ version: "1.2.3" }),
-        [`${root}/buckets/custom/bucket/codex-nightly.json`]: JSON.stringify({ version: "1.3.0" }),
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: shim,
+    platform: "win32",
+    commands: { scoop },
+    files: {
+      [`${root}/shims/codex.shim`]: `path = "${root}/apps/codex-nightly/current/codex.exe"`,
+      [`${root}/apps/codex-nightly/current/install.json`]: JSON.stringify({ bucket: "custom" }),
+      [`${root}/apps/codex-nightly/current/manifest.json`]: JSON.stringify({ version: "1.2.3" }),
+      [`${root}/buckets/custom/bucket/codex-nightly.json`]: JSON.stringify({ version: "1.3.0" }),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by Scoop",
@@ -157,28 +177,21 @@ it.effect("proves a custom global Scoop root from Scoop configuration", () => {
   const globalRoot = "D:/Shared/ScoopGlobal";
   const shim = `${globalRoot}/shims/codex.exe`;
   const scoop = `${userRoot}/shims/scoop.ps1`;
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: shim,
-      platform: "win32",
-      commands: { scoop },
-      files: {
-        [`${globalRoot}/shims/codex.shim`]: `path = "${globalRoot}/apps/codex/current/codex.exe"`,
-        [`${globalRoot}/apps/codex/current/install.json`]: JSON.stringify({ bucket: "main" }),
-        [`${globalRoot}/apps/codex/current/manifest.json`]: JSON.stringify({ version: "1.2.3" }),
-        [`${userRoot}/buckets/main/bucket/codex.json`]: JSON.stringify({ version: "1.3.0" }),
-      },
-      probes: {
-        [`${scoop} config global_path`]: {
-          stdout: globalRoot,
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: shim,
+    platform: "win32",
+    commands: { scoop },
+    files: {
+      [`${globalRoot}/shims/codex.shim`]: `path = "${globalRoot}/apps/codex/current/codex.exe"`,
+      [`${globalRoot}/apps/codex/current/install.json`]: JSON.stringify({ bucket: "main" }),
+      [`${globalRoot}/apps/codex/current/manifest.json`]: JSON.stringify({ version: "1.2.3" }),
+      [`${userRoot}/buckets/main/bucket/codex.json`]: JSON.stringify({ version: "1.3.0" }),
+    },
+    probes: {
+      [`${scoop} config global_path`]: probe(globalRoot),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by Scoop",
@@ -198,32 +211,25 @@ it.effect("treats SCOOP_GLOBAL as authoritative over Scoop configuration", () =>
   const environmentGlobalRoot = "E:/Authoritative/ScoopGlobal";
   const shim = `${observedGlobalRoot}/shims/codex.exe`;
   const scoop = `${userRoot}/shims/scoop.ps1`;
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: shim,
-      platform: "win32",
-      environment: { PATH: "test-path", SCOOP_GLOBAL: environmentGlobalRoot },
-      commands: { scoop },
-      files: {
-        [`${observedGlobalRoot}/shims/codex.shim`]: `path = "${observedGlobalRoot}/apps/codex/current/codex.exe"`,
-        [`${observedGlobalRoot}/apps/codex/current/install.json`]: JSON.stringify({
-          bucket: "main",
-        }),
-        [`${observedGlobalRoot}/apps/codex/current/manifest.json`]: JSON.stringify({
-          version: "1.2.3",
-        }),
-      },
-      probes: {
-        [`${scoop} config global_path`]: {
-          stdout: observedGlobalRoot,
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: shim,
+    platform: "win32",
+    environment: { PATH: "test-path", SCOOP_GLOBAL: environmentGlobalRoot },
+    commands: { scoop },
+    files: {
+      [`${observedGlobalRoot}/shims/codex.shim`]: `path = "${observedGlobalRoot}/apps/codex/current/codex.exe"`,
+      [`${observedGlobalRoot}/apps/codex/current/install.json`]: JSON.stringify({
+        bucket: "main",
+      }),
+      [`${observedGlobalRoot}/apps/codex/current/manifest.json`]: JSON.stringify({
+        version: "1.2.3",
+      }),
+    },
+    probes: {
+      [`${scoop} config global_path`]: probe(observedGlobalRoot),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Unknown installation — verification failed",
@@ -235,20 +241,13 @@ it.effect("treats SCOOP_GLOBAL as authoritative over Scoop configuration", () =>
 });
 
 it.effect("keeps an unknown bare command manual-only", () => {
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: "/custom/bin/codex",
-      commands: { npm: "/usr/local/bin/npm" },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: "/custom/bin/codex",
+    commands: { npm: "/usr/local/bin/npm" },
+  }).pipe(
     Effect.map((installation) => {
-      expect(installation).toMatchObject({
-        label: "Unknown installation",
-        ownershipVerified: false,
-        update: null,
-      });
+      expectManualInstallation(installation);
     }),
   );
 });
@@ -257,33 +256,19 @@ it.effect("pins npm updates to the verified package prefix", () => {
   const packagePrefix = "/opt/node-a";
   const packageRoot = `${packagePrefix}/lib/node_modules/@openai/codex`;
   const npm = "/opt/node-b/bin/npm";
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: `${packagePrefix}/bin/codex`,
-      realCommandPath: `${packageRoot}/bin/codex.js`,
-      commands: { npm },
-      files: {
-        [`${packageRoot}/package.json`]: JSON.stringify({
-          name: "@openai/codex",
-          version: "1.0.0",
-        }),
-      },
-      probes: {
-        [`${npm} root -g`]: {
-          stdout: "/opt/node-b/lib/node_modules",
-          stderr: "",
-          exitCode: 0,
-        },
-        [`${npm} view @openai/codex@latest version --json`]: {
-          stdout: '"1.1.0"',
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: `${packagePrefix}/bin/codex`,
+    realCommandPath: `${packageRoot}/bin/codex.js`,
+    commands: { npm },
+    files: {
+      [`${packageRoot}/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${npm} root -g`]: probe("/opt/node-b/lib/node_modules"),
+      [`${npm} view @openai/codex@latest version --json`]: probe('"1.1.0"'),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by npm",
@@ -310,34 +295,20 @@ it.effect("rejects an npm package nested under another global package", () => {
   const prefix = "/opt/node";
   const packageRoot = `${prefix}/lib/node_modules/host/node_modules/@openai/codex`;
   const npm = `${prefix}/bin/npm`;
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: `${prefix}/bin/codex`,
-      realCommandPath: `${packageRoot}/bin/codex.js`,
-      commands: { npm },
-      files: {
-        [`${packageRoot}/package.json`]: JSON.stringify({
-          name: "@openai/codex",
-          version: "1.0.0",
-        }),
-      },
-      probes: {
-        [`${npm} root -g`]: {
-          stdout: `${prefix}/lib/node_modules`,
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: `${prefix}/bin/codex`,
+    realCommandPath: `${packageRoot}/bin/codex.js`,
+    commands: { npm },
+    files: {
+      [`${packageRoot}/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${npm} root -g`]: probe(`${prefix}/lib/node_modules`),
+    },
+  }).pipe(
     Effect.map((installation) => {
-      expect(installation).toMatchObject({
-        label: "Unknown installation — verification failed",
-        ownershipVerified: false,
-        update: null,
-      });
+      expectManualInstallation(installation, true);
     }),
   );
 });
@@ -346,61 +317,36 @@ it.effect("rejects a nested npm package in a Windows global prefix", () => {
   const prefix = "C:/Users/test/AppData/Roaming/npm";
   const packageRoot = `${prefix}/node_modules/host/node_modules/@openai/codex`;
   const npm = `${prefix}/npm.cmd`;
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: `${prefix}/codex.cmd`,
-      realCommandPath: `${packageRoot}/bin/codex.js`,
-      platform: "win32",
-      commands: { npm },
-      files: {
-        [`${packageRoot}/package.json`]: JSON.stringify({
-          name: "@openai/codex",
-          version: "1.0.0",
-        }),
-      },
-      probes: {
-        [`${npm} root -g`]: {
-          stdout: `${prefix}/node_modules`,
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: `${prefix}/codex.cmd`,
+    realCommandPath: `${packageRoot}/bin/codex.js`,
+    platform: "win32",
+    commands: { npm },
+    files: {
+      [`${packageRoot}/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${npm} root -g`]: probe(`${prefix}/node_modules`),
+    },
+  }).pipe(
     Effect.map((installation) => {
-      expect(installation).toMatchObject({
-        label: "Unknown installation — verification failed",
-        ownershipVerified: false,
-        update: null,
-      });
+      expectManualInstallation(installation, true);
     }),
   );
 });
 
 it.effect("does not fall back to npm when a managed package path has no available owner", () =>
-  resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: "/opt/node/lib/node_modules/@openai/codex/bin/codex.js",
-      commands: { npm: "/usr/local/bin/npm" },
-      probes: {
-        "/usr/local/bin/npm root -g": {
-          stdout: "/usr/local/lib/node_modules",
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: "/opt/node/lib/node_modules/@openai/codex/bin/codex.js",
+    commands: { npm: "/usr/local/bin/npm" },
+    probes: {
+      "/usr/local/bin/npm root -g": probe("/usr/local/lib/node_modules"),
+    },
+  }).pipe(
     Effect.map((installation) => {
-      expect(installation).toMatchObject({
-        label: "Unknown installation — verification failed",
-        ownershipVerified: false,
-        update: null,
-      });
+      expectManualInstallation(installation, true);
     }),
   ),
 );
@@ -408,35 +354,21 @@ it.effect("does not fall back to npm when a managed package path has no availabl
 it.effect("proves npm ownership through a Windows global command wrapper", () => {
   const prefix = "C:/Users/test/AppData/Roaming/npm";
   const npm = `${prefix}/npm.cmd`;
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: `${prefix}/codex.cmd`,
-      platform: "win32",
-      commands: { npm },
-      files: {
-        [`${prefix}/codex.cmd`]:
-          '@IF EXIST "%~dp0\\node.exe" ("%~dp0\\node.exe" "%~dp0\\node_modules\\@openai\\codex\\bin\\codex.js")',
-        [`${prefix}/node_modules/@openai/codex/package.json`]: JSON.stringify({
-          name: "@openai/codex",
-          version: "1.0.0",
-        }),
-      },
-      probes: {
-        [`${npm} root -g`]: {
-          stdout: `${prefix}/node_modules`,
-          stderr: "",
-          exitCode: 0,
-        },
-        [`${npm} view @openai/codex@latest version --json`]: {
-          stdout: '"1.1.0"',
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: `${prefix}/codex.cmd`,
+    platform: "win32",
+    commands: { npm },
+    files: {
+      [`${prefix}/codex.cmd`]:
+        '@IF EXIST "%~dp0\\node.exe" ("%~dp0\\node.exe" "%~dp0\\node_modules\\@openai\\codex\\bin\\codex.js")',
+      [`${prefix}/node_modules/@openai/codex/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${npm} root -g`]: probe(`${prefix}/node_modules`),
+      [`${npm} view @openai/codex@latest version --json`]: probe('"1.1.0"'),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by npm",
@@ -465,35 +397,21 @@ it.effect("reads a POSIX package wrapper once across Node manager probes", () =>
   const packageRoot = `${prefix}/share/pnpm/global/v5/node_modules/@openai/codex`;
   const pnpm = `${prefix}/bin/pnpm`;
   const textFileReads: Array<{ readonly path: string; readonly maxBytes?: number }> = [];
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: wrapper,
-      commands: { pnpm },
-      textFileReads,
-      files: {
-        [wrapper]:
-          '#!/bin/sh\nexec "$basedir/../share/pnpm/global/v5/node_modules/@openai/codex/bin/codex.js" "$@"',
-        [`${packageRoot}/package.json`]: JSON.stringify({
-          name: "@openai/codex",
-          version: "1.0.0",
-        }),
-      },
-      probes: {
-        [`${pnpm} root -g`]: {
-          stdout: `${prefix}/share/pnpm/global/v5/node_modules`,
-          stderr: "",
-          exitCode: 0,
-        },
-        [`${pnpm} view @openai/codex@latest version --json`]: {
-          stdout: '"1.1.0"',
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: wrapper,
+    commands: { pnpm },
+    textFileReads,
+    files: {
+      [wrapper]:
+        '#!/bin/sh\nexec "$basedir/../share/pnpm/global/v5/node_modules/@openai/codex/bin/codex.js" "$@"',
+      [`${packageRoot}/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${pnpm} root -g`]: probe(`${prefix}/share/pnpm/global/v5/node_modules`),
+      [`${pnpm} view @openai/codex@latest version --json`]: probe('"1.1.0"'),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by pnpm",
@@ -510,23 +428,16 @@ it.effect("reads a POSIX package wrapper once across Node manager probes", () =>
 it.effect("skips oversized command wrappers without weakening ownership", () => {
   const wrapper = "/home/test/.local/bin/codex";
   const textFileReads: Array<{ readonly path: string; readonly maxBytes?: number }> = [];
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: wrapper,
-      textFileReads,
-      files: {
-        [wrapper]: `${"x".repeat(64 * 1_024)}\n/node_modules/@openai/codex/bin/codex.js`,
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: wrapper,
+    textFileReads,
+    files: {
+      [wrapper]: `${"x".repeat(64 * 1_024)}\n/node_modules/@openai/codex/bin/codex.js`,
+    },
+  }).pipe(
     Effect.map((installation) => {
-      expect(installation).toMatchObject({
-        label: "Unknown installation",
-        ownershipVerified: false,
-        update: null,
-      });
+      expectManualInstallation(installation);
       expect(textFileReads).toEqual([{ path: wrapper, maxBytes: 64 * 1_024 }]);
     }),
   );
@@ -537,25 +448,19 @@ it.effect("does not match a wrapper for a package with a shared name prefix", ()
   const npm = `${prefix}/npm.cmd`;
   const wrapper = `${prefix}/codex.cmd`;
   const packageRoot = `${prefix}/node_modules/@openai/codex`;
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: wrapper,
-      platform: "win32",
-      commands: { npm },
-      files: {
-        [wrapper]: `node  "%~dp0\\node_modules\\@openai\\codex-malicious\\bin\\codex.js" %*`,
-        [`${packageRoot}/package.json`]: JSON.stringify({
-          name: "@openai/codex",
-          version: "1.0.0",
-        }),
-      },
-      probes: {
-        [`${npm} root -g`]: { stdout: `${prefix}/node_modules`, stderr: "", exitCode: 0 },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: wrapper,
+    platform: "win32",
+    commands: { npm },
+    files: {
+      [wrapper]: `node  "%~dp0\\node_modules\\@openai\\codex-malicious\\bin\\codex.js" %*`,
+      [`${packageRoot}/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${npm} root -g`]: probe(`${prefix}/node_modules`),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation.update).toBeNull();
       expect(installation.ownershipVerified).toBe(false);
@@ -567,35 +472,21 @@ it.effect("resolves a pnpm Windows wrapper into its versioned global package roo
   const home = "C:/Users/test/AppData/Local/pnpm";
   const packageRoot = `${home}/global/v11/hash/node_modules/@openai/codex`;
   const pnpm = "C:/Users/test/scoop/shims/pnpm.exe";
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: `${home}/bin/codex.CMD`,
-      platform: "win32",
-      commands: { pnpm },
-      files: {
-        [`${home}/bin/codex.CMD`]:
-          '@"%~dp0\\..\\global\\v11\\hash\\node_modules\\@openai\\codex\\bin\\codex.exe" %*',
-        [`${packageRoot}/package.json`]: JSON.stringify({
-          name: "@openai/codex",
-          version: "1.0.0",
-        }),
-      },
-      probes: {
-        [`${pnpm} root -g`]: {
-          stdout: `${home}/global/v11`,
-          stderr: "",
-          exitCode: 0,
-        },
-        [`${pnpm} view @openai/codex@latest version --json`]: {
-          stdout: '"1.1.0"',
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: `${home}/bin/codex.CMD`,
+    platform: "win32",
+    commands: { pnpm },
+    files: {
+      [`${home}/bin/codex.CMD`]:
+        '@"%~dp0\\..\\global\\v11\\hash\\node_modules\\@openai\\codex\\bin\\codex.exe" %*',
+      [`${packageRoot}/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${pnpm} root -g`]: probe(`${home}/global/v11`),
+      [`${pnpm} view @openai/codex@latest version --json`]: probe('"1.1.0"'),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by pnpm",
@@ -612,38 +503,24 @@ it.effect("proves npm ownership across a Scoop Node persistent-bin junction", ()
   const persistentBin = "C:/Users/test/scoop/persist/nodejs-lts/bin";
   const packageRoot = `${persistentBin}/node_modules/@openai/codex`;
   const npm = "C:/Users/test/scoop/apps/nodejs-lts/current/npm.cmd";
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: `${currentBin}/codex.cmd`,
-      platform: "win32",
-      commands: { npm },
-      realPaths: {
-        [`${currentBin}/node_modules/@openai/codex`.toLowerCase()]: packageRoot,
-      },
-      files: {
-        [`${currentBin}/codex.cmd`]:
-          '@ECHO off\nSET dp0=%~dp0\n"%dp0%\\node_modules\\@openai\\codex\\bin\\codex.exe" %*',
-        [`${packageRoot}/package.json`]: JSON.stringify({
-          name: "@openai/codex",
-          version: "1.0.0",
-        }),
-      },
-      probes: {
-        [`${npm} root -g`]: {
-          stdout: `${persistentBin}/node_modules`,
-          stderr: "",
-          exitCode: 0,
-        },
-        [`${npm} view @openai/codex@latest version --json`]: {
-          stdout: '"1.1.0"',
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: `${currentBin}/codex.cmd`,
+    platform: "win32",
+    commands: { npm },
+    realPaths: {
+      [`${currentBin}/node_modules/@openai/codex`.toLowerCase()]: packageRoot,
+    },
+    files: {
+      [`${currentBin}/codex.cmd`]:
+        '@ECHO off\nSET dp0=%~dp0\n"%dp0%\\node_modules\\@openai\\codex\\bin\\codex.exe" %*',
+      [`${packageRoot}/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${npm} root -g`]: probe(`${persistentBin}/node_modules`),
+      [`${npm} view @openai/codex@latest version --json`]: probe('"1.1.0"'),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by npm",
@@ -659,29 +536,19 @@ it.effect("proves npm ownership across a Scoop Node persistent-bin junction", ()
 it.effect("proves Bun ownership for its copied Windows global executable", () => {
   const home = "C:/Users/test/.bun";
   const bun = `${home}/bin/bun.exe`;
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: `${home}/bin/codex.exe`,
-      platform: "win32",
-      commands: { bun },
-      files: {
-        [`${home}/install/global/node_modules/@openai/codex/package.json`]: JSON.stringify({
-          name: "@openai/codex",
-          version: "1.0.0",
-        }),
-      },
-      probes: {
-        [`${bun} pm bin -g`]: { stdout: `${home}/bin`, stderr: "", exitCode: 0 },
-        [`${bun} pm view @openai/codex version`]: {
-          stdout: "1.1.0",
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: `${home}/bin/codex.exe`,
+    platform: "win32",
+    commands: { bun },
+    files: {
+      [`${home}/install/global/node_modules/@openai/codex/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${bun} pm bin -g`]: probe(`${home}/bin`),
+      [`${bun} pm view @openai/codex version`]: probe("1.1.0"),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by Bun",
@@ -698,36 +565,27 @@ it.effect("proves Homebrew ownership and fails closed for unresolved shims", () 
   const resolve = (version: string) => {
     const formulaPrefix = "/opt/homebrew/opt/codex";
     const realFormulaPrefix = `/opt/homebrew/Cellar/codex/${version}`;
-    return resolveInstallation(
-      context({
-        binaryPath: "codex",
-        resolvedCommandPath: "/opt/homebrew/bin/codex",
-        realCommandPath: `${realFormulaPrefix}/bin/codex`,
-        commands: { brew },
-        realPaths: { [formulaPrefix]: realFormulaPrefix },
-        probes: {
-          [`${brew} --prefix --installed codex`]: {
-            stdout: formulaPrefix,
-            stderr: "",
-            exitCode: 0,
-          },
-          [`${brew} --caskroom codex`]: { stdout: "", stderr: "", exitCode: 1 },
-          [`${brew} info --json=v2 codex`]: {
-            stdout: JSON.stringify({
-              formulae: [
-                {
-                  installed: [{ version }],
-                  versions: { stable: "1.1.0" },
-                },
-              ],
-            }),
-            stderr: "",
-            exitCode: 0,
-          },
-        },
-      }),
-      catalog,
-    );
+    return resolveCatalog({
+      binaryPath: "codex",
+      resolvedCommandPath: "/opt/homebrew/bin/codex",
+      realCommandPath: `${realFormulaPrefix}/bin/codex`,
+      commands: { brew },
+      realPaths: { [formulaPrefix]: realFormulaPrefix },
+      probes: {
+        [`${brew} --prefix --installed codex`]: probe(formulaPrefix),
+        [`${brew} --caskroom codex`]: probe("", 1),
+        [`${brew} info --json=v2 codex`]: probe(
+          JSON.stringify({
+            formulae: [
+              {
+                installed: [{ version }],
+                versions: { stable: "1.1.0" },
+              },
+            ],
+          }),
+        ),
+      },
+    });
   };
   return Effect.gen(function* () {
     const before = yield* resolve("1.0.0");
@@ -741,52 +599,36 @@ it.effect("proves Homebrew ownership and fails closed for unresolved shims", () 
     expect(after.identityKey).toBe(before.identityKey);
     expect(after.lockKey).toBe(before.lockKey);
 
-    const unresolved = yield* resolveInstallation(
-      context({
-        binaryPath: "codex",
-        resolvedCommandPath: "/opt/homebrew/bin/codex",
-        commands: { npm: "/usr/local/bin/npm" },
-        probes: {
-          "/usr/local/bin/npm root -g": {
-            stdout: "/usr/local/lib/node_modules",
-            stderr: "",
-            exitCode: 0,
-          },
-        },
-      }),
-      catalog,
-    );
-    expect(unresolved).toMatchObject({
-      label: "Unknown installation — verification failed",
-      ownershipVerified: false,
-      update: null,
+    const unresolved = yield* resolveCatalog({
+      binaryPath: "codex",
+      resolvedCommandPath: "/opt/homebrew/bin/codex",
+      commands: { npm: "/usr/local/bin/npm" },
+      probes: {
+        "/usr/local/bin/npm root -g": probe("/usr/local/lib/node_modules"),
+      },
     });
+    expectManualInstallation(unresolved, true);
   });
 });
 
 it.effect("accepts Homebrew cask metadata with a scalar installed version", () => {
   const brew = "/opt/homebrew/bin/brew";
   const caskPrefix = "/opt/homebrew/Caskroom/codex";
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: "/opt/homebrew/bin/codex",
-      realCommandPath: `${caskPrefix}/0.149.1/codex-aarch64-apple-darwin`,
-      commands: { brew },
-      probes: {
-        [`${brew} --prefix --installed codex`]: { stdout: "", stderr: "", exitCode: 1 },
-        [`${brew} --caskroom codex`]: { stdout: caskPrefix, stderr: "", exitCode: 0 },
-        [`${brew} info --json=v2 codex`]: {
-          stdout: JSON.stringify({
-            casks: [{ installed: "0.149.1", version: "0.150.0" }],
-          }),
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: "/opt/homebrew/bin/codex",
+    realCommandPath: `${caskPrefix}/0.149.1/codex-aarch64-apple-darwin`,
+    commands: { brew },
+    probes: {
+      [`${brew} --prefix --installed codex`]: probe("", 1),
+      [`${brew} --caskroom codex`]: probe(caskPrefix),
+      [`${brew} info --json=v2 codex`]: probe(
+        JSON.stringify({
+          casks: [{ installed: "0.149.1", version: "0.150.0" }],
+        }),
+      ),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by Homebrew",
@@ -803,37 +645,28 @@ it.effect("uses cask metadata and updates when formula and cask names collide", 
   const formulaPrefix = "/opt/homebrew/opt/codex";
   const realFormulaPrefix = "/opt/homebrew/Cellar/codex/9.0.0";
   const caskPrefix = "/opt/homebrew/Caskroom/codex";
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: "/opt/homebrew/bin/codex",
-      realCommandPath: `${caskPrefix}/0.149.1/codex-aarch64-apple-darwin`,
-      commands: { brew },
-      realPaths: { [formulaPrefix]: realFormulaPrefix },
-      probes: {
-        [`${brew} --prefix --installed codex`]: {
-          stdout: formulaPrefix,
-          stderr: "",
-          exitCode: 0,
-        },
-        [`${brew} --caskroom codex`]: { stdout: caskPrefix, stderr: "", exitCode: 0 },
-        [`${brew} info --json=v2 codex`]: {
-          stdout: JSON.stringify({
-            formulae: [
-              {
-                installed: [{ version: "9.0.0" }],
-                versions: { stable: "9.1.0" },
-              },
-            ],
-            casks: [{ installed: ["0.149.1"], version: "0.150.0" }],
-          }),
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: "/opt/homebrew/bin/codex",
+    realCommandPath: `${caskPrefix}/0.149.1/codex-aarch64-apple-darwin`,
+    commands: { brew },
+    realPaths: { [formulaPrefix]: realFormulaPrefix },
+    probes: {
+      [`${brew} --prefix --installed codex`]: probe(formulaPrefix),
+      [`${brew} --caskroom codex`]: probe(caskPrefix),
+      [`${brew} info --json=v2 codex`]: probe(
+        JSON.stringify({
+          formulae: [
+            {
+              installed: [{ version: "9.0.0" }],
+              versions: { stable: "9.1.0" },
+            },
+          ],
+          casks: [{ installed: ["0.149.1"], version: "0.150.0" }],
+        }),
+      ),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by Homebrew",
@@ -853,26 +686,21 @@ it.effect("derives a Homebrew alias from the verified Caskroom path", () => {
   const brew = "/opt/homebrew/bin/brew";
   const formula = "codex@latest";
   const caskPrefix = `/opt/homebrew/Caskroom/${formula}`;
-  return resolveInstallation(
-    context({
-      binaryPath: "codex",
-      resolvedCommandPath: "/opt/homebrew/bin/codex",
-      realCommandPath: `${caskPrefix}/0.150.0/codex-aarch64-apple-darwin`,
-      commands: { brew },
-      probes: {
-        [`${brew} --prefix --installed ${formula}`]: { stdout: "", stderr: "", exitCode: 1 },
-        [`${brew} --caskroom ${formula}`]: { stdout: caskPrefix, stderr: "", exitCode: 0 },
-        [`${brew} info --json=v2 ${formula}`]: {
-          stdout: JSON.stringify({
-            casks: [{ installed: "0.150.0", version: "0.151.0" }],
-          }),
-          stderr: "",
-          exitCode: 0,
-        },
-      },
-    }),
-    catalog,
-  ).pipe(
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: "/opt/homebrew/bin/codex",
+    realCommandPath: `${caskPrefix}/0.150.0/codex-aarch64-apple-darwin`,
+    commands: { brew },
+    probes: {
+      [`${brew} --prefix --installed ${formula}`]: probe("", 1),
+      [`${brew} --caskroom ${formula}`]: probe(caskPrefix),
+      [`${brew} info --json=v2 ${formula}`]: probe(
+        JSON.stringify({
+          casks: [{ installed: "0.150.0", version: "0.151.0" }],
+        }),
+      ),
+    },
+  }).pipe(
     Effect.map((installation) => {
       expect(installation).toMatchObject({
         label: "Managed by Homebrew",
@@ -885,20 +713,13 @@ it.effect("derives a Homebrew alias from the verified Caskroom path", () => {
 });
 
 it.effect("keeps an unclassified explicit path manual-only", () =>
-  resolveInstallation(
-    context({
-      binaryPath: "/custom/bin/codex",
-      resolvedCommandPath: "/custom/bin/codex",
-      commands: { npm: "/usr/local/bin/npm" },
-    }),
-    catalog,
-  ).pipe(
+  resolveCatalog({
+    binaryPath: "/custom/bin/codex",
+    resolvedCommandPath: "/custom/bin/codex",
+    commands: { npm: "/usr/local/bin/npm" },
+  }).pipe(
     Effect.map((installation) => {
-      expect(installation).toMatchObject({
-        label: "Unknown installation",
-        ownershipVerified: false,
-        update: null,
-      });
+      expectManualInstallation(installation);
     }),
   ),
 );
@@ -912,52 +733,28 @@ it.effect("proves WinGet ownership and updates through the mapped source name", 
     "C:\\Users\\test\\AppData\\Local\\Microsoft\\WinGet\\Packages\\OpenAI.Codex_Microsoft.Winget.Source_8wekyb3d8bbwe\\codex.exe";
   const winget = "C:\\Users\\test\\AppData\\Local\\Microsoft\\WindowsApps\\winget.exe";
   const probes: Record<string, MaintenanceProbeResult> = {
-    [`${reg} query HKCU\\${uninstall} /s /f OpenAI.Codex /d /e /reg:64`]: {
-      stdout: key,
-      stderr: "",
-      exitCode: 0,
-    },
-    [`${reg} query HKLM\\${uninstall} /s /f OpenAI.Codex /d /e /reg:64`]: {
-      stdout: "",
-      stderr: "",
-      exitCode: 1,
-    },
-    [`${reg} query HKLM\\${uninstall} /s /f OpenAI.Codex /d /e /reg:32`]: {
-      stdout: "",
-      stderr: "",
-      exitCode: 1,
-    },
-    [`${reg} query ${key} /reg:64`]: {
-      stdout: `${key}\n    DisplayVersion    REG_SZ    1.0.0\n    WinGetPackageIdentifier    REG_SZ    OpenAI.Codex\n    WinGetSourceIdentifier    REG_SZ    Microsoft.Winget.Source_8wekyb3d8bbwe\n    SymlinkFullPath    REG_SZ    ${link}\n    TargetFullPath    REG_SZ    ${target}`,
-      stderr: "",
-      exitCode: 0,
-    },
-    [`${winget} source export --disable-interactivity`]: {
-      stdout:
-        '{"Data":"Microsoft.Winget.Source_8wekyb3d8bbwe","Identifier":"Microsoft.Winget.Source_8wekyb3d8bbwe","Name":"winget"}',
-      stderr: "",
-      exitCode: 0,
-    },
+    [`${reg} query HKCU\\${uninstall} /s /f OpenAI.Codex /d /e /reg:64`]: probe(key),
+    [`${reg} query HKLM\\${uninstall} /s /f OpenAI.Codex /d /e /reg:64`]: probe("", 1),
+    [`${reg} query HKLM\\${uninstall} /s /f OpenAI.Codex /d /e /reg:32`]: probe("", 1),
+    [`${reg} query ${key} /reg:64`]: probe(
+      `${key}\n    DisplayVersion    REG_SZ    1.0.0\n    WinGetPackageIdentifier    REG_SZ    OpenAI.Codex\n    WinGetSourceIdentifier    REG_SZ    Microsoft.Winget.Source_8wekyb3d8bbwe\n    SymlinkFullPath    REG_SZ    ${link}\n    TargetFullPath    REG_SZ    ${target}`,
+    ),
+    [`${winget} source export --disable-interactivity`]: probe(
+      '{"Data":"Microsoft.Winget.Source_8wekyb3d8bbwe","Identifier":"Microsoft.Winget.Source_8wekyb3d8bbwe","Name":"winget"}',
+    ),
     [`${winget} show --id OpenAI.Codex --exact --source winget --versions --accept-source-agreements --disable-interactivity`]:
-      {
-        stdout: "Version\n-------\n1.1.0\n1.0.0",
-        stderr: "",
-        exitCode: 0,
-      },
+      probe("Version\n-------\n1.1.0\n1.0.0"),
   };
   const showKey = `${winget} show --id OpenAI.Codex --exact --source winget --versions --accept-source-agreements --disable-interactivity`;
   const resolve = (resolvedProbes: Readonly<Record<string, MaintenanceProbeResult>>) =>
-    resolveInstallation(
-      context({
-        binaryPath: "codex",
-        resolvedCommandPath: link,
-        realCommandPath: target,
-        platform: "win32",
-        commands: { winget },
-        probes: resolvedProbes,
-      }),
-      catalog,
-    );
+    resolveCatalog({
+      binaryPath: "codex",
+      resolvedCommandPath: link,
+      realCommandPath: target,
+      platform: "win32",
+      commands: { winget },
+      probes: resolvedProbes,
+    });
   return Effect.gen(function* () {
     const installation = yield* resolve(probes);
     expect(installation).toMatchObject({
@@ -982,12 +779,12 @@ it.effect("proves WinGet ownership and updates through the mapped source name", 
     });
     const ascendingVersions = yield* resolve({
       ...probes,
-      [showKey]: { stdout: "Version\n-------\n1.0.0\n1.1.0", stderr: "", exitCode: 0 },
+      [showKey]: probe("Version\n-------\n1.0.0\n1.1.0"),
     });
     expect(ascendingVersions.latestVersion).toBe("1.1.0");
     const failedShow = yield* resolve({
       ...probes,
-      [showKey]: { stdout: "Error 1.9.0", stderr: "source unavailable", exitCode: 1 },
+      [showKey]: probe("Error 1.9.0", 1, "source unavailable"),
     });
     expect(failedShow.latestVersion).toBeNull();
   });

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -177,6 +177,48 @@ it.effect("proves a custom global Scoop root from Scoop configuration", () => {
   );
 });
 
+it.effect("treats SCOOP_GLOBAL as authoritative over Scoop configuration", () => {
+  const userRoot = "C:/Users/test/scoop";
+  const observedGlobalRoot = "D:/Shared/ScoopGlobal";
+  const environmentGlobalRoot = "E:/Authoritative/ScoopGlobal";
+  const shim = `${observedGlobalRoot}/shims/codex.exe`;
+  const scoop = `${userRoot}/shims/scoop.ps1`;
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: shim,
+      platform: "win32",
+      environment: { PATH: "test-path", SCOOP_GLOBAL: environmentGlobalRoot },
+      commands: { scoop },
+      files: {
+        [`${observedGlobalRoot}/shims/codex.shim`]: `path = "${observedGlobalRoot}/apps/codex/current/codex.exe"`,
+        [`${observedGlobalRoot}/apps/codex/current/install.json`]: JSON.stringify({
+          bucket: "main",
+        }),
+        [`${observedGlobalRoot}/apps/codex/current/manifest.json`]: JSON.stringify({
+          version: "1.2.3",
+        }),
+      },
+      probes: {
+        [`${scoop} config global_path`]: {
+          stdout: observedGlobalRoot,
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Unknown installation — verification failed",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
+  );
+});
+
 it.effect("keeps an unknown bare command manual-only", () => {
   return resolveInstallation(
     context({

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -535,13 +535,15 @@ it.effect("proves Bun ownership for its copied Windows global executable", () =>
 it.effect("proves Homebrew ownership and fails closed for unresolved shims", () => {
   const brew = "/opt/homebrew/bin/brew";
   const resolve = (version: string) => {
-    const formulaPrefix = `/opt/homebrew/Cellar/codex/${version}`;
+    const formulaPrefix = "/opt/homebrew/opt/codex";
+    const realFormulaPrefix = `/opt/homebrew/Cellar/codex/${version}`;
     return resolveInstallation(
       context({
         binaryPath: "codex",
         resolvedCommandPath: "/opt/homebrew/bin/codex",
-        realCommandPath: `${formulaPrefix}/bin/codex`,
+        realCommandPath: `${realFormulaPrefix}/bin/codex`,
         commands: { brew },
+        realPaths: { [formulaPrefix]: realFormulaPrefix },
         probes: {
           [`${brew} --prefix --installed codex`]: {
             stdout: formulaPrefix,

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 
 import {
   canonicalPath,
+  INSTALLER_METADATA_MAX_BYTES,
   type InstallationContext,
   type MaintenanceProbeResult,
   type ResolvedInstallation,
@@ -40,7 +41,7 @@ interface TestContextInput {
   readonly commands?: Readonly<Record<string, string>>;
   readonly probes?: Readonly<Record<string, MaintenanceProbeResult>>;
   readonly realPaths?: Readonly<Record<string, string>>;
-  readonly textFileReads?: Array<{ readonly path: string; readonly maxBytes?: number }>;
+  readonly textFileReads?: Array<{ readonly path: string }>;
 }
 
 function context(input: TestContextInput): InstallationContext {
@@ -58,13 +59,11 @@ function context(input: TestContextInput): InstallationContext {
     realCommandPath: input.realCommandPath ?? input.resolvedCommandPath,
     environment: input.environment ?? { PATH: "test-path" },
     platform: input.platform ?? "linux",
-    readTextFile: (path, maxBytes) => {
-      input.textFileReads?.push({ path, ...(maxBytes === undefined ? {} : { maxBytes }) });
+    readTextFile: (path) => {
+      input.textFileReads?.push({ path });
       const value = files.get(path.replaceAll("\\", "/").toLowerCase()) ?? null;
       return Effect.succeed(
-        value !== null && maxBytes !== undefined && Buffer.byteLength(value) > maxBytes
-          ? null
-          : value,
+        value !== null && Buffer.byteLength(value) > INSTALLER_METADATA_MAX_BYTES ? null : value,
       );
     },
     realPath: (path) =>
@@ -245,9 +244,15 @@ it.effect("keeps an unknown bare command manual-only", () => {
     binaryPath: "codex",
     resolvedCommandPath: "/custom/bin/codex",
     commands: { npm: "/usr/local/bin/npm" },
+    probes: {
+      "/usr/local/bin/npm root -g": probe("/usr/local/lib/node_modules"),
+      "/usr/local/bin/npm view @openai/codex@latest version --json": probe('"9.9.9"'),
+    },
   }).pipe(
     Effect.map((installation) => {
       expectManualInstallation(installation);
+      expect(installation.ownershipVerified).toBe(false);
+      expect(installation.update).toBeNull();
     }),
   );
 });
@@ -361,7 +366,7 @@ it.effect("proves npm ownership through a Windows global command wrapper", () =>
     commands: { npm },
     files: {
       [`${prefix}/codex.cmd`]:
-        '@IF EXIST "%~dp0\\node.exe" ("%~dp0\\node.exe" "%~dp0\\node_modules\\@openai\\codex\\bin\\codex.js")',
+        '@IF EXIST "%~dp0\\node.exe" ("%~dp0\\node.exe" "%~dp0\\node_modules\\@openai\\codex\\bin\\codex.js" %*)',
       [`${prefix}/node_modules/@openai/codex/package.json`]: packageManifest("1.0.0"),
     },
     probes: {
@@ -396,7 +401,7 @@ it.effect("reads a POSIX package wrapper once across Node manager probes", () =>
   const wrapper = `${prefix}/bin/codex`;
   const packageRoot = `${prefix}/share/pnpm/global/v5/node_modules/@openai/codex`;
   const pnpm = `${prefix}/bin/pnpm`;
-  const textFileReads: Array<{ readonly path: string; readonly maxBytes?: number }> = [];
+  const textFileReads: Array<{ readonly path: string }> = [];
   return resolveCatalog({
     binaryPath: "codex",
     resolvedCommandPath: wrapper,
@@ -418,16 +423,14 @@ it.effect("reads a POSIX package wrapper once across Node manager probes", () =>
         currentVersion: "1.0.0",
         latestVersion: "1.1.0",
       });
-      expect(textFileReads.filter((read) => read.path === wrapper)).toEqual([
-        { path: wrapper, maxBytes: 64 * 1_024 },
-      ]);
+      expect(textFileReads.filter((read) => read.path === wrapper)).toEqual([{ path: wrapper }]);
     }),
   );
 });
 
 it.effect("skips oversized command wrappers without weakening ownership", () => {
   const wrapper = "/home/test/.local/bin/codex";
-  const textFileReads: Array<{ readonly path: string; readonly maxBytes?: number }> = [];
+  const textFileReads: Array<{ readonly path: string }> = [];
   return resolveCatalog({
     binaryPath: "codex",
     resolvedCommandPath: wrapper,
@@ -438,7 +441,7 @@ it.effect("skips oversized command wrappers without weakening ownership", () => 
   }).pipe(
     Effect.map((installation) => {
       expectManualInstallation(installation);
-      expect(textFileReads).toEqual([{ path: wrapper, maxBytes: 64 * 1_024 }]);
+      expect(textFileReads).toEqual([{ path: wrapper }]);
     }),
   );
 });
@@ -464,6 +467,94 @@ it.effect("does not match a wrapper for a package with a shared name prefix", ()
     Effect.map((installation) => {
       expect(installation.update).toBeNull();
       expect(installation.ownershipVerified).toBe(false);
+    }),
+  );
+});
+
+it.effect("rejects package text that is not the wrapper execution target", () => {
+  const prefix = "/opt/node";
+  const wrapper = `${prefix}/bin/codex`;
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: wrapper,
+    commands: { npm: `${prefix}/bin/npm` },
+    files: {
+      [wrapper]:
+        'echo "/opt/node/lib/node_modules/@openai/codex/bin/codex.js" "$@"\nexec "/tmp/unrelated-codex"',
+      [`${prefix}/lib/node_modules/@openai/codex/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${prefix}/bin/npm root -g`]: probe(`${prefix}/lib/node_modules`),
+    },
+  }).pipe(
+    Effect.map((installation) => {
+      expectManualInstallation(installation, true);
+    }),
+  );
+});
+
+it.effect("rejects wrappers with an unowned alternate execution target", () => {
+  const prefix = "/opt/node";
+  const wrapper = `${prefix}/bin/codex`;
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: wrapper,
+    commands: { npm: `${prefix}/bin/npm` },
+    files: {
+      [wrapper]: [
+        `exec "$basedir/../lib/node_modules/@openai/codex/bin/codex.js" "$@"`,
+        `exec "/tmp/unrelated-codex" "$@"`,
+      ].join("\n"),
+      [`${prefix}/lib/node_modules/@openai/codex/package.json`]: packageManifest("1.0.0"),
+    },
+    probes: {
+      [`${prefix}/bin/npm root -g`]: probe(`${prefix}/lib/node_modules`),
+    },
+  }).pipe(
+    Effect.map((installation) => {
+      expectManualInstallation(installation, true);
+    }),
+  );
+});
+
+it.effect("fails closed for malformed package metadata", () => {
+  const prefix = "/opt/node";
+  const wrapper = `${prefix}/bin/codex`;
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: wrapper,
+    commands: { npm: `${prefix}/bin/npm` },
+    files: {
+      [wrapper]: `exec "$basedir/../lib/node_modules/@openai/codex/bin/codex.js" "$@"`,
+      [`${prefix}/lib/node_modules/@openai/codex/package.json`]: "{not-json",
+    },
+    probes: {
+      [`${prefix}/bin/npm root -g`]: probe(`${prefix}/lib/node_modules`),
+    },
+  }).pipe(
+    Effect.map((installation) => {
+      expectManualInstallation(installation, true);
+    }),
+  );
+});
+
+it.effect("fails closed for oversized package metadata", () => {
+  const prefix = "/opt/node";
+  const wrapper = `${prefix}/bin/codex`;
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: wrapper,
+    commands: { npm: `${prefix}/bin/npm` },
+    files: {
+      [wrapper]: `exec "$basedir/../lib/node_modules/@openai/codex/bin/codex.js" "$@"`,
+      [`${prefix}/lib/node_modules/@openai/codex/package.json`]: `${packageManifest("1.0.0")}${" ".repeat(INSTALLER_METADATA_MAX_BYTES)}`,
+    },
+    probes: {
+      [`${prefix}/bin/npm root -g`]: probe(`${prefix}/lib/node_modules`),
+    },
+  }).pipe(
+    Effect.map((installation) => {
+      expectManualInstallation(installation, true);
     }),
   );
 });
@@ -502,6 +593,8 @@ it.effect("proves npm ownership across a Scoop Node persistent-bin junction", ()
   const currentBin = "C:/Users/test/scoop/apps/nodejs-lts/current/bin";
   const persistentBin = "C:/Users/test/scoop/persist/nodejs-lts/bin";
   const packageRoot = `${persistentBin}/node_modules/@openai/codex`;
+  const currentTarget = `${currentBin}/node_modules/@openai/codex/bin/codex.exe`;
+  const persistentTarget = `${persistentBin}/node_modules/@openai/codex/bin/codex.exe`;
   const npm = "C:/Users/test/scoop/apps/nodejs-lts/current/npm.cmd";
   return resolveCatalog({
     binaryPath: "codex",
@@ -510,6 +603,7 @@ it.effect("proves npm ownership across a Scoop Node persistent-bin junction", ()
     commands: { npm },
     realPaths: {
       [`${currentBin}/node_modules/@openai/codex`.toLowerCase()]: packageRoot,
+      [currentTarget.toLowerCase()]: persistentTarget,
     },
     files: {
       [`${currentBin}/codex.cmd`]:
@@ -611,6 +705,72 @@ it.effect("proves Homebrew ownership and fails closed for unresolved shims", () 
   });
 });
 
+it.effect("does not classify a Linux /usr/local/bin executable as Homebrew", () =>
+  resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: "/usr/local/bin/codex",
+    realCommandPath: "/usr/local/bin/codex",
+    commands: {
+      brew: "/home/linuxbrew/.linuxbrew/bin/brew",
+      npm: "/usr/local/bin/npm",
+    },
+    probes: {
+      "/usr/local/bin/npm root -g": probe("/usr/local/lib/node_modules"),
+    },
+  }).pipe(
+    Effect.map((installation) => {
+      expectManualInstallation(installation, true);
+    }),
+  ),
+);
+
+it.effect("preserves a matching tap-qualified Homebrew formula", () => {
+  const brew = "/opt/homebrew/bin/brew";
+  const formula = "example/tap/scoped-package-tool";
+  const formulaPrefix = "/opt/homebrew/opt/scoped-package-tool";
+  const realFormulaPrefix = "/opt/homebrew/Cellar/scoped-package-tool/1.2.3";
+  const tapCatalog = makeProviderInstallationCatalog({
+    provider,
+    packageName: "@example/scoped-package-tool",
+    executableName: "scoped-package-tool",
+    homebrewFormula: formula,
+    native: null,
+    instructionsUrl: "https://example.com/scoped-package-tool",
+  });
+  return resolveInstallation(
+    context({
+      binaryPath: "scoped-package-tool",
+      resolvedCommandPath: "/opt/homebrew/bin/scoped-package-tool",
+      realCommandPath: `${realFormulaPrefix}/bin/scoped-package-tool`,
+      commands: { brew },
+      realPaths: { [formulaPrefix]: realFormulaPrefix },
+      probes: {
+        [`${brew} --prefix --installed ${formula}`]: probe(formulaPrefix),
+        [`${brew} --caskroom ${formula}`]: probe("", 1),
+        [`${brew} info --json=v2 ${formula}`]: probe(
+          JSON.stringify({
+            formulae: [
+              {
+                installed: [{ version: "1.2.3" }],
+                versions: { stable: "1.2.4" },
+              },
+            ],
+          }),
+        ),
+      },
+    }),
+    tapCatalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by Homebrew",
+        ownershipVerified: true,
+        update: { executable: brew, args: ["upgrade", formula] },
+      });
+    }),
+  );
+});
+
 it.effect("accepts Homebrew cask metadata with a scalar installed version", () => {
   const brew = "/opt/homebrew/bin/brew";
   const caskPrefix = "/opt/homebrew/Caskroom/codex";
@@ -634,6 +794,35 @@ it.effect("accepts Homebrew cask metadata with a scalar installed version", () =
         label: "Managed by Homebrew",
         currentVersion: "0.149.1",
         latestVersion: "0.150.0",
+        update: { executable: brew, args: ["upgrade", "--cask", "codex"] },
+      });
+    }),
+  );
+});
+
+it.effect("normalizes Homebrew cask build suffixes as channel metadata", () => {
+  const brew = "/opt/homebrew/bin/brew";
+  const caskPrefix = "/opt/homebrew/Caskroom/codex";
+  return resolveCatalog({
+    binaryPath: "codex",
+    resolvedCommandPath: "/opt/homebrew/bin/codex",
+    realCommandPath: `${caskPrefix}/1.2.3,4566/codex-aarch64-apple-darwin`,
+    commands: { brew },
+    probes: {
+      [`${brew} --prefix --installed codex`]: probe("", 1),
+      [`${brew} --caskroom codex`]: probe(caskPrefix),
+      [`${brew} info --json=v2 codex`]: probe(
+        JSON.stringify({
+          casks: [{ installed: "1.2.3,4566", version: "1.2.3,4567" }],
+        }),
+      ),
+    },
+  }).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by Homebrew",
+        currentVersion: "1.2.3",
+        latestVersion: "1.2.3",
         update: { executable: brew, args: ["upgrade", "--cask", "codex"] },
       });
     }),

--- a/apps/server/src/provider/maintenance/catalogs.test.ts
+++ b/apps/server/src/provider/maintenance/catalogs.test.ts
@@ -39,6 +39,7 @@ function context(input: {
   readonly commands?: Readonly<Record<string, string>>;
   readonly probes?: Readonly<Record<string, MaintenanceProbeResult>>;
   readonly realPaths?: Readonly<Record<string, string>>;
+  readonly textFileReads?: Array<{ readonly path: string; readonly maxBytes?: number }>;
 }): InstallationContext {
   const files = new Map(
     Object.entries(input.files ?? {}).map(([path, value]) => [
@@ -55,8 +56,15 @@ function context(input: {
     realCommandPath: input.realCommandPath ?? input.resolvedCommandPath,
     environment: input.environment ?? { PATH: "test-path" },
     platform: input.platform ?? "linux",
-    readTextFile: (path) =>
-      Effect.succeed(files.get(path.replaceAll("\\", "/").toLowerCase()) ?? null),
+    readTextFile: (path, maxBytes) => {
+      input.textFileReads?.push({ path, ...(maxBytes === undefined ? {} : { maxBytes }) });
+      const value = files.get(path.replaceAll("\\", "/").toLowerCase()) ?? null;
+      return Effect.succeed(
+        value !== null && maxBytes !== undefined && Buffer.byteLength(value) > maxBytes
+          ? null
+          : value,
+      );
+    },
     realPath: (path) =>
       Effect.succeed(input.realPaths?.[path.replaceAll("\\", "/").toLowerCase()] ?? path),
     resolveCommand: (command) => Effect.succeed(input.commands?.[command] ?? null),
@@ -452,6 +460,79 @@ it.effect("proves npm ownership through a Windows global command wrapper", () =>
   );
 });
 
+it.effect("reads a POSIX package wrapper once across Node manager probes", () => {
+  const prefix = "/home/test/.local";
+  const wrapper = `${prefix}/bin/codex`;
+  const packageRoot = `${prefix}/share/pnpm/global/v5/node_modules/@openai/codex`;
+  const pnpm = `${prefix}/bin/pnpm`;
+  const textFileReads: Array<{ readonly path: string; readonly maxBytes?: number }> = [];
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: wrapper,
+      commands: { pnpm },
+      textFileReads,
+      files: {
+        [wrapper]:
+          '#!/bin/sh\nexec "$basedir/../share/pnpm/global/v5/node_modules/@openai/codex/bin/codex.js" "$@"',
+        [`${packageRoot}/package.json`]: JSON.stringify({
+          name: "@openai/codex",
+          version: "1.0.0",
+        }),
+      },
+      probes: {
+        [`${pnpm} root -g`]: {
+          stdout: `${prefix}/share/pnpm/global/v5/node_modules`,
+          stderr: "",
+          exitCode: 0,
+        },
+        [`${pnpm} view @openai/codex@latest version --json`]: {
+          stdout: '"1.1.0"',
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by pnpm",
+        currentVersion: "1.0.0",
+        latestVersion: "1.1.0",
+      });
+      expect(textFileReads.filter((read) => read.path === wrapper)).toEqual([
+        { path: wrapper, maxBytes: 64 * 1_024 },
+      ]);
+    }),
+  );
+});
+
+it.effect("skips oversized command wrappers without weakening ownership", () => {
+  const wrapper = "/home/test/.local/bin/codex";
+  const textFileReads: Array<{ readonly path: string; readonly maxBytes?: number }> = [];
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: wrapper,
+      textFileReads,
+      files: {
+        [wrapper]: `${"x".repeat(64 * 1_024)}\n/node_modules/@openai/codex/bin/codex.js`,
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Unknown installation",
+        ownershipVerified: false,
+        update: null,
+      });
+      expect(textFileReads).toEqual([{ path: wrapper, maxBytes: 64 * 1_024 }]);
+    }),
+  );
+});
+
 it.effect("does not match a wrapper for a package with a shared name prefix", () => {
   const prefix = "C:/Users/test/AppData/Roaming/npm";
   const npm = `${prefix}/npm.cmd`;
@@ -712,7 +793,58 @@ it.effect("accepts Homebrew cask metadata with a scalar installed version", () =
         label: "Managed by Homebrew",
         currentVersion: "0.149.1",
         latestVersion: "0.150.0",
-        update: { executable: brew, args: ["upgrade", "codex"] },
+        update: { executable: brew, args: ["upgrade", "--cask", "codex"] },
+      });
+    }),
+  );
+});
+
+it.effect("uses cask metadata and updates when formula and cask names collide", () => {
+  const brew = "/opt/homebrew/bin/brew";
+  const formulaPrefix = "/opt/homebrew/opt/codex";
+  const realFormulaPrefix = "/opt/homebrew/Cellar/codex/9.0.0";
+  const caskPrefix = "/opt/homebrew/Caskroom/codex";
+  return resolveInstallation(
+    context({
+      binaryPath: "codex",
+      resolvedCommandPath: "/opt/homebrew/bin/codex",
+      realCommandPath: `${caskPrefix}/0.149.1/codex-aarch64-apple-darwin`,
+      commands: { brew },
+      realPaths: { [formulaPrefix]: realFormulaPrefix },
+      probes: {
+        [`${brew} --prefix --installed codex`]: {
+          stdout: formulaPrefix,
+          stderr: "",
+          exitCode: 0,
+        },
+        [`${brew} --caskroom codex`]: { stdout: caskPrefix, stderr: "", exitCode: 0 },
+        [`${brew} info --json=v2 codex`]: {
+          stdout: JSON.stringify({
+            formulae: [
+              {
+                installed: [{ version: "9.0.0" }],
+                versions: { stable: "9.1.0" },
+              },
+            ],
+            casks: [{ installed: ["0.149.1"], version: "0.150.0" }],
+          }),
+          stderr: "",
+          exitCode: 0,
+        },
+      },
+    }),
+    catalog,
+  ).pipe(
+    Effect.map((installation) => {
+      expect(installation).toMatchObject({
+        label: "Managed by Homebrew",
+        currentVersion: "0.149.1",
+        latestVersion: "0.150.0",
+        update: {
+          executable: brew,
+          args: ["upgrade", "--cask", "codex"],
+          displayCommand: "brew upgrade --cask codex",
+        },
       });
     }),
   );
@@ -747,7 +879,7 @@ it.effect("derives a Homebrew alias from the verified Caskroom path", () => {
         label: "Managed by Homebrew",
         currentVersion: "0.150.0",
         latestVersion: "0.151.0",
-        update: { executable: brew, args: ["upgrade", formula] },
+        update: { executable: brew, args: ["upgrade", "--cask", formula] },
       });
     }),
   );

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -1,0 +1,787 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+
+import type { ProviderDriverKind } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import {
+  canonicalPath,
+  defineInstallation,
+  installationIdentity,
+  matched,
+  notMatched,
+  type InstallationCatalog,
+  type InstallationContext,
+  type ResolvedInstallation,
+  undetermined,
+} from "./definition.ts";
+import { normalizeMaintenanceVersion } from "./version.ts";
+
+export interface ProviderMaintenanceDefinitionInput {
+  readonly provider: ProviderDriverKind;
+  readonly packageName: string;
+  readonly executableName: string;
+  readonly homebrewFormula: string | null;
+  readonly native: {
+    readonly label: string;
+    readonly updateArgs: ReadonlyArray<string>;
+    readonly ownsPath: (normalizedPath: string) => boolean;
+    readonly environment?: (
+      executable: string,
+      environment: NodeJS.ProcessEnv,
+    ) => NodeJS.ProcessEnv;
+  } | null;
+  readonly instructionsUrl: string;
+  readonly wingetPackageId?: string;
+}
+
+function normalize(context: InstallationContext, path: string): string {
+  return canonicalPath(path, context.platform);
+}
+
+function pathApi(context: InstallationContext) {
+  return context.platform === "win32" ? NodePath.win32 : NodePath.posix;
+}
+
+function within(context: InstallationContext, child: string, parent: string): boolean {
+  const root = normalize(context, parent).replace(/\/$/, "");
+  const path = normalize(context, child);
+  return path === root || path.startsWith(`${root}/`);
+}
+
+function json(value: string | null): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function records(value: unknown): ReadonlyArray<Record<string, unknown>> {
+  return Array.isArray(value)
+    ? value.filter(
+        (item): item is Record<string, unknown> =>
+          typeof item === "object" && item !== null && !Array.isArray(item),
+      )
+    : [];
+}
+
+function output(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return typeof parsed === "string" ? parsed.trim() || null : trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+function packageRoot(path: string, packageName: string): string | null {
+  const normalized = path.replaceAll("\\", "/");
+  const needle = `/node_modules/${packageName}/`;
+  const index = normalized.toLowerCase().lastIndexOf(needle.toLowerCase());
+  return index < 0 ? null : normalized.slice(0, index + needle.length - 1);
+}
+
+function packageRootFromWrapper(
+  context: InstallationContext,
+  wrapper: string | null,
+  wrapperPath: string | null,
+  packageName: string,
+): string | null {
+  if (!wrapper || !wrapperPath) return null;
+  const path = pathApi(context);
+  const embedded = packageRoot(wrapper, packageName);
+  if (embedded && path.isAbsolute(embedded)) return embedded;
+  const normalized = wrapper.replaceAll("\\", "/");
+  const packageSuffix = `/node_modules/${packageName}/`;
+  const suffixIndex = normalized.toLowerCase().lastIndexOf(packageSuffix.toLowerCase());
+  if (suffixIndex < 0) {
+    return null;
+  }
+  const prefix = normalized.slice(0, suffixIndex);
+  const lowerPrefix = prefix.toLowerCase();
+  const windowsMarkers = ["%~dp0", "%dp0%"] as const;
+  const windowsMarker = windowsMarkers
+    .map((marker) => ({ marker, index: lowerPrefix.lastIndexOf(marker) }))
+    .sort((left, right) => right.index - left.index)[0];
+  const windowsBaseIndex = windowsMarker?.index ?? -1;
+  if (windowsBaseIndex >= 0) {
+    return path.resolve(
+      path.dirname(wrapperPath),
+      prefix.slice(windowsBaseIndex + (windowsMarker?.marker.length ?? 0)).replace(/^\/+/, ""),
+      "node_modules",
+      ...packageName.split("/"),
+    );
+  }
+  const shellBaseIndex = prefix.lastIndexOf("$basedir");
+  if (shellBaseIndex >= 0) {
+    return path.resolve(
+      path.dirname(wrapperPath),
+      prefix.slice(shellBaseIndex + "$basedir".length).replace(/^\/+/, ""),
+      "node_modules",
+      ...packageName.split("/"),
+    );
+  }
+  return path.join(path.dirname(wrapperPath), "node_modules", ...packageName.split("/"));
+}
+
+function wrapperHasAmbiguousPackagePrefix(wrapper: string | null, packageName: string): boolean {
+  if (!wrapper) return false;
+  const normalized = wrapper.replaceAll("\\", "/").toLowerCase();
+  const prefix = `/node_modules/${packageName.toLowerCase()}`;
+  return normalized.includes(prefix) && !normalized.includes(`${prefix}/`);
+}
+
+const npmGlobalUpdateArgs = (packageName: string) => [
+  "install",
+  "-g",
+  `--allow-scripts=${packageName}`,
+  `${packageName}@latest`,
+];
+
+const nodeManagers = [
+  {
+    id: "vite-plus",
+    label: "Vite+",
+    command: "vp",
+    rootArgs: ["root", "-g"],
+    latestArgs: (name: string) => ["view", `${name}@latest`, "version", "--json"],
+    updateArgs: (name: string) => ["i", "-g", name],
+  },
+  {
+    id: "bun",
+    label: "Bun",
+    command: "bun",
+    rootArgs: ["pm", "bin", "-g"],
+    latestArgs: (name: string) => ["pm", "view", name, "version"],
+    updateArgs: (name: string) => ["install", "-g", `${name}@latest`],
+  },
+  {
+    id: "pnpm",
+    label: "pnpm",
+    command: "pnpm",
+    rootArgs: ["root", "-g"],
+    latestArgs: (name: string) => ["view", `${name}@latest`, "version", "--json"],
+    updateArgs: (name: string) => ["add", "-g", `${name}@latest`],
+  },
+  {
+    id: "npm",
+    label: "npm",
+    command: "npm",
+    rootArgs: ["root", "-g"],
+    latestArgs: (name: string) => ["view", `${name}@latest`, "version", "--json"],
+    updateArgs: npmGlobalUpdateArgs,
+  },
+] as const;
+
+type NodeManager = (typeof nodeManagers)[number];
+interface NodeEvidence {
+  readonly manager: NodeManager;
+  readonly executable: string;
+  readonly root: string;
+  readonly currentVersion: string | null;
+}
+
+function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: NodeManager) {
+  return Effect.fn(`detect-${manager.id}`)(function* (context: InstallationContext) {
+    const observed = normalize(
+      context,
+      context.realCommandPath ?? context.resolvedCommandPath ?? context.binaryPath,
+    );
+    const wrapper = yield* context.readTextFile(context.resolvedCommandPath ?? "");
+    let root =
+      packageRoot(observed, input.packageName) ??
+      packageRootFromWrapper(context, wrapper, context.resolvedCommandPath, input.packageName);
+    if (!root && wrapperHasAmbiguousPackagePrefix(wrapper, input.packageName)) {
+      return undetermined("The command wrapper's package ownership is ambiguous.");
+    }
+    if (!root && manager.id !== "bun") return notMatched;
+    const executable = yield* context.resolveCommand(manager.command);
+    if (!executable) {
+      return root ? undetermined("The owning package manager is unavailable.") : notMatched;
+    }
+    const rootProbe = yield* context.run(executable, manager.rootArgs, context.environment);
+    const managerRoot = output(rootProbe?.stdout);
+    if (!rootProbe || rootProbe.exitCode !== 0 || !managerRoot) {
+      return notMatched;
+    }
+    const resolvedManagerRoot = yield* context.realPath(managerRoot);
+    const ownershipRoot =
+      manager.id === "bun" ? pathApi(context).dirname(resolvedManagerRoot) : resolvedManagerRoot;
+    root ??=
+      manager.id === "bun" && within(context, observed, managerRoot)
+        ? pathApi(context).join(
+            ownershipRoot,
+            "install",
+            "global",
+            "node_modules",
+            input.packageName,
+          )
+        : null;
+    if (!root) return notMatched;
+    root = yield* context.realPath(root);
+    const manifest = json(yield* context.readTextFile(pathApi(context).join(root, "package.json")));
+    if (text(manifest?.name) !== input.packageName) return notMatched;
+    if (!within(context, root, ownershipRoot)) return notMatched;
+    return matched({
+      manager,
+      executable,
+      root: resolvedManagerRoot,
+      currentVersion: normalizeMaintenanceVersion(text(manifest?.version)),
+    });
+  });
+}
+
+function resolveNodePackage(input: ProviderMaintenanceDefinitionInput, manager: NodeManager) {
+  return Effect.fn(`resolve-${manager.id}`)(function* (
+    evidence: NodeEvidence,
+    context: InstallationContext,
+  ) {
+    const latest = yield* context.run(
+      evidence.executable,
+      evidence.manager.latestArgs(input.packageName),
+      context.environment,
+    );
+    const updateArgs = evidence.manager.updateArgs(input.packageName);
+    return resolved(input, context, {
+      kind: evidence.manager.id,
+      label: `Managed by ${evidence.manager.label}`,
+      root: evidence.root,
+      executable: evidence.executable,
+      currentVersion: evidence.currentVersion,
+      latestVersion: normalizeMaintenanceVersion(output(latest?.stdout)),
+      args: updateArgs,
+      displayCommand: `${evidence.manager.command} ${updateArgs.join(" ")}`,
+    });
+  });
+}
+
+function resolved(
+  input: ProviderMaintenanceDefinitionInput,
+  context: InstallationContext,
+  value: {
+    readonly kind: string;
+    readonly label: string;
+    readonly root: string;
+    readonly executable: string;
+    readonly currentVersion: string | null;
+    readonly latestVersion: string | null;
+    readonly args: ReadonlyArray<string>;
+    readonly displayCommand: string;
+    readonly environment?: NodeJS.ProcessEnv;
+    readonly ownershipVerified?: boolean;
+    readonly identityQualifier?: string;
+    readonly identityExecutable?: string;
+  },
+): ResolvedInstallation {
+  return {
+    identityKey: installationIdentity({
+      definition: `${input.provider}-${value.kind}`,
+      executable: normalize(context, value.identityExecutable ?? value.executable),
+      package: input.packageName,
+      qualifier: value.identityQualifier ?? null,
+      root: normalize(context, value.root),
+    }),
+    lockKey: `${value.kind}:${normalize(context, value.root)}`,
+    label: value.label,
+    ownershipVerified: value.ownershipVerified ?? true,
+    packageName: input.packageName,
+    currentVersion: value.currentVersion,
+    latestVersion: value.latestVersion,
+    update: {
+      executable: value.executable,
+      args: value.args,
+      environment: value.environment ?? context.environment,
+      displayCommand: value.displayCommand,
+    },
+    instructionsUrl: input.instructionsUrl,
+  };
+}
+
+function nativeDefinition(input: ProviderMaintenanceDefinitionInput) {
+  if (!input.native) return null;
+  const native = input.native;
+  return defineInstallation<string>({
+    id: `${input.provider}-native`,
+    detect: (context) => {
+      const executable = context.realCommandPath ?? context.resolvedCommandPath;
+      return Effect.succeed(
+        executable && native.ownsPath(normalize(context, executable))
+          ? matched(executable)
+          : notMatched,
+      );
+    },
+    resolve: (executable, context) =>
+      Effect.succeed(
+        resolved(input, context, {
+          kind: "native",
+          label: native.label,
+          root: pathApi(context).dirname(executable),
+          executable,
+          identityExecutable: context.resolvedCommandPath ?? executable,
+          currentVersion: null,
+          latestVersion: null,
+          args: native.updateArgs,
+          ...(native.environment
+            ? { environment: native.environment(executable, context.environment) }
+            : {}),
+          displayCommand: `${input.executableName} ${native.updateArgs.join(" ")}`,
+        }),
+      ),
+  });
+}
+
+function stableHomebrewRoot(context: InstallationContext, prefix: string): string {
+  const normalized = normalize(context, prefix);
+  const lower = normalized.toLowerCase();
+  const marker = ["/cellar/", "/caskroom/"].find((candidate) => lower.includes(candidate));
+  if (!marker) return normalized;
+  const markerIndex = lower.indexOf(marker);
+  const formulaStart = markerIndex + marker.length;
+  const formulaEnd = normalized.indexOf("/", formulaStart);
+  return formulaEnd < 0 ? normalized : normalized.slice(0, formulaEnd);
+}
+
+function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
+  return defineInstallation<{
+    executable: string;
+    prefix: string;
+    currentVersion: string | null;
+    latestVersion: string | null;
+  }>({
+    id: `${input.provider}-homebrew`,
+    detect: Effect.fn("detect-homebrew")(function* (context) {
+      if (!input.homebrewFormula) return notMatched;
+      const observed = normalize(context, context.realCommandPath ?? context.binaryPath);
+      const observedLower = observed.toLowerCase();
+      if (!observedLower.includes("/cellar/") && !observedLower.includes("/caskroom/")) {
+        return notMatched;
+      }
+      const executable = yield* context.resolveCommand("brew");
+      if (!executable) return undetermined("Homebrew executable is unavailable.");
+      const formula = input.homebrewFormula;
+      const formulaPrefixProbe = yield* context.run(
+        executable,
+        ["--prefix", "--installed", formula],
+        context.environment,
+      );
+      const formulaPrefix = output(formulaPrefixProbe?.stdout);
+      const caskPrefixProbe = yield* context.run(
+        executable,
+        ["--caskroom", formula],
+        context.environment,
+      );
+      const caskPrefix = output(caskPrefixProbe?.stdout);
+      const prefix =
+        formulaPrefixProbe?.exitCode === 0 &&
+        formulaPrefix &&
+        within(context, observed, formulaPrefix)
+          ? formulaPrefix
+          : caskPrefixProbe?.exitCode === 0 && caskPrefix && within(context, observed, caskPrefix)
+            ? caskPrefix
+            : null;
+      if (!prefix) return undetermined("Homebrew formula ownership could not be verified.");
+      const infoProbe = yield* context.run(
+        executable,
+        ["info", "--json=v2", formula],
+        context.environment,
+      );
+      const info = json(infoProbe?.stdout ?? null);
+      if (!infoProbe || infoProbe.exitCode !== 0 || !info) {
+        return undetermined("Homebrew formula metadata is unavailable.");
+      }
+      const formulaInfo = records(info.formulae)[0];
+      const caskInfo = records(info.casks)[0];
+      const versions = formulaInfo?.versions;
+      const stable =
+        typeof versions === "object" && versions !== null && !Array.isArray(versions)
+          ? text((versions as Record<string, unknown>).stable)
+          : null;
+      const installedFormula = records(formulaInfo?.installed)[0];
+      const installedCask = Array.isArray(caskInfo?.installed) ? text(caskInfo.installed[0]) : null;
+      const currentVersion = normalizeMaintenanceVersion(
+        text(installedFormula?.version) ?? installedCask,
+      );
+      if (!currentVersion) return undetermined("Homebrew installed version is unavailable.");
+      return matched({
+        executable,
+        prefix,
+        currentVersion,
+        latestVersion: normalizeMaintenanceVersion(stable ?? text(caskInfo?.version)),
+      });
+    }),
+    resolve: (evidence, context) => {
+      const formula = input.homebrewFormula!;
+      return Effect.succeed(
+        resolved(input, context, {
+          kind: "homebrew",
+          label: "Managed by Homebrew",
+          root: stableHomebrewRoot(context, evidence.prefix),
+          executable: evidence.executable,
+          currentVersion: evidence.currentVersion,
+          latestVersion: evidence.latestVersion,
+          args: ["upgrade", formula],
+          displayCommand: `brew upgrade ${formula}`,
+        }),
+      );
+    },
+  });
+}
+
+function scoopDefinition(input: ProviderMaintenanceDefinitionInput) {
+  return defineInstallation<{
+    root: string;
+    executable: string;
+    app: string;
+    bucket: string;
+    global: boolean;
+    current: string | null;
+    latest: string | null;
+  }>({
+    id: `${input.provider}-scoop`,
+    detect: Effect.fn("detect-scoop")(function* (context) {
+      if (context.platform !== "win32" || !context.resolvedCommandPath) return notMatched;
+      const observed = normalize(context, context.resolvedCommandPath);
+      const marker = "/shims/";
+      const index = observed.lastIndexOf(marker);
+      if (index < 0) return notMatched;
+      const root = context.resolvedCommandPath.replaceAll("\\", "/").slice(0, index);
+      const shim = context.resolvedCommandPath.replace(/\.(?:exe|cmd|ps1)$/i, "") + ".shim";
+      const target = (yield* context.readTextFile(shim))?.match(/^path\s*=\s*"([^"]+)"/m)?.[1];
+      const targetPath = target ? normalize(context, target) : null;
+      const app = targetPath?.match(/\/apps\/([^/]+)\/current(?:\/|$)/)?.[1];
+      if (
+        !target ||
+        !app ||
+        !within(context, target, pathApi(context).join(root, "apps", app, "current"))
+      ) {
+        return undetermined("Scoop shim ownership metadata is unreadable.");
+      }
+      const install = json(
+        yield* context.readTextFile(
+          pathApi(context).join(root, "apps", app, "current", "install.json"),
+        ),
+      );
+      const manifest = json(
+        yield* context.readTextFile(
+          pathApi(context).join(root, "apps", app, "current", "manifest.json"),
+        ),
+      );
+      if (!install || !manifest) return undetermined("Scoop metadata is unreadable.");
+      const bucket = text(install.bucket);
+      if (!bucket) return undetermined("Scoop bucket provenance is unavailable.");
+      const executable = yield* context.resolveCommand("scoop");
+      if (!executable) return undetermined("Scoop is unavailable.");
+      const executablePath = normalize(context, executable);
+      const managerMarker = "/shims/";
+      const managerIndex = executablePath.lastIndexOf(managerMarker);
+      if (managerIndex < 0) return undetermined("The owning Scoop root is unavailable.");
+      const managerRoot = executable.replaceAll("\\", "/").slice(0, managerIndex);
+      let global = !within(context, executable, root);
+      if (global) {
+        const globalProbe = yield* context.run(
+          executable,
+          ["config", "SCOOP_GLOBAL"],
+          context.environment,
+        );
+        const globalRoot = output(globalProbe?.stdout);
+        if (
+          !globalProbe ||
+          globalProbe.exitCode !== 0 ||
+          !globalRoot ||
+          normalize(context, globalRoot) !== normalize(context, root)
+        ) {
+          return undetermined("The global Scoop root owning this shim could not be verified.");
+        }
+      }
+      const available = json(
+        yield* context.readTextFile(
+          pathApi(context).join(managerRoot, "buckets", bucket, "bucket", `${app}.json`),
+        ),
+      );
+      return matched({
+        root,
+        executable,
+        app,
+        bucket,
+        global,
+        current: normalizeMaintenanceVersion(text(manifest.version)),
+        latest: normalizeMaintenanceVersion(text(available?.version)),
+      });
+    }),
+    resolve: (evidence, context) =>
+      Effect.succeed(
+        resolved(input, context, {
+          kind: "scoop",
+          label: "Managed by Scoop",
+          root: evidence.root,
+          executable: evidence.executable,
+          currentVersion: evidence.current,
+          latestVersion: evidence.latest,
+          args: [
+            "update",
+            `${evidence.bucket}/${evidence.app}`,
+            ...(evidence.global ? ["--global"] : []),
+          ],
+          displayCommand: `scoop update ${evidence.bucket}/${evidence.app}${evidence.global ? " --global" : ""}`,
+          identityQualifier: `${evidence.bucket}/${evidence.app}/${evidence.global ? "global" : "user"}`,
+        }),
+      ),
+  });
+}
+
+interface ArpEntry {
+  readonly displayVersion: string | null;
+  readonly packageId: string | null;
+  readonly sourceId: string | null;
+  readonly symlinkPath: string | null;
+  readonly targetPath: string | null;
+}
+
+export function parseWingetPortableArp(outputText: string): ReadonlyArray<ArpEntry> {
+  const entries: Array<ArpEntry> = [];
+  let values = new Map<string, string>();
+  const flush = () => {
+    const packageId = values.get("WinGetPackageIdentifier") ?? null;
+    if (packageId) {
+      entries.push({
+        packageId,
+        displayVersion: values.get("DisplayVersion") ?? null,
+        sourceId: values.get("WinGetSourceIdentifier") ?? null,
+        symlinkPath: values.get("SymlinkFullPath") ?? null,
+        targetPath: values.get("TargetFullPath") ?? null,
+      });
+    }
+    values = new Map();
+  };
+  for (const line of outputText.split(/\r?\n/)) {
+    if (/^HKEY_/i.test(line.trim())) flush();
+    const match = line.match(/^\s*([^\s].*?)\s+REG_\w+\s+(.*?)\s*$/);
+    if (match) values.set(match[1]!, match[2]!);
+  }
+  flush();
+  return entries;
+}
+
+export function parseWingetSources(outputText: string): ReadonlyArray<{
+  readonly data: string | null;
+  readonly identifier: string;
+  readonly name: string;
+}> {
+  return outputText.split(/\r?\n/).flatMap((line) => {
+    const source = json(line);
+    const identifier = text(source?.Identifier);
+    const name = text(source?.Name);
+    return identifier && name ? [{ data: text(source?.Data), identifier, name }] : [];
+  });
+}
+
+function wingetDefinition(input: ProviderMaintenanceDefinitionInput) {
+  if (!input.wingetPackageId) return null;
+  const packageId = input.wingetPackageId;
+  return defineInstallation<{
+    executable: string;
+    source: string;
+    sourceIdentifier: string;
+    scope: "machine" | "user";
+    current: string | null;
+  }>({
+    id: `${input.provider}-winget`,
+    detect: Effect.fn("detect-winget")(function* (context) {
+      if (context.platform !== "win32") return notMatched;
+      const observed = normalize(context, context.resolvedCommandPath ?? context.binaryPath);
+      const real = normalize(context, context.realCommandPath ?? observed);
+      if (!observed.includes("/microsoft/winget/") && !real.includes("/microsoft/winget/"))
+        return notMatched;
+      const reg = pathApi(context).join(
+        context.environment.SystemRoot ?? "C:\\Windows",
+        "System32",
+        "reg.exe",
+      );
+      const root = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
+      const searches = [
+        { root: `HKCU\\${root}`, scope: "user", view: "/reg:64" },
+        { root: `HKLM\\${root}`, scope: "machine", view: "/reg:64" },
+        { root: `HKLM\\${root}`, scope: "machine", view: "/reg:32" },
+      ] as const;
+      const searchResults = yield* Effect.forEach(searches, (search) =>
+        context.run(
+          reg,
+          ["query", search.root, "/s", "/f", packageId, "/d", "/e", search.view],
+          context.environment,
+        ),
+      );
+      if (
+        searchResults.some(
+          (result) => result === null || (result.exitCode !== 0 && result.exitCode !== 1),
+        )
+      ) {
+        return undetermined("WinGet ARP metadata is unreadable.");
+      }
+      const keys = searches.flatMap((search, searchIndex) =>
+        (searchResults[searchIndex]?.stdout.match(/^HKEY_[^\r\n]+/gim) ?? []).map((key) => ({
+          key: key.trim(),
+          scope: search.scope,
+          view: search.view,
+        })),
+      );
+      if (keys.length === 0) return undetermined("WinGet package metadata is unavailable.");
+      const entryResults = yield* Effect.forEach(keys, ({ key, view }) =>
+        context.run(reg, ["query", key, view], context.environment),
+      );
+      if (entryResults.some((result) => result === null || result.exitCode !== 0)) {
+        return undetermined("WinGet package metadata could not be read.");
+      }
+      const matches = entryResults
+        .flatMap((result, resultIndex) =>
+          parseWingetPortableArp(result?.stdout ?? "").map((entry) => ({
+            entry,
+            scope: keys[resultIndex]!.scope,
+          })),
+        )
+        .filter(
+          ({ entry }) =>
+            entry.packageId === packageId &&
+            ((entry.symlinkPath && normalize(context, entry.symlinkPath) === observed) ||
+              (entry.targetPath && normalize(context, entry.targetPath) === real)),
+        );
+      if (matches.length === 0)
+        return undetermined("WinGet executable ownership could not be verified.");
+      if (matches.length !== 1 || !matches[0]!.entry.sourceId)
+        return undetermined("WinGet ownership is ambiguous.");
+      const executable = yield* context.resolveCommand("winget");
+      if (!executable) return undetermined("WinGet is unavailable.");
+      const sourceProbe = yield* context.run(
+        executable,
+        ["source", "export", "--disable-interactivity"],
+        context.environment,
+      );
+      const source = parseWingetSources(sourceProbe?.stdout ?? "").find(
+        (candidate) =>
+          candidate.identifier === matches[0]!.entry.sourceId ||
+          candidate.data === matches[0]!.entry.sourceId ||
+          candidate.name === matches[0]!.entry.sourceId,
+      )?.name;
+      if (!sourceProbe || sourceProbe.exitCode !== 0 || !source) {
+        return undetermined("The WinGet source owning this package is unavailable.");
+      }
+      return matched({
+        executable,
+        source,
+        sourceIdentifier: matches[0]!.entry.sourceId!,
+        scope: matches[0]!.scope,
+        current: normalizeMaintenanceVersion(matches[0]!.entry.displayVersion),
+      });
+    }),
+    resolve: Effect.fn("resolve-winget")(function* (evidence, context) {
+      const show = yield* context.run(
+        evidence.executable,
+        [
+          "show",
+          "--id",
+          packageId,
+          "--exact",
+          "--source",
+          evidence.source,
+          "--versions",
+          "--accept-source-agreements",
+          "--disable-interactivity",
+        ],
+        context.environment,
+      );
+      const latest =
+        show && show.exitCode === 0
+          ? ((show.stdout.match(/\b\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\b/g) ?? [])
+              .map(normalizeMaintenanceVersion)
+              .find((value): value is string => value !== null) ?? null)
+          : null;
+      return resolved(input, context, {
+        kind: "winget",
+        label: "Managed by WinGet",
+        root: pathApi(context).dirname(evidence.executable),
+        executable: evidence.executable,
+        currentVersion: evidence.current,
+        latestVersion: latest,
+        args: [
+          "upgrade",
+          "--id",
+          packageId,
+          "--exact",
+          "--source",
+          evidence.source,
+          "--scope",
+          evidence.scope,
+          "--accept-source-agreements",
+          "--disable-interactivity",
+        ],
+        displayCommand: `winget upgrade --id ${packageId} --exact --source ${evidence.source} --scope ${evidence.scope}`,
+        identityQualifier: `${evidence.sourceIdentifier}/${evidence.source}/${packageId}/${evidence.scope}`,
+      });
+    }),
+  });
+}
+
+function legacyFallback(input: ProviderMaintenanceDefinitionInput) {
+  return defineInstallation<{ executable: string; root: string }>({
+    id: `${input.provider}-unknown`,
+    detect: Effect.fn("detect-legacy-npm")(function* (context) {
+      if (!context.isBareCommand) return notMatched;
+      const executable = yield* context.resolveCommand("npm");
+      if (!executable) return notMatched;
+      const probe = yield* context.run(executable, ["root", "-g"], context.environment);
+      const root = output(probe?.stdout);
+      return probe?.exitCode === 0 && root
+        ? matched({ executable, root })
+        : undetermined("Legacy npm target is unavailable.");
+    }),
+    resolve: Effect.fn("resolve-legacy-npm")(function* (evidence, context) {
+      const latest = yield* context.run(
+        evidence.executable,
+        ["view", `${input.packageName}@latest`, "version", "--json"],
+        context.environment,
+      );
+      return resolved(input, context, {
+        kind: "unknown",
+        label: "Unknown installation — legacy npm fallback",
+        root: evidence.root,
+        executable: evidence.executable,
+        currentVersion: null,
+        latestVersion: normalizeMaintenanceVersion(output(latest?.stdout)),
+        args: npmGlobalUpdateArgs(input.packageName),
+        displayCommand: `npm install -g --allow-scripts=${input.packageName} ${input.packageName}@latest`,
+        ownershipVerified: false,
+      });
+    }),
+  });
+}
+
+export function makeProviderInstallationCatalog(
+  input: ProviderMaintenanceDefinitionInput,
+): InstallationCatalog {
+  return {
+    installations: [
+      nativeDefinition(input),
+      homebrewDefinition(input),
+      scoopDefinition(input),
+      wingetDefinition(input),
+      ...nodeManagers.map((manager) =>
+        defineInstallation<NodeEvidence>({
+          id: `${input.provider}-${manager.id}`,
+          detect: detectNodePackage(input, manager),
+          resolve: resolveNodePackage(input, manager),
+        }),
+      ),
+    ].filter((definition): definition is NonNullable<typeof definition> => definition !== null),
+    fallbacks: [legacyFallback(input)],
+  };
+}

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -352,6 +352,14 @@ function stableHomebrewRoot(context: InstallationContext, prefix: string): strin
   return formulaEnd < 0 ? normalized : normalized.slice(0, formulaEnd);
 }
 
+function isHomebrewShimPath(path: string): boolean {
+  return (
+    path.startsWith("/opt/homebrew/bin/") ||
+    path.startsWith("/usr/local/bin/") ||
+    path.includes("/.linuxbrew/bin/")
+  );
+}
+
 function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
   return defineInstallation<{
     executable: string;
@@ -365,7 +373,9 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
       const observed = normalize(context, context.realCommandPath ?? context.binaryPath);
       const observedLower = observed.toLowerCase();
       if (!observedLower.includes("/cellar/") && !observedLower.includes("/caskroom/")) {
-        return notMatched;
+        return isHomebrewShimPath(observedLower)
+          ? undetermined("Homebrew shim ownership could not be verified.")
+          : notMatched;
       }
       const executable = yield* context.resolveCommand("brew");
       if (!executable) return undetermined("Homebrew executable is unavailable.");

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -93,54 +93,109 @@ function packageRoot(path: string, packageName: string): string | null {
   return index < 0 ? null : normalized.slice(0, index + needle.length - 1);
 }
 
+function wrapperTargetPath(
+  context: InstallationContext,
+  wrapperPath: string,
+  expression: string,
+): string | null {
+  const path = pathApi(context);
+  const normalized = expression.replace(/^@/, "").replaceAll("\\", "/");
+  const lower = normalized.toLowerCase();
+  for (const marker of ["%~dp0", "%dp0%", "$basedir", "${basedir}"] as const) {
+    if (lower.startsWith(marker.toLowerCase())) {
+      return path.resolve(
+        path.dirname(wrapperPath),
+        normalized.slice(marker.length).replace(/^\/+/, ""),
+      );
+    }
+  }
+  if (normalized.includes("$") || normalized.includes("%")) return null;
+  return path.isAbsolute(normalized)
+    ? normalized
+    : path.resolve(path.dirname(wrapperPath), normalized);
+}
+
+function wrapperInvocationTargets(
+  context: InstallationContext,
+  wrapper: string | null,
+  wrapperPath: string | null,
+): ReadonlyArray<string> | null {
+  if (!wrapper || !wrapperPath) return null;
+  const isNodeLauncher = (token: string | undefined) => {
+    const normalized = token?.replace(/^@/, "").replaceAll("\\", "/").toLowerCase();
+    const executable = normalized?.split("/").at(-1);
+    return normalized === "%_prog%" || executable === "node" || executable === "node.exe";
+  };
+  const invocationLines = wrapper.split(/\r?\n/).flatMap((line) => {
+    const trimmed = line.trim();
+    if (
+      !trimmed ||
+      trimmed.startsWith("#") ||
+      trimmed.startsWith("::") ||
+      /^rem(?:\s|$)/i.test(trimmed)
+    ) {
+      return [];
+    }
+    const tokens = [...trimmed.matchAll(/"([^"]*)"|'([^']*)'|([^\s()"']+)/g)].map(
+      (match) => match[1] ?? match[2] ?? match[3] ?? "",
+    );
+    const forwardedArgsIndex = tokens.findIndex((token) => token === "$@" || token === "%*");
+    if (forwardedArgsIndex < 0) return [];
+    const targetIndex = forwardedArgsIndex - 1;
+    const target = tokens[targetIndex];
+    const launcher = tokens[targetIndex - 1];
+    const directLaunch =
+      context.platform === "win32"
+        ? targetIndex === 0 || launcher === "@"
+        : launcher?.replace(/^@/, "").toLowerCase() === "exec";
+    const nodeLaunch =
+      isNodeLauncher(launcher) &&
+      (context.platform === "win32" ||
+        tokens[targetIndex - 2]?.replace(/^@/, "").toLowerCase() === "exec");
+    return target && (directLaunch || nodeLaunch) ? [target] : [""];
+  });
+  if (invocationLines.length === 0) return null;
+  const targets = invocationLines.map((expression) =>
+    wrapperTargetPath(context, wrapperPath, expression),
+  );
+  return targets.every((target): target is string => target !== null) ? targets : null;
+}
+
 function packageRootFromWrapper(
   context: InstallationContext,
   wrapper: string | null,
   wrapperPath: string | null,
   packageName: string,
-): string | null {
-  if (!wrapper || !wrapperPath) return null;
-  const path = pathApi(context);
-  const embedded = packageRoot(wrapper, packageName);
-  if (embedded && path.isAbsolute(embedded)) return embedded;
-  const normalized = wrapper.replaceAll("\\", "/");
-  const packageSuffix = `/node_modules/${packageName}/`;
-  const suffixIndex = normalized.toLowerCase().lastIndexOf(packageSuffix.toLowerCase());
-  if (suffixIndex < 0) {
-    return null;
-  }
-  const prefix = normalized.slice(0, suffixIndex);
-  const lowerPrefix = prefix.toLowerCase();
-  const windowsMarkers = ["%~dp0", "%dp0%"] as const;
-  const windowsMarker = windowsMarkers
-    .map((marker) => ({ marker, index: lowerPrefix.lastIndexOf(marker) }))
-    .sort((left, right) => right.index - left.index)[0];
-  const windowsBaseIndex = windowsMarker?.index ?? -1;
-  if (windowsBaseIndex >= 0) {
-    return path.resolve(
-      path.dirname(wrapperPath),
-      prefix.slice(windowsBaseIndex + (windowsMarker?.marker.length ?? 0)).replace(/^\/+/, ""),
-      "node_modules",
-      ...packageName.split("/"),
+) {
+  return Effect.gen(function* () {
+    const targets = wrapperInvocationTargets(context, wrapper, wrapperPath);
+    if (!targets) return null;
+    const roots = yield* Effect.forEach(targets, (target) =>
+      Effect.gen(function* () {
+        const realTarget = yield* context.realPath(target);
+        const lexicalRoot = packageRoot(target, packageName);
+        const realTargetRoot = packageRoot(realTarget, packageName);
+        const root = realTargetRoot ?? lexicalRoot;
+        if (!root) return null;
+        const realRoot = yield* context.realPath(root);
+        return within(context, realTarget, realRoot) ? realRoot : null;
+      }),
     );
-  }
-  const shellBaseIndex = prefix.lastIndexOf("$basedir");
-  if (shellBaseIndex >= 0) {
-    return path.resolve(
-      path.dirname(wrapperPath),
-      prefix.slice(shellBaseIndex + "$basedir".length).replace(/^\/+/, ""),
-      "node_modules",
-      ...packageName.split("/"),
-    );
-  }
-  return path.join(path.dirname(wrapperPath), "node_modules", ...packageName.split("/"));
+    const verifiedRoots = roots.filter((root): root is string => root !== null);
+    const first = verifiedRoots[0];
+    return first &&
+      verifiedRoots.length === roots.length &&
+      verifiedRoots.every((root) => normalize(context, root) === normalize(context, first))
+      ? first
+      : null;
+  });
 }
 
-function wrapperHasAmbiguousPackagePrefix(wrapper: string | null, packageName: string): boolean {
+function wrapperMentionsPackage(wrapper: string | null, packageName: string): boolean {
   if (!wrapper) return false;
   const normalized = wrapper.replaceAll("\\", "/").toLowerCase();
   const prefix = `/node_modules/${packageName.toLowerCase()}`;
-  return normalized.includes(prefix) && !normalized.includes(`${prefix}/`);
+  return normalized.includes(prefix);
 }
 
 const npmGlobalUpdateArgs = (packageName: string) => [
@@ -198,7 +253,6 @@ const nodeManagers = [
 ] as const;
 
 type NodeManager = (typeof nodeManagers)[number];
-const NODE_WRAPPER_MAX_BYTES = 64 * 1_024;
 interface NodeEvidence {
   readonly executable: string;
   readonly updateRoot: string;
@@ -211,14 +265,15 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
       context,
       context.realCommandPath ?? context.resolvedCommandPath ?? context.binaryPath,
     );
-    const wrapper = yield* context.readTextFile(
-      context.resolvedCommandPath ?? "",
-      NODE_WRAPPER_MAX_BYTES,
+    const wrapper = yield* context.readTextFile(context.resolvedCommandPath ?? "");
+    const wrapperRoot = yield* packageRootFromWrapper(
+      context,
+      wrapper,
+      context.resolvedCommandPath,
+      input.packageName,
     );
-    let root =
-      packageRoot(observed, input.packageName) ??
-      packageRootFromWrapper(context, wrapper, context.resolvedCommandPath, input.packageName);
-    if (!root && wrapperHasAmbiguousPackagePrefix(wrapper, input.packageName)) {
+    let root = packageRoot(observed, input.packageName) ?? wrapperRoot;
+    if (!root && wrapperMentionsPackage(wrapper, input.packageName)) {
       return undetermined;
     }
     if (!root && manager.id !== "bun") return notMatched;
@@ -247,7 +302,7 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
     if (!root) return notMatched;
     root = yield* context.realPath(root);
     const manifest = json(yield* context.readTextFile(pathApi(context).join(root, "package.json")));
-    if (text(manifest?.name) !== input.packageName) return notMatched;
+    if (text(manifest?.name) !== input.packageName) return undetermined;
     let updateRoot = resolvedManagerRoot;
     if (manager.id === "npm") {
       const prefix = npmGlobalPrefix(context, root, input.packageName);
@@ -410,6 +465,12 @@ function homebrewPackageFromPath(path: string): string | null {
   return path.slice(start).split("/")[0] || null;
 }
 
+function normalizeHomebrewCaskVersion(value: string | null): string | null {
+  // Homebrew appends cask build/revision data after a comma; provider
+  // version precedence is determined by the version before it.
+  return normalizeMaintenanceVersion(value?.split(",", 1)[0]);
+}
+
 function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
   if (!input.homebrewFormula) return null;
   const configuredFormula = input.homebrewFormula;
@@ -431,9 +492,12 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
       const executable = yield* context.resolveCommand("brew");
       if (!executable) return undetermined;
       const pathPackage = homebrewPackageFromPath(observed);
+      const configuredBaseName = configuredFormula.split("/").at(-1);
+      const configuredMatchesPath =
+        pathPackage !== null && configuredBaseName?.toLowerCase() === pathPackage.toLowerCase();
       const candidates = [
         ...new Set(
-          [pathPackage, configuredFormula].filter(
+          [configuredMatchesPath ? configuredFormula : null, pathPackage, configuredFormula].filter(
             (candidate): candidate is string => candidate !== null,
           ),
         ),
@@ -500,18 +564,21 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
         ? text(caskInfo.installed[0])
         : text(caskInfo?.installed);
       const currentVersion = normalizeMaintenanceVersion(
-        packageType === "formula" ? text(installedFormula?.version) : installedCask,
+        packageType === "formula" ? text(installedFormula?.version) : null,
       );
-      if (!currentVersion) return undetermined;
+      const normalizedCurrentVersion =
+        packageType === "formula" ? currentVersion : normalizeHomebrewCaskVersion(installedCask);
+      if (!normalizedCurrentVersion) return undetermined;
       return matched({
         executable,
         formula,
         packageType,
         prefix,
-        currentVersion,
-        latestVersion: normalizeMaintenanceVersion(
-          packageType === "formula" ? stable : text(caskInfo?.version),
-        ),
+        currentVersion: normalizedCurrentVersion,
+        latestVersion:
+          packageType === "formula"
+            ? normalizeMaintenanceVersion(stable)
+            : normalizeHomebrewCaskVersion(text(caskInfo?.version)),
       });
     }),
     resolve: (evidence, context) => {

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -149,6 +149,18 @@ const npmGlobalUpdateArgs = (packageName: string) => [
   `${packageName}@latest`,
 ];
 
+function npmGlobalPrefix(context: InstallationContext, packageRoot: string) {
+  const normalizedRoot = normalize(context, packageRoot);
+  if (context.platform === "win32") {
+    const marker = "/node_modules/";
+    const markerIndex = normalizedRoot.lastIndexOf(marker);
+    return markerIndex > 0 ? packageRoot.replaceAll("\\", "/").slice(0, markerIndex) : null;
+  }
+  const marker = "/lib/node_modules/";
+  const markerIndex = normalizedRoot.lastIndexOf(marker);
+  return markerIndex > 0 ? packageRoot.replaceAll("\\", "/").slice(0, markerIndex) : null;
+}
+
 const nodeManagers = [
   {
     id: "vite-plus",
@@ -188,7 +200,7 @@ type NodeManager = (typeof nodeManagers)[number];
 interface NodeEvidence {
   readonly manager: NodeManager;
   readonly executable: string;
-  readonly root: string;
+  readonly updateRoot: string;
   readonly currentVersion: string | null;
 }
 
@@ -232,11 +244,29 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
     root = yield* context.realPath(root);
     const manifest = json(yield* context.readTextFile(pathApi(context).join(root, "package.json")));
     if (text(manifest?.name) !== input.packageName) return notMatched;
-    if (!within(context, root, ownershipRoot)) return notMatched;
+    let updateRoot = resolvedManagerRoot;
+    if (manager.id === "npm") {
+      const prefix = npmGlobalPrefix(context, root);
+      if (!prefix) {
+        return undetermined("The npm global prefix owning this package could not be verified.");
+      }
+      if (
+        context.platform === "win32" &&
+        !within(context, root, ownershipRoot) &&
+        (!context.resolvedCommandPath ||
+          normalize(context, pathApi(context).dirname(context.resolvedCommandPath)) !==
+            normalize(context, prefix))
+      ) {
+        return undetermined("The npm wrapper does not belong to the detected global prefix.");
+      }
+      updateRoot = prefix;
+    } else if (!within(context, root, ownershipRoot)) {
+      return notMatched;
+    }
     return matched({
       manager,
       executable,
-      root: resolvedManagerRoot,
+      updateRoot,
       currentVersion: normalizeMaintenanceVersion(text(manifest?.version)),
     });
   });
@@ -252,11 +282,19 @@ function resolveNodePackage(input: ProviderMaintenanceDefinitionInput, manager: 
       evidence.manager.latestArgs(input.packageName),
       context.environment,
     );
-    const updateArgs = evidence.manager.updateArgs(input.packageName);
+    const updateArgs =
+      evidence.manager.id === "npm"
+        ? [
+            ...npmGlobalUpdateArgs(input.packageName).slice(0, 2),
+            "--prefix",
+            evidence.updateRoot,
+            ...npmGlobalUpdateArgs(input.packageName).slice(2),
+          ]
+        : evidence.manager.updateArgs(input.packageName);
     return resolved(input, context, {
       kind: evidence.manager.id,
       label: `Managed by ${evidence.manager.label}`,
-      root: evidence.root,
+      root: evidence.updateRoot,
       executable: evidence.executable,
       currentVersion: evidence.currentVersion,
       latestVersion: normalizeMaintenanceVersion(output(latest?.stdout)),
@@ -741,40 +779,6 @@ function wingetDefinition(input: ProviderMaintenanceDefinitionInput) {
   });
 }
 
-function legacyFallback(input: ProviderMaintenanceDefinitionInput) {
-  return defineInstallation<{ executable: string; root: string }>({
-    id: `${input.provider}-unknown`,
-    detect: Effect.fn("detect-legacy-npm")(function* (context) {
-      if (!context.isBareCommand) return notMatched;
-      const executable = yield* context.resolveCommand("npm");
-      if (!executable) return notMatched;
-      const probe = yield* context.run(executable, ["root", "-g"], context.environment);
-      const root = output(probe?.stdout);
-      return probe?.exitCode === 0 && root
-        ? matched({ executable, root })
-        : undetermined("Legacy npm target is unavailable.");
-    }),
-    resolve: Effect.fn("resolve-legacy-npm")(function* (evidence, context) {
-      const latest = yield* context.run(
-        evidence.executable,
-        ["view", `${input.packageName}@latest`, "version", "--json"],
-        context.environment,
-      );
-      return resolved(input, context, {
-        kind: "unknown",
-        label: "Unknown installation — legacy npm fallback",
-        root: evidence.root,
-        executable: evidence.executable,
-        currentVersion: null,
-        latestVersion: normalizeMaintenanceVersion(output(latest?.stdout)),
-        args: npmGlobalUpdateArgs(input.packageName),
-        displayCommand: `npm install -g --allow-scripts=${input.packageName} ${input.packageName}@latest`,
-        ownershipVerified: false,
-      });
-    }),
-  });
-}
-
 export function makeProviderInstallationCatalog(
   input: ProviderMaintenanceDefinitionInput,
 ): InstallationCatalog {
@@ -792,6 +796,5 @@ export function makeProviderInstallationCatalog(
         }),
       ),
     ].filter((definition): definition is NonNullable<typeof definition> => definition !== null),
-    fallbacks: [legacyFallback(input)],
   };
 }

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -443,12 +443,13 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
             context.environment,
           );
           const formulaPrefix = output(formulaPrefixProbe?.stdout);
+          const realFormulaPrefix = formulaPrefix ? yield* context.realPath(formulaPrefix) : null;
           if (
             formulaPrefixProbe?.exitCode === 0 &&
-            formulaPrefix &&
-            within(context, observed, formulaPrefix)
+            realFormulaPrefix &&
+            within(context, observed, realFormulaPrefix)
           ) {
-            return { formula, prefix: formulaPrefix };
+            return { formula, prefix: realFormulaPrefix };
           }
           const caskPrefixProbe = yield* context.run(
             executable,
@@ -456,10 +457,11 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
             context.environment,
           );
           const caskPrefix = output(caskPrefixProbe?.stdout);
+          const realCaskPrefix = caskPrefix ? yield* context.realPath(caskPrefix) : null;
           return caskPrefixProbe?.exitCode === 0 &&
-            caskPrefix &&
-            within(context, observed, caskPrefix)
-            ? { formula, prefix: caskPrefix }
+            realCaskPrefix &&
+            within(context, observed, realCaskPrefix)
+            ? { formula, prefix: realCaskPrefix }
             : null;
         }),
       );

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -90,7 +90,16 @@ function packageRoot(path: string, packageName: string): string | null {
   const normalized = path.replaceAll("\\", "/");
   const needle = `/node_modules/${packageName}/`;
   const index = normalized.toLowerCase().lastIndexOf(needle.toLowerCase());
-  return index < 0 ? null : normalized.slice(0, index + needle.length - 1);
+  if (index < 0 || normalized.slice(0, index).toLowerCase().includes("/node_modules/")) {
+    return null;
+  }
+  return normalized.slice(0, index + needle.length - 1);
+}
+
+function hasNestedPackageRoot(path: string, packageName: string): boolean {
+  const normalized = path.replaceAll("\\", "/").toLowerCase();
+  const index = normalized.lastIndexOf(`/node_modules/${packageName.toLowerCase()}/`);
+  return index >= 0 && normalized.slice(0, index).includes("/node_modules/");
 }
 
 function wrapperTargetPath(
@@ -273,7 +282,11 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
       input.packageName,
     );
     let root = packageRoot(observed, input.packageName) ?? wrapperRoot;
-    if (!root && wrapperMentionsPackage(wrapper, input.packageName)) {
+    if (
+      !root &&
+      (hasNestedPackageRoot(observed, input.packageName) ||
+        wrapperMentionsPackage(wrapper, input.packageName))
+    ) {
       return undetermined;
     }
     if (!root && manager.id !== "bun") return notMatched;
@@ -493,8 +506,15 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
       if (!executable) return undetermined;
       const pathPackage = homebrewPackageFromPath(observed);
       const configuredBaseName = configuredFormula.split("/").at(-1);
-      const configuredMatchesPath =
-        pathPackage !== null && configuredBaseName?.toLowerCase() === pathPackage.toLowerCase();
+      if (
+        !pathPackage ||
+        !configuredBaseName ||
+        (pathPackage.toLowerCase() !== configuredBaseName.toLowerCase() &&
+          !pathPackage.toLowerCase().startsWith(`${configuredBaseName.toLowerCase()}@`))
+      ) {
+        return undetermined;
+      }
+      const configuredMatchesPath = configuredBaseName.toLowerCase() === pathPackage.toLowerCase();
       const candidates = [
         ...new Set(
           [configuredMatchesPath ? configuredFormula : null, pathPackage, configuredFormula].filter(

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -26,6 +26,7 @@ export interface ProviderMaintenanceDefinitionInput {
     readonly label: string;
     readonly updateArgs: ReadonlyArray<string>;
     readonly ownsPath: (normalizedPath: string) => boolean;
+    readonly identityRoot?: (normalizedPath: string) => string | null;
     readonly environment?: (
       executable: string,
       environment: NodeJS.ProcessEnv,
@@ -364,7 +365,9 @@ function nativeDefinition(input: ProviderMaintenanceDefinitionInput) {
         resolved(input, context, {
           kind: "native",
           label: native.label,
-          root: pathApi(context).dirname(executable),
+          root:
+            native.identityRoot?.(normalize(context, executable)) ??
+            pathApi(context).dirname(executable),
           executable,
           identityExecutable: context.resolvedCommandPath ?? executable,
           currentVersion: null,

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -573,20 +573,20 @@ function scoopDefinition(input: ProviderMaintenanceDefinitionInput) {
       const global = !within(context, executable, root);
       if (global) {
         const environmentRoot = text(context.environment.SCOOP_GLOBAL);
-        const configProbe =
-          environmentRoot && normalize(context, environmentRoot) === normalize(context, root)
-            ? null
-            : yield* context.run(executable, ["config", "global_path"], context.environment);
-        const configuredRoot = output(configProbe?.stdout);
+        const configProbe = environmentRoot
+          ? null
+          : yield* context.run(executable, ["config", "global_path"], context.environment);
+        const configOutput = output(configProbe?.stdout);
+        const configuredRoot =
+          configProbe?.exitCode === 0 && configOutput && pathApi(context).isAbsolute(configOutput)
+            ? configOutput
+            : null;
         const defaultRoot = pathApi(context).join(
           context.environment.ProgramData ?? "C:\\ProgramData",
           "scoop",
         );
-        const ownsGlobalRoot = [environmentRoot, configuredRoot, defaultRoot].some(
-          (candidate) =>
-            candidate !== null && normalize(context, candidate) === normalize(context, root),
-        );
-        if (!ownsGlobalRoot) {
+        const effectiveGlobalRoot = environmentRoot ?? configuredRoot ?? defaultRoot;
+        if (normalize(context, effectiveGlobalRoot) !== normalize(context, root)) {
           return undetermined("The global Scoop root owning this shim could not be verified.");
         }
       }

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -219,12 +219,12 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
       packageRoot(observed, input.packageName) ??
       packageRootFromWrapper(context, wrapper, context.resolvedCommandPath, input.packageName);
     if (!root && wrapperHasAmbiguousPackagePrefix(wrapper, input.packageName)) {
-      return undetermined("The command wrapper's package ownership is ambiguous.");
+      return undetermined;
     }
     if (!root && manager.id !== "bun") return notMatched;
     const executable = yield* context.resolveCommand(manager.command);
     if (!executable) {
-      return root ? undetermined("The owning package manager is unavailable.") : notMatched;
+      return root ? undetermined : notMatched;
     }
     const rootProbe = yield* context.run(executable, manager.rootArgs, context.environment);
     const managerRoot = output(rootProbe?.stdout);
@@ -252,7 +252,7 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
     if (manager.id === "npm") {
       const prefix = npmGlobalPrefix(context, root, input.packageName);
       if (!prefix) {
-        return undetermined("The npm global prefix owning this package could not be verified.");
+        return undetermined;
       }
       if (
         context.platform === "win32" &&
@@ -261,7 +261,7 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
           normalize(context, pathApi(context).dirname(context.resolvedCommandPath)) !==
             normalize(context, prefix))
       ) {
-        return undetermined("The npm wrapper does not belong to the detected global prefix.");
+        return undetermined;
       }
       updateRoot = prefix;
     } else if (!within(context, root, ownershipRoot)) {
@@ -426,12 +426,10 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
       const observed = normalize(context, context.realCommandPath ?? context.binaryPath);
       const observedLower = observed.toLowerCase();
       if (!observedLower.includes("/cellar/") && !observedLower.includes("/caskroom/")) {
-        return isHomebrewShimPath(observedLower)
-          ? undetermined("Homebrew shim ownership could not be verified.")
-          : notMatched;
+        return isHomebrewShimPath(observedLower) ? undetermined : notMatched;
       }
       const executable = yield* context.resolveCommand("brew");
-      if (!executable) return undetermined("Homebrew executable is unavailable.");
+      if (!executable) return undetermined;
       const pathPackage = homebrewPackageFromPath(observed);
       const candidates = [
         ...new Set(
@@ -479,7 +477,7 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
           readonly prefix: string;
         } => candidate !== null,
       );
-      if (!ownership) return undetermined("Homebrew formula ownership could not be verified.");
+      if (!ownership) return undetermined;
       const { formula, packageType, prefix } = ownership;
       const infoProbe = yield* context.run(
         executable,
@@ -488,7 +486,7 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
       );
       const info = json(infoProbe?.stdout ?? null);
       if (!infoProbe || infoProbe.exitCode !== 0 || !info) {
-        return undetermined("Homebrew formula metadata is unavailable.");
+        return undetermined;
       }
       const formulaInfo = records(info.formulae)[0];
       const caskInfo = records(info.casks)[0];
@@ -504,7 +502,7 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
       const currentVersion = normalizeMaintenanceVersion(
         packageType === "formula" ? text(installedFormula?.version) : installedCask,
       );
-      if (!currentVersion) return undetermined("Homebrew installed version is unavailable.");
+      if (!currentVersion) return undetermined;
       return matched({
         executable,
         formula,
@@ -566,7 +564,7 @@ function scoopDefinition(input: ProviderMaintenanceDefinitionInput) {
         !app ||
         !within(context, target, pathApi(context).join(root, "apps", app, "current"))
       ) {
-        return undetermined("Scoop shim ownership metadata is unreadable.");
+        return undetermined;
       }
       const install = json(
         yield* context.readTextFile(
@@ -578,16 +576,16 @@ function scoopDefinition(input: ProviderMaintenanceDefinitionInput) {
           pathApi(context).join(root, "apps", app, "current", "manifest.json"),
         ),
       );
-      if (!install || !manifest) return undetermined("Scoop metadata is unreadable.");
+      if (!install || !manifest) return undetermined;
       const bucket = text(install.bucket);
-      if (!bucket) return undetermined("Scoop bucket provenance is unavailable.");
+      if (!bucket) return undetermined;
       const executable = yield* context.resolveCommand("scoop");
-      if (!executable) return undetermined("Scoop is unavailable.");
+      if (!executable) return undetermined;
       const slashExecutable = executable.replaceAll("\\", "/");
       const executablePath = slashExecutable.toLowerCase();
       const managerMarker = "/shims/";
       const managerIndex = executablePath.lastIndexOf(managerMarker);
-      if (managerIndex < 0) return undetermined("The owning Scoop root is unavailable.");
+      if (managerIndex < 0) return undetermined;
       const managerRoot = slashExecutable.slice(0, managerIndex);
       const global = !within(context, executable, root);
       if (global) {
@@ -606,7 +604,7 @@ function scoopDefinition(input: ProviderMaintenanceDefinitionInput) {
         );
         const effectiveGlobalRoot = environmentRoot ?? configuredRoot ?? defaultRoot;
         if (normalize(context, effectiveGlobalRoot) !== normalize(context, root)) {
-          return undetermined("The global Scoop root owning this shim could not be verified.");
+          return undetermined;
         }
       }
       const available = json(
@@ -731,7 +729,7 @@ function wingetDefinition(input: ProviderMaintenanceDefinitionInput) {
           (result) => result === null || (result.exitCode !== 0 && result.exitCode !== 1),
         )
       ) {
-        return undetermined("WinGet ARP metadata is unreadable.");
+        return undetermined;
       }
       const keys = searches.flatMap((search, searchIndex) =>
         (searchResults[searchIndex]?.stdout.match(/^HKEY_[^\r\n]+/gim) ?? []).map((key) => ({
@@ -740,12 +738,12 @@ function wingetDefinition(input: ProviderMaintenanceDefinitionInput) {
           view: search.view,
         })),
       );
-      if (keys.length === 0) return undetermined("WinGet package metadata is unavailable.");
+      if (keys.length === 0) return undetermined;
       const entryResults = yield* Effect.forEach(keys, ({ key, view }) =>
         context.run(reg, ["query", key, view], context.environment),
       );
       if (entryResults.some((result) => result === null || result.exitCode !== 0)) {
-        return undetermined("WinGet package metadata could not be read.");
+        return undetermined;
       }
       const matches = entryResults
         .flatMap((result, resultIndex) =>
@@ -760,12 +758,10 @@ function wingetDefinition(input: ProviderMaintenanceDefinitionInput) {
             ((entry.symlinkPath && normalize(context, entry.symlinkPath) === observed) ||
               (entry.targetPath && normalize(context, entry.targetPath) === real)),
         );
-      if (matches.length === 0)
-        return undetermined("WinGet executable ownership could not be verified.");
-      if (matches.length !== 1 || !matches[0]!.entry.sourceId)
-        return undetermined("WinGet ownership is ambiguous.");
+      if (matches.length === 0) return undetermined;
+      if (matches.length !== 1 || !matches[0]!.entry.sourceId) return undetermined;
       const executable = yield* context.resolveCommand("winget");
-      if (!executable) return undetermined("WinGet is unavailable.");
+      if (!executable) return undetermined;
       const sourceProbe = yield* context.run(
         executable,
         ["source", "export", "--disable-interactivity"],
@@ -778,7 +774,7 @@ function wingetDefinition(input: ProviderMaintenanceDefinitionInput) {
           candidate.name === matches[0]!.entry.sourceId,
       )?.name;
       if (!sourceProbe || sourceProbe.exitCode !== 0 || !source) {
-        return undetermined("The WinGet source owning this package is unavailable.");
+        return undetermined;
       }
       return matched({
         executable,

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -200,7 +200,6 @@ const nodeManagers = [
 type NodeManager = (typeof nodeManagers)[number];
 const NODE_WRAPPER_MAX_BYTES = 64 * 1_024;
 interface NodeEvidence {
-  readonly manager: NodeManager;
   readonly executable: string;
   readonly updateRoot: string;
   readonly currentVersion: string | null;
@@ -269,7 +268,6 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
       return notMatched;
     }
     return matched({
-      manager,
       executable,
       updateRoot,
       currentVersion: normalizeMaintenanceVersion(text(manifest?.version)),
@@ -284,27 +282,27 @@ function resolveNodePackage(input: ProviderMaintenanceDefinitionInput, manager: 
   ) {
     const latest = yield* context.run(
       evidence.executable,
-      evidence.manager.latestArgs(input.packageName),
+      manager.latestArgs(input.packageName),
       context.environment,
     );
     const updateArgs =
-      evidence.manager.id === "npm"
+      manager.id === "npm"
         ? [
             ...npmGlobalUpdateArgs(input.packageName).slice(0, 2),
             "--prefix",
             evidence.updateRoot,
             ...npmGlobalUpdateArgs(input.packageName).slice(2),
           ]
-        : evidence.manager.updateArgs(input.packageName);
+        : manager.updateArgs(input.packageName);
     return resolved(input, context, {
-      kind: evidence.manager.id,
-      label: `Managed by ${evidence.manager.label}`,
+      kind: manager.id,
+      label: `Managed by ${manager.label}`,
       root: evidence.updateRoot,
       executable: evidence.executable,
       currentVersion: evidence.currentVersion,
       latestVersion: normalizeMaintenanceVersion(output(latest?.stdout)),
       args: updateArgs,
-      displayCommand: `${evidence.manager.command} ${updateArgs.join(" ")}`,
+      displayCommand: `${manager.command} ${updateArgs.join(" ")}`,
     });
   });
 }
@@ -322,7 +320,6 @@ function resolved(
     readonly args: ReadonlyArray<string>;
     readonly displayCommand: string;
     readonly environment?: NodeJS.ProcessEnv;
-    readonly ownershipVerified?: boolean;
     readonly identityQualifier?: string;
     readonly identityExecutable?: string;
   },
@@ -337,7 +334,7 @@ function resolved(
     }),
     lockKey: `${value.kind}:${normalize(context, value.root)}`,
     label: value.label,
-    ownershipVerified: value.ownershipVerified ?? true,
+    ownershipVerified: true,
     packageName: input.packageName,
     currentVersion: value.currentVersion,
     latestVersion: value.latestVersion,
@@ -414,6 +411,8 @@ function homebrewPackageFromPath(path: string): string | null {
 }
 
 function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
+  if (!input.homebrewFormula) return null;
+  const configuredFormula = input.homebrewFormula;
   return defineInstallation<{
     executable: string;
     formula: string;
@@ -424,7 +423,6 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
   }>({
     id: `${input.provider}-homebrew`,
     detect: Effect.fn("detect-homebrew")(function* (context) {
-      if (!input.homebrewFormula) return notMatched;
       const observed = normalize(context, context.realCommandPath ?? context.binaryPath);
       const observedLower = observed.toLowerCase();
       if (!observedLower.includes("/cellar/") && !observedLower.includes("/caskroom/")) {
@@ -437,7 +435,7 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
       const pathPackage = homebrewPackageFromPath(observed);
       const candidates = [
         ...new Set(
-          [pathPackage, input.homebrewFormula].filter(
+          [pathPackage, configuredFormula].filter(
             (candidate): candidate is string => candidate !== null,
           ),
         ),

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -399,9 +399,18 @@ function isHomebrewShimPath(path: string) {
   );
 }
 
+function homebrewPackageFromPath(path: string): string | null {
+  const lower = path.toLowerCase();
+  const marker = ["/cellar/", "/caskroom/"].find((candidate) => lower.includes(candidate));
+  if (!marker) return null;
+  const start = lower.indexOf(marker) + marker.length;
+  return path.slice(start).split("/")[0] || null;
+}
+
 function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
   return defineInstallation<{
     executable: string;
+    formula: string;
     prefix: string;
     currentVersion: string | null;
     latestVersion: string | null;
@@ -418,28 +427,48 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
       }
       const executable = yield* context.resolveCommand("brew");
       if (!executable) return undetermined("Homebrew executable is unavailable.");
-      const formula = input.homebrewFormula;
-      const formulaPrefixProbe = yield* context.run(
-        executable,
-        ["--prefix", "--installed", formula],
-        context.environment,
-      );
-      const formulaPrefix = output(formulaPrefixProbe?.stdout);
-      const caskPrefixProbe = yield* context.run(
-        executable,
-        ["--caskroom", formula],
-        context.environment,
-      );
-      const caskPrefix = output(caskPrefixProbe?.stdout);
-      const prefix =
-        formulaPrefixProbe?.exitCode === 0 &&
-        formulaPrefix &&
-        within(context, observed, formulaPrefix)
-          ? formulaPrefix
-          : caskPrefixProbe?.exitCode === 0 && caskPrefix && within(context, observed, caskPrefix)
-            ? caskPrefix
+      const pathPackage = homebrewPackageFromPath(observed);
+      const candidates = [
+        ...new Set(
+          [pathPackage, input.homebrewFormula].filter(
+            (candidate): candidate is string => candidate !== null,
+          ),
+        ),
+      ];
+      const ownershipCandidates = yield* Effect.forEach(candidates, (formula) =>
+        Effect.gen(function* () {
+          const formulaPrefixProbe = yield* context.run(
+            executable,
+            ["--prefix", "--installed", formula],
+            context.environment,
+          );
+          const formulaPrefix = output(formulaPrefixProbe?.stdout);
+          if (
+            formulaPrefixProbe?.exitCode === 0 &&
+            formulaPrefix &&
+            within(context, observed, formulaPrefix)
+          ) {
+            return { formula, prefix: formulaPrefix };
+          }
+          const caskPrefixProbe = yield* context.run(
+            executable,
+            ["--caskroom", formula],
+            context.environment,
+          );
+          const caskPrefix = output(caskPrefixProbe?.stdout);
+          return caskPrefixProbe?.exitCode === 0 &&
+            caskPrefix &&
+            within(context, observed, caskPrefix)
+            ? { formula, prefix: caskPrefix }
             : null;
-      if (!prefix) return undetermined("Homebrew formula ownership could not be verified.");
+        }),
+      );
+      const ownership = ownershipCandidates.find(
+        (candidate): candidate is { readonly formula: string; readonly prefix: string } =>
+          candidate !== null,
+      );
+      if (!ownership) return undetermined("Homebrew formula ownership could not be verified.");
+      const { formula, prefix } = ownership;
       const infoProbe = yield* context.run(
         executable,
         ["info", "--json=v2", formula],
@@ -466,13 +495,14 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
       if (!currentVersion) return undetermined("Homebrew installed version is unavailable.");
       return matched({
         executable,
+        formula,
         prefix,
         currentVersion,
         latestVersion: normalizeMaintenanceVersion(stable ?? text(caskInfo?.version)),
       });
     }),
     resolve: (evidence, context) => {
-      const formula = input.homebrewFormula!;
+      const formula = evidence.formula;
       return Effect.succeed(
         resolved(input, context, {
           kind: "homebrew",
@@ -540,20 +570,23 @@ function scoopDefinition(input: ProviderMaintenanceDefinitionInput) {
       const managerIndex = executablePath.lastIndexOf(managerMarker);
       if (managerIndex < 0) return undetermined("The owning Scoop root is unavailable.");
       const managerRoot = slashExecutable.slice(0, managerIndex);
-      let global = !within(context, executable, root);
+      const global = !within(context, executable, root);
       if (global) {
-        const globalProbe = yield* context.run(
-          executable,
-          ["config", "SCOOP_GLOBAL"],
-          context.environment,
+        const environmentRoot = text(context.environment.SCOOP_GLOBAL);
+        const configProbe =
+          environmentRoot && normalize(context, environmentRoot) === normalize(context, root)
+            ? null
+            : yield* context.run(executable, ["config", "global_path"], context.environment);
+        const configuredRoot = output(configProbe?.stdout);
+        const defaultRoot = pathApi(context).join(
+          context.environment.ProgramData ?? "C:\\ProgramData",
+          "scoop",
         );
-        const globalRoot = output(globalProbe?.stdout);
-        if (
-          !globalProbe ||
-          globalProbe.exitCode !== 0 ||
-          !globalRoot ||
-          normalize(context, globalRoot) !== normalize(context, root)
-        ) {
+        const ownsGlobalRoot = [environmentRoot, configuredRoot, defaultRoot].some(
+          (candidate) =>
+            candidate !== null && normalize(context, candidate) === normalize(context, root),
+        );
+        if (!ownsGlobalRoot) {
           return undetermined("The global Scoop root owning this shim could not be verified.");
         }
       }

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -198,6 +198,7 @@ const nodeManagers = [
 ] as const;
 
 type NodeManager = (typeof nodeManagers)[number];
+const NODE_WRAPPER_MAX_BYTES = 64 * 1_024;
 interface NodeEvidence {
   readonly manager: NodeManager;
   readonly executable: string;
@@ -211,7 +212,10 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
       context,
       context.realCommandPath ?? context.resolvedCommandPath ?? context.binaryPath,
     );
-    const wrapper = yield* context.readTextFile(context.resolvedCommandPath ?? "");
+    const wrapper = yield* context.readTextFile(
+      context.resolvedCommandPath ?? "",
+      NODE_WRAPPER_MAX_BYTES,
+    );
     let root =
       packageRoot(observed, input.packageName) ??
       packageRootFromWrapper(context, wrapper, context.resolvedCommandPath, input.packageName);
@@ -413,6 +417,7 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
   return defineInstallation<{
     executable: string;
     formula: string;
+    packageType: "formula" | "cask";
     prefix: string;
     currentVersion: string | null;
     latestVersion: string | null;
@@ -451,7 +456,7 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
             realFormulaPrefix &&
             within(context, observed, realFormulaPrefix)
           ) {
-            return { formula, prefix: realFormulaPrefix };
+            return { formula, packageType: "formula" as const, prefix: realFormulaPrefix };
           }
           const caskPrefixProbe = yield* context.run(
             executable,
@@ -463,16 +468,21 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
           return caskPrefixProbe?.exitCode === 0 &&
             realCaskPrefix &&
             within(context, observed, realCaskPrefix)
-            ? { formula, prefix: realCaskPrefix }
+            ? { formula, packageType: "cask" as const, prefix: realCaskPrefix }
             : null;
         }),
       );
       const ownership = ownershipCandidates.find(
-        (candidate): candidate is { readonly formula: string; readonly prefix: string } =>
-          candidate !== null,
+        (
+          candidate,
+        ): candidate is {
+          readonly formula: string;
+          readonly packageType: "formula" | "cask";
+          readonly prefix: string;
+        } => candidate !== null,
       );
       if (!ownership) return undetermined("Homebrew formula ownership could not be verified.");
-      const { formula, prefix } = ownership;
+      const { formula, packageType, prefix } = ownership;
       const infoProbe = yield* context.run(
         executable,
         ["info", "--json=v2", formula],
@@ -494,19 +504,26 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
         ? text(caskInfo.installed[0])
         : text(caskInfo?.installed);
       const currentVersion = normalizeMaintenanceVersion(
-        text(installedFormula?.version) ?? installedCask,
+        packageType === "formula" ? text(installedFormula?.version) : installedCask,
       );
       if (!currentVersion) return undetermined("Homebrew installed version is unavailable.");
       return matched({
         executable,
         formula,
+        packageType,
         prefix,
         currentVersion,
-        latestVersion: normalizeMaintenanceVersion(stable ?? text(caskInfo?.version)),
+        latestVersion: normalizeMaintenanceVersion(
+          packageType === "formula" ? stable : text(caskInfo?.version),
+        ),
       });
     }),
     resolve: (evidence, context) => {
       const formula = evidence.formula;
+      const args =
+        evidence.packageType === "cask"
+          ? (["upgrade", "--cask", formula] as const)
+          : (["upgrade", formula] as const);
       return Effect.succeed(
         resolved(input, context, {
           kind: "homebrew",
@@ -515,8 +532,8 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
           executable: evidence.executable,
           currentVersion: evidence.currentVersion,
           latestVersion: evidence.latestVersion,
-          args: ["upgrade", formula],
-          displayCommand: `brew upgrade ${formula}`,
+          args,
+          displayCommand: `brew ${args.join(" ")}`,
         }),
       );
     },

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -390,7 +390,7 @@ function stableHomebrewRoot(context: InstallationContext, prefix: string): strin
   return formulaEnd < 0 ? normalized : normalized.slice(0, formulaEnd);
 }
 
-function isHomebrewShimPath(path: string): boolean {
+function isHomebrewShimPath(path: string) {
   return (
     path.startsWith("/opt/homebrew/bin/") ||
     path.startsWith("/usr/local/bin/") ||

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -456,7 +456,9 @@ function homebrewDefinition(input: ProviderMaintenanceDefinitionInput) {
           ? text((versions as Record<string, unknown>).stable)
           : null;
       const installedFormula = records(formulaInfo?.installed)[0];
-      const installedCask = Array.isArray(caskInfo?.installed) ? text(caskInfo.installed[0]) : null;
+      const installedCask = Array.isArray(caskInfo?.installed)
+        ? text(caskInfo.installed[0])
+        : text(caskInfo?.installed);
       const currentVersion = normalizeMaintenanceVersion(
         text(installedFormula?.version) ?? installedCask,
       );

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -15,7 +15,7 @@ import {
   type ResolvedInstallation,
   undetermined,
 } from "./definition.ts";
-import { normalizeMaintenanceVersion } from "./version.ts";
+import { compareMaintenanceVersions, normalizeMaintenanceVersion } from "./version.ts";
 
 export interface ProviderMaintenanceDefinitionInput {
   readonly provider: ProviderDriverKind;
@@ -150,15 +150,16 @@ const npmGlobalUpdateArgs = (packageName: string) => [
 ];
 
 function npmGlobalPrefix(context: InstallationContext, packageRoot: string) {
-  const normalizedRoot = normalize(context, packageRoot);
+  const slashRoot = packageRoot.replaceAll("\\", "/");
+  const comparableRoot = context.platform === "win32" ? slashRoot.toLowerCase() : slashRoot;
   if (context.platform === "win32") {
     const marker = "/node_modules/";
-    const markerIndex = normalizedRoot.lastIndexOf(marker);
-    return markerIndex > 0 ? packageRoot.replaceAll("\\", "/").slice(0, markerIndex) : null;
+    const markerIndex = comparableRoot.lastIndexOf(marker);
+    return markerIndex > 0 ? slashRoot.slice(0, markerIndex) : null;
   }
   const marker = "/lib/node_modules/";
-  const markerIndex = normalizedRoot.lastIndexOf(marker);
-  return markerIndex > 0 ? packageRoot.replaceAll("\\", "/").slice(0, markerIndex) : null;
+  const markerIndex = comparableRoot.lastIndexOf(marker);
+  return markerIndex > 0 ? slashRoot.slice(0, markerIndex) : null;
 }
 
 const nodeManagers = [
@@ -501,11 +502,12 @@ function scoopDefinition(input: ProviderMaintenanceDefinitionInput) {
     id: `${input.provider}-scoop`,
     detect: Effect.fn("detect-scoop")(function* (context) {
       if (context.platform !== "win32" || !context.resolvedCommandPath) return notMatched;
-      const observed = normalize(context, context.resolvedCommandPath);
+      const resolvedCommandPath = context.resolvedCommandPath.replaceAll("\\", "/");
+      const observed = resolvedCommandPath.toLowerCase();
       const marker = "/shims/";
       const index = observed.lastIndexOf(marker);
       if (index < 0) return notMatched;
-      const root = context.resolvedCommandPath.replaceAll("\\", "/").slice(0, index);
+      const root = resolvedCommandPath.slice(0, index);
       const shim = context.resolvedCommandPath.replace(/\.(?:exe|cmd|ps1)$/i, "") + ".shim";
       const target = (yield* context.readTextFile(shim))?.match(/^path\s*=\s*"([^"]+)"/m)?.[1];
       const targetPath = target ? normalize(context, target) : null;
@@ -532,11 +534,12 @@ function scoopDefinition(input: ProviderMaintenanceDefinitionInput) {
       if (!bucket) return undetermined("Scoop bucket provenance is unavailable.");
       const executable = yield* context.resolveCommand("scoop");
       if (!executable) return undetermined("Scoop is unavailable.");
-      const executablePath = normalize(context, executable);
+      const slashExecutable = executable.replaceAll("\\", "/");
+      const executablePath = slashExecutable.toLowerCase();
       const managerMarker = "/shims/";
       const managerIndex = executablePath.lastIndexOf(managerMarker);
       if (managerIndex < 0) return undetermined("The owning Scoop root is unavailable.");
-      const managerRoot = executable.replaceAll("\\", "/").slice(0, managerIndex);
+      const managerRoot = slashExecutable.slice(0, managerIndex);
       let global = !within(context, executable, root);
       if (global) {
         const globalProbe = yield* context.run(
@@ -751,9 +754,16 @@ function wingetDefinition(input: ProviderMaintenanceDefinitionInput) {
       );
       const latest =
         show && show.exitCode === 0
-          ? ((show.stdout.match(/\b\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\b/g) ?? [])
+          ? (show.stdout.match(/\b\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\b/g) ?? [])
               .map(normalizeMaintenanceVersion)
-              .find((value): value is string => value !== null) ?? null)
+              .filter((value): value is string => value !== null)
+              .reduce<string | null>(
+                (maximum, value) =>
+                  maximum === null || compareMaintenanceVersions(value, maximum) === 1
+                    ? value
+                    : maximum,
+                null,
+              )
           : null;
       return resolved(input, context, {
         kind: "winget",

--- a/apps/server/src/provider/maintenance/catalogs.ts
+++ b/apps/server/src/provider/maintenance/catalogs.ts
@@ -149,17 +149,16 @@ const npmGlobalUpdateArgs = (packageName: string) => [
   `${packageName}@latest`,
 ];
 
-function npmGlobalPrefix(context: InstallationContext, packageRoot: string) {
+function npmGlobalPrefix(context: InstallationContext, packageRoot: string, packageName: string) {
   const slashRoot = packageRoot.replaceAll("\\", "/");
   const comparableRoot = context.platform === "win32" ? slashRoot.toLowerCase() : slashRoot;
-  if (context.platform === "win32") {
-    const marker = "/node_modules/";
-    const markerIndex = comparableRoot.lastIndexOf(marker);
-    return markerIndex > 0 ? slashRoot.slice(0, markerIndex) : null;
-  }
-  const marker = "/lib/node_modules/";
-  const markerIndex = comparableRoot.lastIndexOf(marker);
-  return markerIndex > 0 ? slashRoot.slice(0, markerIndex) : null;
+  const marker = context.platform === "win32" ? "/node_modules/" : "/lib/node_modules/";
+  const markerIndex = comparableRoot.indexOf(marker);
+  if (markerIndex <= 0) return null;
+  const packagePath = comparableRoot.slice(markerIndex + marker.length).replace(/\/+$/, "");
+  const comparablePackageName =
+    context.platform === "win32" ? packageName.toLowerCase() : packageName;
+  return packagePath === comparablePackageName ? slashRoot.slice(0, markerIndex) : null;
 }
 
 const nodeManagers = [
@@ -247,7 +246,7 @@ function detectNodePackage(input: ProviderMaintenanceDefinitionInput, manager: N
     if (text(manifest?.name) !== input.packageName) return notMatched;
     let updateRoot = resolvedManagerRoot;
     if (manager.id === "npm") {
-      const prefix = npmGlobalPrefix(context, root);
+      const prefix = npmGlobalPrefix(context, root, input.packageName);
       if (!prefix) {
         return undetermined("The npm global prefix owning this package could not be verified.");
       }

--- a/apps/server/src/provider/maintenance/definition.ts
+++ b/apps/server/src/provider/maintenance/definition.ts
@@ -1,0 +1,129 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeCrypto from "node:crypto";
+import * as NodePath from "node:path";
+
+import type { ProviderDriverKind } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+export type InstallationDetection<Evidence> =
+  | { readonly _tag: "Matched"; readonly evidence: Evidence }
+  | { readonly _tag: "NotMatched" }
+  | { readonly _tag: "Undetermined"; readonly reason: string };
+
+export interface MaintenanceProbeResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+export interface InstallationContext {
+  readonly provider: ProviderDriverKind;
+  readonly packageName: string;
+  readonly binaryPath: string;
+  readonly isBareCommand: boolean;
+  readonly resolvedCommandPath: string | null;
+  readonly realCommandPath: string | null;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly platform: NodeJS.Platform;
+  readonly readTextFile: (path: string) => Effect.Effect<string | null>;
+  readonly realPath: (path: string) => Effect.Effect<string>;
+  readonly resolveCommand: (command: string) => Effect.Effect<string | null>;
+  readonly run: (
+    executable: string,
+    args: ReadonlyArray<string>,
+    environment?: NodeJS.ProcessEnv,
+  ) => Effect.Effect<MaintenanceProbeResult | null>;
+}
+
+export interface UpdateCommand {
+  readonly executable: string;
+  readonly args: ReadonlyArray<string>;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly displayCommand: string;
+}
+
+export interface ResolvedInstallation {
+  readonly identityKey: string;
+  readonly lockKey: string;
+  readonly label: string;
+  readonly ownershipVerified: boolean;
+  readonly packageName: string | null;
+  readonly currentVersion: string | null;
+  readonly latestVersion: string | null;
+  readonly update: UpdateCommand | null;
+  readonly instructionsUrl: string | null;
+}
+
+export interface InstallationDefinition<Evidence> {
+  readonly id: string;
+  readonly detect: (context: InstallationContext) => Effect.Effect<InstallationDetection<Evidence>>;
+  readonly resolve: (
+    evidence: Evidence,
+    context: InstallationContext,
+  ) => Effect.Effect<ResolvedInstallation>;
+}
+
+export interface AnyInstallationDefinition {
+  readonly id: string;
+  readonly detectAndResolve: (
+    context: InstallationContext,
+  ) => Effect.Effect<
+    | { readonly _tag: "Matched"; readonly installation: ResolvedInstallation }
+    | { readonly _tag: "NotMatched" }
+    | { readonly _tag: "Undetermined"; readonly reason: string }
+  >;
+}
+
+export function defineInstallation<Evidence>(
+  definition: InstallationDefinition<Evidence>,
+): AnyInstallationDefinition {
+  return {
+    id: definition.id,
+    detectAndResolve: Effect.fn(`detectAndResolve:${definition.id}`)(function* (context) {
+      const detection = yield* definition.detect(context);
+      switch (detection._tag) {
+        case "Matched":
+          return {
+            _tag: "Matched",
+            installation: yield* definition.resolve(detection.evidence, context),
+          } as const;
+        case "NotMatched":
+          return { _tag: "NotMatched" } as const;
+        case "Undetermined":
+          return detection;
+      }
+    }),
+  };
+}
+
+export interface InstallationCatalog {
+  readonly installations: ReadonlyArray<AnyInstallationDefinition>;
+  readonly fallbacks: ReadonlyArray<AnyInstallationDefinition>;
+}
+
+export function installationIdentity(input: Readonly<Record<string, string | null>>): string {
+  const canonical = Object.fromEntries(
+    Object.entries(input)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => [key, value ?? ""]),
+  );
+  return NodeCrypto.createHash("sha256")
+    .update(`t3-provider-maintenance-v1\0${JSON.stringify(canonical)}`, "utf8")
+    .digest("hex");
+}
+
+export function canonicalPath(path: string, platform: NodeJS.Platform): string {
+  const pathApi = platform === "win32" ? NodePath.win32 : NodePath.posix;
+  const normalized = pathApi.normalize(pathApi.resolve(path));
+  return platform === "win32" ? normalized.replaceAll("\\", "/").toLowerCase() : normalized;
+}
+
+export function matched<Evidence>(evidence: Evidence): InstallationDetection<Evidence> {
+  return { _tag: "Matched", evidence };
+}
+
+export const notMatched: InstallationDetection<never> = { _tag: "NotMatched" };
+
+export function undetermined(reason: string): InstallationDetection<never> {
+  return { _tag: "Undetermined", reason };
+}

--- a/apps/server/src/provider/maintenance/definition.ts
+++ b/apps/server/src/provider/maintenance/definition.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 export type InstallationDetection<Evidence> =
   | { readonly _tag: "Matched"; readonly evidence: Evidence }
   | { readonly _tag: "NotMatched" }
-  | { readonly _tag: "Undetermined"; readonly reason: string };
+  | { readonly _tag: "Undetermined" };
 
 export interface MaintenanceProbeResult {
   readonly stdout: string;
@@ -63,13 +63,12 @@ export interface InstallationDefinition<Evidence> {
 }
 
 export interface AnyInstallationDefinition {
-  readonly id: string;
   readonly detectAndResolve: (
     context: InstallationContext,
   ) => Effect.Effect<
     | { readonly _tag: "Matched"; readonly installation: ResolvedInstallation }
     | { readonly _tag: "NotMatched" }
-    | { readonly _tag: "Undetermined"; readonly reason: string }
+    | { readonly _tag: "Undetermined" }
   >;
 }
 
@@ -77,7 +76,6 @@ export function defineInstallation<Evidence>(
   definition: InstallationDefinition<Evidence>,
 ): AnyInstallationDefinition {
   return {
-    id: definition.id,
     detectAndResolve: Effect.fn(`detectAndResolve:${definition.id}`)(function* (context) {
       const detection = yield* definition.detect(context);
       switch (detection._tag) {
@@ -122,6 +120,4 @@ export function matched<Evidence>(evidence: Evidence): InstallationDetection<Evi
 
 export const notMatched: InstallationDetection<never> = { _tag: "NotMatched" };
 
-export function undetermined(reason: string): InstallationDetection<never> {
-  return { _tag: "Undetermined", reason };
-}
+export const undetermined: InstallationDetection<never> = { _tag: "Undetermined" };

--- a/apps/server/src/provider/maintenance/definition.ts
+++ b/apps/server/src/provider/maintenance/definition.ts
@@ -98,7 +98,6 @@ export function defineInstallation<Evidence>(
 
 export interface InstallationCatalog {
   readonly installations: ReadonlyArray<AnyInstallationDefinition>;
-  readonly fallbacks: ReadonlyArray<AnyInstallationDefinition>;
 }
 
 export function installationIdentity(input: Readonly<Record<string, string | null>>): string {

--- a/apps/server/src/provider/maintenance/definition.ts
+++ b/apps/server/src/provider/maintenance/definition.ts
@@ -25,7 +25,7 @@ export interface InstallationContext {
   readonly realCommandPath: string | null;
   readonly environment: NodeJS.ProcessEnv;
   readonly platform: NodeJS.Platform;
-  readonly readTextFile: (path: string) => Effect.Effect<string | null>;
+  readonly readTextFile: (path: string, maxBytes?: number) => Effect.Effect<string | null>;
   readonly realPath: (path: string) => Effect.Effect<string>;
   readonly resolveCommand: (command: string) => Effect.Effect<string | null>;
   readonly run: (

--- a/apps/server/src/provider/maintenance/definition.ts
+++ b/apps/server/src/provider/maintenance/definition.ts
@@ -20,7 +20,6 @@ export interface InstallationContext {
   readonly provider: ProviderDriverKind;
   readonly packageName: string;
   readonly binaryPath: string;
-  readonly isBareCommand: boolean;
   readonly resolvedCommandPath: string | null;
   readonly realCommandPath: string | null;
   readonly environment: NodeJS.ProcessEnv;

--- a/apps/server/src/provider/maintenance/definition.ts
+++ b/apps/server/src/provider/maintenance/definition.ts
@@ -16,6 +16,8 @@ export interface MaintenanceProbeResult {
   readonly exitCode: number;
 }
 
+export const INSTALLER_METADATA_MAX_BYTES = 64 * 1_024;
+
 export interface InstallationContext {
   readonly provider: ProviderDriverKind;
   readonly packageName: string;
@@ -24,7 +26,7 @@ export interface InstallationContext {
   readonly realCommandPath: string | null;
   readonly environment: NodeJS.ProcessEnv;
   readonly platform: NodeJS.Platform;
-  readonly readTextFile: (path: string, maxBytes?: number) => Effect.Effect<string | null>;
+  readonly readTextFile: (path: string) => Effect.Effect<string | null>;
   readonly realPath: (path: string) => Effect.Effect<string>;
   readonly resolveCommand: (command: string) => Effect.Effect<string | null>;
   readonly run: (

--- a/apps/server/src/provider/maintenance/resolver.ts
+++ b/apps/server/src/provider/maintenance/resolver.ts
@@ -1,0 +1,51 @@
+import * as Effect from "effect/Effect";
+
+import type {
+  AnyInstallationDefinition,
+  InstallationCatalog,
+  InstallationContext,
+  ResolvedInstallation,
+} from "./definition.ts";
+
+function resolveFirst(
+  context: InstallationContext,
+  definitions: ReadonlyArray<AnyInstallationDefinition>,
+) {
+  return Effect.gen(function* () {
+    const reasons: Array<string> = [];
+    for (const definition of definitions) {
+      const result = yield* definition.detectAndResolve(context);
+      if (result._tag === "Matched") return result;
+      if (result._tag === "Undetermined") reasons.push(`${definition.id}: ${result.reason}`);
+    }
+    return reasons.length > 0
+      ? ({ _tag: "Undetermined", reasons } as const)
+      : ({ _tag: "NotMatched" } as const);
+  });
+}
+
+export const resolveInstallation = Effect.fn("resolveInstallation")(function* (
+  context: InstallationContext,
+  catalog: InstallationCatalog,
+) {
+  const owned = yield* resolveFirst(context, catalog.installations);
+  if (owned._tag === "Matched") return owned.installation;
+  if (owned._tag === "Undetermined") return manualInstallation(context, true);
+  const fallback = yield* resolveFirst(context, catalog.fallbacks);
+  if (fallback._tag === "Matched") return fallback.installation;
+  return manualInstallation(context, fallback._tag === "Undetermined");
+});
+
+function manualInstallation(context: InstallationContext, failed: boolean): ResolvedInstallation {
+  return {
+    identityKey: "manual",
+    lockKey: `manual:${context.provider}`,
+    label: failed ? "Unknown installation — verification failed" : "Unknown installation",
+    ownershipVerified: false,
+    packageName: context.packageName,
+    currentVersion: null,
+    latestVersion: null,
+    update: null,
+    instructionsUrl: null,
+  };
+}

--- a/apps/server/src/provider/maintenance/resolver.ts
+++ b/apps/server/src/provider/maintenance/resolver.ts
@@ -12,15 +12,13 @@ function resolveFirst(
   definitions: ReadonlyArray<AnyInstallationDefinition>,
 ) {
   return Effect.gen(function* () {
-    const reasons: Array<string> = [];
+    let undetermined = false;
     for (const definition of definitions) {
       const result = yield* definition.detectAndResolve(context);
       if (result._tag === "Matched") return result;
-      if (result._tag === "Undetermined") reasons.push(`${definition.id}: ${result.reason}`);
+      if (result._tag === "Undetermined") undetermined = true;
     }
-    return reasons.length > 0
-      ? ({ _tag: "Undetermined", reasons } as const)
-      : ({ _tag: "NotMatched" } as const);
+    return undetermined ? ({ _tag: "Undetermined" } as const) : ({ _tag: "NotMatched" } as const);
   });
 }
 

--- a/apps/server/src/provider/maintenance/resolver.ts
+++ b/apps/server/src/provider/maintenance/resolver.ts
@@ -30,10 +30,7 @@ export const resolveInstallation = Effect.fn("resolveInstallation")(function* (
 ) {
   const owned = yield* resolveFirst(context, catalog.installations);
   if (owned._tag === "Matched") return owned.installation;
-  if (owned._tag === "Undetermined") return manualInstallation(context, true);
-  const fallback = yield* resolveFirst(context, catalog.fallbacks);
-  if (fallback._tag === "Matched") return fallback.installation;
-  return manualInstallation(context, fallback._tag === "Undetermined");
+  return manualInstallation(context, owned._tag === "Undetermined");
 });
 
 function manualInstallation(context: InstallationContext, failed: boolean): ResolvedInstallation {

--- a/apps/server/src/provider/maintenance/resolver.ts
+++ b/apps/server/src/provider/maintenance/resolver.ts
@@ -29,11 +29,10 @@ export const resolveInstallation = Effect.fn("resolveInstallation")(function* (
   const textFiles = new Map<string, string | null>();
   const cachedContext: InstallationContext = {
     ...context,
-    readTextFile: Effect.fn("readCachedInstallationTextFile")(function* (path, maxBytes) {
-      const cacheKey = `${path}\0${maxBytes ?? "unbounded"}`;
-      if (textFiles.has(cacheKey)) return textFiles.get(cacheKey) ?? null;
-      const value = yield* context.readTextFile(path, maxBytes);
-      textFiles.set(cacheKey, value);
+    readTextFile: Effect.fn("readCachedInstallationTextFile")(function* (path) {
+      if (textFiles.has(path)) return textFiles.get(path) ?? null;
+      const value = yield* context.readTextFile(path);
+      textFiles.set(path, value);
       return value;
     }),
   };

--- a/apps/server/src/provider/maintenance/resolver.ts
+++ b/apps/server/src/provider/maintenance/resolver.ts
@@ -28,7 +28,18 @@ export const resolveInstallation = Effect.fn("resolveInstallation")(function* (
   context: InstallationContext,
   catalog: InstallationCatalog,
 ) {
-  const owned = yield* resolveFirst(context, catalog.installations);
+  const textFiles = new Map<string, string | null>();
+  const cachedContext: InstallationContext = {
+    ...context,
+    readTextFile: Effect.fn("readCachedInstallationTextFile")(function* (path, maxBytes) {
+      const cacheKey = `${path}\0${maxBytes ?? "unbounded"}`;
+      if (textFiles.has(cacheKey)) return textFiles.get(cacheKey) ?? null;
+      const value = yield* context.readTextFile(path, maxBytes);
+      textFiles.set(cacheKey, value);
+      return value;
+    }),
+  };
+  const owned = yield* resolveFirst(cachedContext, catalog.installations);
   if (owned._tag === "Matched") return owned.installation;
   return manualInstallation(context, owned._tag === "Undetermined");
 });

--- a/apps/server/src/provider/maintenance/version.test.ts
+++ b/apps/server/src/provider/maintenance/version.test.ts
@@ -1,0 +1,20 @@
+import { expect, it } from "@effect/vitest";
+
+import { compareMaintenanceVersions, normalizeMaintenanceVersion } from "./version.ts";
+
+it("normalizes only valid full semantic versions", () => {
+  expect(normalizeMaintenanceVersion("v1.2.3+build.01")).toBe("1.2.3+build.01");
+  expect(normalizeMaintenanceVersion("1.0.0+foo-01")).toBe("1.0.0+foo-01");
+  expect(normalizeMaintenanceVersion("1.0.0-01")).toBeNull();
+});
+
+it("compares abbreviated versions and ignores build metadata", () => {
+  expect(compareMaintenanceVersions("1.2", "1.2.0")).toBe(0);
+  expect(compareMaintenanceVersions("1.0.0+abc", "1.0.0+xyz")).toBe(0);
+});
+
+it("follows prerelease precedence without losing numeric precision", () => {
+  expect(compareMaintenanceVersions("1.0.0-alpha.1", "1.0.0-alpha.beta")).toBe(-1);
+  expect(compareMaintenanceVersions("1.0.0-9007199254740992", "1.0.0-9007199254740993")).toBe(-1);
+  expect(compareMaintenanceVersions("1.0.0-01", "1.0.0-1")).toBeNull();
+});

--- a/apps/server/src/provider/maintenance/version.test.ts
+++ b/apps/server/src/provider/maintenance/version.test.ts
@@ -5,12 +5,19 @@ import { compareMaintenanceVersions, normalizeMaintenanceVersion } from "./versi
 it("normalizes only valid full semantic versions", () => {
   expect(normalizeMaintenanceVersion("v1.2.3+build.01")).toBe("1.2.3+build.01");
   expect(normalizeMaintenanceVersion("1.0.0+foo-01")).toBe("1.0.0+foo-01");
+  expect(normalizeMaintenanceVersion("1.0.0-alpha.0")).toBe("1.0.0-alpha.0");
+  expect(normalizeMaintenanceVersion("1.2")).toBeNull();
+  expect(normalizeMaintenanceVersion("01.2.3")).toBeNull();
+  expect(normalizeMaintenanceVersion("1.2.3-alpha..1")).toBeNull();
+  expect(normalizeMaintenanceVersion("1.2.3+")).toBeNull();
   expect(normalizeMaintenanceVersion("1.0.0-01")).toBeNull();
 });
 
 it("compares abbreviated versions and ignores build metadata", () => {
   expect(compareMaintenanceVersions("1.2", "1.2.0")).toBe(0);
+  expect(compareMaintenanceVersions("v1", "1.0.0")).toBe(0);
   expect(compareMaintenanceVersions("1.0.0+abc", "1.0.0+xyz")).toBe(0);
+  expect(compareMaintenanceVersions("1.02", "1.2.0")).toBeNull();
 });
 
 it("follows prerelease precedence without losing numeric precision", () => {

--- a/apps/server/src/provider/maintenance/version.ts
+++ b/apps/server/src/provider/maintenance/version.ts
@@ -1,0 +1,67 @@
+const FULL_SEMVER =
+  /^(?:v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const COMPARABLE_SEMVER =
+  /^(?:v)?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+interface ParsedSemver {
+  readonly major: bigint;
+  readonly minor: bigint;
+  readonly patch: bigint;
+  readonly prerelease: ReadonlyArray<string>;
+}
+
+function hasValidPrerelease(value: string): boolean {
+  const prerelease = value.match(/^[^-+]+(?:-(?<prerelease>[^+]+))?(?:\+|$)/)?.groups?.prerelease;
+  return (
+    prerelease === undefined ||
+    prerelease
+      .split(".")
+      .every((identifier) => !/^\d+$/.test(identifier) || /^(?:0|[1-9]\d*)$/.test(identifier))
+  );
+}
+
+export function normalizeMaintenanceVersion(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || !FULL_SEMVER.test(trimmed) || !hasValidPrerelease(trimmed)) return null;
+  return trimmed.startsWith("v") ? trimmed.slice(1) : trimmed;
+}
+
+function parse(value: string): ParsedSemver | null {
+  const match = hasValidPrerelease(value) ? COMPARABLE_SEMVER.exec(value) : null;
+  return match
+    ? {
+        major: BigInt(match[1]!),
+        minor: BigInt(match[2] ?? 0),
+        patch: BigInt(match[3] ?? 0),
+        prerelease: match[4]?.split(".") ?? [],
+      }
+    : null;
+}
+
+function comparePrerelease(left: ReadonlyArray<string>, right: ReadonlyArray<string>): number {
+  if (left.length === 0 || right.length === 0) {
+    return left.length === right.length ? 0 : left.length === 0 ? 1 : -1;
+  }
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const a = left[index];
+    const b = right[index];
+    if (a === undefined || b === undefined) return a === b ? 0 : a === undefined ? -1 : 1;
+    if (a === b) continue;
+    const aNumeric = /^\d+$/.test(a);
+    const bNumeric = /^\d+$/.test(b);
+    if (aNumeric && bNumeric) return BigInt(a) < BigInt(b) ? -1 : 1;
+    if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+    return a < b ? -1 : 1;
+  }
+  return 0;
+}
+
+export function compareMaintenanceVersions(left: string, right: string): number | null {
+  const a = parse(left);
+  const b = parse(right);
+  if (!a || !b) return null;
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (a[key] !== b[key]) return a[key] < b[key] ? -1 : 1;
+  }
+  return comparePrerelease(a.prerelease, b.prerelease);
+}

--- a/apps/server/src/provider/maintenance/version.ts
+++ b/apps/server/src/provider/maintenance/version.ts
@@ -1,6 +1,4 @@
-const FULL_SEMVER =
-  /^(?:v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
-const COMPARABLE_SEMVER =
+const SEMVER =
   /^(?:v)?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 interface ParsedSemver {
@@ -10,32 +8,29 @@ interface ParsedSemver {
   readonly prerelease: ReadonlyArray<string>;
 }
 
-function hasValidPrerelease(value: string): boolean {
-  const prerelease = value.match(/^[^-+]+(?:-(?<prerelease>[^+]+))?(?:\+|$)/)?.groups?.prerelease;
-  return (
-    prerelease === undefined ||
-    prerelease
-      .split(".")
-      .every((identifier) => !/^\d+$/.test(identifier) || /^(?:0|[1-9]\d*)$/.test(identifier))
-  );
-}
-
 export function normalizeMaintenanceVersion(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
-  if (!trimmed || !FULL_SEMVER.test(trimmed) || !hasValidPrerelease(trimmed)) return null;
+  if (!trimmed || !parse(trimmed, true)) return null;
   return trimmed.startsWith("v") ? trimmed.slice(1) : trimmed;
 }
 
-function parse(value: string): ParsedSemver | null {
-  const match = hasValidPrerelease(value) ? COMPARABLE_SEMVER.exec(value) : null;
-  return match
-    ? {
-        major: BigInt(match[1]!),
-        minor: BigInt(match[2] ?? 0),
-        patch: BigInt(match[3] ?? 0),
-        prerelease: match[4]?.split(".") ?? [],
-      }
-    : null;
+function parse(value: string, requireFull = false): ParsedSemver | null {
+  const match = SEMVER.exec(value);
+  if (!match || (requireFull && (match[2] === undefined || match[3] === undefined))) return null;
+  const prerelease = match[4]?.split(".") ?? [];
+  if (
+    prerelease.some(
+      (identifier) => /^\d+$/.test(identifier) && !/^(?:0|[1-9]\d*)$/.test(identifier),
+    )
+  ) {
+    return null;
+  }
+  return {
+    major: BigInt(match[1]!),
+    minor: BigInt(match[2] ?? 0),
+    patch: BigInt(match[3] ?? 0),
+    prerelease,
+  };
 }
 
 function comparePrerelease(left: ReadonlyArray<string>, right: ReadonlyArray<string>): number {

--- a/apps/server/src/provider/makeManagedServerProvider.test.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.test.ts
@@ -158,7 +158,7 @@ describe("makeManagedServerProvider", () => {
           const checkCalls = yield* Ref.make(0);
           const releaseCheck = yield* Deferred.make<void>();
           const provider = yield* makeManagedServerProvider<TestSettings>({
-            maintenanceCapabilities,
+            resolveMaintenance: Effect.succeed(maintenanceCapabilities),
             getSettings: Effect.succeed({ enabled: true }),
             streamSettings: Stream.empty,
             haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
@@ -198,7 +198,7 @@ describe("makeManagedServerProvider", () => {
         const checkCalls = yield* Ref.make(0);
         const initialCheckDone = yield* Deferred.make<void>();
         yield* makeManagedServerProvider<TestSettings>({
-          maintenanceCapabilities,
+          resolveMaintenance: Effect.succeed(maintenanceCapabilities),
           getSettings: Effect.succeed({ enabled: true }),
           streamSettings: Stream.empty,
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
@@ -229,7 +229,7 @@ describe("makeManagedServerProvider", () => {
         const checkCalls = yield* Ref.make(0);
         const initialCheckDone = yield* Deferred.make<void>();
         yield* makeManagedServerProvider<TestSettings>({
-          maintenanceCapabilities,
+          resolveMaintenance: Effect.succeed(maintenanceCapabilities),
           getSettings: Effect.succeed({ enabled: true }),
           streamSettings: Stream.empty,
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
@@ -256,7 +256,7 @@ describe("makeManagedServerProvider", () => {
         const checkCalls = yield* Ref.make(0);
         const initialCheckDone = yield* Deferred.make<void>();
         const provider = yield* makeManagedServerProvider<TestSettings>({
-          maintenanceCapabilities,
+          resolveMaintenance: Effect.succeed(maintenanceCapabilities),
           getSettings: Effect.succeed({ enabled: true }),
           streamSettings: Stream.empty,
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
@@ -311,7 +311,7 @@ describe("makeManagedServerProvider", () => {
         const periodicCheckDone = yield* Deferred.make<void>();
 
         yield* makeManagedServerProvider<TestSettings>({
-          maintenanceCapabilities,
+          resolveMaintenance: Effect.succeed(maintenanceCapabilities),
           getSettings: Effect.succeed({ enabled: true }),
           streamSettings: Stream.empty,
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
@@ -353,7 +353,7 @@ describe("makeManagedServerProvider", () => {
         const releaseInitialCheck = yield* Deferred.make<void>();
         const releaseSettingsCheck = yield* Deferred.make<void>();
         const provider = yield* makeManagedServerProvider<TestSettings>({
-          maintenanceCapabilities,
+          resolveMaintenance: Effect.succeed(maintenanceCapabilities),
           getSettings: Ref.get(settingsRef),
           streamSettings: Stream.fromPubSub(settingsChanges),
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
@@ -397,7 +397,7 @@ describe("makeManagedServerProvider", () => {
         const initialCheckDone = yield* Deferred.make<void>();
         const enrichmentCalls = yield* Ref.make(0);
         yield* makeManagedServerProvider<TestSettings>({
-          maintenanceCapabilities,
+          resolveMaintenance: Effect.succeed(maintenanceCapabilities),
           getSettings: Effect.succeed({ enabled: true }),
           streamSettings: Stream.fromPubSub(settingsChanges),
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
@@ -430,7 +430,7 @@ describe("makeManagedServerProvider", () => {
         const releaseEnrichment = yield* Deferred.make<void>();
         const releaseCheck = yield* Deferred.make<void>();
         const provider = yield* makeManagedServerProvider<TestSettings>({
-          maintenanceCapabilities,
+          resolveMaintenance: Effect.succeed(maintenanceCapabilities),
           getSettings: Effect.succeed({ enabled: true }),
           streamSettings: Stream.empty,
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
@@ -471,7 +471,7 @@ describe("makeManagedServerProvider", () => {
         const secondCallbackReady = yield* Deferred.make<void>();
         const allowFirstRefresh = yield* Deferred.make<void>();
         const provider = yield* makeManagedServerProvider<TestSettings>({
-          maintenanceCapabilities,
+          resolveMaintenance: Effect.succeed(maintenanceCapabilities),
           getSettings: Effect.succeed({ enabled: true }),
           streamSettings: Stream.empty,
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -17,6 +17,7 @@ import * as Semaphore from "effect/Semaphore";
 
 import * as BackgroundPolicy from "../background/BackgroundPolicy.ts";
 import { ServerSettingsService } from "../serverSettings.ts";
+import type { ProviderMaintenanceCapabilities } from "./providerMaintenance.ts";
 import type { ServerProviderShape } from "./Services/ServerProvider.ts";
 
 interface ProviderSnapshotState {
@@ -27,8 +28,8 @@ interface ProviderSnapshotState {
 export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(function* <
   Settings,
 >(input: {
-  readonly maintenanceCapabilities: ServerProviderShape["maintenanceCapabilities"];
-  readonly resolveMaintenance?: ServerProviderShape["resolveMaintenance"];
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly resolveMaintenance?: Effect.Effect<ProviderMaintenanceCapabilities>;
   readonly getSettings: Effect.Effect<Settings, ServerSettingsError>;
   readonly streamSettings: Stream.Stream<Settings>;
   readonly haveSettingsChanged: (previous: Settings, next: Settings) => boolean;
@@ -239,7 +240,6 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
   );
 
   return {
-    maintenanceCapabilities: input.maintenanceCapabilities,
     resolveMaintenance: input.resolveMaintenance ?? Effect.succeed(input.maintenanceCapabilities),
     getSnapshot: Ref.get(snapshotStateRef).pipe(Effect.map((state) => state.snapshot)),
     refresh: refreshSnapshot().pipe(Effect.tapError(Effect.logError), Effect.orDie),

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -17,7 +17,6 @@ import * as Semaphore from "effect/Semaphore";
 
 import * as BackgroundPolicy from "../background/BackgroundPolicy.ts";
 import { ServerSettingsService } from "../serverSettings.ts";
-import type { ProviderMaintenanceCapabilities } from "./providerMaintenance.ts";
 import type { ServerProviderShape } from "./Services/ServerProvider.ts";
 
 interface ProviderSnapshotState {
@@ -28,8 +27,7 @@ interface ProviderSnapshotState {
 export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(function* <
   Settings,
 >(input: {
-  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
-  readonly resolveMaintenance?: Effect.Effect<ProviderMaintenanceCapabilities>;
+  readonly resolveMaintenance: ServerProviderShape["resolveMaintenance"];
   readonly getSettings: Effect.Effect<Settings, ServerSettingsError>;
   readonly streamSettings: Stream.Stream<Settings>;
   readonly haveSettingsChanged: (previous: Settings, next: Settings) => boolean;
@@ -240,7 +238,7 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
   );
 
   return {
-    resolveMaintenance: input.resolveMaintenance ?? Effect.succeed(input.maintenanceCapabilities),
+    resolveMaintenance: input.resolveMaintenance,
     getSnapshot: Ref.get(snapshotStateRef).pipe(Effect.map((state) => state.snapshot)),
     refresh: refreshSnapshot().pipe(Effect.tapError(Effect.logError), Effect.orDie),
     get streamChanges() {

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -28,6 +28,7 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
   Settings,
 >(input: {
   readonly maintenanceCapabilities: ServerProviderShape["maintenanceCapabilities"];
+  readonly resolveMaintenance?: ServerProviderShape["resolveMaintenance"];
   readonly getSettings: Effect.Effect<Settings, ServerSettingsError>;
   readonly streamSettings: Stream.Stream<Settings>;
   readonly haveSettingsChanged: (previous: Settings, next: Settings) => boolean;
@@ -239,6 +240,7 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
 
   return {
     maintenanceCapabilities: input.maintenanceCapabilities,
+    resolveMaintenance: input.resolveMaintenance ?? Effect.succeed(input.maintenanceCapabilities),
     getSnapshot: Ref.get(snapshotStateRef).pipe(Effect.map((state) => state.snapshot)),
     refresh: refreshSnapshot().pipe(Effect.tapError(Effect.logError), Effect.orDie),
     get streamChanges() {

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -12,7 +12,7 @@ import { HttpClient } from "effect/unstable/http";
 import {
   createProviderVersionAdvisory,
   enrichProviderSnapshotWithVersionAdvisory,
-  makePackageManagedProviderMaintenanceResolver,
+  makeProviderMaintenanceResolver,
   makeProviderMaintenanceCapabilities,
   makeStaticProviderMaintenanceResolver,
   normalizeCommandPath,
@@ -22,6 +22,11 @@ import {
 } from "./providerMaintenance.ts";
 
 const driver = (value: string) => ProviderDriverKind.make(value);
+const writeNodeManagerFixture = (binDir: string, manager: string, globalRoot: string) => {
+  const executable = NodePath.join(binDir, manager);
+  NodeFS.writeFileSync(executable, `#!/bin/sh\nprintf '%s\\n' '${globalRoot}'\n`);
+  NodeFS.chmodSync(executable, 0o755);
+};
 const makeTempDir = (name: string) =>
   Crypto.Crypto.pipe(
     Effect.flatMap((crypto) => crypto.randomUUIDv4),
@@ -31,26 +36,30 @@ const isNativeTestCommandPath =
   (expectedPathSegment: string) =>
   (commandPath: string): boolean =>
     normalizeCommandPath(commandPath).includes(expectedPathSegment);
-const packageToolUpdate = makePackageManagedProviderMaintenanceResolver({
+const packageToolUpdate = makeProviderMaintenanceResolver({
   provider: driver("packageTool"),
-  npmPackageName: "@example/package-tool",
+  packageName: "@example/package-tool",
   homebrewFormula: "package-tool",
   nativeUpdate: null,
 });
-const nativePackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
+const nativePackageToolUpdate = makeProviderMaintenanceResolver({
   provider: driver("nativePackageTool"),
-  npmPackageName: "@example/native-package-tool",
+  packageName: "@example/native-package-tool",
   homebrewFormula: "native-package-tool",
   nativeUpdate: {
     executable: "native-package-tool",
     args: ["update"],
     lockKey: "native-package-tool-native",
     isCommandPath: isNativeTestCommandPath("/.local/bin/native-package-tool"),
+    environment: (executable, environment) => ({
+      ...environment,
+      PACKAGE_TOOL_INSTALL_DIR: NodePath.dirname(executable),
+    }),
   },
 });
-const scopedPackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
+const scopedPackageToolUpdate = makeProviderMaintenanceResolver({
   provider: driver("scopedPackageTool"),
-  npmPackageName: "@example/scoped-package-tool",
+  packageName: "@example/scoped-package-tool",
   homebrewFormula: "example/tap/scoped-package-tool",
   nativeUpdate: {
     executable: "scoped-package-tool",
@@ -112,7 +121,10 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
   it.effect("does not fetch latest provider versions when update checks are disabled", () =>
     enrichProviderSnapshotWithVersionAdvisory(
       installedPackageToolProvider,
-      packageToolUpdate.resolve(),
+      {
+        ...packageToolUpdate.resolve(),
+        latestVersion: "9.9.9",
+      },
       {
         enableProviderUpdateChecks: false,
       },
@@ -183,6 +195,37 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  it("compares abbreviated current versions without treating them as current", () => {
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("packageTool"),
+        currentVersion: "1.2",
+        latestVersion: "1.3.0",
+      }),
+    ).toMatchObject({
+      status: "behind_latest",
+      currentVersion: "1.2",
+      latestVersion: "1.3.0",
+    });
+  });
+
+  it("compares version components without losing integer precision", () => {
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("packageTool"),
+        currentVersion: "9007199254740992.0.0",
+        latestVersion: "9007199254740993.0.0",
+      }),
+    ).toMatchObject({ status: "behind_latest" });
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("packageTool"),
+        currentVersion: "1.0.0-9007199254740992",
+        latestVersion: "1.0.0-9007199254740993",
+      }),
+    ).toMatchObject({ status: "behind_latest" });
+  });
+
   it("keeps update commands owned by provider maintenance capabilities", () => {
     expect(staticToolUpdate.resolve()).toEqual({
       provider: driver("staticTool"),
@@ -199,114 +242,84 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
-  it.effect(
-    "switches package-managed providers to vite-plus updates when the resolved binary lives in vite-plus global bin",
-    () =>
-      Effect.gen(function* () {
-        const tempDir = yield* makeTempDir("t3-vite-plus-capabilities");
-        const vitePlusBinDir = NodePath.join(tempDir, ".vite-plus", "bin");
-        NodeFS.mkdirSync(vitePlusBinDir, { recursive: true });
-        const packageToolPath = NodePath.join(vitePlusBinDir, "package-tool");
-        NodeFS.writeFileSync(packageToolPath, "#!/bin/sh\n");
-        NodeFS.chmodSync(packageToolPath, 0o755);
+  it.effect("does not trust a vite-plus-shaped path without package ownership metadata", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-vite-plus-capabilities");
+      const vitePlusBinDir = NodePath.join(tempDir, ".vite-plus", "bin");
+      NodeFS.mkdirSync(vitePlusBinDir, { recursive: true });
+      const packageToolPath = NodePath.join(vitePlusBinDir, "package-tool");
+      NodeFS.writeFileSync(packageToolPath, "#!/bin/sh\n");
+      NodeFS.chmodSync(packageToolPath, 0o755);
 
-        const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
-          packageToolUpdate,
-          {
-            binaryPath: "package-tool",
-            env: {
-              PATH: vitePlusBinDir,
-            },
-          },
-        ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
+      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(packageToolUpdate, {
+        binaryPath: "package-tool",
+        env: {
+          PATH: vitePlusBinDir,
+        },
+      }).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
 
-        expect(capabilities).toEqual({
-          provider: driver("packageTool"),
-          packageName: "@example/package-tool",
-          update: {
-            command: "vp i -g @example/package-tool",
-
-            executable: "vp",
-
-            args: ["i", "-g", "@example/package-tool"],
-
-            lockKey: "vite-plus-global",
-          },
-        });
-      }),
+      expect(capabilities).toMatchObject({
+        provider: driver("packageTool"),
+        packageName: "@example/package-tool",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
   );
 
-  it.effect(
-    "switches package-managed providers to bun updates when the resolved binary lives in bun's global bin",
-    () =>
-      Effect.gen(function* () {
-        const tempDir = yield* makeTempDir("t3-bun-capabilities");
-        const bunBinDir = NodePath.join(tempDir, ".bun", "bin");
-        NodeFS.mkdirSync(bunBinDir, { recursive: true });
-        NodeFS.writeFileSync(NodePath.join(bunBinDir, "native-package-tool.exe"), "MZ");
+  it.effect("does not trust a Bun-shaped path without package ownership metadata", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-bun-capabilities");
+      const bunBinDir = NodePath.join(tempDir, ".bun", "bin");
+      NodeFS.mkdirSync(bunBinDir, { recursive: true });
+      NodeFS.writeFileSync(NodePath.join(bunBinDir, "native-package-tool.exe"), "MZ");
 
-        const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
-          nativePackageToolUpdate,
-          {
-            binaryPath: "native-package-tool",
-            env: {
-              PATH: bunBinDir,
-              PATHEXT: ".COM;.EXE;.BAT;.CMD",
-            },
+      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+        nativePackageToolUpdate,
+        {
+          binaryPath: "native-package-tool",
+          env: {
+            PATH: bunBinDir,
+            PATHEXT: ".COM;.EXE;.BAT;.CMD",
           },
-        ).pipe(Effect.provideService(HostProcessPlatform, "win32"));
+        },
+      ).pipe(Effect.provideService(HostProcessPlatform, "win32"));
 
-        expect(capabilities).toEqual({
-          provider: driver("nativePackageTool"),
-          packageName: "@example/native-package-tool",
-          update: {
-            command: "bun i -g @example/native-package-tool@latest",
-
-            executable: "bun",
-
-            args: ["i", "-g", "@example/native-package-tool@latest"],
-
-            lockKey: "bun-global",
-          },
-        });
-      }),
+      expect(capabilities).toMatchObject({
+        provider: driver("nativePackageTool"),
+        packageName: "@example/native-package-tool",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
   );
 
-  it.effect(
-    "switches package-managed providers to pnpm updates when the resolved binary lives in pnpm's global bin",
-    () =>
-      Effect.gen(function* () {
-        const tempDir = yield* makeTempDir("t3-pnpm-capabilities");
-        const pnpmHomeDir = NodePath.join(tempDir, ".local", "share", "pnpm");
-        NodeFS.mkdirSync(pnpmHomeDir, { recursive: true });
-        const scopedPackageToolPath = NodePath.join(pnpmHomeDir, "scoped-package-tool");
-        NodeFS.writeFileSync(scopedPackageToolPath, "#!/bin/sh\n");
-        NodeFS.chmodSync(scopedPackageToolPath, 0o755);
+  it.effect("does not trust a pnpm-shaped path without package ownership metadata", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-pnpm-capabilities");
+      const pnpmHomeDir = NodePath.join(tempDir, ".local", "share", "pnpm");
+      NodeFS.mkdirSync(pnpmHomeDir, { recursive: true });
+      const scopedPackageToolPath = NodePath.join(pnpmHomeDir, "scoped-package-tool");
+      NodeFS.writeFileSync(scopedPackageToolPath, "#!/bin/sh\n");
+      NodeFS.chmodSync(scopedPackageToolPath, 0o755);
 
-        const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
-          scopedPackageToolUpdate,
-          {
-            binaryPath: "scoped-package-tool",
-            env: {
-              PATH: pnpmHomeDir,
-            },
+      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+        scopedPackageToolUpdate,
+        {
+          binaryPath: "scoped-package-tool",
+          env: {
+            PATH: pnpmHomeDir,
           },
-        ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
+        },
+      ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
 
-        expect(capabilities).toEqual({
-          provider: driver("scopedPackageTool"),
-          packageName: "@example/scoped-package-tool",
-          update: {
-            command: "pnpm add -g @example/scoped-package-tool@latest",
-
-            executable: "pnpm",
-
-            args: ["add", "-g", "@example/scoped-package-tool@latest"],
-
-            lockKey: "pnpm-global",
-          },
-        });
-      }),
+      expect(capabilities).toMatchObject({
+        provider: driver("scopedPackageTool"),
+        packageName: "@example/scoped-package-tool",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
   );
 
   it("switches package-tool to Homebrew updates when the binary resolves through Homebrew", () => {
@@ -353,17 +366,17 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           },
         ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
 
-        expect(capabilities).toEqual({
+        expect(capabilities).toMatchObject({
           provider: driver("nativePackageTool"),
           packageName: "@example/native-package-tool",
+          ownershipVerified: true,
           update: {
-            command: "native-package-tool update",
-
-            executable: "native-package-tool",
-
+            executable: nativePackageToolPath,
             args: ["update"],
-
-            lockKey: "native-package-tool-native",
+            environment: {
+              PATH: nativeBinDir,
+              PACKAGE_TOOL_INSTALL_DIR: nativeBinDir,
+            },
           },
         });
       }),
@@ -390,17 +403,13 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           },
         ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
 
-        expect(capabilities).toEqual({
+        expect(capabilities).toMatchObject({
           provider: driver("scopedPackageTool"),
           packageName: "@example/scoped-package-tool",
+          ownershipVerified: true,
           update: {
-            command: "scoped-package-tool upgrade",
-
-            executable: "scoped-package-tool",
-
+            executable: scopedPackageToolPath,
             args: ["upgrade"],
-
-            lockKey: "scoped-package-tool-native",
           },
         });
       }),
@@ -452,57 +461,72 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
-  it.effect("keeps npm updates for binaries symlinked into npm's global node_modules tree", () =>
-    Effect.gen(function* () {
-      const tempDir = yield* makeTempDir("t3-npm-capabilities");
-      const binDir = NodePath.join(tempDir, "bin");
-      const packageBinDir = NodePath.join(
-        tempDir,
-        "lib",
-        "node_modules",
-        "@example",
-        "package-tool",
-        "bin",
-      );
-      NodeFS.mkdirSync(binDir, { recursive: true });
-      NodeFS.mkdirSync(packageBinDir, { recursive: true });
-      const packageBinPath = NodePath.join(packageBinDir, "package-tool.js");
-      const symlinkPath = NodePath.join(binDir, "package-tool");
-      NodeFS.writeFileSync(packageBinPath, "#!/usr/bin/env node\n");
-      NodeFS.chmodSync(packageBinPath, 0o755);
-      NodeFS.symlinkSync(packageBinPath, symlinkPath);
+  it.effect(
+    "keeps npm updates for binaries symlinked into npm's global node_modules tree",
+    (testContext) =>
+      Effect.gen(function* () {
+        if ((yield* HostProcessPlatform) === "win32") testContext.skip();
+        const tempDir = yield* makeTempDir("t3-npm-capabilities");
+        const binDir = NodePath.join(tempDir, "bin");
+        const packageBinDir = NodePath.join(
+          tempDir,
+          "lib",
+          "node_modules",
+          "@example",
+          "package-tool",
+          "bin",
+        );
+        NodeFS.mkdirSync(binDir, { recursive: true });
+        NodeFS.mkdirSync(packageBinDir, { recursive: true });
+        const packageBinPath = NodePath.join(packageBinDir, "package-tool.js");
+        const symlinkPath = NodePath.join(binDir, "package-tool");
+        NodeFS.writeFileSync(packageBinPath, "#!/usr/bin/env node\n");
+        NodeFS.writeFileSync(
+          NodePath.join(NodePath.dirname(packageBinDir), "package.json"),
+          '{"name":"@example/package-tool","version":"1.0.0"}',
+        );
+        NodeFS.chmodSync(packageBinPath, 0o755);
+        NodeFS.symlinkSync(packageBinPath, symlinkPath);
+        writeNodeManagerFixture(binDir, "npm", NodePath.join(tempDir, "lib", "node_modules"));
 
-      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(packageToolUpdate, {
-        binaryPath: symlinkPath,
-        env: {
-          PATH: "",
-        },
-      });
+        const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+          packageToolUpdate,
+          {
+            binaryPath: symlinkPath,
+            env: {
+              PATH: binDir,
+            },
+          },
+        );
 
-      expect(capabilities).toEqual({
-        provider: driver("packageTool"),
-        packageName: "@example/package-tool",
-        update: {
-          command:
-            "npm install -g --allow-scripts=@example/package-tool @example/package-tool@latest",
+        expect(capabilities).toMatchObject({
+          provider: driver("packageTool"),
+          packageName: "@example/package-tool",
+          installationLabel: "Managed by npm",
+          ownershipVerified: true,
+          currentVersion: "1.0.0",
+          update: {
+            command:
+              "npm install -g --allow-scripts=@example/package-tool @example/package-tool@latest",
 
-          executable: "npm",
+            executable: NodePath.join(binDir, "npm"),
 
-          args: [
-            "install",
-            "-g",
-            "--allow-scripts=@example/package-tool",
-            "@example/package-tool@latest",
-          ],
+            args: [
+              "install",
+              "-g",
+              "--allow-scripts=@example/package-tool",
+              "@example/package-tool@latest",
+            ],
 
-          lockKey: "npm-global",
-        },
-      });
-    }),
+            lockKey: `npm:${NodePath.join(tempDir, "lib", "node_modules")}`,
+          },
+        });
+      }),
   );
 
-  it.effect("uses Effect FileSystem realPath when detecting pnpm global symlinks", () =>
+  it.effect("uses Effect FileSystem realPath when detecting pnpm global symlinks", (testContext) =>
     Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") testContext.skip();
       const tempDir = yield* makeTempDir("t3-pnpm-realpath-capabilities");
       const binDir = NodePath.join(tempDir, "bin");
       const packageBinDir = NodePath.join(
@@ -522,36 +546,56 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       const packageBinPath = NodePath.join(packageBinDir, "package-tool.js");
       const symlinkPath = NodePath.join(binDir, "package-tool");
       NodeFS.writeFileSync(packageBinPath, "#!/usr/bin/env node\n");
+      NodeFS.writeFileSync(
+        NodePath.join(NodePath.dirname(packageBinDir), "package.json"),
+        '{"name":"@example/package-tool","version":"1.0.0"}',
+      );
       NodeFS.chmodSync(packageBinPath, 0o755);
       NodeFS.symlinkSync(packageBinPath, symlinkPath);
+      writeNodeManagerFixture(
+        binDir,
+        "pnpm",
+        NodePath.join(tempDir, ".local", "share", "pnpm", "global", "5", "node_modules"),
+      );
 
       const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(packageToolUpdate, {
         binaryPath: symlinkPath,
         env: {
-          PATH: "",
+          PATH: binDir,
         },
       });
 
-      expect(capabilities).toEqual({
+      expect(capabilities).toMatchObject({
         provider: driver("packageTool"),
         packageName: "@example/package-tool",
+        installationLabel: "Managed by pnpm",
+        ownershipVerified: true,
+        currentVersion: "1.0.0",
         update: {
           command: "pnpm add -g @example/package-tool@latest",
 
-          executable: "pnpm",
+          executable: NodePath.join(binDir, "pnpm"),
 
           args: ["add", "-g", "@example/package-tool@latest"],
 
-          lockKey: "pnpm-global",
+          lockKey: `pnpm:${NodePath.join(
+            tempDir,
+            ".local",
+            "share",
+            "pnpm",
+            "global",
+            "5",
+            "node_modules",
+          )}`,
         },
       });
     }),
   );
 
   it("allows the package's own install scripts in npm global updates", () => {
-    const claudeUpdate = makePackageManagedProviderMaintenanceResolver({
+    const claudeUpdate = makeProviderMaintenanceResolver({
       provider: driver("claudeAgent"),
-      npmPackageName: "@anthropic-ai/claude-code",
+      packageName: "@anthropic-ai/claude-code",
       homebrewFormula: "claude-code",
       nativeUpdate: {
         executable: "claude",

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -147,7 +147,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     ),
   );
 
-  it("marks providers with unknown current versions as unknown", () => {
+  it("marks providers with missing or invalid current versions as unknown", () => {
     expect(
       createProviderVersionAdvisory({
         driver: driver("packageTool"),
@@ -157,6 +157,17 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     ).toMatchObject({
       status: "unknown",
       currentVersion: null,
+      latestVersion: "9.9.9",
+    });
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("packageTool"),
+        currentVersion: "development",
+        latestVersion: "9.9.9",
+      }),
+    ).toMatchObject({
+      status: "unknown",
+      currentVersion: "development",
       latestVersion: "9.9.9",
     });
   });

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -17,7 +17,10 @@ import * as TestClock from "effect/testing/TestClock";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { GrokMaintenanceResolver } from "./Drivers/GrokDriver.ts";
-import type { InstallationContext } from "./maintenance/definition.ts";
+import {
+  INSTALLER_METADATA_MAX_BYTES,
+  type InstallationContext,
+} from "./maintenance/definition.ts";
 import {
   createProviderVersionAdvisory,
   enrichProviderSnapshotWithVersionAdvisory,
@@ -27,6 +30,7 @@ import {
   makeStaticProviderMaintenanceResolver,
   normalizeCommandPath,
   ProviderVersionCache,
+  readProviderMaintenanceMetadata,
   resolveLatestProviderVersion,
   resolveProviderMaintenanceCapabilitiesEffect,
   runMaintenanceProbe,
@@ -277,6 +281,16 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       expect(before.lockKey).toBe(after.lockKey);
       expect(before.ownershipVerified).toBe(true);
       expect(after.ownershipVerified).toBe(true);
+      expect(before.update).toMatchObject({
+        executable:
+          "/home/test/.codex/packages/standalone/releases/1.0.0-x86_64-unknown-linux-musl/bin/codex",
+        args: ["update"],
+      });
+      expect(after.update).toMatchObject({
+        executable:
+          "/home/test/.codex/packages/standalone/releases/1.1.0-x86_64-unknown-linux-musl/bin/codex",
+        args: ["update"],
+      });
     }),
   );
 
@@ -290,6 +304,20 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         expect(result).toBeNull();
       }),
     ),
+  );
+
+  it.effect("rejects oversized and invalid UTF-8 installer metadata", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-provider-maintenance-metadata");
+      NodeFS.mkdirSync(tempDir, { recursive: true });
+      const oversized = NodePath.join(tempDir, "oversized.json");
+      const invalidUtf8 = NodePath.join(tempDir, "invalid-utf8.json");
+      NodeFS.writeFileSync(oversized, Buffer.alloc(INSTALLER_METADATA_MAX_BYTES + 1, 0x61));
+      NodeFS.writeFileSync(invalidUtf8, Buffer.from([0x7b, 0xc3, 0x28, 0x7d]));
+
+      expect(yield* readProviderMaintenanceMetadata(oversized)).toBeNull();
+      expect(yield* readProviderMaintenanceMetadata(invalidUtf8)).toBeNull();
+    }),
   );
 
   it.effect("does not swallow interruption after a maintenance process starts", () =>

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -9,6 +9,7 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import { HttpClient } from "effect/unstable/http";
+import { GrokMaintenanceResolver } from "./Drivers/GrokDriver.ts";
 import {
   createProviderVersionAdvisory,
   enrichProviderSnapshotWithVersionAdvisory,
@@ -417,6 +418,59 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           },
         });
       }),
+  );
+
+  it.effect("resolves Grok native updates only for the standalone installer path", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-grok-native-capabilities");
+      const nativeBinDir = NodePath.join(tempDir, ".grok", "bin");
+      NodeFS.mkdirSync(nativeBinDir, { recursive: true });
+      const nativeGrokPath = NodePath.join(nativeBinDir, "grok");
+      NodeFS.writeFileSync(nativeGrokPath, "#!/bin/sh\n");
+      NodeFS.chmodSync(nativeGrokPath, 0o755);
+      const realNativeGrokPath = NodeFS.realpathSync(nativeGrokPath);
+
+      const nativeCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+        GrokMaintenanceResolver,
+        {
+          binaryPath: "grok",
+          env: { PATH: nativeBinDir },
+        },
+      ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
+
+      expect(nativeCapabilities).toMatchObject({
+        provider: driver("grok"),
+        packageName: "@xai-official/grok",
+        installationLabel: "Managed by native installer",
+        ownershipVerified: true,
+        update: {
+          command: "grok update",
+          executable: realNativeGrokPath,
+          args: ["update"],
+        },
+      });
+
+      const unownedBinDir = NodePath.join(tempDir, "bin");
+      NodeFS.mkdirSync(unownedBinDir, { recursive: true });
+      const unownedGrokPath = NodePath.join(unownedBinDir, "grok");
+      NodeFS.writeFileSync(unownedGrokPath, "#!/bin/sh\n");
+      NodeFS.chmodSync(unownedGrokPath, 0o755);
+
+      const unownedCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+        GrokMaintenanceResolver,
+        {
+          binaryPath: "grok",
+          env: { PATH: unownedBinDir },
+        },
+      ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
+
+      expect(unownedCapabilities).toMatchObject({
+        provider: driver("grok"),
+        packageName: "@xai-official/grok",
+        ownershipVerified: false,
+        update: null,
+      });
+    }),
   );
 
   it.effect(

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -12,6 +12,7 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
 import { HttpClient } from "effect/unstable/http";
 import { GrokMaintenanceResolver } from "./Drivers/GrokDriver.ts";
 import type { InstallationContext } from "./maintenance/definition.ts";
@@ -177,6 +178,39 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       expect(Exit.isSuccess(next) ? next.value : null).toEqual(capabilities);
       expect(probeCount).toBe(2);
     }),
+  );
+
+  it.effect("bounds total installation resolution time and falls back to manual updates", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-maintenance-resolution-timeout");
+      NodeFS.mkdirSync(tempDir, { recursive: true });
+      const executable = NodePath.join(tempDir, "package-tool");
+      NodeFS.writeFileSync(executable, "#!/bin/sh\n");
+      NodeFS.chmodSync(executable, 0o755);
+      const resolutionStarted = yield* Deferred.make<void>();
+      const slowResolver = {
+        ...packageToolUpdate,
+        resolve: () =>
+          makeProviderMaintenanceCapabilities({
+            provider: driver("packageTool"),
+            packageName: "@example/package-tool",
+            updateExecutable: executable,
+            updateArgs: ["update"],
+            updateLockKey: "unsafe-legacy-update",
+          }),
+        resolveInstallation: () =>
+          Deferred.succeed(resolutionStarted, undefined).pipe(Effect.andThen(Effect.never)),
+      };
+
+      const fiber = yield* resolveProviderMaintenanceCapabilitiesEffect(slowResolver, {
+        binaryPath: executable,
+        env: { PATH: tempDir },
+      }).pipe(Effect.forkChild);
+      yield* Deferred.await(resolutionStarted);
+      yield* TestClock.adjust("10 seconds");
+
+      expect(yield* Fiber.join(fiber)).toEqual(packageToolUpdate.resolve());
+    }).pipe(Effect.provide(TestClock.layer())),
   );
 
   it.effect("keeps Codex standalone identity stable across release directories", () =>

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -16,6 +16,7 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   makeProviderMaintenanceResolver,
   makeProviderMaintenanceCapabilities,
+  makeProviderMaintenanceCapabilitySources,
   makeStaticProviderMaintenanceResolver,
   normalizeCommandPath,
   ProviderVersionCache,
@@ -98,6 +99,39 @@ const installedPackageToolProvider: ServerProvider = {
 };
 
 it.layer(NodeServices.layer)("providerMaintenance", (it) => {
+  it.effect("caches advisory ownership probes and invalidates them before fresh resolution", () =>
+    Effect.gen(function* () {
+      let probeCount = 0;
+      const fallback = packageToolUpdate.resolve();
+      const resolveFresh = Effect.sync(() => {
+        probeCount += 1;
+        return makeProviderMaintenanceCapabilities({
+          provider: driver("packageTool"),
+          packageName: "@example/package-tool",
+          updateExecutable: "/usr/local/bin/npm",
+          updateArgs: ["install", "-g", "@example/package-tool@latest"],
+          updateLockKey: "npm:/usr/local",
+          currentVersion: `${probeCount}.0.0`,
+        });
+      });
+      const enabled = yield* makeProviderMaintenanceCapabilitySources(resolveFresh, fallback, {
+        enabled: true,
+      });
+
+      expect((yield* enabled.advisory).currentVersion).toBe("1.0.0");
+      expect((yield* enabled.advisory).currentVersion).toBe("1.0.0");
+      expect((yield* enabled.fresh).currentVersion).toBe("2.0.0");
+      expect((yield* enabled.advisory).currentVersion).toBe("3.0.0");
+      expect(probeCount).toBe(3);
+
+      const disabled = yield* makeProviderMaintenanceCapabilitySources(resolveFresh, fallback, {
+        enabled: false,
+      });
+      expect(yield* disabled.advisory).toEqual(fallback);
+      expect(probeCount).toBe(3);
+    }),
+  );
+
   it.effect("rejects truncated maintenance probe output", () =>
     runMaintenanceProbe({
       executable: NodeProcess.execPath,

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -199,9 +199,8 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       status: "behind_latest",
       currentVersion: "2.1.110",
       latestVersion: "2.1.117",
-      updateCommand:
-        "npm install -g --allow-scripts=@example/native-package-tool @example/native-package-tool@latest",
-      canUpdate: true,
+      updateCommand: null,
+      canUpdate: false,
       message: "Install the update now or review provider settings.",
     });
   });
@@ -333,7 +332,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     }),
   );
 
-  it("switches package-tool to Homebrew updates when the binary resolves through Homebrew", () => {
+  it("does not classify package-managed installations outside the catalog", () => {
     expect(
       packageToolUpdate.resolve({
         binaryPath: "/opt/homebrew/bin/package-tool",
@@ -344,15 +343,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     ).toEqual({
       provider: driver("packageTool"),
       packageName: "@example/package-tool",
-      update: {
-        command: "brew upgrade package-tool",
-
-        executable: "brew",
-
-        args: ["upgrade", "package-tool"],
-
-        lockKey: "homebrew",
-      },
+      update: null,
     });
   });
 
@@ -366,6 +357,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         const nativePackageToolPath = NodePath.join(nativeBinDir, "native-package-tool");
         NodeFS.writeFileSync(nativePackageToolPath, "#!/bin/sh\n");
         NodeFS.chmodSync(nativePackageToolPath, 0o755);
+        const realNativePackageToolPath = NodeFS.realpathSync(nativePackageToolPath);
 
         const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
           nativePackageToolUpdate,
@@ -382,11 +374,11 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           packageName: "@example/native-package-tool",
           ownershipVerified: true,
           update: {
-            executable: nativePackageToolPath,
+            executable: realNativePackageToolPath,
             args: ["update"],
             environment: {
               PATH: nativeBinDir,
-              PACKAGE_TOOL_INSTALL_DIR: nativeBinDir,
+              PACKAGE_TOOL_INSTALL_DIR: NodePath.dirname(realNativePackageToolPath),
             },
           },
         });
@@ -403,6 +395,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         const scopedPackageToolPath = NodePath.join(nativeBinDir, "scoped-package-tool");
         NodeFS.writeFileSync(scopedPackageToolPath, "#!/bin/sh\n");
         NodeFS.chmodSync(scopedPackageToolPath, 0o755);
+        const realScopedPackageToolPath = NodeFS.realpathSync(scopedPackageToolPath);
 
         const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
           scopedPackageToolUpdate,
@@ -419,58 +412,12 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           packageName: "@example/scoped-package-tool",
           ownershipVerified: true,
           update: {
-            executable: scopedPackageToolPath,
+            executable: realScopedPackageToolPath,
             args: ["upgrade"],
           },
         });
       }),
   );
-
-  it("switches native-package-tool to Homebrew updates when the binary resolves through Homebrew", () => {
-    expect(
-      nativePackageToolUpdate.resolve({
-        binaryPath: "/opt/homebrew/bin/native-package-tool",
-        env: {
-          PATH: "",
-        },
-      }),
-    ).toEqual({
-      provider: driver("nativePackageTool"),
-      packageName: "@example/native-package-tool",
-      update: {
-        command: "brew upgrade native-package-tool",
-
-        executable: "brew",
-
-        args: ["upgrade", "native-package-tool"],
-
-        lockKey: "homebrew",
-      },
-    });
-  });
-
-  it("switches scoped-package-tool to Homebrew updates when the binary resolves through Homebrew", () => {
-    expect(
-      scopedPackageToolUpdate.resolve({
-        binaryPath: "/opt/homebrew/bin/scoped-package-tool",
-        env: {
-          PATH: "",
-        },
-      }),
-    ).toEqual({
-      provider: driver("scopedPackageTool"),
-      packageName: "@example/scoped-package-tool",
-      update: {
-        command: "brew upgrade example/tap/scoped-package-tool",
-
-        executable: "brew",
-
-        args: ["upgrade", "example/tap/scoped-package-tool"],
-
-        lockKey: "homebrew",
-      },
-    });
-  });
 
   it.effect(
     "keeps npm updates for binaries symlinked into npm's global node_modules tree",
@@ -499,6 +446,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         NodeFS.chmodSync(packageBinPath, 0o755);
         NodeFS.symlinkSync(packageBinPath, symlinkPath);
         writeNodeManagerFixture(binDir, "npm", NodePath.join(tempDir, "lib", "node_modules"));
+        const realTempDir = NodeFS.realpathSync(tempDir);
 
         const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
           packageToolUpdate,
@@ -517,19 +465,20 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           ownershipVerified: true,
           currentVersion: "1.0.0",
           update: {
-            command:
-              "npm install -g --allow-scripts=@example/package-tool @example/package-tool@latest",
+            command: `npm install -g --prefix ${realTempDir} --allow-scripts=@example/package-tool @example/package-tool@latest`,
 
             executable: NodePath.join(binDir, "npm"),
 
             args: [
               "install",
               "-g",
+              "--prefix",
+              realTempDir,
               "--allow-scripts=@example/package-tool",
               "@example/package-tool@latest",
             ],
 
-            lockKey: `npm:${NodePath.join(tempDir, "lib", "node_modules")}`,
+            lockKey: `npm:${realTempDir}`,
           },
         });
       }),
@@ -568,6 +517,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         "pnpm",
         NodePath.join(tempDir, ".local", "share", "pnpm", "global", "5", "node_modules"),
       );
+      const realTempDir = NodeFS.realpathSync(tempDir);
 
       const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(packageToolUpdate, {
         binaryPath: symlinkPath,
@@ -590,7 +540,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           args: ["add", "-g", "@example/package-tool@latest"],
 
           lockKey: `pnpm:${NodePath.join(
-            tempDir,
+            realTempDir,
             ".local",
             "share",
             "pnpm",
@@ -603,7 +553,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     }),
   );
 
-  it("allows the package's own install scripts in npm global updates", () => {
+  it("keeps package-managed resolvers manual until installation ownership is resolved", () => {
     const claudeUpdate = makeProviderMaintenanceResolver({
       provider: driver("claudeAgent"),
       packageName: "@anthropic-ai/claude-code",
@@ -619,21 +569,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     expect(claudeUpdate.resolve()).toEqual({
       provider: driver("claudeAgent"),
       packageName: "@anthropic-ai/claude-code",
-      update: {
-        command:
-          "npm install -g --allow-scripts=@anthropic-ai/claude-code @anthropic-ai/claude-code@latest",
-
-        executable: "npm",
-
-        args: [
-          "install",
-          "-g",
-          "--allow-scripts=@anthropic-ai/claude-code",
-          "@anthropic-ai/claude-code@latest",
-        ],
-
-        lockKey: "npm-global",
-      },
+      update: null,
     });
   });
 

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -4,6 +4,7 @@ import * as NodeFS from "node:fs";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
+import * as NodeProcess from "node:process";
 import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Crypto from "effect/Crypto";
@@ -20,6 +21,7 @@ import {
   ProviderVersionCache,
   resolveLatestProviderVersion,
   resolveProviderMaintenanceCapabilitiesEffect,
+  runMaintenanceProbe,
 } from "./providerMaintenance.ts";
 
 const driver = (value: string) => ProviderDriverKind.make(value);
@@ -93,6 +95,18 @@ const installedPackageToolProvider: ServerProvider = {
 };
 
 it.layer(NodeServices.layer)("providerMaintenance", (it) => {
+  it.effect("rejects truncated maintenance probe output", () =>
+    runMaintenanceProbe({
+      executable: NodeProcess.execPath,
+      args: ["-e", 'process.stdout.write("x".repeat(64_001))'],
+      environment: NodeProcess.env,
+    }).pipe(
+      Effect.map((result) => {
+        expect(result).toBeNull();
+      }),
+    ),
+  );
+
   it.effect("reads cached versions through the injectable cache reference", () =>
     resolveLatestProviderVersion(packageToolUpdate.resolve()).pipe(
       Effect.provideService(

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -8,9 +8,13 @@ import * as NodeProcess from "node:process";
 import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Crypto from "effect/Crypto";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import { HttpClient } from "effect/unstable/http";
 import { GrokMaintenanceResolver } from "./Drivers/GrokDriver.ts";
+import type { InstallationContext } from "./maintenance/definition.ts";
 import {
   createProviderVersionAdvisory,
   enrichProviderSnapshotWithVersionAdvisory,
@@ -46,6 +50,14 @@ const packageToolUpdate = makeProviderMaintenanceResolver({
   executableName: "package-tool",
   homebrewFormula: "package-tool",
   nativeUpdate: null,
+});
+const codexStandaloneUpdate = makeProviderMaintenanceResolver({
+  provider: driver("codex"),
+  packageName: "@openai/codex",
+  executableName: "codex",
+  homebrewFormula: "codex",
+  nativeUpdate: null,
+  instructionsUrl: "https://developers.openai.com/codex/cli/",
 });
 const nativePackageToolUpdate = makeProviderMaintenanceResolver({
   provider: driver("nativePackageTool"),
@@ -129,6 +141,75 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       });
       expect(yield* disabled.advisory).toEqual(fallback);
       expect(probeCount).toBe(3);
+    }),
+  );
+
+  it.effect("does not cache an interrupted advisory probe", () =>
+    Effect.gen(function* () {
+      let probeCount = 0;
+      const firstProbeStarted = yield* Deferred.make<void>();
+      const fallback = packageToolUpdate.resolve();
+      const capabilities = makeProviderMaintenanceCapabilities({
+        provider: driver("packageTool"),
+        packageName: "@example/package-tool",
+        updateExecutable: null,
+        updateArgs: [],
+        updateLockKey: null,
+        currentVersion: "1.0.0",
+      });
+      const resolveFresh = Effect.gen(function* () {
+        probeCount += 1;
+        if (probeCount === 1) {
+          yield* Deferred.succeed(firstProbeStarted, undefined);
+          return yield* Effect.never;
+        }
+        return capabilities;
+      });
+      const sources = yield* makeProviderMaintenanceCapabilitySources(resolveFresh, fallback, {
+        enabled: true,
+      });
+      const interruptedProbe = yield* Effect.forkChild(sources.advisory);
+      yield* Deferred.await(firstProbeStarted);
+      yield* Fiber.interrupt(interruptedProbe);
+
+      const next = yield* sources.advisory.pipe(Effect.exit);
+      expect(Exit.isSuccess(next)).toBe(true);
+      expect(Exit.isSuccess(next) ? next.value : null).toEqual(capabilities);
+      expect(probeCount).toBe(2);
+    }),
+  );
+
+  it.effect("keeps Codex standalone identity stable across release directories", () =>
+    Effect.gen(function* () {
+      const resolveInstallation = codexStandaloneUpdate.resolveInstallation;
+      if (!resolveInstallation) {
+        return yield* Effect.die("missing installation resolver");
+      }
+      const resolve = (version: string) => {
+        const resolvedCommandPath = "/home/test/.local/bin/codex";
+        const context: InstallationContext = {
+          provider: driver("codex"),
+          packageName: "@openai/codex",
+          binaryPath: "codex",
+          isBareCommand: true,
+          resolvedCommandPath,
+          realCommandPath: `/home/test/.codex/packages/standalone/releases/${version}-x86_64-unknown-linux-musl/bin/codex`,
+          environment: { PATH: "/home/test/.local/bin" },
+          platform: "linux",
+          readTextFile: () => Effect.succeed(null),
+          realPath: (path) => Effect.succeed(path),
+          resolveCommand: () => Effect.succeed(null),
+          run: () => Effect.succeed(null),
+        };
+        return resolveInstallation(context);
+      };
+      const before = yield* resolve("1.0.0");
+      const after = yield* resolve("1.1.0");
+
+      expect(before.identityKey).toBe(after.identityKey);
+      expect(before.lockKey).toBe(after.lockKey);
+      expect(before.ownershipVerified).toBe(true);
+      expect(after.ownershipVerified).toBe(true);
     }),
   );
 

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -42,12 +42,14 @@ const isNativeTestCommandPath =
 const packageToolUpdate = makeProviderMaintenanceResolver({
   provider: driver("packageTool"),
   packageName: "@example/package-tool",
+  executableName: "package-tool",
   homebrewFormula: "package-tool",
   nativeUpdate: null,
 });
 const nativePackageToolUpdate = makeProviderMaintenanceResolver({
   provider: driver("nativePackageTool"),
   packageName: "@example/native-package-tool",
+  executableName: "native-package-tool",
   homebrewFormula: "native-package-tool",
   nativeUpdate: {
     executable: "native-package-tool",
@@ -63,6 +65,7 @@ const nativePackageToolUpdate = makeProviderMaintenanceResolver({
 const scopedPackageToolUpdate = makeProviderMaintenanceResolver({
   provider: driver("scopedPackageTool"),
   packageName: "@example/scoped-package-tool",
+  executableName: "scoped-package-tool",
   homebrewFormula: "example/tap/scoped-package-tool",
   nativeUpdate: {
     executable: "scoped-package-tool",
@@ -625,6 +628,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     const claudeUpdate = makeProviderMaintenanceResolver({
       provider: driver("claudeAgent"),
       packageName: "@anthropic-ai/claude-code",
+      executableName: "claude",
       homebrewFormula: "claude-code",
       nativeUpdate: {
         executable: "claude",

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -66,9 +66,7 @@ const nativePackageToolUpdate = makeProviderMaintenanceResolver({
   executableName: "native-package-tool",
   homebrewFormula: "native-package-tool",
   nativeUpdate: {
-    executable: "native-package-tool",
     args: ["update"],
-    lockKey: "native-package-tool-native",
     isCommandPath: isNativeTestCommandPath("/.local/bin/native-package-tool"),
     environment: (executable, environment) => ({
       ...environment,
@@ -82,9 +80,7 @@ const scopedPackageToolUpdate = makeProviderMaintenanceResolver({
   executableName: "scoped-package-tool",
   homebrewFormula: "example/tap/scoped-package-tool",
   nativeUpdate: {
-    executable: "scoped-package-tool",
     args: ["upgrade"],
-    lockKey: "scoped-package-tool-native",
     isCommandPath: isNativeTestCommandPath("/.scoped-package-tool/bin/scoped-package-tool"),
   },
 });
@@ -261,7 +257,6 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           provider: driver("codex"),
           packageName: "@openai/codex",
           binaryPath: "codex",
-          isBareCommand: true,
           resolvedCommandPath,
           realCommandPath: `/home/test/.codex/packages/standalone/releases/${version}-x86_64-unknown-linux-musl/bin/codex`,
           environment: { PATH: "/home/test/.local/bin" },
@@ -816,9 +811,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       executableName: "claude",
       homebrewFormula: "claude-code",
       nativeUpdate: {
-        executable: "claude",
         args: ["update"],
-        lockKey: "claude-native",
         isCommandPath: isNativeTestCommandPath("/.local/bin/claude"),
       },
     });

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -7,6 +7,7 @@ import * as NodePath from "node:path";
 import * as NodeProcess from "node:process";
 import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -14,6 +15,7 @@ import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as TestClock from "effect/testing/TestClock";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
 import { GrokMaintenanceResolver } from "./Drivers/GrokDriver.ts";
 import type { InstallationContext } from "./maintenance/definition.ts";
 import {
@@ -288,6 +290,30 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         expect(result).toBeNull();
       }),
     ),
+  );
+
+  it.effect("does not swallow interruption after a maintenance process starts", () =>
+    Effect.gen(function* () {
+      const delegate = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const processStarted = yield* Deferred.make<void>();
+      const coordinatingSpawner = ChildProcessSpawner.make((command) =>
+        delegate.spawn(command).pipe(Effect.tap(() => Deferred.succeed(processStarted, undefined))),
+      );
+      const fiber = yield* runMaintenanceProbe({
+        executable: NodeProcess.execPath,
+        args: ["-e", "setInterval(() => {}, 1_000)"],
+        environment: NodeProcess.env,
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, coordinatingSpawner),
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.await(processStarted);
+      yield* Fiber.interrupt(fiber);
+      const exit = yield* Fiber.await(fiber);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(Exit.isFailure(exit) && exit.cause.reasons.some(Cause.isInterruptReason)).toBe(true);
+    }),
   );
 
   it.effect("reads cached versions through the injectable cache reference", () =>

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -13,7 +13,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as TestClock from "effect/testing/TestClock";
-import { HttpClient } from "effect/unstable/http";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { GrokMaintenanceResolver } from "./Drivers/GrokDriver.ts";
 import type { InstallationContext } from "./maintenance/definition.ts";
 import {
@@ -180,7 +180,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     }),
   );
 
-  it.effect("bounds total installation resolution time and falls back to manual updates", () =>
+  it.effect("bounds total installation resolution time without falling back to npm", () =>
     Effect.gen(function* () {
       const tempDir = yield* makeTempDir("t3-maintenance-resolution-timeout");
       NodeFS.mkdirSync(tempDir, { recursive: true });
@@ -209,7 +209,43 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       yield* Deferred.await(resolutionStarted);
       yield* TestClock.adjust("10 seconds");
 
-      expect(yield* Fiber.join(fiber)).toEqual(packageToolUpdate.resolve());
+      const capabilities = yield* Fiber.join(fiber);
+      const requests: Array<string> = [];
+      const provider = yield* enrichProviderSnapshotWithVersionAdvisory(
+        installedPackageToolProvider,
+        capabilities,
+        { enableProviderUpdateChecks: true },
+      ).pipe(
+        Effect.provideService(ProviderVersionCache, new Map()),
+        Effect.provideService(
+          HttpClient.HttpClient,
+          HttpClient.make((request) =>
+            Effect.sync(() => {
+              requests.push(request.url);
+              return HttpClientResponse.fromWeb(
+                request,
+                Response.json(
+                  { version: "9.9.9" },
+                  { headers: { "content-type": "application/json" } },
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+
+      expect(capabilities).toEqual({
+        ...packageToolUpdate.resolve(),
+        latestVersion: null,
+      });
+      expect(Object.hasOwn(capabilities, "latestVersion")).toBe(true);
+      expect(requests).toEqual([]);
+      expect(provider.versionAdvisory).toMatchObject({
+        status: "unknown",
+        latestVersion: null,
+        canUpdate: false,
+        updateCommand: null,
+      });
     }).pipe(Effect.provide(TestClock.layer())),
   );
 

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -3,19 +3,29 @@ import {
   type ServerProvider,
   type ServerProviderVersionAdvisory,
 } from "@t3tools/contracts";
-import { compareSemverVersions } from "@t3tools/shared/semver";
-import { resolveCommandPath } from "@t3tools/shared/shell";
+import { resolveCommandPath, resolveSpawnCommand } from "@t3tools/shared/shell";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
+import { makeProviderInstallationCatalog } from "./maintenance/catalogs.ts";
+import type { InstallationContext, ResolvedInstallation } from "./maintenance/definition.ts";
+import { resolveInstallation } from "./maintenance/resolver.ts";
+import { compareMaintenanceVersions } from "./maintenance/version.ts";
 
 const LATEST_VERSION_CACHE_TTL_MS = 60 * 60 * 1_000;
 const LATEST_VERSION_TIMEOUT_MS = 4_000;
+const MAINTENANCE_PROBE_TIMEOUT_MS = 10_000;
 const PROVIDER_UPDATE_ACTION_TOAST_MESSAGE = "Install the update now or review provider settings.";
 
 const compactEnv = (input: Record<string, Option.Option<string>>): NodeJS.ProcessEnv =>
@@ -36,11 +46,57 @@ const CommandLookupEnvConfig = Config.all({
 }).pipe(Config.map(compactEnv));
 
 const readCommandLookupEnv = CommandLookupEnvConfig.pipe(Effect.orElseSucceed(() => ({})));
+const MAINTENANCE_PROBE_MAX_BYTES = 64_000;
+
+const runMaintenanceProbe = Effect.fn("runMaintenanceProbe")(function* (input: {
+  readonly executable: string;
+  readonly args: ReadonlyArray<string>;
+  readonly environment: NodeJS.ProcessEnv;
+}) {
+  yield* FileSystem.FileSystem;
+  yield* Path.Path;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const resolved = yield* resolveSpawnCommand(input.executable, input.args, {
+    env: input.environment,
+    extendEnv: true,
+  }).pipe(Effect.option);
+  if (Option.isNone(resolved)) return null;
+  const result = yield* Effect.gen(function* () {
+    const child = yield* spawner.spawn(
+      ChildProcess.make(resolved.value.command, resolved.value.args, {
+        env: input.environment,
+        extendEnv: true,
+        shell: resolved.value.shell,
+      }),
+    );
+    yield* Effect.addFinalizer(() => child.kill().pipe(Effect.ignore));
+    const [stdout, stderr, exitCode] = yield* Effect.all(
+      [
+        collectUint8StreamText({ stream: child.stdout, maxBytes: MAINTENANCE_PROBE_MAX_BYTES }),
+        collectUint8StreamText({ stream: child.stderr, maxBytes: MAINTENANCE_PROBE_MAX_BYTES }),
+        child.exitCode,
+      ],
+      { concurrency: "unbounded" },
+    );
+    return { stdout: stdout.text, stderr: stderr.text, exitCode: Number(exitCode) };
+  }).pipe(
+    Effect.scoped,
+    Effect.timeoutOption(Duration.millis(MAINTENANCE_PROBE_TIMEOUT_MS)),
+    Effect.catchCause(() => Effect.succeed(Option.none())),
+  );
+  return Option.getOrNull(result);
+});
 
 export interface ProviderMaintenanceCapabilities {
   readonly provider: ProviderDriverKind;
   readonly packageName: string | null;
   readonly update: ProviderMaintenanceCommandAction | null;
+  readonly identityKey?: string | null;
+  readonly installationLabel?: string | null;
+  readonly ownershipVerified?: boolean;
+  readonly currentVersion?: string | null;
+  readonly latestVersion?: string | null;
+  readonly instructionsUrl?: string | null;
 }
 
 export interface ProviderMaintenanceCommandAction {
@@ -48,6 +104,7 @@ export interface ProviderMaintenanceCommandAction {
   readonly executable: string;
   readonly args: ReadonlyArray<string>;
   readonly lockKey: string;
+  readonly environment?: NodeJS.ProcessEnv;
 }
 
 export interface ProviderMaintenanceCapabilityResolutionOptions {
@@ -61,18 +118,28 @@ export interface ProviderMaintenanceCapabilitiesResolver {
   readonly resolve: (
     options?: ProviderMaintenanceCapabilityResolutionOptions,
   ) => ProviderMaintenanceCapabilities;
+  readonly resolveInstallation?: (
+    context: InstallationContext,
+  ) => Effect.Effect<ResolvedInstallation>;
 }
 
-export interface PackageManagedProviderMaintenanceDefinition {
+export interface ProviderMaintenanceDefinition {
   readonly provider: ProviderDriverKind;
-  readonly npmPackageName: string;
+  readonly packageName: string;
   readonly homebrewFormula: string | null;
   readonly nativeUpdate: {
     readonly executable: string;
     readonly args: ReadonlyArray<string>;
     readonly lockKey: string;
     readonly isCommandPath: (commandPath: string) => boolean;
+    readonly environment?: (
+      executable: string,
+      environment: NodeJS.ProcessEnv,
+    ) => NodeJS.ProcessEnv;
   } | null;
+  readonly executableName?: string;
+  readonly instructionsUrl?: string;
+  readonly wingetPackageId?: string;
 }
 
 export interface ProviderVersionCacheEntry {
@@ -100,20 +167,37 @@ export function makeProviderMaintenanceCapabilities(input: {
   readonly updateExecutable: string | null;
   readonly updateArgs: ReadonlyArray<string>;
   readonly updateLockKey: string | null;
+  readonly updateCommand?: string;
+  readonly updateEnvironment?: NodeJS.ProcessEnv;
+  readonly identityKey?: string | null;
+  readonly installationLabel?: string | null;
+  readonly ownershipVerified?: boolean;
+  readonly currentVersion?: string | null;
+  readonly latestVersion?: string | null;
+  readonly instructionsUrl?: string | null;
 }): ProviderMaintenanceCapabilities {
   const update =
     input.updateExecutable === null || input.updateLockKey === null
       ? null
       : {
-          command: [input.updateExecutable, ...input.updateArgs].join(" "),
+          command: input.updateCommand ?? [input.updateExecutable, ...input.updateArgs].join(" "),
           executable: input.updateExecutable,
           args: input.updateArgs,
           lockKey: input.updateLockKey,
+          ...(input.updateEnvironment ? { environment: input.updateEnvironment } : {}),
         };
   return {
     provider: input.provider,
     packageName: input.packageName,
     update,
+    ...("identityKey" in input ? { identityKey: input.identityKey ?? null } : {}),
+    ...("installationLabel" in input ? { installationLabel: input.installationLabel ?? null } : {}),
+    ...("ownershipVerified" in input
+      ? { ownershipVerified: input.ownershipVerified ?? false }
+      : {}),
+    ...("currentVersion" in input ? { currentVersion: input.currentVersion ?? null } : {}),
+    ...("latestVersion" in input ? { latestVersion: input.latestVersion ?? null } : {}),
+    ...("instructionsUrl" in input ? { instructionsUrl: input.instructionsUrl ?? null } : {}),
   };
 }
 
@@ -131,11 +215,11 @@ export function makeManualOnlyProviderMaintenanceCapabilities(input: {
 }
 
 function makeNpmGlobalProviderMaintenanceCapabilities(
-  definition: PackageManagedProviderMaintenanceDefinition,
+  definition: ProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilities {
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
-    packageName: definition.npmPackageName,
+    packageName: definition.packageName,
     updateExecutable: "npm",
     // npm 12 blocks install scripts by default (empty allow-scripts allowlist)
     // and still exits 0, so a package whose postinstall finishes the install
@@ -145,62 +229,62 @@ function makeNpmGlobalProviderMaintenanceCapabilities(
     updateArgs: [
       "install",
       "-g",
-      `--allow-scripts=${definition.npmPackageName}`,
-      `${definition.npmPackageName}@latest`,
+      `--allow-scripts=${definition.packageName}`,
+      `${definition.packageName}@latest`,
     ],
     updateLockKey: "npm-global",
   });
 }
 
 function makeBunGlobalProviderMaintenanceCapabilities(
-  definition: PackageManagedProviderMaintenanceDefinition,
+  definition: ProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilities {
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
-    packageName: definition.npmPackageName,
+    packageName: definition.packageName,
     updateExecutable: "bun",
-    updateArgs: ["i", "-g", `${definition.npmPackageName}@latest`],
+    updateArgs: ["i", "-g", `${definition.packageName}@latest`],
     updateLockKey: "bun-global",
   });
 }
 
 function makePnpmGlobalProviderMaintenanceCapabilities(
-  definition: PackageManagedProviderMaintenanceDefinition,
+  definition: ProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilities {
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
-    packageName: definition.npmPackageName,
+    packageName: definition.packageName,
     updateExecutable: "pnpm",
-    updateArgs: ["add", "-g", `${definition.npmPackageName}@latest`],
+    updateArgs: ["add", "-g", `${definition.packageName}@latest`],
     updateLockKey: "pnpm-global",
   });
 }
 
 function makeVitePlusGlobalProviderMaintenanceCapabilities(
-  definition: PackageManagedProviderMaintenanceDefinition,
+  definition: ProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilities {
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
-    packageName: definition.npmPackageName,
+    packageName: definition.packageName,
     updateExecutable: "vp",
-    updateArgs: ["i", "-g", definition.npmPackageName],
+    updateArgs: ["i", "-g", definition.packageName],
     updateLockKey: "vite-plus-global",
   });
 }
 
 function makeHomebrewProviderMaintenanceCapabilities(
-  definition: PackageManagedProviderMaintenanceDefinition,
+  definition: ProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilities {
   if (!definition.homebrewFormula) {
     return makeManualOnlyProviderMaintenanceCapabilities({
       provider: definition.provider,
-      packageName: definition.npmPackageName,
+      packageName: definition.packageName,
     });
   }
 
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
-    packageName: definition.npmPackageName,
+    packageName: definition.packageName,
     updateExecutable: "brew",
     updateArgs: ["upgrade", definition.homebrewFormula],
     updateLockKey: "homebrew",
@@ -208,7 +292,7 @@ function makeHomebrewProviderMaintenanceCapabilities(
 }
 
 function makeNativeProviderMaintenanceCapabilities(
-  definition: PackageManagedProviderMaintenanceDefinition,
+  definition: ProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilities | null {
   if (!definition.nativeUpdate) {
     return null;
@@ -216,7 +300,7 @@ function makeNativeProviderMaintenanceCapabilities(
 
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
-    packageName: definition.npmPackageName,
+    packageName: definition.packageName,
     updateExecutable: definition.nativeUpdate.executable,
     updateArgs: definition.nativeUpdate.args,
     updateLockKey: definition.nativeUpdate.lockKey,
@@ -273,8 +357,8 @@ function isHomebrewCommandPath(commandPath: string): boolean {
   );
 }
 
-export function resolvePackageManagedProviderMaintenance(
-  definition: PackageManagedProviderMaintenanceDefinition,
+function resolveLegacyProviderMaintenance(
+  definition: ProviderMaintenanceDefinition,
   options?: ProviderMaintenanceCapabilityResolutionOptions,
 ): ProviderMaintenanceCapabilities {
   const binaryPath = nonEmptyString(options?.binaryPath);
@@ -324,15 +408,47 @@ export function resolvePackageManagedProviderMaintenance(
 
   return makeManualOnlyProviderMaintenanceCapabilities({
     provider: definition.provider,
-    packageName: definition.npmPackageName,
+    packageName: definition.packageName,
   });
 }
 
-export function makePackageManagedProviderMaintenanceResolver(
-  definition: PackageManagedProviderMaintenanceDefinition,
+export function makeProviderMaintenanceResolver(
+  definition: ProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilitiesResolver {
+  const executableName =
+    definition.executableName ??
+    (definition.provider === ProviderDriverKind.make("claudeAgent")
+      ? "claude"
+      : definition.provider === ProviderDriverKind.make("opencode")
+        ? "opencode"
+        : "codex");
+  const catalog = makeProviderInstallationCatalog({
+    provider: definition.provider,
+    packageName: definition.packageName,
+    executableName,
+    homebrewFormula: definition.homebrewFormula,
+    native: definition.nativeUpdate
+      ? {
+          label: "Managed by native installer",
+          updateArgs: definition.nativeUpdate.args,
+          ownsPath: definition.nativeUpdate.isCommandPath,
+          ...(definition.nativeUpdate.environment
+            ? { environment: definition.nativeUpdate.environment }
+            : {}),
+        }
+      : definition.provider === ProviderDriverKind.make("codex")
+        ? {
+            label: "Managed by Codex standalone installer",
+            updateArgs: ["update"],
+            ownsPath: (path) => path.includes("/.codex/packages/standalone/releases/"),
+          }
+        : null,
+    instructionsUrl: definition.instructionsUrl ?? "https://t3.codes/docs/providers",
+    ...(definition.wingetPackageId ? { wingetPackageId: definition.wingetPackageId } : {}),
+  });
   return {
-    resolve: (options) => resolvePackageManagedProviderMaintenance(definition, options),
+    resolve: (options) => resolveLegacyProviderMaintenance(definition, options),
+    resolveInstallation: (context) => resolveInstallation(context, catalog),
   };
 }
 
@@ -342,6 +458,29 @@ export function makeStaticProviderMaintenanceResolver(
   return {
     resolve: () => capabilities,
   };
+}
+
+function capabilitiesFromInstallation(
+  provider: ProviderDriverKind,
+  installation: ResolvedInstallation,
+): ProviderMaintenanceCapabilities {
+  return makeProviderMaintenanceCapabilities({
+    provider,
+    packageName: installation.packageName,
+    updateExecutable: installation.update?.executable ?? null,
+    updateArgs: installation.update?.args ?? [],
+    updateLockKey: installation.update ? installation.lockKey : null,
+    ...(installation.update ? { updateCommand: installation.update.displayCommand } : {}),
+    ...(installation.update?.environment
+      ? { updateEnvironment: installation.update.environment }
+      : {}),
+    identityKey: installation.identityKey,
+    installationLabel: installation.label,
+    ownershipVerified: installation.ownershipVerified,
+    currentVersion: installation.currentVersion,
+    latestVersion: installation.latestVersion,
+    instructionsUrl: installation.instructionsUrl,
+  });
 }
 
 function makeManualProviderMaintenanceCapabilities(
@@ -374,15 +513,63 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
   }
 
   const fileSystem = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const platform = yield* HostProcessPlatform;
   const realCommandPath = yield* fileSystem
     .realPath(resolvedCommandPath)
     .pipe(Effect.orElseSucceed(() => resolvedCommandPath));
-  return resolver.resolve({
+  const resolutionOptions = {
     ...options,
     env,
     resolvedCommandPath,
     realCommandPath,
-  });
+  };
+  if (!resolver.resolveInstallation) {
+    return resolver.resolve(resolutionOptions);
+  }
+  const legacy = resolver.resolve(resolutionOptions);
+  const context: InstallationContext = {
+    provider: legacy.provider,
+    packageName: legacy.packageName ?? "",
+    binaryPath,
+    isBareCommand: !hasPathSeparator(binaryPath),
+    resolvedCommandPath,
+    realCommandPath,
+    environment: env,
+    platform,
+    readTextFile: (path) =>
+      path
+        ? fileSystem.readFileString(path).pipe(
+            Effect.map(Option.some),
+            Effect.orElseSucceed(() => Option.none()),
+            Effect.map(Option.getOrNull),
+          )
+        : Effect.succeed(null),
+    realPath: (path) => fileSystem.realPath(path).pipe(Effect.orElseSucceed(() => path)),
+    resolveCommand: (command) =>
+      resolveCommandPath(command, { env }).pipe(
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, pathService),
+        Effect.map(Option.some),
+        Effect.catchTags({ CommandResolutionError: () => Effect.succeed(Option.none()) }),
+        Effect.map(Option.getOrNull),
+      ),
+    run: (executable, args, environment = env) =>
+      runMaintenanceProbe({
+        executable,
+        args,
+        environment,
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, pathService),
+      ),
+  };
+  return capabilitiesFromInstallation(
+    legacy.provider,
+    yield* resolver.resolveInstallation(context),
+  );
 });
 
 function deriveVersionAdvisory(input: {
@@ -395,7 +582,7 @@ function deriveVersionAdvisory(input: {
   if (!input.latestVersion) {
     return { status: "unknown", message: null };
   }
-  if (compareSemverVersions(input.currentVersion, input.latestVersion) < 0) {
+  if (compareMaintenanceVersions(input.currentVersion, input.latestVersion) === -1) {
     return {
       status: "behind_latest",
       message: PROVIDER_UPDATE_ACTION_TOAST_MESSAGE,
@@ -413,15 +600,17 @@ export function createProviderVersionAdvisory(input: {
 }): ServerProviderVersionAdvisory {
   const capabilities =
     input.maintenanceCapabilities ?? makeManualProviderMaintenanceCapabilities(input.driver);
-  const latestVersion = input.latestVersion ?? null;
+  const latestVersion =
+    "latestVersion" in input ? (input.latestVersion ?? null) : (capabilities.latestVersion ?? null);
+  const currentVersion = capabilities.currentVersion ?? input.currentVersion;
   const advisory = deriveVersionAdvisory({
-    currentVersion: input.currentVersion,
+    currentVersion,
     latestVersion,
   });
 
   return {
     status: advisory.status,
-    currentVersion: input.currentVersion,
+    currentVersion,
     latestVersion,
     updateCommand: capabilities.update?.command ?? null,
     canUpdate: capabilities.update !== null,
@@ -456,6 +645,9 @@ const fetchNpmLatestVersion = Effect.fn("fetchNpmLatestVersion")(function* (pack
 export const resolveLatestProviderVersion = Effect.fn("resolveLatestProviderVersion")(function* (
   maintenanceCapabilities: ProviderMaintenanceCapabilities,
 ) {
+  if (maintenanceCapabilities.latestVersion !== undefined) {
+    return maintenanceCapabilities.latestVersion;
+  }
   const packageName = maintenanceCapabilities.packageName;
   if (!packageName) {
     return null;
@@ -498,6 +690,7 @@ export const enrichProviderSnapshotWithVersionAdvisory = Effect.fn(
       versionAdvisory: createProviderVersionAdvisory({
         driver: snapshot.driver,
         currentVersion: snapshot.version,
+        latestVersion: null,
         checkedAt: snapshot.checkedAt,
         maintenanceCapabilities: capabilities,
       }),

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -582,7 +582,11 @@ function deriveVersionAdvisory(input: {
   if (!input.latestVersion) {
     return { status: "unknown", message: null };
   }
-  if (compareMaintenanceVersions(input.currentVersion, input.latestVersion) === -1) {
+  const comparison = compareMaintenanceVersions(input.currentVersion, input.latestVersion);
+  if (comparison === null) {
+    return { status: "unknown", message: null };
+  }
+  if (comparison < 0) {
     return {
       status: "behind_latest",
       message: PROVIDER_UPDATE_ACTION_TOAST_MESSAGE,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -6,6 +6,7 @@ import {
 import { resolveCommandPath, resolveSpawnCommand } from "@t3tools/shared/shell";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Clock from "effect/Clock";
+import * as Cause from "effect/Cause";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -88,7 +89,12 @@ export const runMaintenanceProbe = Effect.fn("runMaintenanceProbe")(function* (i
   }).pipe(
     Effect.scoped,
     Effect.timeoutOption(Duration.millis(MAINTENANCE_PROBE_TIMEOUT_MS)),
-    Effect.catchCause(() => Effect.succeed(Option.none())),
+    Effect.catchCause((cause) => {
+      const interruptionReasons = cause.reasons.filter(Cause.isInterruptReason);
+      return interruptionReasons.length > 0
+        ? Effect.failCause(Cause.fromReasons<never>(interruptionReasons))
+        : Effect.succeed(Option.none());
+    }),
   );
   return Option.getOrNull(result);
 });

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -305,6 +305,32 @@ function makeManualProviderMaintenanceCapabilities(
   });
 }
 
+export const makeProviderMaintenanceCapabilitySources = Effect.fn(
+  "makeProviderMaintenanceCapabilitySources",
+)(function* (
+  resolveFresh: Effect.Effect<ProviderMaintenanceCapabilities>,
+  fallback: ProviderMaintenanceCapabilities,
+  options: { readonly enabled: boolean },
+) {
+  if (!options.enabled) {
+    return {
+      advisory: Effect.succeed(fallback),
+      fresh: resolveFresh,
+    } as const;
+  }
+
+  const [advisory, invalidateAdvisory] = yield* Effect.cachedInvalidateWithTTL(
+    resolveFresh,
+    "5 minutes",
+  );
+  return {
+    advisory,
+    // Update execution must never trust cached ownership. Invalidating here
+    // also makes the next advisory observe the post-update installation.
+    fresh: invalidateAdvisory.pipe(Effect.andThen(resolveFresh)),
+  } as const;
+});
+
 export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
   "resolveProviderMaintenanceCapabilitiesEffect",
 )(function* (

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -48,7 +48,7 @@ const CommandLookupEnvConfig = Config.all({
 const readCommandLookupEnv = CommandLookupEnvConfig.pipe(Effect.orElseSucceed(() => ({})));
 const MAINTENANCE_PROBE_MAX_BYTES = 64_000;
 
-const runMaintenanceProbe = Effect.fn("runMaintenanceProbe")(function* (input: {
+export const runMaintenanceProbe = Effect.fn("runMaintenanceProbe")(function* (input: {
   readonly executable: string;
   readonly args: ReadonlyArray<string>;
   readonly environment: NodeJS.ProcessEnv;
@@ -78,6 +78,7 @@ const runMaintenanceProbe = Effect.fn("runMaintenanceProbe")(function* (input: {
       ],
       { concurrency: "unbounded" },
     );
+    if (stdout.truncated || stderr.truncated) return null;
     return { stdout: stdout.text, stderr: stderr.text, exitCode: Number(exitCode) };
   }).pipe(
     Effect.scoped,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -29,6 +29,7 @@ import { compareMaintenanceVersions } from "./maintenance/version.ts";
 const LATEST_VERSION_CACHE_TTL_MS = 60 * 60 * 1_000;
 const LATEST_VERSION_TIMEOUT_MS = 4_000;
 const MAINTENANCE_PROBE_TIMEOUT_MS = 10_000;
+const MAINTENANCE_RESOLUTION_TIMEOUT_MS = 10_000;
 const MAINTENANCE_ADVISORY_CACHE_TTL_MS = 5 * 60 * 1_000;
 const PROVIDER_UPDATE_ACTION_TOAST_MESSAGE = "Install the update now or review provider settings.";
 
@@ -397,6 +398,10 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
     return resolver.resolve(resolutionOptions);
   }
   const legacy = resolver.resolve(resolutionOptions);
+  const timeoutFallback = makeManualOnlyProviderMaintenanceCapabilities({
+    provider: legacy.provider,
+    packageName: legacy.packageName,
+  });
   const context: InstallationContext = {
     provider: legacy.provider,
     packageName: legacy.packageName ?? "",
@@ -434,9 +439,16 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
         Effect.provideService(Path.Path, pathService),
       ),
   };
-  return capabilitiesFromInstallation(
-    legacy.provider,
-    yield* resolver.resolveInstallation(context),
+  return yield* resolver.resolveInstallation(context).pipe(
+    Effect.map((installation) => capabilitiesFromInstallation(legacy.provider, installation)),
+    // Package-manager probes are sequential and each has its own timeout. Keep
+    // their combined latency bounded so maintenance detection cannot delay
+    // provider startup indefinitely. The fallback never authorizes an update,
+    // even if a custom resolver's legacy result does.
+    Effect.timeoutOrElse({
+      duration: Duration.millis(MAINTENANCE_RESOLUTION_TIMEOUT_MS),
+      orElse: () => Effect.succeed(timeoutFallback),
+    }),
   );
 });
 

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -398,10 +398,13 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
     return resolver.resolve(resolutionOptions);
   }
   const legacy = resolver.resolve(resolutionOptions);
-  const timeoutFallback = makeManualOnlyProviderMaintenanceCapabilities({
-    provider: legacy.provider,
-    packageName: legacy.packageName,
-  });
+  const timeoutFallback = {
+    ...makeManualOnlyProviderMaintenanceCapabilities({
+      provider: legacy.provider,
+      packageName: legacy.packageName,
+    }),
+    latestVersion: null,
+  };
   const context: InstallationContext = {
     provider: legacy.provider,
     packageName: legacy.packageName ?? "",

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -135,9 +135,7 @@ export interface ProviderMaintenanceDefinition {
   readonly executableName: string;
   readonly homebrewFormula: string | null;
   readonly nativeUpdate: {
-    readonly executable: string;
     readonly args: ReadonlyArray<string>;
-    readonly lockKey: string;
     readonly isCommandPath: (commandPath: string) => boolean;
     readonly environment?: (
       executable: string,
@@ -425,7 +423,6 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
     provider: legacy.provider,
     packageName: legacy.packageName ?? "",
     binaryPath,
-    isBareCommand: !hasPathSeparator(binaryPath),
     resolvedCommandPath,
     realCommandPath,
     environment: env,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -405,6 +405,22 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
     }),
     latestVersion: null,
   };
+  const readTextFile = Effect.fn("readProviderMaintenanceTextFile")(function* (
+    path: string,
+    maxBytes?: number,
+  ) {
+    if (!path) return null;
+    return yield* (
+      maxBytes === undefined
+        ? fileSystem.readFileString(path).pipe(Effect.map((text) => text as string | null))
+        : collectUint8StreamText({
+            stream: fileSystem.stream(path, { bytesToRead: maxBytes + 1 }),
+            maxBytes,
+          }).pipe(
+            Effect.map((result) => (result.truncated || result.invalidUtf8 ? null : result.text)),
+          )
+    ).pipe(Effect.orElseSucceed(() => null));
+  });
   const context: InstallationContext = {
     provider: legacy.provider,
     packageName: legacy.packageName ?? "",
@@ -414,14 +430,7 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
     realCommandPath,
     environment: env,
     platform,
-    readTextFile: (path) =>
-      path
-        ? fileSystem.readFileString(path).pipe(
-            Effect.map(Option.some),
-            Effect.orElseSucceed(() => Option.none()),
-            Effect.map(Option.getOrNull),
-          )
-        : Effect.succeed(null),
+    readTextFile,
     realPath: (path) => fileSystem.realPath(path).pipe(Effect.orElseSucceed(() => path)),
     resolveCommand: (command) =>
       resolveCommandPath(command, { env }).pipe(

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -127,6 +127,7 @@ export interface ProviderMaintenanceCapabilitiesResolver {
 export interface ProviderMaintenanceDefinition {
   readonly provider: ProviderDriverKind;
   readonly packageName: string;
+  readonly executableName: string;
   readonly homebrewFormula: string | null;
   readonly nativeUpdate: {
     readonly executable: string;
@@ -138,7 +139,6 @@ export interface ProviderMaintenanceDefinition {
       environment: NodeJS.ProcessEnv,
     ) => NodeJS.ProcessEnv;
   } | null;
-  readonly executableName?: string;
   readonly instructionsUrl?: string;
   readonly wingetPackageId?: string;
 }
@@ -226,17 +226,10 @@ export function normalizeCommandPath(commandPath: string): string {
 export function makeProviderMaintenanceResolver(
   definition: ProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilitiesResolver {
-  const executableName =
-    definition.executableName ??
-    (definition.provider === ProviderDriverKind.make("claudeAgent")
-      ? "claude"
-      : definition.provider === ProviderDriverKind.make("opencode")
-        ? "opencode"
-        : "codex");
   const catalog = makeProviderInstallationCatalog({
     provider: definition.provider,
     packageName: definition.packageName,
-    executableName,
+    executableName: definition.executableName,
     homebrewFormula: definition.homebrewFormula,
     native: definition.nativeUpdate
       ? {

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -23,7 +23,11 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
 import { makeProviderInstallationCatalog } from "./maintenance/catalogs.ts";
-import type { InstallationContext, ResolvedInstallation } from "./maintenance/definition.ts";
+import {
+  INSTALLER_METADATA_MAX_BYTES,
+  type InstallationContext,
+  type ResolvedInstallation,
+} from "./maintenance/definition.ts";
 import { resolveInstallation } from "./maintenance/resolver.ts";
 import { compareMaintenanceVersions } from "./maintenance/version.ts";
 
@@ -98,6 +102,20 @@ export const runMaintenanceProbe = Effect.fn("runMaintenanceProbe")(function* (i
   );
   return Option.getOrNull(result);
 });
+
+export const readProviderMaintenanceMetadata = Effect.fn("readProviderMaintenanceMetadata")(
+  function* (path: string) {
+    if (!path) return null;
+    const fileSystem = yield* FileSystem.FileSystem;
+    return yield* collectUint8StreamText({
+      stream: fileSystem.stream(path, { bytesToRead: INSTALLER_METADATA_MAX_BYTES + 1 }),
+      maxBytes: INSTALLER_METADATA_MAX_BYTES,
+    }).pipe(
+      Effect.map((result) => (result.truncated || result.invalidUtf8 ? null : result.text)),
+      Effect.orElseSucceed(() => null),
+    );
+  },
+);
 
 export interface ProviderMaintenanceCapabilities {
   readonly provider: ProviderDriverKind;
@@ -409,22 +427,10 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
     }),
     latestVersion: null,
   };
-  const readTextFile = Effect.fn("readProviderMaintenanceTextFile")(function* (
-    path: string,
-    maxBytes?: number,
-  ) {
-    if (!path) return null;
-    return yield* (
-      maxBytes === undefined
-        ? fileSystem.readFileString(path).pipe(Effect.map((text) => text as string | null))
-        : collectUint8StreamText({
-            stream: fileSystem.stream(path, { bytesToRead: maxBytes + 1 }),
-            maxBytes,
-          }).pipe(
-            Effect.map((result) => (result.truncated || result.invalidUtf8 ? null : result.text)),
-          )
-    ).pipe(Effect.orElseSucceed(() => null));
-  });
+  const readTextFile = (path: string) =>
+    readProviderMaintenanceMetadata(path).pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+    );
   const context: InstallationContext = {
     provider: legacy.provider,
     packageName: legacy.packageName ?? "",

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -5,6 +5,7 @@ import {
 } from "@t3tools/contracts";
 import { resolveCommandPath, resolveSpawnCommand } from "@t3tools/shared/shell";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Clock from "effect/Clock";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -13,7 +14,9 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
@@ -26,6 +29,7 @@ import { compareMaintenanceVersions } from "./maintenance/version.ts";
 const LATEST_VERSION_CACHE_TTL_MS = 60 * 60 * 1_000;
 const LATEST_VERSION_TIMEOUT_MS = 4_000;
 const MAINTENANCE_PROBE_TIMEOUT_MS = 10_000;
+const MAINTENANCE_ADVISORY_CACHE_TTL_MS = 5 * 60 * 1_000;
 const PROVIDER_UPDATE_ACTION_TOAST_MESSAGE = "Install the update now or review provider settings.";
 
 const compactEnv = (input: Record<string, Option.Option<string>>): NodeJS.ProcessEnv =>
@@ -223,6 +227,13 @@ export function normalizeCommandPath(commandPath: string): string {
   return commandPath.replaceAll("\\", "/").toLowerCase();
 }
 
+function codexStandaloneRoot(commandPath: string): string | null {
+  const normalized = normalizeCommandPath(commandPath);
+  const marker = "/.codex/packages/standalone/releases/";
+  const markerIndex = normalized.indexOf(marker);
+  return markerIndex < 0 ? null : normalized.slice(0, markerIndex + marker.length - 1);
+}
+
 export function makeProviderMaintenanceResolver(
   definition: ProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilitiesResolver {
@@ -244,7 +255,8 @@ export function makeProviderMaintenanceResolver(
         ? {
             label: "Managed by Codex standalone installer",
             updateArgs: ["update"],
-            ownsPath: (path) => path.includes("/.codex/packages/standalone/releases/"),
+            ownsPath: (path) => codexStandaloneRoot(path) !== null,
+            identityRoot: codexStandaloneRoot,
           }
         : null,
     instructionsUrl: definition.instructionsUrl ?? "https://t3.codes/docs/providers",
@@ -319,15 +331,32 @@ export const makeProviderMaintenanceCapabilitySources = Effect.fn(
     } as const;
   }
 
-  const [advisory, invalidateAdvisory] = yield* Effect.cachedInvalidateWithTTL(
-    resolveFresh,
-    "5 minutes",
+  const advisoryCache = yield* Ref.make<{
+    readonly expiresAt: number;
+    readonly value: ProviderMaintenanceCapabilities;
+  } | null>(null);
+  const advisorySemaphore = yield* Semaphore.make(1);
+  const invalidateAdvisory = Ref.set(advisoryCache, null);
+  const advisory = advisorySemaphore.withPermits(1)(
+    Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      const cached = yield* Ref.get(advisoryCache);
+      if (cached && now < cached.expiresAt) {
+        return cached.value;
+      }
+      const value = yield* resolveFresh;
+      yield* Ref.set(advisoryCache, {
+        expiresAt: (yield* Clock.currentTimeMillis) + MAINTENANCE_ADVISORY_CACHE_TTL_MS,
+        value,
+      });
+      return value;
+    }),
   );
   return {
     advisory,
     // Update execution must never trust cached ownership. Invalidating here
     // also makes the next advisory observe the post-update installation.
-    fresh: invalidateAdvisory.pipe(Effect.andThen(resolveFresh)),
+    fresh: advisorySemaphore.withPermits(1)(invalidateAdvisory.pipe(Effect.andThen(resolveFresh))),
   } as const;
 });
 

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -214,202 +214,12 @@ export function makeManualOnlyProviderMaintenanceCapabilities(input: {
   });
 }
 
-function makeNpmGlobalProviderMaintenanceCapabilities(
-  definition: ProviderMaintenanceDefinition,
-): ProviderMaintenanceCapabilities {
-  return makeProviderMaintenanceCapabilities({
-    provider: definition.provider,
-    packageName: definition.packageName,
-    updateExecutable: "npm",
-    // npm 12 blocks install scripts by default (empty allow-scripts allowlist)
-    // and still exits 0, so a package whose postinstall finishes the install
-    // (claude copies its native binary over a placeholder stub) is left broken
-    // while the update reports success. Allow this one package's scripts.
-    // Older npm warns about the unknown config and continues.
-    updateArgs: [
-      "install",
-      "-g",
-      `--allow-scripts=${definition.packageName}`,
-      `${definition.packageName}@latest`,
-    ],
-    updateLockKey: "npm-global",
-  });
-}
-
-function makeBunGlobalProviderMaintenanceCapabilities(
-  definition: ProviderMaintenanceDefinition,
-): ProviderMaintenanceCapabilities {
-  return makeProviderMaintenanceCapabilities({
-    provider: definition.provider,
-    packageName: definition.packageName,
-    updateExecutable: "bun",
-    updateArgs: ["i", "-g", `${definition.packageName}@latest`],
-    updateLockKey: "bun-global",
-  });
-}
-
-function makePnpmGlobalProviderMaintenanceCapabilities(
-  definition: ProviderMaintenanceDefinition,
-): ProviderMaintenanceCapabilities {
-  return makeProviderMaintenanceCapabilities({
-    provider: definition.provider,
-    packageName: definition.packageName,
-    updateExecutable: "pnpm",
-    updateArgs: ["add", "-g", `${definition.packageName}@latest`],
-    updateLockKey: "pnpm-global",
-  });
-}
-
-function makeVitePlusGlobalProviderMaintenanceCapabilities(
-  definition: ProviderMaintenanceDefinition,
-): ProviderMaintenanceCapabilities {
-  return makeProviderMaintenanceCapabilities({
-    provider: definition.provider,
-    packageName: definition.packageName,
-    updateExecutable: "vp",
-    updateArgs: ["i", "-g", definition.packageName],
-    updateLockKey: "vite-plus-global",
-  });
-}
-
-function makeHomebrewProviderMaintenanceCapabilities(
-  definition: ProviderMaintenanceDefinition,
-): ProviderMaintenanceCapabilities {
-  if (!definition.homebrewFormula) {
-    return makeManualOnlyProviderMaintenanceCapabilities({
-      provider: definition.provider,
-      packageName: definition.packageName,
-    });
-  }
-
-  return makeProviderMaintenanceCapabilities({
-    provider: definition.provider,
-    packageName: definition.packageName,
-    updateExecutable: "brew",
-    updateArgs: ["upgrade", definition.homebrewFormula],
-    updateLockKey: "homebrew",
-  });
-}
-
-function makeNativeProviderMaintenanceCapabilities(
-  definition: ProviderMaintenanceDefinition,
-): ProviderMaintenanceCapabilities | null {
-  if (!definition.nativeUpdate) {
-    return null;
-  }
-
-  return makeProviderMaintenanceCapabilities({
-    provider: definition.provider,
-    packageName: definition.packageName,
-    updateExecutable: definition.nativeUpdate.executable,
-    updateArgs: definition.nativeUpdate.args,
-    updateLockKey: definition.nativeUpdate.lockKey,
-  });
-}
-
 export function hasPathSeparator(value: string): boolean {
   return value.includes("/") || value.includes("\\");
 }
 
 export function normalizeCommandPath(commandPath: string): string {
   return commandPath.replaceAll("\\", "/").toLowerCase();
-}
-
-function isBunGlobalCommandPath(commandPath: string): boolean {
-  return normalizeCommandPath(commandPath).includes("/.bun/bin/");
-}
-
-function isVitePlusGlobalCommandPath(commandPath: string): boolean {
-  return normalizeCommandPath(commandPath).includes("/.vite-plus/bin/");
-}
-
-function isPnpmGlobalCommandPath(commandPath: string): boolean {
-  const normalized = normalizeCommandPath(commandPath);
-  return (
-    normalized.includes("/.local/share/pnpm/") ||
-    normalized.includes("/library/pnpm/") ||
-    normalized.includes("/local/share/pnpm/") ||
-    normalized.includes("/appdata/local/pnpm/") ||
-    normalized.includes("/pnpm/global/")
-  );
-}
-
-function isNpmGlobalCommandPath(commandPath: string): boolean {
-  const normalized = normalizeCommandPath(commandPath);
-  return (
-    normalized.includes("/node_modules/.bin/") ||
-    normalized.includes("/lib/node_modules/") ||
-    normalized.includes("/npm/node_modules/")
-  );
-}
-
-function isHomebrewCommandPath(commandPath: string): boolean {
-  const normalized = normalizeCommandPath(commandPath);
-  return (
-    normalized.includes("/opt/homebrew/cellar/") ||
-    normalized.includes("/usr/local/cellar/") ||
-    normalized.includes("/homebrew/cellar/") ||
-    normalized.includes("/opt/homebrew/caskroom/") ||
-    normalized.includes("/usr/local/caskroom/") ||
-    normalized.includes("/homebrew/caskroom/") ||
-    normalized.startsWith("/opt/homebrew/bin/") ||
-    normalized.startsWith("/usr/local/bin/")
-  );
-}
-
-function resolveLegacyProviderMaintenance(
-  definition: ProviderMaintenanceDefinition,
-  options?: ProviderMaintenanceCapabilityResolutionOptions,
-): ProviderMaintenanceCapabilities {
-  const binaryPath = nonEmptyString(options?.binaryPath);
-  if (!binaryPath) {
-    return makeNpmGlobalProviderMaintenanceCapabilities(definition);
-  }
-
-  const resolvedCommandPath =
-    options?.resolvedCommandPath ?? (hasPathSeparator(binaryPath) ? binaryPath : null);
-
-  if (resolvedCommandPath) {
-    const commandPaths = [
-      resolvedCommandPath,
-      ...(options?.realCommandPath ? [options.realCommandPath] : []),
-    ];
-
-    const nativeUpdate = definition.nativeUpdate;
-    if (
-      nativeUpdate &&
-      commandPaths.some((commandPath) => nativeUpdate.isCommandPath(commandPath))
-    ) {
-      return (
-        makeNativeProviderMaintenanceCapabilities(definition) ??
-        makeNpmGlobalProviderMaintenanceCapabilities(definition)
-      );
-    }
-    if (commandPaths.some(isVitePlusGlobalCommandPath)) {
-      return makeVitePlusGlobalProviderMaintenanceCapabilities(definition);
-    }
-    if (commandPaths.some(isBunGlobalCommandPath)) {
-      return makeBunGlobalProviderMaintenanceCapabilities(definition);
-    }
-    if (commandPaths.some(isPnpmGlobalCommandPath)) {
-      return makePnpmGlobalProviderMaintenanceCapabilities(definition);
-    }
-    if (commandPaths.some(isNpmGlobalCommandPath)) {
-      return makeNpmGlobalProviderMaintenanceCapabilities(definition);
-    }
-    if (commandPaths.some(isHomebrewCommandPath)) {
-      return makeHomebrewProviderMaintenanceCapabilities(definition);
-    }
-  }
-
-  if (!hasPathSeparator(binaryPath)) {
-    return makeNpmGlobalProviderMaintenanceCapabilities(definition);
-  }
-
-  return makeManualOnlyProviderMaintenanceCapabilities({
-    provider: definition.provider,
-    packageName: definition.packageName,
-  });
 }
 
 export function makeProviderMaintenanceResolver(
@@ -447,7 +257,11 @@ export function makeProviderMaintenanceResolver(
     ...(definition.wingetPackageId ? { wingetPackageId: definition.wingetPackageId } : {}),
   });
   return {
-    resolve: (options) => resolveLegacyProviderMaintenance(definition, options),
+    resolve: () =>
+      makeManualOnlyProviderMaintenanceCapabilities({
+        provider: definition.provider,
+        packageName: definition.packageName,
+      }),
     resolveInstallation: (context) => resolveInstallation(context, catalog),
   };
 }
@@ -467,11 +281,16 @@ function capabilitiesFromInstallation(
   return makeProviderMaintenanceCapabilities({
     provider,
     packageName: installation.packageName,
-    updateExecutable: installation.update?.executable ?? null,
-    updateArgs: installation.update?.args ?? [],
-    updateLockKey: installation.update ? installation.lockKey : null,
-    ...(installation.update ? { updateCommand: installation.update.displayCommand } : {}),
-    ...(installation.update?.environment
+    updateExecutable:
+      installation.ownershipVerified && installation.update ? installation.update.executable : null,
+    updateArgs:
+      installation.ownershipVerified && installation.update ? installation.update.args : [],
+    updateLockKey:
+      installation.ownershipVerified && installation.update ? installation.lockKey : null,
+    ...(installation.ownershipVerified && installation.update
+      ? { updateCommand: installation.update.displayCommand }
+      : {}),
+    ...(installation.ownershipVerified && installation.update?.environment
       ? { updateEnvironment: installation.update.environment }
       : {}),
     identityKey: installation.identityKey,

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -189,7 +189,7 @@ function makeRegistry(
       getProviders: Ref.get(providersRef),
       refresh: () => Ref.get(providersRef),
       refreshInstance: () => Ref.get(providersRef),
-      getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
+      resolveProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
         Effect.succeed(lifecycleFor(provider)),
       setProviderMaintenanceActionState,
       streamChanges: Stream.empty,
@@ -249,6 +249,193 @@ describe("providerMaintenanceRunner", () => {
     );
   });
 
+  it.effect("re-resolves ownership before spawning and stops when the installation changed", () => {
+    let resolutionCount = 0;
+    let spawnCount = 0;
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry(baseProvider);
+      const stored = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "/opt/npm/bin/npm",
+        updateArgs: ["install", "-g", "@openai/codex@latest"],
+        updateLockKey: "npm:/opt/npm",
+        identityKey: "installation-before",
+        ownershipVerified: true,
+      });
+      const changed = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "/home/test/scoop/shims/scoop",
+        updateArgs: ["update", "main/codex"],
+        updateLockKey: "scoop:/home/test/scoop",
+        identityKey: "installation-after",
+        ownershipVerified: true,
+      });
+      const guardedRegistry: ProviderRegistryShape = {
+        ...registry,
+        resolveProviderMaintenanceCapabilitiesForInstance: () =>
+          Effect.succeed(resolutionCount++ === 0 ? stored : changed),
+      };
+      const updater = yield* makeTestRunner(guardedRegistry);
+
+      const result = yield* updater.updateProvider(CODEX_DRIVER);
+
+      assert.strictEqual(spawnCount, 0);
+      assert.strictEqual(result.providers[0]?.updateState?.status, "failed");
+      assert.strictEqual(
+        result.providers[0]?.updateState?.message,
+        "Provider installation changed. Refresh and try again.",
+      );
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.0.0"),
+          mockSpawnerLayer(() => {
+            spawnCount += 1;
+            return {};
+          }),
+        ),
+      ),
+    );
+  });
+
+  it.effect("stops when re-resolution changes the update lock", () => {
+    let resolutionCount = 0;
+    let spawnCount = 0;
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry(baseProvider);
+      const stored = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "npm",
+        updateArgs: ["install", "-g", "@openai/codex@latest"],
+        updateLockKey: "npm:/opt/npm",
+      });
+      const changed = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "npm",
+        updateArgs: ["install", "-g", "@openai/codex@latest"],
+        updateLockKey: "npm:/srv/npm",
+      });
+      const updater = yield* makeTestRunner({
+        ...registry,
+        resolveProviderMaintenanceCapabilitiesForInstance: () =>
+          Effect.succeed(resolutionCount++ === 0 ? stored : changed),
+      });
+
+      const result = yield* updater.updateProvider(CODEX_DRIVER);
+
+      assert.strictEqual(spawnCount, 0);
+      assert.strictEqual(result.providers[0]?.updateState?.status, "failed");
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.0.0"),
+          mockSpawnerLayer(() => {
+            spawnCount += 1;
+            return {};
+          }),
+        ),
+      ),
+    );
+  });
+
+  it.effect("accepts a verified update executable on a Windows UNC share", () => {
+    const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry(baseProvider);
+      const capabilities = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "\\\\server\\share\\scoop.cmd",
+        updateArgs: ["update", "main/codex"],
+        updateLockKey: "scoop:\\\\server\\share",
+        identityKey: "scoop-unc-installation",
+        ownershipVerified: true,
+      });
+      const updater = yield* makeTestRunner({
+        ...registry,
+        resolveProviderMaintenanceCapabilitiesForInstance: () => Effect.succeed(capabilities),
+      });
+
+      yield* updater.updateProvider(CODEX_DRIVER);
+
+      assert.deepStrictEqual(calls, [
+        {
+          command: "\\\\server\\share\\scoop.cmd",
+          args: ["update", "main/codex"],
+        },
+      ]);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.0.0"),
+          mockSpawnerLayer((command, args) => {
+            calls.push({ command, args });
+            return { stdout: "updated" };
+          }),
+        ),
+      ),
+    );
+  });
+
+  it.effect("does not report success when installation identity changes after the command", () => {
+    let resolutionCount = 0;
+    let spawnCount = 0;
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry(baseProvider);
+      const before = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "/home/test/scoop/shims/scoop",
+        updateArgs: ["update", "main/codex"],
+        updateLockKey: "scoop:/home/test/scoop",
+        identityKey: "installation-before",
+        ownershipVerified: true,
+      });
+      const after = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "/opt/npm/bin/npm",
+        updateArgs: ["install", "-g", "@openai/codex@latest"],
+        updateLockKey: "npm:/opt/npm",
+        identityKey: "installation-after",
+        ownershipVerified: true,
+      });
+      const guardedRegistry: ProviderRegistryShape = {
+        ...registry,
+        resolveProviderMaintenanceCapabilitiesForInstance: () =>
+          Effect.succeed(resolutionCount++ < 2 ? before : after),
+      };
+      const updater = yield* makeTestRunner(guardedRegistry);
+
+      const result = yield* updater.updateProvider(CODEX_DRIVER);
+
+      assert.strictEqual(spawnCount, 1);
+      assert.strictEqual(result.providers[0]?.updateState?.status, "unchanged");
+      assert.strictEqual(
+        result.providers[0]?.updateState?.message,
+        "Update command completed, but the provider installation changed during verification.",
+      );
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.0.0"),
+          mockSpawnerLayer(() => {
+            spawnCount += 1;
+            return {};
+          }),
+        ),
+      ),
+    );
+  });
+
   it.effect("uses the resolved provider capabilities when choosing the update executable", () => {
     const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
     return Effect.gen(function* () {
@@ -266,7 +453,7 @@ describe("providerMaintenanceRunner", () => {
       });
       const updater = yield* makeTestRunner({
         ...registry,
-        getProviderMaintenanceCapabilitiesForInstance: () =>
+        resolveProviderMaintenanceCapabilitiesForInstance: () =>
           Effect.succeed(
             makeProviderMaintenanceCapabilities({
               provider: CODEX_DRIVER,
@@ -351,7 +538,7 @@ describe("providerMaintenanceRunner", () => {
       ]);
       const updater = yield* makeTestRunner({
         ...registry,
-        getProviderMaintenanceCapabilitiesForInstance: (instanceId, provider) =>
+        resolveProviderMaintenanceCapabilitiesForInstance: (instanceId, provider) =>
           Effect.succeed(
             makeProviderMaintenanceCapabilities({
               provider,
@@ -512,7 +699,7 @@ describe("providerMaintenanceRunner", () => {
       const { registry } = yield* makeRegistry([baseProvider, baseOpenCodeProvider]);
       const updater = yield* makeTestRunner({
         ...registry,
-        getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
+        resolveProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
           Effect.succeed(
             makeProviderMaintenanceCapabilities({
               provider,
@@ -585,7 +772,7 @@ describe("providerMaintenanceRunner", () => {
       const { registry } = yield* makeRegistry(baseProvider);
       const updater = yield* makeTestRunner({
         ...registry,
-        getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
+        resolveProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
           Effect.succeed(
             makeProviderMaintenanceCapabilities({
               provider,

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -694,49 +694,6 @@ describe("providerMaintenanceRunner", () => {
     ),
   );
 
-  it.effect(
-    "does not report a known-latest update as successful when its version does not advance",
-    () =>
-      Effect.gen(function* () {
-        const { registry } = yield* makeRegistry({
-          ...baseProvider,
-          version: "1.0.0",
-        });
-        const knownLatestCapabilities = makeProviderMaintenanceCapabilities({
-          provider: CODEX_DRIVER,
-          packageName: "@openai/codex",
-          updateExecutable: "/usr/local/bin/npm",
-          updateArgs: ["install", "-g", "@openai/codex@latest"],
-          updateLockKey: "npm:/usr/local",
-          identityKey: "codex-npm-installation",
-          ownershipVerified: true,
-          currentVersion: "1.0.0",
-          latestVersion: "1.0.0",
-        });
-        const updater = yield* makeTestRunner({
-          ...registry,
-          resolveProviderMaintenanceCapabilitiesForInstance: () =>
-            Effect.succeed(knownLatestCapabilities),
-        });
-
-        const result = yield* updater.updateProvider(CODEX_DRIVER);
-
-        assert.strictEqual(result.providers[0]?.updateState?.status, "unchanged");
-        assert.strictEqual(
-          result.providers[0]?.updateState?.message,
-          "Update command completed, but the provider version did not advance.",
-        );
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            NonWindowsPlatform,
-            latestVersionHttpClient("1.0.0"),
-            mockSpawnerLayer(() => ({ stdout: "already current" })),
-          ),
-        ),
-      ),
-  );
-
   it.effect("reports a native update as successful when its version advances", () =>
     Effect.gen(function* () {
       const { registry, providersRef } = yield* makeRegistry({

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -623,17 +623,26 @@ describe("providerMaintenanceRunner", () => {
     "marks successful commands as unchanged when the refreshed provider is still outdated",
     () =>
       Effect.gen(function* () {
-        const { registry } = yield* makeRegistry({
+        const { registry, providersRef } = yield* makeRegistry({
           ...baseProvider,
           installed: true,
           version: "0.1.0",
         });
-        const updater = yield* makeTestRunner(registry);
+        const updater = yield* makeTestRunner({
+          ...registry,
+          refreshInstance: () =>
+            Ref.updateAndGet(providersRef, (providers) =>
+              providers.map((provider) => ({ ...provider, version: "0.2.0" })),
+            ),
+        });
 
         const result = yield* updater.updateProvider(CODEX_DRIVER);
 
         assert.strictEqual(result.providers[0]?.updateState?.status, "unchanged");
-        assert.include(result.providers[0]?.updateState?.message ?? "", "did not advance");
+        assert.strictEqual(
+          result.providers[0]?.updateState?.message,
+          "Update command completed, but T3 Code still detects an outdated provider version.",
+        );
       }).pipe(
         Effect.provide(
           Layer.mergeAll(

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -197,6 +197,7 @@ function makeRegistry(
 
     return {
       registry,
+      providersRef,
       updateStatesRef,
     };
   });
@@ -636,6 +637,87 @@ describe("providerMaintenanceRunner", () => {
           ),
         ),
       ),
+  );
+
+  it.effect("does not report a native update as successful when its version does not advance", () =>
+    Effect.gen(function* () {
+      const { registry } = yield* makeRegistry({
+        ...baseProvider,
+        version: "1.0.0",
+      });
+      const nativeCapabilities = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "/home/test/.local/bin/codex",
+        updateArgs: ["update"],
+        updateLockKey: "codex-native",
+        identityKey: "codex-native-installation",
+        ownershipVerified: true,
+        currentVersion: null,
+        latestVersion: null,
+      });
+      const updater = yield* makeTestRunner({
+        ...registry,
+        resolveProviderMaintenanceCapabilitiesForInstance: () => Effect.succeed(nativeCapabilities),
+      });
+
+      const result = yield* updater.updateProvider(CODEX_DRIVER);
+
+      assert.strictEqual(result.providers[0]?.updateState?.status, "unchanged");
+      assert.strictEqual(
+        result.providers[0]?.updateState?.message,
+        "Update command completed, but the provider version did not advance.",
+      );
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("1.0.0"),
+          mockSpawnerLayer(() => ({ stdout: "already current" })),
+        ),
+      ),
+    ),
+  );
+
+  it.effect("reports a native update as successful when its version advances", () =>
+    Effect.gen(function* () {
+      const { registry, providersRef } = yield* makeRegistry({
+        ...baseProvider,
+        version: "1.0.0",
+      });
+      const nativeCapabilities = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "/home/test/.local/bin/codex",
+        updateArgs: ["update"],
+        updateLockKey: "codex-native",
+        identityKey: "codex-native-installation",
+        ownershipVerified: true,
+        currentVersion: null,
+        latestVersion: null,
+      });
+      const updater = yield* makeTestRunner({
+        ...registry,
+        resolveProviderMaintenanceCapabilitiesForInstance: () => Effect.succeed(nativeCapabilities),
+        refreshInstance: () =>
+          Ref.updateAndGet(providersRef, (providers) =>
+            providers.map((provider) => ({ ...provider, version: "1.1.0" })),
+          ),
+      });
+
+      const result = yield* updater.updateProvider(CODEX_DRIVER);
+
+      assert.strictEqual(result.providers[0]?.updateState?.status, "succeeded");
+      assert.strictEqual(result.providers[0]?.updateState?.message, "Provider updated.");
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("1.1.0"),
+          mockSpawnerLayer(() => ({ stdout: "updated" })),
+        ),
+      ),
+    ),
   );
 
   it.effect("prevents concurrent updates for the same provider", () => {

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -769,6 +769,47 @@ describe("providerMaintenanceRunner", () => {
     ),
   );
 
+  it.effect("reports a native update as successful when its version becomes known", () =>
+    Effect.gen(function* () {
+      const { registry, providersRef } = yield* makeRegistry({
+        ...baseProvider,
+        version: null,
+      });
+      const nativeCapabilities = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "/home/test/.local/bin/codex",
+        updateArgs: ["update"],
+        updateLockKey: "codex-native",
+        identityKey: "codex-native-installation",
+        ownershipVerified: true,
+        currentVersion: null,
+        latestVersion: null,
+      });
+      const updater = yield* makeTestRunner({
+        ...registry,
+        resolveProviderMaintenanceCapabilitiesForInstance: () => Effect.succeed(nativeCapabilities),
+        refreshInstance: () =>
+          Ref.updateAndGet(providersRef, (providers) =>
+            providers.map((provider) => ({ ...provider, version: "1.1.0" })),
+          ),
+      });
+
+      const result = yield* updater.updateProvider(CODEX_DRIVER);
+
+      assert.strictEqual(result.providers[0]?.updateState?.status, "succeeded");
+      assert.strictEqual(result.providers[0]?.updateState?.message, "Provider updated.");
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("1.1.0"),
+          mockSpawnerLayer(() => ({ stdout: "updated" })),
+        ),
+      ),
+    ),
+  );
+
   it.effect("prevents concurrent updates for the same provider", () => {
     const startedLatch: { resolve: () => void } = { resolve: () => {} };
     const releaseLatch: { resolve: () => void } = { resolve: () => {} };

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -525,7 +525,7 @@ describe("providerMaintenanceRunner", () => {
       const personalInstanceId = ProviderInstanceId.make("codex_personal");
       const workInstanceId = ProviderInstanceId.make("codex_work");
       const refreshedInstanceIds: Array<ProviderInstanceId> = [];
-      const { registry } = yield* makeRegistry([
+      const { registry, providersRef } = yield* makeRegistry([
         {
           ...baseProvider,
           instanceId: personalInstanceId,
@@ -552,7 +552,13 @@ describe("providerMaintenanceRunner", () => {
             Effect.tap(() => Effect.sync(() => assert.strictEqual(instanceId, personalInstanceId))),
           ),
         refreshInstance: (instanceId) =>
-          registry.refreshInstance(instanceId).pipe(
+          Ref.updateAndGet(providersRef, (providers) =>
+            providers.map((provider) =>
+              provider.instanceId === instanceId
+                ? { ...provider, version: "0.124.0-alpha.4" }
+                : provider,
+            ),
+          ).pipe(
             Effect.tap(() =>
               Effect.sync(() => {
                 refreshedInstanceIds.push(instanceId);
@@ -627,7 +633,7 @@ describe("providerMaintenanceRunner", () => {
         const result = yield* updater.updateProvider(CODEX_DRIVER);
 
         assert.strictEqual(result.providers[0]?.updateState?.status, "unchanged");
-        assert.include(result.providers[0]?.updateState?.message ?? "", "still detects");
+        assert.include(result.providers[0]?.updateState?.message ?? "", "did not advance");
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
@@ -677,6 +683,49 @@ describe("providerMaintenanceRunner", () => {
         ),
       ),
     ),
+  );
+
+  it.effect(
+    "does not report a known-latest update as successful when its version does not advance",
+    () =>
+      Effect.gen(function* () {
+        const { registry } = yield* makeRegistry({
+          ...baseProvider,
+          version: "1.0.0",
+        });
+        const knownLatestCapabilities = makeProviderMaintenanceCapabilities({
+          provider: CODEX_DRIVER,
+          packageName: "@openai/codex",
+          updateExecutable: "/usr/local/bin/npm",
+          updateArgs: ["install", "-g", "@openai/codex@latest"],
+          updateLockKey: "npm:/usr/local",
+          identityKey: "codex-npm-installation",
+          ownershipVerified: true,
+          currentVersion: "1.0.0",
+          latestVersion: "1.0.0",
+        });
+        const updater = yield* makeTestRunner({
+          ...registry,
+          resolveProviderMaintenanceCapabilitiesForInstance: () =>
+            Effect.succeed(knownLatestCapabilities),
+        });
+
+        const result = yield* updater.updateProvider(CODEX_DRIVER);
+
+        assert.strictEqual(result.providers[0]?.updateState?.status, "unchanged");
+        assert.strictEqual(
+          result.providers[0]?.updateState?.message,
+          "Update command completed, but the provider version did not advance.",
+        );
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            NonWindowsPlatform,
+            latestVersionHttpClient("1.0.0"),
+            mockSpawnerLayer(() => ({ stdout: "already current" })),
+          ),
+        ),
+      ),
   );
 
   it.effect("reports a native update as successful when its version advances", () =>

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -7,6 +7,7 @@ import {
   type ServerProviderUpdatedPayload,
   type ServerProviderUpdateState,
 } from "@t3tools/contracts";
+import * as NodePath from "node:path";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
@@ -73,6 +74,7 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
     readonly spawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
     readonly command: string;
     readonly args: ReadonlyArray<string>;
+    readonly environment?: NodeJS.ProcessEnv;
   }) {
     const collectCommandResult = Effect.fn("ProviderMaintenanceRunner.collectCommandResult")(
       function* () {
@@ -81,9 +83,18 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
         // which a bare ChildProcess.spawn cannot launch (spawn npm ENOENT);
         // resolveSpawnCommand finds the real `.cmd` and routes it through the
         // shell. On Linux/macOS (incl. the WSL backend) this is a no-op.
-        const resolved = yield* resolveSpawnCommand(input.command, input.args);
+        const resolved = yield* resolveSpawnCommand(
+          input.command,
+          input.args,
+          input.environment ? { env: input.environment, extendEnv: true } : {},
+        );
         const child = yield* input.spawner
-          .spawn(ChildProcess.make(resolved.command, resolved.args, { shell: resolved.shell }))
+          .spawn(
+            ChildProcess.make(resolved.command, resolved.args, {
+              ...(input.environment ? { env: input.environment, extendEnv: true } : {}),
+              shell: resolved.shell,
+            }),
+          )
           .pipe(
             Effect.mapError(
               (cause) =>
@@ -201,11 +212,16 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
   const providerRegistry = yield* ProviderRegistry;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
-  const runMaintenanceCommand = (command: string, args: ReadonlyArray<string>) =>
+  const runMaintenanceCommand = (
+    command: string,
+    args: ReadonlyArray<string>,
+    environment?: NodeJS.ProcessEnv,
+  ) =>
     runProviderMaintenanceCommandWithSpawner({
       spawner,
       command,
       args,
+      ...(environment ? { environment } : {}),
     });
   const commandCoordinator = yield* makeProviderMaintenanceCommandCoordinator({
     makeAlreadyRunningError: () =>
@@ -293,7 +309,7 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
         ? defaultInstanceIdForDriver(provider)
         : (target.instanceId ?? defaultInstanceIdForDriver(provider));
     const targetKey = `instance:${instanceId}`;
-    const capabilities = yield* providerRegistry.getProviderMaintenanceCapabilitiesForInstance(
+    const capabilities = yield* providerRegistry.resolveProviderMaintenanceCapabilitiesForInstance(
       instanceId,
       provider,
     );
@@ -339,7 +355,50 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
               }),
             );
 
-            const result = yield* runMaintenanceCommand(update.executable, update.args);
+            const freshCapabilities =
+              yield* providerRegistry.resolveProviderMaintenanceCapabilitiesForInstance(
+                instanceId,
+                provider,
+              );
+            const freshUpdate = freshCapabilities.update;
+            if (
+              !freshUpdate ||
+              freshUpdate.lockKey !== update.lockKey ||
+              (capabilities.identityKey !== null &&
+                capabilities.identityKey !== undefined &&
+                freshCapabilities.identityKey !== capabilities.identityKey)
+            ) {
+              return yield* finish(
+                makeUpdateState({
+                  status: "failed",
+                  startedAt,
+                  finishedAt: yield* nowIso,
+                  message: "Provider installation changed. Refresh and try again.",
+                }),
+              );
+            }
+
+            if (
+              freshCapabilities.identityKey !== null &&
+              freshCapabilities.identityKey !== undefined &&
+              !NodePath.posix.isAbsolute(freshUpdate.executable) &&
+              !NodePath.win32.isAbsolute(freshUpdate.executable)
+            ) {
+              return yield* finish(
+                makeUpdateState({
+                  status: "failed",
+                  startedAt,
+                  finishedAt: yield* nowIso,
+                  message: "Provider update executable could not be verified.",
+                }),
+              );
+            }
+
+            const result = yield* runMaintenanceCommand(
+              freshUpdate.executable,
+              freshUpdate.args,
+              freshUpdate.environment,
+            );
             const finishedAt = yield* nowIso;
             if (result.timedOut || result.exitCode !== 0) {
               return yield* finish(
@@ -353,9 +412,30 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
               );
             }
 
+            const verificationCapabilities =
+              yield* providerRegistry.resolveProviderMaintenanceCapabilitiesForInstance(
+                instanceId,
+                provider,
+              );
+            if (
+              freshCapabilities.identityKey !== null &&
+              freshCapabilities.identityKey !== undefined &&
+              verificationCapabilities.identityKey !== freshCapabilities.identityKey
+            ) {
+              return yield* finish(
+                makeUpdateState({
+                  status: "unchanged",
+                  startedAt,
+                  finishedAt,
+                  message:
+                    "Update command completed, but the provider installation changed during verification.",
+                  output: commandOutput(result),
+                }),
+              );
+            }
             const { verifiedProviders } = yield* verifyRefreshedProvider(
               provider,
-              capabilities,
+              verificationCapabilities,
               instanceId,
             );
             const couldNotVerify = verifiedProviders.length === 0;

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -1,3 +1,4 @@
+// @effect-diagnostics nodeBuiltinImport:off - Provider paths may use either POSIX or Windows syntax.
 import {
   defaultInstanceIdForDriver,
   ProviderDriverKind,

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -444,19 +444,21 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
               instanceId,
             );
             const couldNotVerify = verifiedProviders.length === 0;
-            const requiresVersionAdvance = freshCapabilities.latestVersion === null;
+            const hasVersionBeforeUpdate =
+              versionBeforeUpdate !== null && versionBeforeUpdate !== undefined;
+            const requiresVersionAdvance =
+              freshCapabilities.latestVersion === null || hasVersionBeforeUpdate;
             const versionAdvanced =
-              versionBeforeUpdate !== null &&
-              versionBeforeUpdate !== undefined &&
+              hasVersionBeforeUpdate &&
               verifiedProviders.some(
                 (verifiedProvider) =>
                   verifiedProvider.version !== null &&
                   compareMaintenanceVersions(versionBeforeUpdate, verifiedProvider.version) === -1,
               );
-            const nativeVersionUnchanged = requiresVersionAdvance && !versionAdvanced;
+            const versionUnchanged = requiresVersionAdvance && !versionAdvanced;
             const stillOutdated =
               couldNotVerify ||
-              nativeVersionUnchanged ||
+              versionUnchanged ||
               verifiedProviders.some((verifiedProvider) => isOutdatedProvider(verifiedProvider));
             return yield* finish(
               makeUpdateState({
@@ -465,7 +467,7 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
                 finishedAt,
                 message: couldNotVerify
                   ? "Update command completed, but T3 Code could not verify the provider version."
-                  : nativeVersionUnchanged
+                  : versionUnchanged
                     ? "Update command completed, but the provider version did not advance."
                     : stillOutdated
                       ? "Update command completed, but T3 Code still detects an outdated provider version."

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -27,6 +27,7 @@ import { ProviderRegistry } from "./Services/ProviderRegistry.ts";
 import { makeProviderMaintenanceCommandCoordinator } from "./providerMaintenanceCommandCoordinator.ts";
 import { enrichProviderSnapshotWithVersionAdvisory } from "./providerMaintenance.ts";
 import type { ProviderMaintenanceCapabilities } from "./providerMaintenance.ts";
+import { compareMaintenanceVersions } from "./maintenance/version.ts";
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
 const isServerProviderUpdateError = Schema.is(ServerProviderUpdateError);
 
@@ -361,6 +362,9 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
                 instanceId,
                 provider,
               );
+            const versionBeforeUpdate = (yield* providerRegistry.getProviders).find(
+              (candidate) => candidate.driver === provider && candidate.instanceId === instanceId,
+            )?.version;
             const freshUpdate = freshCapabilities.update;
             if (
               !freshUpdate ||
@@ -440,8 +444,19 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
               instanceId,
             );
             const couldNotVerify = verifiedProviders.length === 0;
+            const requiresVersionAdvance = freshCapabilities.latestVersion === null;
+            const versionAdvanced =
+              versionBeforeUpdate !== null &&
+              versionBeforeUpdate !== undefined &&
+              verifiedProviders.some(
+                (verifiedProvider) =>
+                  verifiedProvider.version !== null &&
+                  compareMaintenanceVersions(versionBeforeUpdate, verifiedProvider.version) === -1,
+              );
+            const nativeVersionUnchanged = requiresVersionAdvance && !versionAdvanced;
             const stillOutdated =
               couldNotVerify ||
+              nativeVersionUnchanged ||
               verifiedProviders.some((verifiedProvider) => isOutdatedProvider(verifiedProvider));
             return yield* finish(
               makeUpdateState({
@@ -450,9 +465,11 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
                 finishedAt,
                 message: couldNotVerify
                   ? "Update command completed, but T3 Code could not verify the provider version."
-                  : stillOutdated
-                    ? "Update command completed, but T3 Code still detects an outdated provider version."
-                    : "Provider updated.",
+                  : nativeVersionUnchanged
+                    ? "Update command completed, but the provider version did not advance."
+                    : stillOutdated
+                      ? "Update command completed, but T3 Code still detects an outdated provider version."
+                      : "Provider updated.",
                 output: commandOutput(result),
               }),
             );

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -448,13 +448,12 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
               versionBeforeUpdate !== null && versionBeforeUpdate !== undefined;
             const requiresVersionAdvance =
               freshCapabilities.latestVersion === null || hasVersionBeforeUpdate;
-            const versionAdvanced =
-              hasVersionBeforeUpdate &&
-              verifiedProviders.some(
-                (verifiedProvider) =>
-                  verifiedProvider.version !== null &&
-                  compareMaintenanceVersions(versionBeforeUpdate, verifiedProvider.version) === -1,
-              );
+            const versionAdvanced = verifiedProviders.some(
+              (verifiedProvider) =>
+                verifiedProvider.version !== null &&
+                (!hasVersionBeforeUpdate ||
+                  compareMaintenanceVersions(versionBeforeUpdate, verifiedProvider.version) === -1),
+            );
             const versionUnchanged = requiresVersionAdvance && !versionAdvanced;
             const stillOutdated =
               couldNotVerify ||

--- a/apps/server/src/provider/testUtils/providerRegistryMock.ts
+++ b/apps/server/src/provider/testUtils/providerRegistryMock.ts
@@ -11,7 +11,7 @@ export const makeProviderRegistryMock = (
   getProviders: Effect.succeed(providers),
   refresh: () => Effect.succeed(providers),
   refreshInstance: () => Effect.succeed(providers),
-  getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
+  resolveProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
     Effect.succeed(makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null })),
   setProviderMaintenanceActionState: () => Effect.succeed(providers),
   streamChanges: Stream.empty,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -654,7 +654,7 @@ const buildAppUnderTest = (options?: {
             getProviders: Effect.succeed([]),
             refresh: () => Effect.succeed([]),
             refreshInstance: () => Effect.succeed([]),
-            getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
+            resolveProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
               Effect.succeed(
                 makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null }),
               ),

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -19,6 +19,13 @@ export type ProviderUpdateCandidate = ServerProvider & {
   };
 };
 
+export type ProviderSettingsUpdateCandidate = ServerProvider & {
+  readonly versionAdvisory: NonNullable<ServerProvider["versionAdvisory"]> & {
+    readonly canUpdate: true;
+    readonly updateCommand: string;
+  };
+};
+
 export type ProviderUpdateToastType = "warning" | "loading" | "error" | "success";
 export type ProviderUpdateToastPhase = "initial" | "running" | "failed" | "unchanged" | "succeeded";
 
@@ -147,6 +154,16 @@ export function collectProviderUpdateCandidates(
   providers: ReadonlyArray<ServerProvider>,
 ): ProviderUpdateCandidate[] {
   return dedupeProvidersByDriver(providers.filter(isProviderUpdateCandidate));
+}
+
+export function isProviderSettingsUpdateCandidate(
+  provider: ServerProvider,
+): provider is ProviderSettingsUpdateCandidate {
+  return (
+    provider.enabled &&
+    provider.versionAdvisory?.canUpdate === true &&
+    provider.versionAdvisory.updateCommand !== null
+  );
 }
 
 export function hasOneClickUpdateProviderCandidate(

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -119,4 +119,52 @@ describe("deriveProviderModelsForDisplay", () => {
       expect(markup).toContain("is not a symlink");
     }
   });
+
+  it("shows unknown update advisories as a muted refresh action in the list row", () => {
+    const instanceId = ProviderInstanceId.make("codex");
+    const driver = ProviderDriverKind.make("codex");
+    const liveProvider: ServerProvider = {
+      instanceId,
+      driver,
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready",
+      auth: { status: "authenticated" },
+      checkedAt: "2026-08-29T12:00:00.000Z",
+      models: [],
+      slashCommands: [],
+      skills: [],
+      versionAdvisory: {
+        status: "unknown",
+        currentVersion: "1.0.0",
+        latestVersion: null,
+        updateCommand: "codex update",
+        canUpdate: true,
+        checkedAt: "2026-08-29T12:00:00.000Z",
+        message: null,
+      },
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(ProviderInstanceCard, {
+        instanceId,
+        instance: { driver },
+        driverOption: undefined,
+        liveProvider,
+        mode: "list",
+        onUpdate: () => undefined,
+        hiddenModels: [],
+        favoriteModels: [],
+        modelOrder: [],
+        onHiddenModelsChange: () => undefined,
+        onFavoriteModelsChange: () => undefined,
+        onModelOrderChange: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('aria-label="Check for updates"');
+    expect(markup).toContain('class="lucide lucide-refresh-cw size-3.5 text-muted-foreground"');
+    expect(markup).not.toContain("lucide-arrow-up-circle");
+  });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -6,6 +6,7 @@ import {
   DownloadIcon,
   LoaderIcon,
   PlusIcon,
+  RefreshCwIcon,
   Trash2Icon,
   XIcon,
 } from "lucide-react";
@@ -715,11 +716,17 @@ export function ProviderInstanceCard({
                           "size-5 rounded-sm p-0",
                           versionAdvisory.emphasis === "strong"
                             ? "text-warning hover:text-warning"
-                            : "text-update-foreground hover:text-update-foreground",
+                            : versionAdvisory.emphasis === "muted"
+                              ? "text-muted-foreground hover:text-foreground"
+                              : "text-update-foreground hover:text-update-foreground",
                         )}
                         aria-label={`${versionAdvisory.title} — view details`}
                       >
-                        <ArrowUpCircleIcon className="size-3.5" />
+                        {versionAdvisory.icon === "refresh" ? (
+                          <RefreshCwIcon className="size-3.5" />
+                        ) : (
+                          <ArrowUpCircleIcon className="size-3.5" />
+                        )}
                       </Button>
                     }
                   />

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -717,7 +717,7 @@ export function ProviderInstanceCard({
                             ? "text-warning hover:text-warning"
                             : "text-update-foreground hover:text-update-foreground",
                         )}
-                        aria-label="Update available — view details"
+                        aria-label={`${versionAdvisory.title} — view details`}
                       >
                         <ArrowUpCircleIcon className="size-3.5" />
                       </Button>
@@ -731,7 +731,7 @@ export function ProviderInstanceCard({
                     <div className="grid min-w-0 gap-3">
                       <div className="grid gap-0.5">
                         <p className="text-[13px] font-semibold leading-tight text-foreground">
-                          Update available
+                          {versionAdvisory.title}
                         </p>
                         <p
                           className={cn(

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -660,8 +660,16 @@ export function ProviderInstanceCard({
               ) : null}
               {versionCodeNode}
               {versionAdvisory ? (
-                <span role="img" aria-label="Update available" className="inline-flex shrink-0">
-                  <ArrowUpCircleIcon className="size-3.5 text-update-foreground" />
+                <span
+                  role="img"
+                  aria-label={versionAdvisory.title}
+                  className="inline-flex shrink-0"
+                >
+                  {versionAdvisory.icon === "refresh" ? (
+                    <RefreshCwIcon className="size-3.5 text-muted-foreground" />
+                  ) : (
+                    <ArrowUpCircleIcon className="size-3.5 text-update-foreground" />
+                  )}
                 </span>
               ) : null}
             </span>

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -713,7 +713,7 @@ export function ProviderInstanceCard({
                         size="icon-xs"
                         variant="ghost"
                         className={cn(
-                          "size-5 rounded-sm p-0",
+                          "size-5 rounded-sm p-0 [--control-icon-color:currentColor]",
                           versionAdvisory.emphasis === "strong"
                             ? "text-warning hover:text-warning"
                             : versionAdvisory.emphasis === "muted"

--- a/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
@@ -116,6 +116,21 @@ function provider(): ServerProvider {
   };
 }
 
+function nativeProvider(): ServerProvider {
+  return {
+    ...provider(),
+    versionAdvisory: {
+      status: "unknown",
+      currentVersion: "1.0.0",
+      latestVersion: null,
+      updateCommand: "codex update",
+      canUpdate: true,
+      checkedAt: "2026-07-24T12:00:00.000Z",
+      message: null,
+    },
+  };
+}
+
 function renderPanel(options?: {
   readonly readOnly?: boolean;
 }): ReactElement<Record<string, unknown>> {
@@ -172,6 +187,25 @@ describe("EnvironmentProviderSettings routing", () => {
       (element) =>
         element.props.instanceId === codexId && typeof element.props.onRunUpdate === "function",
     );
+    expect(providerCard).not.toBeNull();
+    (providerCard?.props.onRunUpdate as (() => void) | undefined)?.();
+    await flushPromises();
+
+    expect(commands.updateProvider).toHaveBeenCalledWith({
+      environmentId,
+      input: { provider: ProviderDriverKind.make("codex"), instanceId: codexId },
+    });
+  });
+
+  it("offers a verified native updater in settings when latest is unknown", async () => {
+    atoms.providers = [nativeProvider()];
+    const panel = renderPanel();
+    const providerCard = visitElements(
+      panel,
+      (element) =>
+        element.props.instanceId === codexId && typeof element.props.onRunUpdate === "function",
+    );
+
     expect(providerCard).not.toBeNull();
     (providerCard?.props.onRunUpdate as (() => void) | undefined)?.();
     await flushPromises();

--- a/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
@@ -216,6 +216,67 @@ describe("EnvironmentProviderSettings routing", () => {
     });
   });
 
+  it("scopes the updating state to the selected provider instance", async () => {
+    settingsState.value = {
+      ...DEFAULT_UNIFIED_SETTINGS,
+      providerInstances: {
+        [customId]: {
+          driver: ProviderDriverKind.make("codex"),
+          enabled: true,
+        },
+      },
+    };
+    atoms.providers = [
+      provider(),
+      {
+        ...provider(),
+        instanceId: customId,
+        versionAdvisory: {
+          ...provider().versionAdvisory!,
+          updateCommand: "npm install -g --prefix /work @openai/codex@latest",
+        },
+      },
+    ];
+    let finishUpdate: ((result: { readonly _tag: "Success" }) => void) | undefined;
+    commands.updateProvider.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishUpdate = resolve;
+        }),
+    );
+
+    let panel = renderPanel();
+    const defaultEditor = visitElements(
+      panel,
+      (element) => element.props.instanceId === codexId && element.props.mode === "editor",
+    );
+    (defaultEditor?.props.onRunUpdate as (() => void) | undefined)?.();
+    await Promise.resolve();
+
+    panel = renderPanel();
+    const updatingDefaultEditor = visitElements(
+      panel,
+      (element) => element.props.instanceId === codexId && element.props.mode === "editor",
+    );
+    expect(updatingDefaultEditor?.props.isUpdating).toBe(true);
+
+    const customRow = visitElements(
+      panel,
+      (element) => element.props.instanceId === customId && element.props.mode === "list",
+    );
+    (customRow?.props.onSelect as (() => void) | undefined)?.();
+    panel = renderPanel();
+    const customEditor = visitElements(
+      panel,
+      (element) => element.props.instanceId === customId && element.props.mode === "editor",
+    );
+    expect(customEditor?.props.isUpdating).toBe(false);
+    expect(customEditor?.props.onRunUpdate).toBeTypeOf("function");
+
+    finishUpdate?.({ _tag: "Success" });
+    await flushPromises();
+  });
+
   it("keeps provider selection available while write controls are read only", () => {
     settingsState.value = {
       ...DEFAULT_UNIFIED_SETTINGS,

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -56,11 +56,9 @@ import {
   connectionPhasePingClassName,
 } from "../ConnectionStatusDot";
 import {
-  canOneClickUpdateProviderCandidate,
-  collectProviderUpdateCandidates,
-  hasOneClickUpdateProviderCandidate,
+  isProviderSettingsUpdateCandidate,
   isProviderUpdateActive,
-  type ProviderUpdateCandidate,
+  type ProviderSettingsUpdateCandidate,
 } from "../ProviderUpdateLaunchNotification.logic";
 import { Button } from "../ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
@@ -435,13 +433,14 @@ export function EnvironmentProviderSettings({
   const refreshingRef = useRef(false);
   const updatingDriversRef = useRef<Set<ProviderDriverKind>>(new Set());
 
-  const providerUpdateCandidates = useMemo(
-    () => collectProviderUpdateCandidates(serverProviders),
-    [serverProviders],
-  );
   const providerUpdateCandidateByInstanceId = useMemo(
-    () => new Map(providerUpdateCandidates.map((candidate) => [candidate.instanceId, candidate])),
-    [providerUpdateCandidates],
+    () =>
+      new Map(
+        serverProviders
+          .filter(isProviderSettingsUpdateCandidate)
+          .map((candidate) => [candidate.instanceId, candidate]),
+      ),
+    [serverProviders],
   );
   const visibleProviderSettings = PROVIDER_SETTINGS.filter(
     (providerSettings) =>
@@ -491,7 +490,7 @@ export function EnvironmentProviderSettings({
   }, [environmentId, refreshServerProviders]);
 
   const runProviderUpdate = useCallback(
-    async (candidate: ProviderUpdateCandidate) => {
+    async (candidate: ProviderSettingsUpdateCandidate) => {
       // Ref-based re-entry guard, mirroring refreshProviders: a state updater
       // may run after this function returns, so it cannot gate the dispatch.
       if (updatingDriversRef.current.has(candidate.driver)) {
@@ -731,12 +730,10 @@ export function EnvironmentProviderSettings({
           (provider) =>
             provider.driver === updateCandidate.driver && isProviderUpdateActive(provider),
         ));
-    const showInlineUpdateButton =
-      updateCandidate !== undefined &&
-      hasOneClickUpdateProviderCandidate(updateCandidate, serverProviders);
+    const showInlineUpdateButton = updateCandidate !== undefined;
     const canRunInlineUpdate =
       updateCandidate !== undefined &&
-      canOneClickUpdateProviderCandidate(updateCandidate, serverProviders) &&
+      !isDriverUpdateRunning &&
       !updatingProviderDrivers.has(updateCandidate.driver);
     const modelPreferences = settings.providerModelPreferences?.[row.instanceId] ?? {
       hiddenModels: [],

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -720,16 +720,11 @@ export function EnvironmentProviderSettings({
     const liveProvider = serverProviders.find(
       (candidate) => candidate.instanceId === row.instanceId,
     );
-    const updateCandidate = liveProvider
-      ? providerUpdateCandidateByInstanceId.get(liveProvider.instanceId)
-      : undefined;
+    const updateCandidate = providerUpdateCandidateByInstanceId.get(row.instanceId);
     const isInstanceUpdateRunning =
       updateCandidate !== undefined &&
       (updatingProviderInstanceIds.has(updateCandidate.instanceId) ||
-        serverProviders.some(
-          (provider) =>
-            provider.instanceId === updateCandidate.instanceId && isProviderUpdateActive(provider),
-        ));
+        isProviderUpdateActive(updateCandidate));
     const showInlineUpdateButton = updateCandidate !== undefined;
     const canRunInlineUpdate = updateCandidate !== undefined && !isInstanceUpdateRunning;
     const modelPreferences = settings.providerModelPreferences?.[row.instanceId] ?? {

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -427,11 +427,11 @@ export function EnvironmentProviderSettings({
   const [isAddInstanceDialogOpen, setIsAddInstanceDialogOpen] = useState(false);
   const [selectedInstanceId, setSelectedInstanceId] = useState<ProviderInstanceId | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [updatingProviderDrivers, setUpdatingProviderDrivers] = useState<
-    ReadonlySet<ProviderDriverKind>
+  const [updatingProviderInstanceIds, setUpdatingProviderInstanceIds] = useState<
+    ReadonlySet<ProviderInstanceId>
   >(() => new Set());
   const refreshingRef = useRef(false);
-  const updatingDriversRef = useRef<Set<ProviderDriverKind>>(new Set());
+  const updatingInstanceIdsRef = useRef<Set<ProviderInstanceId>>(new Set());
 
   const providerUpdateCandidateByInstanceId = useMemo(
     () =>
@@ -493,11 +493,11 @@ export function EnvironmentProviderSettings({
     async (candidate: ProviderSettingsUpdateCandidate) => {
       // Ref-based re-entry guard, mirroring refreshProviders: a state updater
       // may run after this function returns, so it cannot gate the dispatch.
-      if (updatingDriversRef.current.has(candidate.driver)) {
+      if (updatingInstanceIdsRef.current.has(candidate.instanceId)) {
         return;
       }
-      updatingDriversRef.current.add(candidate.driver);
-      setUpdatingProviderDrivers((previous) => new Set(previous).add(candidate.driver));
+      updatingInstanceIdsRef.current.add(candidate.instanceId);
+      setUpdatingProviderInstanceIds((previous) => new Set(previous).add(candidate.instanceId));
 
       const result = await updateProvider({
         environmentId,
@@ -519,13 +519,13 @@ export function EnvironmentProviderSettings({
           }),
         );
       }
-      updatingDriversRef.current.delete(candidate.driver);
-      setUpdatingProviderDrivers((previous) => {
-        if (!previous.has(candidate.driver)) {
+      updatingInstanceIdsRef.current.delete(candidate.instanceId);
+      setUpdatingProviderInstanceIds((previous) => {
+        if (!previous.has(candidate.instanceId)) {
           return previous;
         }
         const next = new Set(previous);
-        next.delete(candidate.driver);
+        next.delete(candidate.instanceId);
         return next;
       });
     },
@@ -723,18 +723,15 @@ export function EnvironmentProviderSettings({
     const updateCandidate = liveProvider
       ? providerUpdateCandidateByInstanceId.get(liveProvider.instanceId)
       : undefined;
-    const isDriverUpdateRunning =
+    const isInstanceUpdateRunning =
       updateCandidate !== undefined &&
-      (updatingProviderDrivers.has(updateCandidate.driver) ||
+      (updatingProviderInstanceIds.has(updateCandidate.instanceId) ||
         serverProviders.some(
           (provider) =>
-            provider.driver === updateCandidate.driver && isProviderUpdateActive(provider),
+            provider.instanceId === updateCandidate.instanceId && isProviderUpdateActive(provider),
         ));
     const showInlineUpdateButton = updateCandidate !== undefined;
-    const canRunInlineUpdate =
-      updateCandidate !== undefined &&
-      !isDriverUpdateRunning &&
-      !updatingProviderDrivers.has(updateCandidate.driver);
+    const canRunInlineUpdate = updateCandidate !== undefined && !isInstanceUpdateRunning;
     const modelPreferences = settings.providerModelPreferences?.[row.instanceId] ?? {
       hiddenModels: [],
       modelOrder: [],
@@ -806,7 +803,9 @@ export function EnvironmentProviderSettings({
               }
             : undefined
         }
-        isUpdating={mode === "editor" && showInlineUpdateButton ? isDriverUpdateRunning : undefined}
+        isUpdating={
+          mode === "editor" && showInlineUpdateButton ? isInstanceUpdateRunning : undefined
+        }
       />
     );
   };

--- a/apps/web/src/components/settings/providerStatus.test.ts
+++ b/apps/web/src/components/settings/providerStatus.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getProviderVersionAdvisoryPresentation } from "./providerStatus";
+
+describe("getProviderVersionAdvisoryPresentation", () => {
+  it("presents a verified native update action without claiming a newer version exists", () => {
+    expect(
+      getProviderVersionAdvisoryPresentation({
+        status: "unknown",
+        currentVersion: "1.0.0",
+        latestVersion: null,
+        updateCommand: "codex update",
+        canUpdate: true,
+        checkedAt: "2026-08-27T21:00:00.000Z",
+        message: null,
+      }),
+    ).toEqual({
+      title: "Check for updates",
+      detail: "Run the verified installer update, then T3 Code will check the version again.",
+      updateCommand: "codex update",
+      emphasis: "normal",
+    });
+  });
+});

--- a/apps/web/src/components/settings/providerStatus.test.ts
+++ b/apps/web/src/components/settings/providerStatus.test.ts
@@ -18,7 +18,26 @@ describe("getProviderVersionAdvisoryPresentation", () => {
       title: "Check for updates",
       detail: "Run the verified installer update, then T3 Code will check the version again.",
       updateCommand: "codex update",
+      emphasis: "muted",
+      icon: "refresh",
+    });
+  });
+
+  it("keeps known updates on the semantic update treatment", () => {
+    expect(
+      getProviderVersionAdvisoryPresentation({
+        status: "behind_latest",
+        currentVersion: "1.0.0",
+        latestVersion: "1.1.0",
+        updateCommand: "npm install -g @openai/codex@latest",
+        canUpdate: true,
+        checkedAt: "2026-08-27T21:00:00.000Z",
+        message: "Update available.",
+      }),
+    ).toMatchObject({
+      title: "Update available",
       emphasis: "normal",
+      icon: "update",
     });
   });
 });

--- a/apps/web/src/components/settings/providerStatus.ts
+++ b/apps/web/src/components/settings/providerStatus.ts
@@ -93,12 +93,24 @@ export function getProviderVersionLabel(version: string | null | undefined) {
 export function getProviderVersionAdvisoryPresentation(
   advisory: ServerProviderVersionAdvisory | undefined,
 ): {
+  readonly title: string;
   readonly detail: string;
   readonly updateCommand: string | null;
   readonly emphasis: "normal" | "strong";
 } | null {
-  if (!advisory || advisory.status === "current" || advisory.status === "unknown") {
+  if (!advisory || advisory.status === "current") {
     return null;
+  }
+
+  if (advisory.status === "unknown") {
+    return advisory.canUpdate && advisory.updateCommand
+      ? {
+          title: "Check for updates",
+          detail: "Run the verified installer update, then T3 Code will check the version again.",
+          updateCommand: advisory.updateCommand,
+          emphasis: "normal" as const,
+        }
+      : null;
   }
 
   const label = "Update available";
@@ -106,6 +118,7 @@ export function getProviderVersionAdvisoryPresentation(
   const versionLabel = getProviderVersionLabel(version);
 
   return {
+    title: label,
     detail:
       advisory.message ??
       (versionLabel

--- a/apps/web/src/components/settings/providerStatus.ts
+++ b/apps/web/src/components/settings/providerStatus.ts
@@ -96,7 +96,8 @@ export function getProviderVersionAdvisoryPresentation(
   readonly title: string;
   readonly detail: string;
   readonly updateCommand: string | null;
-  readonly emphasis: "normal" | "strong";
+  readonly emphasis: "muted" | "normal" | "strong";
+  readonly icon: "refresh" | "update";
 } | null {
   if (!advisory || advisory.status === "current") {
     return null;
@@ -108,7 +109,8 @@ export function getProviderVersionAdvisoryPresentation(
           title: "Check for updates",
           detail: "Run the verified installer update, then T3 Code will check the version again.",
           updateCommand: advisory.updateCommand,
-          emphasis: "normal" as const,
+          emphasis: "muted" as const,
+          icon: "refresh" as const,
         }
       : null;
   }
@@ -126,5 +128,6 @@ export function getProviderVersionAdvisoryPresentation(
         : `${label}: install the latest provider version.`),
     updateCommand: advisory.updateCommand,
     emphasis: "normal" as const,
+    icon: "update" as const,
   };
 }


### PR DESCRIPTION
## Problem

T3 could resolve a provider executable from one concrete installation while applying an update through a different installer or package-manager prefix. For example, the active executable could be owned by Scoop or by one npm prefix while the updater selected from PATH targeted another installation.

This change replaces installer guessing with installation-aware resolution for Claude, Codex, OpenCode, and Grok. T3 resolves the active executable, verifies its owning installation from installer metadata, derives the exact update command and environment, and re-resolves installation identity immediately before and after execution.

For catalog-managed providers, one-click updates are exposed only when ownership can be verified. Unknown or ambiguous installations remain manual-only. The implementation covers native installers, npm, pnpm, Bun, Vite+ compatibility, Homebrew, Scoop, and portable WinGet.

## What changed

- adds a declarative installation catalog with shared detector, version resolver, update action, environment, cache-key, and instructions primitives
- covers native, npm, pnpm, Bun, Vite+ compatibility, Homebrew, Scoop, and portable WinGet installations
- proves manager ownership from the resolved executable and manager metadata before enabling one-click updates
- bounds all installer metadata reads to 64 KiB, rejects oversized or invalid UTF-8 evidence, and caches repeated reads within one resolution
- distinguishes Homebrew formulae from casks and emits cask-aware upgrade commands
- keeps unknown or ambiguous ownership manual-only; bare commands are resolved through PATH and must be proven by the installation catalog
- pins npm updates to the verified owning global prefix, even when the resolved npm executable has a different default prefix
- carries installation-specific update environments and executes the exact resolved native executable
- re-resolves installation identity immediately before and after updating to prevent stale or mismatched updates
- updates the provider-maintenance server contract for fresh per-instance resolution and adjusts Settings for per-instance progress and verified “Check for updates” actions
- avoids mixing npm latest-version checks with native updates; native latest remains unknown until an official channel resolver is available

## Related issues and superseded fixes

Closes #5629
Closes #6245
Closes #7730

This supersedes the narrower fixes proposed in #5630, #6247, #7731, and #8832.

These reports expose the same underlying correctness problem in different forms:
T3 could identify one provider installation while deriving the updater, package
name, or latest-version channel from assumptions belonging to another
installation.

This PR replaces those independent heuristics with one ownership-verified
installation model. The active executable is resolved first; its owning
installer and update target must then be proven from installer metadata.
Unknown or ambiguous installations remain manual-only, and ownership is
revalidated immediately before and after an update.

Related but intentionally out of scope: #4066, #6115, #7406, #8280, #4211,
#8247, and #8363.

## Validation

- Windows focused tests: 50 passed, 2 skipped because Windows denied POSIX symlink creation with `EPERM`
- Linux/WSL focused tests: 52 passed
- macOS focused tests: 54 passed
- latest focused validation at `208aa5600`: 89/89 runnable maintenance and managed-provider tests passed, with 2 POSIX symlink cases skipped on Windows because symlink creation was denied; 13/13 Settings/advisory tests passed
- server and web typecheck
- targeted lint, formatting, and diff checks
- real Claude npm update on Windows and Linux
- real Codex npm one-click updates from 0.150.0 to 0.150.1 on Windows and WSL/Linux using isolated executable prefixes (validated at commit `413ffc51`); the active Scoop installation remained untouched
- real macOS prefix-pinned npm updates: Claude Code 2.1.240 → 2.1.241 and OpenCode 1.18.20 → 1.18.21 in isolated prefixes, with stable installation identity and lock target
- real macOS Homebrew ownership resolution and cask upgrade dry-run for the active Codex cask
- real Claude native Linux update from 2.1.227 to 2.1.229
- real Scoop ownership/update validation for Claude and OpenCode
- isolated Windows Scoop and WinGet ownership/no-false-update validation for Codex; no version transition was available because Scoop was already current and WinGet’s source latest was 0.146.1
- WinGet package/source metadata validation for all three provider IDs

Developed and validated iteratively in T3 Code across macOS, Linux/WSL, and Windows, with real installer/update trials and independent automated review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added installation detection and update support for native, npm, pnpm, Bun, Homebrew, Scoop, and WinGet installations.
  - Added native updates and provider-specific environments for Claude, Codex, OpenCode, and Grok.
  - Added “Check for updates” guidance when update status is uncertain.
  - Added refresh indicators and per-provider-instance update progress in settings.

- **Bug Fixes**
  - Updates now verify installation ownership, paths, identity, and versions before and after execution.
  - Prevented updates for unsafe, changed, unverified, or unsupported installations.
  - Improved Windows path, portable installation, and version comparison handling.
  - Update notifications now provide clearer provider-specific guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how provider update commands are chosen and executed; incorrect ownership logic could update the wrong install or block legitimate updates, and the lazy resolution path affects registry and settings UX.
> 
> **Overview**
> Replaces PATH-based installer guessing with **installation-aware maintenance**: the server resolves the active provider binary, proves which package manager or installer owns it, and only then exposes one-click update commands (npm prefix pinning, Homebrew/Scoop/WinGet, native installers, etc.). Unverified or ambiguous installs stay **manual-only**.
> 
> **Contract and wiring:** `ServerProviderShape` now carries `resolveMaintenance` as a lazy `Effect` instead of a static `maintenanceCapabilities`. Drivers (Claude, Codex, OpenCode, Grok) use `makeProviderMaintenanceResolver` plus `makeProviderMaintenanceCapabilitySources` (cached **advisory** probes vs **fresh** resolution before updates). Provider env merges with `HostProcessEnvironment`; `ProviderRegistry` exposes `resolveProviderMaintenanceCapabilitiesForInstance`.
> 
> **New `maintenance/` stack:** catalog detectors (`catalogs.ts`), shared types (`definition.ts`), ordered resolution with fail-closed manual fallback (`resolver.ts`), and strict semver helpers (`version.ts`), with broad unit coverage. Grok moves from manual-only to full package/native maintenance metadata.
> 
> **Safety:** bounded metadata reads, probe output limits, resolution timeouts that do not fall back to unsafe npm updates, and stricter version advisory rules (e.g. native installs without a verified latest channel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208aa5600f941708e57500974e6918d143d06b9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace package-managed maintenance resolvers with installation-aware `makeProviderMaintenanceResolver`
> - Replaces `makePackageManagedProviderMaintenanceResolver` with `makeProviderMaintenanceResolver` across Claude, Codex, Cursor, Grok, and OpenCode drivers; definitions now use `packageName`, `executableName`, `instructionsUrl`, and `wingetPackageId` instead of `npmPackageName` and nested `nativeUpdate.executable`/`lockKey`.
> - Introduces a new maintenance catalog/resolver subsystem in [apps/server/src/provider/maintenance/](https://github.com/pingdotgg/t3code/pull/6436/files#diff-29e07b82e9a6d131c91fb8c2a24371b9751dcc98d9fcf61daff5c511e162a9a5) that detects installations via bounded probes, verifies ownership, resolves real executable paths, and falls back to a manual-only installation when nothing matches.
> - Changes `ServerProviderShape.maintenanceCapabilities` from a synchronous value to an effectful `resolveMaintenance: Effect<ProviderMaintenanceCapabilities>`, and renames `ProviderRegistry.getProviderMaintenanceCapabilitiesForInstance` to `resolveProviderMaintenanceCapabilitiesForInstance`; all drivers, tests, and mocks are updated.
> - The maintenance runner in [providerMaintenanceRunner.ts](https://github.com/pingdotgg/t3code/pull/6436/files#diff-53af42bf8411ec1355506cb2396e258735619c36076bec3d8d708d8b697275dc) now re-resolves capabilities before and after running an update, verifies `identityKey` and `lockKey` stability, requires absolute executable paths, and classifies success by version advancement via `compareMaintenanceVersions`.
> - UI in [ProviderInstanceCard.tsx](https://github.com/pingdotgg/t3code/pull/6436/files#diff-abfacda8242e42a51ed23d2b21b91d4822ff52c2dfb6650be36af9d8c82302e9) and [providerStatus.ts](https://github.com/pingdotgg/t3code/pull/6436/files#diff-29f82599bd9e3758e651b26db3d787ab623fa61350b9009233b476cd7d4e67fc) now shows a muted "Check for updates" action with a refresh icon when the advisory status is `unknown` but a verified `updateCommand` exists.
> - Risk: `ServerProviderShape` and `ProviderRegistryShape` API changes break any out-of-tree implementations that read `maintenanceCapabilities` synchronously or call `getProviderMaintenanceCapabilitiesForInstance`; the runner now aborts updates if `identityKey` changes mid-update or if the update executable is not an absolute path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 208aa56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->





