### PR TITLE
fix(mobile): select parts of agent responses on Android

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -571,6 +571,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
 
     const createMarkdownRenderers = (
       bodyTextColor: string,
+      headingTextColor: string,
       inlineTextColor: string,
       inlineCodeTextColor: string,
       blockBackgroundColor: string,
@@ -589,7 +590,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
               marginBottom: preserveSoftBreaks ? 0 : 10,
             },
             heading: (level) => ({
-              color: bodyTextColor,
+              color: headingTextColor,
               fontFamily: boldFontFamily,
               fontSize:
                 level === 1
@@ -786,6 +787,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         styles: userStyles,
         renderers: createMarkdownRenderers(
           markdownUserBodyColor,
+          markdownUserBodyColor,
           markdownUserCodeText,
           markdownUserInlineCodeText,
           markdownUserFenceBg,
@@ -820,6 +822,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         styles: assistantStyles,
         renderers: createMarkdownRenderers(
           markdownBodyColor,
+          markdownStrongColor,
           markdownCodeText,
           markdownInlineCodeText,
           markdownCodeBg,

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -103,6 +103,7 @@ import {
 import { useMarkdownCodeHighlight } from "./markdownCodeHighlightState";
 import { useAssetUrl } from "../../state/assets";
 import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
+import { createAndroidSelectableMarkdownRenderers } from "./androidSelectableMarkdownRenderers";
 
 const WIDE_MARKDOWN_BLOCK_OPTIONS = {
   includeOrderedLists: Platform.OS === "android",
@@ -569,6 +570,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
     };
 
     const createMarkdownRenderers = (
+      bodyTextColor: string,
       inlineTextColor: string,
       inlineCodeTextColor: string,
       blockBackgroundColor: string,
@@ -577,6 +579,48 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
       preserveSoftBreaks: boolean,
       highlightCode: boolean,
     ): CustomRenderers => ({
+      ...(Platform.OS === "android"
+        ? createAndroidSelectableMarkdownRenderers({
+            paragraph: {
+              color: bodyTextColor,
+              fontFamily: regularFontFamily,
+              fontSize: markdownFontSizes.m,
+              lineHeight: markdownFontSizes.bodyLineHeight,
+              marginBottom: preserveSoftBreaks ? 0 : 10,
+            },
+            heading: (level) => ({
+              color: bodyTextColor,
+              fontFamily: boldFontFamily,
+              fontSize:
+                level === 1
+                  ? markdownFontSizes.h1
+                  : level === 2
+                    ? markdownFontSizes.h2
+                    : level === 3
+                      ? markdownFontSizes.h3
+                      : level === 4
+                        ? markdownFontSizes.h4
+                        : level === 5
+                          ? markdownFontSizes.h5
+                          : markdownFontSizes.h6,
+              lineHeight:
+                (level === 1
+                  ? markdownFontSizes.h1
+                  : level === 2
+                    ? markdownFontSizes.h2
+                    : level === 3
+                      ? markdownFontSizes.h3
+                      : level === 4
+                        ? markdownFontSizes.h4
+                        : level === 5
+                          ? markdownFontSizes.h5
+                          : markdownFontSizes.h6) * 1.3,
+              fontWeight: "700",
+              marginTop: preserveSoftBreaks ? 8 : 18,
+              marginBottom: preserveSoftBreaks ? 4 : 8,
+            }),
+          })
+        : {}),
       link: ({ children, href = "" }) => {
         const presentation = resolveMarkdownLinkPresentation(href);
         if (presentation.kind === "file") {
@@ -741,6 +785,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         theme: userTheme,
         styles: userStyles,
         renderers: createMarkdownRenderers(
+          markdownUserBodyColor,
           markdownUserCodeText,
           markdownUserInlineCodeText,
           markdownUserFenceBg,
@@ -774,6 +819,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         theme: assistantTheme,
         styles: assistantStyles,
         renderers: createMarkdownRenderers(
+          markdownBodyColor,
           markdownCodeText,
           markdownInlineCodeText,
           markdownCodeBg,

--- a/apps/mobile/src/features/threads/androidSelectableMarkdownRenderers.test.tsx
+++ b/apps/mobile/src/features/threads/androidSelectableMarkdownRenderers.test.tsx
@@ -45,4 +45,32 @@ describe("createAndroidSelectableMarkdownRenderers", () => {
       expect(child.props.parentIsText).toBe(true);
     },
   );
+
+  it("preserves distinct paragraph and heading styles", () => {
+    const renderers = createAndroidSelectableMarkdownRenderers({
+      paragraph: { color: "#111111" },
+      heading: () => ({ color: "#222222" }),
+    });
+    const Renderer = () => null;
+    const baseProps = {
+      children: null,
+      Renderer,
+    };
+    const paragraph = renderers.paragraph?.({
+      ...baseProps,
+      node: { type: "paragraph", children: [] },
+    });
+    const heading = renderers.heading?.({
+      ...baseProps,
+      level: 2,
+      node: { type: "heading", children: [] },
+    });
+
+    expect(isValidElement(paragraph) && paragraph.props).toMatchObject({
+      style: { color: "#111111" },
+    });
+    expect(isValidElement(heading) && heading.props).toMatchObject({
+      style: { color: "#222222" },
+    });
+  });
 });

--- a/apps/mobile/src/features/threads/androidSelectableMarkdownRenderers.test.tsx
+++ b/apps/mobile/src/features/threads/androidSelectableMarkdownRenderers.test.tsx
@@ -1,0 +1,48 @@
+import { isValidElement } from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("react-native", () => ({ Text: "Text" }));
+
+import { createAndroidSelectableMarkdownRenderers } from "./androidSelectableMarkdownRenderers";
+
+describe("createAndroidSelectableMarkdownRenderers", () => {
+  it.each(["paragraph", "heading"] as const)(
+    "renders %s blocks as partially selectable native text",
+    (blockType) => {
+      const renderers = createAndroidSelectableMarkdownRenderers({
+        paragraph: {},
+        heading: () => ({}),
+      });
+      const renderer = renderers[blockType];
+      const Renderer = () => null;
+      const element = renderer?.({
+        children: null,
+        node: {
+          type: blockType,
+          children: [{ type: "text", content: "select only these words" }],
+        },
+        Renderer,
+        ...(blockType === "heading" ? { level: 2 as const } : {}),
+      });
+
+      expect(isValidElement(element)).toBe(true);
+      if (!isValidElement(element)) {
+        throw new Error("Expected a React element");
+      }
+      const elementProps = element.props as {
+        readonly selectable?: boolean;
+        readonly children: ReadonlyArray<{
+          readonly type: unknown;
+          readonly props: { readonly parentIsText?: boolean };
+        }>;
+      };
+      expect(elementProps).toMatchObject({ selectable: true });
+      const child = elementProps.children[0];
+      if (!child) {
+        throw new Error("Expected a nested text renderer");
+      }
+      expect(child.type).toBe(Renderer);
+      expect(child.props.parentIsText).toBe(true);
+    },
+  );
+});

--- a/apps/mobile/src/features/threads/androidSelectableMarkdownRenderers.tsx
+++ b/apps/mobile/src/features/threads/androidSelectableMarkdownRenderers.tsx
@@ -1,0 +1,40 @@
+import { Text as NativeText, type TextStyle } from "react-native";
+import type { CustomRenderers } from "react-native-nitro-markdown";
+
+export interface AndroidSelectableMarkdownRendererStyles {
+  readonly paragraph: TextStyle;
+  readonly heading: (level: number) => TextStyle;
+}
+
+export function createAndroidSelectableMarkdownRenderers(
+  styles: AndroidSelectableMarkdownRendererStyles,
+): Pick<CustomRenderers, "heading" | "paragraph"> {
+  return {
+    paragraph: ({ node, Renderer }) => (
+      <NativeText selectable style={styles.paragraph}>
+        {node.children?.map((child, index) => (
+          <Renderer
+            key={`${child.type}:${child.beg ?? index}:${child.end ?? index}`}
+            node={child}
+            depth={1}
+            inListItem={false}
+            parentIsText
+          />
+        ))}
+      </NativeText>
+    ),
+    heading: ({ node, Renderer, level = 1 }) => (
+      <NativeText selectable style={styles.heading(level)}>
+        {node.children?.map((child, index) => (
+          <Renderer
+            key={`${child.type}:${child.beg ?? index}:${child.end ?? index}`}
+            node={child}
+            depth={1}
+            inListItem={false}
+            parentIsText
+          />
+        ))}
+      </NativeText>
+    ),
+  };
+}


### PR DESCRIPTION
On Android, you could not select and copy just part of an agent response. Long-pressing normal response text did not show selection handles, so the only practical option was the copy button, which copies the entire response. The browser does not have this problem.

Android now renders response paragraphs and headings as selectable native text, so you can long-press, adjust the selection handles, and copy only the passage you need. Markdown formatting and links still use the existing renderer, and headings retain their existing colors. Browser/desktop behavior is unchanged; iOS keeps its separate selectable Markdown implementation.

## Verification

- `vp test run apps/mobile/src/features/threads/androidSelectableMarkdownRenderers.test.tsx` — 3 tests passed
- `vp lint apps/mobile/src/features/threads/ThreadFeed.tsx apps/mobile/src/features/threads/androidSelectableMarkdownRenderers.tsx apps/mobile/src/features/threads/androidSelectableMarkdownRenderers.test.tsx --report-unused-disable-directives` — passed
- `vp run --filter @t3tools/mobile typecheck` — passed
- Android device verification and interaction video were not run because this host has no Android SDK, `adb`, or emulator; the PR remains a draft pending that check.

Implemented by gpt-5.6-sol through the Codex harness in T3 Code.
