### PR TITLE
feat(web): open files in containing folder

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -82,6 +82,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.projectsSearchEntries]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsWriteFile]: AuthOrchestrationOperateScope,
   [WS_METHODS.shellOpenInEditor]: AuthOrchestrationOperateScope,
+  [WS_METHODS.shellRevealInFileManager]: AuthOrchestrationOperateScope,
   [WS_METHODS.filesystemBrowse]: AuthOrchestrationReadScope,
   [WS_METHODS.assetsCreateUrl]: AuthOrchestrationReadScope,
   [WS_METHODS.attachmentsCreateUploadUrl]: AuthOrchestrationOperateScope,

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -94,6 +94,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.pullRequests).toBe(true);
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
       expect(second.capabilities.threadPullRequestLinking).toBe(true);
+      expect(second.capabilities.fileManagerReveal).toBe(true);
       expect(second.capabilities.agentActivityPublishing).toBe(false);
     }),
   );

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -154,6 +154,7 @@ export const make = Effect.gen(function* () {
       threadPinReorder: true,
       threadTitleRegeneration: true,
       threadPullRequestLinking: true,
+      fileManagerReveal: true,
       ...(serverSelfUpdate === null ? {} : { serverSelfUpdate }),
       ...(serverSelfUpdate === "boot-service" ? { serverSelfUpdateProgress: true } : {}),
     },

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -94,6 +94,165 @@ it.effect("launches the default browser through the platform command", () => {
   );
 });
 
