### PR TITLE
refactor(web): collapse the sidebar header into one row

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -41,14 +41,11 @@ import {
   CircleDashedIcon,
   ClockIcon,
   FolderIcon,
-  FolderPlusIcon,
   GitBranchIcon,
   MessageSquareIcon,
   PinIcon,
   PlusIcon,
-  SearchIcon,
   ServerIcon,
-  SettingsIcon,
   SquarePenIcon,
   TerminalIcon,
   Undo2Icon,
@@ -163,9 +160,9 @@ import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
-import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
+import { SidebarThreadHeader } from "./sidebar/SidebarThreadHeader";
 import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
 import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import {
@@ -3236,193 +3233,31 @@ export default function Sidebar() {
           // Lifted above the stage backdrop, whose fade bleeds below the
           // header and would otherwise paint across the search row's outline.
           <SidebarGroup className="relative z-[1] gap-1 p-[var(--sidebar-content-inset)]">
-            <div className="flex items-center gap-1">
-              <div className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground">
-                <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
-                <Input
-                  ref={threadSearchInputRef}
-                  nativeInput
-                  unstyled
-                  type="search"
-                  value={threadSearchQuery}
-                  onChange={(event) => {
-                    setThreadSearchQuery(event.currentTarget.value);
-                    setActiveSearchResultIndex(0);
-                  }}
-                  onKeyDown={handleThreadSearchKeyDown}
-                  placeholder="Search"
-                  aria-label="Search threads"
-                  role="combobox"
-                  aria-autocomplete="list"
-                  aria-expanded={isSearchingThreads && threadSearchResults.length > 0}
-                  aria-controls={
-                    isSearchingThreads && threadSearchResults.length > 0
-                      ? "sidebar-thread-search-results"
-                      : undefined
-                  }
-                  aria-activedescendant={
-                    isSearchingThreads && threadSearchResults[activeSearchResultIndex]
-                      ? `sidebar-thread-search-result-${activeSearchResultIndex}`
-                      : undefined
-                  }
-                  className="min-w-0 flex-1 [&_[data-slot=input]]:h-auto [&_[data-slot=input]]:p-0 [&_[data-slot=input]]:leading-normal [&_[data-slot=input]]:text-sm [&_[data-slot=input]]:font-medium [&_[data-slot=input]]:text-sidebar-foreground [&_[data-slot=input]]:placeholder:text-sidebar-muted-foreground"
-                />
-                {isSearchingThreads ? (
-                  <Button
-                    type="button"
-                    size="icon-xs"
-                    variant="ghost"
-                    className="size-5 shrink-0 rounded-sm text-sidebar-muted-foreground hover:bg-sidebar-control-surface hover:text-sidebar-foreground"
-                    aria-label="Clear thread search"
-                    onClick={() => {
-                      clearThreadSearch();
-                      threadSearchInputRef.current?.focus();
-                    }}
-                  >
-                    <XIcon className="size-3" />
-                  </Button>
-                ) : null}
-              </div>
-              <div className="shrink-0">
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <SidebarMenuButton
-                        size="icon"
-                        type="button"
-                        className="relative focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
-                        onClick={handleNewThreadClick}
-                        disabled={projects.length === 0}
-                        aria-label="New thread"
-                      />
-                    }
-                  >
-                    <SquarePenIcon />
-                    <span
-                      className="pointer-events-none absolute left-1/2 top-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-                      aria-hidden="true"
-                    />
-                  </TooltipTrigger>
-                  <TooltipPopup side="right">
-                    {projectGroups.length > 1 ? (
-                      <span className="flex flex-col gap-0.5">
-                        <span>
-                          {newThreadShortcutLabel
-                            ? `New thread (${newThreadShortcutLabel})`
-                            : "New thread"}
-                        </span>
-                        <span className="text-muted-foreground">
-                          New thread in current project: Shift+click
-                          {newThreadInProjectShortcutLabel
-                            ? ` (${newThreadInProjectShortcutLabel})`
-                            : ""}
-                        </span>
-                      </span>
-                    ) : newThreadShortcutLabel ? (
-                      `New thread (${newThreadShortcutLabel})`
-                    ) : (
-                      "New thread"
-                    )}
-                  </TooltipPopup>
-                </Tooltip>
-              </div>
-            </div>
             {projectGroups.length > 0 ? (
-              <div className="flex items-center gap-1">
-                <Menu open={projectScopeMenuOpen} onOpenChange={setProjectScopeMenuOpen}>
-                  <MenuTrigger
-                    render={
-                      <SidebarMenuButton
-                        aria-label="Filter threads by project"
-                        className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
-                      />
-                    }
-                  >
-                    {scopedProjectGroup ? (
-                      <ProjectFavicon
-                        environmentId={scopedProjectGroup.environmentId}
-                        cwd={scopedProjectGroup.workspaceRoot}
-                        faviconPath={scopedProjectGroup.faviconPath}
-                        className="size-4 shrink-0"
-                      />
-                    ) : (
-                      <FolderIcon className="size-4 shrink-0" />
-                    )}
-                    <span className="min-w-0 flex-1 truncate">
-                      {scopedProjectGroup?.displayName ?? "All projects"}
-                    </span>
-                    <ChevronDownIcon className="-mr-px size-4 shrink-0" />
-                  </MenuTrigger>
-                  <MenuPopup align="start" className="w-(--anchor-width)">
-                    <MenuRadioGroup
-                      value={projectScopeKey ?? "all"}
-                      onValueChange={(value) =>
-                        setProjectScopeKey(value === "all" ? null : (value as string))
-                      }
-                    >
-                      <MenuRadioItem
-                        value="all"
-                        closeOnClick
-                        className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
-                      >
-                        <FolderIcon className="size-4 shrink-0" />
-                        <span className="min-w-0 truncate text-sm">All projects</span>
-                      </MenuRadioItem>
-                      {projectGroups.map((project) => {
-                        const scopeKey = project.projectKey;
-                        return (
-                          <MenuRadioItem
-                            key={scopeKey}
-                            value={scopeKey}
-                            closeOnClick
-                            className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
-                          >
-                            <ProjectFavicon
-                              environmentId={project.environmentId}
-                              cwd={project.workspaceRoot}
-                              faviconPath={project.faviconPath}
-                              className="size-4 shrink-0"
-                            />
-                            <span className="min-w-0 truncate text-sm">{project.displayName}</span>
-                            <button
-                              type="button"
-                              aria-label={`Project settings for ${project.displayName}`}
-                              title={`Project settings for ${project.displayName}`}
-                              className="ml-auto inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-icon-muted outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-                              onPointerDown={(event) => event.stopPropagation()}
-                              onClick={(event) => {
-                                void handleProjectSettings(event, project);
-                              }}
-                            >
-                              <SettingsIcon className="size-3.5" />
-                            </button>
-                          </MenuRadioItem>
-                        );
-                      })}
-                    </MenuRadioGroup>
-                  </MenuPopup>
-                </Menu>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <SidebarMenuButton
-                        size="icon"
-                        className="relative shrink-0 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
-                        onClick={openAddProjectCommandPalette}
-                        type="button"
-                        aria-label="New project"
-                      />
-                    }
-                  >
-                    <FolderPlusIcon />
-                    <span
-                      className="pointer-events-none absolute left-1/2 top-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-                      aria-hidden="true"
-                    />
-                  </TooltipTrigger>
-                  <TooltipPopup side="right">New project</TooltipPopup>
-                </Tooltip>
-              </div>
+              <SidebarThreadHeader
+                projectGroups={projectGroups}
+                scopedProjectGroup={scopedProjectGroup}
+                projectScopeKey={projectScopeKey}
+                onProjectScopeChange={setProjectScopeKey}
+                projectScopeMenuOpen={projectScopeMenuOpen}
+                onProjectScopeMenuOpenChange={setProjectScopeMenuOpen}
+                onProjectSettings={handleProjectSettings}
+                onNewProject={openAddProjectCommandPalette}
+                onNewThread={handleNewThreadClick}
+                newThreadDisabled={projects.length === 0}
+                newThreadShortcutLabel={newThreadShortcutLabel}
+                searchInputRef={threadSearchInputRef}
+                searchQuery={threadSearchQuery}
+                onSearchQueryChange={(value) => {
+                  setThreadSearchQuery(value);
+                  setActiveSearchResultIndex(0);
+                }}
+                onSearchKeyDown={handleThreadSearchKeyDown}
+                isSearching={isSearchingThreads}
+                hasSearchResults={threadSearchResults.length > 0}
+                activeSearchResultIndex={activeSearchResultIndex}
+                onClearSearch={clearThreadSearch}
+              />
             ) : null}
           </SidebarGroup>
         }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2226,6 +2226,15 @@ export default function Sidebar() {
     setThreadSearchQuery("");
     setActiveSearchResultIndex(0);
   }, []);
