### PR TITLE
fix(claude): discover skills from installed plugins

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -301,4 +301,182 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
       assert.deepEqual(skills, []);
     }),
   );
+
+  it.effect("names installed plugin skills `<plugin>:<skill>` across all three layouts", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const pluginsDir = path.join(configDir, "plugins");
+
+      // Layout 1: a cached install, addressed by `installPath`.
+      const cached = path.join(pluginsDir, "cache", "shop", "cached", "1.0.0");
+      yield* writeSkill(path.join(cached, "skills"), "build", "---\nname: build\n---\n");
+
+      // Layout 2: a plugin inside a marketplace checkout. The stale
+      // `installPath` left behind still exists and still has a `skills`
+      // directory — it just holds no skill, so the search must go on.
+      const shop = path.join(pluginsDir, "marketplaces", "shop");
+      yield* writeSkill(path.join(shop, "plugins", "nested", "skills"), "ship", "---\n---\n");
+      yield* fs.makeDirectory(path.join(tempDir, "stale", "skills", "leftover"), {
+        recursive: true,
+      });
+
+      // Layout 3: a marketplace whose root *is* the plugin.
+      const flat = path.join(pluginsDir, "marketplaces", "flat");
+      yield* writeSkill(path.join(flat, "skills"), "audit", "---\nname: audit\n---\n");
+
+      // Written as literal JSON rather than built with JSON.stringify, which
+      // the repo's `preferSchemaOverJson` rule rejects. `stale` and `gone` are
+      // the installPath a directory-sourced marketplace leaves behind — one
+      // still on disk, one deleted — and `empty@nowhere` is installed but
+      // ships no skills from a marketplace nothing knows about.
+      const json = (value: string) => value.replaceAll("'", '"');
+      yield* fs.writeFileString(
+        path.join(pluginsDir, "installed_plugins.json"),
+        json(`{'plugins':{
+          'cached@shop':[{'installPath':'${cached}'}],
+          'nested@shop':[{'installPath':'${path.join(tempDir, "stale")}'}],
+          'flat@flat':[{'installPath':'${path.join(tempDir, "gone")}'}],
+          'empty@nowhere':[{}]
+        }}`),
+      );
+      yield* fs.writeFileString(
+        path.join(pluginsDir, "known_marketplaces.json"),
+        json(`{'shop':{'installLocation':'${shop}'},'flat':{'installLocation':'${flat}'}}`),
+      );
+
+      // A marketplace plugin nobody installed must stay out of the picker.
+      yield* writeSkill(path.join(shop, "plugins", "unwanted", "skills"), "nope", "---\n---\n");
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, undefined, {});
+
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["cached:build", "flat:audit", "nested:ship"],
+      );
+    }),
+  );
+
+  it.effect("discovers the skills a plugin manifest declares outside `skills/<name>`", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const pluginsDir = path.join(configDir, "plugins");
+      const json = (value: string) => value.replaceAll("'", '"');
+
+      // A plugin that buckets its skills a level deeper than the conventional
+      // scan reaches, and lists them in its manifest — the shape
+      // `mattpocock-skills` ships.
+      const bucketed = path.join(pluginsDir, "cache", "shop", "bucketed", "1.0.0");
+      yield* writeSkill(
+        path.join(bucketed, "skills", "engineering"),
+        "tdd",
+        "---\nname: tdd\n---\n",
+      );
+      yield* writeSkill(path.join(bucketed, "skills", "in-progress"), "draft", "---\n---\n");
+      yield* fs.makeDirectory(path.join(bucketed, ".claude-plugin"), { recursive: true });
+      yield* fs.writeFileString(
+        path.join(bucketed, ".claude-plugin", "plugin.json"),
+        json("{'skills':['./skills/engineering/tdd']}"),
+      );
+
+      // An older plugin keeps its manifest at the plugin root, and its skills
+      // sit where the conventional scan already finds them.
+      const rootManifest = path.join(pluginsDir, "cache", "shop", "rooted", "1.0.0");
+      yield* writeSkill(path.join(rootManifest, "skills"), "wt", "---\nname: wt\n---\n");
+      yield* fs.writeFileString(
+        path.join(rootManifest, "plugin.json"),
+        json("{'skills':['./skills/wt']}"),
+      );
+
+      // A manifest may name a folder of skills instead of one skill, and may
+      // carry a bare string instead of an array.
+      const folder = path.join(pluginsDir, "cache", "shop", "folder", "1.0.0");
+      yield* writeSkill(path.join(folder, "extra"), "audit", "---\nname: audit\n---\n");
+      yield* fs.makeDirectory(path.join(folder, ".claude-plugin"), { recursive: true });
+      yield* fs.writeFileString(
+        path.join(folder, ".claude-plugin", "plugin.json"),
+        json("{'skills':'./extra'}"),
+      );
+
+      yield* fs.writeFileString(
+        path.join(pluginsDir, "installed_plugins.json"),
+        json(`{'plugins':{
+          'bucketed@shop':[{'installPath':'${bucketed}'}],
+          'rooted@shop':[{'installPath':'${rootManifest}'}],
+          'folder@shop':[{'installPath':'${folder}'}]
+        }}`),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, undefined, {});
+
+      // The declared skill reaches the picker; the undeclared one a level down
+      // does not, matching what the CLI loads. A manifest that repeats a
+      // conventional skill yields it once.
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["bucketed:tdd", "folder:audit", "rooted:wt"],
+      );
+    }),
+  );
+
+  it.effect("skips plugins switched off in settings and installs owned by another workspace", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const pluginsDir = path.join(configDir, "plugins");
+      const workspace = path.join(tempDir, "workspace");
+      const json = (value: string) => value.replaceAll("'", '"');
+
+      const install = Effect.fn(function* (name: string) {
+        const root = path.join(pluginsDir, "cache", "shop", name, "1.0.0");
+        yield* writeSkill(path.join(root, "skills"), name, `---\nname: ${name}\n---\n`);
+        return root;
+      });
+      const on = yield* install("on");
+      const off = yield* install("off");
+      const mine = yield* install("mine");
+      const theirs = yield* install("theirs");
+      const everywhere = yield* install("everywhere");
+      const here = yield* install("here");
+
+      yield* fs.writeFileString(
+        path.join(configDir, "settings.json"),
+        json("{'enabledPlugins':{'on@shop':true,'off@shop':false}}"),
+      );
+      yield* fs.makeDirectory(path.join(workspace, ".claude"), { recursive: true });
+      yield* fs.writeFileString(
+        path.join(workspace, ".claude", "settings.local.json"),
+        json("{'enabledPlugins':{'mine@shop':true}}"),
+      );
+      yield* fs.writeFileString(
+        path.join(pluginsDir, "installed_plugins.json"),
+        json(`{'plugins':{
+          'on@shop':[{'installPath':'${on}'}],
+          'off@shop':[{'installPath':'${off}'}],
+          'mine@shop':[{'scope':'local','projectPath':'${workspace}','installPath':'${mine}'}],
+          'theirs@shop':[{'scope':'local','projectPath':'${path.join(tempDir, "elsewhere")}','installPath':'${theirs}'}],
+          'both@shop':[
+            {'scope':'user','installPath':'${everywhere}'},
+            {'scope':'local','projectPath':'${workspace}','installPath':'${here}'}
+          ]
+        }}`),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace, {});
+
+      // `both@shop` is installed twice and the user entry is listed first, so
+      // only picking the more specific project entry yields `here`.
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["both:here", "mine:mine", "on:on"],
+      );
+    }),
+  );
 });

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -1,13 +1,14 @@
 /**
  * ClaudeSkills — filesystem discovery of Claude Code skills for the `$` picker.
  *
- * Claude Code loads skills from `<config dir>/skills` (user scope), then
- * `<cwd>/.agents/skills` and `<cwd>/.claude/skills` (project scope), one
- * directory per skill with a `SKILL.md` carrying YAML frontmatter. Later roots
- * win on name collisions, so precedence is user, `.agents`, then `.claude`.
- * The Agent SDK init handshake surfaces skills only as slash commands without
- * their filesystem paths, so the provider snapshot scans the same locations
- * directly, mirroring how the Codex app-server reports its skills.
+ * Claude Code loads skills from `<config dir>/skills` (user scope), from every
+ * installed plugin, and from `<cwd>/.agents/skills` and `<cwd>/.claude/skills`
+ * (project scope), one directory per skill with a `SKILL.md` carrying YAML
+ * frontmatter. Later roots win on name collisions, so precedence is user,
+ * plugins, `.agents`, then `.claude`. The Agent SDK init handshake surfaces
+ * skills only as slash commands without their filesystem paths, so the
+ * provider snapshot scans the same locations directly, mirroring how the
+ * Codex app-server reports its skills.
  *
  * @module provider/Drivers/ClaudeSkills
  */
