### PR TITLE
fix(chat): show Codex generated images in the thread

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/index.ts
+++ b/apps/mobile/modules/t3-markdown-text/index.ts
@@ -21,6 +21,7 @@ export {
   type MarkdownHighlightedToken,
 } from "./src/SelectableMarkdownText";
 export type {
+  MarkdownImageRenderProps,
   NativeMarkdownTextStyle,
   SelectableMarkdownSkill,
   SelectableMarkdownTextProps,

--- a/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownBlock.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownBlock.ios.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import { Image, ScrollView, Text, useColorScheme, View } from "react-native";
 import type { MarkdownNode } from "react-native-nitro-markdown/headless";
 
@@ -13,8 +13,13 @@ import { NativeMarkdownSelectableText } from "./NativeMarkdownSelectableText.ios
 import type {
   MarkdownCodeHighlighter,
   MarkdownHighlightedToken,
+  MarkdownImageRenderProps,
   NativeMarkdownTextStyle,
 } from "./SelectableMarkdownText.types";
+
+const MarkdownImageRenderContext = createContext<
+  ((props: MarkdownImageRenderProps) => ReactNode) | undefined
+>(undefined);
 
 type HighlightedCode = ReadonlyArray<ReadonlyArray<MarkdownHighlightedToken>>;
 
@@ -380,6 +385,10 @@ function NativeMarkdownImage(props: {
   readonly onLinkPress?: (href: string) => void;
 }) {
   const href = props.node.href;
+  const renderImage = useContext(MarkdownImageRenderContext);
+  if (href && renderImage) {
+    return <>{renderImage({ href, alt: props.node.alt ?? props.node.title })}</>;
+  }
   if (!href) {
     return (
       <SelectableNode
@@ -554,10 +563,31 @@ export function NativeMarkdownBlock(props: {
   readonly textStyle: NativeMarkdownTextStyle;
   readonly highlightCode: MarkdownCodeHighlighter;
   readonly onLinkPress?: (href: string) => void;
+  readonly renderImage?: (props: MarkdownImageRenderProps) => ReactNode;
   readonly depth?: number;
   readonly compact?: boolean;
 }) {
   const depth = props.depth ?? 0;
+  const block = <NativeMarkdownBlockInner {...props} depth={depth} />;
+  if (!props.renderImage) {
+    return block;
+  }
+  return (
+    <MarkdownImageRenderContext.Provider value={props.renderImage}>
+      {block}
+    </MarkdownImageRenderContext.Provider>
+  );
+}
+
+function NativeMarkdownBlockInner(props: {
+  readonly node: MarkdownNode;
+  readonly textStyle: NativeMarkdownTextStyle;
+  readonly highlightCode: MarkdownCodeHighlighter;
+  readonly onLinkPress?: (href: string) => void;
+  readonly depth: number;
+  readonly compact?: boolean;
+}) {
+  const depth = props.depth;
   switch (props.node.type) {
     case "document":
       return (

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
@@ -20,6 +20,7 @@ const EMPTY_SKILLS: ReadonlyArray<SelectableMarkdownSkill> = [];
 export type {
   MarkdownCodeHighlighter,
   MarkdownHighlightedToken,
+  MarkdownImageRenderProps,
   NativeMarkdownTextStyle,
   SelectableMarkdownSkill,
   SelectableMarkdownTextProps,
@@ -36,6 +37,7 @@ export function SelectableMarkdownText({
   highlightCode,
   preserveSoftBreaks = false,
   onLinkPress,
+  renderImage,
   marginTop = 0,
   marginBottom = 0,
 }: SelectableMarkdownTextProps) {
@@ -72,6 +74,7 @@ export function SelectableMarkdownText({
               textStyle={textStyle}
               highlightCode={highlightCode}
               onLinkPress={onLinkPress}
+              renderImage={renderImage}
             />
           ) : (
             <NativeMarkdownSelectableText

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.types.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 export interface NativeMarkdownTextStyle {
   readonly color: string;
   readonly strongColor: string;
@@ -36,6 +38,11 @@ export interface SelectableMarkdownSkill {
   readonly displayName?: string | null;
 }
 
+export interface MarkdownImageRenderProps {
+  readonly href: string;
+  readonly alt?: string;
+}
+
 export interface SelectableMarkdownTextProps {
   readonly markdown: string;
   readonly textStyle: NativeMarkdownTextStyle;
@@ -43,6 +50,7 @@ export interface SelectableMarkdownTextProps {
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
   readonly preserveSoftBreaks?: boolean;
   readonly onLinkPress?: (href: string) => void;
+  readonly renderImage?: (props: MarkdownImageRenderProps) => ReactNode;
   readonly marginTop?: number;
   readonly marginBottom?: number;
 }

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -3,6 +3,7 @@ import { KeyboardAwareLegendList } from "@legendapp/list/keyboard";
 import { type LegendListRef } from "@legendapp/list/react-native";
 import type { EnvironmentId, MessageId, ThreadId, TurnId } from "@t3tools/contracts";
 import { CHAT_LIST_ANCHOR_OFFSET, resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
+import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
 import { formatElapsed } from "@t3tools/shared/orchestrationTiming";
 import { SymbolView } from "../../components/AppSymbol";
 import { HeaderHeightContext } from "@react-navigation/elements";
@@ -101,8 +102,8 @@ import {
   WORK_GROUP_TOGGLE_HEIGHT,
 } from "./thread-work-log";
 import { useMarkdownCodeHighlight } from "./markdownCodeHighlightState";
-import { useAssetUrl } from "../../state/assets";
-import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
+import { useAssetUrl, useAssetUrlState } from "../../state/assets";
+import { resolveWorkspaceFilePath, resolveWorkspaceRelativeFilePath } from "../files/filePath";
 
 const WIDE_MARKDOWN_BLOCK_OPTIONS = {
   includeOrderedLists: Platform.OS === "android",
@@ -165,6 +166,86 @@ export interface ThreadFeedProps {
     readonly loading: boolean;
     readonly onLoadEarlier: () => void;
   } | null;
+}
+
+function MarkdownWorkspaceImage(props: {
+  readonly href: string;
+  readonly alt?: string;
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+  readonly workspaceRoot?: string | null;
+  readonly onPressImage: (uri: string) => void;
+}) {
+  const presentation = resolveMarkdownLinkPresentation(props.href);
+  const remoteUri =
+    presentation.kind === "external"
+      ? presentation.href
+      : /^https?:\/\//i.test(props.href)
+        ? props.href
+        : null;
+  const filePath = presentation.kind === "file" ? presentation.path : null;
+  const absolutePath =
+    filePath === null
+      ? null
+      : props.workspaceRoot
+        ? resolveWorkspaceFilePath(props.workspaceRoot, filePath)
+        : filePath;
+  const canPreviewFile = absolutePath !== null && isWorkspaceImagePreviewPath(absolutePath);
+  const assetUrl = useAssetUrlState(
+    props.environmentId,
+    canPreviewFile && absolutePath !== null
+      ? {
+          _tag: "workspace-file",
+          threadId: props.threadId,
+          path: absolutePath,
+        }
+      : null,
+  );
+  const assetUri = assetUrl._tag === "Success" ? assetUrl.url : null;
+  const uri = remoteUri ?? assetUri;
+  const [failedUri, setFailedUri] = useState<string | null>(null);
+
+  if (
+    (remoteUri === null && canPreviewFile && assetUrl._tag === "Failure") ||
+    (uri !== null && failedUri === uri)
+  ) {
+    return (
+      <Text className="my-2 rounded-[12px] bg-neutral-200 px-3 py-2 text-xs text-foreground-muted dark:bg-neutral-800">
+        Unable to load image{props.alt ? ` “${props.alt}”` : ""}.
+      </Text>
+    );
+  }
+
+  if (uri === null && canPreviewFile) {
+    return (
+      <View className="my-2 h-40 items-center justify-center rounded-[12px] bg-neutral-200 dark:bg-neutral-800">
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (uri === null) {
+    return props.alt ? (
+      <Text className="my-1 text-xs text-foreground-muted">{props.alt}</Text>
+    ) : null;
+  }
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={props.alt ? `Preview ${props.alt}` : "Preview image"}
+      className="my-2 overflow-hidden rounded-[12px] bg-neutral-200 dark:bg-neutral-800"
+      onPress={() => props.onPressImage(uri)}
+    >
+      <Image
+        source={{ uri }}
+        className="aspect-[4/3] w-full"
+        resizeMode="contain"
+        onError={() => setFailedUri(uri)}
+      />
+    </TouchableOpacity>
+  );
 }
 
 function MessageAttachmentImage(props: {
@@ -820,7 +901,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
 
 function renderFeedEntry(
   info: { item: ThreadFeedEntry; index: number },
-  props: Pick<ThreadFeedProps, "environmentId" | "skills"> & {
+  props: Pick<ThreadFeedProps, "environmentId" | "threadId" | "workspaceRoot" | "skills"> & {
     readonly copiedRowId: string | null;
     readonly expandedWorkRows: Record<string, boolean>;
     readonly terminalAssistantMessageIds: ReadonlySet<string>;
@@ -929,6 +1010,16 @@ function renderFeedEntry(
                 reviewCommentColors={props.reviewCommentColors}
                 skills={props.skills}
                 onLinkPress={props.onMarkdownLinkPress}
+                renderImage={({ href, alt }) => (
+                  <MarkdownWorkspaceImage
+                    href={href}
+                    alt={alt}
+                    environmentId={props.environmentId}
+                    threadId={props.threadId}
+                    workspaceRoot={props.workspaceRoot}
+                    onPressImage={props.onPressImage}
+                  />
+                )}
               />
             ) : null}
             {attachments.map((attachment) => {
@@ -980,11 +1071,33 @@ function renderFeedEntry(
               skills={props.skills}
               textStyle={styles.nativeTextStyle}
               onLinkPress={props.onMarkdownLinkPress}
+              renderImage={({ href, alt }) => (
+                <MarkdownWorkspaceImage
+                  href={href}
+                  alt={alt}
+                  environmentId={props.environmentId}
+                  threadId={props.threadId}
+                  workspaceRoot={props.workspaceRoot}
+                  onPressImage={props.onPressImage}
+                />
+              )}
             />
           ) : (
             <Markdown
               options={{ gfm: true }}
-              renderers={styles.renderers}
+              renderers={{
+                ...styles.renderers,
+                image: ({ src, alt }) => (
+                  <MarkdownWorkspaceImage
+                    href={src ?? ""}
+                    alt={alt}
+                    environmentId={props.environmentId}
+                    threadId={props.threadId}
+                    workspaceRoot={props.workspaceRoot}
+                    onPressImage={props.onPressImage}
+                  />
+                ),
+              }}
               styles={styles.styles}
               theme={styles.theme}
             >
@@ -1027,6 +1140,16 @@ function renderFeedEntry(
       copiedRowId={props.copiedRowId}
       expandedRows={props.expandedWorkRows}
       iconSubtleColor={iconSubtleColor}
+      renderImage={(path) => (
+        <MarkdownWorkspaceImage
+          href={path}
+          alt="Generated image"
+          environmentId={props.environmentId}
+          threadId={props.threadId}
+          workspaceRoot={props.workspaceRoot}
+          onPressImage={props.onPressImage}
+        />
+      )}
       onCopyRow={props.onCopyWorkRow}
       onToggleRow={props.onToggleWorkRow}
     />
@@ -1065,6 +1188,7 @@ function UserMessageContent(props: {
   readonly reviewCommentColors: ReviewCommentColors;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
   readonly onLinkPress: (href: string) => void;
+  readonly renderImage?: (input: { href: string; alt?: string }) => ReactNode;
 }) {
   const segments = parseReviewCommentMessageSegments(props.text);
   const hasReviewComment = segments.some((segment) => segment.kind === "review-comment");
@@ -1077,13 +1201,22 @@ function UserMessageContent(props: {
           textStyle={props.markdownStyles.nativeTextStyle}
           preserveSoftBreaks
           onLinkPress={props.onLinkPress}
+          renderImage={props.renderImage}
         />
       );
     }
     return (
       <Markdown
         options={{ gfm: true }}
-        renderers={props.markdownStyles.renderers}
+        renderers={{
+          ...props.markdownStyles.renderers,
+          ...(props.renderImage
+            ? {
+                image: ({ src, alt }: { src?: string; alt?: string }) =>
+                  props.renderImage?.({ href: src ?? "", alt }) ?? null,
+              }
+            : {}),
+        }}
         styles={props.markdownStyles.styles}
         theme={props.markdownStyles.theme}
       >
@@ -1118,12 +1251,21 @@ function UserMessageContent(props: {
             textStyle={props.markdownStyles.nativeTextStyle}
             preserveSoftBreaks
             onLinkPress={props.onLinkPress}
+            renderImage={props.renderImage}
           />
         ) : (
           <Markdown
             key={segment.id}
             options={{ gfm: true }}
-            renderers={props.markdownStyles.renderers}
+            renderers={{
+              ...props.markdownStyles.renderers,
+              ...(props.renderImage
+                ? {
+                    image: ({ src, alt }: { src?: string; alt?: string }) =>
+                      props.renderImage?.({ href: src ?? "", alt }) ?? null,
+                  }
+                : {}),
+            }}
             styles={props.markdownStyles.styles}
             theme={props.markdownStyles.theme}
           >
@@ -1805,9 +1947,11 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
         case "working":
           return workingRowHeight;
         case "activity-group":
-          // Expanded rows append a variable detail block — fall back to
-          // measurement for those groups.
-          return entry.activities.some((activity) => expandedWorkRows[activity.id])
+          // Expanded rows and image previews have variable height — fall back
+          // to measurement for those groups.
+          return entry.activities.some(
+            (activity) => expandedWorkRows[activity.id] || activity.imagePath !== null,
+          )
             ? undefined
             : collapsedWorkLogHeight(entry.activities, appearance.baseFontSize);
         default:
@@ -1821,6 +1965,8 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     (info: { item: ThreadFeedEntry; index: number }) =>
       renderFeedEntry(info, {
         environmentId: props.environmentId,
+        threadId: props.threadId,
+        workspaceRoot: props.workspaceRoot,
         copiedRowId,
         expandedWorkRows,
         terminalAssistantMessageIds,
@@ -1857,6 +2003,8 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       onToggleWorkGroup,
       onToggleWorkRow,
       props.environmentId,
+      props.threadId,
+      props.workspaceRoot,
       props.skills,
     ],
   );

--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -1,4 +1,5 @@
 import * as Haptics from "expo-haptics";
+import type { ReactNode } from "react";
 import { type AppSymbolName, SymbolView } from "../../components/AppSymbol";
 import { LayoutAnimation, Pressable, ScrollView, useColorScheme, View } from "react-native";
 
@@ -124,6 +125,7 @@ export function ThreadWorkLog(props: {
   readonly copiedRowId: string | null;
   readonly expandedRows: Readonly<Record<string, boolean>>;
   readonly iconSubtleColor: import("react-native").ColorValue;
+  readonly renderImage?: (path: string) => ReactNode;
   readonly onCopyRow: (rowId: string, value: string) => void;
   readonly onToggleRow: (rowId: string) => void;
 }) {
@@ -247,6 +249,10 @@ export function ThreadWorkLog(props: {
                   </View>
                 </View>
               </Pressable>
+
+              {row.imagePath && props.renderImage ? (
+                <View className="ml-7">{props.renderImage(row.imagePath)}</View>
+              ) : null}
 
               {fullDetail ? (
                 <View className="ml-7 border-l border-neutral-300/60 pb-1 pl-3 pt-0.5 dark:border-white/[0.12]">

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -274,6 +274,35 @@ describe("buildThreadFeed", () => {
     );
   });
 
+  it("exposes generated-image paths to mobile work rows", () => {
+    const savedPath = "/home/sam/.codex/generated_images/hero.png";
+    const thread = makeThread({
+      id: ThreadId.make("thread-image"),
+      projectId: ProjectId.make("project-1"),
+      title: "Generated image",
+      activities: [
+        makeActivity({
+          id: EventId.make("image-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Generated image",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          payload: {
+            title: "Generated image",
+            itemType: "image_view",
+            data: { item: { type: "imageGeneration", savedPath } },
+          },
+        }),
+      ],
+    });
+
+    const group = buildThreadFeed(thread)[0];
+    expect(group).toMatchObject({
+      type: "activity-group",
+      activities: [{ imagePath: savedPath }],
+    });
+  });
+
   it("keeps MCP inputs available to expanded mobile work rows", () => {
     const turnId = TurnId.make("turn-mcp");
     const thread = makeThread({
@@ -583,6 +612,7 @@ describe("buildThreadFeed", () => {
       turnId: null,
       summary: `Tool ${id}`,
       detail: null,
+      imagePath: null,
       canExpand: false,
       getFullDetail: () => null,
       getCopyText: () => id,

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -36,6 +36,7 @@ export interface ThreadFeedActivity {
   readonly turnId: TurnId | null;
   readonly summary: string;
   readonly detail: string | null;
+  readonly imagePath: string | null;
   readonly canExpand: boolean;
   readonly getFullDetail: () => string | null;
   readonly getCopyText: () => string;
@@ -66,6 +67,7 @@ interface WorkLogEntry {
   turnId: TurnId | null;
   label: string;
   detail?: string;
+  imagePath?: string;
   command?: string;
   rawCommand?: string;
   changedFiles?: ReadonlyArray<string>;
@@ -391,7 +393,11 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   };
   const itemType = extractWorkLogItemType(payload);
   const requestKind = extractWorkLogRequestKind(payload);
-  if (
+  const imagePath = itemType === "image_view" ? extractImageViewPath(payload) : null;
+  if (imagePath) {
+    entry.detail = imagePath;
+    entry.imagePath = imagePath;
+  } else if (
     !taskDetailAsLabel &&
     payload &&
     typeof payload.detail === "string" &&
@@ -495,6 +501,7 @@ function mergeDerivedWorkLogEntries(
 ): DerivedWorkLogEntry {
   const changedFiles = mergeChangedFiles(previous.changedFiles, next.changedFiles);
   const detail = next.detail ?? previous.detail;
+  const imagePath = next.imagePath ?? previous.imagePath;
   const command = next.command ?? previous.command;
   const rawCommand = next.rawCommand ?? previous.rawCommand;
   const toolTitle = next.toolTitle ?? previous.toolTitle;
@@ -507,6 +514,7 @@ function mergeDerivedWorkLogEntries(
     ...previous,
     ...next,
     ...(detail ? { detail } : {}),
+    ...(imagePath ? { imagePath } : {}),
     ...(command ? { command } : {}),
     ...(rawCommand ? { rawCommand } : {}),
     ...(changedFiles.length > 0 ? { changedFiles } : {}),
@@ -950,6 +958,17 @@ function stripTrailingExitCode(value: string): {
     output: normalizedOutput.length > 0 ? normalizedOutput : null,
     ...(Number.isInteger(exitCode) ? { exitCode } : {}),
   };
+}
+
+function extractImageViewPath(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  for (const candidate of [item?.savedPath, item?.path, payload?.detail]) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return null;
 }
 
 function extractWorkLogItemType(
@@ -1560,6 +1579,7 @@ export function buildThreadFeed(
               turnId: entry.turnId,
               summary,
               detail,
+              imagePath: entry.imagePath ?? null,
               canExpand: workEntryHasExpandedBody(entry),
               getFullDetail,
               getCopyText,

--- a/apps/mobile/src/state/assets.ts
+++ b/apps/mobile/src/state/assets.ts
@@ -8,22 +8,39 @@ import { usePreparedConnection } from "./session";
 
 export const assetEnvironment = createAssetEnvironmentAtoms(connectionAtomRuntime);
 
+export type AssetUrlState =
+  | { readonly _tag: "Loading" }
+  | { readonly _tag: "Failure" }
+  | { readonly _tag: "Success"; readonly url: string };
+
 const EMPTY_ASSET_URL_ATOM = Atom.make(AsyncResult.initial<never, never>(false)).pipe(
   Atom.withLabel("mobile-asset-url:empty"),
 );
 
-export function useAssetUrl(
+export function useAssetUrlState(
   environmentId: EnvironmentId | null,
   resource: AssetResource | null,
-): string | null {
+): AssetUrlState {
   const preparedConnection = usePreparedConnection(environmentId);
   const result = useAtomValue(
     environmentId === null || resource === null
       ? EMPTY_ASSET_URL_ATOM
       : assetEnvironment.createUrl({ environmentId, input: { resource } }),
   );
-  if (preparedConnection._tag === "None" || result._tag !== "Success") {
-    return null;
+  if (result._tag === "Failure") {
+    return { _tag: "Failure" };
   }
-  return resolveAssetUrl(preparedConnection.value.httpBaseUrl, result.value.relativeUrl);
+  if (preparedConnection._tag === "None" || result._tag !== "Success") {
+    return { _tag: "Loading" };
+  }
+  const url = resolveAssetUrl(preparedConnection.value.httpBaseUrl, result.value.relativeUrl);
+  return url ? { _tag: "Success", url } : { _tag: "Failure" };
+}
+
+export function useAssetUrl(
+  environmentId: EnvironmentId | null,
+  resource: AssetResource | null,
+): string | null {
+  const state = useAssetUrlState(environmentId, resource);
+  return state._tag === "Success" ? state.url : null;
 }

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -106,6 +106,60 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
+  it.effect("issues exact URLs for Codex generated images outside the workspace", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-workspace-root-",
+      });
+      const generatedRoot = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-generated-images-",
+      });
+      const generatedDir = path.join(generatedRoot, "generated_images");
+      const imagePath = path.join(generatedDir, "hero.png");
+      const siblingPath = path.join(generatedDir, "other.png");
+      yield* fileSystem.makeDirectory(generatedDir, { recursive: true });
+      yield* fileSystem.writeFile(imagePath, new Uint8Array([137, 80, 78, 71]));
+      yield* fileSystem.writeFile(siblingPath, new Uint8Array([137, 80, 78, 71]));
+      const canonicalImagePath = yield* fileSystem.realPath(imagePath);
+
+      const result = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: imagePath,
+        },
+        workspaceRoot: root,
+        generatedImagesRoots: [generatedDir],
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      expect(yield* resolveAsset(token, "hero.png")).toEqual({
+        kind: "file",
+        path: canonicalImagePath,
+      });
+      expect(yield* resolveAsset(token, "other.png")).toBeNull();
+
+      const unrelatedDir = path.join(generatedRoot, "unrelated", "generated_images");
+      const unrelatedPath = path.join(unrelatedDir, "private.png");
+      yield* fileSystem.makeDirectory(unrelatedDir, { recursive: true });
+      yield* fileSystem.writeFile(unrelatedPath, new Uint8Array([137, 80, 78, 71]));
+      const error = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: unrelatedPath,
+        },
+        workspaceRoot: root,
+        generatedImagesRoots: [generatedDir],
+      }).pipe(Effect.flip);
+      expect(error._tag).toBe("AssetWorkspacePathValidationError");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.effect("preserves non-missing canonical path failures when issuing asset URLs", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -160,20 +160,24 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
-  it.effect("preserves non-missing canonical path failures when issuing asset URLs", () =>
+  it.effect("preserves generated image inspection failures when issuing asset URLs", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const root = yield* fileSystem.makeTempDirectoryScoped({
         prefix: "t3-asset-permission-root-",
       });
-      const htmlPath = path.join(root, "report.html");
-      yield* fileSystem.writeFileString(htmlPath, "<p>report</p>");
+      const generatedRoot = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-generated-permission-root-",
+      });
+      const imagePath = path.join(generatedRoot, "generated_images", "image.png");
+      yield* fileSystem.makeDirectory(path.dirname(imagePath), { recursive: true });
+      yield* fileSystem.writeFile(imagePath, new Uint8Array([137, 80, 78, 71]));
       const cause = PlatformError.systemError({
         _tag: "PermissionDenied",
         module: "FileSystem",
         method: "realPath",
-        pathOrDescriptor: htmlPath,
+        pathOrDescriptor: imagePath,
       });
       const failingFileSystem = FileSystem.FileSystem.of({
         ...fileSystem,
@@ -184,9 +188,10 @@ describe("AssetAccess", () => {
         resource: {
           _tag: "workspace-file",
           threadId: ThreadId.make("thread-1"),
-          path: htmlPath,
+          path: imagePath,
         },
         workspaceRoot: root,
+        generatedImagesRoots: [path.dirname(imagePath)],
       }).pipe(Effect.provideService(FileSystem.FileSystem, failingFileSystem), Effect.flip);
 
       expect(error.message).toBe("Failed to inspect the workspace asset.");
@@ -195,7 +200,7 @@ describe("AssetAccess", () => {
         resource: {
           _tag: "workspace-file",
           threadId: "thread-1",
-          path: htmlPath,
+          path: imagePath,
         },
       });
       expect(error.cause).toBe(cause);

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -77,6 +77,13 @@ const AssetClaimsSchema = Schema.Union([
   }),
   Schema.Struct({
     version: Schema.Literal(1),
+    kind: Schema.Literal("host-image-exact"),
+    absolutePath: Schema.String,
+    generatedImagesRoot: Schema.String,
+    expiresAt: Schema.Number,
+  }),
+  Schema.Struct({
+    version: Schema.Literal(1),
     kind: Schema.Literal("attachment"),
     attachmentId: Schema.String,
     expiresAt: Schema.Number,
@@ -166,9 +173,46 @@ const resolveCanonicalWorkspaceFileForRequest = (input: {
     Effect.orElseSucceed(() => null),
   );
 
+const resolveCanonicalHostGeneratedImage = Effect.fn("AssetAccess.resolveCanonicalHostGeneratedImage")(
+  function* (absolutePath: string, generatedImagesRoots: ReadonlyArray<string>) {
+    const path = yield* Path.Path;
+    if (!path.isAbsolute(absolutePath) || !isWorkspaceImagePreviewPath(absolutePath)) return null;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const canonicalFile = yield* optionOnNotFound(fileSystem.realPath(absolutePath));
+    if (Option.isNone(canonicalFile) || !path.isAbsolute(canonicalFile.value)) return null;
+    const info = yield* optionOnNotFound(fileSystem.stat(canonicalFile.value));
+    if (Option.isNone(info) || info.value.type !== "File") return null;
+
+    for (const root of generatedImagesRoots) {
+      const canonicalRoot = yield* optionOnNotFound(fileSystem.realPath(root));
+      if (Option.isNone(canonicalRoot)) continue;
+      const relative = path.relative(canonicalRoot.value, canonicalFile.value);
+      if (relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+        return { path: canonicalFile.value, root: canonicalRoot.value };
+      }
+    }
+    return null;
+  },
+);
+
+const resolveCanonicalHostGeneratedImageForRequest = (
+  absolutePath: string,
+  generatedImagesRoot: string,
+) =>
+  resolveCanonicalHostGeneratedImage(absolutePath, [generatedImagesRoot]).pipe(
+    Effect.tapError((cause) =>
+      Effect.logError("Failed to resolve generated image path.", {
+        path: absolutePath,
+        cause,
+      }),
+    ),
+    Effect.orElseSucceed(() => null),
+  );
+
 export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (input: {
   readonly resource: AssetResource;
   readonly workspaceRoot?: string;
+  readonly generatedImagesRoots?: ReadonlyArray<string>;
   readonly projectFaviconPath?: string;
 }) {
   const fileSystem = yield* FileSystem.FileSystem;
@@ -201,6 +245,17 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
       const resolved = yield* workspacePaths
         .resolveRelativePathWithinRoot({ workspaceRoot, relativePath })
         .pipe(
+          Effect.map((value) => ({ _tag: "inside" as const, value })),
+          Effect.catchTags({
+            WorkspacePathOutsideRootError: (cause) =>
+              Effect.succeed({ _tag: "outside" as const, cause }),
+          }),
+        );
+      if (resolved._tag === "outside") {
+        const hostImage = yield* resolveCanonicalHostGeneratedImage(
+          input.resource.path,
+          input.generatedImagesRoots ?? [],
+        ).pipe(
           Effect.mapError(
             (cause) =>
               new AssetWorkspacePathValidationError({
@@ -209,14 +264,30 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
               }),
           ),
         );
-      if (!isWorkspacePreviewEntryPath(resolved.relativePath)) {
+        if (!hostImage) {
+          return yield* new AssetWorkspacePathValidationError({
+            resource: input.resource,
+            cause: resolved.cause,
+          });
+        }
+        claims = {
+          version: 1,
+          kind: "host-image-exact",
+          absolutePath: hostImage.path,
+          generatedImagesRoot: hostImage.root,
+          expiresAt,
+        };
+        fileName = path.basename(hostImage.path);
+        break;
+      }
+      if (!isWorkspacePreviewEntryPath(resolved.value.relativePath)) {
         return yield* new AssetPreviewTypeValidationError({
           resource: input.resource,
         });
       }
       const canonicalFile = yield* resolveCanonicalWorkspaceFile({
         workspaceRoot,
-        relativePath: resolved.relativePath,
+        relativePath: resolved.value.relativePath,
       }).pipe(
         Effect.mapError(
           (cause) =>
@@ -240,22 +311,22 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
             }),
         ),
       );
-      claims = isWorkspaceImagePreviewPath(resolved.relativePath)
+      claims = isWorkspaceImagePreviewPath(resolved.value.relativePath)
         ? {
             version: 1,
             kind: "workspace-file-exact",
             workspaceRoot: canonicalWorkspaceRoot,
-            relativePath: resolved.relativePath,
+            relativePath: resolved.value.relativePath,
             expiresAt,
           }
         : {
             version: 1,
             kind: "workspace-file",
             workspaceRoot: canonicalWorkspaceRoot,
-            baseRelativePath: path.dirname(resolved.relativePath),
+            baseRelativePath: path.dirname(resolved.value.relativePath),
             expiresAt,
           };
-      fileName = path.basename(resolved.relativePath);
+      fileName = path.basename(resolved.value.relativePath);
       break;
     }
     case "attachment": {
@@ -444,6 +515,14 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
   const decodedPath = decodeRelativePath(relativePath);
   if (decodedPath === null) return null;
   const path = yield* Path.Path;
+  if (claims.kind === "host-image-exact") {
+    if (decodedPath !== path.basename(claims.absolutePath)) return null;
+    const hostImage = yield* resolveCanonicalHostGeneratedImageForRequest(
+      claims.absolutePath,
+      claims.generatedImagesRoot,
+    );
+    return hostImage ? ({ kind: "file", path: hostImage.path } satisfies ResolvedAsset) : null;
+  }
   if (claims.kind === "workspace-file-exact") {
     if (decodedPath !== path.basename(claims.relativePath)) return null;
     const exactWorkspaceFile = yield* resolveCanonicalWorkspaceFileForRequest({

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -173,27 +173,27 @@ const resolveCanonicalWorkspaceFileForRequest = (input: {
     Effect.orElseSucceed(() => null),
   );
 
-const resolveCanonicalHostGeneratedImage = Effect.fn("AssetAccess.resolveCanonicalHostGeneratedImage")(
-  function* (absolutePath: string, generatedImagesRoots: ReadonlyArray<string>) {
-    const path = yield* Path.Path;
-    if (!path.isAbsolute(absolutePath) || !isWorkspaceImagePreviewPath(absolutePath)) return null;
-    const fileSystem = yield* FileSystem.FileSystem;
-    const canonicalFile = yield* optionOnNotFound(fileSystem.realPath(absolutePath));
-    if (Option.isNone(canonicalFile) || !path.isAbsolute(canonicalFile.value)) return null;
-    const info = yield* optionOnNotFound(fileSystem.stat(canonicalFile.value));
-    if (Option.isNone(info) || info.value.type !== "File") return null;
+const resolveCanonicalHostGeneratedImage = Effect.fn(
+  "AssetAccess.resolveCanonicalHostGeneratedImage",
+)(function* (absolutePath: string, generatedImagesRoots: ReadonlyArray<string>) {
+  const path = yield* Path.Path;
+  if (!path.isAbsolute(absolutePath) || !isWorkspaceImagePreviewPath(absolutePath)) return null;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const canonicalFile = yield* optionOnNotFound(fileSystem.realPath(absolutePath));
+  if (Option.isNone(canonicalFile) || !path.isAbsolute(canonicalFile.value)) return null;
+  const info = yield* optionOnNotFound(fileSystem.stat(canonicalFile.value));
+  if (Option.isNone(info) || info.value.type !== "File") return null;
 
-    for (const root of generatedImagesRoots) {
-      const canonicalRoot = yield* optionOnNotFound(fileSystem.realPath(root));
-      if (Option.isNone(canonicalRoot)) continue;
-      const relative = path.relative(canonicalRoot.value, canonicalFile.value);
-      if (relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)) {
-        return { path: canonicalFile.value, root: canonicalRoot.value };
-      }
+  for (const root of generatedImagesRoots) {
+    const canonicalRoot = yield* optionOnNotFound(fileSystem.realPath(root));
+    if (Option.isNone(canonicalRoot)) continue;
+    const relative = path.relative(canonicalRoot.value, canonicalFile.value);
+    if (relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+      return { path: canonicalFile.value, root: canonicalRoot.value };
     }
-    return null;
-  },
-);
+  }
+  return null;
+});
 
 const resolveCanonicalHostGeneratedImageForRequest = (
   absolutePath: string,
@@ -258,7 +258,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         ).pipe(
           Effect.mapError(
             (cause) =>
-              new AssetWorkspacePathValidationError({
+              new AssetWorkspaceAssetInspectionError({
                 resource: input.resource,
                 cause,
               }),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -209,6 +209,12 @@ function truncateDetail(value: string, limit = 180): string {
   return value.length > limit ? `${value.slice(0, limit - 3)}...` : value;
 }
 
+function toolLifecycleDetail(itemType: string, detail: string | undefined): string | undefined {
+  if (!detail) return undefined;
+  // Image paths must stay intact so clients can issue asset URLs.
+  return itemType === "image_view" ? detail : truncateDetail(detail);
+}
+
 function normalizeProposedPlanMarkdown(planMarkdown: string | undefined): string | undefined {
   const trimmed = planMarkdown?.trim();
   if (!trimmed) {
@@ -795,7 +801,9 @@ export function runtimeEventToActivities(
           payload: {
             itemType: event.payload.itemType,
             ...(event.payload.status ? { status: event.payload.status } : {}),
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.detail
+              ? { detail: toolLifecycleDetail(event.payload.itemType, event.payload.detail) }
+              : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId
@@ -821,7 +829,9 @@ export function runtimeEventToActivities(
           summary: event.payload.title ?? "Tool",
           payload: {
             itemType: event.payload.itemType,
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.detail
+              ? { detail: toolLifecycleDetail(event.payload.itemType, event.payload.detail) }
+              : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId
@@ -847,7 +857,9 @@ export function runtimeEventToActivities(
           summary: `${event.payload.title ?? "Tool"} started`,
           payload: {
             itemType: event.payload.itemType,
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.detail
+              ? { detail: toolLifecycleDetail(event.payload.itemType, event.payload.detail) }
+              : {}),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId
               ? { parentToolUseId: event.payload.parentToolUseId }

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -613,6 +613,84 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("maps completed image generation items to generated-image work entries", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+      const savedPath = "/home/sambhav/.codex/generated_images/hero.png";
+
+      yield* runtime.emit({
+        id: asEventId("evt-image-gen-complete"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "item/completed",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        itemId: asItemId("img_1"),
+        payload: {
+          completedAtMs: 1_778_000_000_000,
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "imageGeneration",
+            id: "img_1",
+            result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+            revisedPrompt: "a ceramic mug",
+            savedPath,
+            status: "completed",
+          },
+        },
+      });
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some" || firstEvent.value.type !== "item.completed") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.payload.itemType, "image_view");
+      NodeAssert.equal(firstEvent.value.payload.title, "Generated image");
+      NodeAssert.equal(firstEvent.value.payload.detail, savedPath);
+    }),
+  );
+
+  it.effect("maps completed image view items to image-view work entries", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      yield* runtime.emit({
+        id: asEventId("evt-image-view-complete"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "item/completed",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        itemId: asItemId("img_view_1"),
+        payload: {
+          completedAtMs: 1_778_000_000_000,
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "imageView",
+            id: "img_view_1",
+            path: "/Users/sambhav/project/assets/icon.png",
+          },
+        },
+      });
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some" || firstEvent.value.type !== "item.completed") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.payload.itemType, "image_view");
+      NodeAssert.equal(firstEvent.value.payload.title, "Image view");
+      NodeAssert.equal(firstEvent.value.payload.detail, "/Users/sambhav/project/assets/icon.png");
+    }),
+  );
+
   it.effect("maps completed plan items to canonical proposed-plan completion events", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -262,7 +262,7 @@ function itemTitle(itemType: CanonicalItemType, item?: CodexLifecycleItem): stri
     case "web_search":
       return "Web search";
     case "image_view":
-      return "Image view";
+      return item?.type === "imageGeneration" ? "Generated image" : "Image view";
     case "error":
       return "Error";
     default:
@@ -270,7 +270,34 @@ function itemTitle(itemType: CanonicalItemType, item?: CodexLifecycleItem): stri
   }
 }
 
+const IMAGE_GENERATION_RESULT_PATH_MAX_CHARS = 1024;
+
+function imageGenerationResultPath(result: string | undefined): string | undefined {
+  const trimmed = trimText(result);
+  if (!trimmed || trimmed.length > IMAGE_GENERATION_RESULT_PATH_MAX_CHARS) {
+    return undefined;
+  }
+  if (trimmed.includes("\n") || /\s/.test(trimmed)) {
+    return undefined;
+  }
+  if (trimmed.includes("/") || trimmed.includes("\\")) {
+    return trimmed;
+  }
+  return undefined;
+}
+
 function itemDetail(itemType: CanonicalItemType, item: CodexLifecycleItem): string | undefined {
+  if (item.type === "imageGeneration") {
+    return (
+      trimText(item.savedPath ?? undefined) ??
+      imageGenerationResultPath(item.result) ??
+      trimText(item.revisedPrompt ?? undefined)
+    );
+  }
+  if (item.type === "imageView") {
+    return trimText(item.path);
+  }
+
   const itemRecord = item as Record<string, unknown>;
   const action = itemRecord.action as Record<string, unknown> | undefined;
   const actionQueries = Array.isArray(action?.queries) ? action.queries : [];

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -5,6 +5,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -48,7 +49,9 @@ import {
   FilesystemBrowseError,
   AssetWorkspaceContextNotFoundError,
   AssetWorkspaceContextResolutionError,
+  CodexSettings,
   RpcClientId,
+  type ServerSettings as ServerSettingsValue,
   EnvironmentAuthorizationError,
   ThreadId,
   type TerminalAttachStreamEvent,
@@ -79,6 +82,8 @@ import {
   observeRpcStreamEffect as instrumentRpcStreamEffect,
 } from "./observability/RpcInstrumentation.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
+import { mergeProviderInstanceEnvironment } from "./provider/ProviderInstanceEnvironment.ts";
+import { resolveCodexHomeLayout } from "./provider/Drivers/CodexHomeLayout.ts";
 import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner.ts";
 import * as ServerSelfUpdate from "./cloud/selfUpdate.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
@@ -107,6 +112,7 @@ import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts
 import * as ResourceTelemetry from "./resourceTelemetry/ResourceTelemetry.ts";
 import * as UsageService from "./usage/UsageService.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
+import { expandHomePath } from "./pathExpansion.ts";
 import * as PullRequestService from "./pullRequest/PullRequestService.ts";
 import * as SourceControlDiscovery from "./sourceControl/SourceControlDiscovery.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
@@ -127,6 +133,33 @@ const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchComma
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const EDITOR_DISCOVERY_TIMEOUT = Duration.seconds(5);
+const decodeCodexSettings = Schema.decodeUnknownOption(CodexSettings);
+
+const resolveCodexGeneratedImagesRoots = Effect.fn("resolveCodexGeneratedImagesRoots")(
+  function* (settings: ServerSettingsValue) {
+    const path = yield* Path.Path;
+    const roots: string[] = [];
+    const instances = Object.values(settings.providerInstances)
+      .filter((instance) => instance.driver === "codex")
+      .map((instance) => ({ config: instance.config, environment: instance.environment }));
+    const defaultInstance = settings.providerInstances.codex;
+    if (!defaultInstance) {
+      instances.push({ config: settings.providers.codex, environment: undefined });
+    }
+    for (const instance of instances) {
+      const config = Option.getOrNull(decodeCodexSettings(instance.config ?? {}));
+      if (!config) continue;
+      const layout = yield* resolveCodexHomeLayout(config);
+      const environmentHome = mergeProviderInstanceEnvironment(instance.environment).CODEX_HOME;
+      const home =
+        layout.effectiveHomePath ??
+        (environmentHome?.trim() ? path.resolve(expandHomePath(environmentHome)) : null) ??
+        layout.sharedHomePath;
+      roots.push(path.join(home, "generated_images"));
+    }
+    return roots;
+  },
+);
 
 export const resolveAvailableEditorsForConfig = <A, E, R>(
   discovery: Effect.Effect<ReadonlyArray<A>, E, R>,
@@ -1902,9 +1935,17 @@ const makeWsRpcLayer = (
                   resource: input.resource,
                 });
               }
+              const generatedImagesRoots = yield* serverSettings.getSettings.pipe(
+                Effect.flatMap(resolveCodexGeneratedImagesRoots),
+                Effect.tapError((cause) =>
+                  Effect.logError("Failed to resolve Codex generated-image roots.", { cause }),
+                ),
+                Effect.orElseSucceed(() => []),
+              );
               return yield* issueAssetUrl({
                 resource: input.resource,
                 workspaceRoot: thread.value.worktreePath ?? project.value.workspaceRoot,
+                generatedImagesRoots,
               });
             }),
             { "rpc.aggregate": "workspace" },

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -14,6 +14,7 @@ import {
   WrapTextIcon,
 } from "lucide-react";
 import type { ScopedThreadRef, ServerProviderSkill } from "@t3tools/contracts";
+import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -44,6 +45,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { remarkGithubAlerts } from "../markdown-github-alerts";
+import { ChatRemoteImage, ChatWorkspaceImage } from "./chat/ChatWorkspaceImage";
 import { renderSkillInlineMarkdownChildren } from "./chat/SkillInlineText";
 import { CHAT_FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
@@ -157,6 +159,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   protocols: {
     ...defaultSchema.protocols,
     href: [...(defaultSchema.protocols?.href ?? []), "file"],
+    src: [...(defaultSchema.protocols?.src ?? []), "file"],
   },
 } satisfies Parameters<typeof rehypeSanitize>[0];
 
@@ -1541,6 +1544,30 @@ function ChatMarkdown({
             }}
           />
         );
+      },
+      img({ src, alt }) {
+        const fileLinkMeta = src ? resolveMarkdownFileLinkMeta(src, cwd) : null;
+        if (
+          fileLinkMeta &&
+          isWorkspaceImagePreviewPath(fileLinkMeta.filePath) &&
+          threadRef
+        ) {
+          return (
+            <ChatWorkspaceImage
+              environmentId={threadRef.environmentId}
+              threadRef={threadRef}
+              path={fileLinkMeta.filePath}
+              alt={alt ?? fileLinkMeta.basename}
+            />
+          );
+        }
+        if (src && /^https?:\/\//i.test(src)) {
+          return <ChatRemoteImage src={src} alt={alt ?? ""} />;
+        }
+        if (fileLinkMeta) {
+          return fileLinkChip(fileLinkMeta, `![${alt ?? fileLinkMeta.basename}](${src})`);
+        }
+        return src ? <img src={src} alt={alt ?? ""} /> : null;
       },
       a({ node, href, children, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";

--- a/apps/web/src/components/chat/ChatWorkspaceImage.tsx
+++ b/apps/web/src/components/chat/ChatWorkspaceImage.tsx
@@ -1,0 +1,118 @@
+import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
+import { LoaderCircle } from "lucide-react";
+import { useState } from "react";
+
+import { useAssetUrlState } from "~/assets/assetUrls";
+import { cn } from "~/lib/utils";
+
+import { ExpandedImageDialog } from "./ExpandedImageDialog";
+
+export function ChatRemoteImage(props: {
+  readonly src: string;
+  readonly alt: string;
+  readonly className?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const name = props.alt.trim().length > 0 ? props.alt : "Image";
+
+  if (failed) {
+    return (
+      <div className="my-2 rounded-lg border border-border/80 bg-background/70 px-3 py-2 text-secondary-label text-xs">
+        Unable to load image{props.alt ? ` “${props.alt}”` : ""}.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={cn(
+          "my-2 block max-w-full cursor-zoom-in overflow-hidden rounded-lg border border-border/80 bg-background/70",
+          props.className,
+        )}
+        aria-label={`Preview ${name}`}
+        onClick={() => setExpanded(true)}
+      >
+        <img
+          src={props.src}
+          alt={name}
+          className="block h-auto max-h-[360px] max-w-full object-contain"
+          onError={() => setFailed(true)}
+        />
+      </button>
+      {expanded ? (
+        <ExpandedImageDialog
+          preview={{ images: [{ src: props.src, name }], index: 0 }}
+          onClose={() => setExpanded(false)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export function ChatWorkspaceImage(props: {
+  readonly environmentId: EnvironmentId;
+  readonly threadRef: ScopedThreadRef;
+  readonly path: string;
+  readonly alt: string;
+  readonly className?: string;
+}) {
+  const assetUrl = useAssetUrlState(props.environmentId, {
+    _tag: "workspace-file",
+    threadId: props.threadRef.threadId,
+    path: props.path,
+  });
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const name = props.alt.trim().length > 0 ? props.alt : fileNameFromPath(props.path);
+
+  if (assetUrl._tag === "Failure" || (assetUrl._tag === "Success" && failedUrl === assetUrl.url)) {
+    return (
+      <div className="my-2 rounded-lg border border-border/80 bg-background/70 px-3 py-2 text-secondary-label text-xs">
+        Unable to load image{name ? ` “${name}”` : ""}.
+      </div>
+    );
+  }
+
+  if (assetUrl._tag !== "Success") {
+    return (
+      <div className="my-2 flex min-h-[120px] items-center justify-center rounded-lg border border-border/80 bg-background/70 text-muted-foreground">
+        <LoaderCircle className="size-4 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={cn(
+          "my-2 block max-w-full cursor-zoom-in overflow-hidden rounded-lg border border-border/80 bg-background/70",
+          props.className,
+        )}
+        aria-label={`Preview ${name}`}
+        onClick={() => setExpanded(true)}
+      >
+        <img
+          src={assetUrl.url}
+          alt={name}
+          className="block h-auto max-h-[360px] max-w-full object-contain"
+          onError={() => setFailedUrl(assetUrl.url)}
+        />
+      </button>
+      {expanded ? (
+        <ExpandedImageDialog
+          preview={{ images: [{ src: assetUrl.url, name }], index: 0 }}
+          onClose={() => setExpanded(false)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function fileNameFromPath(path: string): string {
+  const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
+}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -15,6 +15,7 @@ import {
 const EMPTY_AGENT_PANEL_MODEL = emptyAgentPanelModel();
 const NOOP_OPEN_AGENTS = () => {};
 import { resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
+import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
 import {
   createContext,
   Fragment,
@@ -45,6 +46,7 @@ import {
   resolveFileDiffPath,
 } from "../../lib/diffRendering";
 import ChatMarkdown from "../ChatMarkdown";
+import { ChatWorkspaceImage } from "./ChatWorkspaceImage";
 import {
   BotIcon,
   CheckIcon,
@@ -114,6 +116,7 @@ import {
 } from "./userMessageTerminalContexts";
 import { SkillInlineText } from "./SkillInlineText";
 import { formatWorkspaceRelativePath } from "../../filePathDisplay";
+import { resolveMarkdownFileLinkMeta } from "../../markdown-links";
 import {
   buildReviewCommentRenderablePatch,
   formatReviewCommentFence,
@@ -1947,6 +1950,7 @@ type WorkEntryIconName =
   | "globe"
   | "hammer"
   | "message-circle"
+  | "paintbrush"
   | "square-pen"
   | "terminal"
   | "wrench"
@@ -1969,6 +1973,8 @@ function WorkEntryIconSvg({ name, className }: { name: WorkEntryIconName; classN
       return <HammerIcon className={className} aria-hidden />;
     case "message-circle":
       return <MessageCircleIcon className={className} aria-hidden />;
+    case "paintbrush":
+      return <PaintbrushIcon className={className} aria-hidden />;
     case "square-pen":
       return <SquarePenIcon className={className} aria-hidden />;
     case "terminal":
@@ -2008,6 +2014,23 @@ function workToneIcon(tone: TimelineWorkEntry["tone"]): {
     iconName: "zap",
     className: "text-foreground",
   };
+}
+
+function workEntryLooksLikeGeneratedImage(workEntry: Pick<TimelineWorkEntry, "toolTitle" | "label">) {
+  const title = `${workEntry.toolTitle ?? ""} ${workEntry.label}`.toLowerCase();
+  return title.includes("generated image");
+}
+
+function workEntryImagePath(
+  workEntry: Pick<TimelineWorkEntry, "itemType" | "detail">,
+  workspaceRoot: string | undefined,
+): string | null {
+  if (workEntry.itemType !== "image_view") return null;
+  const candidate = workEntry.detail?.trim();
+  if (!candidate) return null;
+  const meta = resolveMarkdownFileLinkMeta(candidate, workspaceRoot);
+  if (!meta || !isWorkspaceImagePreviewPath(meta.filePath)) return null;
+  return meta.filePath;
 }
 
 function workEntryPreview(
@@ -2081,7 +2104,9 @@ function workEntryIconName(workEntry: TimelineWorkEntry): WorkEntryIconName {
     return "square-pen";
   }
   if (workEntry.itemType === "web_search") return "globe";
-  if (workEntry.itemType === "image_view") return "eye";
+  if (workEntry.itemType === "image_view") {
+    return workEntryLooksLikeGeneratedImage(workEntry) ? "paintbrush" : "eye";
+  }
 
   switch (workEntry.itemType) {
     case "mcp_tool_call":
@@ -2228,7 +2253,9 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   workspaceRoot: string | undefined;
 }) {
   const { workEntry, workspaceRoot } = props;
+  const { threadRef } = use(TimelineRowCtx);
   const activity = use(TimelineRowActivityCtx);
+  const imagePath = workEntryImagePath(workEntry, workspaceRoot);
   const [expanded, setExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
@@ -2367,6 +2394,16 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           </div>
         </div>
       </div>
+      {imagePath && threadRef ? (
+        <div className="ms-7 mt-1" onClick={stopRowToggle} onPointerDown={stopRowToggle}>
+          <ChatWorkspaceImage
+            environmentId={threadRef.environmentId}
+            threadRef={threadRef}
+            path={imagePath}
+            alt={workEntry.detail ?? "Generated image"}
+          />
+        </div>
+      ) : null}
       {expanded && canExpand && expandedBody ? (
         <div
           className="mt-1 ms-7 cursor-default border-s border-border/45 ps-3 pt-0.5"

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1245,6 +1245,38 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("prefers Codex image generation savedPath over truncated tool detail", () => {
+    const savedPath = "/home/sambhav/.codex/generated_images/a-very-long-hero-image-name.png";
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "image-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Generated image",
+        payload: {
+          itemType: "image_view",
+          title: "Generated image",
+          detail: `${savedPath.slice(0, 20)}...`,
+          data: {
+            item: {
+              type: "imageGeneration",
+              savedPath,
+              status: "completed",
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities);
+    expect(entry).toMatchObject({
+      id: "image-complete",
+      toolTitle: "Generated image",
+      detail: savedPath,
+      itemType: "image_view",
+    });
+  });
+
   it("uses completed read-file output previews and still collapses the same tool call", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -847,7 +847,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   };
   const itemType = extractWorkLogItemType(payload);
   const requestKind = extractWorkLogRequestKind(payload);
-  if (detail) {
+  const imagePath = itemType === "image_view" ? extractImageViewPath(payload) : null;
+  if (imagePath) {
+    entry.detail = imagePath;
+  } else if (detail) {
     entry.detail = detail;
   }
   if (commandPreview.command) {
@@ -1441,6 +1444,17 @@ function stripTrailingExitCode(value: string): {
     output: normalizedOutput.length > 0 ? normalizedOutput : null,
     ...(Number.isInteger(exitCode) ? { exitCode } : {}),
   };
+}
+
+function extractImageViewPath(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  for (const candidate of [item?.savedPath, item?.path, payload?.detail]) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return null;
 }
 
 function extractWorkLogItemType(


### PR DESCRIPTION
## What Changed

Codex imagegen already writes a file and emits `savedPath`. T3 dropped that path, labeled the row **Image view**, and only served workspace files, so generated images never showed in chat.

- Keep `savedPath` on the Codex item and label it **Generated image**
- Serve `$CODEX_HOME/generated_images` through signed asset URLs (not the base64 `result` over the websocket)
- Render the file inline in web and mobile chat (markdown `![]()` and the work row)

## Why

The file is already on disk and the protocol already names it. Chat should show the picture, including remote clients.

## UI Changes

- Before: work row is a generic **Image view** / file path; markdown `![]()` does not load
- After: the generated file renders inline in the thread and can be expanded

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds host-path asset access outside the workspace with root allowlisting—security-sensitive but scoped to Codex `generated_images` and exact basename tokens; broad touch across server assets, ingestion, and both clients.
> 
> **Overview**
> **Codex-generated images now render inline** in web and mobile chat (markdown images and work-log rows) instead of showing only a path or a generic “Image view” label.
> 
> On the **server**, Codex `imageGeneration` / `imageView` items keep full `savedPath` (no truncation for `image_view`), map to **Generated image** where appropriate, and workspace asset URLs can fall back to **`host-image-exact`** tokens for files under configured Codex `generated_images` roots when the path is outside the project workspace. WebSocket asset issuance passes those roots from server settings.
> 
> **Clients** add custom markdown image rendering (`renderImage` on native markdown; `ChatWorkspaceImage` / `MarkdownWorkspaceImage`) with signed workspace URLs, loading/error UI, and tap-to-preview. Work-log activities expose `imagePath` from lifecycle payloads for inline previews. Mobile asset hooks gain `useAssetUrlState` for non-binary loading/failure handling; list sizing skips fixed height when a row has an image preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1816fc23639c4e9086c7c2e1d2d45730b2a0e29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show Codex-generated images inline in chat threads on web and mobile
> - Adds end-to-end support for rendering `image_view` work log entries as inline image previews in both the web `MessagesTimeline` and mobile `ThreadFeed`, with click-to-expand dialogs and loading/failure states.
> - Introduces a new `host-image-exact` asset claim in [`AssetAccess.ts`](https://github.com/pingdotgg/t3code/pull/6441/files#diff-7106051c89d4fb8e7cebeee854e81bb55fdf03ec154089eb8c7499ef78ae51c1) so the server can securely serve generated images that live outside the workspace root, validated against configured `generatedImagesRoots`.
> - Extends [`CodexAdapter.ts`](https://github.com/pingdotgg/t3code/pull/6441/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) to populate `detail` on `imageGeneration`/`imageView` items with the saved file path, and preserves full (untruncated) paths through the ingestion pipeline for `image_view` events.
> - Adds a `renderImage` prop to `NativeMarkdownBlock` and `SelectableMarkdownText` so custom image renderers can be injected into the markdown tree on mobile.
> - Risk: `image_view` detail strings are no longer truncated anywhere in the pipeline; very long paths are passed through as-is.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1816fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->