### PR TITLE
fix(usage): exclude offline environments from pending totals

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -481,7 +481,7 @@ function UsageCoverageNotice(props: {
       ) : null}
       {failed.map((environment) => (
         <Text key={environment.environmentId} className="text-sm text-foreground-muted">
-          {environment.label} could not report usage.
+          {environment.error}
         </Text>
       ))}
       {stale.map((environment) => (

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -10,6 +10,7 @@
  * @module state/usage
  */
 import { useAtomValue } from "@effect/atom-react";
+import { connectionPhaseCanAnswer } from "@t3tools/client-runtime/connection";
 import {
   USAGE_CONTRACT_VERSION,
   type EnvironmentId,
@@ -29,6 +30,7 @@ export interface EnvironmentUsageStatus {
   readonly environmentId: EnvironmentId;
   readonly label: string;
   readonly isPending: boolean;
+  /** Ready-to-render sentence for why this environment contributed nothing. */
   readonly error: string | null;
   readonly summary: UsageSummary | null;
 }
@@ -48,12 +50,24 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
     const statuses: EnvironmentUsageStatus[] = [];
     for (const [environmentId, presentation] of presentations) {
       const result = get(serverEnvironment.usageSummary({ environmentId, input }));
+      const label = presentation.entry.target.label;
+      const summary = Option.getOrNull(AsyncResult.value(result));
+      // A sleeping device leaves its request pending indefinitely: the query
+      // only fails once a connection exists to fail on. Its dropped connection
+      // is the terminal signal, so the page never waits on it.
+      const unreachable =
+        summary === null && !connectionPhaseCanAnswer(presentation.connection.phase);
       statuses.push({
         environmentId,
-        label: presentation.entry.target.label,
-        isPending: result.waiting,
-        error: result._tag === "Failure" ? "This environment could not report usage." : null,
-        summary: Option.getOrNull(AsyncResult.value(result)),
+        label,
+        isPending: result.waiting && !unreachable,
+        error:
+          result._tag === "Failure"
+            ? `${label} could not report usage.`
+            : unreachable
+              ? `${label} is not reachable and is left out of these totals.`
+              : null,
+        summary,
       });
     }
     return statuses;

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -30,7 +30,6 @@ export interface EnvironmentUsageStatus {
   readonly environmentId: EnvironmentId;
   readonly label: string;
   readonly isPending: boolean;
-  /** Ready-to-render sentence for why this environment contributed nothing. */
   readonly error: string | null;
   readonly summary: UsageSummary | null;
 }
@@ -52,19 +51,15 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
       const result = get(serverEnvironment.usageSummary({ environmentId, input }));
       const label = presentation.entry.target.label;
       const summary = Option.getOrNull(AsyncResult.value(result));
-      // A sleeping device leaves its request pending indefinitely: the query
-      // only fails once a connection exists to fail on. Its dropped connection
-      // is the terminal signal, so the page never waits on it.
-      const unreachable =
-        summary === null && !connectionPhaseCanAnswer(presentation.connection.phase);
+      const canAnswer = connectionPhaseCanAnswer(presentation.connection.phase);
       statuses.push({
         environmentId,
         label,
-        isPending: result.waiting && !unreachable,
+        isPending: result.waiting && canAnswer,
         error:
           result._tag === "Failure"
             ? `${label} could not report usage.`
-            : unreachable
+            : summary === null && !canAnswer
               ? `${label} is not reachable and is left out of these totals.`
               : null,
         summary,

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -470,10 +470,10 @@ function Metric({
 }
 
 /**
- * Says plainly when the totals are incomplete: an environment that failed, or
- * one whose transcripts another environment already reported. Environments
- * that are still answering never reach this notice; the page shows the
- * loading skeleton until every one is terminal.
+ * Says plainly when the totals are incomplete: an environment that failed or is
+ * unreachable, or one whose transcripts another environment already reported.
+ * Environments that are still answering never reach this notice; the page shows
+ * the loading skeleton until every one is terminal.
  */
 function UsageCoverageNotice({
   environments,
@@ -495,7 +495,7 @@ function UsageCoverageNotice({
   return (
     <div className="flex flex-col gap-1 border border-border px-3 py-2 text-xs text-muted-foreground">
       {failed.map((environment) => (
-        <span key={environment.label}>{environment.label} could not report usage.</span>
+        <span key={environment.environmentId}>{environment.error}</span>
       ))}
       {stale.map((environment) => (
         <span key={environment.label}>

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -470,10 +470,10 @@ function Metric({
 }
 
 /**
- * Says plainly when the totals are incomplete: an environment that failed or is
- * unreachable, or one whose transcripts another environment already reported.
- * Environments that are still answering never reach this notice; the page shows
- * the loading skeleton until every one is terminal.
+ * Says plainly when the totals are incomplete: an environment that failed, or
+ * one whose transcripts another environment already reported. Environments
+ * that are still answering never reach this notice; the page shows the
+ * loading skeleton until every one is terminal.
  */
 function UsageCoverageNotice({
   environments,
@@ -495,7 +495,7 @@ function UsageCoverageNotice({
   return (
     <div className="flex flex-col gap-1 border border-border px-3 py-2 text-xs text-muted-foreground">
       {failed.map((environment) => (
-        <span key={environment.environmentId}>{environment.error}</span>
+        <span key={environment.label}>{environment.error}</span>
       ))}
       {stale.map((environment) => (
         <span key={environment.label}>

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -27,7 +27,6 @@ export interface EnvironmentUsageStatus {
   readonly environmentId: EnvironmentId;
   readonly label: string;
   readonly isPending: boolean;
-  /** Ready-to-render sentence for why this environment contributed nothing. */
   readonly error: string | null;
   readonly summary: UsageSummary | null;
 }
@@ -49,19 +48,15 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
       const result = get(serverEnvironment.usageSummary({ environmentId, input }));
       const label = presentation.entry.target.label;
       const summary = Option.getOrNull(AsyncResult.value(result));
-      // A sleeping device leaves its request pending indefinitely: the query
-      // only fails once a connection exists to fail on. Its dropped connection
-      // is the terminal signal, so the page never waits on it.
-      const unreachable =
-        summary === null && !connectionPhaseCanAnswer(presentation.connection.phase);
+      const canAnswer = connectionPhaseCanAnswer(presentation.connection.phase);
       statuses.push({
         environmentId,
         label,
-        isPending: result.waiting && !unreachable,
+        isPending: result.waiting && canAnswer,
         error:
           result._tag === "Failure"
             ? `${label} could not report usage.`
-            : unreachable
+            : summary === null && !canAnswer
               ? `${label} is not reachable and is left out of these totals.`
               : null,
         summary,

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -7,6 +7,7 @@
  * @module state/usage
  */
 import { useAtomValue } from "@effect/atom-react";
+import { connectionPhaseCanAnswer } from "@t3tools/client-runtime/connection";
 import {
   USAGE_CONTRACT_VERSION,
   type EnvironmentId,
@@ -26,6 +27,7 @@ export interface EnvironmentUsageStatus {
   readonly environmentId: EnvironmentId;
   readonly label: string;
   readonly isPending: boolean;
+  /** Ready-to-render sentence for why this environment contributed nothing. */
   readonly error: string | null;
   readonly summary: UsageSummary | null;
 }
@@ -45,12 +47,24 @@ const usageByWindowAtom = Atom.family((windowKey: string) =>
     const statuses: EnvironmentUsageStatus[] = [];
     for (const [environmentId, presentation] of presentations) {
       const result = get(serverEnvironment.usageSummary({ environmentId, input }));
+      const label = presentation.entry.target.label;
+      const summary = Option.getOrNull(AsyncResult.value(result));
+      // A sleeping device leaves its request pending indefinitely: the query
+      // only fails once a connection exists to fail on. Its dropped connection
+      // is the terminal signal, so the page never waits on it.
+      const unreachable =
+        summary === null && !connectionPhaseCanAnswer(presentation.connection.phase);
       statuses.push({
         environmentId,
-        label: presentation.entry.target.label,
-        isPending: result.waiting,
-        error: result._tag === "Failure" ? "This environment could not report usage." : null,
-        summary: Option.getOrNull(AsyncResult.value(result)),
+        label,
+        isPending: result.waiting && !unreachable,
+        error:
+          result._tag === "Failure"
+            ? `${label} could not report usage.`
+            : unreachable
+              ? `${label} is not reachable and is left out of these totals.`
+              : null,
+        summary,
       });
     }
     return statuses;

--- a/packages/client-runtime/src/connection/presentation.test.ts
+++ b/packages/client-runtime/src/connection/presentation.test.ts
@@ -10,7 +10,6 @@ import {
 } from "./model.ts";
 import {
   connectionCatalogDisplayUrl,
-  connectionPhaseCanAnswer,
   connectionPhaseMessage,
   connectionStatusText,
   connectionStatusTitle,
@@ -166,15 +165,6 @@ describe("connection presentation", () => {
       error: null,
       traceId: null,
     });
-  });
-
-  it("stops expecting answers from a dropped environment", () => {
-    expect(connectionPhaseCanAnswer("available")).toBe(true);
-    expect(connectionPhaseCanAnswer("connecting")).toBe(true);
-    expect(connectionPhaseCanAnswer("connected")).toBe(true);
-    expect(connectionPhaseCanAnswer("reconnecting")).toBe(false);
-    expect(connectionPhaseCanAnswer("offline")).toBe(false);
-    expect(connectionPhaseCanAnswer("error")).toBe(false);
   });
 
   it("preserves an explicitly available environment while offline", () => {

--- a/packages/client-runtime/src/connection/presentation.test.ts
+++ b/packages/client-runtime/src/connection/presentation.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./model.ts";
 import {
   connectionCatalogDisplayUrl,
+  connectionPhaseCanAnswer,
   connectionPhaseMessage,
   connectionStatusText,
   connectionStatusTitle,
@@ -165,6 +166,15 @@ describe("connection presentation", () => {
       error: null,
       traceId: null,
     });
+  });
+
+  it("stops expecting answers from a dropped environment", () => {
+    expect(connectionPhaseCanAnswer("available")).toBe(true);
+    expect(connectionPhaseCanAnswer("connecting")).toBe(true);
+    expect(connectionPhaseCanAnswer("connected")).toBe(true);
+    expect(connectionPhaseCanAnswer("reconnecting")).toBe(false);
+    expect(connectionPhaseCanAnswer("offline")).toBe(false);
+    expect(connectionPhaseCanAnswer("error")).toBe(false);
   });
 
   it("preserves an explicitly available environment while offline", () => {

--- a/packages/client-runtime/src/connection/presentation.ts
+++ b/packages/client-runtime/src/connection/presentation.ts
@@ -55,24 +55,8 @@ export function presentConnectionState(
   }
 }
 
-/**
- * True while the client can still expect this environment to answer a request.
- * A device that has dropped out sits in `reconnecting`, `offline` or `error`
- * and its in-flight queries stay pending until it comes back, so callers that
- * must settle within a bounded time read the connection as the terminal signal
- * instead of waiting on a request that never fails.
- */
 export function connectionPhaseCanAnswer(phase: EnvironmentConnectionPhase): boolean {
-  switch (phase) {
-    case "available":
-    case "connecting":
-    case "connected":
-      return true;
-    case "offline":
-    case "reconnecting":
-    case "error":
-      return false;
-  }
+  return phase === "available" || phase === "connecting" || phase === "connected";
 }
 
 export function connectionStatusText(connection: EnvironmentConnectionPresentation): string {

--- a/packages/client-runtime/src/connection/presentation.ts
+++ b/packages/client-runtime/src/connection/presentation.ts
@@ -55,6 +55,26 @@ export function presentConnectionState(
   }
 }
 
+/**
+ * True while the client can still expect this environment to answer a request.
+ * A device that has dropped out sits in `reconnecting`, `offline` or `error`
+ * and its in-flight queries stay pending until it comes back, so callers that
+ * must settle within a bounded time read the connection as the terminal signal
+ * instead of waiting on a request that never fails.
+ */
+export function connectionPhaseCanAnswer(phase: EnvironmentConnectionPhase): boolean {
+  switch (phase) {
+    case "available":
+    case "connecting":
+    case "connected":
+      return true;
+    case "offline":
+    case "reconnecting":
+    case "error":
+      return false;
+  }
+}
+
 export function connectionStatusText(connection: EnvironmentConnectionPresentation): string {
   switch (connection.phase) {
     case "available":


### PR DESCRIPTION
Offline environments leave usage summary queries pending indefinitely, which keeps the usage page in its loading state and can pin mobile pull-to-refresh.

Treat connection phases that cannot currently answer as terminal for pending-state calculations. When no cached summary exists, show that the environment was excluded from the totals; when a cached summary exists, keep displaying it without leaving refresh active.

This applies the same behavior to web and mobile through a small shared connection-phase predicate.

Checks:
- `pnpm exec vp run --filter @t3tools/client-runtime --filter @t3tools/web --filter @t3tools/mobile typecheck`
- `git diff --check`

Generated with GPT-5.6-sol in the Codex harness through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude offline environments from pending usage totals
> - Adds `connectionPhaseCanAnswer` utility in [`presentation.ts`](https://github.com/pingdotgg/t3code/pull/6455/files#diff-696aa7c2bcbe229bb02c6650bd93c240a3bf10020da226e64d7158f5dd4da6b3) that returns true for `available`, `connecting`, and `connected` phases.
> - In `usageByWindowAtom` (web and mobile), sets `isPending` to false for environments whose connection phase cannot answer, so offline environments no longer inflate pending totals.
> - Offline environments with no summary now show a `'{label} is not reachable and is left out of these totals.'` error instead of the generic failure message.
> - `UsageCoverageNotice` on both platforms now renders the environment-provided `error` string directly, supporting varied error messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6cd362.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->