+it.effect("reveals files with the linux file manager", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-file-manager-" });
+    const commandPath = path.join(binDir, "xdg-open");
+    yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(commandPath, 0o755);
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.revealInFileManager({ path: "/tmp/project with spaces/src/index.ts" });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "linux",
+          env: { PATH: binDir, DISPLAY: ":0" },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.equal(spawned.command, "xdg-open");
+    assert.deepEqual(spawned.args, ["/tmp/project with spaces/src"]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("opens the containing folder when the Finder target is missing", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-file-manager-" });
+    const commandPath = path.join(binDir, "open");
+    yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(commandPath, 0o755);
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.revealInFileManager({ path: "/tmp/project with spaces/src/index.ts" });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "darwin",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.equal(spawned.command, "open");
+    assert.deepEqual(spawned.args, ["/tmp/project with spaces/src"]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("selects an existing file in Finder", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-file-manager-" });
+    const commandPath = path.join(binDir, "open");
+    const targetPath = path.join(binDir, "project with spaces", "src", "index.ts");
+    yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(commandPath, 0o755);
+    yield* fileSystem.makeDirectory(path.dirname(targetPath), { recursive: true });
+    yield* fileSystem.writeFileString(targetPath, "");
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.revealInFileManager({ path: targetPath });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "darwin",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.equal(spawned.command, "open");
+    assert.deepEqual(spawned.args, ["-R", targetPath]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("opens the containing folder when the Explorer target is missing", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-file-manager-" });
+    yield* fileSystem.writeFileString(path.join(binDir, "explorer.CMD"), "@echo off\r\n");
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.revealInFileManager({ path: "C:\\project files\\src\\index.ts" });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "win32",
+          env: { PATH: binDir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.equal(spawned.command, "explorer");
+    assert.deepEqual(spawned.args, [`C:\\project files\\src`]);
+    assert.equal(spawned.options.shell, false);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("selects an existing file in Windows Explorer", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-file-manager-" });
+    const targetPath = path.join(binDir, "project files", "src", "index.ts");
+    yield* fileSystem.writeFileString(path.join(binDir, "explorer.CMD"), "@echo off\r\n");
+    yield* fileSystem.makeDirectory(path.dirname(targetPath), { recursive: true });
+    yield* fileSystem.writeFileString(targetPath, "");
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.revealInFileManager({ path: targetPath });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "win32",
+          env: { PATH: binDir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.equal(spawned.command, "explorer");
+    assert.deepEqual(spawned.args, ["/select,", targetPath.replaceAll("/", "\\")]);
+    assert.equal(spawned.options.shell, false);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
 it.effect("launches an installed editor with platform-safe arguments", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
@@ -280,6 +439,199 @@ it.effect("rescans after an interrupted discovery instead of caching the interru
     ),
   );
 });
+it.effect("does not advertise a file manager on headless Linux", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-headless-linux-" });
+    const commandPath = path.join(binDir, "xdg-open");
+    yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(commandPath, 0o755);
+
+    const editors = yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      return yield* launcher.resolveAvailableEditors();
+    }).pipe(Effect.provide(testLayer({ platform: "linux", env: { PATH: binDir } })));
+
+    assert.equal(editors.includes("file-manager"), false);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("uses Windows Explorer from WSL without WSLg", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-wsl-explorer-" });
+    const commandPath = path.join(binDir, "explorer.exe");
+    const targetPath = path.join(binDir, "project with spaces", "src", "index.ts");
+    yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(commandPath, 0o755);
+    yield* fileSystem.makeDirectory(path.dirname(targetPath), { recursive: true });
+    yield* fileSystem.writeFileString(targetPath, "");
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    const env = { PATH: binDir, WSL_DISTRO_NAME: "Ubuntu-22.04" };
+    const editors = yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      const availableEditors = yield* launcher.resolveAvailableEditors();
+      yield* launcher.revealInFileManager({ path: targetPath });
+      return availableEditors;
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "linux",
+          env,
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.equal(editors.includes("file-manager"), true);
+    assert.ok(spawned);
+    assert.equal(spawned.command, "explorer.exe");
+    assert.deepEqual(spawned.args, [
+      "/select,",
+      `\\\\wsl.localhost\\Ubuntu-22.04${targetPath.replaceAll("/", "\\")}`,
+    ]);
+    assert.equal(spawned.options.shell, false);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("uses Windows Explorer from WSL with WSLg", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-wslg-explorer-" });
+    const explorerPath = path.join(binDir, "explorer.exe");
+    const xdgOpenPath = path.join(binDir, "xdg-open");
+    const targetPath = path.join(binDir, "project with spaces", "src", "index.ts");
+    yield* fileSystem.writeFileString(explorerPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(explorerPath, 0o755);
+    yield* fileSystem.writeFileString(xdgOpenPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(xdgOpenPath, 0o755);
+    yield* fileSystem.makeDirectory(path.dirname(targetPath), { recursive: true });
+    yield* fileSystem.writeFileString(targetPath, "");
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    const env = {
+      PATH: binDir,
+      WSL_DISTRO_NAME: "Ubuntu-22.04",
+      DISPLAY: ":0",
+      WAYLAND_DISPLAY: "wayland-0",
+    };
+    const editors = yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      const availableEditors = yield* launcher.resolveAvailableEditors();
+      yield* launcher.revealInFileManager({ path: targetPath });
+      return availableEditors;
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "linux",
+          env,
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.equal(editors.includes("file-manager"), true);
+    assert.ok(spawned);
+    assert.equal(spawned.command, "explorer.exe");
+    assert.deepEqual(spawned.args, [
+      "/select,",
+      `\\\\wsl.localhost\\Ubuntu-22.04${targetPath.replaceAll("/", "\\")}`,
+    ]);
+    assert.equal(spawned.options.shell, false);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("advertises a file manager in a Linux graphical session", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-desktop-linux-" });
+    const commandPath = path.join(binDir, "xdg-open");
+    yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(commandPath, 0o755);
+
+    const editors = yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      return yield* launcher.resolveAvailableEditors();
+    }).pipe(
+      Effect.provide(
+        testLayer({ platform: "linux", env: { PATH: binDir, WAYLAND_DISPLAY: "wayland-0" } }),
+      ),
+    );
+
+    assert.equal(editors.includes("file-manager"), true);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("rejects a direct file manager reveal on headless Linux", () =>
+  Effect.gen(function* () {
+    const launcher = yield* ExternalLauncher.ExternalLauncher;
+    const error = yield* launcher
+      .revealInFileManager({ path: "/tmp/project/src/index.ts" })
+      .pipe(Effect.flip);
+    assert.instanceOf(error, ExternalLauncher.ExternalLauncherUnsupportedEditorError);
+  }).pipe(Effect.provide(testLayer({ platform: "linux", env: { PATH: "" } }))),
+);
+
+it.effect("does not advertise a file manager over SSH", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-ssh-macos-" });
+    const commandPath = path.join(binDir, "open");
+    yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(commandPath, 0o755);
+
+    const editors = yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      return yield* launcher.resolveAvailableEditors();
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "darwin",
+          env: { PATH: binDir, SSH_CONNECTION: "client server" },
+        }),
+      ),
+    );
+
+    assert.equal(editors.includes("file-manager"), false);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("does not advertise Explorer from a Windows service", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-windows-service-" });
+    yield* fileSystem.writeFileString(path.join(binDir, "explorer.CMD"), "@echo off\r\n");
+
+    const editors = yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      return yield* launcher.resolveAvailableEditors();
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "win32",
+          env: {
+            PATH: binDir,
+            PATHEXT: ".COM;.EXE;.BAT;.CMD",
+            SESSIONNAME: "Services",
+          },
+        }),
+      ),
+    );
+
+    assert.equal(editors.includes("file-manager"), false);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
 
 it.effect("rejects unknown editors through the service API", () =>
   Effect.gen(function* () {

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -94,19 +94,22 @@ it.effect("launches the default browser through the platform command", () => {
   );
 });
 
-it.effect("reveals files with the linux file manager", () =>
+it.effect("opens the nearest existing folder for a missing Linux target", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-file-manager-" });
     const commandPath = path.join(binDir, "xdg-open");
+    const workspacePath = path.join(binDir, "project with spaces");
+    const targetPath = path.join(workspacePath, "missing", "src", "index.ts");
     yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
     yield* fileSystem.chmod(commandPath, 0o755);
+    yield* fileSystem.makeDirectory(workspacePath);
 
     let spawned: ChildProcess.StandardCommand | undefined;
     yield* Effect.gen(function* () {
       const launcher = yield* ExternalLauncher.ExternalLauncher;
-      yield* launcher.revealInFileManager({ path: "/tmp/project with spaces/src/index.ts" });
+      yield* launcher.revealInFileManager({ path: targetPath });
     }).pipe(
       Effect.provide(
         testLayer({
@@ -121,23 +124,26 @@ it.effect("reveals files with the linux file manager", () =>
 
     assert.ok(spawned);
     assert.equal(spawned.command, "xdg-open");
-    assert.deepEqual(spawned.args, ["/tmp/project with spaces/src"]);
+    assert.deepEqual(spawned.args, [workspacePath]);
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 
-it.effect("opens the containing folder when the Finder target is missing", () =>
+it.effect("opens the nearest existing folder when the Finder target is missing", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-file-manager-" });
     const commandPath = path.join(binDir, "open");
+    const workspacePath = path.join(binDir, "project with spaces");
+    const targetPath = path.join(workspacePath, "missing", "src", "index.ts");
     yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
     yield* fileSystem.chmod(commandPath, 0o755);
+    yield* fileSystem.makeDirectory(workspacePath);
 
     let spawned: ChildProcess.StandardCommand | undefined;
     yield* Effect.gen(function* () {
       const launcher = yield* ExternalLauncher.ExternalLauncher;
-      yield* launcher.revealInFileManager({ path: "/tmp/project with spaces/src/index.ts" });
+      yield* launcher.revealInFileManager({ path: targetPath });
     }).pipe(
       Effect.provide(
         testLayer({
@@ -152,7 +158,40 @@ it.effect("opens the containing folder when the Finder target is missing", () =>
 
     assert.ok(spawned);
     assert.equal(spawned.command, "open");
-    assert.deepEqual(spawned.args, ["/tmp/project with spaces/src"]);
+    assert.deepEqual(spawned.args, [workspacePath]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("opens an existing directory in Finder", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-file-manager-" });
+    const commandPath = path.join(binDir, "open");
+    const targetPath = path.join(binDir, "project with spaces");
+    yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+    yield* fileSystem.chmod(commandPath, 0o755);
+    yield* fileSystem.makeDirectory(targetPath);
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.revealInFileManager({ path: targetPath });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "darwin",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    assert.equal(spawned.command, "open");
+    assert.deepEqual(spawned.args, [targetPath]);
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -532,7 +532,7 @@ it.effect("uses Windows Explorer from WSL without WSLg", () =>
     assert.equal(spawned.command, "explorer.exe");
     assert.deepEqual(spawned.args, [
       "/select,",
-      `\\\\wsl.localhost\\Ubuntu-22.04${targetPath.replaceAll("/", "\\")}`,
+      `\\\\wsl$\\Ubuntu-22.04${targetPath.replaceAll("/", "\\")}`,
     ]);
     assert.equal(spawned.options.shell, false);
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
@@ -582,7 +582,7 @@ it.effect("uses Windows Explorer from WSL with WSLg", () =>
     assert.equal(spawned.command, "explorer.exe");
     assert.deepEqual(spawned.args, [
       "/select,",
-      `\\\\wsl.localhost\\Ubuntu-22.04${targetPath.replaceAll("/", "\\")}`,
+      `\\\\wsl$\\Ubuntu-22.04${targetPath.replaceAll("/", "\\")}`,
     ]);
     assert.equal(spawned.options.shell, false);
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -16,6 +16,7 @@ import {
   ExternalLauncherUnsupportedEditorError,
   type EditorId,
   type LaunchEditorInput,
+  type RevealInFileManagerInput,
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { isCommandAvailable, resolveSpawnCommand } from "@t3tools/shared/shell";
@@ -45,7 +46,7 @@ export {
   ExternalLauncherUnsupportedEditorError,
   isExternalLauncherError,
 } from "@t3tools/contracts";
-export type { LaunchEditorInput };
+export type { LaunchEditorInput, RevealInFileManagerInput };
 interface EditorLaunch {
   readonly editor: EditorId;
   readonly target: string;
@@ -66,6 +67,7 @@ interface TargetPathAndPosition {
 }
 
 const TARGET_WITH_POSITION_PATTERN = /^(.*?):(\d+)(?::(\d+))?$/;
+const WSL_DISTRO_NAME_PATTERN = /^\w(?:[\w .-]*\w)?$/;
 const POWERSHELL_ARGUMENTS_PREFIX = [
   "-NoProfile",
   "-NonInteractive",
@@ -106,6 +108,14 @@ const CommandLookupEnvConfig = Config.all({
   Path: Config.string("Path").pipe(Config.option),
   path: Config.string("path").pipe(Config.option),
   PATHEXT: Config.string("PATHEXT").pipe(Config.option),
+  DISPLAY: Config.string("DISPLAY").pipe(Config.option),
+  WAYLAND_DISPLAY: Config.string("WAYLAND_DISPLAY").pipe(Config.option),
+  WSL_DISTRO_NAME: Config.string("WSL_DISTRO_NAME").pipe(Config.option),
+  WSL_INTEROP: Config.string("WSL_INTEROP").pipe(Config.option),
+  SSH_CONNECTION: Config.string("SSH_CONNECTION").pipe(Config.option),
+  SSH_TTY: Config.string("SSH_TTY").pipe(Config.option),
+  SESSIONNAME: Config.string("SESSIONNAME").pipe(Config.option),
+  container: Config.string("container").pipe(Config.option),
 }).pipe(Config.map(compactEnv));
 
 const readBrowserLaunchEnv = BrowserLaunchEnvConfig.pipe(Effect.orElseSucceed(() => ({})));
@@ -223,7 +233,73 @@ function resolveWindowsBrowserLaunch(target: string, command: string): ProcessLa
   };
 }
 
-function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
+function resolveWslDistroName(env: NodeJS.ProcessEnv): string | undefined {
+  const distroName = env.WSL_DISTRO_NAME?.trim();
+  return distroName && WSL_DISTRO_NAME_PATTERN.test(distroName) ? distroName : undefined;
+}
+
+function shouldUseWindowsFileManagerFromWsl(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return shouldUseWindowsBrowserFromWsl(platform, env) && resolveWslDistroName(env) !== undefined;
+}
+
+function hasGraphicalFileManagerSession(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  if (env.SSH_CONNECTION?.trim() || env.SSH_TTY?.trim()) return false;
+  if (shouldUseWindowsFileManagerFromWsl(platform, env)) return true;
+  if (platform === "linux") {
+    return Boolean(env.DISPLAY?.trim() || env.WAYLAND_DISPLAY?.trim());
+  }
+  if (platform === "win32") {
+    return env.SESSIONNAME?.trim().toLowerCase() !== "services";
+  }
+  return true;
+}
+
+function normalizeWindowsFileManagerPath(target: string): string {
+  return target.replaceAll("/", "\\");
+}
+
+function resolveWslFileManagerPath(target: string, env: NodeJS.ProcessEnv): string {
+  const distroName = resolveWslDistroName(env);
+  if (!distroName) return target;
+  return `\\\\wsl.localhost\\${distroName}${normalizeWindowsFileManagerPath(target)}`;
+}
+
+function fileManagerFolderPath(platform: NodeJS.Platform, target: string, path: Path.Path): string {
+  if (platform !== "win32") return path.dirname(target);
+
+  const normalized = normalizeWindowsFileManagerPath(target);
+  const separatorIndex = normalized.lastIndexOf("\\");
+  if (separatorIndex < 0) return ".";
+  if (separatorIndex === 2 && normalized[1] === ":") return normalized.slice(0, 3);
+  return normalized.slice(0, separatorIndex) || "\\";
+}
+
+function fileManagerRevealArgs(
+  platform: NodeJS.Platform,
+  target: string,
+  targetExists: boolean,
+  path: Path.Path,
+  env: NodeJS.ProcessEnv,
+): ReadonlyArray<string> {
+  if (shouldUseWindowsFileManagerFromWsl(platform, env)) {
+    const revealTarget = targetExists ? target : fileManagerFolderPath(platform, target, path);
+    const windowsTarget = resolveWslFileManagerPath(revealTarget, env);
+    return targetExists ? ["/select,", windowsTarget] : [windowsTarget];
+  }
+  if (!targetExists) return [fileManagerFolderPath(platform, target, path)];
+  if (platform === "darwin") return ["-R", target];
+  if (platform === "win32") return ["/select,", normalizeWindowsFileManagerPath(target)];
+  return [fileManagerFolderPath(platform, target, path)];
+}
+
+function fileManagerCommandForPlatform(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
+  if (shouldUseWindowsFileManagerFromWsl(platform, env)) return "explorer.exe";
   switch (platform) {
     case "darwin":
       return "open";
@@ -270,7 +346,8 @@ const buildAvailableEditors = Effect.fn("externalLauncher.buildAvailableEditors"
 
   for (const editor of EDITORS) {
     if (editor.commands === null) {
-      const command = fileManagerCommandForPlatform(platform);
+      if (!hasGraphicalFileManagerSession(platform, env)) continue;
+      const command = fileManagerCommandForPlatform(platform, env);
       if (yield* isCommandAvailable(command, { env })) {
         available.push(editor.id);
       }
@@ -337,6 +414,10 @@ export class ExternalLauncher extends Context.Service<
      * Launches the editor as a detached process so server startup is not blocked.
      */
     readonly launchEditor: (input: LaunchEditorInput) => Effect.Effect<void, ExternalLauncherError>;
+    /** Reveal a workspace file in the host file manager. */
+    readonly revealInFileManager: (
+      input: RevealInFileManagerInput,
+    ) => Effect.Effect<void, ExternalLauncherError>;
   }
 >()("t3/process/externalLauncher") {}
 
@@ -376,13 +457,52 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
     return yield* new ExternalLauncherUnsupportedEditorError({ editor: input.editor });
   }
 
+  const path = yield* Path.Path;
+  const target = shouldUseWindowsFileManagerFromWsl(platform, env)
+    ? path.resolve(input.cwd)
+    : input.cwd;
   return {
     editor: editorDef.id,
-    target: input.cwd,
-    command: fileManagerCommandForPlatform(platform),
-    args: [input.cwd],
+    target,
+    command: fileManagerCommandForPlatform(platform, env),
+    args: [
+      shouldUseWindowsFileManagerFromWsl(platform, env)
+        ? resolveWslFileManagerPath(target, env)
+        : target,
+    ],
   };
 });
+
+const resolveFileManagerRevealLaunch = Effect.fn("externalLauncher.resolveFileManagerRevealLaunch")(
+  function* (
+    input: RevealInFileManagerInput,
+  ): Effect.fn.Return<EditorLaunch, ExternalLauncherError, FileSystem.FileSystem | Path.Path> {
+    const platform = yield* HostProcessPlatform;
+    const env = yield* readCommandLookupEnv;
+    if (!hasGraphicalFileManagerSession(platform, env)) {
+      return yield* new ExternalLauncherUnsupportedEditorError({ editor: "file-manager" });
+    }
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const target = shouldUseWindowsFileManagerFromWsl(platform, env)
+      ? path.resolve(input.path)
+      : input.path;
+    const targetExists = yield* fileSystem.exists(target).pipe(Effect.orElseSucceed(() => false));
+    const args = fileManagerRevealArgs(platform, target, targetExists, path, env);
+
+    yield* Effect.annotateCurrentSpan({
+      "externalLauncher.target": target,
+      "externalLauncher.platform": platform,
+    });
+
+    return {
+      editor: "file-manager",
+      target,
+      command: fileManagerCommandForPlatform(platform, env),
+      args,
+    };
+  },
+);
 
 const launchAndUnref = Effect.fn("externalLauncher.launchAndUnref")(function* (
   launch: ProcessLaunch,
@@ -496,6 +616,14 @@ export const make = Effect.gen(function* () {
     launchEditor: (input) =>
       provideCommandResolutionServices(
         Effect.flatMap(resolveEditorLaunch(input), (launch) =>
+          launchEditorProcess(launch).pipe(
+            Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+          ),
+        ),
+      ),
+    revealInFileManager: (input) =>
+      provideCommandResolutionServices(
+        Effect.flatMap(resolveFileManagerRevealLaunch(input), (launch) =>
           launchEditorProcess(launch).pipe(
             Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
           ),

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -60,6 +60,11 @@ interface ProcessLaunch {
   readonly options: ChildProcess.CommandOptions;
 }
 
+interface FileManagerRevealTarget {
+  readonly path: string;
+  readonly isDirectory: boolean;
+}
+
 interface TargetPathAndPosition {
   readonly path: string;
   readonly line: string;
@@ -280,19 +285,45 @@ function fileManagerFolderPath(platform: NodeJS.Platform, target: string, path: 
   return normalized.slice(0, separatorIndex) || "\\";
 }
 
+const resolveFileManagerRevealTarget = Effect.fn("externalLauncher.resolveFileManagerRevealTarget")(
+  function* (
+    platform: NodeJS.Platform,
+    target: string,
+  ): Effect.fn.Return<FileManagerRevealTarget, never, FileSystem.FileSystem | Path.Path> {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const fallbackPath = fileManagerFolderPath(platform, target, path);
+    let candidate = target;
+
+    while (true) {
+      const info = yield* fileSystem.stat(candidate).pipe(Effect.orElseSucceed(() => null));
+      if (info) {
+        return { path: candidate, isDirectory: info.type === "Directory" };
+      }
+
+      const parent = fileManagerFolderPath(platform, candidate, path);
+      if (parent === candidate) {
+        return { path: fallbackPath, isDirectory: true };
+      }
+      candidate = parent;
+    }
+  },
+);
+
 function fileManagerRevealArgs(
   platform: NodeJS.Platform,
-  target: string,
-  targetExists: boolean,
+  revealTarget: FileManagerRevealTarget,
   path: Path.Path,
   env: NodeJS.ProcessEnv,
 ): ReadonlyArray<string> {
+  const target = revealTarget.path;
   if (shouldUseWindowsFileManagerFromWsl(platform, env)) {
-    const revealTarget = targetExists ? target : fileManagerFolderPath(platform, target, path);
-    const windowsTarget = resolveWslFileManagerPath(revealTarget, env);
-    return targetExists ? ["/select,", windowsTarget] : [windowsTarget];
+    const windowsTarget = resolveWslFileManagerPath(target, env);
+    return revealTarget.isDirectory ? [windowsTarget] : ["/select,", windowsTarget];
   }
-  if (!targetExists) return [fileManagerFolderPath(platform, target, path)];
+  if (revealTarget.isDirectory) {
+    return [platform === "win32" ? normalizeWindowsFileManagerPath(target) : target];
+  }
   if (platform === "darwin") return ["-R", target];
   if (platform === "win32") return ["/select,", normalizeWindowsFileManagerPath(target)];
   return [fileManagerFolderPath(platform, target, path)];
@@ -482,13 +513,12 @@ const resolveFileManagerRevealLaunch = Effect.fn("externalLauncher.resolveFileMa
     if (!hasGraphicalFileManagerSession(platform, env)) {
       return yield* new ExternalLauncherUnsupportedEditorError({ editor: "file-manager" });
     }
-    const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const target = shouldUseWindowsFileManagerFromWsl(platform, env)
       ? path.resolve(input.path)
       : input.path;
-    const targetExists = yield* fileSystem.exists(target).pipe(Effect.orElseSucceed(() => false));
-    const args = fileManagerRevealArgs(platform, target, targetExists, path, env);
+    const revealTarget = yield* resolveFileManagerRevealTarget(platform, target);
+    const args = fileManagerRevealArgs(platform, revealTarget, path, env);
 
     yield* Effect.annotateCurrentSpan({
       "externalLauncher.target": target,

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -272,7 +272,7 @@ function normalizeWindowsFileManagerPath(target: string): string {
 function resolveWslFileManagerPath(target: string, env: NodeJS.ProcessEnv): string {
   const distroName = resolveWslDistroName(env);
   if (!distroName) return target;
-  return `\\\\wsl.localhost\\${distroName}${normalizeWindowsFileManagerPath(target)}`;
+  return `\\\\wsl$\\${distroName}${normalizeWindowsFileManagerPath(target)}`;
 }
 
 function fileManagerFolderPath(platform: NodeJS.Platform, target: string, path: Path.Path): string {

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5318,6 +5318,33 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("routes websocket rpc shell.revealInFileManager", () =>
+    Effect.gen(function* () {
+      let revealedInput: { path: string } | null = null;
+      yield* buildAppUnderTest({
+        layers: {
+          externalLauncher: {
+            revealInFileManager: (input) =>
+              Effect.sync(() => {
+                revealedInput = input;
+              }),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[WS_METHODS.shellRevealInFileManager]({
+            path: "/tmp/project/src/index.ts",
+          }),
+        ),
+      );
+
+      assert.deepEqual(revealedInput, { path: "/tmp/project/src/index.ts" });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("routes websocket rpc shell.openInEditor errors", () =>
     Effect.gen(function* () {
       const externalLauncherError = new ExternalLauncherCommandNotFoundError({

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1965,6 +1965,12 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.shellOpenInEditor, externalLauncher.launchEditor(input), {
             "rpc.aggregate": "workspace",
           }),
+        [WS_METHODS.shellRevealInFileManager]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.shellRevealInFileManager,
+            externalLauncher.revealInFileManager(input),
+            { "rpc.aggregate": "workspace" },
+          ),
         [WS_METHODS.filesystemBrowse]: (input) =>
           observeRpcEffect(
             WS_METHODS.filesystemBrowse,

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -10,6 +10,7 @@ vi.mock("../state/session", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../state/session")>()),
   usePreparedConnection: () => ({ _tag: "Loading" }),
 }));
+vi.mock("../state/environments", () => ({ useEnvironment: () => null }));
 vi.mock("../state/entities", () => ({
   readThreadShell: () => null,
   useActiveEnvironmentId: () => EnvironmentId.make("env-windows"),

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -56,6 +56,11 @@ import {
   resolveExternalWebLinkHost,
   showExternalLinkContextMenu,
 } from "./chat/externalLinkContextMenu";
+import {
+  buildFileLinkContextMenuItems,
+  canRevealFileLinkInManager,
+  resolveFileLinkEnvironmentId,
+} from "./chat/fileLinkContextMenu";
 import { hasSpecificPierreIconForFileName, syntheticFileNameForLanguageId } from "../pierre-icons";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import { Button } from "./ui/button";
@@ -93,10 +98,12 @@ import { useAssetUrlState } from "../assets/assetUrls";
 import { cn } from "../lib/utils";
 import { useRightPanelStore } from "../rightPanelStore";
 import { readThreadShell, useActiveEnvironmentId, useProjects } from "../state/entities";
+import { useEnvironment } from "../state/environments";
 import { serverEnvironment } from "../state/server";
 import { assetEnvironment } from "../state/assets";
 import { usePreparedConnection } from "../state/session";
 import { previewEnvironment } from "../state/preview";
+import { shellEnvironment } from "../state/shell";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { projectEnvironment } from "../state/projects";
@@ -866,6 +873,7 @@ function UncachedShikiCodeBlock({
 
 interface MarkdownFileLinkProps {
   href: string;
+  filePath: string;
   targetPath: string;
   iconPath: string;
   displayPath: string;
@@ -877,6 +885,8 @@ interface MarkdownFileLinkProps {
   threadRef?: ScopedThreadRef | undefined;
   onOpen: (targetPath: string) => Promise<AtomCommandResult<unknown, unknown>>;
   onOpenInPanel: (workspaceRelativePath: string, line: number | undefined) => void;
+  canRevealInFileManager: boolean;
+  onRevealInFileManager: (filePath: string) => Promise<AtomCommandResult<unknown, unknown>>;
   onOpenInBrowser?: (() => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
   className?: string | undefined;
 }
@@ -1218,6 +1228,7 @@ function MarkdownExternalLinkContent({
 
 const MarkdownFileLink = memo(function MarkdownFileLink({
   href,
+  filePath,
   targetPath,
   iconPath,
   displayPath,
@@ -1229,6 +1240,8 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   threadRef,
   onOpen,
   onOpenInPanel,
+  canRevealInFileManager,
+  onRevealInFileManager,
   onOpenInBrowser,
   className,
 }: MarkdownFileLinkProps) {
@@ -1266,6 +1279,38 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
       }
     })();
   }, [onOpen, targetPath]);
+
+  const handleRevealInFileManager = useCallback(() => {
+    void (async () => {
+      try {
+        const result = await onRevealInFileManager(filePath);
+        if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
+          return;
+        }
+        reportMarkdownActionFailure(
+          { operation: "open-file-in-folder", target: filePath },
+          result.cause,
+        );
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Unable to open folder",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      } catch (cause) {
+        reportMarkdownActionFailure({ operation: "open-file-in-folder", target: filePath }, cause);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Unable to open folder",
+            description: cause instanceof Error ? cause.message : "An error occurred.",
+          }),
+        );
+      }
+    })();
+  }, [filePath, onRevealInFileManager]);
 
   const handleOpenInFilePreview = useCallback(() => {
     if (!threadRef || !workspaceRelativePath) {
@@ -1362,19 +1407,19 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
 
       try {
         const clicked = await api.contextMenu.show(
-          [
-            { id: "open", label: "Open in editor" },
-            ...(onOpenInBrowser
-              ? ([{ id: "open-in-browser", label: "Open in integrated browser" }] as const)
-              : []),
-            { id: "copy-relative", label: "Copy relative path" },
-            { id: "copy-full", label: "Copy full path" },
-          ] as const,
+          buildFileLinkContextMenuItems({
+            canRevealInFileManager,
+            canOpenInBrowser: onOpenInBrowser !== undefined,
+          }),
           { x: event.clientX, y: event.clientY },
         );
 
         if (clicked === "open") {
           handleOpenInEditor();
+          return;
+        }
+        if (clicked === "open-in-folder") {
+          handleRevealInFileManager();
           return;
         }
         if (clicked === "open-in-browser") {
@@ -1395,7 +1440,16 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         );
       }
     },
-    [displayPath, handleCopy, handleOpenInBrowser, handleOpenInEditor, onOpenInBrowser, targetPath],
+    [
+      canRevealInFileManager,
+      displayPath,
+      handleCopy,
+      handleOpenInBrowser,
+      handleOpenInEditor,
+      handleRevealInFileManager,
+      onOpenInBrowser,
+      targetPath,
+    ],
   );
 
   return (
@@ -1445,6 +1499,7 @@ function areMarkdownFileLinkPropsEqual(
 ): boolean {
   return (
     previous.href === next.href &&
+    previous.filePath === next.filePath &&
     previous.targetPath === next.targetPath &&
     previous.iconPath === next.iconPath &&
     previous.displayPath === next.displayPath &&
@@ -1456,6 +1511,8 @@ function areMarkdownFileLinkPropsEqual(
     previous.threadRef === next.threadRef &&
     previous.onOpen === next.onOpen &&
     previous.onOpenInPanel === next.onOpenInPanel &&
+    previous.canRevealInFileManager === next.canRevealInFileManager &&
+    previous.onRevealInFileManager === next.onRevealInFileManager &&
     previous.onOpenInBrowser === next.onOpenInBrowser &&
     previous.className === next.className
   );
@@ -1485,17 +1542,25 @@ function ChatMarkdown({
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
   });
-  const preparedConnection = usePreparedConnection(threadRef?.environmentId ?? null);
-  const environmentId = useActiveEnvironmentId();
+  const revealInFileManager = useAtomCommand(shellEnvironment.revealInFileManager, {
+    reportFailure: false,
+  });
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const environmentId = resolveFileLinkEnvironmentId(threadRef?.environmentId, activeEnvironmentId);
+  const environment = useEnvironment(environmentId);
+  const preparedConnection = usePreparedConnection(environmentId);
   const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
+  const availableEditors = serverConfig?.availableEditors ?? [];
+  const openInPreferredEditor = useOpenInPreferredEditor(environmentId, availableEditors);
+  const canRevealInFileManager = canRevealFileLinkInManager({
+    connectionPhase: environment?.connection.phase,
+    supportsRevealRpc: serverConfig?.environment.capabilities.fileManagerReveal === true,
+    availableEditors,
+  });
   const threadServerConfig = useAtomValue(
     serverEnvironment.configValueAtom(threadRef?.environmentId ?? environmentId),
   );
   const projects = useProjects();
-  const openInPreferredEditor = useOpenInPreferredEditor(
-    environmentId,
-    serverConfig?.availableEditors ?? [],
-  );
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
   const markdownFileLinkMetaByHref = useMemo(() => {
     const metaByHref = new Map<
@@ -1613,6 +1678,20 @@ function ChatMarkdown({
     },
     [openPreview, threadRef],
   );
+  const revealMarkdownFileInFileManager = useCallback(
+    (filePath: string): Promise<AtomCommandResult<unknown, unknown>> => {
+      if (environmentId === null) {
+        return Promise.resolve(
+          AsyncResult.failure(Cause.fail(new Error("No environment is selected."))),
+        );
+      }
+      return revealInFileManager({
+        environmentId,
+        input: { path: filePath },
+      });
+    },
+    [environmentId, revealInFileManager],
+  );
   const openMarkdownFileInPreview = useCallback(
     (path: string) => {
       if (!threadRef || preparedConnection._tag === "None") {
@@ -1695,6 +1774,7 @@ function ChatMarkdown({
       return (
         <MarkdownFileLink
           href={fileLinkMeta.targetPath}
+          filePath={fileLinkMeta.filePath}
           targetPath={fileLinkMeta.targetPath}
           iconPath={fileLinkMeta.filePath}
           displayPath={fileLinkMeta.displayPath}
@@ -1706,6 +1786,8 @@ function ChatMarkdown({
           threadRef={threadRef}
           onOpen={openInPreferredEditor}
           onOpenInPanel={openFileInPanel}
+          canRevealInFileManager={canRevealInFileManager}
+          onRevealInFileManager={revealMarkdownFileInFileManager}
           onOpenInBrowser={
             threadRef &&
             isPreviewSupportedInRuntime() &&
@@ -1984,6 +2066,7 @@ function ChatMarkdown({
       },
     };
   }, [
+    canRevealInFileManager,
     cwd,
     diffThemeName,
     fileLinkParentSuffixByPath,
@@ -1993,6 +2076,7 @@ function ChatMarkdown({
     onTaskListChange,
     openFileInPanel,
     openInPreferredEditor,
+    revealMarkdownFileInFileManager,
     openChangeRequestLink,
     openExternalLinkInPreview,
     openMarkdownFileInPreview,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -14,6 +14,7 @@ import {
   WrapTextIcon,
 } from "lucide-react";
 import type {
+  EnvironmentId,
   ScopedThreadRef,
   ServerProviderSkill,
   ThreadLinkedPullRequest,
@@ -134,6 +135,7 @@ interface ChatMarkdownProps {
   text: string;
   cwd: string | undefined;
   threadRef?: ScopedThreadRef | undefined;
+  environmentId?: EnvironmentId | undefined;
   onTaskListChange?: ((input: { markerOffset: number; checked: boolean }) => void) | undefined;
   isStreaming?: boolean;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
@@ -1515,6 +1517,7 @@ function ChatMarkdown({
   text,
   cwd,
   threadRef,
+  environmentId: contentEnvironmentId,
   onTaskListChange,
   isStreaming = false,
   skills = EMPTY_MARKDOWN_SKILLS,
@@ -1539,7 +1542,11 @@ function ChatMarkdown({
     reportFailure: false,
   });
   const activeEnvironmentId = useActiveEnvironmentId();
-  const environmentId = resolveFileLinkEnvironmentId(threadRef?.environmentId, activeEnvironmentId);
+  const environmentId = resolveFileLinkEnvironmentId(
+    threadRef?.environmentId,
+    activeEnvironmentId,
+    contentEnvironmentId,
+  );
   const environment = useEnvironment(environmentId);
   const preparedConnection = usePreparedConnection(environmentId);
   const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -86,6 +86,7 @@ import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation
 import {
   extractMarkdownLinkHrefs,
   normalizeMarkdownLinkDestination,
+  normalizeMarkdownLinkHrefKey,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
@@ -965,14 +966,6 @@ function extractInlineCodeSpans(text: string): string[] {
     }
   }
   return spans;
-}
-
-function normalizeMarkdownLinkHrefKey(href: string): string {
-  const normalizedHref = normalizeMarkdownLinkDestination(href);
-  const rewrittenHref = rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
-  return WINDOWS_DRIVE_PATH_REGEX.test(rewrittenHref)
-    ? rewrittenHref.replaceAll("\\", "/")
-    : rewrittenHref;
 }
 
 const MARKDOWN_LINK_FAVICON_CLASS_NAME = "block size-full shrink-0 select-none";

--- a/apps/web/src/components/chat/fileLinkContextMenu.test.ts
+++ b/apps/web/src/components/chat/fileLinkContextMenu.test.ts
@@ -1,0 +1,74 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildFileLinkContextMenuItems,
+  canRevealFileLinkInManager,
+  resolveFileLinkEnvironmentId,
+} from "./fileLinkContextMenu";
+
+describe("file link environment", () => {
+  it("routes through the thread environment before the active environment", () => {
+    const threadEnvironmentId = EnvironmentId.make("thread-environment");
+    expect(
+      resolveFileLinkEnvironmentId(threadEnvironmentId, EnvironmentId.make("active-environment")),
+    ).toBe(threadEnvironmentId);
+  });
+
+  it("falls back to the active environment without thread context", () => {
+    const activeEnvironmentId = EnvironmentId.make("active-environment");
+    expect(resolveFileLinkEnvironmentId(undefined, activeEnvironmentId)).toBe(activeEnvironmentId);
+  });
+
+  it.each([
+    {
+      connectionPhase: "reconnecting",
+      supportsRevealRpc: true,
+      availableEditors: ["file-manager"],
+    },
+    { connectionPhase: "connected", supportsRevealRpc: false, availableEditors: ["file-manager"] },
+    { connectionPhase: "connected", supportsRevealRpc: true, availableEditors: [] },
+  ] as const)("hides reveal when support is incomplete", (input) => {
+    expect(canRevealFileLinkInManager(input)).toBe(false);
+  });
+
+  it("allows reveal only when connected with rpc and file manager support", () => {
+    expect(
+      canRevealFileLinkInManager({
+        connectionPhase: "connected",
+        supportsRevealRpc: true,
+        availableEditors: ["file-manager"],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("chat file link context menu", () => {
+  it("puts Open in folder first when the environment supports it", () => {
+    expect(
+      buildFileLinkContextMenuItems({
+        canRevealInFileManager: true,
+        canOpenInBrowser: false,
+      }),
+    ).toEqual([
+      { id: "open-in-folder", label: "Open in folder" },
+      { id: "open", label: "Open in editor" },
+      { id: "copy-relative", label: "Copy relative path" },
+      { id: "copy-full", label: "Copy full path" },
+    ]);
+  });
+
+  it("hides Open in folder when the environment does not support it", () => {
+    expect(
+      buildFileLinkContextMenuItems({
+        canRevealInFileManager: false,
+        canOpenInBrowser: true,
+      }),
+    ).toEqual([
+      { id: "open", label: "Open in editor" },
+      { id: "open-in-browser", label: "Open in integrated browser" },
+      { id: "copy-relative", label: "Copy relative path" },
+      { id: "copy-full", label: "Copy full path" },
+    ]);
+  });
+});

--- a/apps/web/src/components/chat/fileLinkContextMenu.test.ts
+++ b/apps/web/src/components/chat/fileLinkContextMenu.test.ts
@@ -20,6 +20,14 @@ describe("file link environment", () => {
     expect(resolveFileLinkEnvironmentId(undefined, activeEnvironmentId)).toBe(activeEnvironmentId);
   });
 
+  it("routes non-thread content through its owning environment", () => {
+    const activeEnvironmentId = EnvironmentId.make("active-environment");
+    const contentEnvironmentId = EnvironmentId.make("content-environment");
+    expect(resolveFileLinkEnvironmentId(undefined, activeEnvironmentId, contentEnvironmentId)).toBe(
+      contentEnvironmentId,
+    );
+  });
+
   it.each([
     {
       connectionPhase: "reconnecting",

--- a/apps/web/src/components/chat/fileLinkContextMenu.ts
+++ b/apps/web/src/components/chat/fileLinkContextMenu.ts
@@ -1,0 +1,45 @@
+import type { ContextMenuItem, EditorId, EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
+
+export type FileLinkContextMenuAction =
+  | "open-in-folder"
+  | "open"
+  | "open-in-browser"
+  | "copy-relative"
+  | "copy-full";
+
+export function resolveFileLinkEnvironmentId(
+  threadEnvironmentId: EnvironmentId | undefined,
+  activeEnvironmentId: EnvironmentId | null,
+): EnvironmentId | null {
+  return threadEnvironmentId ?? activeEnvironmentId;
+}
+
+export function canRevealFileLinkInManager(input: {
+  readonly connectionPhase: EnvironmentConnectionPhase | undefined;
+  readonly supportsRevealRpc: boolean;
+  readonly availableEditors: ReadonlyArray<EditorId>;
+}): boolean {
+  return (
+    input.connectionPhase === "connected" &&
+    input.supportsRevealRpc &&
+    input.availableEditors.includes("file-manager")
+  );
+}
+
+export function buildFileLinkContextMenuItems(input: {
+  readonly canRevealInFileManager: boolean;
+  readonly canOpenInBrowser: boolean;
+}): readonly ContextMenuItem<FileLinkContextMenuAction>[] {
+  return [
+    ...(input.canRevealInFileManager
+      ? ([{ id: "open-in-folder", label: "Open in folder" }] as const)
+      : []),
+    { id: "open", label: "Open in editor" },
+    ...(input.canOpenInBrowser
+      ? ([{ id: "open-in-browser", label: "Open in integrated browser" }] as const)
+      : []),
+    { id: "copy-relative", label: "Copy relative path" },
+    { id: "copy-full", label: "Copy full path" },
+  ];
+}

--- a/apps/web/src/components/chat/fileLinkContextMenu.ts
+++ b/apps/web/src/components/chat/fileLinkContextMenu.ts
@@ -11,8 +11,9 @@ export type FileLinkContextMenuAction =
 export function resolveFileLinkEnvironmentId(
   threadEnvironmentId: EnvironmentId | undefined,
   activeEnvironmentId: EnvironmentId | null,
+  contentEnvironmentId?: EnvironmentId | undefined,
 ): EnvironmentId | null {
-  return threadEnvironmentId ?? activeEnvironmentId;
+  return threadEnvironmentId ?? contentEnvironmentId ?? activeEnvironmentId;
 }
 
 export function canRevealFileLinkInManager(input: {

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -1,4 +1,5 @@
 import { ExternalLinkIcon, PaperclipIcon, PlayIcon } from "lucide-react";
+import type { EnvironmentId } from "@t3tools/contracts";
 
 import { cn } from "~/lib/utils";
 
@@ -19,10 +20,12 @@ import { splitPullRequestBody } from "./pullRequestMarkdown.logic";
 export function PullRequestMarkdown({
   text,
   cwd,
+  environmentId,
   className,
 }: {
   text: string;
   cwd: string;
+  environmentId: EnvironmentId;
   className?: string;
 }) {
   const segments = splitPullRequestBody(text);
@@ -30,7 +33,14 @@ export function PullRequestMarkdown({
     <div className={cn("space-y-3", className)}>
       {segments.map((segment) => {
         if (segment.kind === "markdown") {
-          return <ChatMarkdown key={segment.id} text={segment.text} cwd={cwd} />;
+          return (
+            <ChatMarkdown
+              key={segment.id}
+              text={segment.text}
+              cwd={cwd}
+              environmentId={environmentId}
+            />
+          );
         }
         const isVideo = segment.media === "video";
         const Icon = isVideo ? PlayIcon : PaperclipIcon;

--- a/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { EnvironmentId } from "@t3tools/contracts";
 
 import { cn } from "~/lib/utils";
 
@@ -17,6 +18,7 @@ import { PullRequestMarkdown } from "./PullRequestMarkdown";
 export function PullRequestMarkdownEditor({
   value,
   cwd,
+  environmentId,
   placeholder,
   label,
   saving,
@@ -27,6 +29,7 @@ export function PullRequestMarkdownEditor({
 }: {
   readonly value: string;
   readonly cwd: string;
+  readonly environmentId: EnvironmentId;
   readonly placeholder?: string | undefined;
   readonly label: string;
   readonly saving: boolean;
@@ -81,7 +84,7 @@ export function PullRequestMarkdownEditor({
           {empty ? (
             <p className="text-xs text-muted-foreground">Nothing to preview.</p>
           ) : (
-            <PullRequestMarkdown text={draft} cwd={cwd} />
+            <PullRequestMarkdown text={draft} cwd={cwd} environmentId={environmentId} />
           )}
         </div>
       ) : (

--- a/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
@@ -273,6 +273,7 @@ export function ReviewThreadCard({
                     className="mt-1"
                     value={comment.body}
                     cwd={workspaceRoot}
+                    environmentId={environmentId}
                     label="Edit comment"
                     saving={savingEdit}
                     onSave={(body) => void saveEdit(comment.id, body)}
@@ -284,6 +285,7 @@ export function ReviewThreadCard({
                       className="min-w-0 flex-1 text-sm"
                       text={comment.body}
                       cwd={workspaceRoot}
+                      environmentId={environmentId}
                     />
                     {canEditComment(comment) ? (
                       <Button

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -94,6 +94,7 @@ function reviewStateLabel(state: string): string {
 /** What every remark in the conversation needs to be rewritten where it sits. */
 interface CommentEditing {
   readonly cwd: string;
+  readonly environmentId: EnvironmentId;
   readonly canEdit: (comment: PullRequestComment) => boolean;
   readonly editingId: string | null;
   readonly saving: boolean;
@@ -120,6 +121,7 @@ function CommentBody({
         className={className}
         value={comment.body}
         cwd={editing.cwd}
+        environmentId={editing.environmentId}
         label="Edit comment"
         saving={editing.saving}
         onSave={(body) => editing.onSave(comment, body)}
@@ -129,7 +131,12 @@ function CommentBody({
   }
   return (
     <div className={cn("flex items-start gap-1", className)}>
-      <PullRequestMarkdown className="min-w-0 flex-1" text={comment.body} cwd={editing.cwd} />
+      <PullRequestMarkdown
+        className="min-w-0 flex-1"
+        text={comment.body}
+        cwd={editing.cwd}
+        environmentId={editing.environmentId}
+      />
       {editing.canEdit(comment) ? (
         <Button
           size="icon-xs"
@@ -489,6 +496,7 @@ export function PullRequestSummaryTab({
 
   const commentEditing: CommentEditing = {
     cwd: detail.workspaceRoot,
+    environmentId,
     canEdit: (comment) => canEditPullRequestComment(detail, comment),
     editingId: editingCommentId,
     saving: commentSaving,
@@ -649,6 +657,7 @@ export function PullRequestSummaryTab({
               allowEmpty
               value={detail.body}
               cwd={detail.workspaceRoot}
+              environmentId={environmentId}
               label="Pull request description"
               placeholder="Describe this pull request"
               saving={bodySaving}
@@ -661,6 +670,7 @@ export function PullRequestSummaryTab({
                 className="min-w-0 flex-1"
                 text={detail.body.trim().length > 0 ? detail.body : "_No description provided._"}
                 cwd={detail.workspaceRoot}
+                environmentId={environmentId}
               />
               {canEditPullRequestChangeRequest(detail) ? (
                 <Button

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -59,11 +59,21 @@ interface ReactionSurface {
   readonly onRefresh: () => void;
 }
 
-function TimelineBody({ body, markdown, cwd }: { body: string; markdown: boolean; cwd: string }) {
+function TimelineBody({
+  body,
+  markdown,
+  cwd,
+  environmentId,
+}: {
+  body: string;
+  markdown: boolean;
+  cwd: string;
+  environmentId: EnvironmentId;
+}) {
   return (
     <div className="mt-3">
       {markdown ? (
-        <PullRequestMarkdown text={body} cwd={cwd} />
+        <PullRequestMarkdown text={body} cwd={cwd} environmentId={environmentId} />
       ) : (
         <p className="whitespace-pre-wrap text-xs text-muted-foreground">{body}</p>
       )}
@@ -235,6 +245,7 @@ function ConversationCard({
           <PullRequestMarkdownEditor
             value={editable.body}
             cwd={cwd}
+            environmentId={reactions.environmentId}
             label="Edit comment"
             saving={saving}
             onSave={(body) => void save(body)}
@@ -243,7 +254,12 @@ function ConversationCard({
         </div>
       ) : event.body ? (
         <div className="px-2 pb-2">
-          <TimelineBody body={event.body} markdown={event.markdown} cwd={cwd} />
+          <TimelineBody
+            body={event.body}
+            markdown={event.markdown}
+            cwd={cwd}
+            environmentId={reactions.environmentId}
+          />
         </div>
       ) : null}
       {reactions.canReact || event.reactions.length > 0 ? (
@@ -505,7 +521,12 @@ function ReviewVerdictEvent({
           {/* An approval usually carries no words. When it does they are the review, so they stay
               visible rather than being folded away with the ordinary conversation. */}
           {event.body ? (
-            <TimelineBody body={event.body} markdown={event.markdown} cwd={cwd} />
+            <TimelineBody
+              body={event.body}
+              markdown={event.markdown}
+              cwd={cwd}
+              environmentId={reactions.environmentId}
+            />
           ) : null}
         </div>
         <OpenOnHostButton url={event.url} onOpen={onOpen} />

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown";
 
 import {
   extractMarkdownLinkHrefs,
+  normalizeMarkdownLinkHrefKey,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
@@ -76,6 +77,23 @@ describe("shouldOpenMarkdownFileLinkInBrowserByDefault", () => {
     expect(shouldOpenMarkdownFileLinkInBrowserByDefault("report.PDF?download=1")).toBe(true);
     expect(shouldOpenMarkdownFileLinkInBrowserByDefault("report.html")).toBe(false);
     expect(shouldOpenMarkdownFileLinkInBrowserByDefault("report.xml")).toBe(false);
+  });
+});
+
+describe("markdown link href metadata", () => {
+  it("extracts angle-bracketed destinations containing spaces", () => {
+    expect(extractMarkdownLinkHrefs("[file](<src/my file.ts>)")).toEqual(["src/my file.ts"]);
+  });
+
+  it("matches source destinations containing spaces to rendered file metadata", () => {
+    const [sourceHref = ""] = extractMarkdownLinkHrefs("[file](<src/my file.ts>)");
+    const renderedHref = "src/my%20file.ts";
+    expect(normalizeMarkdownLinkHrefKey(sourceHref)).toBe(
+      normalizeMarkdownLinkHrefKey(renderedHref),
+    );
+    expect(
+      resolveMarkdownFileLinkMeta(normalizeMarkdownLinkHrefKey(sourceHref), "/repo/project"),
+    ).toMatchObject({ filePath: "/repo/project/src/my file.ts" });
   });
 });
 

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -242,6 +242,27 @@ describe("resolveMarkdownFileLinkTarget", () => {
     });
   });
 
+  it("resolves the exact file path used by open in folder", () => {
+    expect(resolveMarkdownFileLinkMeta("src/file%20name.ts:12:4", "/repo/project")).toMatchObject({
+      filePath: "/repo/project/src/file name.ts",
+      targetPath: "/repo/project/src/file name.ts:12:4",
+      line: 12,
+      column: 4,
+    });
+    expect(resolveMarkdownFileLinkMeta("/tmp/report.ts:9", "/repo/project")).toMatchObject({
+      filePath: "/tmp/report.ts",
+      targetPath: "/tmp/report.ts:9",
+      line: 9,
+    });
+  });
+
+  it("resolves missing paths without requiring browser-side file access", () => {
+    expect(resolveMarkdownFileLinkMeta("src/not-created-yet.ts", "/repo/project")).toMatchObject({
+      filePath: "/repo/project/src/not-created-yet.ts",
+      workspaceRelativePath: "src/not-created-yet.ts",
+    });
+  });
+
   it("normalizes slash-prefixed windows drive paths before resolving", () => {
     expect(
       resolveMarkdownFileLinkTarget(

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -95,6 +95,12 @@ describe("markdown link href metadata", () => {
       resolveMarkdownFileLinkMeta(normalizeMarkdownLinkHrefKey(sourceHref), "/repo/project"),
     ).toMatchObject({ filePath: "/repo/project/src/my file.ts" });
   });
+
+  it("normalizes Windows separators before matching rendered hrefs", () => {
+    expect(normalizeMarkdownLinkHrefKey("C:\\Program Files\\project\\main.ts")).toBe(
+      normalizeMarkdownLinkHrefKey("C:/Program%20Files/project/main.ts"),
+    );
+  });
 });
 
 describe("rewriteMarkdownFileUriHref", () => {

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -92,6 +92,19 @@ export function normalizeMarkdownLinkDestination(value: string): string {
   return unwrapMarkdownLinkDestination(value.trim());
 }
 
+export function normalizeMarkdownLinkHrefKey(href: string): string {
+  const normalizedHref = normalizeMarkdownLinkDestination(href);
+  const rewrittenHref = rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
+  const normalizedWindowsPath = WINDOWS_DRIVE_PATH_PATTERN.test(rewrittenHref)
+    ? rewrittenHref.replaceAll("\\", "/")
+    : rewrittenHref;
+  try {
+    return encodeURI(normalizedWindowsPath).replace(/%25(?=[0-9A-Fa-f]{2})/g, "%");
+  } catch {
+    return normalizedWindowsPath;
+  }
+}
+
 function stripSearchAndHash(value: string): { path: string; hash: string } {
   const hashIndex = value.indexOf("#");
   const pathWithSearch = hashIndex >= 0 ? value.slice(0, hashIndex) : value;

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Install and first run](./user/install.md)
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
+- [Opening file links](./user/file-links.md)
 - [Organizing threads](./user/thread-sidebar.md)
 - [Review usage](./user/usage.md)
 - [Customize a project icon](./user/project-settings.md)

--- a/docs/user/file-links.md
+++ b/docs/user/file-links.md
@@ -1,0 +1,8 @@
+# Open file links
+
+Click a rendered file link in chat to open it in your preferred editor. Right-click the link and
+choose **Open in folder** to reveal the file in Finder or Windows Explorer. On Linux, the action
+opens the file's containing directory.
+
+File actions run in the environment that owns the thread, including remote environments. **Open
+in folder** appears only while that environment is connected and has a supported file manager.

--- a/docs/user/file-links.md
+++ b/docs/user/file-links.md
@@ -1,8 +1,11 @@
 # Open file links
 
-Click a rendered file link in chat to open it in your preferred editor. Right-click the link and
-choose **Open in folder** to reveal the file in Finder or Windows Explorer. On Linux, the action
-opens the file's containing directory.
+Click a rendered file link in chat to open it in the file viewer. Files such as PDFs that require
+browser rendering open in the integrated browser instead. Command-click on macOS or Control-click
+on other platforms to open the link in your preferred editor. Right-click the link and choose
+**Open in folder** to reveal the file in Finder or Windows Explorer. On Linux, the action opens the
+file's containing directory.
 
 File actions run in the environment that owns the thread, including remote environments. **Open
 in folder** appears only while that environment is connected and has a supported file manager.
+The action is available in the web and desktop clients; there is no corresponding mobile action.

--- a/packages/client-runtime/src/state/shellCommands.ts
+++ b/packages/client-runtime/src/state/shellCommands.ts
@@ -12,5 +12,9 @@ export function createShellEnvironmentAtoms<R, E>(
       label: "environment-data:shell:open-in-editor",
       tag: WS_METHODS.shellOpenInEditor,
     }),
+    revealInFileManager: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:shell:reveal-in-file-manager",
+      tag: WS_METHODS.shellRevealInFileManager,
+    }),
   };
 }

--- a/packages/contracts/src/editor.test.ts
+++ b/packages/contracts/src/editor.test.ts
@@ -1,0 +1,18 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+
+import { RevealInFileManagerInput } from "./editor.ts";
+
+const decodeRevealInFileManagerInput = Schema.decodeUnknownSync(RevealInFileManagerInput);
+
+describe("RevealInFileManagerInput", () => {
+  it("preserves leading and trailing spaces in valid file paths", () => {
+    expect(decodeRevealInFileManagerInput({ path: " /tmp/report " })).toEqual({
+      path: " /tmp/report ",
+    });
+  });
+
+  it("rejects an empty path", () => {
+    expect(() => decodeRevealInFileManagerInput({ path: "" })).toThrow();
+  });
+});

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -76,7 +76,7 @@ export const LaunchEditorInput = Schema.Struct({
 export type LaunchEditorInput = typeof LaunchEditorInput.Type;
 
 export const RevealInFileManagerInput = Schema.Struct({
-  path: TrimmedNonEmptyString,
+  path: Schema.String.check(Schema.isNonEmpty()),
 });
 export type RevealInFileManagerInput = typeof RevealInFileManagerInput.Type;
 

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -75,6 +75,11 @@ export const LaunchEditorInput = Schema.Struct({
 });
 export type LaunchEditorInput = typeof LaunchEditorInput.Type;
 
+export const RevealInFileManagerInput = Schema.Struct({
+  path: TrimmedNonEmptyString,
+});
+export type RevealInFileManagerInput = typeof RevealInFileManagerInput.Type;
+
 const remoteSchemeOf = (editor: EditorDefinition): string | undefined => editor.remoteScheme;
 
 /** Editors that can open a remote workspace via `vscode-remote` deep links. */

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -71,6 +71,9 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   threadTitleRegeneration: Schema.optionalKey(Schema.Boolean),
   /** Server persists a pull request reference on thread.meta.update. */
   threadPullRequestLinking: Schema.optionalKey(Schema.Boolean),
+  /** Server understands shell.revealInFileManager. Absent on older servers,
+      so clients hide the action instead of sending an unsupported RPC. */
+  fileManagerReveal: Schema.optionalKey(Schema.Boolean),
   /** The update path clients should offer for this server. Absent on
       servers that must be relaunched manually (dev checkouts, Windows
       foreground runs, pre-update servers). */

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import * as Rpc from "effect/unstable/rpc/Rpc";
 import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
 
-import { ExternalLauncherError, LaunchEditorInput } from "./editor.ts";
+import { ExternalLauncherError, LaunchEditorInput, RevealInFileManagerInput } from "./editor.ts";
 import {
   AuthAccessStreamError,
   AuthAccessStreamEvent,
@@ -219,6 +219,7 @@ export const WS_METHODS = {
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
+  shellRevealInFileManager: "shell.revealInFileManager",
 
   // Filesystem methods
   filesystemBrowse: "filesystem.browse",
@@ -671,6 +672,11 @@ export const WsShellOpenInEditorRpc = Rpc.make(WS_METHODS.shellOpenInEditor, {
   error: Schema.Union([ExternalLauncherError, EnvironmentAuthorizationError]),
 });
 
+export const WsShellRevealInFileManagerRpc = Rpc.make(WS_METHODS.shellRevealInFileManager, {
+  payload: RevealInFileManagerInput,
+  error: Schema.Union([ExternalLauncherError, EnvironmentAuthorizationError]),
+});
+
 export const WsFilesystemBrowseRpc = Rpc.make(WS_METHODS.filesystemBrowse, {
   payload: FilesystemBrowseInput,
   success: FilesystemBrowseResult,
@@ -1067,6 +1073,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsProjectsSearchEntriesRpc,
   WsProjectsWriteFileRpc,
   WsShellOpenInEditorRpc,
+  WsShellRevealInFileManagerRpc,
   WsFilesystemBrowseRpc,
   WsAssetsCreateUrlRpc,
   WsAttachmentsCreateUploadUrlRpc,


### PR DESCRIPTION
## Problem

File links in chat can open in an editor or copy their path, but cannot reveal the file in the host file manager. This is especially awkward when using T3 Code from WSL/WSLg and the file needs to be opened through Windows Explorer.

## Fix

- add **Open in folder** to the existing file-link context menu
- route the action through the thread's environment so remote environments use their own host
- preserve existing editor and copy actions
- reveal the selected file in Finder and Explorer
- open existing directories directly and fall back to the nearest existing parent for stale paths
- open the containing directory on graphical Linux
- use Windows Explorer for WSL and WSLg, including WSL path conversion
- advertise the action only when the environment supports it
- document the interaction and desktop/web-only surface; mobile has no corresponding action
- add focused contract, launcher, menu, and RPC coverage

This is a user-owned replacement for the app-created #5366 so the branch can be maintained from a normal fork.

## Evidence

### Before

The existing file-link menu exposes editor and copy actions only.

![Before: file-link menu without Open in folder](https://raw.githubusercontent.com/MatthewFeroz/t3code/7e5fd268c/docs/user/assets/open-in-folder-before.png)

### After

The branch adds **Open in folder** as the first action while preserving the existing actions.

![After: file-link menu with Open in folder first](https://raw.githubusercontent.com/MatthewFeroz/t3code/7e5fd268c/docs/user/assets/open-in-folder-after.png)

## Testing

- `GOMAXPROCS=2 corepack pnpm --filter @t3tools/contracts typecheck`
- `GOMAXPROCS=2 corepack pnpm --filter @t3tools/client-runtime typecheck`
- `GOMAXPROCS=2 corepack pnpm --filter t3 typecheck`
- `GOMAXPROCS=1 corepack pnpm --filter @t3tools/web typecheck`
- `corepack pnpm --filter @t3tools/contracts exec vp test run src/editor.test.ts` — 2 passed
- `GOMAXPROCS=2 corepack pnpm --filter t3 exec vp test run src/process/externalLauncher.test.ts src/environment/ServerEnvironment.test.ts` — 22 passed
- `GOMAXPROCS=2 corepack pnpm --filter t3 exec vp test run src/server.test.ts -t "routes websocket rpc shell.revealInFileManager"` — 1 passed
- `corepack pnpm --filter @t3tools/web exec vp test run src/components/chat/fileLinkContextMenu.test.ts src/markdown-links.test.ts` — 65 passed

The interaction was also exercised against the local dev build using **GPT-5.6 Luna** through the Codex provider; Luna generated the rendered file link and the `shell.revealInFileManager` RPC completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The feature spawns detached host file-manager processes from server-resolved paths, with substantial platform and WSL branching where mis-detected session env vars could hide or mis-route reveals.
> 
> **Overview**
> Adds **Open in folder** for rendered chat file links, wired end-to-end from the UI through a new `shell.revealInFileManager` RPC.
> 
> The server exposes a `fileManagerReveal` capability and implements `ExternalLauncher.revealInFileManager` with platform-specific behavior: select files in Finder/Explorer, open containing directories on graphical Linux, walk up to the nearest existing parent for missing paths, and route WSL/WSLg through `explorer.exe` with `\\wsl$\…` paths. The file-manager editor is only advertised when the host has a graphical session (not SSH, headless Linux, or Windows Services).
> 
> In the web client, file-link context menus gain **Open in folder** when the owning environment is connected, supports the RPC, and lists `file-manager` among available editors. Actions target the thread/content environment (including pull request markdown previews). Link metadata normalization is tightened so paths with spaces and Windows separators still match for reveal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf0ae80a2e138fea7337bdc65d3b6b3fa77a7c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Open in folder' action to markdown file links
> - Adds a `shell.revealInFileManager` RPC and `fileManagerReveal` capability to open a file's containing folder in the native OS file manager.
> - Server logic resolves the nearest existing path and builds platform-specific arguments for macOS Finder, Windows Explorer, Linux `xdg-open`, and WSL `explorer.exe`.
> - The web `ChatMarkdown` component exposes an "Open in folder" context menu item for file links when the environment is connected and the capability is supported.
> - Risk: WSL environments missing a valid `WSL_DISTRO_NAME` env var will not use `explorer.exe`, and headless Linux, SSH, and Windows Services sessions are explicitly suppressed by `hasGraphicalFileManagerSession`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbf0ae8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

model: GPT-5.6 Luna
harness: Codex via T3 Code dev build


