### PR TITLE
fix(web): theme context menus on Windows and Linux

### DIFF
--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -19,6 +19,8 @@ class FakeDomEvent {
   }
 }
 
+let activeElement: FakeElement | null = null;
+
 class FakeElement {
   children: FakeElement[] = [];
   parent: FakeElement | null = null;
@@ -27,7 +29,9 @@ class FakeElement {
   className = "";
   disabled = false;
   type = "";
+  tabIndex = 0;
   private textValue = "";
+  private readonly attributes = new Map<string, string>();
   private readonly listeners = new Map<string, FakeListener[]>();
 
   constructor(readonly tagName: string) {}
@@ -47,6 +51,9 @@ class FakeElement {
       this.parent.children.splice(index, 1);
     }
     this.parent = null;
+    if (activeElement === this) {
+      activeElement = null;
+    }
   }
 
   addEventListener(type: string, listener: FakeListener) {
@@ -56,10 +63,27 @@ class FakeElement {
   }
 
   dispatchEvent(event: FakeDomEvent) {
+    if (!("target" in event)) {
+      Object.assign(event, { target: this });
+    }
     for (const listener of this.listeners.get(event.type) ?? []) {
       listener(event);
     }
     return true;
+  }
+
+  focus() {
+    activeElement = this;
+  }
+
+  scrollIntoView() {}
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null;
   }
 
   set textContent(value: string) {
@@ -118,6 +142,10 @@ class FakeDocument {
   body = new FakeBody();
   private readonly listeners = new Map<string, FakeListener[]>();
 
+  get activeElement() {
+    return activeElement;
+  }
+
   createElement(tagName: string) {
     return new FakeElement(tagName);
   }
@@ -139,6 +167,13 @@ class FakeDocument {
     }
   }
 
+  dispatchEvent(event: FakeDomEvent) {
+    for (const listener of this.listeners.get(event.type) ?? []) {
+      listener(event);
+    }
+    return true;
+  }
+
   querySelectorAll(tagName: string) {
     return this.body.querySelectorAll(tagName);
   }
@@ -150,7 +185,14 @@ function findButton(label: string): FakeElement | undefined {
     .find((button) => button.textContent.includes(label));
 }
 
+function keyboardEvent(key: string, target: FakeElement | undefined) {
+  const event = new KeyboardEvent("keydown", { key });
+  Object.assign(event, { target });
+  return event;
+}
+
 beforeEach(() => {
+  activeElement = null;
   vi.stubGlobal("document", new FakeDocument());
   vi.stubGlobal("window", {
     innerWidth: 1280,
@@ -213,6 +255,55 @@ describe("showContextMenuFallback", () => {
     renameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     await expect(selectionPromise).resolves.toBe("rename");
+  });
+
+  it("supports keyboard navigation and activation", async () => {
+    const selectionPromise = showContextMenuFallback([
+      { id: "rename", label: "Rename" },
+      { id: "delete", label: "Delete", destructive: true },
+    ]);
+    const document = globalThis.document as unknown as FakeDocument;
+    const renameButton = findButton("Rename");
+    const deleteButton = findButton("Delete");
+
+    expect(document.activeElement).toBe(renameButton);
+    const moveDown = keyboardEvent("ArrowDown", renameButton);
+    document.dispatchEvent(moveDown);
+    expect(moveDown.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(deleteButton);
+
+    const activate = keyboardEvent("Enter", deleteButton);
+    document.dispatchEvent(activate);
+    await expect(selectionPromise).resolves.toBe("delete");
+  });
+
+  it("opens and closes nested menus with the keyboard", async () => {
+    const selectionPromise = showContextMenuFallback([
+      {
+        id: "rename:submenu",
+        label: "Rename project",
+        children: [
+          { id: "rename:project-a", label: "/tmp/project-a" },
+          { id: "rename:project-b", label: "/tmp/project-b" },
+        ],
+      },
+    ]);
+    const document = globalThis.document as unknown as FakeDocument;
+    const parentButton = findButton("Rename project");
+
+    document.dispatchEvent(keyboardEvent("ArrowRight", parentButton));
+    const childButton = findButton("/tmp/project-a");
+    expect(document.activeElement).toBe(childButton);
+
+    document.dispatchEvent(keyboardEvent("ArrowLeft", childButton));
+    expect(document.activeElement).toBe(parentButton);
+
+    document.dispatchEvent(keyboardEvent("ArrowRight", parentButton));
+    const secondChildButton = findButton("/tmp/project-b");
+    document.dispatchEvent(keyboardEvent("ArrowDown", childButton));
+    document.dispatchEvent(keyboardEvent("Enter", secondChildButton));
+
+    await expect(selectionPromise).resolves.toBe("rename:project-b");
   });
 
   it("ignores a click from the gesture that opened the menu", async () => {

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -239,6 +239,7 @@ describe("showContextMenuFallback", () => {
     const deleteButton = findButton("Delete");
     expect(renameButton?.className).toContain("text-foreground");
     expect(deleteButton?.className).toContain("text-destructive-foreground");
+    expect(menu?.getAttribute("data-slot")).toBe("menu-popup");
 
     renameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     await expect(selectionPromise).resolves.toBe("rename");
@@ -294,16 +295,52 @@ describe("showContextMenuFallback", () => {
     document.dispatchEvent(keyboardEvent("ArrowRight", parentButton));
     const childButton = findButton("/tmp/project-a");
     expect(document.activeElement).toBe(childButton);
+    expect(parentButton?.getAttribute("aria-expanded")).toBe("true");
 
     document.dispatchEvent(keyboardEvent("ArrowLeft", childButton));
     expect(document.activeElement).toBe(parentButton);
+    expect(parentButton?.getAttribute("aria-expanded")).toBe("false");
 
     document.dispatchEvent(keyboardEvent("ArrowRight", parentButton));
     const secondChildButton = findButton("/tmp/project-b");
-    document.dispatchEvent(keyboardEvent("ArrowDown", childButton));
+    expect(parentButton?.getAttribute("aria-expanded")).toBe("true");
+    document.dispatchEvent(keyboardEvent("ArrowDown", findButton("/tmp/project-a")));
     document.dispatchEvent(keyboardEvent("Enter", secondChildButton));
 
     await expect(selectionPromise).resolves.toBe("rename:project-b");
+  });
+
+  it("restores focus when pointer navigation closes a submenu", () => {
+    showContextMenuFallback([
+      {
+        id: "rename:submenu",
+        label: "Rename project",
+        children: [{ id: "rename:project-a", label: "/tmp/project-a" }],
+      },
+      { id: "mark-unread", label: "Mark unread" },
+    ]);
+
+    const parentButton = findButton("Rename project");
+    parentButton?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    const childButton = findButton("/tmp/project-a");
+    const siblingButton = findButton("Mark unread");
+    childButton?.focus();
+    siblingButton?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+
+    expect(document.activeElement).toBe(parentButton);
+  });
+
+  it("restores focus to the opener after cleanup", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const selectionPromise = showContextMenuFallback([{ id: "rename", label: "Rename" }]);
+    const renameButton = findButton("Rename");
+    renameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await expect(selectionPromise).resolves.toBe("rename");
+    expect(document.activeElement).toBe(opener);
   });
 
   it("ignores a click from the gesture that opened the menu", async () => {

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -323,9 +323,9 @@ describe("showContextMenuFallback", () => {
     const parentButton = findButton("Rename project");
     parentButton?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
     const childButton = findButton("/tmp/project-a");
-    const siblingButton = findButton("Mark unread");
     childButton?.focus();
-    siblingButton?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    const rootMenu = (document as unknown as FakeDocument).body.children[0];
+    rootMenu?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
 
     expect(document.activeElement).toBe(parentButton);
   });
@@ -341,6 +341,32 @@ describe("showContextMenuFallback", () => {
 
     await expect(selectionPromise).resolves.toBe("rename");
     expect(document.activeElement).toBe(opener);
+  });
+
+  it("keeps keyboard focus aligned with hovered menu items", () => {
+    showContextMenuFallback([
+      {
+        id: "project-a",
+        label: "Project A",
+        children: [{ id: "project-a:branch", label: "Project A branch" }],
+      },
+      {
+        id: "project-b",
+        label: "Project B",
+        children: [{ id: "project-b:branch", label: "Project B branch" }],
+      },
+      { id: "mark-unread", label: "Mark unread" },
+    ]);
+
+    const projectA = findButton("Project A");
+    const projectB = findButton("Project B");
+    const markUnread = findButton("Mark unread");
+    projectA?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    projectB?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+
+    expect(document.activeElement).toBe(projectB);
+    document.dispatchEvent(keyboardEvent("ArrowDown", projectB));
+    expect(document.activeElement).toBe(markUnread);
   });
 
   it("ignores a click from the gesture that opened the menu", async () => {

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -183,6 +183,25 @@ afterEach(() => {
 });
 
 describe("showContextMenuFallback", () => {
+  it("uses themed surface and action tokens for app menus", async () => {
+    const selectionPromise = showContextMenuFallback([
+      { id: "rename", label: "Rename" },
+      { id: "delete", label: "Delete", destructive: true },
+    ]);
+
+    const menu = (document as unknown as FakeDocument).body.children[0];
+    expect(menu?.className).toContain("dropdown-glass");
+    expect(menu?.style.cssText).toContain("var(--popover-foreground)");
+
+    const renameButton = findButton("Rename");
+    const deleteButton = findButton("Delete");
+    expect(renameButton?.className).toContain("text-foreground");
+    expect(deleteButton?.className).toContain("text-destructive-foreground");
+
+    renameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await expect(selectionPromise).resolves.toBe("rename");
+  });
+
   it("resolves a clicked flat menu item", async () => {
     const selectionPromise = showContextMenuFallback([
       { id: "rename", label: "Rename" },

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -111,6 +111,7 @@ export function showContextMenuFallback<T extends string>(
   position?: { x: number; y: number },
 ): Promise<T | null> {
   return new Promise<T | null>((resolve) => {
+    const previousActiveElement = document.activeElement as HTMLElement | null;
     const menuStack: HTMLDivElement[] = [];
     const menuParentButtons: Array<HTMLButtonElement | null> = [];
     const buttonMetadata = new WeakMap<
@@ -134,15 +135,26 @@ export function showContextMenuFallback<T extends string>(
       for (const menu of menuStack) {
         menu.remove();
       }
+      previousActiveElement?.focus();
       resolve(result);
     };
 
     const closeMenusFromLevel = (level: number) => {
       while (menuStack.length > level) {
         const childLevel = menuStack.length - 1;
-        menuParentButtons[childLevel]?.setAttribute("aria-expanded", "false");
+        const childMenu = menuStack[childLevel];
+        const parentButton = menuParentButtons[childLevel];
+        if (
+          childMenu &&
+          parentButton &&
+          isNodeWithinMenuStack(document.activeElement, [childMenu])
+        ) {
+          parentButton.focus();
+        }
+        parentButton?.setAttribute("aria-expanded", "false");
         menuParentButtons.pop();
-        menuStack.pop()?.remove();
+        menuStack.pop();
+        childMenu?.remove();
       }
     };
 
@@ -190,18 +202,22 @@ export function showContextMenuFallback<T extends string>(
       switch (event.key) {
         case "ArrowDown":
           event.preventDefault();
+          closeMenusFromLevel(menuIndex + 1);
           focusMenuItem(menu, currentIndex + 1);
           break;
         case "ArrowUp":
           event.preventDefault();
+          closeMenusFromLevel(menuIndex + 1);
           focusMenuItem(menu, currentIndex - 1);
           break;
         case "Home":
           event.preventDefault();
+          closeMenusFromLevel(menuIndex + 1);
           focusMenuItem(menu, 0);
           break;
         case "End":
           event.preventDefault();
+          closeMenusFromLevel(menuIndex + 1);
           focusMenuItem(menu, buttons.length - 1);
           break;
         case "ArrowRight":
@@ -267,6 +283,7 @@ export function showContextMenuFallback<T extends string>(
       menu.dataset.level = String(level);
       menu.setAttribute("role", "menu");
       menu.setAttribute("aria-orientation", "vertical");
+      menu.setAttribute("data-slot", "menu-popup");
       menuParentButtons[level] = parentButton ?? null;
 
       const inner = document.createElement("div");
@@ -370,13 +387,14 @@ export function showContextMenuFallback<T extends string>(
 
           const openSubmenu = (shouldFocusFirst: boolean) => {
             const rect = button.getBoundingClientRect();
-            button.setAttribute("aria-expanded", "true");
             openMenu(item.children!, rect.right + 4, rect.top, level + 1, shouldFocusFirst, button);
 
             const childMenu = menuStack[level + 1];
             if (!childMenu) {
+              button.setAttribute("aria-expanded", "false");
               return;
             }
+            button.setAttribute("aria-expanded", "true");
             const childRect = childMenu.getBoundingClientRect();
             if (childRect.right > window.innerWidth) {
               clampMenuPosition(childMenu, rect.left - childRect.width - 4, rect.top);

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -103,7 +103,8 @@ function isNodeWithinMenuStack(target: EventTarget | null, menuStack: readonly H
 
 /**
  * Imperative DOM-based context menu for non-Electron environments.
- * Supports nested submenus and resolves with the clicked leaf item id.
+ * Supports keyboard and pointer navigation through nested submenus and resolves
+ * with the selected leaf item id.
  */
 export function showContextMenuFallback<T extends string>(
   items: readonly ContextMenuItem<T>[],
@@ -111,6 +112,14 @@ export function showContextMenuFallback<T extends string>(
 ): Promise<T | null> {
   return new Promise<T | null>((resolve) => {
     const menuStack: HTMLDivElement[] = [];
+    const menuParentButtons: Array<HTMLButtonElement | null> = [];
+    const buttonMetadata = new WeakMap<
+      HTMLButtonElement,
+      {
+        readonly item: ContextMenuItem<T>;
+        readonly openSubmenu: (focusFirstItem: boolean) => void;
+      }
+    >();
     let isDisposed = false;
     let canDismissFromPointer = false;
 
@@ -128,10 +137,98 @@ export function showContextMenuFallback<T extends string>(
       resolve(result);
     };
 
+    const closeMenusFromLevel = (level: number) => {
+      while (menuStack.length > level) {
+        const childLevel = menuStack.length - 1;
+        menuParentButtons[childLevel]?.setAttribute("aria-expanded", "false");
+        menuParentButtons.pop();
+        menuStack.pop()?.remove();
+      }
+    };
+
+    const getEnabledMenuButtons = (menu: HTMLDivElement): HTMLButtonElement[] =>
+      Array.from(menu.querySelectorAll<HTMLButtonElement>("button")).filter(
+        (button) => !button.disabled,
+      );
+
+    const focusMenuItem = (menu: HTMLDivElement, index: number) => {
+      const buttons = getEnabledMenuButtons(menu);
+      if (buttons.length === 0) {
+        return;
+      }
+      const normalizedIndex = (index + buttons.length) % buttons.length;
+      const button = buttons[normalizedIndex];
+      if (!button) {
+        return;
+      }
+      button.focus();
+      button.scrollIntoView?.({ block: "nearest" });
+    };
+
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
         cleanup(null);
+        return;
+      }
+
+      const eventTarget = event.target ?? document.activeElement;
+      const menuIndex = menuStack.findIndex((menu) => isNodeWithinMenuStack(eventTarget, [menu]));
+      const menu = menuStack[menuIndex];
+      if (!menu) {
+        return;
+      }
+
+      const buttons = getEnabledMenuButtons(menu);
+      const button = buttons.find((candidate) => candidate === eventTarget);
+      const metadata = button ? buttonMetadata.get(button) : undefined;
+      if (!button || !metadata) {
+        return;
+      }
+
+      const currentIndex = buttons.indexOf(button);
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          focusMenuItem(menu, currentIndex + 1);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          focusMenuItem(menu, currentIndex - 1);
+          break;
+        case "Home":
+          event.preventDefault();
+          focusMenuItem(menu, 0);
+          break;
+        case "End":
+          event.preventDefault();
+          focusMenuItem(menu, buttons.length - 1);
+          break;
+        case "ArrowRight":
+          if (metadata.item.children && metadata.item.children.length > 0) {
+            event.preventDefault();
+            metadata.openSubmenu(true);
+          }
+          break;
+        case "ArrowLeft": {
+          const parentButton = menuParentButtons[menuIndex];
+          if (!parentButton) {
+            return;
+          }
+          event.preventDefault();
+          closeMenusFromLevel(menuIndex);
+          parentButton.focus();
+          break;
+        }
+        case "Enter":
+        case " ":
+          event.preventDefault();
+          if (metadata.item.children && metadata.item.children.length > 0) {
+            metadata.openSubmenu(true);
+          } else {
+            cleanup(metadata.item.id);
+          }
+          break;
       }
     };
 
@@ -150,17 +247,13 @@ export function showContextMenuFallback<T extends string>(
       cleanup(null);
     };
 
-    const closeMenusFromLevel = (level: number) => {
-      while (menuStack.length > level) {
-        menuStack.pop()?.remove();
-      }
-    };
-
     const openMenu = (
       entries: readonly ContextMenuItem<T>[],
       preferredLeft: number,
       preferredTop: number,
       level: number,
+      focusFirstItem = false,
+      parentButton?: HTMLButtonElement,
     ) => {
       closeMenusFromLevel(level);
 
@@ -172,6 +265,9 @@ export function showContextMenuFallback<T extends string>(
       menu.style.left = `${preferredLeft}px`;
       menu.style.top = `${preferredTop}px`;
       menu.dataset.level = String(level);
+      menu.setAttribute("role", "menu");
+      menu.setAttribute("aria-orientation", "vertical");
+      menuParentButtons[level] = parentButton ?? null;
 
       const inner = document.createElement("div");
       inner.className =
@@ -194,6 +290,8 @@ export function showContextMenuFallback<T extends string>(
 
         const button = document.createElement("button");
         button.type = "button";
+        button.tabIndex = -1;
+        button.setAttribute("role", "menuitem");
         const isDisabled = item.disabled === true;
         button.disabled = isDisabled;
         const rowBase =
@@ -231,42 +329,68 @@ export function showContextMenuFallback<T extends string>(
           chevron.className = "ms-auto shrink-0 text-muted-foreground/80 text-sm leading-none";
           chevron.textContent = ">";
           button.appendChild(chevron);
+          button.setAttribute("aria-haspopup", "menu");
+          button.setAttribute("aria-expanded", "false");
         }
 
         if (!isDisabled) {
+          let isHovered = false;
+          let isFocused = false;
+          const applyInteractionStyles = () => {
+            const isActive = isHovered || isFocused;
+            button.style.background = isActive
+              ? isLeafDestructive
+                ? "color-mix(in srgb, var(--destructive) 10%, transparent)"
+                : "var(--accent)"
+              : "transparent";
+            button.style.color = isActive
+              ? isLeafDestructive
+                ? "var(--destructive-foreground)"
+                : "var(--accent-foreground)"
+              : isLeafDestructive
+                ? "var(--destructive-foreground)"
+                : "var(--foreground)";
+          };
+          button.addEventListener("focus", () => {
+            isFocused = true;
+            applyInteractionStyles();
+          });
+          button.addEventListener("blur", () => {
+            isFocused = false;
+            applyInteractionStyles();
+          });
           button.addEventListener("mouseenter", () => {
-            button.style.background = isLeafDestructive
-              ? "color-mix(in srgb, var(--destructive) 10%, transparent)"
-              : "var(--accent)";
-            button.style.color = isLeafDestructive
-              ? "var(--destructive-foreground)"
-              : "var(--accent-foreground)";
+            isHovered = true;
+            applyInteractionStyles();
           });
           button.addEventListener("mouseleave", () => {
-            button.style.background = "transparent";
-            button.style.color = isLeafDestructive
-              ? "var(--destructive-foreground)"
-              : "var(--foreground)";
+            isHovered = false;
+            applyInteractionStyles();
           });
+
+          const openSubmenu = (shouldFocusFirst: boolean) => {
+            const rect = button.getBoundingClientRect();
+            button.setAttribute("aria-expanded", "true");
+            openMenu(item.children!, rect.right + 4, rect.top, level + 1, shouldFocusFirst, button);
+
+            const childMenu = menuStack[level + 1];
+            if (!childMenu) {
+              return;
+            }
+            const childRect = childMenu.getBoundingClientRect();
+            if (childRect.right > window.innerWidth) {
+              clampMenuPosition(childMenu, rect.left - childRect.width - 4, rect.top);
+            }
+          };
+          buttonMetadata.set(button, { item, openSubmenu });
 
           if (hasChildren) {
             button.addEventListener("mouseenter", () => {
-              const rect = button.getBoundingClientRect();
-              const nextLeft = rect.right + 4;
-              const nextTop = rect.top;
-              openMenu(item.children!, nextLeft, nextTop, level + 1);
-
-              const childMenu = menuStack[level + 1];
-              if (!childMenu) {
-                return;
-              }
-              const childRect = childMenu.getBoundingClientRect();
-              if (childRect.right > window.innerWidth) {
-                clampMenuPosition(childMenu, rect.left - childRect.width - 4, rect.top);
-              }
+              openSubmenu(false);
             });
             button.addEventListener("click", (event) => {
               event.preventDefault();
+              openSubmenu(true);
             });
           } else {
             button.addEventListener("mouseenter", () => {
@@ -292,13 +416,16 @@ export function showContextMenuFallback<T extends string>(
 
       requestAnimationFrame(() => {
         clampMenuPosition(menu, preferredLeft, preferredTop);
+        if (focusFirstItem) {
+          focusMenuItem(menu, 0);
+        }
       });
     };
 
     document.addEventListener("keydown", onKeyDown);
     document.addEventListener("pointerdown", onPointerDown, true);
     document.addEventListener("contextmenu", onContextMenu, true);
-    openMenu(items, position?.x ?? 0, position?.y ?? 0, 0);
+    openMenu(items, position?.x ?? 0, position?.y ?? 0, 0, true);
 
     requestAnimationFrame(() => {
       canDismissFromPointer = true;

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -404,6 +404,7 @@ export function showContextMenuFallback<T extends string>(
 
           if (hasChildren) {
             button.addEventListener("mouseenter", () => {
+              button.focus();
               openSubmenu(false);
             });
             button.addEventListener("click", (event) => {
@@ -412,6 +413,7 @@ export function showContextMenuFallback<T extends string>(
             });
           } else {
             button.addEventListener("mouseenter", () => {
+              button.focus();
               closeMenusFromLevel(level + 1);
             });
             button.addEventListener("click", () => {

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -50,6 +50,10 @@ function testWindow(): Window & typeof globalThis {
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
+  vi.stubGlobal("navigator", {
+    platform: "Linux x86_64",
+    userAgent: "Mozilla/5.0 (X11; Linux x86_64)",
+  });
   if (globalThis.window === undefined) {
     Object.defineProperty(globalThis, "window", {
       configurable: true,
@@ -64,6 +68,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
@@ -85,6 +90,52 @@ describe("LocalApi", () => {
     expect(showContextMenuFallbackMock).toHaveBeenCalledWith(items, { x: 4, y: 5 });
   });
 
+  it("uses the themed context-menu fallback on Windows desktop", async () => {
+    vi.stubGlobal("navigator", {
+      platform: "Win32",
+      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    });
+    showContextMenuFallbackMock.mockResolvedValue("rename");
+    const showContextMenu = vi.fn().mockResolvedValue("delete");
+    testWindow().desktopBridge = { showContextMenu } as unknown as DesktopBridge;
+
+    const { createLocalApi } = await import("./localApi");
+    const items = [{ id: "rename", label: "Rename" }] as const;
+
+    await expect(createLocalApi().contextMenu.show(items, { x: 4, y: 5 })).resolves.toBe("rename");
+    expect(showContextMenu).not.toHaveBeenCalled();
+    expect(showContextMenuFallbackMock).toHaveBeenCalledWith(items, { x: 4, y: 5 });
+  });
+
+  it("uses the themed context-menu fallback on Linux desktop", async () => {
+    showContextMenuFallbackMock.mockResolvedValue("rename");
+    const showContextMenu = vi.fn().mockResolvedValue("delete");
+    testWindow().desktopBridge = { showContextMenu } as unknown as DesktopBridge;
+
+    const { createLocalApi } = await import("./localApi");
+    const items = [{ id: "rename", label: "Rename" }] as const;
+
+    await expect(createLocalApi().contextMenu.show(items, { x: 4, y: 5 })).resolves.toBe("rename");
+    expect(showContextMenu).not.toHaveBeenCalled();
+    expect(showContextMenuFallbackMock).toHaveBeenCalledWith(items, { x: 4, y: 5 });
+  });
+
+  it("keeps the native context-menu bridge on macOS desktop", async () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    });
+    const showContextMenu = vi.fn().mockResolvedValue("rename");
+    testWindow().desktopBridge = { showContextMenu } as unknown as DesktopBridge;
+
+    const { createLocalApi } = await import("./localApi");
+    const items = [{ id: "rename", label: "Rename" }] as const;
+
+    await expect(createLocalApi().contextMenu.show(items, { x: 4, y: 5 })).resolves.toBe("rename");
+    expect(showContextMenu).toHaveBeenCalledWith(items, { x: 4, y: 5 });
+    expect(showContextMenuFallbackMock).not.toHaveBeenCalled();
+  });
+
   it("uses the themed confirmation host when it is available", async () => {
     requestConfirmDialogMock.mockResolvedValue(true);
     const { createLocalApi } = await import("./localApi");
@@ -104,6 +155,10 @@ describe("LocalApi", () => {
   });
 
   it("delegates host capabilities and persistence to the desktop bridge", async () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    });
     const showContextMenu = vi.fn().mockResolvedValue("delete");
     const pickFolder = vi.fn().mockResolvedValue("/tmp/project");
     const getClientSettings = vi.fn().mockResolvedValue(DEFAULT_CLIENT_SETTINGS);

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -7,6 +7,20 @@ import { resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
 
 let cachedApi: LocalApi | undefined;
 
+/**
+ * Native Electron menus can follow light/dark mode, but they cannot consume
+ * the renderer's custom T3 theme variables. Keep app menus in the renderer on
+ * web, Windows, and Linux so those builds share the same themed implementation.
+ * macOS stays native until its menu treatment is revisited.
+ */
+function isMacOSHost(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return (
+    navigator.platform.toLowerCase().startsWith("mac") ||
+    navigator.userAgent.toLowerCase().includes("mac os")
+  );
+}
+
 function createBrowserLocalApi(): LocalApi {
   return {
     dialogs: {
@@ -36,7 +50,7 @@ function createBrowserLocalApi(): LocalApi {
         items: readonly ContextMenuItem<T>[],
         position?: { x: number; y: number },
       ): Promise<T | null> => {
-        if (window.desktopBridge) {
+        if (window.desktopBridge && isMacOSHost()) {
           return window.desktopBridge.showContextMenu(items, position) as Promise<T | null>;
         }
         return showContextMenuFallback(items, position);


### PR DESCRIPTION
## Summary

Desktop context menus currently use Electron's native renderer on every platform, so Windows and Linux do not follow T3's themed menu surface. This keeps macOS native for now and routes web, Windows, and Linux through the existing renderer fallback.

The platform decision is covered by focused tests for browser, Windows, Linux, and macOS behavior. The fallback test also verifies themed menu classes, variables, and keyboard navigation.

## Verification

- `pnpm --filter @t3tools/web test -- src/localApi.test.ts src/contextMenuFallback.test.ts` (web unit suite: 245 files, 2,385 tests passed)
- `pnpm --filter @t3tools/web typecheck`
- `vp lint apps/web/src/localApi.ts apps/web/src/localApi.test.ts apps/web/src/contextMenuFallback.test.ts`
- `vp fmt --check apps/web/src/localApi.ts apps/web/src/localApi.test.ts apps/web/src/contextMenuFallback.test.ts`
- Playwright right-click capture from an isolated T3 preview using the Ocean dark theme and 18 px interface font

## Before

![Native context menu before](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/80b76af2-8743-40bf-9eff-31f2ca279dc9/thread-context-menu-before.png)

## After

![Themed Ocean context menu captured with Playwright at 18 px](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/91529368-d5f3-4e72-97bc-bb1aec57bd92/thread-context-menu-themed-ocean-large.png)

Model/harness: GPT-5.6 via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes visible context-menu behavior on Windows/Linux desktop and adds non-trivial focus/keyboard logic, though scope is limited to menu UI and is covered by new tests.
> 
> **Overview**
> **Windows and Linux** desktop apps now use the in-renderer `showContextMenuFallback` for context menus so they pick up T3 theme tokens; **macOS** still uses the Electron `desktopBridge` native menu via new `isMacOSHost()` gating in `localApi`.
> 
> The fallback menu gains **keyboard navigation** (arrows, Home/End, Enter/Space, Escape), **nested submenu** open/close with `aria-expanded`, **focus restore** on dismiss and after selection, and **pointer hover** kept in sync with focus. Menus expose `role="menu"` / `menuitem` and themed styling assertions in tests.
> 
> `localApi.test.ts` adds platform-specific routing tests; `contextMenuFallback.test.ts` extends the fake DOM for focus/keyboard coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4427822ff9df4449aed8503573d7ef823bc54de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use themed context menu fallback on Windows and Linux instead of native desktop bridge
> - On Windows and Linux, `createBrowserLocalApi.contextMenu.show` now routes to `showContextMenuFallback` even when a desktop bridge is present; macOS continues to use the native bridge via the new `isMacOSHost` helper in [localApi.ts](https://github.com/pingdotgg/t3code/pull/6440/files#diff-75efdcd889ced82f7f5ce4977d3e67c293986a4024762b6d5c1a5bda4b9452da).
> - `showContextMenuFallback` in [contextMenuFallback.ts](https://github.com/pingdotgg/t3code/pull/6440/files#diff-032cd4155f179490fdc876b54fb96f2609ab2552587ed8b42b9963c1d250a3be) gains full keyboard navigation (Arrow keys, Home/End, Enter/Space), nested submenu open/close via ArrowRight/ArrowLeft, ARIA roles and attributes, hover/focus alignment, and focus restoration on close.
> - Behavioral Change: desktop builds on Windows and Linux no longer call the native context menu bridge, so menus will render with the themed web fallback rather than OS-native styling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f442782.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