@@ -22,6 +23,70 @@ import { parse as parseYamlDocument } from "yaml";
 import { expandHomePath } from "../../pathExpansion.ts";
 
 type ClaudeSkillScope = "user" | "project";
+
+/** One skill folder, the directory holding a `SKILL.md`. `prefix` namespaces a plugin's skills. */
+interface ClaudeSkillDirectory {
+  readonly directory: string;
+  readonly scope: ClaudeSkillScope;
+  readonly prefix?: string;
+}
+
+// The plugin manifests are user-editable JSON with no schema guarantee, so
+// every field is narrowed before use rather than asserted.
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim().length > 0 ? value : undefined;
+
+/** Parse a JSON file, yielding `undefined` when it is missing or malformed. */
+const readJsonFile = (filePath: string): Effect.Effect<unknown, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    return yield* fileSystem.readFileString(filePath).pipe(
+      Effect.map((contents): unknown => {
+        try {
+          return JSON.parse(contents);
+        } catch {
+          return undefined;
+        }
+      }),
+      Effect.orElseSucceed(() => undefined),
+    );
+  });
+
+/**
+ * The skill folders directly under `parent`, sorted for deterministic
+ * collisions. A `skills` directory holds stray files and stale leftovers too,
+ * so the `SKILL.md` is what makes an entry a skill — without that check a
+ * plugin path that merely looks inhabited would end the search for the one
+ * that really holds the skills.
+ */
+const listSkillDirectories = Effect.fn("listSkillDirectories")(function* (
+  parent: string,
+  scope: ClaudeSkillScope,
+  prefix?: string,
+): Effect.fn.Return<ReadonlyArray<ClaudeSkillDirectory>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const entries = yield* fileSystem
+    .readDirectory(parent)
+    .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+
+  const directories: Array<ClaudeSkillDirectory> = [];
+  for (const entry of [...entries].sort()) {
+    const directory = path.join(parent, entry);
+    const isSkill = yield* fileSystem
+      .exists(path.join(directory, "SKILL.md"))
+      .pipe(Effect.orElseSucceed(() => false));
+    if (isSkill) {
+      directories.push({ directory, scope, ...(prefix ? { prefix } : {}) });
+    }
+  }
+  return directories;
+});
 
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
@@ -85,12 +150,181 @@ const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(funct
 });
 
 /**
- * Enumerate Claude Code skills from the user config dir, workspace
- * `.agents/skills`, and workspace `.claude/skills`, in that order. Discovery
- * is best-effort: unreadable roots and malformed skill entries are skipped so
- * a broken skill never degrades the provider snapshot. On name collisions,
- * later roots win: `.agents` beats user and `.claude` beats `.agents`, matching
- * Claude Code's resolution.
+ * The `plugin@marketplace` switches from every settings layer the CLI merges,
+ * most specific last. A plugin can be installed and still turned off, and its
+ * skills do not load while it is.
+ */
+const readEnabledPlugins = Effect.fn("readEnabledPlugins")(function* (
+  configDirPath: string,
+  cwd: string | undefined,
+): Effect.fn.Return<Record<string, unknown>, never, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const files = [
+    path.join(configDirPath, "settings.json"),
+    ...(cwd
+      ? [
+          path.join(cwd, ".claude", "settings.json"),
+          path.join(cwd, ".claude", "settings.local.json"),
+        ]
+      : []),
+  ];
+
+  const merged: Record<string, unknown> = {};
+  for (const file of files) {
+    Object.assign(merged, asRecord(asRecord(yield* readJsonFile(file))?.enabledPlugins));
+  }
+  return merged;
+});
+
+/**
+ * The skill folders a plugin rooted at `pluginRoot` contributes.
+ *
+ * `skills/<name>` is the conventional layout, and a plugin manifest may also
+ * point at skills kept elsewhere in the tree — `mattpocock-skills` buckets
+ * every one of them under `skills/<category>/<name>`, which the conventional
+ * scan alone never reaches. The manifest lives at `.claude-plugin/plugin.json`,
+ * with older plugins keeping it at the plugin root.
+ *
+ * A manifest entry usually names one skill folder, and is read as a folder of
+ * them when it carries no `SKILL.md` of its own — both shapes ship today, and
+ * guessing wrong drops the plugin's skills silently.
+ */
+const pluginSkillDirectories = Effect.fn("pluginSkillDirectories")(function* (
+  pluginRoot: string,
+  plugin: string,
+): Effect.fn.Return<ReadonlyArray<ClaudeSkillDirectory>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const directories = [
+    ...(yield* listSkillDirectories(path.join(pluginRoot, "skills"), "user", plugin)),
+  ];
+
+  const manifest =
+    asRecord(yield* readJsonFile(path.join(pluginRoot, ".claude-plugin", "plugin.json"))) ??
+    asRecord(yield* readJsonFile(path.join(pluginRoot, "plugin.json")));
+  const skills = manifest?.skills;
+  const declared = Array.isArray(skills) ? skills : [skills];
+
+  const seen = new Set(directories.map((entry) => entry.directory));
+  for (const value of declared) {
+    const relative = asString(value);
+    if (relative === undefined) {
+      continue;
+    }
+    const declaredPath = path.resolve(pluginRoot, relative);
+    const isSkill = yield* fileSystem
+      .exists(path.join(declaredPath, "SKILL.md"))
+      .pipe(Effect.orElseSucceed(() => false));
+
+    for (const entry of isSkill
+      ? [{ directory: declaredPath, scope: "user" as const, prefix: plugin }]
+      : yield* listSkillDirectories(declaredPath, "user", plugin)) {
+      if (seen.has(entry.directory)) {
+        continue;
+      }
+      seen.add(entry.directory);
+      directories.push(entry);
+    }
+  }
+  return directories;
+});
+
+/**
+ * Skill folders contributed by installed plugins.
+ *
+ * Claude Code exposes a plugin's skills as `<plugin>:<skill>`, so the prefix is
+ * part of the name the composer sends back — an unprefixed `ponytail` is not a
+ * skill Claude Code resolves.
+ *
+ * Only plugins the CLI would actually load count, so a marketplace's other
+ * offerings, plugins switched off in `settings.json`, and installs belonging to
+ * a different workspace all stay out of the picker: surfacing them fills it
+ * with skills that fail at send time. The install record does not say where the
+ * skills sit, though, and three layouts are in the wild — a cached install, a
+ * plugin inside a marketplace checkout, and a marketplace whose root *is* the
+ * plugin (`installPath` is stale for directory-sourced marketplaces, so it
+ * cannot be trusted alone). The first candidate that yields skills wins.
+ */
+const discoverPluginSkillDirectories = Effect.fn("discoverPluginSkillDirectories")(function* (
+  configDirPath: string,
+  cwd: string | undefined,
+): Effect.fn.Return<ReadonlyArray<ClaudeSkillDirectory>, never, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const pluginsDir = path.join(configDirPath, "plugins");
+
+  const installed = asRecord(
+    asRecord(yield* readJsonFile(path.join(pluginsDir, "installed_plugins.json")))?.plugins,
+  );
+  if (!installed) {
+    return [];
+  }
+  const marketplaces = asRecord(
+    yield* readJsonFile(path.join(pluginsDir, "known_marketplaces.json")),
+  );
+  const enabledPlugins = yield* readEnabledPlugins(configDirPath, cwd);
+  const workspace = cwd ? path.resolve(cwd) : undefined;
+
+  const directories: Array<ClaudeSkillDirectory> = [];
+  for (const [key, value] of Object.entries(installed)) {
+    const [plugin, marketplace] = key.split("@");
+    // An explicit `false` is the only way a plugin is off; an install the
+    // settings never mention is on, which is how a fresh install behaves.
+    if (!plugin || enabledPlugins[key] === false) {
+      continue;
+    }
+    const installLocation = marketplace
+      ? asString(asRecord(marketplaces?.[marketplace])?.installLocation)
+      : undefined;
+
+    // A project-scoped install belongs to the workspace it names and is not
+    // loaded anywhere else. A plugin installed both ways resolves to the
+    // project entry, which is the more specific one — never to whichever the
+    // manifest happens to list first.
+    const applicable = (Array.isArray(value) ? value : [])
+      .flatMap((entry) => {
+        const record = asRecord(entry);
+        const projectPath = asString(record?.projectPath);
+        if (projectPath === undefined) {
+          return [{ record, projectScoped: false }];
+        }
+        return path.resolve(projectPath) === workspace ? [{ record, projectScoped: true }] : [];
+      })
+      .sort((left, right) => Number(right.projectScoped) - Number(left.projectScoped));
+
+    for (const { record } of applicable) {
+      const candidates = [
+        asString(record?.installPath),
+        installLocation ? path.join(installLocation, "plugins", plugin) : undefined,
+        installLocation,
+      ];
+      let found = false;
+      for (const candidate of candidates) {
+        if (candidate === undefined) {
+          continue;
+        }
+        const skills = yield* pluginSkillDirectories(candidate, plugin);
+        if (skills.length > 0) {
+          directories.push(...skills);
+          found = true;
+          break;
+        }
+      }
+      // One install per plugin reaches the picker: several entries mean
+      // several scopes, and they all resolve to the same `<plugin>:` names.
+      if (found) {
+        break;
+      }
+    }
+  }
+  return directories;
+});
+
+/**
+ * Enumerate Claude Code skills from the user config dir and the workspace.
+ * Discovery is best-effort: unreadable roots and malformed skill entries are
+ * skipped so a broken skill never degrades the provider snapshot. On name
+ * collisions the project-scoped skill wins, matching Claude Code's
+ * most-specific-wins resolution.
  */
 export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* (
   config: Pick<ClaudeSettings, "homePath">,
@@ -101,54 +335,54 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
   const path = yield* Path.Path;
   const configDirPath = yield* resolveClaudeConfigDirPath(config, environment ?? process.env, cwd);
 
-  const roots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = [
-    { directory: path.join(configDirPath, "skills"), scope: "user" },
+  // Later entries win on name collisions, matching Claude Code's
+  // most-specific-wins resolution: user, then plugins, then the workspace.
+  const skillDirectories: ReadonlyArray<ClaudeSkillDirectory> = [
+    ...(yield* listSkillDirectories(path.join(configDirPath, "skills"), "user")),
+    ...(yield* discoverPluginSkillDirectories(configDirPath, cwd)),
     ...(cwd
       ? [
-          { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
-          { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
+          ...(yield* listSkillDirectories(path.join(cwd, ".agents", "skills"), "project")),
+          ...(yield* listSkillDirectories(path.join(cwd, ".claude", "skills"), "project")),
         ]
       : []),
   ];
 
   const skillsByName = new Map<string, ServerProviderSkill>();
-  for (const root of roots) {
-    const entries = yield* fileSystem
-      .readDirectory(root.directory)
-      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
-
-    for (const entry of [...entries].sort()) {
-      const skillPath = path.join(root.directory, entry, "SKILL.md");
-      const contents = yield* fileSystem
-        .readFileString(skillPath)
-        .pipe(Effect.orElseSucceed(() => undefined));
-      if (contents === undefined) {
-        continue;
-      }
-
-      const frontmatter = parseSkillFrontmatter(contents);
-      // Malformed frontmatter means the skill won't load in Claude Code
-      // either — skip it rather than surfacing a broken entry under its
-      // directory name.
-      if (frontmatter.kind === "malformed") {
-        continue;
-      }
-
-      const name = (frontmatter.kind === "parsed" ? frontmatter.name : undefined) ?? entry.trim();
-      if (!name) {
-        continue;
-      }
-
-      skillsByName.set(name, {
-        name,
-        path: skillPath,
-        enabled: true,
-        scope: root.scope,
-        ...(frontmatter.kind === "parsed" && frontmatter.description
-          ? { description: frontmatter.description }
-          : {}),
-      });
+  for (const skill of skillDirectories) {
+    const skillPath = path.join(skill.directory, "SKILL.md");
+    const contents = yield* fileSystem
+      .readFileString(skillPath)
+      .pipe(Effect.orElseSucceed(() => undefined));
+    if (contents === undefined) {
+      continue;
     }
+
+    const frontmatter = parseSkillFrontmatter(contents);
+    // Malformed frontmatter means the skill won't load in Claude Code
+    // either — skip it rather than surfacing a broken entry under its
+    // directory name.
+    if (frontmatter.kind === "malformed") {
+      continue;
+    }
+
+    const base =
+      (frontmatter.kind === "parsed" ? frontmatter.name : undefined) ??
+      path.basename(skill.directory).trim();
+    if (!base) {
+      continue;
+    }
+    const name = skill.prefix ? `${skill.prefix}:${base}` : base;
+
+    skillsByName.set(name, {
+      name,
+      path: skillPath,
+      enabled: true,
+      scope: skill.scope,
+      ...(frontmatter.kind === "parsed" && frontmatter.description
+        ? { description: frontmatter.description }
+        : {}),
+    });
   }
 
   return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -36,10 +36,14 @@ the rest of your environment stay as they are.
 
 ## Where Claude Skills Are Loaded
 
-T3 Code looks for Claude skills in the Claude config directory's `skills` folder, then
-`<workspace>/.agents/skills`, then `<workspace>/.claude/skills`.
+T3 Code looks for Claude skills in the Claude config directory's `skills` folder, then in every
+installed plugin, then `<workspace>/.agents/skills`, then `<workspace>/.claude/skills`.
 
 If the same skill name exists in more than one folder, the later folder wins.
+
+Plugin skills carry the plugin's name, so a `tdd` skill from the `mattpocock-skills` plugin appears
+as `mattpocock-skills:tdd` — the same name Claude Code itself uses. A plugin you have switched off,
+or one installed for a different project, stays out of the list.
 
 ## I Want Work And Personal Claude Accounts
 


### PR DESCRIPTION
## What Changed

Claude skill discovery now also reads the roots contributed by installed plugins, so plugin skills reach the `$` picker under the `<plugin>:<skill>` name Claude Code resolves.

Two files plus a doc line, no new dependency, no contract or UI change.

## Why

Fixes #5622. `discoverClaudeSkills` scanned `<config dir>/skills` and the workspace only. Every skill installed through a plugin was therefore invisible in the picker — on my machine, 8 skills out of 52 were discoverable, and the issue reports the same for `mattpocock-skills`.

Four decisions worth explaining, since none of them is obvious from the diff:

**Read `installed_plugins.json`, don't glob the plugin tree.** A marketplace checkout carries skills for every plugin it *offers*, not just the ones installed. Globbing would fill the picker with skills the CLI refuses to load — worse than missing them, because selecting one fails at send time.

**Skip what the CLI would not load, for the same reason.** A plugin can be installed and switched off in `settings.json`, and an install can be project-scoped to a different workspace. Neither loads, so neither belongs in the picker. On my machine that is 39 phantom entries — sentry, vercel and friends — kept out.

**Try three candidate paths per plugin.** The install record does not say where a plugin's skills live, and three layouts exist in the wild: a cached install, a plugin inside a marketplace checkout, and a marketplace whose root *is* the plugin. `installPath` alone is not enough — it is stale for directory-sourced marketplaces. The first candidate that actually yields skills wins, so a layout that does not exist costs one listing.

**Read both the conventional folder and the manifest.** `skills/<name>` is the usual layout, and a plugin manifest may point at skills kept elsewhere in the tree. `mattpocock-skills` buckets every one of its own under `skills/<category>/<name>`, which a scan of `skills/*` never reaches — 25 skills, all of them invisible without this. A manifest entry names one skill folder, or a folder of them when it carries no `SKILL.md` of its own; both shapes ship today, and guessing wrong drops the skills silently rather than loudly.

**Prefix the names.** Claude Code exposes a plugin's skill as `<plugin>:<skill>`, and the composer sends the name straight back to the provider — an unprefixed `ponytail` is not a name the CLI resolves.

Manifests are user-editable JSON with no schema guarantee, so every field is narrowed (`asRecord` / `asString`) rather than asserted; a malformed manifest yields no roots instead of throwing.

## UI Changes

None — no new surface, no layout change. The observable difference is that skills which were already installed now appear in the existing `$` picker.

## Test plan

- Rebased onto `main`, which resolves the conflict with #5488 (`.agents/skills`); plugin roots slot in between the user root and the workspace ones, so precedence stays user → plugins → `.agents` → `.claude`.
- `apps/server` — `vp run typecheck`: no errors.
- `apps/server` — `vp test run src/provider/Drivers/ClaudeSkills.test.ts`: 12 passed (10 pre-existing, 2 new).
- The new cases build plugin trees in a temp dir. One asserts a manifest-declared skill nested under `skills/<category>/<name>` is found while an undeclared sibling is not, and that a manifest naming a folder of skills is read as one; the other asserts a plugin switched off in `settings.json` and an install owned by another workspace both stay out, while a project-scoped install for *this* workspace comes in — and, for a plugin installed both ways, that the project entry wins even though the user entry is listed first.
- Lint clean on both files.
- Verified end to end against my real config: 8 → 52 skills discovered, matching exactly what the CLI itself loads in that workspace, and invoking a prefixed skill from the picker works.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — n/a, no UI change
- [ ] I included a video for animation/interaction changes — n/a

---

Updated to address the review findings: nested plugin skills are now discovered through the manifest, and install scope no longer leaks across projects. The disabled-plugin filter came along with the second one — same class of bug, and the larger half of it in practice. The second round added manifest-entry tolerance and most-specific-install precedence; the two findings I left alone are answered inline.

Written with Claude Opus 5 in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discover skills from installed Claude plugins and prefix them as `<plugin>:<skill>`
> - Extends `discoverClaudeSkills` in [ClaudeSkills.ts](https://github.com/pingdotgg/t3code/pull/6453/files#diff-df655ed95ed759ff78376524f2ceda1b436b639952ddab7e7e19f618a43e77c3) to read `installed_plugins.json` and `known_marketplaces.json`, locate skill directories contributed by each plugin, and surface them with a `<plugin>:<skill>` name prefix.
> - Respects `enabledPlugins` settings from global and workspace-level config files; plugins explicitly disabled or installed for a different workspace are excluded.
> - Precedence order is now: user skills → plugin skills → workspace skills (`.agents` then `.claude`).
> - Behavioral Change: plugin skills now appear between user and workspace skills in the collision precedence chain, which may change which definition wins when names conflict.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13519c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial filesystem and JSON parsing on the provider snapshot path; mistakes could surface wrong or unusable skill names, but behavior is best-effort with tests and no contract/UI changes.
> 
> **Overview**
> **Claude skill discovery** now includes skills from installed Claude Code plugins so they show up in the `$` picker with the same `<plugin>:<skill>` names the CLI uses.
> 
> `discoverClaudeSkills` reads `installed_plugins.json` and `known_marketplaces.json`, merges `enabledPlugins` from user and workspace settings, and only surfaces plugins the CLI would load (not disabled, not another project’s local install). For each plugin it tries `installPath`, marketplace `plugins/<name>`, and marketplace root until it finds skills; it scans `skills/*` and manifest paths in `plugin.json` / `.claude-plugin/plugin.json`, including nested or folder-declared skills. Precedence is **user → plugins → `.agents` → `.claude`**, with project skills still winning on collisions.
> 
> User docs describe plugin skills and naming. New tests cover the three install layouts, manifest-only paths, and enablement / workspace scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13519c2760bee9691c45b80c38febeb4b97db5b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->