### PR TITLE
fix: the $ skill picker now lists the active project's skills

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -7,6 +7,7 @@ import type {
   ProviderInteractionMode,
   RuntimeMode,
   ServerConfig as T3ServerConfig,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import {
   detectComposerTrigger,
@@ -106,6 +107,12 @@ export interface ThreadComposerProps {
   readonly activeThreadBusy: boolean;
   readonly environmentId: EnvironmentId;
   readonly projectCwd: string | null;
+  /**
+   * Skills offered by the `$` picker, resolved for the thread's workspace by
+   * the host screen. Not read off `serverConfig`: the provider snapshot's
+   * skills describe the server's own startup directory, not this project.
+   */
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
   readonly editorRef?: RefObject<ComposerEditorHandle | null>;
   readonly onChangeDraftMessage: (value: string) => void;
   readonly onPickDraftImages: () => Promise<void>;
@@ -431,7 +438,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     }
 
     if (composerTrigger.kind === "skill") {
-      const enabledSkills = (selectedProviderStatus?.skills ?? []).filter((s) => s.enabled);
+      const enabledSkills = props.skills.filter((s) => s.enabled);
       const normalizedQuery = normalizeSearchQuery(composerTrigger.query, {
         trimLeadingPattern: /^\$+/,
       });
@@ -528,7 +535,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     }
 
     return [];
-  }, [composerTrigger, pathSearch.entries, selectedProviderStatus]);
+  }, [composerTrigger, pathSearch.entries, props.skills, selectedProviderStatus]);
 
   // ── Handle command selection ──────────────────────────────
   const { onChangeDraftMessage, onUpdateInteractionMode, draftMessage, onSendMessage } = props;
@@ -775,7 +782,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               ref={inputRef}
               multiline
               value={props.draftMessage}
