### PR TITLE
fix(web): prevent multi-select questions from auto-advancing

### DIFF
--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -1,5 +1,5 @@
 import { type ApprovalRequestId } from "@t3tools/contracts";
-import { memo, useEffect, useEffectEvent, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { type PendingUserInput } from "../../session-logic";
 import {
   derivePendingUserInputProgress,
@@ -70,6 +70,13 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
     onAdvanceRef.current = onAdvance;
   }, [onAdvance]);
 
+  const clearAutoAdvanceTimer = useCallback(() => {
+    if (autoAdvanceTimerRef.current !== null) {
+      window.clearTimeout(autoAdvanceTimerRef.current);
+      autoAdvanceTimerRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     if (!activeQuestion || activeQuestion.multiSelect || !optimisticSingleSelect) {
       return;
@@ -91,30 +98,28 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
     progress.selectedOptionLabels,
   ]);
 
-  // Clear auto-advance timer on unmount
+  // A scheduled single-select advance only belongs to the question that created it.
   useEffect(() => {
-    return () => {
-      if (autoAdvanceTimerRef.current !== null) {
-        window.clearTimeout(autoAdvanceTimerRef.current);
-      }
-    };
-  }, []);
+    return clearAutoAdvanceTimer;
+  }, [activeQuestion?.id, clearAutoAdvanceTimer]);
 
-  const handleOptionSelection = useEffectEvent((questionId: string, optionLabel: string) => {
-    if (activeQuestion?.multiSelect) {
+  const handleOptionSelection = useCallback(
+    (questionId: string, optionLabel: string, multiSelect: boolean | undefined) => {
+      if (multiSelect) {
+        clearAutoAdvanceTimer();
+        onToggleOption(questionId, optionLabel);
+        return;
+      }
+      setOptimisticSingleSelect({ questionId, optionLabel });
       onToggleOption(questionId, optionLabel);
-      return;
-    }
-    setOptimisticSingleSelect({ questionId, optionLabel });
-    onToggleOption(questionId, optionLabel);
-    if (autoAdvanceTimerRef.current !== null) {
-      window.clearTimeout(autoAdvanceTimerRef.current);
-    }
-    autoAdvanceTimerRef.current = window.setTimeout(() => {
-      autoAdvanceTimerRef.current = null;
-      onAdvanceRef.current();
-    }, 200);
-  });
+      clearAutoAdvanceTimer();
+      autoAdvanceTimerRef.current = window.setTimeout(() => {
+        autoAdvanceTimerRef.current = null;
+        onAdvanceRef.current();
+      }, 200);
+    },
+    [clearAutoAdvanceTimer, onToggleOption],
+  );
 
   // Keyboard shortcut: number keys 1-9 select corresponding options when focus is
   // outside editable fields. Multi-select prompts toggle options in place; single-
@@ -140,11 +145,11 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
       const option = activeQuestion.options[optionIndex];
       if (!option) return;
       event.preventDefault();
-      handleOptionSelection(activeQuestion.id, option.label);
+      handleOptionSelection(activeQuestion.id, option.label, activeQuestion.multiSelect);
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [activeQuestion, isResponding]);
+  }, [activeQuestion, handleOptionSelection, isResponding]);
 
   if (!activeQuestion) {
     return null;
@@ -213,7 +218,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
               type="button"
               disabled={isResponding}
               onClick={() => {
-                handleOptionSelection(activeQuestion.id, option.label);
+                handleOptionSelection(activeQuestion.id, option.label, activeQuestion.multiSelect);
               }}
               className={className}
             >


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Replaced the pending-question option handler’s `useEffectEvent` with `useCallback`.
- Pass the rendered question’s `multiSelect` value directly to the handler.
- Cancel pending single-select auto-advance timers when the active question changes or a multi-select option is chosen.
- Restored the option handler as a dependency of the keyboard shortcut effect.

## Why

Multi-select questions could incorrectly auto-advance after selecting an option. This was reproducible with the sequence `[single] [multi] [multi]`, including after navigating back to the first multi-select question.

The option handler was using `useEffectEvent` as a click handler, which is outside its intended use and could evaluate the selection using stale question state. Passing the current question type explicitly makes the behavior deterministic. Timer cleanup also ensures that a delayed advance belongs only to the single-select question that scheduled it.

## UI Changes

No visual styling changes.

Before: selecting an option on a multi-select question could move immediately to the next question.

https://github.com/user-attachments/assets/54d32fce-9164-487b-8943-76b658afbdf7

After: multi-select options toggle in place. Only single-select questions auto-advance.

https://github.com/user-attachments/assets/0bfb7a56-d15b-4f91-bbcc-0543f3235356

## Testing

- Verified with a Claude Sonnet questionnaire containing `[single] [multi] [multi]`.
- Verified mouse and number-key selection.
- Verified navigating back from the third question and selecting another option on the second question.
- 82 focused tests passed.
- Web typecheck, lint, formatting, and diff checks passed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No screenshots required; there are no visual changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized composer interaction fix with no API or security impact; behavior change is limited to pending user-input option selection.
> 
> **Overview**
> Fixes **multi-select** pending-user-input questions incorrectly **auto-advancing** to the next question after an option click or number-key shortcut (including when navigating back through a mixed single/multi questionnaire).
> 
> Option handling now uses **`useCallback`** instead of **`useEffectEvent`**, and callers pass the current question’s **`multiSelect`** flag so single-select vs multi-select behavior is explicit. **Multi-select** paths only toggle options and **clear** any pending advance timer; **single-select** still schedules the 200ms auto-advance. Timer cleanup runs when the **active question id** changes (not only on unmount), so a delayed advance cannot fire on the wrong question.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d100f1b8e34550c88f9206c996c626eb5ae77698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent multi-select questions from auto-advancing in `ComposerPendingUserInputCard`
> - Multi-select option toggles now cancel any pending auto-advance timer instead of triggering one, so users can select multiple options without the question advancing prematurely.
> - Single-select behavior is unchanged: selecting an option still auto-advances after ~200ms.
> - Auto-advance timers are also cleared when the active question changes or the component unmounts, preventing stale timers from firing across questions.
> - Replaces `useEffectEvent` with `useCallback` in [ComposerPendingUserInputPanel.tsx](https://github.com/pingdotgg/t3code/pull/6443/files#diff-4d79f14a0bb3d90ecac6af885c54e9a485bcd9510c4a339f6bfdbcde568a0b0e) to support passing the `multiSelect` flag into the option selection handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d100f1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->