+  // The header owns the search field, and it unmounts when the last project
+  // goes away (environment disconnects, project removed). A query left behind
+  // would keep hiding the thread list and the empty state with no way to clear
+  // it, so drop it as the field leaves.
+  useEffect(() => {
+    if (projectGroups.length === 0 && threadSearchQuery.length > 0) {
+      clearThreadSearch();
+    }
+  }, [clearThreadSearch, projectGroups.length, threadSearchQuery]);
   const selectThreadSearchResult = useCallback(
     (thread: EnvironmentThreadShell) => {
       clearThreadSearch();
@@ -3254,7 +3263,7 @@ export default function Sidebar() {
                 }}
                 onSearchKeyDown={handleThreadSearchKeyDown}
                 isSearching={isSearchingThreads}
-                hasSearchResults={threadSearchResults.length > 0}
+                searchResultCount={threadSearchResults.length}
                 activeSearchResultIndex={activeSearchResultIndex}
                 onClearSearch={clearThreadSearch}
               />

--- a/apps/web/src/components/sidebar/SidebarThreadHeader.tsx
+++ b/apps/web/src/components/sidebar/SidebarThreadHeader.tsx
@@ -65,7 +65,7 @@ export interface SidebarThreadHeaderProps {
   onSearchQueryChange: (value: string) => void;
   onSearchKeyDown: (event: ReactKeyboardEvent<HTMLInputElement>) => void;
   isSearching: boolean;
-  hasSearchResults: boolean;
+  searchResultCount: number;
   activeSearchResultIndex: number;
   onClearSearch: () => void;
 }
@@ -200,7 +200,12 @@ export function SidebarThreadHeader(props: SidebarThreadHeaderProps) {
  * down rather than covering it.
  */
 function SearchRow({ props, onClose }: { props: SidebarThreadHeaderProps; onClose: () => void }) {
-  const resultsVisible = props.isSearching && props.hasSearchResults;
+  const resultsVisible = props.isSearching && props.searchResultCount > 0;
+  // Results shrink as the query narrows, so the active index can outrun the
+  // list; pointing aria-activedescendant at a removed option strands the
+  // screen reader on nothing.
+  const activeResultExists =
+    resultsVisible && props.activeSearchResultIndex < props.searchResultCount;
   return (
     <div
       id={SEARCH_ROW_ID}
@@ -217,7 +222,12 @@ function SearchRow({ props, onClose }: { props: SidebarThreadHeaderProps; onClos
         onKeyDown={(event) => {
           // Escape clears first and closes second: one press to drop the query
           // without losing the field, another to leave search entirely.
-          if (event.key === "Escape" && props.searchQuery.length === 0) {
+          if (
+            event.key === "Escape" &&
+            !event.nativeEvent.isComposing &&
+            event.nativeEvent.keyCode !== 229 &&
+            props.searchQuery.trim().length === 0
+          ) {
             event.preventDefault();
             onClose();
             return;
@@ -231,7 +241,7 @@ function SearchRow({ props, onClose }: { props: SidebarThreadHeaderProps; onClos
         aria-expanded={resultsVisible}
         aria-controls={resultsVisible ? "sidebar-thread-search-results" : undefined}
         aria-activedescendant={
-          resultsVisible
+          activeResultExists
             ? `sidebar-thread-search-result-${props.activeSearchResultIndex}`
             : undefined
         }

--- a/apps/web/src/components/sidebar/SidebarThreadHeader.tsx
+++ b/apps/web/src/components/sidebar/SidebarThreadHeader.tsx
@@ -1,0 +1,318 @@
+/**
+ * The sidebar header: one row holding project scope, search and new thread.
+ *
+ * The project selector owns the row's text and spans it; search and new-thread
+ * sit at the end as a segmented icon pair; "New project" lives at the bottom of
+ * the project menu.
+ *
+ * Search is a toggle rather than a mode: it opens a second row beneath the scope
+ * row and pushes the thread list down, so the project you are scoped to stays
+ * visible while you filter inside it. Toggling off clears the query, because a
+ * hidden filter still narrowing the list is invisible state.
+ */
+import {
+  ChevronDownIcon,
+  FolderIcon,
+  FolderPlusIcon,
+  SearchIcon,
+  SettingsIcon,
+  SquarePenIcon,
+  XIcon,
+} from "lucide-react";
+import {
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  type RefObject,
+} from "react";
+
+import type { SidebarProjectSnapshot } from "../../sidebarProjectGrouping";
+import { cn } from "~/lib/utils";
+import { Input } from "../ui/input";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSeparator,
+  MenuTrigger,
+} from "../ui/menu";
+import { SidebarMenuButton } from "../ui/sidebar";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { ProjectFavicon } from "../ProjectFavicon";
+
+export interface SidebarThreadHeaderProps {
+  projectGroups: readonly SidebarProjectSnapshot[];
+  scopedProjectGroup: SidebarProjectSnapshot | null;
+  projectScopeKey: string | null;
+  onProjectScopeChange: (scopeKey: string | null) => void;
+  projectScopeMenuOpen: boolean;
+  onProjectScopeMenuOpenChange: (open: boolean) => void;
+  onProjectSettings: (
+    event: ReactMouseEvent<HTMLButtonElement>,
+    projectGroup: SidebarProjectSnapshot,
+  ) => void;
+  onNewProject: () => void;
+  /** Receives the click so Shift+click can skip the project picker. */
+  onNewThread: (event: ReactMouseEvent) => void;
+  newThreadDisabled: boolean;
+  newThreadShortcutLabel: string | null | undefined;
+  searchInputRef: RefObject<HTMLInputElement | null>;
+  searchQuery: string;
+  onSearchQueryChange: (value: string) => void;
+  onSearchKeyDown: (event: ReactKeyboardEvent<HTMLInputElement>) => void;
+  isSearching: boolean;
+  hasSearchResults: boolean;
+  activeSearchResultIndex: number;
+  onClearSearch: () => void;
+}
+
+const ROW = "flex items-center gap-1";
+
+const SEARCH_ROW_ID = "sidebar-thread-search-row";
+
+const MENU_ITEM =
+  "h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2";
+
+export function SidebarThreadHeader(props: SidebarThreadHeaderProps) {
+  // Search is a toggle, not a mode swap: the field opens as a second row under
+  // the scope row and pushes the thread list down, so the project you are
+  // scoped to never disappears while you search inside it.
+  const [searchOpen, setSearchOpen] = useState(false);
+  // The scope menu is anchored to the whole row rather than to its trigger, so
+  // the popup spans the sidebar's content width and keeps doing so when the
+  // sidebar is resized.
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  // A stray query would keep filtering an invisible list, so closing resets it.
+  const closeSearch = () => {
+    props.onClearSearch();
+    setSearchOpen(false);
+  };
+  const toggleSearch = () => {
+    if (searchOpen) {
+      closeSearch();
+      return;
+    }
+    setSearchOpen(true);
+    window.requestAnimationFrame(() => props.searchInputRef.current?.focus());
+  };
+
+  return (
+    <>
+      <div ref={rowRef} className={ROW}>
+        <Menu open={props.projectScopeMenuOpen} onOpenChange={props.onProjectScopeMenuOpenChange}>
+          <MenuTrigger
+            render={
+              <SidebarMenuButton
+                aria-label="Filter threads by project"
+                className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+              />
+            }
+          >
+            <ScopeIcon group={props.scopedProjectGroup} />
+            <span className="min-w-0 flex-1 truncate">
+              {props.scopedProjectGroup?.displayName ?? "All projects"}
+            </span>
+            <ChevronDownIcon className="-mr-px size-4 shrink-0" />
+          </MenuTrigger>
+          <MenuPopup align="start" anchor={rowRef} className="w-(--anchor-width)">
+            <MenuRadioGroup
+              value={props.projectScopeKey ?? "all"}
+              onValueChange={(value) =>
+                props.onProjectScopeChange(value === "all" ? null : (value as string))
+              }
+            >
+              <MenuRadioItem value="all" closeOnClick className={MENU_ITEM}>
+                <FolderIcon className="size-4 shrink-0" />
+                <span className="min-w-0 flex-1 truncate text-sm">All projects</span>
+              </MenuRadioItem>
+              {props.projectGroups.map((project) => (
+                <MenuRadioItem
+                  key={project.projectKey}
+                  value={project.projectKey}
+                  closeOnClick
+                  className={MENU_ITEM}
+                >
+                  <ProjectFavicon
+                    environmentId={project.environmentId}
+                    cwd={project.workspaceRoot}
+                    faviconPath={project.faviconPath}
+                    className="size-4 shrink-0"
+                  />
+                  <span className="min-w-0 flex-1 truncate text-sm">{project.displayName}</span>
+                  <button
+                    type="button"
+                    aria-label={`Project settings for ${project.displayName}`}
+                    title={`Project settings for ${project.displayName}`}
+                    className="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-icon-muted outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onClick={(event) => props.onProjectSettings(event, project)}
+                  >
+                    <SettingsIcon className="size-3.5" />
+                  </button>
+                </MenuRadioItem>
+              ))}
+            </MenuRadioGroup>
+            <MenuSeparator />
+            <MenuItem className={MENU_ITEM} onClick={props.onNewProject}>
+              <FolderPlusIcon className="size-4 shrink-0" />
+              <span className="min-w-0 truncate text-sm">New project…</span>
+            </MenuItem>
+          </MenuPopup>
+        </Menu>
+        {/* Segmented well: the pair reads as one control instead of two loose
+          buttons competing with the selector beside them. */}
+        <div className="flex shrink-0 items-center rounded-md bg-sidebar-control-surface/60 p-px ring-1 ring-sidebar-border/50">
+          <HeaderIconButton
+            label={searchOpen ? "Hide search" : "Search threads"}
+            className="size-7"
+            isActive={searchOpen}
+            aria-expanded={searchOpen}
+            aria-controls={searchOpen ? SEARCH_ROW_ID : undefined}
+            onClick={toggleSearch}
+          >
+            <SearchIcon />
+          </HeaderIconButton>
+          <HeaderIconButton
+            label={
+              props.newThreadShortcutLabel
+                ? `New thread (${props.newThreadShortcutLabel})`
+                : "New thread"
+            }
+            className="size-7"
+            disabled={props.newThreadDisabled}
+            onClick={props.onNewThread}
+          >
+            <SquarePenIcon />
+          </HeaderIconButton>
+        </div>
+      </div>
+      {searchOpen ? <SearchRow props={props} onClose={closeSearch} /> : null}
+    </>
+  );
+}
+
+/**
+ * Sits under the scope row in normal flow, so opening it pushes the thread list
+ * down rather than covering it.
+ */
+function SearchRow({ props, onClose }: { props: SidebarThreadHeaderProps; onClose: () => void }) {
+  const resultsVisible = props.isSearching && props.hasSearchResults;
+  return (
+    <div
+      id={SEARCH_ROW_ID}
+      className="flex h-8 min-w-0 items-center gap-2 rounded-md bg-sidebar-control-surface/60 px-2 py-1.5 text-sm font-medium ring-1 ring-sidebar-border/50 focus-within:ring-ring"
+    >
+      <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
+      <Input
+        ref={props.searchInputRef}
+        nativeInput
+        unstyled
+        type="search"
+        value={props.searchQuery}
+        onChange={(event) => props.onSearchQueryChange(event.currentTarget.value)}
+        onKeyDown={(event) => {
+          // Escape clears first and closes second: one press to drop the query
+          // without losing the field, another to leave search entirely.
+          if (event.key === "Escape" && props.searchQuery.length === 0) {
+            event.preventDefault();
+            onClose();
+            return;
+          }
+          props.onSearchKeyDown(event);
+        }}
+        placeholder={`Search ${props.scopedProjectGroup?.displayName ?? "all projects"}`}
+        aria-label="Search threads"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={resultsVisible}
+        aria-controls={resultsVisible ? "sidebar-thread-search-results" : undefined}
+        aria-activedescendant={
+          resultsVisible
+            ? `sidebar-thread-search-result-${props.activeSearchResultIndex}`
+            : undefined
+        }
+        className="min-w-0 flex-1 [&_[data-slot=input]]:h-auto [&_[data-slot=input]]:p-0 [&_[data-slot=input]]:leading-normal [&_[data-slot=input]]:text-sm [&_[data-slot=input]]:font-medium [&_[data-slot=input]]:text-sidebar-foreground [&_[data-slot=input]]:placeholder:text-sidebar-muted-foreground"
+      />
+      {/* Clears without closing — the toggle above is what leaves search. */}
+      {props.isSearching ? (
+        <button
+          type="button"
+          aria-label="Clear thread search"
+          onClick={() => {
+            props.onClearSearch();
+            props.searchInputRef.current?.focus();
+          }}
+          className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-sm text-sidebar-muted-foreground outline-none hover:bg-sidebar-control-surface hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <XIcon className="size-3" />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function ScopeIcon({ group }: { group: SidebarProjectSnapshot | null }) {
+  return group ? (
+    <ProjectFavicon
+      environmentId={group.environmentId}
+      cwd={group.workspaceRoot}
+      faviconPath={group.faviconPath}
+      className="size-4 shrink-0"
+    />
+  ) : (
+    <FolderIcon className="size-4 shrink-0" />
+  );
+}
+
+function HeaderIconButton({
+  label,
+  onClick,
+  disabled,
+  className,
+  isActive,
+  children,
+  ...ariaProps
+}: {
+  label: string;
+  onClick: (event: ReactMouseEvent) => void;
+  disabled?: boolean | undefined;
+  className?: string | undefined;
+  isActive?: boolean | undefined;
+  "aria-expanded"?: boolean | undefined;
+  "aria-controls"?: string | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <SidebarMenuButton
+            size="icon"
+            type="button"
+            aria-label={label}
+            disabled={disabled}
+            {...(isActive === undefined ? {} : { isActive })}
+            onClick={onClick}
+            {...ariaProps}
+            className={cn(
+              "relative shrink-0 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
+              className,
+            )}
+          />
+        }
+      >
+        {children}
+        {/* Coarse-pointer hit area, matching the rest of the sidebar chrome. */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-1/2 top-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+        />
+      </TooltipTrigger>
+      <TooltipPopup side="bottom">{label}</TooltipPopup>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## What

The sidebar header spent two rows on four controls, and neither row explained itself: an always-open search field sat beside a new-thread icon, and the project selector sat beside a new-project icon — so the two icon buttons read as a pair when they have nothing to do with each other.

This collapses it into one row.

| Before | After |
| --- | --- |
| <img width="272" alt="two-row header: search field + new thread icon, project selector + new project icon" src="https://raw.githubusercontent.com/gsimone/t3code/assets/sidebar-thread-header/assets/sidebar-thread-header/before.png"> | <img width="272" alt="one-row header: project selector spanning the row, search and new thread as a segmented icon pair" src="https://raw.githubusercontent.com/gsimone/t3code/assets/sidebar-thread-header/assets/sidebar-thread-header/after-closed.png"> |

- The **project selector** owns the row's text and spans it.
- **Search** and **new thread** become a segmented icon pair at the end, so they read as one control rather than two loose buttons competing with the selector.
- **New project** moves to the bottom of the project menu, next to the projects it belongs with.

<img width="272" alt="project menu spanning the sidebar width, with New project at the bottom" src="https://raw.githubusercontent.com/gsimone/t3code/assets/sidebar-thread-header/assets/sidebar-thread-header/after-menu.png">

The scope menu is anchored to the whole row rather than to its trigger, so the popup keeps spanning the sidebar's content width as it did before the selector shrank to make room for the icons — and it still tracks the width if the sidebar is resized.

## Search is now a toggle

Clicking search opens a second row *beneath* the scope row and pushes the thread list down. The project you're scoped to stays visible while you filter inside it — search is not a mode you enter and lose your place in.

| Open | Filtering |
| --- | --- |
| <img width="272" alt="search row open below the scope row, empty" src="https://raw.githubusercontent.com/gsimone/t3code/assets/sidebar-thread-header/assets/sidebar-thread-header/after-search-open.png"> | <img width="272" alt="search row filtering the thread list to one result" src="https://raw.githubusercontent.com/gsimone/t3code/assets/sidebar-thread-header/assets/sidebar-thread-header/after-search-filtered.png"> |

- Clicking the icon again closes the row **and clears the query** — a hidden filter still narrowing the list is invisible state.
- The icon keeps the magnifier glyph and takes an active/pressed state, rather than swapping to an `X`. Swapping would put two X's on screen once you type, and would hide the fact that the row *is* search.
- The `X` inside the field means something different from the toggle: clear the query, stay in search. They're on separate rows, so they don't read as duplicates.
- <kbd>Esc</kbd> clears first, closes second.

The filtering itself is unchanged — same query state, same results list, same keyboard traversal, same `sidebar-thread-search-results` listbox. Only the chrome moved.

## Verification

`apps/web` tests: **1982 passed (219 files)**. Typecheck clean.

Driven through CDP against a seeded environment (6 projects, 8 threads), asserting behaviour rather than eyeballing screenshots:

```
closed    scope visible: true   searchRow: —    listTop: 100   threads: 8   query: —     toggle: "search"
opened    scope visible: true   searchRow: 96   listTop: 136   threads: 8   query: ""    toggle: "hide"
filtered  scope visible: true   searchRow: 96   listTop: 136   threads: 0   results: 1   toggle: "hide"
toggled   scope visible: true   searchRow: —    listTop: 100   threads: 8   query: —     toggle: "search"
```

The scope row stays on screen in all four states; the list moves `100 → 136` and back, confirming push-down rather than overlay; and toggling off restores all 8 threads with the query reset.

Scope popup width, measured in a 256px sidebar with an 8px inset each side:

```
popup: 239px   left: 8px   projects: 8   newProject: true
```

## Note for reviewers

I could not run `pnpm lint` locally — the oxlint JS plugin fails to load in my environment (`Cannot find package 'effect'` imported from `oxlint-plugin-t3code/rules/no-global-process-runtime.ts`). Pre-existing and unrelated to this change, but it means these files haven't been through the repo's lint rules. CI will cover it. `vp fmt` was applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse sidebar header into a single row with a search toggle and project scope menu
> - Extracts the sidebar header into a new [`SidebarThreadHeader`](https://github.com/pingdotgg/t3code/pull/6447/files#diff-e9d49fd86f819b63697fc5466a1f3da53b1e4a417bd0a660a03199fc7207e982) component, replacing the inline search input, project scope selector, and action buttons in [`Sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/6447/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1).
> - Search now lives in a collapsible second row toggled by an icon button; closing the toggle clears the query.
> - The project scope menu spans the full row width and includes per-project settings buttons and a "New project…" item, removing the separate new-project button from the header.
> - Thread search query is automatically cleared when all projects are removed to avoid a hidden filter state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b0d0c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->