-              skills={selectedProviderStatus?.skills ?? []}
+              skills={props.skills}
               selection={composerSelection}
               onChangeText={props.onChangeDraftMessage}
               onSelectionChange={handleSelectionChange}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -107,11 +107,6 @@ export interface ThreadComposerProps {
   readonly activeThreadBusy: boolean;
   readonly environmentId: EnvironmentId;
   readonly projectCwd: string | null;
-  /**
-   * Skills offered by the `$` picker, resolved for the thread's workspace by
-   * the host screen. Not read off `serverConfig`: the provider snapshot's
-   * skills describe the server's own startup directory, not this project.
-   */
   readonly skills: ReadonlyArray<ServerProviderSkill>;
   readonly editorRef?: RefObject<ComposerEditorHandle | null>;
   readonly onChangeDraftMessage: (value: string) => void;

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -64,6 +64,7 @@ import type {
   PendingUserInputDraftAnswer,
   ThreadFeedEntry,
 } from "../../lib/threadActivity";
+import { useWorkspaceSkills } from "../../state/queries";
 import { PendingApprovalCard } from "./PendingApprovalCard";
 import { PendingUserInputCard } from "./PendingUserInputCard";
 import {
@@ -445,11 +446,23 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const contentMaxWidth = isSplitLayout ? CHAT_CONTENT_MAX_WIDTH : undefined;
   const selectedInstanceId = props.selectedThread.modelSelection.instanceId;
   useStreamingHaptics(props.selectedThread.id, props.selectedThreadFeed);
+  // Skills belong to the thread's workspace, not to the server's startup cwd
+  // (which is all the provider snapshot can describe). `threadCwd` is the
+  // thread's worktree when it has one, else the project root — the same
+  // directory the agent will run in. The snapshot stays the fallback while the
+  // request is in flight or against a server that predates the RPC.
+  const workspaceSkills = useWorkspaceSkills({
+    environmentId: props.environmentId,
+    instanceId: selectedInstanceId,
+    cwd: props.threadCwd,
+  });
   const selectedProviderSkills = useMemo(
     () =>
+      workspaceSkills.skills ??
       props.serverConfig?.providers.find((provider) => provider.instanceId === selectedInstanceId)
-        ?.skills ?? [],
-    [props.serverConfig, selectedInstanceId],
+        ?.skills ??
+      [],
+    [props.serverConfig, selectedInstanceId, workspaceSkills.skills],
   );
 
   useLayoutEffect(() => {
@@ -729,6 +742,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                 activeThreadBusy={props.activeThreadBusy}
                 environmentId={props.environmentId}
                 projectCwd={props.projectWorkspaceRoot}
+                skills={selectedProviderSkills}
                 bottomInset={composerBottomInset}
                 onChangeDraftMessage={props.onChangeDraftMessage}
                 onPickDraftImages={props.onPickDraftImages}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -446,11 +446,6 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const contentMaxWidth = isSplitLayout ? CHAT_CONTENT_MAX_WIDTH : undefined;
   const selectedInstanceId = props.selectedThread.modelSelection.instanceId;
   useStreamingHaptics(props.selectedThread.id, props.selectedThreadFeed);
-  // Skills belong to the thread's workspace, not to the server's startup cwd
-  // (which is all the provider snapshot can describe). `threadCwd` is the
-  // thread's worktree when it has one, else the project root — the same
-  // directory the agent will run in. The snapshot stays the fallback while the
-  // request is in flight or against a server that predates the RPC.
   const workspaceSkills = useWorkspaceSkills({
     environmentId: props.environmentId,
     instanceId: selectedInstanceId,

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -50,7 +50,7 @@ import {
   updateComposerDraftSettings,
   useComposerDraft,
 } from "../../state/use-composer-drafts";
-import { useBranches } from "../../state/queries";
+import { useBranches, useWorkspaceSkills } from "../../state/queries";
 import {
   flattenQueuedThreadMessages,
   threadOutboxManager,
@@ -436,12 +436,22 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         option.selection.instanceId === selectedModel.instanceId &&
         option.selection.model === selectedModel.model,
     ) ?? null;
+  // A draft has no worktree yet, so its workspace is the selected project's
+  // root. Asking the server for that directory's skills beats the provider
+  // snapshot, whose skills belong to the server's own startup cwd.
+  const workspaceSkills = useWorkspaceSkills({
+    environmentId: selectedProject?.environmentId ?? null,
+    instanceId: selectedModel?.instanceId ?? null,
+    cwd: selectedProject?.workspaceRoot || null,
+  });
   const selectedProviderSkills = useMemo(
     () =>
+      workspaceSkills.skills ??
       selectedEnvironmentServerConfig?.providers.find(
         (provider) => provider.instanceId === selectedModel?.instanceId,
-      )?.skills ?? [],
-    [selectedEnvironmentServerConfig, selectedModel?.instanceId],
+      )?.skills ??
+      [],
+    [selectedEnvironmentServerConfig, selectedModel?.instanceId, workspaceSkills.skills],
   );
   const setSelectedModelKey = useCallback(
     // Options ride along in the same write: a follow-up setSelectedModelOptions

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -436,9 +436,6 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         option.selection.instanceId === selectedModel.instanceId &&
         option.selection.model === selectedModel.model,
     ) ?? null;
-  // A draft has no worktree yet, so its workspace is the selected project's
-  // root. Asking the server for that directory's skills beats the provider
-  // snapshot, whose skills belong to the server's own startup cwd.
   const workspaceSkills = useWorkspaceSkills({
     environmentId: selectedProject?.environmentId ?? null,
     instanceId: selectedModel?.instanceId ?? null,

--- a/apps/mobile/src/state/queries.ts
+++ b/apps/mobile/src/state/queries.ts
@@ -137,9 +137,13 @@ export function useBranches(input: {
  * The provider snapshot in `serverConfig` carries a `skills` list, but the
  * server discovers it once against its own startup cwd, so it belongs to
  * whichever directory the server was launched from rather than the project
- * being viewed. Resolves to `null` until the server answers (and if it never
- * does), which lets callers fall back to the snapshot instead of blanking the
- * picker.
+ * being viewed.
+ *
+ * `skills` is `null` whenever nothing is known: the request is in flight, it
+ * failed, or the server answered without a list because its own discovery
+ * could not run. Callers fall back to the snapshot in all three cases. An
+ * empty array is different — it means this workspace really has no skills,
+ * and the `??` fallbacks at the call sites deliberately keep it.
  */
 export function useWorkspaceSkills(input: {
   readonly environmentId: EnvironmentId | null;

--- a/apps/mobile/src/state/queries.ts
+++ b/apps/mobile/src/state/queries.ts
@@ -1,4 +1,9 @@
-import type { EnvironmentId, OrchestrationThread, ThreadId } from "@t3tools/contracts";
+import type {
+  EnvironmentId,
+  OrchestrationThread,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
 import {
   createThreadSearchResultsAtomFamily,
   makeThreadSearchKey,
@@ -12,6 +17,7 @@ import { useEffect, useMemo, useState } from "react";
 import { orchestrationEnvironment } from "./orchestration";
 import { projectEnvironment } from "./projects";
 import { useEnvironmentQuery } from "./query";
+import { serverEnvironment } from "./server";
 import { useEnvironmentThread } from "./threads";
 import { vcsEnvironment } from "./vcs";
 import {
@@ -123,6 +129,44 @@ export function useBranches(input: {
         })
       : null,
   );
+}
+
+/**
+ * Skills for one workspace, asked of the server per request.
+ *
+ * The provider snapshot in `serverConfig` carries a `skills` list, but the
+ * server discovers it once against its own startup cwd, so it belongs to
+ * whichever directory the server was launched from rather than the project
+ * being viewed. Resolves to `null` until the server answers (and if it never
+ * does), which lets callers fall back to the snapshot instead of blanking the
+ * picker.
+ */
+export function useWorkspaceSkills(input: {
+  readonly environmentId: EnvironmentId | null;
+  readonly instanceId: ProviderInstanceId | null;
+  readonly cwd: string | null;
+}) {
+  // A stand-in project carries an empty workspaceRoot, which the request
+  // schema rejects — treat it like "no workspace" rather than issuing a call
+  // that can only fail.
+  const cwd = input.cwd?.trim() ? input.cwd : null;
+  const result = useEnvironmentQuery(
+    input.environmentId !== null && cwd !== null
+      ? serverEnvironment.workspaceSkills({
+          environmentId: input.environmentId,
+          input: {
+            ...(input.instanceId ? { instanceId: input.instanceId } : {}),
+            cwd,
+          },
+        })
+      : null,
+  );
+
+  return {
+    skills: result.data?.skills ?? null,
+    error: result.error,
+    isPending: result.isPending,
+  };
 }
 
 export function useComposerPathSearch(target: ComposerPathSearchTarget) {

--- a/apps/mobile/src/state/queries.ts
+++ b/apps/mobile/src/state/queries.ts
@@ -132,27 +132,15 @@ export function useBranches(input: {
 }
 
 /**
- * Skills for one workspace, asked of the server per request.
- *
- * The provider snapshot in `serverConfig` carries a `skills` list, but the
- * server discovers it once against its own startup cwd, so it belongs to
- * whichever directory the server was launched from rather than the project
- * being viewed.
- *
- * `skills` is `null` whenever nothing is known: the request is in flight, it
- * failed, or the server answered without a list because its own discovery
- * could not run. Callers fall back to the snapshot in all three cases. An
- * empty array is different — it means this workspace really has no skills,
- * and the `??` fallbacks at the call sites deliberately keep it.
+ * Skills for one workspace; `null` while nothing is known, hence the `??` at
+ * call sites. An empty array is an answer and is deliberately kept.
  */
 export function useWorkspaceSkills(input: {
   readonly environmentId: EnvironmentId | null;
   readonly instanceId: ProviderInstanceId | null;
   readonly cwd: string | null;
 }) {
-  // A stand-in project carries an empty workspaceRoot, which the request
-  // schema rejects — treat it like "no workspace" rather than issuing a call
-  // that can only fail.
+  // A stand-in project carries an empty workspaceRoot, which the schema rejects.
   const cwd = input.cwd?.trim() ? input.cwd : null;
   const result = useEnvironmentQuery(
     input.environmentId !== null && cwd !== null

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -32,8 +32,6 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverProbe]: AuthOrchestrationReadScope,
   [WS_METHODS.serverGetConfig]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRefreshProviders]: AuthOrchestrationOperateScope,
-  // Enumerating a workspace's skills is a read of the same provider state the
-  // config snapshot already exposes to read-only clients.
   [WS_METHODS.serverListWorkspaceSkills]: AuthOrchestrationReadScope,
   [WS_METHODS.serverUpdateProvider]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServer]: AuthOrchestrationOperateScope,

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -32,6 +32,9 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverProbe]: AuthOrchestrationReadScope,
   [WS_METHODS.serverGetConfig]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRefreshProviders]: AuthOrchestrationOperateScope,
+  // Enumerating a workspace's skills is a read of the same provider state the
+  // config snapshot already exposes to read-only clients.
+  [WS_METHODS.serverListWorkspaceSkills]: AuthOrchestrationReadScope,
   [WS_METHODS.serverUpdateProvider]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServer]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServerWithProgress]: AuthOrchestrationOperateScope,

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -165,11 +165,6 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       });
       const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
 
-      // Workspace-scoped skill discovery. The snapshot's `skills` list is
-      // scanned once against the server's own cwd, which is a single global
-      // directory chosen at startup; the picker needs the skills of whichever
-      // project the client is looking at, so the cwd arrives per call and the
-      // results are cached per workspace.
       const listWorkspaceSkills = yield* makeWorkspaceSkillsCache((workspaceCwd) =>
         discoverClaudeSkills(effectiveConfig, workspaceCwd, processEnv).pipe(
           Effect.provideService(FileSystem.FileSystem, fileSystem),

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -54,7 +54,9 @@ import {
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
+import { makeWorkspaceSkillsCache } from "../workspaceSkills.ts";
 import { makeClaudeCapabilitiesCacheKey, makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import { discoverClaudeSkills } from "./ClaudeSkills.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
@@ -163,6 +165,18 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       });
       const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
 
+      // Workspace-scoped skill discovery. The snapshot's `skills` list is
+      // scanned once against the server's own cwd, which is a single global
+      // directory chosen at startup; the picker needs the skills of whichever
+      // project the client is looking at, so the cwd arrives per call and the
+      // results are cached per workspace.
+      const listWorkspaceSkills = yield* makeWorkspaceSkillsCache((workspaceCwd) =>
+        discoverClaudeSkills(effectiveConfig, workspaceCwd, processEnv).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.provideService(Path.Path, path),
+        ),
+      );
+
       const checkProvider = checkClaudeProviderStatus(
         effectiveConfig,
         () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
@@ -216,6 +230,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         snapshot,
         adapter,
         textGeneration,
+        listWorkspaceSkills,
       } satisfies ProviderInstance;
     }),
 };

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -106,15 +106,34 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
 
   const skillsByName = new Map<string, ServerProviderSkill>();
   for (const root of roots) {
-    const entries = yield* fileSystem
-      .readDirectory(root.directory)
-      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+    // A missing skills directory is the common case (most users have no
+    // project skills), so this stays at debug — but it is logged, because an
+    // unreadable directory and an empty picker are otherwise indistinguishable.
+    const entries = yield* fileSystem.readDirectory(root.directory).pipe(
+      Effect.tapError((cause) =>
+        Effect.logDebug("claude skill root is not readable", {
+          directory: root.directory,
+          scope: root.scope,
+          cause,
+        }),
+      ),
+      Effect.orElseSucceed((): ReadonlyArray<string> => []),
+    );
 
     for (const entry of [...entries].sort()) {
       const skillPath = path.join(root.directory, entry, "SKILL.md");
-      const contents = yield* fileSystem
-        .readFileString(skillPath)
-        .pipe(Effect.orElseSucceed(() => undefined));
+      const contents = yield* fileSystem.readFileString(skillPath).pipe(
+        Effect.tapError((cause) =>
+          // Expected for non-skill entries (a stray `README.md`, a directory
+          // without `SKILL.md`); a permission error lands here too.
+          Effect.logDebug("claude skill entry has no readable SKILL.md", {
+            path: skillPath,
+            scope: root.scope,
+            cause,
+          }),
+        ),
+        Effect.orElseSucceed(() => undefined),
+      );
       if (contents === undefined) {
         continue;
       }
@@ -122,8 +141,13 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
       const frontmatter = parseSkillFrontmatter(contents);
       // Malformed frontmatter means the skill won't load in Claude Code
       // either — skip it rather than surfacing a broken entry under its
-      // directory name.
+      // directory name. Unlike the cases above this is a real authoring
+      // mistake, so it warns: the user wrote a skill that nothing will load.
       if (frontmatter.kind === "malformed") {
+        yield* Effect.logWarning("claude skill has malformed YAML frontmatter; skipping", {
+          path: skillPath,
+          scope: root.scope,
+        });
         continue;
       }
 

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -106,9 +106,8 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
 
   const skillsByName = new Map<string, ServerProviderSkill>();
   for (const root of roots) {
-    // A missing skills directory is the common case (most users have no
-    // project skills), so this stays at debug — but it is logged, because an
-    // unreadable directory and an empty picker are otherwise indistinguishable.
+    // Debug, not warning: a missing skills directory is the common case. Still
+    // logged, so an unreadable one is not silently an empty picker.
     const entries = yield* fileSystem.readDirectory(root.directory).pipe(
       Effect.tapError((cause) =>
         Effect.logDebug("claude skill root is not readable", {
@@ -124,8 +123,6 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
       const skillPath = path.join(root.directory, entry, "SKILL.md");
       const contents = yield* fileSystem.readFileString(skillPath).pipe(
         Effect.tapError((cause) =>
-          // Expected for non-skill entries (a stray `README.md`, a directory
-          // without `SKILL.md`); a permission error lands here too.
           Effect.logDebug("claude skill entry has no readable SKILL.md", {
             path: skillPath,
             scope: root.scope,
@@ -141,8 +138,7 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
       const frontmatter = parseSkillFrontmatter(contents);
       // Malformed frontmatter means the skill won't load in Claude Code
       // either — skip it rather than surfacing a broken entry under its
-      // directory name. Unlike the cases above this is a real authoring
-      // mistake, so it warns: the user wrote a skill that nothing will load.
+      // directory name.
       if (frontmatter.kind === "malformed") {
         yield* Effect.logWarning("claude skill has malformed YAML frontmatter; skipping", {
           path: skillPath,

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -36,12 +36,17 @@ import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderDriverError } from "../Errors.ts";
 import { makeCodexAdapter } from "../Layers/CodexAdapter.ts";
-import { checkCodexProviderStatus, makePendingCodexProvider } from "../Layers/CodexProvider.ts";
+import {
+  checkCodexProviderStatus,
+  listCodexWorkspaceSkills,
+  makePendingCodexProvider,
+} from "../Layers/CodexProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import type { ProviderDriver, ProviderInstance } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { makeWorkspaceSkillsCache } from "../workspaceSkills.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
   makePackageManagedProviderMaintenanceResolver,
@@ -170,6 +175,16 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         Effect.map(stampIdentity),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
       );
+      // Workspace-scoped skill discovery. The snapshot probe asks the
+      // app-server about the server's own cwd — one global directory picked at
+      // startup — so the picker would otherwise show another project's skills.
+      // Each lookup spawns an app-server, hence the per-workspace cache.
+      const listWorkspaceSkills = yield* makeWorkspaceSkillsCache((workspaceCwd) =>
+        listCodexWorkspaceSkills(effectiveConfig, workspaceCwd, processEnv).pipe(
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        ),
+      );
+
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CodexSettings>>({
         maintenanceCapabilities,
@@ -208,6 +223,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         snapshot,
         adapter,
         textGeneration,
+        listWorkspaceSkills,
       } satisfies ProviderInstance;
     }),
 };

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -175,10 +175,6 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         Effect.map(stampIdentity),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
       );
-      // Workspace-scoped skill discovery. The snapshot probe asks the
-      // app-server about the server's own cwd — one global directory picked at
-      // startup — so the picker would otherwise show another project's skills.
-      // Each lookup spawns an app-server, hence the per-workspace cache.
       const listWorkspaceSkills = yield* makeWorkspaceSkillsCache((workspaceCwd) =>
         listCodexWorkspaceSkills(effectiveConfig, workspaceCwd, processEnv).pipe(
           Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -319,12 +319,19 @@ export function buildCodexInitializeParams(): CodexSchema.V1InitializeParams {
   };
 }
 
-const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (input: {
+/**
+ * Spawn `codex app-server` and complete its initialize handshake.
+ *
+ * The returned client stays usable for as long as the caller's scope is open;
+ * closing that scope tears the child process down. Both the status probe and
+ * the workspace-scoped skills lookup go through here so there is exactly one
+ * description of how we launch the app-server.
+ */
+const openCodexAppServerClient = Effect.fn("openCodexAppServerClient")(function* (input: {
   readonly binaryPath: string;
   readonly homePath?: string;
   readonly launchArgs?: string;
   readonly cwd: string;
-  readonly customModels?: ReadonlyArray<string>;
   readonly environment?: NodeJS.ProcessEnv;
 }) {
   // `~` is not shell-expanded when env vars are set via `child_process.spawn`,
@@ -385,6 +392,19 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   const versionMatch = initialize.userAgent.match(/\/([^\s]+)/);
   const version = versionMatch ? versionMatch[1] : undefined;
 
+  return { client, version } as const;
+});
+
+const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (input: {
+  readonly binaryPath: string;
+  readonly homePath?: string;
+  readonly launchArgs?: string;
+  readonly cwd: string;
+  readonly customModels?: ReadonlyArray<string>;
+  readonly environment?: NodeJS.ProcessEnv;
+}) {
+  const { client, version } = yield* openCodexAppServerClient(input);
+
   const accountResponse = yield* client.request("account/read", {});
   if (!accountResponse.account && accountResponse.requiresOpenaiAuth) {
     return {
@@ -414,6 +434,61 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     skills: parseCodexSkillsListResponse(skillsResponse, input.cwd),
   } satisfies CodexAppServerProviderSnapshot;
 });
+
+const requestCodexWorkspaceSkills = Effect.fn("requestCodexWorkspaceSkills")(function* (input: {
+  readonly binaryPath: string;
+  readonly homePath?: string;
+  readonly launchArgs?: string;
+  readonly cwd: string;
+  readonly environment?: NodeJS.ProcessEnv;
+}) {
+  const { client } = yield* openCodexAppServerClient(input);
+  // The app-server answers `skills/list` per cwd, so unlike the snapshot probe
+  // (which asks about the server's own directory) this asks about the
+  // workspace the client is looking at.
+  const response = yield* client.request("skills/list", { cwds: [input.cwd] });
+  return parseCodexSkillsListResponse(response, input.cwd);
+});
+
+/**
+ * List the skills Codex would load for one workspace directory.
+ *
+ * Best-effort by contract: a missing binary, an unauthenticated CLI, or a slow
+ * app-server all degrade to an empty list rather than failing the caller. The
+ * picker falls back to the provider snapshot's global list in that case, so a
+ * failure here is never worse than the behaviour that preceded this lookup.
+ */
+export const listCodexWorkspaceSkills = (
+  codexSettings: CodexSettings,
+  cwd: string,
+  environment?: NodeJS.ProcessEnv,
+): Effect.Effect<
+  ReadonlyArray<ServerProviderSkill>,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner
+> => {
+  if (!codexSettings.enabled) {
+    return Effect.succeed([]);
+  }
+  const resolvedEnvironment = environment ?? process.env;
+  return requestCodexWorkspaceSkills({
+    binaryPath: codexSettings.binaryPath,
+    homePath: codexSettings.homePath,
+    launchArgs: resolveCodexLaunchArgs(codexSettings.launchArgs, resolvedEnvironment),
+    cwd,
+    environment: resolvedEnvironment,
+  }).pipe(
+    Effect.scoped,
+    // A typed timeout rather than `timeoutOption` so a slow app-server is
+    // logged on the same path as a spawn failure instead of silently reading
+    // as "this workspace has no skills".
+    Effect.timeout(Duration.millis(AUTH_PROBE_TIMEOUT_MS)),
+    Effect.tapError((cause) =>
+      Effect.logDebug("codex workspace skill discovery failed", { cwd, cause }),
+    ),
+    Effect.orElseSucceed((): ReadonlyArray<ServerProviderSkill> => []),
+  );
+};
 
 const emptyCodexModelsFromSettings = (codexSettings: CodexSettings): ServerProvider["models"] => {
   const models = new Set<string>();

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -453,17 +453,20 @@ const requestCodexWorkspaceSkills = Effect.fn("requestCodexWorkspaceSkills")(fun
 /**
  * List the skills Codex would load for one workspace directory.
  *
- * Best-effort by contract: a missing binary, an unauthenticated CLI, or a slow
- * app-server all degrade to an empty list rather than failing the caller. The
- * picker falls back to the provider snapshot's global list in that case, so a
- * failure here is never worse than the behaviour that preceded this lookup.
+ * Best-effort by contract, and careful about which kind of "no skills" it
+ * reports: a missing binary, an unauthenticated CLI, or a slow app-server
+ * yield `undefined` — "we could not look" — so callers keep falling back to
+ * the provider snapshot's global list. An empty array is reserved for answers
+ * we actually got: a disabled provider, or an app-server that listed nothing
+ * for this workspace. Returning `[]` for a failed probe would suppress every
+ * fallback downstream and blank the picker on a transient error.
  */
 export const listCodexWorkspaceSkills = (
   codexSettings: CodexSettings,
   cwd: string,
   environment?: NodeJS.ProcessEnv,
 ): Effect.Effect<
-  ReadonlyArray<ServerProviderSkill>,
+  ReadonlyArray<ServerProviderSkill> | undefined,
   never,
   ChildProcessSpawner.ChildProcessSpawner
 > => {
@@ -486,7 +489,7 @@ export const listCodexWorkspaceSkills = (
     Effect.tapError((cause) =>
       Effect.logDebug("codex workspace skill discovery failed", { cwd, cause }),
     ),
-    Effect.orElseSucceed((): ReadonlyArray<ServerProviderSkill> => []),
+    Effect.orElseSucceed((): ReadonlyArray<ServerProviderSkill> | undefined => undefined),
   );
 };
 

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -320,12 +320,8 @@ export function buildCodexInitializeParams(): CodexSchema.V1InitializeParams {
 }
 
 /**
- * Spawn `codex app-server` and complete its initialize handshake.
- *
- * The returned client stays usable for as long as the caller's scope is open;
- * closing that scope tears the child process down. Both the status probe and
- * the workspace-scoped skills lookup go through here so there is exactly one
- * description of how we launch the app-server.
+ * Spawn `codex app-server` and complete its initialize handshake. Closing the
+ * caller's scope tears the child process down.
  */
 const openCodexAppServerClient = Effect.fn("openCodexAppServerClient")(function* (input: {
   readonly binaryPath: string;
@@ -443,23 +439,14 @@ const requestCodexWorkspaceSkills = Effect.fn("requestCodexWorkspaceSkills")(fun
   readonly environment?: NodeJS.ProcessEnv;
 }) {
   const { client } = yield* openCodexAppServerClient(input);
-  // The app-server answers `skills/list` per cwd, so unlike the snapshot probe
-  // (which asks about the server's own directory) this asks about the
-  // workspace the client is looking at.
   const response = yield* client.request("skills/list", { cwds: [input.cwd] });
   return parseCodexSkillsListResponse(response, input.cwd);
 });
 
 /**
- * List the skills Codex would load for one workspace directory.
- *
- * Best-effort by contract, and careful about which kind of "no skills" it
- * reports: a missing binary, an unauthenticated CLI, or a slow app-server
- * yield `undefined` — "we could not look" — so callers keep falling back to
- * the provider snapshot's global list. An empty array is reserved for answers
- * we actually got: a disabled provider, or an app-server that listed nothing
- * for this workspace. Returning `[]` for a failed probe would suppress every
- * fallback downstream and blank the picker on a transient error.
+ * List the skills Codex would load for one workspace directory. Answering
+ * needs a live app-server, so unlike Claude's filesystem scan this can yield
+ * `undefined` ("could not look") rather than `[]`.
  */
 export const listCodexWorkspaceSkills = (
   codexSettings: CodexSettings,
@@ -482,9 +469,8 @@ export const listCodexWorkspaceSkills = (
     environment: resolvedEnvironment,
   }).pipe(
     Effect.scoped,
-    // A typed timeout rather than `timeoutOption` so a slow app-server is
-    // logged on the same path as a spawn failure instead of silently reading
-    // as "this workspace has no skills".
+    // A typed timeout, not `timeoutOption`, so a slow app-server is logged and
+    // reported like a spawn failure rather than as "no skills here".
     Effect.timeout(Duration.millis(AUTH_PROBE_TIMEOUT_MS)),
     Effect.tapError((cause) =>
       Effect.logDebug("codex workspace skill discovery failed", { cwd, cause }),

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1838,16 +1838,12 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
 
       it.effect("reports unknown, not empty, when codex workspace discovery cannot run", () =>
         Effect.gen(function* () {
-          // An uninstalled CLI must not be reported as "this workspace has no
-          // skills": that would outrank the snapshot fallback every caller
-          // holds and blank the picker until the cache expired.
           const failed = yield* listCodexWorkspaceSkills(defaultCodexSettings, "/repos/alpha").pipe(
             Effect.provide(failingSpawnerLayer("spawn codex ENOENT")),
           );
           assert.strictEqual(failed, undefined);
 
-          // A disabled provider is an answer, not a failure — there is
-          // nothing to discover and nothing to fall back to.
+          // A disabled provider is an answer, not a failure.
           const disabled = yield* listCodexWorkspaceSkills(
             disabledCodexSettings,
             "/repos/alpha",
@@ -1857,10 +1853,6 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
       );
 
       // ── workspace-scoped skills ─────────────────────────────────
-      //
-      // The registry routes `listWorkspaceSkills` to live instances and
-      // carries the caller's workspace through untouched — it has no cwd of
-      // its own that could stand in for the client's project.
 
       const makeSkillsInstance = (input: {
         readonly instanceId: string;
@@ -2007,9 +1999,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             listWorkspaceSkills: () => Effect.succeed([]),
           });
 
-          // A driver with no skill surface at all (Grok, Cursor, OpenCode)
-          // knows there is nothing to offer — that is an answer, and the
-          // picker should render its empty state.
+          // A driver with no skill surface at all (Grok, Cursor, OpenCode).
           assert.deepStrictEqual(
             yield* withSkillsRegistry([withoutSkillSurface], (registry) =>
               registry.listWorkspaceSkills({
@@ -2020,7 +2010,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             [],
           );
 
-          // So is a successful probe that found no skills in this workspace.
+          // A successful probe that found no skills in this workspace.
           assert.deepStrictEqual(
             yield* withSkillsRegistry([answeringEmpty], (registry) =>
               registry.listWorkspaceSkills({
@@ -2045,8 +2035,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             listWorkspaceSkills: () => Effect.die(new Error("driver exploded")),
           });
 
-          // An instance id nobody recognises: we learned nothing about this
-          // workspace, so say so rather than claiming it has no skills.
+          // An instance id nobody recognises.
           assert.strictEqual(
             yield* withSkillsRegistry([withoutSkillSurface], (registry) =>
               registry.listWorkspaceSkills({
@@ -2068,9 +2057,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             undefined,
           );
 
-          // A driver defect is logged and swallowed, and counts as "unknown"
-          // for the same reason — the RPC must not fail, but it must not
-          // invent an empty answer either.
+          // A driver defect: logged and swallowed, and still "unknown".
           assert.strictEqual(
             yield* withSkillsRegistry([defective], (registry) =>
               registry.listWorkspaceSkills({

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1831,6 +1831,193 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           assert.strictEqual(status.message, "Codex is disabled in T3 Code settings.");
         }),
       );
+
+      // ── workspace-scoped skills ─────────────────────────────────
+      //
+      // The registry routes `listWorkspaceSkills` to live instances and
+      // carries the caller's workspace through untouched — it has no cwd of
+      // its own that could stand in for the client's project.
+
+      const makeSkillsInstance = (input: {
+        readonly instanceId: string;
+        readonly listWorkspaceSkills?: ProviderInstance["listWorkspaceSkills"];
+      }): ProviderInstance => {
+        const driverKind = ProviderDriverKind.make("codex");
+        const instanceId = ProviderInstanceId.make(input.instanceId);
+        const provider = {
+          instanceId,
+          driver: driverKind,
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-06-10T00:00:00.000Z",
+          version: "1.0.0",
+          models: [],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        return {
+          instanceId,
+          driverKind,
+          continuationIdentity: {
+            driverKind,
+            continuationKey: `codex:instance:${input.instanceId}`,
+          },
+          displayName: undefined,
+          enabled: true,
+          snapshot: {
+            maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+              provider: driverKind,
+              packageName: null,
+            }),
+            getSnapshot: Effect.succeed(provider),
+            refresh: Effect.succeed(provider),
+            streamChanges: Stream.empty,
+          },
+          adapter: {} as ProviderInstance["adapter"],
+          textGeneration: {} as ProviderInstance["textGeneration"],
+          ...(input.listWorkspaceSkills ? { listWorkspaceSkills: input.listWorkspaceSkills } : {}),
+        } satisfies ProviderInstance;
+      };
+
+      const withSkillsRegistry = <A, E, R>(
+        instances: ReadonlyArray<ProviderInstance>,
+        use: (registry: ProviderRegistry.ProviderRegistryShape) => Effect.Effect<A, E, R>,
+      ) =>
+        Effect.gen(function* () {
+          const instanceRegistryLayer = Layer.succeed(
+            ProviderInstanceRegistry.ProviderInstanceRegistry,
+            {
+              getInstance: (instanceId) =>
+                Effect.succeed(
+                  instances.find((candidate) => candidate.instanceId === instanceId) ?? undefined,
+                ),
+              listInstances: Effect.succeed(instances),
+              listUnavailable: Effect.succeed([]),
+              streamChanges: Stream.empty,
+              subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
+            },
+          );
+          const scope = yield* Scope.make();
+          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+          const runtimeServices = yield* Layer.build(
+            ProviderRegistryLive.pipe(
+              Layer.provideMerge(instanceRegistryLayer),
+              Layer.provideMerge(
+                ServerConfig.layerTest(process.cwd(), {
+                  prefix: "t3-provider-registry-workspace-skills-",
+                }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ).pipe(Scope.provide(scope));
+          return yield* Effect.flatMap(ProviderRegistry.ProviderRegistry, use).pipe(
+            Effect.provide(runtimeServices),
+          );
+        });
+
+      it.effect("asks only the targeted instance, passing the requested workspace through", () =>
+        Effect.gen(function* () {
+          const otherCalls = yield* Ref.make(0);
+          const targeted = makeSkillsInstance({
+            instanceId: "codex_personal",
+            listWorkspaceSkills: (cwd) =>
+              Effect.succeed([
+                { name: `skill-in-${cwd}`, path: `${cwd}/.codex/skills/x`, enabled: true },
+              ]),
+          });
+          const other = makeSkillsInstance({
+            instanceId: "codex_work",
+            listWorkspaceSkills: () =>
+              Ref.update(otherCalls, (count) => count + 1).pipe(Effect.as([])),
+          });
+
+          const skills = yield* withSkillsRegistry([targeted, other], (registry) =>
+            registry.listWorkspaceSkills({
+              instanceId: ProviderInstanceId.make("codex_personal"),
+              cwd: "/repos/alpha",
+            }),
+          );
+
+          assert.deepStrictEqual(
+            skills.map((skill) => skill.name),
+            ["skill-in-/repos/alpha"],
+          );
+          assert.strictEqual(yield* Ref.get(otherCalls), 0);
+        }),
+      );
+
+      it.effect("merges every live instance when none is targeted, first name wins", () =>
+        Effect.gen(function* () {
+          const first = makeSkillsInstance({
+            instanceId: "codex_personal",
+            listWorkspaceSkills: () =>
+              Effect.succeed([
+                { name: "deploy", path: "/personal/deploy", enabled: true },
+                { name: "review", path: "/personal/review", enabled: true },
+              ]),
+          });
+          const second = makeSkillsInstance({
+            instanceId: "codex_work",
+            listWorkspaceSkills: () =>
+              Effect.succeed([{ name: "deploy", path: "/work/deploy", enabled: true }]),
+          });
+
+          const skills = yield* withSkillsRegistry([first, second], (registry) =>
+            registry.listWorkspaceSkills({ cwd: "/repos/alpha" }),
+          );
+
+          assert.deepStrictEqual(skills.map((skill) => `${skill.name}:${skill.path}`).toSorted(), [
+            "deploy:/personal/deploy",
+            "review:/personal/review",
+          ]);
+        }),
+      );
+
+      it.effect("degrades to an empty list instead of failing the caller", () =>
+        Effect.gen(function* () {
+          const withoutSkillSurface = makeSkillsInstance({ instanceId: "codex_plain" });
+          const failing = makeSkillsInstance({
+            instanceId: "codex_broken",
+            listWorkspaceSkills: () => Effect.die(new Error("driver exploded")),
+          });
+
+          // Unknown instance id.
+          assert.deepStrictEqual(
+            yield* withSkillsRegistry([withoutSkillSurface], (registry) =>
+              registry.listWorkspaceSkills({
+                instanceId: ProviderInstanceId.make("codex_missing"),
+                cwd: "/repos/alpha",
+              }),
+            ),
+            [],
+          );
+
+          // Driver with no skill surface (Grok, Cursor, OpenCode).
+          assert.deepStrictEqual(
+            yield* withSkillsRegistry([withoutSkillSurface], (registry) =>
+              registry.listWorkspaceSkills({
+                instanceId: ProviderInstanceId.make("codex_plain"),
+                cwd: "/repos/alpha",
+              }),
+            ),
+            [],
+          );
+
+          // A driver defect is logged and swallowed: the picker falls back to
+          // the snapshot rather than surfacing an RPC failure.
+          assert.deepStrictEqual(
+            yield* withSkillsRegistry([failing], (registry) =>
+              registry.listWorkspaceSkills({
+                instanceId: ProviderInstanceId.make("codex_broken"),
+                cwd: "/repos/alpha",
+              }),
+            ),
+            [],
+          );
+        }),
+      );
     });
 
     // ── checkClaudeProviderStatus tests ──────────────────────────

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -31,7 +31,11 @@ import { deepMerge } from "@t3tools/shared/Struct";
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
 
-import { checkCodexProviderStatus, type CodexAppServerProviderSnapshot } from "./CodexProvider.ts";
+import {
+  checkCodexProviderStatus,
+  listCodexWorkspaceSkills,
+  type CodexAppServerProviderSnapshot,
+} from "./CodexProvider.ts";
 import { checkClaudeProviderStatus } from "./ClaudeProvider.ts";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import * as OpenCodeRuntime from "../opencodeRuntime.ts";
@@ -1832,6 +1836,26 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         }),
       );
 
+      it.effect("reports unknown, not empty, when codex workspace discovery cannot run", () =>
+        Effect.gen(function* () {
+          // An uninstalled CLI must not be reported as "this workspace has no
+          // skills": that would outrank the snapshot fallback every caller
+          // holds and blank the picker until the cache expired.
+          const failed = yield* listCodexWorkspaceSkills(defaultCodexSettings, "/repos/alpha").pipe(
+            Effect.provide(failingSpawnerLayer("spawn codex ENOENT")),
+          );
+          assert.strictEqual(failed, undefined);
+
+          // A disabled provider is an answer, not a failure — there is
+          // nothing to discover and nothing to fall back to.
+          const disabled = yield* listCodexWorkspaceSkills(
+            disabledCodexSettings,
+            "/repos/alpha",
+          ).pipe(Effect.provide(failingSpawnerLayer("spawn codex ENOENT")));
+          assert.deepStrictEqual(disabled, []);
+        }),
+      );
+
       // ── workspace-scoped skills ─────────────────────────────────
       //
       // The registry routes `listWorkspaceSkills` to live instances and
@@ -1941,7 +1965,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           );
 
           assert.deepStrictEqual(
-            skills.map((skill) => skill.name),
+            skills?.map((skill) => skill.name),
             ["skill-in-/repos/alpha"],
           );
           assert.strictEqual(yield* Ref.get(otherCalls), 0);
@@ -1968,33 +1992,24 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             registry.listWorkspaceSkills({ cwd: "/repos/alpha" }),
           );
 
-          assert.deepStrictEqual(skills.map((skill) => `${skill.name}:${skill.path}`).toSorted(), [
+          assert.deepStrictEqual(skills?.map((skill) => `${skill.name}:${skill.path}`).toSorted(), [
             "deploy:/personal/deploy",
             "review:/personal/review",
           ]);
         }),
       );
 
-      it.effect("degrades to an empty list instead of failing the caller", () =>
+      it.effect("reports an empty list only when a driver actually answered", () =>
         Effect.gen(function* () {
           const withoutSkillSurface = makeSkillsInstance({ instanceId: "codex_plain" });
-          const failing = makeSkillsInstance({
-            instanceId: "codex_broken",
-            listWorkspaceSkills: () => Effect.die(new Error("driver exploded")),
+          const answeringEmpty = makeSkillsInstance({
+            instanceId: "codex_empty",
+            listWorkspaceSkills: () => Effect.succeed([]),
           });
 
-          // Unknown instance id.
-          assert.deepStrictEqual(
-            yield* withSkillsRegistry([withoutSkillSurface], (registry) =>
-              registry.listWorkspaceSkills({
-                instanceId: ProviderInstanceId.make("codex_missing"),
-                cwd: "/repos/alpha",
-              }),
-            ),
-            [],
-          );
-
-          // Driver with no skill surface (Grok, Cursor, OpenCode).
+          // A driver with no skill surface at all (Grok, Cursor, OpenCode)
+          // knows there is nothing to offer — that is an answer, and the
+          // picker should render its empty state.
           assert.deepStrictEqual(
             yield* withSkillsRegistry([withoutSkillSurface], (registry) =>
               registry.listWorkspaceSkills({
@@ -2005,16 +2020,88 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             [],
           );
 
-          // A driver defect is logged and swallowed: the picker falls back to
-          // the snapshot rather than surfacing an RPC failure.
+          // So is a successful probe that found no skills in this workspace.
           assert.deepStrictEqual(
+            yield* withSkillsRegistry([answeringEmpty], (registry) =>
+              registry.listWorkspaceSkills({
+                instanceId: ProviderInstanceId.make("codex_empty"),
+                cwd: "/repos/alpha",
+              }),
+            ),
+            [],
+          );
+        }),
+      );
+
+      it.effect("reports nothing at all when no target could answer", () =>
+        Effect.gen(function* () {
+          const withoutSkillSurface = makeSkillsInstance({ instanceId: "codex_plain" });
+          const failing = makeSkillsInstance({
+            instanceId: "codex_broken",
+            listWorkspaceSkills: () => Effect.succeed(undefined),
+          });
+          const defective = makeSkillsInstance({
+            instanceId: "codex_defective",
+            listWorkspaceSkills: () => Effect.die(new Error("driver exploded")),
+          });
+
+          // An instance id nobody recognises: we learned nothing about this
+          // workspace, so say so rather than claiming it has no skills.
+          assert.strictEqual(
+            yield* withSkillsRegistry([withoutSkillSurface], (registry) =>
+              registry.listWorkspaceSkills({
+                instanceId: ProviderInstanceId.make("codex_missing"),
+                cwd: "/repos/alpha",
+              }),
+            ),
+            undefined,
+          );
+
+          // A driver that could not look (binary missing, probe timed out).
+          assert.strictEqual(
             yield* withSkillsRegistry([failing], (registry) =>
               registry.listWorkspaceSkills({
                 instanceId: ProviderInstanceId.make("codex_broken"),
                 cwd: "/repos/alpha",
               }),
             ),
-            [],
+            undefined,
+          );
+
+          // A driver defect is logged and swallowed, and counts as "unknown"
+          // for the same reason — the RPC must not fail, but it must not
+          // invent an empty answer either.
+          assert.strictEqual(
+            yield* withSkillsRegistry([defective], (registry) =>
+              registry.listWorkspaceSkills({
+                instanceId: ProviderInstanceId.make("codex_defective"),
+                cwd: "/repos/alpha",
+              }),
+            ),
+            undefined,
+          );
+        }),
+      );
+
+      it.effect("merges the instances that answered when only some fail", () =>
+        Effect.gen(function* () {
+          const answering = makeSkillsInstance({
+            instanceId: "codex_personal",
+            listWorkspaceSkills: () =>
+              Effect.succeed([{ name: "deploy", path: "/personal/deploy", enabled: true }]),
+          });
+          const failing = makeSkillsInstance({
+            instanceId: "codex_work",
+            listWorkspaceSkills: () => Effect.succeed(undefined),
+          });
+
+          const skills = yield* withSkillsRegistry([failing, answering], (registry) =>
+            registry.listWorkspaceSkills({ cwd: "/repos/alpha" }),
+          );
+
+          assert.deepStrictEqual(
+            skills?.map((skill) => skill.name),
+            ["deploy"],
           );
         }),
       );

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -27,6 +27,7 @@ import {
   ProviderDriverKind,
   type ProviderInstanceId,
   type ServerProvider,
+  type ServerProviderSkill,
   type ServerProviderUpdateState,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
@@ -496,6 +497,59 @@ export const ProviderRegistryLive = Layer.effect(
       return yield* refreshOneSource(providerSource);
     });
 
+    /**
+     * Ask live instances what skills a workspace exposes.
+     *
+     * The cwd comes from the caller because nothing on this layer knows which
+     * project a client is looking at: `ProviderRegistry` depends only on
+     * `ServerConfig` (whose `cwd` is the server's single startup directory)
+     * and `ProviderInstanceRegistry`. Drivers own the discovery and its
+     * caching; here we only route, dedupe, and swallow driver defects so an
+     * exotic driver can never take the picker down.
+     */
+    const listWorkspaceSkills = Effect.fn("listWorkspaceSkills")(function* (input: {
+      readonly instanceId?: ProviderInstanceId | undefined;
+      readonly cwd: string;
+    }) {
+      const instances = Array.from((yield* Ref.get(liveSubsRef)).values());
+      const targets =
+        input.instanceId === undefined
+          ? instances
+          : instances.filter((candidate) => candidate.instanceId === input.instanceId);
+
+      const skillLists = yield* Effect.forEach(
+        targets,
+        (instance) =>
+          (
+            instance.listWorkspaceSkills?.(input.cwd) ??
+            Effect.succeed<ReadonlyArray<ServerProviderSkill>>([])
+          ).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("workspace skill discovery failed", {
+                instanceId: instance.instanceId,
+                driver: instance.driverKind,
+                cwd: input.cwd,
+                cause: Cause.pretty(cause),
+              }).pipe(Effect.as<ReadonlyArray<ServerProviderSkill>>([])),
+            ),
+          ),
+        { concurrency: "unbounded" },
+      );
+
+      // First writer wins on duplicate names: within one instance the driver
+      // already applied its own precedence (project over user), and across
+      // instances the order follows the registry's instance order.
+      const skillsByName = new Map<string, ServerProviderSkill>();
+      for (const skills of skillLists) {
+        for (const skill of skills) {
+          if (!skillsByName.has(skill.name)) {
+            skillsByName.set(skill.name, skill);
+          }
+        }
+      }
+      return [...skillsByName.values()];
+    });
+
     const getProviderMaintenanceCapabilitiesForInstance = Effect.fn(
       "getProviderMaintenanceCapabilitiesForInstance",
     )(function* (instanceId: ProviderInstanceId, provider: ProviderDriverKind) {
@@ -710,6 +764,7 @@ export const ProviderRegistryLive = Layer.effect(
         refresh(provider).pipe(Effect.catchCause(recoverRefreshFailure)),
       refreshInstance: (instanceId: ProviderInstanceId) =>
         refreshInstance(instanceId).pipe(Effect.catchCause(recoverRefreshFailure)),
+      listWorkspaceSkills,
       getProviderMaintenanceCapabilitiesForInstance,
       setProviderMaintenanceActionState,
       get streamChanges() {

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -497,21 +497,6 @@ export const ProviderRegistryLive = Layer.effect(
       return yield* refreshOneSource(providerSource);
     });
 
-    /**
-     * Ask live instances what skills a workspace exposes.
-     *
-     * The cwd comes from the caller because nothing on this layer knows which
-     * project a client is looking at: `ProviderRegistry` depends only on
-     * `ServerConfig` (whose `cwd` is the server's single startup directory)
-     * and `ProviderInstanceRegistry`. Drivers own the discovery and its
-     * caching; here we only route, dedupe, and swallow driver defects so an
-     * exotic driver can never take the picker down.
-     *
-     * A driver that could not look reports `undefined`, and so do we when no
-     * target produced an answer — including an instance id nobody recognises.
-     * Collapsing that into `[]` would tell the caller "this workspace has no
-     * skills" and suppress the fallback it is holding.
-     */
     const listWorkspaceSkills = Effect.fn("listWorkspaceSkills")(function* (input: {
       readonly instanceId?: ProviderInstanceId | undefined;
       readonly cwd: string;
@@ -525,9 +510,8 @@ export const ProviderRegistryLive = Layer.effect(
       const skillLists = yield* Effect.forEach(
         targets,
         (instance) =>
-          // A driver without the capability has no skill surface at all
-          // (Grok, Cursor, OpenCode) — an honest empty answer, not a
-          // failure.
+          // No capability means no skill surface (Grok, Cursor, OpenCode):
+          // an empty answer, not a failure.
           (
             instance.listWorkspaceSkills?.(input.cwd) ??
             Effect.succeed<ReadonlyArray<ServerProviderSkill> | undefined>([])
@@ -551,9 +535,8 @@ export const ProviderRegistryLive = Layer.effect(
         return undefined;
       }
 
-      // First writer wins on duplicate names: within one instance the driver
-      // already applied its own precedence (project over user), and across
-      // instances the order follows the registry's instance order.
+      // First writer wins: each driver already applied its own precedence
+      // (project over user), and instance order decides between drivers.
       const skillsByName = new Map<string, ServerProviderSkill>();
       for (const skills of answeredSkillLists) {
         for (const skill of skills) {

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -506,6 +506,11 @@ export const ProviderRegistryLive = Layer.effect(
      * and `ProviderInstanceRegistry`. Drivers own the discovery and its
      * caching; here we only route, dedupe, and swallow driver defects so an
      * exotic driver can never take the picker down.
+     *
+     * A driver that could not look reports `undefined`, and so do we when no
+     * target produced an answer — including an instance id nobody recognises.
+     * Collapsing that into `[]` would tell the caller "this workspace has no
+     * skills" and suppress the fallback it is holding.
      */
     const listWorkspaceSkills = Effect.fn("listWorkspaceSkills")(function* (input: {
       readonly instanceId?: ProviderInstanceId | undefined;
@@ -520,9 +525,12 @@ export const ProviderRegistryLive = Layer.effect(
       const skillLists = yield* Effect.forEach(
         targets,
         (instance) =>
+          // A driver without the capability has no skill surface at all
+          // (Grok, Cursor, OpenCode) — an honest empty answer, not a
+          // failure.
           (
             instance.listWorkspaceSkills?.(input.cwd) ??
-            Effect.succeed<ReadonlyArray<ServerProviderSkill>>([])
+            Effect.succeed<ReadonlyArray<ServerProviderSkill> | undefined>([])
           ).pipe(
             Effect.catchCause((cause) =>
               Effect.logWarning("workspace skill discovery failed", {
@@ -530,17 +538,24 @@ export const ProviderRegistryLive = Layer.effect(
                 driver: instance.driverKind,
                 cwd: input.cwd,
                 cause: Cause.pretty(cause),
-              }).pipe(Effect.as<ReadonlyArray<ServerProviderSkill>>([])),
+              }).pipe(Effect.as<ReadonlyArray<ServerProviderSkill> | undefined>(undefined)),
             ),
           ),
         { concurrency: "unbounded" },
       );
 
+      const answeredSkillLists = skillLists.filter(
+        (skills): skills is ReadonlyArray<ServerProviderSkill> => skills !== undefined,
+      );
+      if (answeredSkillLists.length === 0) {
+        return undefined;
+      }
+
       // First writer wins on duplicate names: within one instance the driver
       // already applied its own precedence (project over user), and across
       // instances the order follows the registry's instance order.
       const skillsByName = new Map<string, ServerProviderSkill>();
-      for (const skills of skillLists) {
+      for (const skills of answeredSkillLists) {
         for (const skill of skills) {
           if (!skillsByName.has(skill.name)) {
             skillsByName.set(skill.name, skill);

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -25,6 +25,7 @@ import type {
   ProviderDriverKind,
   ProviderInstanceEnvironment,
   ProviderInstanceId,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import type * as Effect from "effect/Effect";
 import type * as Schema from "effect/Schema";
@@ -71,6 +72,22 @@ export interface ProviderInstance {
   readonly snapshot: ServerProviderShape;
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
   readonly textGeneration: TextGeneration.TextGeneration["Service"];
+  /**
+   * Optional capability: enumerate the skills this instance would load for a
+   * given workspace directory.
+   *
+   * `snapshot` carries a `skills` list too, but that one is discovered once
+   * against the server's own cwd — a single process-wide directory that has
+   * nothing to do with the project a client is looking at. This capability
+   * takes the workspace in the request instead, so the answer is scoped to
+   * the caller's repo. Only drivers with a skill surface (Claude, Codex)
+   * implement it; the rest leave it undefined and callers fall back to the
+   * snapshot.
+   *
+   * Discovery is best-effort by contract: the returned effect never fails,
+   * it degrades to whatever was readable.
+   */
+  readonly listWorkspaceSkills?: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
 }
 
 export interface ProviderContinuationIdentity {

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -84,10 +84,19 @@ export interface ProviderInstance {
    * implement it; the rest leave it undefined and callers fall back to the
    * snapshot.
    *
-   * Discovery is best-effort by contract: the returned effect never fails,
-   * it degrades to whatever was readable.
+   * Discovery is best-effort by contract: the returned effect never fails.
+   * It distinguishes two outcomes that must not be conflated —
+   *   - a list (possibly empty) means discovery ran and this is the answer;
+   *   - `undefined` means discovery could not run at all (binary missing,
+   *     probe timed out, request errored) and the driver knows nothing.
+   *
+   * An empty array would otherwise read as "this workspace has no skills" and
+   * suppress every fallback the caller has, blanking the picker on a
+   * transient failure.
    */
-  readonly listWorkspaceSkills?: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
+  readonly listWorkspaceSkills?: (
+    cwd: string,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderSkill> | undefined>;
 }
 
 export interface ProviderContinuationIdentity {

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -73,26 +73,15 @@ export interface ProviderInstance {
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
   readonly textGeneration: TextGeneration.TextGeneration["Service"];
   /**
-   * Optional capability: enumerate the skills this instance would load for a
-   * given workspace directory.
+   * Enumerate the skills this instance would load for a workspace directory.
+   * Only drivers with a skill surface (Claude, Codex) implement it; the rest
+   * leave it undefined and callers fall back to `snapshot.skills`.
    *
-   * `snapshot` carries a `skills` list too, but that one is discovered once
-   * against the server's own cwd — a single process-wide directory that has
-   * nothing to do with the project a client is looking at. This capability
-   * takes the workspace in the request instead, so the answer is scoped to
-   * the caller's repo. Only drivers with a skill surface (Claude, Codex)
-   * implement it; the rest leave it undefined and callers fall back to the
-   * snapshot.
-   *
-   * Discovery is best-effort by contract: the returned effect never fails.
-   * It distinguishes two outcomes that must not be conflated —
-   *   - a list (possibly empty) means discovery ran and this is the answer;
-   *   - `undefined` means discovery could not run at all (binary missing,
-   *     probe timed out, request errored) and the driver knows nothing.
-   *
-   * An empty array would otherwise read as "this workspace has no skills" and
-   * suppress every fallback the caller has, blanking the picker on a
-   * transient failure.
+   * Never fails, and keeps two outcomes apart: a list (possibly empty) is an
+   * answer, while `undefined` means discovery could not run at all (binary
+   * missing, probe timed out). Reporting `[]` for a failed probe would read as
+   * "no skills here" and suppress every fallback the caller has, blanking the
+   * picker on a transient failure.
    */
   readonly listWorkspaceSkills?: (
     cwd: string,

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -60,15 +60,19 @@ export interface ProviderRegistryShape {
    * the caller (which already resolved the thread's worktree or the project's
    * root) decides what to scan.
    *
-   * Best-effort: unknown instances, drivers without a skill surface, and
-   * unreadable directories all resolve with an empty list instead of failing.
-   * When `instanceId` is omitted every live instance is asked and the results
+   * Best-effort, and never fails. `undefined` means nothing could be
+   * discovered — an unknown instance, or every asked driver failing — and
+   * tells the caller to keep using whatever it had. A list, including an
+   * empty one, is an answer: drivers without a skill surface legitimately
+   * report `[]`, as does a workspace that really has no skills.
+   *
+   * When `instanceId` is omitted every live instance is asked and the answers
    * are merged, matching `refresh`'s untargeted semantics.
    */
   readonly listWorkspaceSkills: (input: {
     readonly instanceId?: ProviderInstanceId | undefined;
     readonly cwd: string;
-  }) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
+  }) => Effect.Effect<ReadonlyArray<ServerProviderSkill> | undefined>;
 
   /**
    * Resolve the maintenance capabilities owned by one live provider instance.

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -50,24 +50,9 @@ export interface ProviderRegistryShape {
   ) => Effect.Effect<ReadonlyArray<ServerProvider>>;
 
   /**
-   * List the skills one workspace directory exposes, asking the live
-   * instance's driver rather than reading the snapshot.
-   *
-   * `ServerProvider.skills` is discovered once against the server's own cwd —
-   * a process-wide directory fixed at startup — so it cannot answer "what
-   * skills does the project this client is viewing have?". The registry has no
-   * access to the projects table, so the workspace travels in the request and
-   * the caller (which already resolved the thread's worktree or the project's
-   * root) decides what to scan.
-   *
-   * Best-effort, and never fails. `undefined` means nothing could be
-   * discovered — an unknown instance, or every asked driver failing — and
-   * tells the caller to keep using whatever it had. A list, including an
-   * empty one, is an answer: drivers without a skill surface legitimately
-   * report `[]`, as does a workspace that really has no skills.
-   *
-   * When `instanceId` is omitted every live instance is asked and the answers
-   * are merged, matching `refresh`'s untargeted semantics.
+   * List the skills one workspace directory exposes, asking live drivers
+   * rather than reading the snapshot. Omitting `instanceId` asks every live
+   * instance and merges the answers, like `refresh`.
    */
   readonly listWorkspaceSkills: (input: {
     readonly instanceId?: ProviderInstanceId | undefined;

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -10,6 +10,7 @@ import type {
   ProviderInstanceId,
   ProviderDriverKind,
   ServerProvider,
+  ServerProviderSkill,
   ServerProviderUpdateState,
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
@@ -47,6 +48,27 @@ export interface ProviderRegistryShape {
   readonly refreshInstance: (
     instanceId: ProviderInstanceId,
   ) => Effect.Effect<ReadonlyArray<ServerProvider>>;
+
+  /**
+   * List the skills one workspace directory exposes, asking the live
+   * instance's driver rather than reading the snapshot.
+   *
+   * `ServerProvider.skills` is discovered once against the server's own cwd —
+   * a process-wide directory fixed at startup — so it cannot answer "what
+   * skills does the project this client is viewing have?". The registry has no
+   * access to the projects table, so the workspace travels in the request and
+   * the caller (which already resolved the thread's worktree or the project's
+   * root) decides what to scan.
+   *
+   * Best-effort: unknown instances, drivers without a skill surface, and
+   * unreadable directories all resolve with an empty list instead of failing.
+   * When `instanceId` is omitted every live instance is asked and the results
+   * are merged, matching `refresh`'s untargeted semantics.
+   */
+  readonly listWorkspaceSkills: (input: {
+    readonly instanceId?: ProviderInstanceId | undefined;
+    readonly cwd: string;
+  }) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
 
   /**
    * Resolve the maintenance capabilities owned by one live provider instance.

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -189,6 +189,7 @@ function makeRegistry(
       getProviders: Ref.get(providersRef),
       refresh: () => Ref.get(providersRef),
       refreshInstance: () => Ref.get(providersRef),
+      listWorkspaceSkills: () => Effect.succeed([]),
       getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
         Effect.succeed(lifecycleFor(provider)),
       setProviderMaintenanceActionState,

--- a/apps/server/src/provider/testUtils/providerRegistryMock.ts
+++ b/apps/server/src/provider/testUtils/providerRegistryMock.ts
@@ -11,6 +11,7 @@ export const makeProviderRegistryMock = (
   getProviders: Effect.succeed(providers),
   refresh: () => Effect.succeed(providers),
   refreshInstance: () => Effect.succeed(providers),
+  listWorkspaceSkills: () => Effect.succeed([]),
   getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
     Effect.succeed(makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null })),
   setProviderMaintenanceActionState: () => Effect.succeed(providers),

--- a/apps/server/src/provider/workspaceSkills.test.ts
+++ b/apps/server/src/provider/workspaceSkills.test.ts
@@ -69,12 +69,14 @@ it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
 
       // Both scopes show up, and the project scope is whichever workspace was
       // asked about — not one process-wide directory picked at startup.
+      const alphaSkills = yield* listWorkspaceSkills(alpha);
+      const betaSkills = yield* listWorkspaceSkills(beta);
       assert.deepStrictEqual(
-        (yield* listWorkspaceSkills(alpha)).map((skill) => `${skill.scope}:${skill.name}`),
+        alphaSkills?.map((skill) => `${skill.scope}:${skill.name}`),
         ["project:alpha-deploy", "user:global-review"],
       );
       assert.deepStrictEqual(
-        (yield* listWorkspaceSkills(beta)).map((skill) => `${skill.scope}:${skill.name}`),
+        betaSkills?.map((skill) => `${skill.scope}:${skill.name}`),
         ["project:beta-deploy", "user:global-review"],
       );
     }),
@@ -102,9 +104,9 @@ it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
       const listWorkspaceSkills = yield* makeClaudeWorkspaceSkills(configDir);
       const skills = yield* listWorkspaceSkills(workspace);
 
-      assert.strictEqual(skills.length, 1);
-      assert.strictEqual(skills[0]?.scope, "project");
-      assert.strictEqual(skills[0]?.description, "Project deploy.");
+      assert.strictEqual(skills?.length, 1);
+      assert.strictEqual(skills?.[0]?.scope, "project");
+      assert.strictEqual(skills?.[0]?.description, "Project deploy.");
     }),
   );
 
@@ -127,7 +129,7 @@ it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
       const skills = yield* listWorkspaceSkills(path.join(tempDir, "does-not-exist"));
 
       assert.deepStrictEqual(
-        skills.map((skill) => skill.name),
+        skills?.map((skill) => skill.name),
         ["global-review"],
       );
     }),
@@ -144,7 +146,38 @@ it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
       yield* listWorkspaceSkills("/repos/alpha");
       yield* listWorkspaceSkills("/repos/beta");
 
+      // An empty answer is still an answer, so it stays cached.
       assert.deepStrictEqual(yield* Ref.get(lookups), ["/repos/alpha", "/repos/beta"]);
+    }),
+  );
+
+  it.effect("retries after a failed lookup instead of caching the unknown", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0);
+      const listWorkspaceSkills = yield* makeWorkspaceSkillsCache(() =>
+        Ref.updateAndGet(attempts, (count) => count + 1).pipe(
+          // First probe fails (no binary, timeout, …), the retry succeeds.
+          Effect.map((count) =>
+            count === 1
+              ? undefined
+              : [{ name: "deploy", path: "/repos/alpha/.codex/skills/deploy", enabled: true }],
+          ),
+        ),
+      );
+
+      // Caching the failure would leave the picker blank for the whole TTL,
+      // because an unknown that reached the client as `[]` outranks every
+      // fallback it has.
+      assert.strictEqual(yield* listWorkspaceSkills("/repos/alpha"), undefined);
+      assert.deepStrictEqual(
+        (yield* listWorkspaceSkills("/repos/alpha"))?.map((skill) => skill.name),
+        ["deploy"],
+      );
+      assert.strictEqual(yield* Ref.get(attempts), 2);
+
+      // The successful answer is cached from then on.
+      yield* listWorkspaceSkills("/repos/alpha");
+      assert.strictEqual(yield* Ref.get(attempts), 2);
     }),
   );
 });

--- a/apps/server/src/provider/workspaceSkills.test.ts
+++ b/apps/server/src/provider/workspaceSkills.test.ts
@@ -23,11 +23,7 @@ const writeSkill = Effect.fn(function* (
 const skillDocument = (name: string, description: string) =>
   ["---", `name: ${name}`, `description: ${description}`, "---"].join("\n");
 
-/**
- * Mirror how `ClaudeDriver` wires discovery: the config and environment are
- * bound once per instance, the workspace arrives per call, and the filesystem
- * services are pre-provided so the cached lookup has no requirements.
- */
+/** Mirrors how `ClaudeDriver` wires discovery: config per instance, cwd per call. */
 const makeClaudeWorkspaceSkills = Effect.fn(function* (configDir: string) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -67,8 +63,6 @@ it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
 
       const listWorkspaceSkills = yield* makeClaudeWorkspaceSkills(configDir);
 
-      // Both scopes show up, and the project scope is whichever workspace was
-      // asked about — not one process-wide directory picked at startup.
       const alphaSkills = yield* listWorkspaceSkills(alpha);
       const betaSkills = yield* listWorkspaceSkills(beta);
       assert.deepStrictEqual(
@@ -124,8 +118,6 @@ it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
       );
 
       const listWorkspaceSkills = yield* makeClaudeWorkspaceSkills(configDir);
-      // A project that was deleted (or a worktree that was pruned) must not
-      // fail the lookup — the picker still needs the user's own skills.
       const skills = yield* listWorkspaceSkills(path.join(tempDir, "does-not-exist"));
 
       assert.deepStrictEqual(
@@ -156,7 +148,6 @@ it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
       const attempts = yield* Ref.make(0);
       const listWorkspaceSkills = yield* makeWorkspaceSkillsCache(() =>
         Ref.updateAndGet(attempts, (count) => count + 1).pipe(
-          // First probe fails (no binary, timeout, …), the retry succeeds.
           Effect.map((count) =>
             count === 1
               ? undefined
@@ -165,9 +156,6 @@ it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
         ),
       );
 
-      // Caching the failure would leave the picker blank for the whole TTL,
-      // because an unknown that reached the client as `[]` outranks every
-      // fallback it has.
       assert.strictEqual(yield* listWorkspaceSkills("/repos/alpha"), undefined);
       assert.deepStrictEqual(
         (yield* listWorkspaceSkills("/repos/alpha"))?.map((skill) => skill.name),
@@ -175,7 +163,6 @@ it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
       );
       assert.strictEqual(yield* Ref.get(attempts), 2);
 
-      // The successful answer is cached from then on.
       yield* listWorkspaceSkills("/repos/alpha");
       assert.strictEqual(yield* Ref.get(attempts), 2);
     }),

--- a/apps/server/src/provider/workspaceSkills.test.ts
+++ b/apps/server/src/provider/workspaceSkills.test.ts
@@ -1,0 +1,150 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
+
+import { discoverClaudeSkills } from "./Drivers/ClaudeSkills.ts";
+import { makeWorkspaceSkillsCache } from "./workspaceSkills.ts";
+
+const writeSkill = Effect.fn(function* (
+  skillsDir: string,
+  directoryName: string,
+  contents: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillDir = path.join(skillsDir, directoryName);
+  yield* fs.makeDirectory(skillDir, { recursive: true });
+  yield* fs.writeFileString(path.join(skillDir, "SKILL.md"), contents);
+});
+
+const skillDocument = (name: string, description: string) =>
+  ["---", `name: ${name}`, `description: ${description}`, "---"].join("\n");
+
+/**
+ * Mirror how `ClaudeDriver` wires discovery: the config and environment are
+ * bound once per instance, the workspace arrives per call, and the filesystem
+ * services are pre-provided so the cached lookup has no requirements.
+ */
+const makeClaudeWorkspaceSkills = Effect.fn(function* (configDir: string) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  return yield* makeWorkspaceSkillsCache((cwd) =>
+    discoverClaudeSkills({ homePath: configDir }, cwd, {}).pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(Path.Path, path),
+    ),
+  );
+});
+
+it.layer(NodeServices.layer)("workspace-scoped skills", (it) => {
+  it.effect("answers each workspace with its own project skills plus the user skills", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-workspace-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const alpha = path.join(tempDir, "alpha");
+      const beta = path.join(tempDir, "beta");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "global-review",
+        skillDocument("global-review", "Available everywhere."),
+      );
+      yield* writeSkill(
+        path.join(alpha, ".claude", "skills"),
+        "alpha-deploy",
+        skillDocument("alpha-deploy", "Deploy alpha."),
+      );
+      yield* writeSkill(
+        path.join(beta, ".claude", "skills"),
+        "beta-deploy",
+        skillDocument("beta-deploy", "Deploy beta."),
+      );
+
+      const listWorkspaceSkills = yield* makeClaudeWorkspaceSkills(configDir);
+
+      // Both scopes show up, and the project scope is whichever workspace was
+      // asked about — not one process-wide directory picked at startup.
+      assert.deepStrictEqual(
+        (yield* listWorkspaceSkills(alpha)).map((skill) => `${skill.scope}:${skill.name}`),
+        ["project:alpha-deploy", "user:global-review"],
+      );
+      assert.deepStrictEqual(
+        (yield* listWorkspaceSkills(beta)).map((skill) => `${skill.scope}:${skill.name}`),
+        ["project:beta-deploy", "user:global-review"],
+      );
+    }),
+  );
+
+  it.effect("lets the workspace's project skill win a name collision", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-workspace-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "deploy",
+        skillDocument("deploy", "User deploy."),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".claude", "skills"),
+        "deploy",
+        skillDocument("deploy", "Project deploy."),
+      );
+
+      const listWorkspaceSkills = yield* makeClaudeWorkspaceSkills(configDir);
+      const skills = yield* listWorkspaceSkills(workspace);
+
+      assert.strictEqual(skills.length, 1);
+      assert.strictEqual(skills[0]?.scope, "project");
+      assert.strictEqual(skills[0]?.description, "Project deploy.");
+    }),
+  );
+
+  it.effect("degrades to user skills when the workspace directory is missing", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-workspace-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "global-review",
+        skillDocument("global-review", "Available everywhere."),
+      );
+
+      const listWorkspaceSkills = yield* makeClaudeWorkspaceSkills(configDir);
+      // A project that was deleted (or a worktree that was pruned) must not
+      // fail the lookup — the picker still needs the user's own skills.
+      const skills = yield* listWorkspaceSkills(path.join(tempDir, "does-not-exist"));
+
+      assert.deepStrictEqual(
+        skills.map((skill) => skill.name),
+        ["global-review"],
+      );
+    }),
+  );
+
+  it.effect("caches per workspace so reopening the picker does not rescan", () =>
+    Effect.gen(function* () {
+      const lookups = yield* Ref.make<ReadonlyArray<string>>([]);
+      const listWorkspaceSkills = yield* makeWorkspaceSkillsCache((cwd) =>
+        Ref.update(lookups, (previous) => [...previous, cwd]).pipe(Effect.as([])),
+      );
+
+      yield* listWorkspaceSkills("/repos/alpha");
+      yield* listWorkspaceSkills("/repos/alpha");
+      yield* listWorkspaceSkills("/repos/beta");
+
+      assert.deepStrictEqual(yield* Ref.get(lookups), ["/repos/alpha", "/repos/beta"]);
+    }),
+  );
+});

--- a/apps/server/src/provider/workspaceSkills.ts
+++ b/apps/server/src/provider/workspaceSkills.ts
@@ -1,0 +1,46 @@
+/**
+ * workspaceSkills — per-workspace caching for driver skill discovery.
+ *
+ * `ProviderInstance.listWorkspaceSkills` is answered on demand, one call per
+ * skill-picker open, and the Codex implementation spawns a `codex app-server`
+ * child process to answer it. Re-running discovery on every keystroke-triggered
+ * picker open would be unacceptably slow, so each instance wraps its lookup in
+ * a short-lived cache keyed by the workspace directory. The cache lives on the
+ * instance, which makes the effective key `(instanceId, cwd)` — two Codex
+ * instances with different `CODEX_HOME`s never share an answer.
+ *
+ * The TTL is deliberately short: a user who just created a `SKILL.md` should
+ * see it in the picker without restarting the server.
+ *
+ * @module provider/workspaceSkills
+ */
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+
+const WORKSPACE_SKILLS_TTL = Duration.seconds(30);
+/**
+ * Enough room for the handful of projects a user switches between in one
+ * sitting; the cache evicts by capacity so a long-lived server that visited
+ * many worktrees does not retain every one of them.
+ */
+const WORKSPACE_SKILLS_CAPACITY = 32;
+
+/**
+ * Wrap a driver's workspace skill discovery in the shared cache policy.
+ *
+ * `discover` must already be best-effort (error channel `never`) — a cache
+ * stores failures too, so a driver that let a transient error through would
+ * keep serving that failure for the whole TTL.
+ */
+export const makeWorkspaceSkillsCache = Effect.fn("makeWorkspaceSkillsCache")(function* (
+  discover: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>,
+) {
+  const cache = yield* Cache.make({
+    capacity: WORKSPACE_SKILLS_CAPACITY,
+    timeToLive: WORKSPACE_SKILLS_TTL,
+    lookup: discover,
+  });
+  return (cwd: string) => Cache.get(cache, cwd);
+});

--- a/apps/server/src/provider/workspaceSkills.ts
+++ b/apps/server/src/provider/workspaceSkills.ts
@@ -1,16 +1,6 @@
 /**
- * workspaceSkills — per-workspace caching for driver skill discovery.
- *
- * `ProviderInstance.listWorkspaceSkills` is answered on demand, one call per
- * skill-picker open, and the Codex implementation spawns a `codex app-server`
- * child process to answer it. Re-running discovery on every keystroke-triggered
- * picker open would be unacceptably slow, so each instance wraps its lookup in
- * a short-lived cache keyed by the workspace directory. The cache lives on the
- * instance, which makes the effective key `(instanceId, cwd)` — two Codex
- * instances with different `CODEX_HOME`s never share an answer.
- *
- * The TTL is deliberately short: a user who just created a `SKILL.md` should
- * see it in the picker without restarting the server.
+ * Per-workspace cache for driver skill discovery. Codex answers by spawning a
+ * `codex app-server`, so reopening the picker must not re-probe.
  *
  * @module provider/workspaceSkills
  */
@@ -20,24 +10,12 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 
 const WORKSPACE_SKILLS_TTL = Duration.seconds(30);
-/**
- * Enough room for the handful of projects a user switches between in one
- * sitting; the cache evicts by capacity so a long-lived server that visited
- * many worktrees does not retain every one of them.
- */
 const WORKSPACE_SKILLS_CAPACITY = 32;
 
 /**
- * Wrap a driver's workspace skill discovery in the shared cache policy.
- *
- * `discover` must already be best-effort (error channel `never`) and must
- * report a failed discovery as `undefined` rather than an empty list, so
- * "nothing here" stays distinguishable from "we could not look".
- *
- * Only answers are cached. A cache retains whatever the lookup produced, so
- * an `undefined` is dropped again immediately — otherwise one unlucky probe
- * would blank the picker for the rest of the TTL, which is exactly the
- * failure this indirection exists to prevent.
+ * Wrap a driver's workspace skill discovery in the shared cache policy. Only
+ * answers are cached; an `undefined` is evicted again immediately so one
+ * unlucky probe does not blank the picker for the rest of the TTL.
  */
 export const makeWorkspaceSkillsCache = Effect.fn("makeWorkspaceSkillsCache")(function* (
   discover: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill> | undefined>,
@@ -53,7 +31,7 @@ export const makeWorkspaceSkillsCache = Effect.fn("makeWorkspaceSkillsCache")(fu
       const skills = yield* Cache.get(cache, cwd);
       if (skills === undefined) {
         // `invalidateWhen` re-reads the stored value, so a concurrent lookup
-        // that already succeeded for this workspace is never thrown away.
+        // that already succeeded is never thrown away.
         yield* Cache.invalidateWhen(cache, cwd, (cached) => cached === undefined);
       }
       return skills;

--- a/apps/server/src/provider/workspaceSkills.ts
+++ b/apps/server/src/provider/workspaceSkills.ts
@@ -30,17 +30,32 @@ const WORKSPACE_SKILLS_CAPACITY = 32;
 /**
  * Wrap a driver's workspace skill discovery in the shared cache policy.
  *
- * `discover` must already be best-effort (error channel `never`) — a cache
- * stores failures too, so a driver that let a transient error through would
- * keep serving that failure for the whole TTL.
+ * `discover` must already be best-effort (error channel `never`) and must
+ * report a failed discovery as `undefined` rather than an empty list, so
+ * "nothing here" stays distinguishable from "we could not look".
+ *
+ * Only answers are cached. A cache retains whatever the lookup produced, so
+ * an `undefined` is dropped again immediately — otherwise one unlucky probe
+ * would blank the picker for the rest of the TTL, which is exactly the
+ * failure this indirection exists to prevent.
  */
 export const makeWorkspaceSkillsCache = Effect.fn("makeWorkspaceSkillsCache")(function* (
-  discover: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>,
+  discover: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill> | undefined>,
 ) {
   const cache = yield* Cache.make({
     capacity: WORKSPACE_SKILLS_CAPACITY,
     timeToLive: WORKSPACE_SKILLS_TTL,
     lookup: discover,
   });
-  return (cwd: string) => Cache.get(cache, cwd);
+
+  return (cwd: string) =>
+    Effect.gen(function* () {
+      const skills = yield* Cache.get(cache, cwd);
+      if (skills === undefined) {
+        // `invalidateWhen` re-reads the stored value, so a concurrent lookup
+        // that already succeeded for this workspace is never thrown away.
+        yield* Cache.invalidateWhen(cache, cwd, (cached) => cached === undefined);
+      }
+      return skills;
+    });
 });

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1450,18 +1450,13 @@ const makeWsRpcLayer = (
         [WS_METHODS.serverListWorkspaceSkills]: (input) =>
           observeRpcEffect(
             WS_METHODS.serverListWorkspaceSkills,
-            // The workspace arrives with the request: the server holds one
-            // global cwd and no notion of which project a client is viewing,
-            // while the client already resolved the thread's worktree (or the
-            // project root) for exactly this purpose.
             providerRegistry
               .listWorkspaceSkills({
                 ...(input.instanceId !== undefined ? { instanceId: input.instanceId } : {}),
                 cwd: input.cwd,
               })
               // Omit the key rather than sending `[]` when discovery could not
-              // run: an absent list leaves the client on its existing fallback,
-              // an empty one would tell it this workspace has no skills.
+              // run, so the client stays on its fallback.
               .pipe(Effect.map((skills) => (skills ? { skills } : {}))),
             { "rpc.aggregate": "server" },
           ),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1459,7 +1459,10 @@ const makeWsRpcLayer = (
                 ...(input.instanceId !== undefined ? { instanceId: input.instanceId } : {}),
                 cwd: input.cwd,
               })
-              .pipe(Effect.map((skills) => ({ skills }))),
+              // Omit the key rather than sending `[]` when discovery could not
+              // run: an absent list leaves the client on its existing fallback,
+              // an empty one would tell it this workspace has no skills.
+              .pipe(Effect.map((skills) => (skills ? { skills } : {}))),
             { "rpc.aggregate": "server" },
           ),
         [WS_METHODS.serverUpdateProvider]: (input) =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1447,6 +1447,21 @@ const makeWsRpcLayer = (
             ).pipe(Effect.map((providers) => ({ providers }))),
             { "rpc.aggregate": "server" },
           ),
+        [WS_METHODS.serverListWorkspaceSkills]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverListWorkspaceSkills,
+            // The workspace arrives with the request: the server holds one
+            // global cwd and no notion of which project a client is viewing,
+            // while the client already resolved the thread's worktree (or the
+            // project root) for exactly this purpose.
+            providerRegistry
+              .listWorkspaceSkills({
+                ...(input.instanceId !== undefined ? { instanceId: input.instanceId } : {}),
+                cwd: input.cwd,
+              })
+              .pipe(Effect.map((skills) => ({ skills }))),
+            { "rpc.aggregate": "server" },
+          ),
         [WS_METHODS.serverUpdateProvider]: (input) =>
           observeRpcEffect(
             WS_METHODS.serverUpdateProvider,

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -28,6 +28,7 @@ import {
   reconcileRetainedMountedThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
+  resolveTranscriptProviderInstanceId,
   scheduleEnvironmentReconnectWarning,
   startNewThreadForProject,
   shouldShowBranchMismatchBanner,
@@ -715,5 +716,37 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     expect(hasServerAcknowledgedLocalDispatch({ ...common, hasPendingApproval: true })).toBe(true);
     expect(hasServerAcknowledgedLocalDispatch({ ...common, hasPendingUserInput: true })).toBe(true);
     expect(hasServerAcknowledgedLocalDispatch({ ...common, threadError: "failed" })).toBe(true);
+  });
+});
+
+describe("resolveTranscriptProviderInstanceId", () => {
+  const sessionInstance = ProviderInstanceId.make("codex_personal");
+  const draftInstance = ProviderInstanceId.make("claude_default");
+
+  it("prefers the instance the thread's session actually ran on", () => {
+    expect(
+      resolveTranscriptProviderInstanceId(
+        makeThread({
+          session: { ...readySession, providerInstanceId: sessionInstance },
+          modelSelection: { instanceId: draftInstance, model: "gpt-5.4" },
+        }),
+      ),
+    ).toBe(sessionInstance);
+  });
+
+  it("falls back to the thread's own model selection before it has a session", () => {
+    expect(
+      resolveTranscriptProviderInstanceId(
+        makeThread({
+          session: null,
+          modelSelection: { instanceId: draftInstance, model: "gpt-5.4" },
+        }),
+      ),
+    ).toBe(draftInstance);
+  });
+
+  it("reports nothing for a missing thread", () => {
+    expect(resolveTranscriptProviderInstanceId(null)).toBeNull();
+    expect(resolveTranscriptProviderInstanceId(undefined)).toBeNull();
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -138,6 +138,17 @@ export function shouldWriteThreadErrorToCurrentServerThread(input: {
   );
 }
 
+/**
+ * The instance a thread's already-sent messages were written against.
+ * Deliberately ignores the composer's current pick: choosing a different
+ * provider for the next turn must not re-highlight the existing transcript.
+ */
+export function resolveTranscriptProviderInstanceId(
+  thread: Pick<Thread, "session" | "modelSelection"> | null | undefined,
+): ModelSelection["instanceId"] | null {
+  return thread?.session?.providerInstanceId ?? thread?.modelSelection?.instanceId ?? null;
+}
+
 export function buildThreadTurnInterruptInput(thread: Pick<Thread, "id" | "session">): {
   threadId: ThreadId;
   turnId?: TurnId;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2660,14 +2660,8 @@ function ChatViewContent(props: ChatViewProps) {
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
-  // `$skill` mentions in the transcript are highlighted against the thread's
-  // own provider instance and workspace. The provider snapshot's `skills` are
-  // discovered once from the server's startup cwd, so they describe some other
-  // directory entirely as soon as the user has more than one project; the
-  // snapshot stays the fallback while this resolves, when it fails, and
-  // against a server too old to know the RPC, so nothing regresses.
-  // (The `$` picker runs its own query inside `ChatComposer`, keyed on the
-  // instance the composer has selected, which can differ from this one.)
+  // Highlights `$skill` mentions in the transcript against the thread's own
+  // instance. `ChatComposer` runs its own query for the `$` picker.
   const timelineWorkspaceSkills = useWorkspaceSkills({
     environmentId,
     instanceId: activeProviderInstanceId ?? null,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2663,16 +2663,26 @@ function ChatViewContent(props: ChatViewProps) {
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
   // Highlights `$skill` mentions in the transcript against the thread's own
   // instance, not `activeProviderInstanceId` — that prefers the composer's
-  // pick, which would re-highlight sent messages on a provider switch.
-  // `ChatComposer` runs its own query for the `$` picker.
+  // pick, which would re-highlight sent messages on a provider switch. Query
+  // and fallback both key off it, or the switch would still bleed through
+  // while the query is unresolved. `ChatComposer` queries for the `$` picker.
+  const transcriptProviderInstanceId = resolveTranscriptProviderInstanceId(activeThread);
   const timelineWorkspaceSkills = useWorkspaceSkills({
     environmentId,
-    instanceId: resolveTranscriptProviderInstanceId(activeThread),
+    instanceId: transcriptProviderInstanceId,
     cwd: activeWorkspaceRoot ?? null,
   });
+  const transcriptProviderStatus = useMemo(
+    () =>
+      transcriptProviderInstanceId === null
+        ? null
+        : (providerStatuses.find((status) => status.instanceId === transcriptProviderInstanceId) ??
+          null),
+    [providerStatuses, transcriptProviderInstanceId],
+  );
   const workspaceSkills = resolveComposerSkills(
     timelineWorkspaceSkills.skills,
-    activeProviderStatus?.skills,
+    transcriptProviderStatus?.skills,
   );
   const activeTerminalLaunchContext =
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -223,6 +223,7 @@ import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import { useWorkspaceSkills } from "../state/queries";
+import { resolveComposerSkills } from "../providerSkillSearch";
 import {
   primaryServerAvailableEditorsAtom,
   primaryServerKeybindingsAtom,
@@ -350,7 +351,6 @@ const IMAGE_ONLY_BOOTSTRAP_PROMPT =
   "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_PROVIDERS: ServerProvider[] = [];
-const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
 function useDraftHeroLayoutTransition(isDraftHeroState: boolean) {
   const transitionGroupRef = useRef<HTMLDivElement | null>(null);
@@ -2673,8 +2673,10 @@ function ChatViewContent(props: ChatViewProps) {
     instanceId: activeProviderInstanceId ?? null,
     cwd: activeWorkspaceRoot ?? null,
   });
-  const workspaceSkills =
-    timelineWorkspaceSkills.skills ?? activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS;
+  const workspaceSkills = resolveComposerSkills(
+    timelineWorkspaceSkills.skills,
+    activeProviderStatus?.skills,
+  );
   const activeTerminalLaunchContext =
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -312,6 +312,7 @@ import {
   reconcileMountedTerminalThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
+  resolveTranscriptProviderInstanceId,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
   shouldWriteThreadErrorToCurrentServerThread,
@@ -2661,10 +2662,12 @@ function ChatViewContent(props: ChatViewProps) {
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
   // Highlights `$skill` mentions in the transcript against the thread's own
-  // instance. `ChatComposer` runs its own query for the `$` picker.
+  // instance, not `activeProviderInstanceId` — that prefers the composer's
+  // pick, which would re-highlight sent messages on a provider switch.
+  // `ChatComposer` runs its own query for the `$` picker.
   const timelineWorkspaceSkills = useWorkspaceSkills({
     environmentId,
-    instanceId: activeProviderInstanceId ?? null,
+    instanceId: resolveTranscriptProviderInstanceId(activeThread),
     cwd: activeWorkspaceRoot ?? null,
   });
   const workspaceSkills = resolveComposerSkills(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -222,6 +222,7 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
+import { useWorkspaceSkills } from "../state/queries";
 import {
   primaryServerAvailableEditorsAtom,
   primaryServerKeybindingsAtom,
@@ -2659,6 +2660,21 @@ function ChatViewContent(props: ChatViewProps) {
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
+  // `$skill` mentions in the transcript are highlighted against the thread's
+  // own provider instance and workspace. The provider snapshot's `skills` are
+  // discovered once from the server's startup cwd, so they describe some other
+  // directory entirely as soon as the user has more than one project; the
+  // snapshot stays the fallback while this resolves, when it fails, and
+  // against a server too old to know the RPC, so nothing regresses.
+  // (The `$` picker runs its own query inside `ChatComposer`, keyed on the
+  // instance the composer has selected, which can differ from this one.)
+  const timelineWorkspaceSkills = useWorkspaceSkills({
+    environmentId,
+    instanceId: activeProviderInstanceId ?? null,
+    cwd: activeWorkspaceRoot ?? null,
+  });
+  const workspaceSkills =
+    timelineWorkspaceSkills.skills ?? activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS;
   const activeTerminalLaunchContext =
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.
@@ -6244,7 +6260,7 @@ function ChatViewContent(props: ChatViewProps) {
                 resolvedTheme={resolvedTheme}
                 timestampFormat={timestampFormat}
                 workspaceRoot={activeWorkspaceRoot}
-                skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
+                skills={workspaceSkills}
                 anchorMessageId={timelineAnchorMessageId}
                 onAnchorReady={onTimelineAnchorReady}
                 contentInsetEndAdjustment={composerOverlayHeight}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -75,6 +75,7 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import { useComposerPathSearch } from "../../lib/composerPathSearchState";
+import { useWorkspaceSkills } from "../../state/queries";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
@@ -106,6 +107,9 @@ import { buildExpandedImagePreview, type ExpandedImagePreview } from "./Expanded
 import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
 import { Separator } from "../ui/separator";
+
+/** Stable identity so the skill-less case never re-renders the prompt editor. */
+const EMPTY_COMPOSER_SKILLS: ServerProvider["skills"] = [];
 
 type ComposerCommandMenuPosition = {
   bottom: number;
@@ -1023,6 +1027,25 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     cwd: isPathTrigger ? gitCwd : null,
     query: isPathTrigger ? pathTriggerQuery : null,
   });
+  // Skills come from the workspace this composer sends into, not from the
+  // provider snapshot: the server discovers `ServerProvider.skills` once
+  // against its own startup cwd, so it describes whatever directory the
+  // server was launched from rather than the user's project. `gitCwd` is
+  // that workspace — the thread's worktree when it has one, else the project
+  // root — and is already what the `@` path picker above searches.
+  //
+  // Keyed on the composer's own selected instance rather than the thread's,
+  // because the model picker below can point the next turn at a different
+  // provider. The snapshot stays the fallback while the request is in flight,
+  // when it fails, and against a server that predates the RPC, so the picker
+  // never shows less than it used to and never flickers empty.
+  const composerWorkspaceSkills = useWorkspaceSkills({
+    environmentId,
+    instanceId: selectedProviderStatus?.instanceId ?? null,
+    cwd: gitCwd,
+  });
+  const composerSkills =
+    composerWorkspaceSkills.skills ?? selectedProviderStatus?.skills ?? EMPTY_COMPOSER_SKILLS;
 
   const composerMenuItems = useMemo<ComposerCommandItem[]>(() => {
     if (!composerTrigger) return [];
@@ -1082,22 +1105,21 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {
-      return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(
-        (skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: formatProviderSkillDisplayName(skill),
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-        }),
-      );
+      return searchProviderSkills(composerSkills, composerTrigger.query).map((skill) => ({
+        id: `skill:${selectedProvider}:${skill.name}`,
+        type: "skill" as const,
+        provider: selectedProvider,
+        skill,
+        label: formatProviderSkillDisplayName(skill),
+        description:
+          skill.shortDescription ??
+          skill.description ??
+          (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+      }));
     }
     return [];
   }, [
+    composerSkills,
     composerTrigger,
     planModeUiEnabled,
     selectedProvider,
@@ -3032,7 +3054,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     ? composerTerminalContexts
                     : []
                 }
-                skills={selectedProviderStatus?.skills ?? []}
+                skills={composerSkills}
                 {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
                 onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                 onChange={onPromptChange}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1024,19 +1024,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     cwd: isPathTrigger ? gitCwd : null,
     query: isPathTrigger ? pathTriggerQuery : null,
   });
-  // Skills come from the workspace this composer sends into, not from the
-  // provider snapshot: the server discovers `ServerProvider.skills` once
-  // against its own startup cwd, so it describes whatever directory the
-  // server was launched from rather than the user's project. `gitCwd` is
-  // that workspace — the thread's worktree when it has one, else the project
-  // root — and is already what the `@` path picker above searches.
-  //
   // Keyed on the composer's own selected instance rather than the thread's,
-  // because the model picker below can point the next turn at a different
-  // provider. The snapshot stays the fallback while the request is in flight,
-  // when the server could not discover anything, and against a server that
-  // predates the RPC, so the picker never shows less than it used to and
-  // never flickers empty.
+  // because the model picker below can aim the next turn at another provider.
   const composerWorkspaceSkills = useWorkspaceSkills({
     environmentId,
     instanceId: selectedProviderStatus?.instanceId ?? null,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -108,9 +108,6 @@ import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
 import { Separator } from "../ui/separator";
 
-/** Stable identity so the skill-less case never re-renders the prompt editor. */
-const EMPTY_COMPOSER_SKILLS: ServerProvider["skills"] = [];
-
 type ComposerCommandMenuPosition = {
   bottom: number;
   left: number;
@@ -227,7 +224,7 @@ import {
   formatProviderDisplayName,
 } from "../../lib/contextWindow";
 import { formatProviderSkillDisplayName } from "../../providerSkillPresentation";
-import { searchProviderSkills } from "../../providerSkillSearch";
+import { resolveComposerSkills, searchProviderSkills } from "../../providerSkillSearch";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import type { ReviewCommentContext } from "../../reviewCommentContext";
 
@@ -1037,15 +1034,18 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // Keyed on the composer's own selected instance rather than the thread's,
   // because the model picker below can point the next turn at a different
   // provider. The snapshot stays the fallback while the request is in flight,
-  // when it fails, and against a server that predates the RPC, so the picker
-  // never shows less than it used to and never flickers empty.
+  // when the server could not discover anything, and against a server that
+  // predates the RPC, so the picker never shows less than it used to and
+  // never flickers empty.
   const composerWorkspaceSkills = useWorkspaceSkills({
     environmentId,
     instanceId: selectedProviderStatus?.instanceId ?? null,
     cwd: gitCwd,
   });
-  const composerSkills =
-    composerWorkspaceSkills.skills ?? selectedProviderStatus?.skills ?? EMPTY_COMPOSER_SKILLS;
+  const composerSkills = resolveComposerSkills(
+    composerWorkspaceSkills.skills,
+    selectedProviderStatus?.skills,
+  );
 
   const composerMenuItems = useMemo<ComposerCommandItem[]>(() => {
     if (!composerTrigger) return [];

--- a/apps/web/src/providerSkillSearch.test.ts
+++ b/apps/web/src/providerSkillSearch.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import type { ServerProviderSkill } from "@t3tools/contracts";
 
-import { searchProviderSkills } from "./providerSkillSearch";
+import { resolveComposerSkills, searchProviderSkills } from "./providerSkillSearch";
 
 function makeSkill(input: Partial<ServerProviderSkill> & Pick<ServerProviderSkill, "name">) {
   return {
@@ -55,5 +55,41 @@ describe("searchProviderSkills", () => {
     ];
 
     expect(searchProviderSkills(skills, "ui").map((skill) => skill.name)).toEqual([]);
+  });
+});
+
+describe("resolveComposerSkills", () => {
+  const snapshotSkills = [makeSkill({ name: "snapshot-skill" })];
+  const workspaceSkills = [makeSkill({ name: "workspace-skill" })];
+
+  it("prefers the workspace answer over the provider snapshot", () => {
+    expect(
+      resolveComposerSkills(workspaceSkills, snapshotSkills).map((skill) => skill.name),
+    ).toEqual(["workspace-skill"]);
+  });
+
+  it("keeps the snapshot list when discovery could not run", () => {
+    // The server answers without a `skills` key when it could not look —
+    // a spawn failure, a timed-out probe, an unknown instance. Treating that
+    // as an empty workspace would blank the picker on a transient failure,
+    // which is worse than the global list it replaced.
+    expect(resolveComposerSkills(null, snapshotSkills).map((skill) => skill.name)).toEqual([
+      "snapshot-skill",
+    ]);
+    expect(resolveComposerSkills(undefined, snapshotSkills).map((skill) => skill.name)).toEqual([
+      "snapshot-skill",
+    ]);
+  });
+
+  it("honours a workspace that genuinely has no skills", () => {
+    // An empty answer is still an answer: the picker must show its empty
+    // state rather than falling back to another directory's skills.
+    expect(resolveComposerSkills([], snapshotSkills)).toEqual([]);
+  });
+
+  it("returns a stable empty list when nothing is known at all", () => {
+    expect(resolveComposerSkills(null, undefined)).toBe(
+      resolveComposerSkills(undefined, undefined),
+    );
   });
 });

--- a/apps/web/src/providerSkillSearch.test.ts
+++ b/apps/web/src/providerSkillSearch.test.ts
@@ -69,10 +69,6 @@ describe("resolveComposerSkills", () => {
   });
 
   it("keeps the snapshot list when discovery could not run", () => {
-    // The server answers without a `skills` key when it could not look —
-    // a spawn failure, a timed-out probe, an unknown instance. Treating that
-    // as an empty workspace would blank the picker on a transient failure,
-    // which is worse than the global list it replaced.
     expect(resolveComposerSkills(null, snapshotSkills).map((skill) => skill.name)).toEqual([
       "snapshot-skill",
     ]);
@@ -82,8 +78,6 @@ describe("resolveComposerSkills", () => {
   });
 
   it("honours a workspace that genuinely has no skills", () => {
-    // An empty answer is still an answer: the picker must show its empty
-    // state rather than falling back to another directory's skills.
     expect(resolveComposerSkills([], snapshotSkills)).toEqual([]);
   });
 

--- a/apps/web/src/providerSkillSearch.ts
+++ b/apps/web/src/providerSkillSearch.ts
@@ -66,6 +66,26 @@ function scoreProviderSkill(skill: ServerProviderSkill, query: string): number |
   return Math.min(...scores);
 }
 
+/** Stable identity so the skill-less case never re-renders its consumers. */
+const NO_SKILLS: ReadonlyArray<ServerProviderSkill> = [];
+
+/**
+ * Choose the skill list a composer should offer for the current workspace.
+ *
+ * `workspaceSkills` is the server's workspace-scoped answer. An array — even
+ * an empty one — means discovery ran, so it wins: this workspace really has
+ * these skills and no others. `null`/`undefined` means the server could not
+ * discover anything (the probe failed, or the request is still in flight), so
+ * we keep showing the provider snapshot's list rather than blanking the
+ * picker on a transient failure.
+ */
+export function resolveComposerSkills(
+  workspaceSkills: ReadonlyArray<ServerProviderSkill> | null | undefined,
+  snapshotSkills: ReadonlyArray<ServerProviderSkill> | undefined,
+): ReadonlyArray<ServerProviderSkill> {
+  return workspaceSkills ?? snapshotSkills ?? NO_SKILLS;
+}
+
 export function searchProviderSkills(
   skills: ReadonlyArray<ServerProviderSkill>,
   query: string,

--- a/apps/web/src/providerSkillSearch.ts
+++ b/apps/web/src/providerSkillSearch.ts
@@ -70,14 +70,9 @@ function scoreProviderSkill(skill: ServerProviderSkill, query: string): number |
 const NO_SKILLS: ReadonlyArray<ServerProviderSkill> = [];
 
 /**
- * Choose the skill list a composer should offer for the current workspace.
- *
- * `workspaceSkills` is the server's workspace-scoped answer. An array — even
- * an empty one — means discovery ran, so it wins: this workspace really has
- * these skills and no others. `null`/`undefined` means the server could not
- * discover anything (the probe failed, or the request is still in flight), so
- * we keep showing the provider snapshot's list rather than blanking the
- * picker on a transient failure.
+ * Choose the skill list a composer should offer for the current workspace. An
+ * array — even an empty one — is an answer and wins; `null`/`undefined` means
+ * the server could not look, so the snapshot's list stays up.
  */
 export function resolveComposerSkills(
   workspaceSkills: ReadonlyArray<ServerProviderSkill> | null | undefined,

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -14,6 +14,7 @@ import type {
   OrchestrationThread,
   ProjectContentMatch,
   ProjectEntryKind,
+  ProviderInstanceId,
   ThreadId,
   VcsListRefsResult,
   VcsRef,
@@ -28,6 +29,7 @@ import { orchestrationEnvironment } from "./orchestration";
 import { isPaginatedBranchesNextPagePending } from "./paginatedBranches";
 import { projectContentSearch, projectEnvironment } from "./projects";
 import { useEnvironmentQuery } from "./query";
+import { serverEnvironment } from "./server";
 import { useEnvironmentThread } from "./threads";
 import { vcsEnvironment } from "./vcs";
 
@@ -300,6 +302,43 @@ export function useProjectPathSearch(
 
 export function useComposerPathSearch(target: ComposerPathSearchTarget) {
   return useProjectPathSearch(target, COMPOSER_PATH_SEARCH_LIMIT);
+}
+
+/**
+ * Skills for one workspace, asked of the server per request.
+ *
+ * The provider snapshot carries a `skills` list, but the server discovers it
+ * once against its own startup cwd, so it belongs to whichever directory the
+ * server was launched from rather than the project being viewed. Resolves to
+ * `null` until the server answers (and if it never does), which lets callers
+ * fall back to the snapshot instead of blanking the picker.
+ */
+export function useWorkspaceSkills(input: {
+  readonly environmentId: EnvironmentId | null;
+  readonly instanceId: ProviderInstanceId | null;
+  readonly cwd: string | null;
+}) {
+  // A stand-in project carries an empty workspaceRoot, which the request
+  // schema rejects — treat it like "no workspace" rather than issuing a call
+  // that can only fail.
+  const cwd = input.cwd?.trim() ? input.cwd : null;
+  const result = useEnvironmentQuery(
+    input.environmentId !== null && cwd !== null
+      ? serverEnvironment.workspaceSkills({
+          environmentId: input.environmentId,
+          input: {
+            ...(input.instanceId ? { instanceId: input.instanceId } : {}),
+            cwd,
+          },
+        })
+      : null,
+  );
+
+  return {
+    skills: result.data?.skills ?? null,
+    error: result.error,
+    isPending: result.isPending,
+  };
 }
 
 interface ProjectContentSearchTarget {

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -304,26 +304,13 @@ export function useComposerPathSearch(target: ComposerPathSearchTarget) {
   return useProjectPathSearch(target, COMPOSER_PATH_SEARCH_LIMIT);
 }
 
-/**
- * Skills for one workspace, asked of the server per request.
- *
- * The provider snapshot carries a `skills` list, but the server discovers it
- * once against its own startup cwd, so it belongs to whichever directory the
- * server was launched from rather than the project being viewed.
- *
- * `skills` is `null` whenever nothing is known: the request is in flight, it
- * failed, or the server answered without a list because its own discovery
- * could not run. Callers fall back to the snapshot in all three cases. An
- * empty array is different — it means this workspace really has no skills.
- */
+/** Skills for one workspace; `null` until the server answers with a list. */
 export function useWorkspaceSkills(input: {
   readonly environmentId: EnvironmentId | null;
   readonly instanceId: ProviderInstanceId | null;
   readonly cwd: string | null;
 }) {
-  // A stand-in project carries an empty workspaceRoot, which the request
-  // schema rejects — treat it like "no workspace" rather than issuing a call
-  // that can only fail.
+  // A stand-in project carries an empty workspaceRoot, which the schema rejects.
   const cwd = input.cwd?.trim() ? input.cwd : null;
   const result = useEnvironmentQuery(
     input.environmentId !== null && cwd !== null

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -309,9 +309,12 @@ export function useComposerPathSearch(target: ComposerPathSearchTarget) {
  *
  * The provider snapshot carries a `skills` list, but the server discovers it
  * once against its own startup cwd, so it belongs to whichever directory the
- * server was launched from rather than the project being viewed. Resolves to
- * `null` until the server answers (and if it never does), which lets callers
- * fall back to the snapshot instead of blanking the picker.
+ * server was launched from rather than the project being viewed.
+ *
+ * `skills` is `null` whenever nothing is known: the request is in flight, it
+ * failed, or the server answered without a list because its own discovery
+ * could not run. Callers fall back to the snapshot in all three cases. An
+ * empty array is different — it means this workspace really has no skills.
  */
 export function useWorkspaceSkills(input: {
   readonly environmentId: EnvironmentId | null;

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -685,13 +685,7 @@ export function createServerEnvironmentAtoms<R, E>(
     updateStateAtom,
     settingsValueAtom,
     providersValueAtom,
-    // Skills for one workspace directory. The provider snapshot carries a
-    // `skills` list too, but the server discovers that one against its own
-    // startup cwd, so it describes whatever directory `npx t3` was run from
-    // rather than the project the user is in. Keyed by (environment, instance,
-    // cwd) through the atom family, and cached long enough that reopening the
-    // `$` picker does not re-scan the filesystem (or respawn `codex
-    // app-server`) on every keystroke.
+    // The stale time keeps reopening the `$` picker from re-probing.
     workspaceSkills: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:server:workspace-skills",
       tag: WS_METHODS.serverListWorkspaceSkills,

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -685,6 +685,18 @@ export function createServerEnvironmentAtoms<R, E>(
     updateStateAtom,
     settingsValueAtom,
     providersValueAtom,
+    // Skills for one workspace directory. The provider snapshot carries a
+    // `skills` list too, but the server discovers that one against its own
+    // startup cwd, so it describes whatever directory `npx t3` was run from
+    // rather than the project the user is in. Keyed by (environment, instance,
+    // cwd) through the atom family, and cached long enough that reopening the
+    // `$` picker does not re-scan the filesystem (or respawn `codex
+    // app-server`) on every keystroke.
+    workspaceSkills: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:server:workspace-skills",
+      tag: WS_METHODS.serverListWorkspaceSkills,
+      staleTimeMs: 30_000,
+    }),
     traceDiagnostics: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:server:trace-diagnostics",
       tag: WS_METHODS.serverGetTraceDiagnostics,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -169,6 +169,8 @@ import {
   ServerSignalProcessResult,
   ServerUpsertKeybindingInput,
   ServerUpsertKeybindingResult,
+  ServerWorkspaceSkillsInput,
+  ServerWorkspaceSkillsResult,
 } from "./server.ts";
 import {
   ResourceTelemetryHistory,
@@ -252,6 +254,7 @@ export const WS_METHODS = {
   serverProbe: "server.probe",
   serverGetConfig: "server.getConfig",
   serverRefreshProviders: "server.refreshProviders",
+  serverListWorkspaceSkills: "server.listWorkspaceSkills",
   serverUpdateProvider: "server.updateProvider",
   serverUpdateServer: "server.updateServer",
   serverUpdateServerWithProgress: "server.updateServerWithProgress",
@@ -346,6 +349,19 @@ export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProv
     instanceId: Schema.optional(ProviderInstanceId),
   }),
   success: ServerProviderUpdatedPayload,
+  error: EnvironmentAuthorizationError,
+});
+
+/**
+ * Workspace-scoped skill discovery. Unlike `ServerProvider.skills` — one
+ * global snapshot taken against the server's startup cwd — this is answered
+ * per request against the `cwd` the caller supplies, which is how a client
+ * showing project A's composer gets project A's skills. `ServerProvider.skills`
+ * stays in place as the fallback for callers that cannot resolve a workspace.
+ */
+export const WsServerListWorkspaceSkillsRpc = Rpc.make(WS_METHODS.serverListWorkspaceSkills, {
+  payload: ServerWorkspaceSkillsInput,
+  success: ServerWorkspaceSkillsResult,
   error: EnvironmentAuthorizationError,
 });
 
@@ -974,6 +990,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerProbeRpc,
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,
+  WsServerListWorkspaceSkillsRpc,
   WsServerUpdateProviderRpc,
   WsServerUpdateServerRpc,
   WsServerUpdateServerWithProgressRpc,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -352,13 +352,6 @@ export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProv
   error: EnvironmentAuthorizationError,
 });
 
-/**
- * Workspace-scoped skill discovery. Unlike `ServerProvider.skills` — one
- * global snapshot taken against the server's startup cwd — this is answered
- * per request against the `cwd` the caller supplies, which is how a client
- * showing project A's composer gets project A's skills. `ServerProvider.skills`
- * stays in place as the fallback for callers that cannot resolve a workspace.
- */
 export const WsServerListWorkspaceSkillsRpc = Rpc.make(WS_METHODS.serverListWorkspaceSkills, {
   payload: ServerWorkspaceSkillsInput,
   success: ServerWorkspaceSkillsResult,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -593,21 +593,15 @@ export const ServerProviderUpdateInput = Schema.Struct({
 export type ServerProviderUpdateInput = typeof ServerProviderUpdateInput.Type;
 
 /**
- * Request skills visible from one workspace directory.
+ * Request the skills visible from one workspace directory — unlike
+ * `ServerProvider.skills`, one snapshot of the server's own startup cwd.
  *
- * `ServerProvider.skills` is a single process-wide snapshot discovered from
- * the server's own startup cwd, so it cannot describe the project the user is
- * actually looking at. The workspace root therefore travels in the request:
- * the client already resolves it (worktree path first, then the project's
- * workspace root) and the provider registry has no access to the projects
- * table, so the client is the only party that knows which directory to scan.
+ * The workspace travels in the request because the server cannot infer it:
+ * `ProviderRegistry` sees only `ServerConfig` and the live provider instances,
+ * never the projects table, so only the client knows which directory to scan.
  */
 export const ServerWorkspaceSkillsInput = Schema.Struct({
-  /**
-   * Provider instance whose driver performs discovery. When omitted the
-   * server asks every live instance and merges the results, matching the
-   * untargeted semantics of `server.refreshProviders`.
-   */
+  /** Omitted asks every live instance and merges the results. */
   instanceId: Schema.optional(ProviderInstanceId),
   /** Absolute workspace directory to scan (thread worktree or project root). */
   cwd: TrimmedNonEmptyString,
@@ -616,13 +610,8 @@ export type ServerWorkspaceSkillsInput = typeof ServerWorkspaceSkillsInput.Type;
 
 export const ServerWorkspaceSkillsResult = Schema.Struct({
   /**
-   * Absent when nothing could be discovered — the provider binary is missing,
-   * the probe timed out, the instance is unknown. Clients keep whatever they
-   * were showing (normally `ServerProvider.skills`) in that case.
-   *
-   * Present-but-empty is the opposite claim: discovery ran and this workspace
-   * really has no skills. Conflating the two would blank the picker whenever
-   * a probe hiccuped.
+   * Absent when nothing could be discovered, so clients keep showing whatever
+   * they had. Present-but-empty means discovery ran and found none.
    */
   skills: Schema.optional(Schema.Array(ServerProviderSkill)),
 });

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -592,6 +592,33 @@ export const ServerProviderUpdateInput = Schema.Struct({
 });
 export type ServerProviderUpdateInput = typeof ServerProviderUpdateInput.Type;
 
+/**
+ * Request skills visible from one workspace directory.
+ *
+ * `ServerProvider.skills` is a single process-wide snapshot discovered from
+ * the server's own startup cwd, so it cannot describe the project the user is
+ * actually looking at. The workspace root therefore travels in the request:
+ * the client already resolves it (worktree path first, then the project's
+ * workspace root) and the provider registry has no access to the projects
+ * table, so the client is the only party that knows which directory to scan.
+ */
+export const ServerWorkspaceSkillsInput = Schema.Struct({
+  /**
+   * Provider instance whose driver performs discovery. When omitted the
+   * server asks every live instance and merges the results, matching the
+   * untargeted semantics of `server.refreshProviders`.
+   */
+  instanceId: Schema.optional(ProviderInstanceId),
+  /** Absolute workspace directory to scan (thread worktree or project root). */
+  cwd: TrimmedNonEmptyString,
+});
+export type ServerWorkspaceSkillsInput = typeof ServerWorkspaceSkillsInput.Type;
+
+export const ServerWorkspaceSkillsResult = Schema.Struct({
+  skills: Schema.Array(ServerProviderSkill),
+});
+export type ServerWorkspaceSkillsResult = typeof ServerWorkspaceSkillsResult.Type;
+
 export class ServerProviderUpdateError extends Schema.TaggedErrorClass<ServerProviderUpdateError>()(
   "ServerProviderUpdateError",
   {

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -615,7 +615,16 @@ export const ServerWorkspaceSkillsInput = Schema.Struct({
 export type ServerWorkspaceSkillsInput = typeof ServerWorkspaceSkillsInput.Type;
 
 export const ServerWorkspaceSkillsResult = Schema.Struct({
-  skills: Schema.Array(ServerProviderSkill),
+  /**
+   * Absent when nothing could be discovered — the provider binary is missing,
+   * the probe timed out, the instance is unknown. Clients keep whatever they
+   * were showing (normally `ServerProvider.skills`) in that case.
+   *
+   * Present-but-empty is the opposite claim: discovery ran and this workspace
+   * really has no skills. Conflating the two would blank the picker whenever
+   * a probe hiccuped.
+   */
+  skills: Schema.optional(Schema.Array(ServerProviderSkill)),
 });
 export type ServerWorkspaceSkillsResult = typeof ServerWorkspaceSkillsResult.Type;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5178,10 +5178,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@yuuang/ffi-rs-android-arm64@1.3.2':
     resolution: {integrity: sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==}


### PR DESCRIPTION
Fixes #6449

### The problem

Skills were discovered once from `ServerConfig.cwd` — the server's single startup directory — so the `$` picker showed whatever repo the server happened to launch next to. With more than one project open that meant another project's skills, or none at all, and a project skill never won a name collision against a same-named user skill.

Discovery was also silent about failures, which made a wrongly-scoped path look identical to "this project has no skills".

### The fix

Add a workspace-scoped `server.listWorkspaceSkills` RPC that carries the workspace **in the request**.

`ProviderRegistry` depends only on `ServerConfig` and `ProviderInstanceRegistry`, so it cannot resolve which project a client is looking at. The clients already compute that path — the thread's worktree, else the project root — so they send it:

- **Claude** rescans `<cwd>/.claude/skills` alongside the user config dir, keeping the existing project-over-user precedence.
- **Codex** asks its app-server `skills/list` for that cwd.
- Drivers with no skill surface resolve to an empty list.

Both answers go through a 30s cache keyed by `(instanceId, cwd)`, so opening the picker does not respawn a Codex app-server on every keystroke.

On the client, the query lives in `ChatComposer` and is keyed on the instance the composer actually has selected, which can differ from the thread's provider. `ChatView` keeps its own query for transcript `$skill` highlighting, keyed on the thread's provider — the right key for already-sent messages.

### "No skills here" vs "could not look"

Discovery distinguishes the two, because collapsing them breaks the fallback below. `listWorkspaceSkills` returns `ReadonlyArray<ServerProviderSkill> | undefined`:

- A **list** — including an empty one — is an answer. An empty list legitimately means the workspace has no skills, and the picker shows its empty state.
- **`undefined`** means discovery could not run: a Codex spawn failure, an unauthenticated CLI, a timeout, or a driver defect. The result key is then omitted from the response and the client keeps the snapshot.

Unknowns are never cached: an `undefined` invalidates its own cache entry, so the next picker open retries rather than serving the failure for the full TTL.

Claude keeps returning a list. It has no all-or-nothing failure mode — a missing `<cwd>/.claude/skills` is the normal state for most projects, and the snapshot it would fall back to comes from the same scan function with a different cwd, so reporting unknown there would resurrect another directory's skills rather than protect anything.

### Compatibility

Purely additive. `ServerProvider.skills` is unchanged and remains the fallback while the query is in flight, when discovery could not run, and on a server that predates the method — so the picker never shows less than it did before, and never flickers empty. No new union literals, no removed or altered fields, no migration.

### Failure handling

Discovery stays best-effort but no longer silent: an unreadable skill root, an unreadable `SKILL.md`, and malformed frontmatter now log instead of vanishing into an empty picker.

### Testing

Covers workspace-scoped discovery, project-over-user precedence on a name collision, an unreadable workspace degrading to user-scope skills rather than erroring, the cache's per-`(instance, cwd)` keying, and the empty-vs-unknown distinction end to end — a failed lookup reporting unknown rather than empty, the cache retrying afterwards, the registry merging only the instances that answered, and the client falling back to the snapshot on an absent list while still rendering the empty state for a genuine one.

Verified manually in a dev build; before/after screenshots are in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider drivers, registry merging, and WS RPC with nuanced empty-vs-unknown semantics; failures are designed to fall back to snapshots without blanking the picker.
> 
> **Overview**
> Fixes the **`$` skill picker** showing skills from the wrong directory by introducing **`server.listWorkspaceSkills`**, with clients sending the thread worktree or project root as **`cwd`** plus an optional provider **`instanceId`**.
> 
> **Server:** Claude rescans user + **`<cwd>/.claude/skills`**; Codex calls **`skills/list`** through a shared app-server helper. Results are merged in **`ProviderRegistry.listWorkspaceSkills`** (targeted instance vs all instances, first name wins). A **30s per-cwd cache** avoids repeated Codex spawns; **`undefined`** means discovery failed and is **not** cached so clients can retry and keep snapshot fallback.
> 
> **Clients (web + mobile):** **`useWorkspaceSkills`** drives the composer and thread flows; **`resolveComposerSkills`** prefers workspace answers over **`ServerProvider.skills`**, while **`resolveTranscriptProviderInstanceId`** keeps transcript **`$skill`** highlighting on the thread's provider, not the composer's next-turn pick.
> 
> **Observability:** Claude skill discovery logs unreadable roots/`SKILL.md` at debug and skips malformed frontmatter with a warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d06a0b8af8824d82d8710ddb40b66d1702e992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix the `$` skill picker to list skills for the active project's workspace
> - Adds a `useWorkspaceSkills` hook (web and mobile) that fetches workspace-specific skills via a new `server.listWorkspaceSkills` WebSocket RPC, with a 30-second client-side cache.
> - Implements `listWorkspaceSkills` on the server by spawning the provider's app-server (Claude via file discovery, Codex via `codex app-server`) and aggregating results across instances.
> - Adds `resolveComposerSkills` to merge workspace-discovered skills with provider snapshot skills, giving workspace skills precedence; used in the composer and timeline.
> - The `$` skill picker in the composer and the skill highlights in the chat timeline now reflect the active project's workspace directory rather than the provider's globally advertised skills.
> - Behavioral Change: users switching providers mid-thread will no longer see skill highlights update in the transcript; highlights are now anchored to the instance that sent the messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43d06a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->