### PR TITLE
fix(mobile): iOS home screen widgets render instead of a containerBackground error

### DIFF
--- a/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
+++ b/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
@@ -15,7 +15,11 @@ import * as Option from "effect/Option";
 import { Atom, AtomRegistry } from "effect/unstable/reactivity";
 
 import type { AgentActivityRowProps } from "../../widgets/AgentActivity";
-import { createLiveWidgetActivitiesAtom, reconcileWidgetActivity } from "./liveWidgetActivity";
+import {
+  createLiveWidgetActivitiesAtom,
+  reconcileWidgetActivity,
+  retainUnconfirmedWidgetActivities,
+} from "./liveWidgetActivity";
 
 const ENVIRONMENT = EnvironmentId.make("local");
 const REMOTE = EnvironmentId.make("remote");
@@ -263,5 +267,60 @@ describe("live widget activity", () => {
     const live = new Map([[ENVIRONMENT, [row(ENVIRONMENT)]]]);
     expect(reconcileWidgetActivity(live, null).activeCount).toBeNull();
     expect(reconcileWidgetActivity(live, { aggregate: null }).activeCount).toBe(1);
+  });
+
+  it("uses an acknowledged matching exclusion scope even when remote activity is capped", () => {
+    const live = new Map([[ENVIRONMENT, [row(ENVIRONMENT)]]]);
+    const filtered = { ...snapshot([row()], 12), excludedEnvironmentIds: [ENVIRONMENT] };
+    expect(reconcileWidgetActivity(live, filtered).activeCount).toBe(13);
+    expect(reconcileWidgetActivity(new Map(), filtered).activeCount).toBeNull();
+    expect(reconcileWidgetActivity(new Map([[REMOTE, []]]), filtered).activeCount).toBeNull();
+  });
+
+  it("does not validate retained work with omission or equal-timestamp conflicting phases", () => {
+    const observed = new Map([
+      [ENVIRONMENT, [row(ENVIRONMENT, ThreadId.make("task"), "completed")]],
+    ]);
+    const stale = snapshot([row(ENVIRONMENT, ThreadId.make("task"))]);
+    expect(retainUnconfirmedWidgetActivities(observed, new Map(), observed, stale)).toEqual(
+      observed,
+    );
+    expect(
+      retainUnconfirmedWidgetActivities(observed, new Map(), observed, { aggregate: null }),
+    ).toEqual(observed);
+    const matching = snapshot(observed.get(ENVIRONMENT)!);
+    expect(retainUnconfirmedWidgetActivities(observed, new Map(), observed, matching).size).toBe(0);
+    expect(retainUnconfirmedWidgetActivities(observed, observed, observed, matching)).toEqual(
+      observed,
+    );
+  });
+
+  it("accepts a newer relay observation but cannot retire local changes made during the read", () => {
+    const observed = new Map([[ENVIRONMENT, [row(ENVIRONMENT)]]]);
+    const newer = snapshot([
+      {
+        ...row(ENVIRONMENT, ThreadId.make("remote-thread"), "completed"),
+        updatedAt: "2026-09-05T12:00:01.000Z",
+      },
+    ]);
+    expect(retainUnconfirmedWidgetActivities(observed, new Map(), observed, newer).size).toBe(0);
+    const changed = new Map([[ENVIRONMENT, [row(ENVIRONMENT)]]]);
+    expect(retainUnconfirmedWidgetActivities(changed, new Map(), observed, newer)).toEqual(changed);
+  });
+
+  it("only validates empty observations when no active rows can be hidden by the cap", () => {
+    const observed = new Map([[ENVIRONMENT, []]]);
+    expect(
+      retainUnconfirmedWidgetActivities(observed, new Map(), observed, snapshot([row()], 12)),
+    ).toEqual(observed);
+    expect(
+      retainUnconfirmedWidgetActivities(observed, new Map(), observed, snapshot([row()])).size,
+    ).toBe(0);
+    expect(
+      retainUnconfirmedWidgetActivities(observed, new Map(), observed, {
+        aggregate: null,
+        excludedEnvironmentIds: [ENVIRONMENT],
+      }),
+    ).toEqual(observed);
   });
 });

--- a/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
+++ b/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "@effect/vitest";
+import { PrimaryConnectionTarget } from "@t3tools/client-runtime/connection";
+import type { EnvironmentCatalogState } from "@t3tools/client-runtime/state/connections";
+import type { EnvironmentShellState } from "@t3tools/client-runtime/state/shell";
+import {
+  EnvironmentId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationProjectShell,
+  type OrchestrationThreadShell,
+} from "@t3tools/contracts";
+import type { RelayAgentActivitySnapshotResponse } from "@t3tools/contracts/relay";
+import * as Option from "effect/Option";
+import { Atom, AtomRegistry } from "effect/unstable/reactivity";
+
+import type { AgentActivityRowProps } from "../../widgets/AgentActivity";
+import { createLiveWidgetActivitiesAtom, reconcileWidgetActivity } from "./liveWidgetActivity";
+
+const ENVIRONMENT = EnvironmentId.make("local");
+const REMOTE = EnvironmentId.make("remote");
+const NOW = "2026-09-05T12:00:00.000Z";
+const NOW_MS = Date.parse(NOW);
+const project: OrchestrationProjectShell = {
+  id: ProjectId.make("project"),
+  title: "Project",
+  workspaceRoot: "/synthetic/project",
+  defaultModelSelection: null,
+  scripts: [],
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+function thread(overrides: Partial<OrchestrationThreadShell> = {}): OrchestrationThreadShell {
+  return {
+    id: ThreadId.make("thread"),
+    projectId: project.id,
+    title: "Task",
+    modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "test-model" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...overrides,
+  };
+}
+
+function session(status: NonNullable<OrchestrationThreadShell["session"]>["status"]) {
+  return {
+    threadId: ThreadId.make("thread"),
+    status,
+    providerName: "codex",
+    runtimeMode: "full-access" as const,
+    activeTurnId: null,
+    lastError: null,
+    updatedAt: NOW,
+  };
+}
+
+function shell(
+  threads: ReadonlyArray<OrchestrationThreadShell>,
+  status: EnvironmentShellState["status"] = "live",
+): EnvironmentShellState {
+  return {
+    status,
+    error: Option.none(),
+    snapshot: Option.some({ projects: [project], threads, snapshotSequence: 1, updatedAt: NOW }),
+  };
+}
+
+function harness(initial: EnvironmentShellState) {
+  const registry = AtomRegistry.make();
+  const shellAtoms = Atom.family((_id: EnvironmentId) => Atom.make(initial));
+  const catalog = Atom.make<EnvironmentCatalogState>({
+    isReady: true,
+    entries: new Map([
+      [
+        ENVIRONMENT,
+        {
+          target: new PrimaryConnectionTarget({
+            environmentId: ENVIRONMENT,
+            label: "Local",
+            httpBaseUrl: "https://local.example.test",
+            wsBaseUrl: "wss://local.example.test/ws",
+          }),
+          profile: Option.none(),
+        },
+      ],
+    ]),
+  });
+  const atom = createLiveWidgetActivitiesAtom({
+    catalogValueAtom: catalog,
+    shellStateValueAtom: shellAtoms,
+    now: () => NOW_MS,
+  });
+  return { registry, atom, catalog, shellAtoms };
+}
+
+function row(
+  environmentId = REMOTE,
+  threadId = ThreadId.make("remote-thread"),
+  phase: AgentActivityRowProps["phase"] = "running",
+) {
+  return {
+    environmentId,
+    threadId,
+    projectTitle: "Project",
+    threadTitle: "Task",
+    modelTitle: "test-model",
+    phase,
+    status: phase === "completed" ? "Done" : "Working",
+    updatedAt: NOW,
+    deepLink: `/threads/${environmentId}/${threadId}`,
+  };
+}
+
+function snapshot(
+  activities: NonNullable<RelayAgentActivitySnapshotResponse["aggregate"]>["activities"],
+  activeCount = activities.filter(
+    (value) => value.phase !== "completed" && value.phase !== "failed",
+  ).length,
+): RelayAgentActivitySnapshotResponse {
+  return {
+    aggregate: {
+      title: "T3 Code",
+      subtitle: "Agent work in progress",
+      activeCount,
+      updatedAt: NOW,
+      activities,
+    },
+  };
+}
+
+describe("live widget activity", () => {
+  it("observes local starts, completion, and deletion without a relay refresh", () => {
+    const h = harness(shell([]));
+    const seen: string[][] = [];
+    const stop = h.registry.subscribe(
+      h.atom,
+      (live) => {
+        seen.push((live.get(ENVIRONMENT) ?? []).map((value) => value.phase));
+      },
+      { immediate: true },
+    );
+    try {
+      h.registry.set(h.shellAtoms(ENVIRONMENT), shell([thread({ session: session("starting") })]));
+      h.registry.set(h.shellAtoms(ENVIRONMENT), shell([thread({ session: session("running") })]));
+      h.registry.set(h.shellAtoms(ENVIRONMENT), shell([thread({ session: session("ready") })]));
+      h.registry.set(h.shellAtoms(ENVIRONMENT), shell([]));
+      expect(seen).toEqual([[], ["starting"], ["running"], ["completed"], []]);
+      expect(h.registry.get(h.atom).has(ENVIRONMENT)).toBe(true);
+    } finally {
+      stop();
+      h.registry.dispose();
+    }
+  });
+
+  it.each(["cached", "synchronizing", "empty"] as const)(
+    "does not claim authority from %s shells",
+    (status) => {
+      const h = harness(shell([thread({ session: session("running") })], status));
+      try {
+        expect(h.registry.get(h.atom).has(ENVIRONMENT)).toBe(false);
+        h.registry.set(h.shellAtoms(ENVIRONMENT), shell([]));
+        expect(h.registry.get(h.atom).get(ENVIRONMENT)).toEqual([]);
+        h.registry.set(
+          h.shellAtoms(ENVIRONMENT),
+          shell([thread({ session: session("running") })], status),
+        );
+        expect(h.registry.get(h.atom).has(ENVIRONMENT)).toBe(false);
+      } finally {
+        h.registry.dispose();
+      }
+    },
+  );
+
+  it("drops ownership when the environment is removed", () => {
+    const h = harness(shell([thread({ session: session("running") })]));
+    try {
+      expect(h.registry.get(h.atom).size).toBe(1);
+      h.registry.set(h.catalog, { isReady: true, entries: new Map() });
+      expect(h.registry.get(h.atom).size).toBe(0);
+    } finally {
+      h.registry.dispose();
+    }
+  });
+
+  it("keeps current attention and recent failures, not old completed history or orphan threads", () => {
+    const h = harness(
+      shell([
+        thread({ id: ThreadId.make("approval"), hasPendingApprovals: true }),
+        thread({ id: ThreadId.make("input"), hasPendingUserInput: true }),
+        thread({ id: ThreadId.make("failure"), session: session("error") }),
+        thread({
+          id: ThreadId.make("old"),
+          session: session("ready"),
+          updatedAt: "2026-09-05T11:00:00.000Z",
+        }),
+        thread({
+          id: ThreadId.make("orphan"),
+          projectId: ProjectId.make("missing"),
+          session: session("running"),
+        }),
+      ]),
+    );
+    try {
+      expect(
+        h.registry
+          .get(h.atom)
+          .get(ENVIRONMENT)
+          ?.map((value) => value.status),
+      ).toEqual(["Approval", "Input", "Failed"]);
+    } finally {
+      h.registry.dispose();
+    }
+  });
+
+  it("replaces an entire live environment, including its idle and deleted threads", () => {
+    const relay = snapshot([row(ENVIRONMENT), row()]);
+    const live = new Map<EnvironmentId, ReadonlyArray<AgentActivityRowProps>>([[ENVIRONMENT, []]]);
+    expect(reconcileWidgetActivity(live, relay)).toEqual({ activeCount: 1, activities: [row()] });
+    live.set(ENVIRONMENT, [row(ENVIRONMENT, ThreadId.make("different-task"))]);
+    expect(reconcileWidgetActivity(live, relay).activeCount).toBe(2);
+    expect(reconcileWidgetActivity(live, relay).activities.map((value) => value.threadId)).toEqual([
+      "different-task",
+      "remote-thread",
+    ]);
+  });
+
+  it("counts all local work before capping displayed rows", () => {
+    const localRows = Array.from({ length: 8 }, (_, index) =>
+      row(ENVIRONMENT, ThreadId.make(`local-${index}`)),
+    );
+    const result = reconcileWidgetActivity(new Map([[ENVIRONMENT, localRows]]), snapshot([row()]));
+    expect(result.activeCount).toBe(9);
+    expect(result.activities).toHaveLength(5);
+  });
+
+  it("does not turn an incomplete legacy count into an exact mixed count", () => {
+    const relay = snapshot(
+      Array.from({ length: 5 }, (_, index) => row(REMOTE, ThreadId.make(`remote-${index}`))),
+      12,
+    );
+    expect(reconcileWidgetActivity(new Map(), relay).activeCount).toBe(12);
+    expect(reconcileWidgetActivity(new Map([[ENVIRONMENT, []]]), relay).activeCount).toBeNull();
+    expect(
+      reconcileWidgetActivity(new Map([[ENVIRONMENT, [row(ENVIRONMENT)]]]), relay).activeCount,
+    ).toBeNull();
+  });
+
+  it("distinguishes an unread relay snapshot from a confirmed empty one", () => {
+    const live = new Map([[ENVIRONMENT, [row(ENVIRONMENT)]]]);
+    expect(reconcileWidgetActivity(live, null).activeCount).toBeNull();
+    expect(reconcileWidgetActivity(live, { aggregate: null }).activeCount).toBe(1);
+  });
+});

--- a/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
+++ b/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
@@ -154,7 +154,12 @@ describe("live widget activity", () => {
     const h = harness(shell([thread({ session: session("ready") })]), Date.now);
     const stop = h.registry.mount(h.atom);
     try {
-      expect(h.registry.get(h.atom).get(ENVIRONMENT)?.map((row) => row.phase)).toEqual(["completed"]);
+      expect(
+        h.registry
+          .get(h.atom)
+          .get(ENVIRONMENT)
+          ?.map((row) => row.phase),
+      ).toEqual(["completed"]);
       await vi.advanceTimersByTimeAsync(16 * 60_000);
       expect(h.registry.get(h.atom).get(ENVIRONMENT)).toEqual([]);
     } finally {

--- a/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
+++ b/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
@@ -11,7 +11,7 @@ import {
   type OrchestrationThreadShell,
 } from "@t3tools/contracts";
 import type { RelayAgentActivitySnapshotResponse } from "@t3tools/contracts/relay";
-import { vi } from "vitest";
+import { vi } from "vite-plus/test";
 import * as Option from "effect/Option";
 import { Atom, AtomRegistry } from "effect/unstable/reactivity";
 

--- a/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
+++ b/apps/mobile/src/features/agent-awareness/liveWidgetActivity.test.ts
@@ -11,6 +11,7 @@ import {
   type OrchestrationThreadShell,
 } from "@t3tools/contracts";
 import type { RelayAgentActivitySnapshotResponse } from "@t3tools/contracts/relay";
+import { vi } from "vitest";
 import * as Option from "effect/Option";
 import { Atom, AtomRegistry } from "effect/unstable/reactivity";
 
@@ -83,7 +84,7 @@ function shell(
   };
 }
 
-function harness(initial: EnvironmentShellState) {
+function harness(initial: EnvironmentShellState, now = () => NOW_MS) {
   const registry = AtomRegistry.make();
   const shellAtoms = Atom.family((_id: EnvironmentId) => Atom.make(initial));
   const catalog = Atom.make<EnvironmentCatalogState>({
@@ -106,7 +107,7 @@ function harness(initial: EnvironmentShellState) {
   const atom = createLiveWidgetActivitiesAtom({
     catalogValueAtom: catalog,
     shellStateValueAtom: shellAtoms,
-    now: () => NOW_MS,
+    now,
   });
   return { registry, atom, catalog, shellAtoms };
 }
@@ -147,6 +148,22 @@ function snapshot(
 }
 
 describe("live widget activity", () => {
+  it("expires terminal rows without a catalog or shell update", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+    const h = harness(shell([thread({ session: session("ready") })]), Date.now);
+    const stop = h.registry.mount(h.atom);
+    try {
+      expect(h.registry.get(h.atom).get(ENVIRONMENT)?.map((row) => row.phase)).toEqual(["completed"]);
+      await vi.advanceTimersByTimeAsync(16 * 60_000);
+      expect(h.registry.get(h.atom).get(ENVIRONMENT)).toEqual([]);
+    } finally {
+      stop();
+      h.registry.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("observes local starts, completion, and deletion without a relay refresh", () => {
     const h = harness(shell([]));
     const seen: string[][] = [];

--- a/apps/mobile/src/features/agent-awareness/liveWidgetActivity.ts
+++ b/apps/mobile/src/features/agent-awareness/liveWidgetActivity.ts
@@ -1,0 +1,111 @@
+import type { EnvironmentCatalogState } from "@t3tools/client-runtime/state/connections";
+import type { EnvironmentShellState } from "@t3tools/client-runtime/state/shell";
+import type { EnvironmentId } from "@t3tools/contracts";
+import type { RelayAgentActivitySnapshotResponse } from "@t3tools/contracts/relay";
+import { projectThreadAwareness } from "@t3tools/shared/agentAwareness";
+import * as DateTime from "effect/DateTime";
+import * as Option from "effect/Option";
+import { Atom } from "effect/unstable/reactivity";
+
+import type { AgentActivityRowProps } from "../../widgets/AgentActivity";
+
+export type LiveWidgetActivities = ReadonlyMap<EnvironmentId, ReadonlyArray<AgentActivityRowProps>>;
+
+const TERMINAL_DISPLAY_MS = 15 * 60 * 1_000;
+const MAX_WIDGET_ROWS = 5;
+
+const statusByPhase = {
+  starting: "Connecting",
+  running: "Working",
+  waiting_for_approval: "Approval",
+  waiting_for_input: "Input",
+  completed: "Done",
+  failed: "Failed",
+  stale: "Waiting",
+} satisfies Record<AgentActivityRowProps["phase"], string>;
+
+function isActive(row: AgentActivityRowProps): boolean {
+  return row.phase !== "completed" && row.phase !== "failed";
+}
+
+/** A live empty shell still owns its environment and suppresses older relay rows. */
+export function createLiveWidgetActivitiesAtom(input: {
+  readonly catalogValueAtom: Atom.Atom<EnvironmentCatalogState>;
+  readonly shellStateValueAtom: (environmentId: EnvironmentId) => Atom.Atom<EnvironmentShellState>;
+  readonly now: () => number;
+}) {
+  return Atom.make((get): LiveWidgetActivities => {
+    const environments = new Map<EnvironmentId, ReadonlyArray<AgentActivityRowProps>>();
+    const now = input.now();
+    for (const environmentId of get(input.catalogValueAtom).entries.keys()) {
+      const shell = get(input.shellStateValueAtom(environmentId));
+      if (shell.status !== "live" || Option.isNone(shell.snapshot)) continue;
+      const snapshot = shell.snapshot.value;
+      const projects = new Map(snapshot.projects.map((project) => [project.id, project]));
+      const rows: AgentActivityRowProps[] = [];
+      for (const thread of snapshot.threads) {
+        const project = projects.get(thread.projectId);
+        if (!project) continue;
+        const state = projectThreadAwareness({ environmentId, project, thread });
+        if (!state) continue;
+        if (
+          (state.phase === "completed" || state.phase === "failed") &&
+          now - DateTime.makeUnsafe(state.updatedAt).epochMilliseconds > TERMINAL_DISPLAY_MS
+        )
+          continue;
+        rows.push({
+          environmentId,
+          threadId: state.threadId,
+          projectTitle: state.projectTitle,
+          threadTitle: state.threadTitle,
+          modelTitle: state.modelTitle,
+          phase: state.phase,
+          status: statusByPhase[state.phase],
+          updatedAt: state.updatedAt,
+          deepLink: state.deepLink,
+        });
+      }
+      environments.set(environmentId, rows);
+    }
+    return environments;
+  }).pipe(Atom.withLabel("mobile:agent-awareness:live-widget-activities"));
+}
+
+function rowPriority(row: AgentActivityRowProps): number {
+  if (row.phase === "waiting_for_approval" || row.phase === "waiting_for_input") return 0;
+  if (row.phase === "failed") return 1;
+  return isActive(row) ? 2 : 3;
+}
+
+/** Null means the capped legacy response cannot establish the combined total. */
+export function reconcileWidgetActivity(
+  live: LiveWidgetActivities,
+  snapshot: RelayAgentActivitySnapshotResponse | null,
+) {
+  const aggregate = snapshot?.aggregate;
+  const relayRows = aggregate?.activities ?? [];
+  const remoteRows = relayRows.filter((row) => !live.has(row.environmentId));
+  const localRows = [...live.values()].flat();
+  const localActiveCount = localRows.filter(isActive).length;
+  const visibleRelayActiveCount = relayRows.filter(isActive).length;
+  const relayCountIsComplete =
+    snapshot !== null &&
+    (aggregate === null ||
+      aggregate === undefined ||
+      aggregate.activeCount === visibleRelayActiveCount);
+  const activeCount =
+    snapshot === null
+      ? null
+      : live.size === 0
+        ? (aggregate?.activeCount ?? 0)
+        : relayCountIsComplete
+          ? localActiveCount + remoteRows.filter(isActive).length
+          : null;
+  const activities = [...localRows, ...remoteRows]
+    .sort(
+      (left, right) =>
+        rowPriority(left) - rowPriority(right) || right.updatedAt.localeCompare(left.updatedAt),
+    )
+    .slice(0, MAX_WIDGET_ROWS);
+  return { activeCount, activities };
+}

--- a/apps/mobile/src/features/agent-awareness/liveWidgetActivity.ts
+++ b/apps/mobile/src/features/agent-awareness/liveWidgetActivity.ts
@@ -77,6 +77,45 @@ function rowPriority(row: AgentActivityRowProps): number {
   return isActive(row) ? 2 : 3;
 }
 
+export function sameWidgetEnvironmentScope(
+  left: ReadonlyArray<string>,
+  right: ReadonlyArray<string>,
+): boolean {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  return leftSet.size === rightSet.size && [...leftSet].every((id) => rightSet.has(id));
+}
+
+/** A disconnect is not a newer observation. Omitted capped rows cannot confirm completion. */
+export function retainUnconfirmedWidgetActivities(
+  observed: LiveWidgetActivities,
+  live: LiveWidgetActivities,
+  readStartedWith: LiveWidgetActivities,
+  snapshot: RelayAgentActivitySnapshotResponse,
+): LiveWidgetActivities {
+  if ((snapshot.excludedEnvironmentIds?.length ?? 0) > 0) return observed;
+  const relayRows = snapshot.aggregate?.activities ?? [];
+  const complete = (snapshot.aggregate?.activeCount ?? 0) === relayRows.filter(isActive).length;
+  const retained = new Map(observed);
+  for (const [environmentId, rows] of observed) {
+    if (live.has(environmentId) || readStartedWith.get(environmentId) !== rows) continue;
+    const environmentRows = relayRows.filter((row) => row.environmentId === environmentId);
+    const confirmed =
+      rows.length === 0
+        ? complete && environmentRows.every((row) => !isActive(row))
+        : rows.every((row) =>
+            environmentRows.some(
+              (remote) =>
+                remote.threadId === row.threadId &&
+                (remote.updatedAt > row.updatedAt ||
+                  (remote.updatedAt === row.updatedAt && remote.phase === row.phase)),
+            ),
+          );
+    if (confirmed) retained.delete(environmentId);
+  }
+  return retained;
+}
+
 /** Null means the capped legacy response cannot establish the combined total. */
 export function reconcileWidgetActivity(
   live: LiveWidgetActivities,
@@ -93,14 +132,23 @@ export function reconcileWidgetActivity(
     (aggregate === null ||
       aggregate === undefined ||
       aggregate.activeCount === visibleRelayActiveCount);
+  const acknowledgedScope = snapshot?.excludedEnvironmentIds;
+  const exactScope =
+    acknowledgedScope !== undefined &&
+    sameWidgetEnvironmentScope(acknowledgedScope, [...live.keys()]);
+  const globalScope = (acknowledgedScope?.length ?? 0) === 0;
   const activeCount =
     snapshot === null
       ? null
-      : live.size === 0
-        ? (aggregate?.activeCount ?? 0)
-        : relayCountIsComplete
-          ? localActiveCount + remoteRows.filter(isActive).length
-          : null;
+      : exactScope
+        ? localActiveCount + (aggregate?.activeCount ?? 0)
+        : !globalScope
+          ? null
+          : live.size === 0
+            ? (aggregate?.activeCount ?? 0)
+            : relayCountIsComplete
+              ? localActiveCount + remoteRows.filter(isActive).length
+              : null;
   const activities = [...localRows, ...remoteRows]
     .sort(
       (left, right) =>

--- a/apps/mobile/src/features/agent-awareness/liveWidgetActivity.ts
+++ b/apps/mobile/src/features/agent-awareness/liveWidgetActivity.ts
@@ -68,7 +68,10 @@ export function createLiveWidgetActivitiesAtom(input: {
       environments.set(environmentId, rows);
     }
     return environments;
-  }).pipe(Atom.withLabel("mobile:agent-awareness:live-widget-activities"));
+  }).pipe(
+    Atom.withRefresh("1 minute"),
+    Atom.withLabel("mobile:agent-awareness:live-widget-activities"),
+  );
 }
 
 function rowPriority(row: AgentActivityRowProps): number {

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -265,7 +265,9 @@ const activeAgentActivitySnapshot = {
 } satisfies RelayAgentActivitySnapshotResponse;
 
 function snapshotRelayLayer(
-  getAgentActivitySnapshot: () => Effect.Effect<
+  getAgentActivitySnapshot: (
+    input: Parameters<ManagedRelay.ManagedRelayClient["Service"]["getAgentActivitySnapshot"]>[0],
+  ) => Effect.Effect<
     RelayAgentActivitySnapshotResponse,
     ManagedRelay.ManagedRelayClientError
   > = () => Effect.succeed(activeAgentActivitySnapshot),
@@ -1775,8 +1777,294 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     }).pipe(Effect.scoped),
   );
 
+  it.effect.each(["cached", "synchronizing"] as const)(
+    "preserves last-observed work instead of false idle on %s",
+    (status) =>
+      Effect.gen(function* () {
+        addLiveEnvironment();
+        setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+        backgroundRuntime.pending.length = 0;
+        yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+          Effect.provide(snapshotRelayLayer(() => Effect.succeed({ aggregate: null }))),
+        );
+        setLiveShell("running");
+        expect(vi.mocked(publishAgentActivityWidget).mock.lastCall?.[0]?.activeCount).toBe(1);
+        setLiveShell("running", status);
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeCount: 1,
+            isStale: true,
+            activities: [expect.objectContaining({ status: "Working" })],
+          }),
+        );
+        setLiveShell(null);
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeCount: 0,
+            isStale: false,
+            activities: [],
+          }),
+        );
+      }),
+  );
+
+  it.effect("does not resurrect older relay Working after observed Done on disconnect", () =>
+    Effect.gen(function* () {
+      addLiveEnvironment();
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      backgroundRuntime.pending.length = 0;
+      const earlier = new Date(Date.now() - 1_000).toISOString();
+      const relaySnapshot: RelayAgentActivitySnapshotResponse = {
+        aggregate: {
+          ...activeAgentActivitySnapshot.aggregate,
+          updatedAt: earlier,
+          activities: [
+            {
+              ...activeAgentActivitySnapshot.aggregate.activities[0],
+              threadId: ThreadId.make("local-thread"),
+              updatedAt: earlier,
+            },
+          ],
+        },
+      };
+      const layer = snapshotRelayLayer(() => Effect.succeed(relaySnapshot));
+      yield* refreshActiveLiveActivityRemoteRegistration().pipe(Effect.provide(layer));
+      setLiveShell("running");
+      setLiveShell("ready");
+      const observed = vi.mocked(publishAgentActivityWidget).mock.lastCall?.[0];
+      expect(observed?.activeCount).toBe(0);
+      setLiveShell("ready", "cached");
+      yield* refreshActiveLiveActivityRemoteRegistration().pipe(Effect.provide(layer));
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeCount: 0,
+          isStale: true,
+          activities: observed?.activities,
+        }),
+      );
+    }),
+  );
+
+  it.effect("uses a scoped count but keeps the unfiltered aggregate for native priming", () =>
+    Effect.gen(function* () {
+      addLiveEnvironment();
+      setLiveShell("running");
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      backgroundRuntime.pending.length = 0;
+      widgetMocks.getInstances.mockReturnValue([]);
+      vi.mocked(loadPreferences).mockResolvedValue({ liveActivitiesEnabled: true } as Preferences);
+      const queries: Array<ReadonlyArray<EnvironmentId> | undefined> = [];
+      const layer = snapshotRelayLayer(({ excludedEnvironmentIds }) => {
+        queries.push(excludedEnvironmentIds);
+        return Effect.succeed(
+          excludedEnvironmentIds
+            ? {
+                aggregate: null,
+                excludedEnvironmentIds,
+              }
+            : activeAgentActivitySnapshot,
+        );
+      });
+      yield* refreshActiveLiveActivityRemoteRegistration().pipe(Effect.provide(layer));
+      expect(queries).toEqual([undefined, [liveEnvironmentId], undefined, [liveEnvironmentId]]);
+      expect(widgetMocks.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activities: activeAgentActivitySnapshot.aggregate.activities,
+        }),
+      );
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
+          isStale: false,
+          activities: [expect.objectContaining({ threadId: "local-thread" })],
+        }),
+      );
+    }),
+  );
+
   it.effect(
-    "uses live idle and deletion over old relay work, and falls back when disconnected",
+    "publishes honest unknown totals for capped older relays without hiding current rows",
+    () =>
+      Effect.gen(function* () {
+        addLiveEnvironment();
+        setLiveShell("running");
+        setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+        backgroundRuntime.pending.length = 0;
+        yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+          Effect.provide(
+            snapshotRelayLayer(() =>
+              Effect.succeed({
+                aggregate: { ...activeAgentActivitySnapshot.aggregate, activeCount: 12 },
+              }),
+            ),
+          ),
+        );
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeCount: null,
+            isStale: false,
+            subtitle: "Activity count unavailable",
+            activities: [expect.objectContaining({ threadId: "local-thread", status: "Working" })],
+          }),
+        );
+      }),
+  );
+
+  it.effect(
+    "publishes complete local rows when the first relay read fails without inferring a total",
+    () =>
+      Effect.gen(function* () {
+        addLiveEnvironment();
+        setLiveShell("running");
+        setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+        backgroundRuntime.pending.length = 0;
+        yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+          Effect.provide(
+            snapshotRelayLayer(() =>
+              Effect.fail(
+                new ManagedRelay.ManagedRelayRequestFailedError({
+                  action: "read relay agent activity snapshot",
+                  transportFailed: true,
+                  cause: new Error("Synthetic first read failure"),
+                }),
+              ),
+            ),
+          ),
+        );
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeCount: null,
+            isStale: false,
+            activities: [expect.objectContaining({ threadId: "local-thread", status: "Working" })],
+          }),
+        );
+      }),
+  );
+
+  it.effect("re-reads a changed exclusion scope instead of publishing the old scoped total", () =>
+    Effect.gen(function* () {
+      addLiveEnvironment();
+      setLiveShell("running");
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      backgroundRuntime.pending.length = 0;
+      const started = yield* Deferred.make<void>();
+      const finish = yield* Deferred.make<void>();
+      const queries: Array<ReadonlyArray<EnvironmentId> | undefined> = [];
+      const layer = snapshotRelayLayer(({ excludedEnvironmentIds }) => {
+        queries.push(excludedEnvironmentIds);
+        if (excludedEnvironmentIds?.length === 1)
+          return Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Deferred.await(finish)),
+            Effect.as({
+              aggregate: { ...activeAgentActivitySnapshot.aggregate, activeCount: 12 },
+              excludedEnvironmentIds,
+            }),
+          );
+        return Effect.succeed({
+          aggregate: null,
+          excludedEnvironmentIds: excludedEnvironmentIds ?? [],
+        });
+      });
+      const refresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+        Effect.provide(layer),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(started);
+      const other = EnvironmentId.make("other");
+      const catalog = appAtomRegistry.get(environmentCatalog.catalogValueAtom);
+      setTestAtom(environmentShell.stateValueAtom(other), {
+        status: "live",
+        error: Option.none(),
+        snapshot: Option.some({
+          projects: [],
+          threads: [],
+          snapshotSequence: 1,
+          updatedAt: new Date().toISOString(),
+        }),
+      });
+      setTestAtom(environmentCatalog.catalogValueAtom, {
+        ...catalog,
+        entries: new Map([
+          ...catalog.entries,
+          [
+            other,
+            {
+              target: new PrimaryConnectionTarget({
+                environmentId: other,
+                label: "Other",
+                httpBaseUrl: "https://other.example.test",
+                wsBaseUrl: "wss://other.example.test/ws",
+              }),
+              profile: Option.none(),
+            },
+          ],
+        ]),
+      });
+      yield* Deferred.succeed(finish, undefined);
+      yield* Fiber.join(refresh);
+      expect(queries).toEqual([undefined, [liveEnvironmentId], [liveEnvironmentId, other]]);
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({ activeCount: 1, isStale: false }),
+      );
+      expect(
+        vi
+          .mocked(publishAgentActivityWidget)
+          .mock.calls.some(([props]) => props.activeCount === 13),
+      ).toBe(false);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("evicts retained observations on catalog removal and account switch", () =>
+    Effect.gen(function* () {
+      addLiveEnvironment();
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      backgroundRuntime.pending.length = 0;
+      const layer = snapshotRelayLayer(({ excludedEnvironmentIds }) =>
+        Effect.succeed({ aggregate: null, excludedEnvironmentIds: excludedEnvironmentIds ?? [] }),
+      );
+      yield* refreshActiveLiveActivityRemoteRegistration().pipe(Effect.provide(layer));
+      setLiveShell("running");
+      setLiveShell("running", "cached");
+      expect(vi.mocked(publishAgentActivityWidget).mock.lastCall?.[0]?.isStale).toBe(true);
+      setTestAtom(environmentCatalog.catalogValueAtom, { isReady: true, entries: new Map() });
+      yield* refreshActiveLiveActivityRemoteRegistration().pipe(Effect.provide(layer));
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({ activeCount: 0, isStale: false, activities: [] }),
+      );
+      addLiveEnvironment();
+      setLiveShell("running");
+      setLiveShell("running", "cached");
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-b"), "user-b");
+      yield* refreshActiveLiveActivityRemoteRegistration().pipe(Effect.provide(layer));
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({ activeCount: 0, isStale: false, activities: [] }),
+      );
+    }),
+  );
+
+  it.effect("publishes freshness changes even when rows and count are unchanged", () =>
+    Effect.gen(function* () {
+      addLiveEnvironment();
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      backgroundRuntime.pending.length = 0;
+      yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+        Effect.provide(snapshotRelayLayer(() => Effect.succeed({ aggregate: null }))),
+      );
+      setLiveShell("running");
+      const count = vi.mocked(publishAgentActivityWidget).mock.calls.length;
+      setLiveShell("running", "cached");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count + 1);
+      expect(vi.mocked(publishAgentActivityWidget).mock.lastCall?.[0]?.isStale).toBe(true);
+      setLiveShell("running", "synchronizing");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count + 1);
+      setLiveShell("running");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count + 2);
+      expect(vi.mocked(publishAgentActivityWidget).mock.lastCall?.[0]?.isStale).toBe(false);
+    }),
+  );
+
+  it.effect(
+    "uses live idle and deletion over relay work, retaining local evidence when disconnected",
     () => {
       addLiveEnvironment();
       setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
@@ -1796,7 +2084,8 @@ describe("makeRelayDeviceRegistrationRequest", () => {
         expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
           expect.objectContaining({
             activeCount: 1,
-            activities: [expect.objectContaining({ threadTitle: "Thread" })],
+            isStale: true,
+            activities: [expect.objectContaining({ threadTitle: "Live task" })],
           }),
         );
         setLiveShell(null);
@@ -1814,9 +2103,10 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     return Effect.gen(function* () {
       yield* refreshActiveLiveActivityRemoteRegistration();
       setLiveShell("running");
-      const publishedBeforeBackground = vi.mocked(publishAgentActivityWidget).mock.calls.length;
       appStateMock.currentState = "background";
       for (const listener of appStateMock.listeners) listener("background");
+      const publishedBeforeBackground = vi.mocked(publishAgentActivityWidget).mock.calls.length;
+      expect(vi.mocked(publishAgentActivityWidget).mock.lastCall?.[0]?.isStale).toBe(true);
       setLiveShell("ready");
       expect(publishAgentActivityWidget).toHaveBeenCalledTimes(publishedBeforeBackground);
       appStateMock.currentState = "active";
@@ -1832,7 +2122,7 @@ describe("makeRelayDeviceRegistrationRequest", () => {
   });
 
   it.effect(
-    "does not keep claiming an unobserved shell when a background relay refresh arrives",
+    "marks retained observations stale when a background relay read cannot validate them",
     () => {
       addLiveEnvironment();
       setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
@@ -1847,7 +2137,8 @@ describe("makeRelayDeviceRegistrationRequest", () => {
         expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
           expect.objectContaining({
             activeCount: 1,
-            activities: [expect.objectContaining({ threadTitle: "Thread" })],
+            isStale: true,
+            activities: [expect.objectContaining({ threadTitle: "Live task" })],
           }),
         );
       }).pipe(Effect.provide(snapshotRelayLayer()));

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -5,6 +5,7 @@ import * as NodeCrypto from "node:crypto";
 import { beforeEach, vi } from "vite-plus/test";
 import { describe, expect, it } from "@effect/vitest";
 import Constants from "expo-constants";
+import type { LiveActivity } from "expo-widgets";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -55,7 +56,7 @@ import {
   shouldRegisterAgentAwarenessDeviceForProvider,
   unregisterAgentAwarenessConnection,
 } from "./remoteRegistration";
-import { publishAgentActivityWidget } from "../../widgets/AgentActivity";
+import { publishAgentActivityWidget, type AgentActivityProps } from "../../widgets/AgentActivity";
 import * as Notifications from "expo-notifications";
 import { appAtomRegistry } from "../../state/atom-registry";
 import { environmentCatalog } from "../../connection/catalog";
@@ -63,7 +64,7 @@ import { environmentShell } from "../../state/shell";
 
 const secureStore = vi.hoisted(() => new Map<string, string>());
 const widgetMocks = vi.hoisted(() => ({
-  getInstances: vi.fn(() => []),
+  getInstances: vi.fn<() => ReadonlyArray<Partial<LiveActivity<AgentActivityProps>>>>(() => []),
   start: vi.fn(() => ({})),
 }));
 const environmentConfigsMock = vi.hoisted(() => ({
@@ -449,6 +450,59 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     environmentConfigsMock.configs.clear();
     vi.mocked(publishAgentActivityWidget).mockClear();
   });
+
+  it.effect.each(["unchanged", "sign-out", "account switch"] as const)(
+    "keeps existing Live Activity tokens with their owner across %s during widget refresh",
+    (transition) =>
+      Effect.gen(function* () {
+        const readStarted = yield* Deferred.make<void>();
+        const finishRead = yield* Deferred.make<void>();
+        const activity = {
+          getPushToken: vi.fn(() => Promise.resolve("old-account-activity-token")),
+          addPushTokenListener: vi.fn(),
+          end: vi.fn(() => Promise.resolve()),
+        };
+        widgetMocks.getInstances.mockReturnValue([activity]);
+        const register = vi.fn<ManagedRelay.ManagedRelayClient["Service"]["registerLiveActivity"]>(
+          () => Effect.succeed({ ok: true }),
+        );
+        const client = yield* ManagedRelay.ManagedRelayClient;
+        setAgentAwarenessRelayTokenProvider(() => Promise.resolve("user-a-token"), "user-a");
+        backgroundRuntime.pending.length = 0;
+        const refresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+          Effect.provideService(ManagedRelay.ManagedRelayClient, {
+            ...client,
+            registerLiveActivity: register,
+            getAgentActivitySnapshot: () =>
+              Deferred.succeed(readStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(finishRead)),
+                Effect.as(activeAgentActivitySnapshot),
+              ),
+          }),
+          Effect.forkChild,
+        );
+        yield* Deferred.await(readStarted);
+        if (transition !== "unchanged") {
+          setAgentAwarenessRelayTokenProvider(null);
+          expect(activity.end).toHaveBeenCalledExactlyOnceWith("immediate");
+          widgetMocks.getInstances.mockReturnValue([]);
+          if (transition === "account switch") {
+            setAgentAwarenessRelayTokenProvider(() => Promise.resolve("user-b-token"), "user-b");
+          }
+        }
+        yield* Deferred.succeed(finishRead, undefined);
+        yield* Fiber.join(refresh);
+        if (transition === "unchanged") {
+          expect(register).toHaveBeenCalledExactlyOnceWith({
+            clerkToken: "user-a-token",
+            payload: { deviceId: "device-1", activityPushToken: "old-account-activity-token" },
+          });
+        } else {
+          expect(register).not.toHaveBeenCalled();
+          expect(activity.getPushToken).not.toHaveBeenCalled();
+        }
+      }).pipe(Effect.provide(snapshotRelayLayer()), Effect.scoped),
+  );
 
   it.effect.each(
     (["global", "scoped"] as const).flatMap((blockedRead) =>

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -450,6 +450,141 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     vi.mocked(publishAgentActivityWidget).mockClear();
   });
 
+  it.effect.each(
+    (["global", "scoped"] as const).flatMap((blockedRead) =>
+      (["scope change", "sign-out", "account switch", "background"] as const).map((transition) => ({
+        blockedRead,
+        transition,
+      })),
+    ),
+  )(
+    "keeps final relay priming independent of $transition during $blockedRead without crossing account ownership",
+    ({ blockedRead, transition }) =>
+      Effect.gen(function* () {
+        if (blockedRead === "scoped") addLiveEnvironment();
+        vi.mocked(loadPreferences).mockResolvedValue({
+          liveActivitiesEnabled: true,
+        } as Preferences);
+        const readStarted = yield* Deferred.make<void>();
+        const finishRead = yield* Deferred.make<void>();
+        const activity = {
+          getPushToken: vi.fn(() => Promise.resolve("activity-token")),
+          addPushTokenListener: vi.fn(),
+        };
+        widgetMocks.start.mockReturnValue(activity);
+        const remoteSnapshot: RelayAgentActivitySnapshotResponse = {
+          aggregate: {
+            ...activeAgentActivitySnapshot.aggregate,
+            activities: activeAgentActivitySnapshot.aggregate.activities.map((row) => ({
+              ...row,
+              environmentId: EnvironmentId.make("remote-environment"),
+            })),
+          },
+        };
+        let globalReads = 0;
+        let scopedReads = 0;
+        const layer = snapshotRelayLayer(({ excludedEnvironmentIds }) => {
+          const kind = excludedEnvironmentIds ? "scoped" : "global";
+          const ordinal = excludedEnvironmentIds ? ++scopedReads : ++globalReads;
+          const snapshot = excludedEnvironmentIds
+            ? { ...remoteSnapshot, excludedEnvironmentIds }
+            : remoteSnapshot;
+          return ordinal === 2 && kind === blockedRead
+            ? Deferred.succeed(readStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(finishRead)),
+                Effect.as(snapshot),
+              )
+            : Effect.succeed(snapshot);
+        });
+        setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+        backgroundRuntime.pending.length = 0;
+        const prime = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+          Effect.provide(layer),
+          Effect.forkChild,
+        );
+        yield* Deferred.await(readStarted);
+        if (transition === "scope change") {
+          if (blockedRead === "global") addLiveEnvironment();
+          else
+            setTestAtom(environmentCatalog.catalogValueAtom, {
+              isReady: true,
+              entries: new Map(),
+            });
+          expect(backgroundRuntime.pending).toHaveLength(1);
+          const refresh = backgroundRuntime.pending.shift();
+          if (!refresh) throw new Error("Expected scope-only widget refresh");
+          const exit = yield* Effect.exit(
+            refresh.operation as Effect.Effect<unknown, unknown, ManagedRelay.ManagedRelayClient>,
+          ).pipe(Effect.provide(layer));
+          refresh.resolve(exit);
+          expect(Exit.isSuccess(exit)).toBe(true);
+          expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              activeCount: 1,
+              activities: remoteSnapshot.aggregate!.activities,
+            }),
+          );
+        } else if (transition === "background") {
+          appStateMock.currentState = "background";
+          for (const listener of appStateMock.listeners) listener("background");
+        } else {
+          setAgentAwarenessRelayTokenProvider(null);
+          if (transition === "account switch")
+            setAgentAwarenessRelayTokenProvider(
+              () => Promise.resolve("clerk-token-user-b"),
+              "user-b",
+            );
+        }
+        const widgetBeforeRelease = vi.mocked(publishAgentActivityWidget).mock.lastCall?.[0];
+        yield* Deferred.succeed(finishRead, undefined);
+        yield* Fiber.join(prime);
+        if (transition === "scope change") {
+          expect({ globalReads, scopedReads }).toEqual({
+            globalReads: 3,
+            scopedReads: blockedRead === "global" ? 1 : 2,
+          });
+          expect(backgroundRuntime.pending).toHaveLength(0);
+          expect(widgetMocks.start).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+              activeCount: 1,
+              activities: remoteSnapshot.aggregate!.activities,
+            }),
+          );
+        } else if (transition === "background") {
+          expect(widgetMocks.start).not.toHaveBeenCalled();
+          expect(activity.getPushToken).not.toHaveBeenCalled();
+          appStateMock.currentState = "active";
+          for (const listener of appStateMock.listeners) listener("active");
+          expect(backgroundRuntime.pending).toHaveLength(1);
+          const foreground = backgroundRuntime.pending.shift();
+          if (!foreground) throw new Error("Expected foreground Live Activity reconciliation");
+          const exit = yield* Effect.exit(
+            foreground.operation as Effect.Effect<
+              unknown,
+              unknown,
+              ManagedRelay.ManagedRelayClient
+            >,
+          ).pipe(Effect.provide(layer));
+          foreground.resolve(exit);
+          expect(Exit.isSuccess(exit)).toBe(true);
+          expect(widgetMocks.start).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+              activeCount: 1,
+              activities: remoteSnapshot.aggregate!.activities,
+            }),
+          );
+          expect(activity.getPushToken).toHaveBeenCalledTimes(1);
+          expect(backgroundRuntime.pending).toHaveLength(0);
+        } else {
+          expect(globalReads).toBe(2);
+          expect(widgetMocks.start).not.toHaveBeenCalled();
+          expect(activity.getPushToken).not.toHaveBeenCalled();
+          expect(widgetBeforeRelease?.activities).toEqual([]);
+          expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(widgetBeforeRelease);
+        }
+      }).pipe(Effect.scoped),
+  );
+
   it.each(["sign-out", "account switch"])(
     "does not restore local-work widget data after %s during preference loading",
     async (transition) => {

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -1520,6 +1520,89 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     }).pipe(Effect.scoped),
   );
 
+  it.effect.each(["global", "scoped"] as const)(
+    "adopts a local arm made during the final %s snapshot read instead of priming twice",
+    (blockedRead) =>
+      Effect.gen(function* () {
+        addLiveEnvironment();
+        const preferences = Promise.resolve({ liveActivitiesEnabled: true } as Preferences);
+        vi.mocked(loadPreferences).mockReturnValue(preferences);
+        environmentConfigsMock.configs.set("env-1", {
+          environment: { capabilities: { agentActivityPublishing: true } },
+        });
+        const readStarted = yield* Deferred.make<void>();
+        const finishRead = yield* Deferred.make<void>();
+        let finishToken!: (token: string) => void;
+        let tokenReadStarted!: () => void;
+        const pendingToken = new Promise<string>((resolve) => {
+          finishToken = resolve;
+        });
+        const tokenRead = new Promise<void>((resolve) => {
+          tokenReadStarted = resolve;
+        });
+        const makeActivity = () => ({
+          getPushToken: vi.fn(() => Promise.resolve("activity-token")),
+          addPushTokenListener: vi.fn(),
+        });
+        const activities: Array<ReturnType<typeof makeActivity>> = [];
+        widgetMocks.getInstances.mockImplementation(() => activities as never);
+        widgetMocks.start.mockImplementation(() => {
+          const activity = makeActivity();
+          if (activities.length === 0)
+            activity.getPushToken.mockImplementationOnce(() => {
+              tokenReadStarted();
+              return pendingToken;
+            });
+          activities.push(activity);
+          return activity;
+        });
+        let globalReads = 0;
+        let scopedReads = 0;
+        const layer = snapshotRelayLayer(({ excludedEnvironmentIds }) => {
+          const kind = excludedEnvironmentIds ? "scoped" : "global";
+          const ordinal = excludedEnvironmentIds ? ++scopedReads : ++globalReads;
+          const snapshot = excludedEnvironmentIds
+            ? { aggregate: null, excludedEnvironmentIds }
+            : activeAgentActivitySnapshot;
+          return ordinal === 2 && kind === blockedRead
+            ? Deferred.succeed(readStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(finishRead)),
+                Effect.as(snapshot),
+              )
+            : Effect.succeed(snapshot);
+        });
+        setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+        backgroundRuntime.pending.length = 0;
+        const refresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+          Effect.provide(layer),
+          Effect.forkChild,
+        );
+        yield* Deferred.await(readStarted);
+        armAgentAwarenessLiveActivityForLocalWork({
+          environmentId: liveEnvironmentId,
+          projectTitle: "Live project",
+          threadTitle: "Local task",
+        });
+        yield* Effect.promise(() => preferences.catch(() => null).then(() => undefined));
+        expect(widgetMocks.start).toHaveBeenCalledTimes(1);
+        const pending = backgroundRuntime.pending.shift();
+        if (!pending) throw new Error("Expected local token registration");
+        const localRegistration = yield* Effect.exit(
+          pending.operation as Effect.Effect<unknown, unknown, ManagedRelay.ManagedRelayClient>,
+        ).pipe(Effect.provide(layer), Effect.forkChild);
+        yield* Effect.promise(() => tokenRead);
+        yield* Deferred.succeed(finishRead, undefined);
+        yield* Fiber.join(refresh);
+        const startsBeforeTokenResolved = widgetMocks.start.mock.calls.length;
+        const readsBeforeTokenResolved = { global: globalReads, scoped: scopedReads };
+        finishToken("activity-token");
+        pending.resolve(yield* Fiber.join(localRegistration));
+        expect(readsBeforeTokenResolved).toEqual({ global: 2, scoped: 2 });
+        expect(startsBeforeTokenResolved).toBe(1);
+        expect(activities).toHaveLength(1);
+      }).pipe(Effect.scoped),
+  );
+
   it.effect("does not prime a Live Activity after cloud sign-out", () =>
     Effect.gen(function* () {
       let preferencesStarted!: () => void;

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -10,10 +10,22 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import { FetchHttpClient } from "effect/unstable/http";
+import { Atom } from "effect/unstable/reactivity";
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
+import { PrimaryConnectionTarget } from "@t3tools/client-runtime/connection";
+import type { EnvironmentCatalogState } from "@t3tools/client-runtime/state/connections";
+import type { EnvironmentShellState } from "@t3tools/client-runtime/state/shell";
 
-import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationProjectShell,
+  type OrchestrationThreadShell,
+} from "@t3tools/contracts";
 import type { RelayAgentActivitySnapshotResponse } from "@t3tools/contracts/relay";
 import { verifyDpopProof } from "@t3tools/shared/dpop";
 import type { SavedRemoteConnection } from "../../lib/connection";
@@ -45,6 +57,9 @@ import {
 } from "./remoteRegistration";
 import { publishAgentActivityWidget } from "../../widgets/AgentActivity";
 import * as Notifications from "expo-notifications";
+import { appAtomRegistry } from "../../state/atom-registry";
+import { environmentCatalog } from "../../connection/catalog";
+import { environmentShell } from "../../state/shell";
 
 const secureStore = vi.hoisted(() => new Map<string, string>());
 const widgetMocks = vi.hoisted(() => ({
@@ -64,6 +79,7 @@ const backgroundRuntime = vi.hoisted(() => ({
   }>,
 }));
 const appStateMock = vi.hoisted(() => ({
+  currentState: "active",
   listeners: [] as Array<(state: string) => void>,
 }));
 const registrationRecordStore = vi.hoisted(() => ({
@@ -95,17 +111,42 @@ vi.mock("../../widgets/AgentActivity", () => ({
   publishAgentActivityWidget: vi.fn(),
 }));
 
-// The state modules pull the whole connection stack (and native expo modules)
-// into the import graph; the arming gate only needs the configs map.
-vi.mock("../../state/atom-registry", () => ({
-  appAtomRegistry: {
-    get: () => environmentConfigsMock.configs,
-  },
-}));
+// Keep the native connection boundary synthetic while exercising the real atom
+// registry and widget observer used by the registered app callbacks.
+vi.mock("../../state/atom-registry", async () => {
+  const { AtomRegistry } = await import("effect/unstable/reactivity");
+  return { appAtomRegistry: AtomRegistry.make() };
+});
 
-vi.mock("../../state/server", () => ({
-  environmentServerConfigsAtom: Symbol("environmentServerConfigsAtom"),
-}));
+vi.mock("../../state/server", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return { environmentServerConfigsAtom: Atom.make(() => environmentConfigsMock.configs) };
+});
+
+vi.mock("../../connection/catalog", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  return {
+    environmentCatalog: {
+      catalogValueAtom: Atom.make<EnvironmentCatalogState>({ isReady: true, entries: new Map() }),
+    },
+  };
+});
+
+vi.mock("../../state/shell", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  const Option = await import("effect/Option");
+  return {
+    environmentShell: {
+      stateValueAtom: Atom.family((_id: EnvironmentId) =>
+        Atom.make<EnvironmentShellState>({
+          status: "empty",
+          snapshot: Option.none(),
+          error: Option.none(),
+        }),
+      ),
+    },
+  };
+});
 
 vi.mock("expo-notifications", () => ({
   addPushTokenListener: vi.fn(() => ({ remove: vi.fn() })),
@@ -147,6 +188,9 @@ vi.mock("react-native", () => ({
     Version: "18.0",
   },
   AppState: {
+    get currentState() {
+      return appStateMock.currentState;
+    },
     addEventListener: (_event: string, listener: (state: string) => void) => {
       appStateMock.listeners.push(listener);
       return {
@@ -221,8 +265,10 @@ const activeAgentActivitySnapshot = {
 } satisfies RelayAgentActivitySnapshotResponse;
 
 function snapshotRelayLayer(
-  getAgentActivitySnapshot: () => Effect.Effect<RelayAgentActivitySnapshotResponse> = () =>
-    Effect.succeed(activeAgentActivitySnapshot),
+  getAgentActivitySnapshot: () => Effect.Effect<
+    RelayAgentActivitySnapshotResponse,
+    ManagedRelay.ManagedRelayClientError
+  > = () => Effect.succeed(activeAgentActivitySnapshot),
 ) {
   Constants.expoConfig!.extra = {
     relay: {
@@ -265,6 +311,93 @@ const relayTestLayer = managedRelayClientLayer("https://relay.example.test").pip
   Layer.provide(Layer.mergeAll(FetchHttpClient.layer, cryptoLayer)),
 );
 
+function setTestAtom<A>(atom: Atom.Atom<A>, value: A): void {
+  if (!Atom.isWritable<A, A>(atom)) throw new Error("Expected a writable fixture atom");
+  appAtomRegistry.set(atom, value);
+}
+
+const liveEnvironmentId = EnvironmentId.make("env-1");
+const liveProjectId = ProjectId.make("project-1");
+
+function setLiveShell(
+  phase: "starting" | "running" | "ready" | null,
+  status: EnvironmentShellState["status"] = "live",
+): void {
+  const now = new Date().toISOString();
+  const project: OrchestrationProjectShell = {
+    id: liveProjectId,
+    title: "Live project",
+    workspaceRoot: "/synthetic/project",
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  const thread: OrchestrationThreadShell = {
+    id: ThreadId.make("local-thread"),
+    projectId: liveProjectId,
+    title: "Live task",
+    modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "test-model" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: now,
+    updatedAt: now,
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    session:
+      phase === null
+        ? null
+        : {
+            threadId: ThreadId.make("local-thread"),
+            status: phase,
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+  };
+  setTestAtom(environmentShell.stateValueAtom(liveEnvironmentId), {
+    status,
+    error: Option.none(),
+    snapshot: Option.some({
+      projects: [project],
+      threads: phase === null ? [] : [thread],
+      snapshotSequence: 1,
+      updatedAt: now,
+    }),
+  });
+}
+
+function addLiveEnvironment(): void {
+  setTestAtom(environmentCatalog.catalogValueAtom, {
+    isReady: true,
+    entries: new Map([
+      [
+        liveEnvironmentId,
+        {
+          target: new PrimaryConnectionTarget({
+            environmentId: liveEnvironmentId,
+            label: "Live environment",
+            httpBaseUrl: "https://local.example.test",
+            wsBaseUrl: "wss://local.example.test/ws",
+          }),
+          profile: Option.none(),
+        },
+      ],
+    ]),
+  });
+  setLiveShell(null);
+}
+
 const runBackgroundOperations = Effect.fn("TestRemoteRegistration.runBackgroundOperations")(
   function* () {
     let idlePasses = 0;
@@ -297,6 +430,8 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     backgroundRuntime.pending.length = 0;
     Constants.expoConfig!.extra = {};
     __resetAgentAwarenessRemoteRegistrationForTest();
+    appAtomRegistry.reset();
+    appStateMock.currentState = "active";
     appStateMock.listeners.length = 0;
     registrationRecordStore.current = null;
     vi.mocked(saveAgentAwarenessRegistrationRecord).mockClear();
@@ -376,12 +511,13 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     await preferenceCallbackDrained;
 
     expect(widgetMocks.start).toHaveBeenCalledTimes(1);
-    expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+    expect(widgetMocks.start).toHaveBeenLastCalledWith(
       expect.objectContaining({
         activeCount: 1,
         activities: [expect.objectContaining({ threadTitle: "Current account thread" })],
       }),
     );
+    expect(publishAgentActivityWidget).not.toHaveBeenCalled();
   });
 
   it("preserves disabled Live Activity preferences in relay registrations", () => {
@@ -1321,7 +1457,7 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     }).pipe(Effect.scoped),
   );
 
-  it.effect("does not overwrite a local work seed with an in-flight widget snapshot", () =>
+  it.effect("keeps the native local-work seed separate from an in-flight widget snapshot", () =>
     Effect.gen(function* () {
       const readStarted = yield* Deferred.make<void>();
       const finishRead = yield* Deferred.make<void>();
@@ -1366,12 +1502,17 @@ describe("makeRelayDeviceRegistrationRequest", () => {
       yield* Deferred.succeed(finishRead, undefined);
       yield* Fiber.join(refresh);
 
+      expect(widgetMocks.start).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          activeCount: 1,
+          activities: [expect.objectContaining({ status: "Connecting" })],
+        }),
+      );
       expect(publishAgentActivityWidget).toHaveBeenCalledTimes(1);
       expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          activeCount: 1,
-          subtitle: "Agent work in progress",
-          activities: [expect.objectContaining({ status: "Connecting" })],
+          activeCount: 0,
+          activities: [],
         }),
       );
     }).pipe(Effect.scoped),
@@ -1455,6 +1596,307 @@ describe("makeRelayDeviceRegistrationRequest", () => {
       );
     }).pipe(Effect.scoped),
   );
+
+  for (const liveActivitiesEnabled of [false, true]) {
+    it.effect(
+      `publishes later local shell work after the registered local-start refresh was idle (Live Activities ${liveActivitiesEnabled})`,
+      () => {
+        addLiveEnvironment();
+        setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+        backgroundRuntime.pending.length = 0;
+        const activity = {
+          getPushToken: vi.fn(() => Promise.resolve("activity-token")),
+          addPushTokenListener: vi.fn(),
+        };
+        widgetMocks.start.mockReturnValueOnce(activity);
+        const preferences = Promise.resolve({ liveActivitiesEnabled } as Preferences);
+        vi.mocked(loadPreferences).mockReturnValue(preferences);
+        armAgentAwarenessLiveActivityForLocalWork({
+          environmentId: liveEnvironmentId,
+          threadTitle: "Live task",
+          projectTitle: "Live project",
+        });
+        const preferencesDrained = preferences.catch(() => null).then(() => undefined);
+
+        return Effect.gen(function* () {
+          yield* Effect.promise(() => preferencesDrained);
+          expect(widgetMocks.start).toHaveBeenCalledTimes(liveActivitiesEnabled ? 1 : 0);
+          yield* runBackgroundOperations();
+          expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+            expect.objectContaining({ activeCount: 0, activities: [] }),
+          );
+          setLiveShell("starting");
+          expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              activeCount: 1,
+              activities: [
+                expect.objectContaining({ threadTitle: "Live task", status: "Connecting" }),
+              ],
+            }),
+          );
+          setLiveShell("running");
+          expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              activeCount: 1,
+              activities: [
+                expect.objectContaining({ threadTitle: "Live task", status: "Working" }),
+              ],
+            }),
+          );
+          setLiveShell("ready");
+          expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              activeCount: 0,
+              activities: [expect.objectContaining({ threadTitle: "Live task", status: "Done" })],
+            }),
+          );
+          setLiveShell(null);
+          expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+            expect.objectContaining({ activeCount: 0, activities: [] }),
+          );
+          expect(backgroundRuntime.pending).toHaveLength(0);
+        }).pipe(Effect.provide(snapshotRelayLayer(() => Effect.succeed({ aggregate: null }))));
+      },
+    );
+  }
+
+  it.effect.each(["completed", "multiple running"] as const)(
+    "keeps %s widget rows when delayed local arming is followed by a relay failure",
+    (state) =>
+      Effect.gen(function* () {
+        addLiveEnvironment();
+        setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+        backgroundRuntime.pending.length = 0;
+        yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+          Effect.provide(snapshotRelayLayer(() => Effect.succeed({ aggregate: null }))),
+        );
+        setLiveShell("running");
+        const activity = {
+          getPushToken: vi.fn(() => Promise.resolve("activity-token")),
+          addPushTokenListener: vi.fn(),
+        };
+        widgetMocks.start.mockReturnValueOnce(activity);
+        let finishPreferences!: (preferences: Preferences) => void;
+        const preferences = new Promise<Preferences>((resolve) => {
+          finishPreferences = resolve;
+        });
+        vi.mocked(loadPreferences).mockReturnValueOnce(preferences);
+        armAgentAwarenessLiveActivityForLocalWork({
+          environmentId: liveEnvironmentId,
+          threadTitle: "Live task",
+          projectTitle: "Live project",
+        });
+        const preferenceCallbackDrained = preferences.catch(() => null).then(() => undefined);
+        expect(widgetMocks.start).not.toHaveBeenCalled();
+
+        if (state === "completed") {
+          setLiveShell("ready");
+        } else {
+          const shell = appAtomRegistry.get(environmentShell.stateValueAtom(liveEnvironmentId));
+          const snapshot = Option.getOrThrow(shell.snapshot);
+          const thread = snapshot.threads[0];
+          if (!thread) throw new Error("Expected the running fixture thread");
+          setTestAtom(environmentShell.stateValueAtom(liveEnvironmentId), {
+            ...shell,
+            snapshot: Option.some({
+              ...snapshot,
+              threads: [
+                thread,
+                { ...thread, id: ThreadId.make("second-thread"), title: "Second live task" },
+              ],
+            }),
+          });
+        }
+        const observed = vi.mocked(publishAgentActivityWidget).mock.lastCall?.[0];
+        expect(observed?.activeCount).toBe(state === "completed" ? 0 : 2);
+        expect(observed?.activities).toHaveLength(state === "completed" ? 1 : 2);
+
+        finishPreferences({ liveActivitiesEnabled: true } as Preferences);
+        yield* Effect.promise(() => preferenceCallbackDrained);
+        expect(widgetMocks.start).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            activeCount: 1,
+            activities: [expect.objectContaining({ status: "Connecting" })],
+          }),
+        );
+        expect(backgroundRuntime.pending).toHaveLength(1);
+        const pending = backgroundRuntime.pending.shift();
+        if (!pending) throw new Error("Expected the local activity registration operation");
+        let failedReads = 0;
+        const failedRelay = snapshotRelayLayer(() => {
+          failedReads++;
+          return Effect.fail(
+            new ManagedRelay.ManagedRelayRequestFailedError({
+              action: "read relay agent activity snapshot",
+              transportFailed: true,
+              cause: new Error("Synthetic snapshot transport failure"),
+            }),
+          );
+        });
+        const exit = yield* Effect.exit(
+          pending.operation as Effect.Effect<unknown, unknown, ManagedRelay.ManagedRelayClient>,
+        ).pipe(Effect.provide(failedRelay));
+        pending.resolve(exit);
+        expect(Exit.isSuccess(exit)).toBe(true);
+        expect(failedReads).toBe(1);
+        expect(activity.getPushToken).toHaveBeenCalledTimes(1);
+        expect(backgroundRuntime.pending).toHaveLength(0);
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(observed);
+      }),
+  );
+
+  it.effect("does not let a delayed idle relay response hide current live work", () =>
+    Effect.gen(function* () {
+      addLiveEnvironment();
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      backgroundRuntime.pending.length = 0;
+      const readStarted = yield* Deferred.make<void>();
+      const finishRead = yield* Deferred.make<void>();
+      const layer = snapshotRelayLayer(() =>
+        Deferred.succeed(readStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(finishRead)),
+          Effect.as({ aggregate: null }),
+        ),
+      );
+      const refresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+        Effect.provide(layer),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(readStarted);
+      setLiveShell("running");
+      yield* Deferred.succeed(finishRead, undefined);
+      yield* Fiber.join(refresh);
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
+          activities: [expect.objectContaining({ threadTitle: "Live task", status: "Working" })],
+        }),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect(
+    "uses live idle and deletion over old relay work, and falls back when disconnected",
+    () => {
+      addLiveEnvironment();
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      backgroundRuntime.pending.length = 0;
+      return Effect.gen(function* () {
+        yield* refreshActiveLiveActivityRemoteRegistration();
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+          expect.objectContaining({ activeCount: 0, activities: [] }),
+        );
+        setLiveShell("running");
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activities: [expect.objectContaining({ threadTitle: "Live task" })],
+          }),
+        );
+        setLiveShell("ready", "cached");
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeCount: 1,
+            activities: [expect.objectContaining({ threadTitle: "Thread" })],
+          }),
+        );
+        setLiveShell(null);
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+          expect.objectContaining({ activeCount: 0, activities: [] }),
+        );
+      }).pipe(Effect.provide(snapshotRelayLayer()));
+    },
+  );
+
+  it.effect("detaches on background and resumes from the latest shell on foreground", () => {
+    addLiveEnvironment();
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+    backgroundRuntime.pending.length = 0;
+    return Effect.gen(function* () {
+      yield* refreshActiveLiveActivityRemoteRegistration();
+      setLiveShell("running");
+      const publishedBeforeBackground = vi.mocked(publishAgentActivityWidget).mock.calls.length;
+      appStateMock.currentState = "background";
+      for (const listener of appStateMock.listeners) listener("background");
+      setLiveShell("ready");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(publishedBeforeBackground);
+      appStateMock.currentState = "active";
+      for (const listener of appStateMock.listeners) listener("active");
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeCount: 0,
+          activities: [expect.objectContaining({ status: "Done" })],
+        }),
+      );
+      expect(backgroundRuntime.pending).toHaveLength(1);
+    }).pipe(Effect.provide(snapshotRelayLayer(() => Effect.succeed({ aggregate: null }))));
+  });
+
+  it.effect(
+    "does not keep claiming an unobserved shell when a background relay refresh arrives",
+    () => {
+      addLiveEnvironment();
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      backgroundRuntime.pending.length = 0;
+      return Effect.gen(function* () {
+        yield* refreshActiveLiveActivityRemoteRegistration();
+        setLiveShell("running");
+        appStateMock.currentState = "background";
+        for (const listener of appStateMock.listeners) listener("background");
+        setLiveShell(null);
+        yield* refreshActiveLiveActivityRemoteRegistration();
+        expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activeCount: 1,
+            activities: [expect.objectContaining({ threadTitle: "Thread" })],
+          }),
+        );
+      }).pipe(Effect.provide(snapshotRelayLayer()));
+    },
+  );
+
+  it.effect("deduplicates timestamp-only shell updates and same-account observer refreshes", () => {
+    addLiveEnvironment();
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+    backgroundRuntime.pending.length = 0;
+    return Effect.gen(function* () {
+      yield* refreshActiveLiveActivityRemoteRegistration();
+      setLiveShell("running");
+      const count = vi.mocked(publishAgentActivityWidget).mock.calls.length;
+      setLiveShell("running");
+      setAgentAwarenessRelayTokenProvider(
+        () => Promise.resolve("refreshed-token-user-a"),
+        "user-a",
+      );
+      setLiveShell("running");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count);
+      setLiveShell("ready");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count + 1);
+    }).pipe(Effect.provide(snapshotRelayLayer(() => Effect.succeed({ aggregate: null }))));
+  });
+
+  it.effect("detaches the shell publisher on sign-out and provider release", () => {
+    addLiveEnvironment();
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+    backgroundRuntime.pending.length = 0;
+    return Effect.gen(function* () {
+      yield* refreshActiveLiveActivityRemoteRegistration();
+      setLiveShell("running");
+      releaseAgentAwarenessRelayTokenProvider();
+      const count = vi.mocked(publishAgentActivityWidget).mock.calls.length;
+      setLiveShell("ready");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count);
+      expect(clearAgentAwarenessRegistrationRecord).not.toHaveBeenCalled();
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      yield* refreshActiveLiveActivityRemoteRegistration();
+      setAgentAwarenessRelayTokenProvider(null);
+      const countAfterSignout = vi.mocked(publishAgentActivityWidget).mock.calls.length;
+      setLiveShell("running");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(countAfterSignout);
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({ activeCount: 0, activities: [] }),
+      );
+    }).pipe(Effect.provide(snapshotRelayLayer(() => Effect.succeed({ aggregate: null }))));
+  });
 
   it.effect("does not restore an in-flight widget snapshot after cloud sign-out", () =>
     Effect.gen(function* () {

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -1070,6 +1070,38 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     }).pipe(Effect.provide(snapshotRelayLayer()));
   });
 
+  it.effect("refreshes the home-screen widget when local Live Activity arming fails", () => {
+    widgetMocks.start.mockImplementationOnce(() => {
+      throw new Error("start failed");
+    });
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+    backgroundRuntime.pending.length = 0;
+    environmentConfigsMock.configs.set("env-1", {
+      environment: { capabilities: { agentActivityPublishing: true } },
+    });
+    vi.mocked(loadPreferences).mockResolvedValueOnce({
+      liveActivitiesEnabled: true,
+    } as Preferences);
+
+    armAgentAwarenessLiveActivityForLocalWork({
+      environmentId: "env-1" as EnvironmentId,
+      threadTitle: "Fix the flaky test",
+      projectTitle: "t3code",
+    });
+
+    return Effect.gen(function* () {
+      yield* runBackgroundOperations();
+
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
+          subtitle: "Agent work in progress",
+          activities: [expect.objectContaining({ status: "Working" })],
+        }),
+      );
+    }).pipe(Effect.provide(snapshotRelayLayer()));
+  });
+
   it.effect("discards an older widget snapshot when a newer refresh finishes first", () =>
     Effect.gen(function* () {
       const firstReadStarted = yield* Deferred.make<void>();

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -1147,18 +1147,20 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     environmentConfigsMock.configs.set("env-1", {
       environment: { capabilities: { agentActivityPublishing: true } },
     });
-    vi.mocked(loadPreferences).mockResolvedValueOnce({
+    const preferences = Promise.resolve({
       liveActivitiesEnabled: true,
     } as Preferences);
+    vi.mocked(loadPreferences).mockReturnValueOnce(preferences);
 
     armAgentAwarenessLiveActivityForLocalWork({
       environmentId: "env-1" as EnvironmentId,
       threadTitle: "Fix the flaky test",
       projectTitle: "t3code",
     });
+    const preferenceCallbackDrained = preferences.catch(() => null).then(() => undefined);
 
     return Effect.gen(function* () {
-      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 0)));
+      yield* Effect.promise(() => preferenceCallbackDrained);
       yield* runBackgroundOperations();
 
       expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
@@ -1177,18 +1179,20 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     environmentConfigsMock.configs.set("env-1", {
       environment: { capabilities: { agentActivityPublishing: true } },
     });
-    vi.mocked(loadPreferences).mockResolvedValueOnce({
+    const preferences = Promise.resolve({
       liveActivitiesEnabled: false,
     } as Preferences);
+    vi.mocked(loadPreferences).mockReturnValueOnce(preferences);
 
     armAgentAwarenessLiveActivityForLocalWork({
       environmentId: "env-1" as EnvironmentId,
       threadTitle: "Fix the flaky test",
       projectTitle: "t3code",
     });
+    const preferenceCallbackDrained = preferences.catch(() => null).then(() => undefined);
 
     return Effect.gen(function* () {
-      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 0)));
+      yield* Effect.promise(() => preferenceCallbackDrained);
       yield* runBackgroundOperations();
 
       expect(widgetMocks.start).not.toHaveBeenCalled();
@@ -1209,18 +1213,20 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     environmentConfigsMock.configs.set("env-1", {
       environment: { capabilities: { agentActivityPublishing: true } },
     });
-    vi.mocked(loadPreferences).mockResolvedValueOnce({
+    const preferences = Promise.resolve({
       liveActivitiesEnabled: true,
     } as Preferences);
+    vi.mocked(loadPreferences).mockReturnValueOnce(preferences);
 
     armAgentAwarenessLiveActivityForLocalWork({
       environmentId: "env-1" as EnvironmentId,
       threadTitle: "Fix the flaky test",
       projectTitle: "t3code",
     });
+    const preferenceCallbackDrained = preferences.catch(() => null).then(() => undefined);
 
     return Effect.gen(function* () {
-      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 0)));
+      yield* Effect.promise(() => preferenceCallbackDrained);
       yield* runBackgroundOperations();
 
       expect(widgetMocks.start).not.toHaveBeenCalled();
@@ -1338,9 +1344,10 @@ describe("makeRelayDeviceRegistrationRequest", () => {
       environmentConfigsMock.configs.set("env-1", {
         environment: { capabilities: { agentActivityPublishing: true } },
       });
-      vi.mocked(loadPreferences).mockResolvedValue({
+      const preferences = Promise.resolve({
         liveActivitiesEnabled: true,
       } as Preferences);
+      vi.mocked(loadPreferences).mockReturnValue(preferences);
 
       const refresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
         Effect.provide(layer),
@@ -1353,7 +1360,8 @@ describe("makeRelayDeviceRegistrationRequest", () => {
         threadTitle: "Fix the flaky test",
         projectTitle: "t3code",
       });
-      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 0)));
+      const preferenceCallbackDrained = preferences.catch(() => null).then(() => undefined);
+      yield* Effect.promise(() => preferenceCallbackDrained);
 
       yield* Deferred.succeed(finishRead, undefined);
       yield* Fiber.join(refresh);

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -1244,6 +1244,60 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     }).pipe(Effect.scoped),
   );
 
+  it.effect("does not overwrite a local work seed with an in-flight widget snapshot", () =>
+    Effect.gen(function* () {
+      const readStarted = yield* Deferred.make<void>();
+      const finishRead = yield* Deferred.make<void>();
+      const layer = snapshotRelayLayer(() =>
+        Deferred.succeed(readStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(finishRead)),
+          Effect.as({ aggregate: null }),
+        ),
+      );
+      const activity = {
+        getPushToken: vi.fn(() => Promise.resolve("activity-token")),
+        addPushTokenListener: vi.fn(),
+      };
+      widgetMocks.getInstances
+        .mockReturnValueOnce([])
+        .mockReturnValueOnce([])
+        .mockReturnValue([activity] as never);
+      widgetMocks.start.mockReturnValueOnce(activity);
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+      environmentConfigsMock.configs.set("env-1", {
+        environment: { capabilities: { agentActivityPublishing: true } },
+      });
+      vi.mocked(loadPreferences).mockResolvedValue({
+        liveActivitiesEnabled: true,
+      } as Preferences);
+
+      const refresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+        Effect.provide(layer),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(readStarted);
+
+      armAgentAwarenessLiveActivityForLocalWork({
+        environmentId: "env-1" as EnvironmentId,
+        threadTitle: "Fix the flaky test",
+        projectTitle: "t3code",
+      });
+      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 0)));
+
+      yield* Deferred.succeed(finishRead, undefined);
+      yield* Fiber.join(refresh);
+
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(1);
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
+          subtitle: "Agent work in progress",
+          activities: [expect.objectContaining({ status: "Connecting" })],
+        }),
+      );
+    }).pipe(Effect.scoped),
+  );
+
   it.effect("does not restore an in-flight widget snapshot after cloud sign-out", () =>
     Effect.gen(function* () {
       const readStarted = yield* Deferred.make<void>();

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -5,8 +5,10 @@ import * as NodeCrypto from "node:crypto";
 import { beforeEach, vi } from "vite-plus/test";
 import { describe, expect, it } from "@effect/vitest";
 import Constants from "expo-constants";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import { FetchHttpClient } from "effect/unstable/http";
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
@@ -218,7 +220,10 @@ const activeAgentActivitySnapshot = {
   },
 } satisfies RelayAgentActivitySnapshotResponse;
 
-function snapshotRelayLayer() {
+function snapshotRelayLayer(
+  getAgentActivitySnapshot: () => Effect.Effect<RelayAgentActivitySnapshotResponse> = () =>
+    Effect.succeed(activeAgentActivitySnapshot),
+) {
   Constants.expoConfig!.extra = {
     relay: {
       url: "https://relay.example.test/",
@@ -238,7 +243,7 @@ function snapshotRelayLayer() {
       registerDevice: () => Effect.die("unused"),
       unregisterDevice: () => Effect.die("unused"),
       registerLiveActivity: () => Effect.succeed({ ok: true }),
-      getAgentActivitySnapshot: () => Effect.succeed(activeAgentActivitySnapshot),
+      getAgentActivitySnapshot,
       resetTokenCache: Effect.void,
     }),
   );
@@ -574,7 +579,7 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     },
   );
 
-  it("ends local Live Activities and stops foreground reconciliation on cloud sign-out", () => {
+  it("ends local Live Activities and clears the home-screen widget on cloud sign-out", () => {
     const end = vi.fn(() => Promise.resolve());
     const activity = {
       getPushToken: vi.fn(() => Promise.resolve("activity-token")),
@@ -588,6 +593,14 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     setAgentAwarenessRelayTokenProvider(null);
 
     expect(end).toHaveBeenCalledWith("immediate");
+    expect(publishAgentActivityWidget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "T3 Code",
+        subtitle: "No active agents",
+        activeCount: 0,
+        activities: [],
+      }),
+    );
     expect(appStateMock.listeners).toHaveLength(0);
   });
 
@@ -1023,4 +1036,119 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(widgetMocks.start).toHaveBeenCalledTimes(1);
   });
+  it.effect("refreshes the home-screen widget after arming local agent work", () => {
+    const activity = {
+      getPushToken: vi.fn(() => Promise.resolve("activity-token")),
+      addPushTokenListener: vi.fn(),
+    };
+    widgetMocks.start.mockReturnValueOnce(activity);
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+    backgroundRuntime.pending.length = 0;
+    environmentConfigsMock.configs.set("env-1", {
+      environment: { capabilities: { agentActivityPublishing: true } },
+    });
+    vi.mocked(loadPreferences).mockResolvedValueOnce({
+      liveActivitiesEnabled: true,
+    } as Preferences);
+
+    armAgentAwarenessLiveActivityForLocalWork({
+      environmentId: "env-1" as EnvironmentId,
+      threadTitle: "Fix the flaky test",
+      projectTitle: "t3code",
+    });
+
+    return Effect.gen(function* () {
+      yield* runBackgroundOperations();
+
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
+          subtitle: "Agent work in progress",
+          activities: [expect.objectContaining({ status: "Working" })],
+        }),
+      );
+    }).pipe(Effect.provide(snapshotRelayLayer()));
+  });
+
+  it.effect("discards an older widget snapshot when a newer refresh finishes first", () =>
+    Effect.gen(function* () {
+      const firstReadStarted = yield* Deferred.make<void>();
+      const finishFirstRead = yield* Deferred.make<void>();
+      const olderSnapshot = {
+        aggregate: {
+          ...activeAgentActivitySnapshot.aggregate,
+          updatedAt: "2026-05-25T13:06:00.000Z",
+          activities: [
+            {
+              ...activeAgentActivitySnapshot.aggregate.activities[0],
+              status: "Older status",
+              updatedAt: "2026-05-25T13:06:00.000Z",
+            },
+          ],
+        },
+      } satisfies RelayAgentActivitySnapshotResponse;
+      let readCount = 0;
+      const layer = snapshotRelayLayer(() => {
+        readCount++;
+        if (readCount === 1) {
+          return Deferred.succeed(firstReadStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(finishFirstRead)),
+            Effect.as(olderSnapshot),
+          );
+        }
+        return Effect.succeed(activeAgentActivitySnapshot);
+      });
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+      backgroundRuntime.pending.length = 0;
+
+      const olderRefresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+        Effect.provide(layer),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(firstReadStarted);
+      yield* refreshActiveLiveActivityRemoteRegistration().pipe(Effect.provide(layer));
+      yield* Deferred.succeed(finishFirstRead, undefined);
+      yield* Fiber.join(olderRefresh);
+
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(1);
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activities: [expect.objectContaining({ status: "Working" })],
+        }),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("does not restore an in-flight widget snapshot after cloud sign-out", () =>
+    Effect.gen(function* () {
+      const readStarted = yield* Deferred.make<void>();
+      const finishRead = yield* Deferred.make<void>();
+      const layer = snapshotRelayLayer(() =>
+        Deferred.succeed(readStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(finishRead)),
+          Effect.as(activeAgentActivitySnapshot),
+        ),
+      );
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+      backgroundRuntime.pending.length = 0;
+
+      const refresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+        Effect.provide(layer),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(readStarted);
+      setAgentAwarenessRelayTokenProvider(null);
+      yield* Deferred.succeed(finishRead, undefined);
+      yield* Fiber.join(refresh);
+
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(1);
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          subtitle: "No active agents",
+          activeCount: 0,
+          activities: [],
+        }),
+      );
+    }).pipe(Effect.scoped),
+  );
 });

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -1335,6 +1335,48 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     }).pipe(Effect.scoped),
   );
 
+  it.effect("does not prime from a snapshot that became idle while preferences loaded", () =>
+    Effect.gen(function* () {
+      let preferencesStarted!: () => void;
+      let finishPreferences!: (preferences: Preferences) => void;
+      const started = new Promise<void>((resolve) => {
+        preferencesStarted = resolve;
+      });
+      const preferences = new Promise<Preferences>((resolve) => {
+        finishPreferences = resolve;
+      });
+      vi.mocked(loadPreferences).mockImplementationOnce(() => {
+        preferencesStarted();
+        return preferences;
+      });
+      let readCount = 0;
+      const layer = snapshotRelayLayer(() => {
+        readCount++;
+        return Effect.succeed(readCount === 1 ? activeAgentActivitySnapshot : { aggregate: null });
+      });
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+      const refresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+        Effect.provide(layer),
+        Effect.forkChild,
+      );
+      yield* Effect.promise(() => started);
+
+      finishPreferences({ liveActivitiesEnabled: true } as Preferences);
+      yield* Fiber.join(refresh);
+
+      expect(readCount).toBe(2);
+      expect(widgetMocks.start).not.toHaveBeenCalled();
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          subtitle: "No active agents",
+          activeCount: 0,
+          activities: [],
+        }),
+      );
+    }).pipe(Effect.scoped),
+  );
+
   it.effect("does not restore an in-flight widget snapshot after cloud sign-out", () =>
     Effect.gen(function* () {
       const readStarted = yield* Deferred.make<void>();

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -1298,6 +1298,43 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     }).pipe(Effect.scoped),
   );
 
+  it.effect("does not prime a Live Activity after cloud sign-out", () =>
+    Effect.gen(function* () {
+      let preferencesStarted!: () => void;
+      let finishPreferences!: (preferences: Preferences) => void;
+      const started = new Promise<void>((resolve) => {
+        preferencesStarted = resolve;
+      });
+      const preferences = new Promise<Preferences>((resolve) => {
+        finishPreferences = resolve;
+      });
+      vi.mocked(loadPreferences).mockImplementationOnce(() => {
+        preferencesStarted();
+        return preferences;
+      });
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+      const refresh = yield* refreshActiveLiveActivityRemoteRegistration().pipe(
+        Effect.provide(snapshotRelayLayer()),
+        Effect.forkChild,
+      );
+      yield* Effect.promise(() => started);
+
+      setAgentAwarenessRelayTokenProvider(null);
+      finishPreferences({ liveActivitiesEnabled: true } as Preferences);
+      yield* Fiber.join(refresh);
+
+      expect(widgetMocks.start).not.toHaveBeenCalled();
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          subtitle: "No active agents",
+          activeCount: 0,
+          activities: [],
+        }),
+      );
+    }).pipe(Effect.scoped),
+  );
+
   it.effect("does not restore an in-flight widget snapshot after cloud sign-out", () =>
     Effect.gen(function* () {
       const readStarted = yield* Deferred.make<void>();

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -313,6 +313,77 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     vi.mocked(publishAgentActivityWidget).mockClear();
   });
 
+  it.each(["sign-out", "account switch"])(
+    "does not restore local-work widget data after %s during preference loading",
+    async (transition) => {
+      let finishPreferences!: (preferences: Preferences) => void;
+      const preferences = new Promise<Preferences>((resolve) => {
+        finishPreferences = resolve;
+      });
+      vi.mocked(loadPreferences).mockReturnValueOnce(preferences);
+      setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+      environmentConfigsMock.configs.set("env-1", {
+        environment: { capabilities: { agentActivityPublishing: true } },
+      });
+
+      armAgentAwarenessLiveActivityForLocalWork({
+        environmentId: "env-1" as EnvironmentId,
+        threadTitle: "Previous account thread",
+        projectTitle: "Previous account project",
+      });
+      expect(loadPreferences).toHaveBeenCalledTimes(1);
+      // Register the same catch/then depth after the production continuation.
+      // Its receipt settles after the already-registered preference callback,
+      // without a timer, polling, or executing queued relay operations.
+      const preferenceCallbackDrained = preferences.catch(() => null).then(() => undefined);
+
+      setAgentAwarenessRelayTokenProvider(null);
+      if (transition === "account switch") {
+        setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-b"), "user-b");
+      }
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({ activeCount: 0, activities: [] }),
+      );
+      finishPreferences({ liveActivitiesEnabled: true } as Preferences);
+      await preferenceCallbackDrained;
+
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({ activeCount: 0, activities: [] }),
+      );
+      expect(widgetMocks.start).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still arms local work after a same-account token refresh during preference loading", async () => {
+    let finishPreferences!: (preferences: Preferences) => void;
+    const preferences = new Promise<Preferences>((resolve) => {
+      finishPreferences = resolve;
+    });
+    vi.mocked(loadPreferences).mockReturnValueOnce(preferences);
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+    environmentConfigsMock.configs.set("env-1", {
+      environment: { capabilities: { agentActivityPublishing: true } },
+    });
+
+    armAgentAwarenessLiveActivityForLocalWork({
+      environmentId: "env-1" as EnvironmentId,
+      threadTitle: "Current account thread",
+      projectTitle: "Current account project",
+    });
+    const preferenceCallbackDrained = preferences.catch(() => null).then(() => undefined);
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("refreshed-token-user-a"), "user-a");
+    finishPreferences({ liveActivitiesEnabled: true } as Preferences);
+    await preferenceCallbackDrained;
+
+    expect(widgetMocks.start).toHaveBeenCalledTimes(1);
+    expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        activeCount: 1,
+        activities: [expect.objectContaining({ threadTitle: "Current account thread" })],
+      }),
+    );
+  });
+
   it("preserves disabled Live Activity preferences in relay registrations", () => {
     expect(
       makeRelayDeviceRegistrationRequest({

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -303,6 +303,8 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     vi.mocked(loadAgentAwarenessRegistrationRecord).mockClear();
     vi.mocked(clearAgentAwarenessRegistrationRecord).mockClear();
     vi.mocked(loadOrCreateAgentAwarenessDeviceId).mockResolvedValue("device-1");
+    vi.mocked(loadPreferences).mockReset();
+    vi.mocked(loadPreferences).mockResolvedValue({ liveActivitiesEnabled: false } as Preferences);
     widgetMocks.getInstances.mockReset();
     widgetMocks.getInstances.mockReturnValue([]);
     widgetMocks.start.mockReset();
@@ -1058,12 +1060,74 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     });
 
     return Effect.gen(function* () {
+      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 0)));
       yield* runBackgroundOperations();
 
       expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
         expect.objectContaining({
           activeCount: 1,
           subtitle: "Agent work in progress",
+          activities: [expect.objectContaining({ status: "Working" })],
+        }),
+      );
+    }).pipe(Effect.provide(snapshotRelayLayer()));
+  });
+
+  it.effect("refreshes the home-screen widget when local Live Activities are disabled", () => {
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+    backgroundRuntime.pending.length = 0;
+    environmentConfigsMock.configs.set("env-1", {
+      environment: { capabilities: { agentActivityPublishing: true } },
+    });
+    vi.mocked(loadPreferences).mockResolvedValueOnce({
+      liveActivitiesEnabled: false,
+    } as Preferences);
+
+    armAgentAwarenessLiveActivityForLocalWork({
+      environmentId: "env-1" as EnvironmentId,
+      threadTitle: "Fix the flaky test",
+      projectTitle: "t3code",
+    });
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 0)));
+      yield* runBackgroundOperations();
+
+      expect(widgetMocks.start).not.toHaveBeenCalled();
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
+          activities: [expect.objectContaining({ status: "Working" })],
+        }),
+      );
+    }).pipe(Effect.provide(snapshotRelayLayer()));
+  });
+
+  it.effect("refreshes the home-screen widget when a local Live Activity is already armed", () => {
+    widgetMocks.getInstances.mockReturnValueOnce([{}] as never);
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+    backgroundRuntime.pending.length = 0;
+    environmentConfigsMock.configs.set("env-1", {
+      environment: { capabilities: { agentActivityPublishing: true } },
+    });
+    vi.mocked(loadPreferences).mockResolvedValueOnce({
+      liveActivitiesEnabled: true,
+    } as Preferences);
+
+    armAgentAwarenessLiveActivityForLocalWork({
+      environmentId: "env-1" as EnvironmentId,
+      threadTitle: "Fix the flaky test",
+      projectTitle: "t3code",
+    });
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 0)));
+      yield* runBackgroundOperations();
+
+      expect(widgetMocks.start).not.toHaveBeenCalled();
+      expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
           activities: [expect.objectContaining({ status: "Working" })],
         }),
       );

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -1094,6 +1094,7 @@ describe("makeRelayDeviceRegistrationRequest", () => {
       yield* runBackgroundOperations();
 
       expect(widgetMocks.start).not.toHaveBeenCalled();
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(1);
       expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
         expect.objectContaining({
           activeCount: 1,
@@ -1125,6 +1126,7 @@ describe("makeRelayDeviceRegistrationRequest", () => {
       yield* runBackgroundOperations();
 
       expect(widgetMocks.start).not.toHaveBeenCalled();
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(1);
       expect(publishAgentActivityWidget).toHaveBeenLastCalledWith(
         expect.objectContaining({
           activeCount: 1,

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -11,7 +11,7 @@ import * as Layer from "effect/Layer";
 import { FetchHttpClient } from "effect/unstable/http";
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
 
-import type { EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { verifyDpopProof } from "@t3tools/shared/dpop";
 import type { SavedRemoteConnection } from "../../lib/connection";
 import { cryptoLayer } from "../cloud/dpop";
@@ -204,7 +204,7 @@ const activeAgentActivitySnapshot = {
     activities: [
       {
         environmentId: "env-1" as EnvironmentId,
-        threadId: "thread-1",
+        threadId: "thread-1" as ThreadId,
         projectTitle: "Project",
         threadTitle: "Thread",
         modelTitle: "gpt-5.4",

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -88,6 +88,7 @@ vi.mock("../../widgets/AgentActivity", () => ({
     getInstances: widgetMocks.getInstances,
     start: widgetMocks.start,
   },
+  publishAgentActivityWidget: vi.fn(),
 }));
 
 // The state modules pull the whole connection stack (and native expo modules)

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -109,7 +109,7 @@ vi.mock("../../widgets/AgentActivity", () => ({
     getInstances: widgetMocks.getInstances,
     start: widgetMocks.start,
   },
-  publishAgentActivityWidget: vi.fn(),
+  publishAgentActivityWidget: vi.fn(() => true),
 }));
 
 // Keep the native connection boundary synthetic while exercising the real atom
@@ -448,7 +448,7 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     widgetMocks.start.mockReset();
     widgetMocks.start.mockReturnValue({});
     environmentConfigsMock.configs.clear();
-    vi.mocked(publishAgentActivityWidget).mockClear();
+    vi.mocked(publishAgentActivityWidget).mockReset().mockReturnValue(true);
   });
 
   it.effect.each(["unchanged", "sign-out", "account switch"] as const)(
@@ -2433,6 +2433,22 @@ describe("makeRelayDeviceRegistrationRequest", () => {
       setLiveShell("running");
       expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count);
       setLiveShell("ready");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count + 1);
+    }).pipe(Effect.provide(snapshotRelayLayer(() => Effect.succeed({ aggregate: null }))));
+  });
+
+  it.effect("retries identical widget content after a failed native publish", () => {
+    addLiveEnvironment();
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"), "user-a");
+    backgroundRuntime.pending.length = 0;
+    return Effect.gen(function* () {
+      yield* refreshActiveLiveActivityRemoteRegistration();
+      vi.mocked(publishAgentActivityWidget).mockReturnValueOnce(false);
+      setLiveShell("running");
+      const count = vi.mocked(publishAgentActivityWidget).mock.calls.length;
+      setLiveShell("running");
+      expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count + 1);
+      setLiveShell("running");
       expect(publishAgentActivityWidget).toHaveBeenCalledTimes(count + 1);
     }).pipe(Effect.provide(snapshotRelayLayer(() => Effect.succeed({ aggregate: null }))));
   });

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -448,6 +448,33 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     }).pipe(Effect.provide(relayTestLayer));
   });
 
+  it.effect("refreshes the widget after a delayed Live Activity push token registers", () => {
+    let onPushToken: ((event: { pushToken: string }) => void) | undefined;
+    const activity = {
+      getPushToken: vi.fn(() => Promise.resolve(null)),
+      addPushTokenListener: vi.fn((listener: (event: { pushToken: string }) => void) => {
+        onPushToken = listener;
+        return { remove: vi.fn() };
+      }),
+    };
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+    return Effect.gen(function* () {
+      expect(yield* registerLiveActivityPushToken({ activity: activity as never })).toBe(false);
+      expect(onPushToken).toBeDefined();
+
+      onPushToken?.({ pushToken: "delayed-activity-token" });
+      yield* runBackgroundOperations();
+
+      expect(publishAgentActivityWidget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
+          subtitle: "Agent work in progress",
+        }),
+      );
+    }).pipe(Effect.provide(snapshotRelayLayer()));
+  });
+
   it.effect("preserves Live Activity push-token lookup failures", () => {
     const cause = new Error("native token lookup failed");
     const activity = {

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -40,6 +40,7 @@ import {
   shouldRegisterAgentAwarenessDeviceForProvider,
   unregisterAgentAwarenessConnection,
 } from "./remoteRegistration";
+import { publishAgentActivityWidget } from "../../widgets/AgentActivity";
 import * as Notifications from "expo-notifications";
 
 const secureStore = vi.hoisted(() => new Map<string, string>());
@@ -194,6 +195,54 @@ function proofIat(proof: string): number {
   return decoded.iat;
 }
 
+const activeAgentActivitySnapshot = {
+  aggregate: {
+    title: "T3 Code",
+    subtitle: "Agent work in progress",
+    activeCount: 1,
+    updatedAt: "2026-05-25T13:07:00.000Z",
+    activities: [
+      {
+        environmentId: "env-1" as EnvironmentId,
+        threadId: "thread-1",
+        projectTitle: "Project",
+        threadTitle: "Thread",
+        modelTitle: "gpt-5.4",
+        phase: "running" as const,
+        status: "Working",
+        updatedAt: "2026-05-25T13:07:00.000Z",
+        deepLink: "/threads/env-1/thread-1",
+      },
+    ],
+  },
+};
+
+function snapshotRelayLayer() {
+  Constants.expoConfig!.extra = {
+    relay: {
+      url: "https://relay.example.test/",
+    },
+  };
+  return Layer.succeed(
+    ManagedRelay.ManagedRelayClient,
+    ManagedRelay.ManagedRelayClient.of({
+      relayUrl: "https://relay.example.test",
+      listEnvironments: () => Effect.die("unused"),
+      listDevices: () => Effect.die("unused"),
+      createEnvironmentLinkChallenge: () => Effect.die("unused"),
+      linkEnvironment: () => Effect.die("unused"),
+      unlinkEnvironment: () => Effect.die("unused"),
+      getEnvironmentStatus: () => Effect.die("unused"),
+      connectEnvironment: () => Effect.die("unused"),
+      registerDevice: () => Effect.die("unused"),
+      unregisterDevice: () => Effect.die("unused"),
+      registerLiveActivity: () => Effect.succeed({ ok: true }),
+      getAgentActivitySnapshot: () => Effect.succeed(activeAgentActivitySnapshot),
+      resetTokenCache: Effect.void,
+    }),
+  );
+}
+
 function savedConnection(): SavedRemoteConnection {
   return {
     environmentId: "env-1" as EnvironmentId,
@@ -250,8 +299,10 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     vi.mocked(loadOrCreateAgentAwarenessDeviceId).mockResolvedValue("device-1");
     widgetMocks.getInstances.mockReset();
     widgetMocks.getInstances.mockReturnValue([]);
-    widgetMocks.start.mockClear();
+    widgetMocks.start.mockReset();
+    widgetMocks.start.mockReturnValue({});
     environmentConfigsMock.configs.clear();
+    vi.mocked(publishAgentActivityWidget).mockClear();
   });
 
   it("preserves disabled Live Activity preferences in relay registrations", () => {
@@ -450,6 +501,48 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     },
   );
 
+  it.effect("publishes the home-screen widget when a Live Activity is already armed", () => {
+    const activity = {
+      getPushToken: vi.fn(() => Promise.resolve("activity-token")),
+      addPushTokenListener: vi.fn(),
+      start: vi.fn(),
+      update: vi.fn(),
+      end: vi.fn(),
+    };
+    widgetMocks.getInstances.mockReturnValue([activity] as never);
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+    return Effect.gen(function* () {
+      yield* refreshActiveLiveActivityRemoteRegistration();
+
+      expect(publishAgentActivityWidget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
+          subtitle: "Agent work in progress",
+          activities: [expect.objectContaining({ status: "Working" })],
+        }),
+      );
+      expect(widgetMocks.start).not.toHaveBeenCalled();
+      expect(activity.start).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(snapshotRelayLayer()));
+  });
+
+  it.effect("publishes the home-screen widget when Live Activities are disabled", () => {
+    setAgentAwarenessRelayTokenProvider(() => Promise.resolve("clerk-token-user-a"));
+
+    return Effect.gen(function* () {
+      yield* refreshActiveLiveActivityRemoteRegistration();
+
+      expect(publishAgentActivityWidget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeCount: 1,
+          subtitle: "Agent work in progress",
+        }),
+      );
+      expect(widgetMocks.start).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(snapshotRelayLayer()));
+  });
+
   it.effect(
     "re-registers active Live Activity tokens when the app returns to the foreground",
     () => {
@@ -538,11 +631,13 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     return Effect.gen(function* () {
       yield* runBackgroundOperations();
 
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      const [request, init] = fetchMock.mock.calls[1] as unknown as [
-        unknown,
-        RequestInit | undefined,
-      ];
+      const deviceCall = fetchMock.mock.calls.find((call) => {
+        const request = call[0];
+        const url = request instanceof Request ? request.url : String(request);
+        return url === "https://relay.example.test/v1/mobile/devices";
+      });
+      expect(deviceCall).toBeDefined();
+      const [request, init] = deviceCall as unknown as [unknown, RequestInit | undefined];
       const url = request instanceof Request ? request.url : String(request);
       const method = request instanceof Request ? request.method : init?.method;
       const headers = request instanceof Request ? request.headers : new Headers(init?.headers);
@@ -788,7 +883,9 @@ describe("makeRelayDeviceRegistrationRequest", () => {
       yield* runBackgroundOperations();
 
       expect(backgroundRuntime.pending).toHaveLength(0);
-      expect(tokenProvider).toHaveBeenCalledTimes(2);
+      // Device registration retries after the first auth miss, and the
+      // home-screen widget refresh independently reads the relay token.
+      expect(tokenProvider).toHaveBeenCalledTimes(3);
     }).pipe(Effect.provide(relayTestLayer));
   });
 

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -12,6 +12,7 @@ import { FetchHttpClient } from "effect/unstable/http";
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
 
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import type { RelayAgentActivitySnapshotResponse } from "@t3tools/contracts/relay";
 import { verifyDpopProof } from "@t3tools/shared/dpop";
 import type { SavedRemoteConnection } from "../../lib/connection";
 import { cryptoLayer } from "../cloud/dpop";
@@ -215,7 +216,7 @@ const activeAgentActivitySnapshot = {
       },
     ],
   },
-};
+} satisfies RelayAgentActivitySnapshotResponse;
 
 function snapshotRelayLayer() {
   Constants.expoConfig!.extra = {

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -1071,6 +1071,17 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
       activities = activities.slice(0, 1);
     }
 
+    // Home-screen widgets are independent of the lock-screen card. Publish
+    // the latest aggregate even when a Live Activity already exists or the
+    // user has turned Live Activities off; otherwise the widget stays on the
+    // "Connecting" snapshot from local arming.
+    const snapshot = yield* readAgentActivitySnapshot();
+    if (snapshot) {
+      publishHomeScreenWidget(
+        snapshot.aggregate ? widgetPropsFromAggregate(snapshot.aggregate) : idleWidgetProps(),
+      );
+    }
+
     // Activities are only ever created here, in the foreground, where the
     // update token can be observed and registered immediately — the relay
     // never remote-starts one (background push-to-start wakes proved too
@@ -1090,12 +1101,6 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
       // The toggle defaults to on: an unset preference (fresh install) must
       // prime, so only an explicit false blocks it.
       if (preferences?.liveActivitiesEnabled !== false) {
-        const snapshot = yield* readAgentActivitySnapshot();
-        if (snapshot) {
-          publishHomeScreenWidget(
-            snapshot.aggregate ? widgetPropsFromAggregate(snapshot.aggregate) : idleWidgetProps(),
-          );
-        }
         // The snapshot request yields; an arm-on-send may have created the
         // card in the meantime. Re-check so two cards are never started.
         const armedMeanwhile = yield* Effect.try({

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -43,6 +43,8 @@ import { makeRelayDeviceRegistrationRequest, resolveApsEnvironment } from "./reg
 import {
   createLiveWidgetActivitiesAtom,
   reconcileWidgetActivity,
+  retainUnconfirmedWidgetActivities,
+  sameWidgetEnvironmentScope,
   type LiveWidgetActivities,
 } from "./liveWidgetActivity";
 
@@ -133,6 +135,7 @@ const liveWidgetActivitiesAtom = createLiveWidgetActivitiesAtom({
 });
 let liveWidgetSubscription: (() => void) | null = null;
 let liveWidgetActivities: LiveWidgetActivities = new Map();
+let observedWidgetActivities: LiveWidgetActivities = new Map();
 let relayWidgetSnapshot: RelayAgentActivitySnapshotResponse | null = null;
 let publishedWidgetContent: string | null = null;
 let activeDeviceRegistration: {
@@ -503,6 +506,7 @@ function publishRegularWidget(props: AgentActivityProps): void {
   // Streaming text changes shell timestamps without changing widget content.
   const content = JSON.stringify({
     activeCount: props.activeCount,
+    isStale: props.isStale,
     activities: props.activities.map(({ updatedAt: _updatedAt, ...row }) => row),
   });
   if (content === publishedWidgetContent) return;
@@ -512,22 +516,28 @@ function publishRegularWidget(props: AgentActivityProps): void {
 
 function publishReconciledWidget(): void {
   if (!relayTokenProvider) return;
-  const result = reconcileWidgetActivity(liveWidgetActivities, relayWidgetSnapshot);
-  // Only established totals can use the existing numeric widget contract.
-  if (result.activeCount === null) return;
+  if (relayWidgetSnapshot === null && observedWidgetActivities.size === 0) return;
+  const result = reconcileWidgetActivity(observedWidgetActivities, relayWidgetSnapshot);
   publishRegularWidget({
     title: "T3 Code",
-    subtitle: result.activeCount > 0 ? "Agent work in progress" : "No active agents",
+    subtitle:
+      result.activeCount === null
+        ? "Activity count unavailable"
+        : result.activeCount > 0
+          ? "Agent work in progress"
+          : "No active agents",
     activeCount: result.activeCount,
+    isStale: [...observedWidgetActivities.keys()].some((id) => !liveWidgetActivities.has(id)),
     updatedAt: new Date().toISOString(),
     activities: result.activities,
   });
 }
 
-function stopLiveWidgetObserver(): void {
+function stopLiveWidgetObserver(clearObservations = true): void {
   liveWidgetSubscription?.();
   liveWidgetSubscription = null;
   liveWidgetActivities = new Map();
+  if (clearObservations) observedWidgetActivities = new Map();
   widgetRefreshGeneration++;
 }
 
@@ -542,8 +552,22 @@ function startLiveWidgetObserver(): void {
   liveWidgetSubscription = appAtomRegistry.subscribe(
     liveWidgetActivitiesAtom,
     (activities) => {
+      const previousScope = [...observedWidgetActivities.keys()];
       liveWidgetActivities = activities;
+      const catalog = appAtomRegistry.get(environmentCatalog.catalogValueAtom);
+      const observed = new Map(observedWidgetActivities);
+      for (const environmentId of observed.keys()) {
+        if (!catalog.entries.has(environmentId)) observed.delete(environmentId);
+      }
+      for (const [environmentId, rows] of activities) observed.set(environmentId, rows);
+      observedWidgetActivities = observed;
       publishReconciledWidget();
+      if (
+        relayWidgetSnapshot !== null &&
+        !sameWidgetEnvironmentScope(previousScope, [...observed.keys()])
+      ) {
+        runRegistrationInBackground(refreshAgentActivityWidget(), "widget scope refresh failed");
+      }
     },
     { immediate: true },
   );
@@ -649,7 +673,9 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
   }
 }
 
-function readAgentActivitySnapshot(): Effect.Effect<
+function readAgentActivitySnapshot(
+  excludedEnvironmentIds?: ReadonlyArray<EnvironmentId>,
+): Effect.Effect<
   RelayAgentActivitySnapshotResponse | null,
   never,
   ManagedRelay.ManagedRelayClient
@@ -661,7 +687,7 @@ function readAgentActivitySnapshot(): Effect.Effect<
       return null;
     }
     const client = yield* ManagedRelay.ManagedRelayClient;
-    return yield* client.getAgentActivitySnapshot({ clerkToken: token });
+    return yield* client.getAgentActivitySnapshot({ clerkToken: token, excludedEnvironmentIds });
   }).pipe(
     Effect.catch((error) =>
       Effect.sync(() => {
@@ -680,6 +706,7 @@ function refreshAgentActivityWidget(): Effect.Effect<
   return Effect.gen(function* () {
     const expectedDeviceGeneration = deviceRegistrationGeneration;
     const expectedRefreshGeneration = ++widgetRefreshGeneration;
+    const readStartedWith = observedWidgetActivities;
     const snapshot = yield* readAgentActivitySnapshot();
     if (
       expectedDeviceGeneration !== deviceRegistrationGeneration ||
@@ -688,7 +715,30 @@ function refreshAgentActivityWidget(): Effect.Effect<
       return null;
     }
     if (snapshot) {
-      relayWidgetSnapshot = snapshot;
+      observedWidgetActivities = retainUnconfirmedWidgetActivities(
+        observedWidgetActivities,
+        liveWidgetActivities,
+        readStartedWith,
+        snapshot,
+      );
+      let widgetSnapshot = snapshot;
+      while (observedWidgetActivities.size > 0) {
+        const excludedEnvironmentIds = [...observedWidgetActivities.keys()];
+        const scoped = yield* readAgentActivitySnapshot(excludedEnvironmentIds);
+        if (
+          expectedDeviceGeneration !== deviceRegistrationGeneration ||
+          expectedRefreshGeneration !== widgetRefreshGeneration ||
+          !relayTokenProvider
+        )
+          return null;
+        if (
+          !sameWidgetEnvironmentScope(excludedEnvironmentIds, [...observedWidgetActivities.keys()])
+        )
+          continue;
+        if (scoped) widgetSnapshot = scoped;
+        break;
+      }
+      relayWidgetSnapshot = widgetSnapshot;
       publishReconciledWidget();
     }
     return snapshot;
@@ -921,7 +971,8 @@ function ensureAppStateListener(): void {
 
   appStateSubscription = AppState.addEventListener("change", (state) => {
     if (state !== "active") {
-      stopLiveWidgetObserver();
+      stopLiveWidgetObserver(false);
+      publishReconciledWidget();
       return;
     }
     startLiveWidgetObserver();

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -708,12 +708,11 @@ function refreshAgentActivityWidget(): Effect.Effect<
     const expectedRefreshGeneration = ++widgetRefreshGeneration;
     const readStartedWith = observedWidgetActivities;
     const snapshot = yield* readAgentActivitySnapshot();
-    if (
-      expectedDeviceGeneration !== deviceRegistrationGeneration ||
-      expectedRefreshGeneration !== widgetRefreshGeneration
-    ) {
+    if (expectedDeviceGeneration !== deviceRegistrationGeneration || !relayTokenProvider) {
       return null;
     }
+    // Superseding widget publication does not invalidate this account's priming snapshot.
+    if (expectedRefreshGeneration !== widgetRefreshGeneration) return snapshot;
     if (snapshot) {
       observedWidgetActivities = retainUnconfirmedWidgetActivities(
         observedWidgetActivities,
@@ -725,12 +724,9 @@ function refreshAgentActivityWidget(): Effect.Effect<
       while (observedWidgetActivities.size > 0) {
         const excludedEnvironmentIds = [...observedWidgetActivities.keys()];
         const scoped = yield* readAgentActivitySnapshot(excludedEnvironmentIds);
-        if (
-          expectedDeviceGeneration !== deviceRegistrationGeneration ||
-          expectedRefreshGeneration !== widgetRefreshGeneration ||
-          !relayTokenProvider
-        )
+        if (expectedDeviceGeneration !== deviceRegistrationGeneration || !relayTokenProvider)
           return null;
+        if (expectedRefreshGeneration !== widgetRefreshGeneration) return snapshot;
         if (
           !sameWidgetEnvironmentScope(excludedEnvironmentIds, [...observedWidgetActivities.keys()])
         )
@@ -1283,6 +1279,13 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
           activities = [...armedMeanwhile];
         } else {
           const latestSnapshot = yield* refreshAgentActivityWidget();
+          if (
+            expectedDeviceGeneration !== deviceRegistrationGeneration ||
+            !relayTokenProvider ||
+            AppState.currentState !== "active"
+          ) {
+            return;
+          }
           if (!latestSnapshot?.aggregate || latestSnapshot.aggregate.activeCount <= 0) {
             return;
           }

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -1247,6 +1247,10 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
     // "Connecting" snapshot from local arming.
     yield* refreshAgentActivityWidget();
 
+    if (expectedDeviceGeneration !== deviceRegistrationGeneration || !relayTokenProvider) {
+      return;
+    }
+
     // Activities are only ever created here, in the foreground, where the
     // update token can be observed and registered immediately — the relay
     // never remote-starts one (background push-to-start wakes proved too

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -1286,27 +1286,38 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
           if (!latestSnapshot?.aggregate || latestSnapshot.aggregate.activeCount <= 0) {
             return;
           }
-          const aggregate = latestSnapshot.aggregate;
-          const primed = yield* Effect.try({
-            try: () => AgentActivity.start(widgetPropsFromAggregate(aggregate)),
-            catch: (cause) =>
-              new AgentAwarenessOperationError({
-                operation: "prime-live-activity",
-                cause,
-              }),
+          // Local arming may finish while either snapshot request is pending.
+          const armedDuringRead = yield* Effect.try({
+            try: () => AgentActivity.getInstances(),
+            catch: () => [] as ReadonlyArray<LiveActivity<AgentActivityProps>>,
           }).pipe(
-            Effect.catch((error) =>
-              Effect.sync(() => {
-                logRegistrationError("live activity priming failed", error);
-                return null;
-              }),
-            ),
+            Effect.orElseSucceed(() => [] as ReadonlyArray<LiveActivity<AgentActivityProps>>),
           );
-          if (primed) {
-            logRegistrationDebug("live activity card primed", {
-              activeCount: aggregate.activeCount,
-            });
-            activities = [primed];
+          if (armedDuringRead.length > 0) {
+            activities = [...armedDuringRead];
+          } else {
+            const aggregate = latestSnapshot.aggregate;
+            const primed = yield* Effect.try({
+              try: () => AgentActivity.start(widgetPropsFromAggregate(aggregate)),
+              catch: (cause) =>
+                new AgentAwarenessOperationError({
+                  operation: "prime-live-activity",
+                  cause,
+                }),
+            }).pipe(
+              Effect.catch((error) =>
+                Effect.sync(() => {
+                  logRegistrationError("live activity priming failed", error);
+                  return null;
+                }),
+              ),
+            );
+            if (primed) {
+              logRegistrationDebug("live activity card primed", {
+                activeCount: aggregate.activeCount,
+              });
+              activities = [primed];
+            }
           }
         }
       }

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -21,6 +21,8 @@ import {
 import type { SavedRemoteConnection } from "../../lib/connection";
 import { runtime } from "../../lib/runtime";
 import { appAtomRegistry } from "../../state/atom-registry";
+import { environmentCatalog } from "../../connection/catalog";
+import { environmentShell } from "../../state/shell";
 import { environmentServerConfigsAtom } from "../../state/server";
 import type { Preferences } from "../../persistence/mobile-preferences";
 import {
@@ -38,6 +40,11 @@ import AgentActivity, {
 import { resolveCloudPublicConfig } from "../cloud/publicConfig";
 import { supportsAgentAwarenessPush } from "./capabilities";
 import { makeRelayDeviceRegistrationRequest, resolveApsEnvironment } from "./registrationPayload";
+import {
+  createLiveWidgetActivitiesAtom,
+  reconcileWidgetActivity,
+  type LiveWidgetActivities,
+} from "./liveWidgetActivity";
 
 const REMOTE_ACTIVITY_REGISTRATION_RETRY_MS = 15_000;
 
@@ -119,6 +126,15 @@ let relayTokenProvider: (() => Promise<string | null>) | null = null;
 let relayTokenProviderIdentity: string | null = null;
 let deviceRegistrationGeneration = 0;
 let widgetRefreshGeneration = 0;
+const liveWidgetActivitiesAtom = createLiveWidgetActivitiesAtom({
+  catalogValueAtom: environmentCatalog.catalogValueAtom,
+  shellStateValueAtom: environmentShell.stateValueAtom,
+  now: Date.now,
+});
+let liveWidgetSubscription: (() => void) | null = null;
+let liveWidgetActivities: LiveWidgetActivities = new Map();
+let relayWidgetSnapshot: RelayAgentActivitySnapshotResponse | null = null;
+let publishedWidgetContent: string | null = null;
 let activeDeviceRegistration: {
   readonly input: DeviceRegistrationInput;
   operation: Promise<void>;
@@ -172,6 +188,8 @@ export function setAgentAwarenessRelayTokenProvider(
     provider !== null &&
     !shouldRegisterAgentAwarenessDeviceForProvider(relayTokenProviderIdentity, identity);
   if (!isExistingIdentity) {
+    stopLiveWidgetObserver();
+    relayWidgetSnapshot = null;
     deviceRegistrationGeneration++;
     activeDeviceRegistration = null;
     pendingDeviceRegistration = null;
@@ -191,7 +209,7 @@ export function setAgentAwarenessRelayTokenProvider(
     // Without a signed-in user the relay can no longer update or end these
     // activities, so they would sit orphaned on the lock screen.
     endLocalLiveActivities("live activity cleanup after cloud sign-out failed");
-    publishAgentActivityWidget(idleWidgetProps());
+    publishRegularWidget(idleWidgetProps());
     setRegistrationStatus("unknown");
     // Sign-out is the only thing that invalidates a stored registration, so the
     // next sign-in re-registers.
@@ -202,6 +220,7 @@ export function setAgentAwarenessRelayTokenProvider(
   }
   ensurePushTokenListener();
   ensureAppStateListener();
+  startLiveWidgetObserver();
   runRegistrationInBackground(
     refreshActiveLiveActivityRemoteRegistration(),
     "active live activity registration after cloud sign-in failed",
@@ -224,6 +243,8 @@ export function setAgentAwarenessRelayTokenProvider(
 // the persisted registration would be wrong — the relay still holds a valid
 // registration and the next mount reuses it.
 export function releaseAgentAwarenessRelayTokenProvider(): void {
+  stopLiveWidgetObserver();
+  relayWidgetSnapshot = null;
   relayTokenProvider = null;
   relayTokenProviderIdentity = null;
   pushTokenSubscription?.remove();
@@ -478,6 +499,56 @@ function idleWidgetProps(): AgentActivityProps {
   };
 }
 
+function publishRegularWidget(props: AgentActivityProps): void {
+  // Streaming text changes shell timestamps without changing widget content.
+  const content = JSON.stringify({
+    activeCount: props.activeCount,
+    activities: props.activities.map(({ updatedAt: _updatedAt, ...row }) => row),
+  });
+  if (content === publishedWidgetContent) return;
+  publishedWidgetContent = content;
+  publishAgentActivityWidget(props);
+}
+
+function publishReconciledWidget(): void {
+  if (!relayTokenProvider) return;
+  const result = reconcileWidgetActivity(liveWidgetActivities, relayWidgetSnapshot);
+  // Only established totals can use the existing numeric widget contract.
+  if (result.activeCount === null) return;
+  publishRegularWidget({
+    title: "T3 Code",
+    subtitle: result.activeCount > 0 ? "Agent work in progress" : "No active agents",
+    activeCount: result.activeCount,
+    updatedAt: new Date().toISOString(),
+    activities: result.activities,
+  });
+}
+
+function stopLiveWidgetObserver(): void {
+  liveWidgetSubscription?.();
+  liveWidgetSubscription = null;
+  liveWidgetActivities = new Map();
+  widgetRefreshGeneration++;
+}
+
+function startLiveWidgetObserver(): void {
+  if (
+    liveWidgetSubscription ||
+    !canRegisterRemoteLiveActivities() ||
+    !relayTokenProvider ||
+    AppState.currentState !== "active"
+  )
+    return;
+  liveWidgetSubscription = appAtomRegistry.subscribe(
+    liveWidgetActivitiesAtom,
+    (activities) => {
+      liveWidgetActivities = activities;
+      publishReconciledWidget();
+    },
+    { immediate: true },
+  );
+}
+
 // Arms the lock-screen card the moment the user starts agent work from this
 // phone, while the app is still foregrounded and the fresh activity's token
 // can be registered immediately. The seeded row is a best-effort placeholder;
@@ -556,11 +627,8 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
       return;
     }
     const props = localWorkStartingWidgetProps(input);
-    // This local seed is newer than any relay snapshot already being read.
-    // Invalidate those reads before publishing so they cannot repaint the
-    // widget with stale idle or aggregate state when they eventually finish.
-    widgetRefreshGeneration++;
-    publishAgentActivityWidget(props);
+    // Only the foreground-only Live Activity needs this optimistic seed.
+    // Regular widgets keep observed state until real work arrives.
     const activity = AgentActivity.start(props);
     logRegistrationDebug("live activity card armed for local work", {
       threadTitle: input.threadTitle,
@@ -620,9 +688,8 @@ function refreshAgentActivityWidget(): Effect.Effect<
       return null;
     }
     if (snapshot) {
-      publishAgentActivityWidget(
-        snapshot.aggregate ? widgetPropsFromAggregate(snapshot.aggregate) : idleWidgetProps(),
-      );
+      relayWidgetSnapshot = snapshot;
+      publishReconciledWidget();
     }
     return snapshot;
   });
@@ -854,8 +921,10 @@ function ensureAppStateListener(): void {
 
   appStateSubscription = AppState.addEventListener("change", (state) => {
     if (state !== "active") {
+      stopLiveWidgetObserver();
       return;
     }
+    startLiveWidgetObserver();
     runRegistrationInBackground(
       refreshActiveLiveActivityRemoteRegistration(),
       "active live activity reconciliation after app foreground failed",
@@ -936,6 +1005,9 @@ export function updateAgentAwarenessRegistrationPreferences(
 }
 
 export function __resetAgentAwarenessRemoteRegistrationForTest(): void {
+  stopLiveWidgetObserver();
+  relayWidgetSnapshot = null;
+  publishedWidgetContent = null;
   environmentConnections.clear();
   pushTokenSubscription?.remove();
   pushTokenSubscription = null;

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -510,8 +510,7 @@ function publishRegularWidget(props: AgentActivityProps): void {
     activities: props.activities.map(({ updatedAt: _updatedAt, ...row }) => row),
   });
   if (content === publishedWidgetContent) return;
-  publishedWidgetContent = content;
-  publishAgentActivityWidget(props);
+  if (publishAgentActivityWidget(props)) publishedWidgetContent = content;
 }
 
 function publishReconciledWidget(): void {

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -552,6 +552,10 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
       return;
     }
     const props = localWorkStartingWidgetProps(input);
+    // This local seed is newer than any relay snapshot already being read.
+    // Invalidate those reads before publishing so they cannot repaint the
+    // widget with stale idle or aggregate state when they eventually finish.
+    widgetRefreshGeneration++;
     publishAgentActivityWidget(props);
     const activity = AgentActivity.start(props);
     logRegistrationDebug("live activity card armed for local work", {

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -1089,6 +1089,7 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
     if (!canRegisterRemoteLiveActivities() || !relayTokenProvider) {
       return;
     }
+    const expectedDeviceGeneration = deviceRegistrationGeneration;
 
     let activities = yield* Effect.try({
       try: () => AgentActivity.getInstances(),
@@ -1139,6 +1140,9 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
             cause,
           }),
       }).pipe(Effect.orElseSucceed(() => null));
+      if (expectedDeviceGeneration !== deviceRegistrationGeneration || !relayTokenProvider) {
+        return;
+      }
       // The toggle defaults to on: an unset preference (fresh install) must
       // prime, so only an explicit false blocks it.
       if (preferences?.liveActivitiesEnabled !== false) {

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -31,7 +31,10 @@ import {
   loadPreferences,
   saveAgentAwarenessRegistrationRecord,
 } from "../../persistence/imperative";
-import AgentActivity, { type AgentActivityProps } from "../../widgets/AgentActivity";
+import AgentActivity, {
+  publishAgentActivityWidget,
+  type AgentActivityProps,
+} from "../../widgets/AgentActivity";
 import { resolveCloudPublicConfig } from "../cloud/publicConfig";
 import { supportsAgentAwarenessPush } from "./capabilities";
 import { makeRelayDeviceRegistrationRequest, resolveApsEnvironment } from "./registrationPayload";
@@ -451,6 +454,35 @@ function environmentPublishesAgentActivity(environmentId: EnvironmentId): boolea
   );
 }
 
+function publishHomeScreenWidget(props: AgentActivityProps): void {
+  if (typeof publishAgentActivityWidget !== "function") {
+    return;
+  }
+  publishAgentActivityWidget(props);
+}
+
+function widgetPropsFromAggregate(
+  aggregate: NonNullable<RelayAgentActivitySnapshotResponse["aggregate"]>,
+): AgentActivityProps {
+  return {
+    title: aggregate.title,
+    subtitle: aggregate.subtitle,
+    activeCount: aggregate.activeCount,
+    updatedAt: aggregate.updatedAt,
+    activities: aggregate.activities,
+  };
+}
+
+function idleWidgetProps(): AgentActivityProps {
+  return {
+    title: "T3 Code",
+    subtitle: "No active agents",
+    activeCount: 0,
+    updatedAt: new Date().toISOString(),
+    activities: [],
+  };
+}
+
 // Arms the lock-screen card the moment the user starts agent work from this
 // phone, while the app is still foregrounded and the fresh activity's token
 // can be registered immediately. The seeded row is a best-effort placeholder;
@@ -491,7 +523,7 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
       return;
     }
     const nowIso = new Date(Date.now()).toISOString();
-    const activity = AgentActivity.start({
+    const props: AgentActivityProps = {
       title: "T3 Code",
       subtitle: "Agent work in progress",
       activeCount: 1,
@@ -509,7 +541,9 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
           deepLink: "/",
         },
       ],
-    });
+    };
+    publishHomeScreenWidget(props);
+    const activity = AgentActivity.start(props);
     logRegistrationDebug("live activity card armed for local work", {
       threadTitle: input.threadTitle,
     });
@@ -1057,6 +1091,11 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
       // prime, so only an explicit false blocks it.
       if (preferences?.liveActivitiesEnabled !== false) {
         const snapshot = yield* readAgentActivitySnapshot();
+        if (snapshot) {
+          publishHomeScreenWidget(
+            snapshot.aggregate ? widgetPropsFromAggregate(snapshot.aggregate) : idleWidgetProps(),
+          );
+        }
         // The snapshot request yields; an arm-on-send may have created the
         // card in the meantime. Re-check so two cards are never started.
         const armedMeanwhile = yield* Effect.try({
@@ -1068,14 +1107,7 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
         } else if (snapshot?.aggregate && snapshot.aggregate.activeCount > 0) {
           const aggregate = snapshot.aggregate;
           const primed = yield* Effect.try({
-            try: () =>
-              AgentActivity.start({
-                title: aggregate.title,
-                subtitle: aggregate.subtitle,
-                activeCount: aggregate.activeCount,
-                updatedAt: aggregate.updatedAt,
-                activities: aggregate.activities,
-              }),
+            try: () => AgentActivity.start(widgetPropsFromAggregate(aggregate)),
             catch: (cause) =>
               new AgentAwarenessOperationError({
                 operation: "prime-live-activity",

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -454,13 +454,6 @@ function environmentPublishesAgentActivity(environmentId: EnvironmentId): boolea
   );
 }
 
-function publishHomeScreenWidget(props: AgentActivityProps): void {
-  if (typeof publishAgentActivityWidget !== "function") {
-    return;
-  }
-  publishAgentActivityWidget(props);
-}
-
 function widgetPropsFromAggregate(
   aggregate: NonNullable<RelayAgentActivitySnapshotResponse["aggregate"]>,
 ): AgentActivityProps {
@@ -542,7 +535,7 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
         },
       ],
     };
-    publishHomeScreenWidget(props);
+    publishAgentActivityWidget(props);
     const activity = AgentActivity.start(props);
     logRegistrationDebug("live activity card armed for local work", {
       threadTitle: input.threadTitle,
@@ -1077,7 +1070,7 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
     // "Connecting" snapshot from local arming.
     const snapshot = yield* readAgentActivitySnapshot();
     if (snapshot) {
-      publishHomeScreenWidget(
+      publishAgentActivityWidget(
         snapshot.aggregate ? widgetPropsFromAggregate(snapshot.aggregate) : idleWidgetProps(),
       );
     }

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -118,6 +118,7 @@ let activeLiveActivityRegistrationRetry: ReturnType<typeof setTimeout> | null = 
 let relayTokenProvider: (() => Promise<string | null>) | null = null;
 let relayTokenProviderIdentity: string | null = null;
 let deviceRegistrationGeneration = 0;
+let widgetRefreshGeneration = 0;
 let activeDeviceRegistration: {
   readonly input: DeviceRegistrationInput;
   operation: Promise<void>;
@@ -190,6 +191,7 @@ export function setAgentAwarenessRelayTokenProvider(
     // Without a signed-in user the relay can no longer update or end these
     // activities, so they would sit orphaned on the lock screen.
     endLocalLiveActivities("live activity cleanup after cloud sign-out failed");
+    publishAgentActivityWidget(idleWidgetProps());
     setRegistrationStatus("unknown");
     // Sign-out is the only thing that invalidates a stored registration, so the
     // next sign-in re-registers.
@@ -541,7 +543,10 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
       threadTitle: input.threadTitle,
     });
     runRegistrationInBackground(
-      registerLiveActivityPushToken({ activity }).pipe(Effect.asVoid),
+      registerLiveActivityPushToken({ activity }).pipe(
+        Effect.ensuring(refreshAgentActivityWidget()),
+        Effect.asVoid,
+      ),
       "live activity arming after local task start failed",
     );
   } catch (error) {
@@ -570,6 +575,30 @@ function readAgentActivitySnapshot(): Effect.Effect<
       }),
     ),
   );
+}
+
+function refreshAgentActivityWidget(): Effect.Effect<
+  RelayAgentActivitySnapshotResponse | null,
+  never,
+  ManagedRelay.ManagedRelayClient
+> {
+  return Effect.gen(function* () {
+    const expectedDeviceGeneration = deviceRegistrationGeneration;
+    const expectedRefreshGeneration = ++widgetRefreshGeneration;
+    const snapshot = yield* readAgentActivitySnapshot();
+    if (
+      expectedDeviceGeneration !== deviceRegistrationGeneration ||
+      expectedRefreshGeneration !== widgetRefreshGeneration
+    ) {
+      return null;
+    }
+    if (snapshot) {
+      publishAgentActivityWidget(
+        snapshot.aggregate ? widgetPropsFromAggregate(snapshot.aggregate) : idleWidgetProps(),
+      );
+    }
+    return snapshot;
+  });
 }
 
 function registerLiveActivityWithRelay(
@@ -892,6 +921,7 @@ export function __resetAgentAwarenessRemoteRegistrationForTest(): void {
   relayTokenProvider = null;
   relayTokenProviderIdentity = null;
   deviceRegistrationGeneration++;
+  widgetRefreshGeneration++;
   activeDeviceRegistration = null;
   pendingDeviceRegistration = null;
   registrationStatus = "unknown";
@@ -1068,12 +1098,7 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
     // the latest aggregate even when a Live Activity already exists or the
     // user has turned Live Activities off; otherwise the widget stays on the
     // "Connecting" snapshot from local arming.
-    const snapshot = yield* readAgentActivitySnapshot();
-    if (snapshot) {
-      publishAgentActivityWidget(
-        snapshot.aggregate ? widgetPropsFromAggregate(snapshot.aggregate) : idleWidgetProps(),
-      );
-    }
+    const snapshot = yield* refreshAgentActivityWidget();
 
     // Activities are only ever created here, in the foreground, where the
     // update token can be observed and registered immediately — the relay

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -1122,7 +1122,7 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
     // the latest aggregate even when a Live Activity already exists or the
     // user has turned Live Activities off; otherwise the widget stays on the
     // "Connecting" snapshot from local arming.
-    const snapshot = yield* refreshAgentActivityWidget();
+    yield* refreshAgentActivityWidget();
 
     // Activities are only ever created here, in the foreground, where the
     // update token can be observed and registered immediately — the relay
@@ -1154,8 +1154,12 @@ export function refreshActiveLiveActivityRemoteRegistration(): Effect.Effect<
         }).pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<LiveActivity<AgentActivityProps>>));
         if (armedMeanwhile.length > 0) {
           activities = [...armedMeanwhile];
-        } else if (snapshot?.aggregate && snapshot.aggregate.activeCount > 0) {
-          const aggregate = snapshot.aggregate;
+        } else {
+          const latestSnapshot = yield* refreshAgentActivityWidget();
+          if (!latestSnapshot?.aggregate || latestSnapshot.aggregate.activeCount <= 0) {
+            return;
+          }
+          const aggregate = latestSnapshot.aggregate;
           const primed = yield* Effect.try({
             try: () => AgentActivity.start(widgetPropsFromAggregate(aggregate)),
             catch: (cause) =>

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -502,42 +502,60 @@ export function armAgentAwarenessLiveActivityForLocalWork(input: {
   void loadPreferences()
     .catch(() => null)
     .then((preferences) => {
+      const widgetProps = localWorkStartingWidgetProps(input);
+      publishAgentActivityWidget(widgetProps);
       if (preferences?.liveActivitiesEnabled === false) {
+        runRegistrationInBackground(
+          refreshAgentActivityWidget(),
+          "widget refresh after local task start failed",
+        );
         return;
       }
-      armAgentAwarenessLiveActivityForLocalWorkNow(input);
+      armAgentAwarenessLiveActivityForLocalWorkNow(input, widgetProps);
     });
 }
 
-function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
+function localWorkStartingWidgetProps(input: {
   readonly threadTitle: string;
   readonly projectTitle: string;
-}): void {
+}): AgentActivityProps {
+  const nowIso = new Date(Date.now()).toISOString();
+  return {
+    title: "T3 Code",
+    subtitle: "Agent work in progress",
+    activeCount: 1,
+    updatedAt: nowIso,
+    activities: [
+      {
+        environmentId: "",
+        threadId: "",
+        projectTitle: input.projectTitle,
+        threadTitle: input.threadTitle,
+        modelTitle: "",
+        phase: "starting",
+        status: "Connecting",
+        updatedAt: nowIso,
+        deepLink: "/",
+      },
+    ],
+  };
+}
+
+function armAgentAwarenessLiveActivityForLocalWorkNow(
+  input: {
+    readonly threadTitle: string;
+    readonly projectTitle: string;
+  },
+  props: AgentActivityProps,
+): void {
   try {
     if (AgentActivity.getInstances().length > 0) {
+      runRegistrationInBackground(
+        refreshAgentActivityWidget(),
+        "widget refresh after local task start failed",
+      );
       return;
     }
-    const nowIso = new Date(Date.now()).toISOString();
-    const props: AgentActivityProps = {
-      title: "T3 Code",
-      subtitle: "Agent work in progress",
-      activeCount: 1,
-      updatedAt: nowIso,
-      activities: [
-        {
-          environmentId: "",
-          threadId: "",
-          projectTitle: input.projectTitle,
-          threadTitle: input.threadTitle,
-          modelTitle: "",
-          phase: "starting",
-          status: "Connecting",
-          updatedAt: nowIso,
-          deepLink: "/",
-        },
-      ],
-    };
-    publishAgentActivityWidget(props);
     const activity = AgentActivity.start(props);
     logRegistrationDebug("live activity card armed for local work", {
       threadTitle: input.threadTitle,

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -499,9 +499,13 @@ export function armAgentAwarenessLiveActivityForLocalWork(input: {
     });
     return;
   }
+  const expectedDeviceGeneration = deviceRegistrationGeneration;
   void loadPreferences()
     .catch(() => null)
     .then((preferences) => {
+      if (deviceRegistrationGeneration !== expectedDeviceGeneration || !relayTokenProvider) {
+        return;
+      }
       if (preferences?.liveActivitiesEnabled === false) {
         runRegistrationInBackground(
           refreshAgentActivityWidget(),

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -502,8 +502,6 @@ export function armAgentAwarenessLiveActivityForLocalWork(input: {
   void loadPreferences()
     .catch(() => null)
     .then((preferences) => {
-      const widgetProps = localWorkStartingWidgetProps(input);
-      publishAgentActivityWidget(widgetProps);
       if (preferences?.liveActivitiesEnabled === false) {
         runRegistrationInBackground(
           refreshAgentActivityWidget(),
@@ -511,7 +509,7 @@ export function armAgentAwarenessLiveActivityForLocalWork(input: {
         );
         return;
       }
-      armAgentAwarenessLiveActivityForLocalWorkNow(input, widgetProps);
+      armAgentAwarenessLiveActivityForLocalWorkNow(input);
     });
 }
 
@@ -541,13 +539,10 @@ function localWorkStartingWidgetProps(input: {
   };
 }
 
-function armAgentAwarenessLiveActivityForLocalWorkNow(
-  input: {
-    readonly threadTitle: string;
-    readonly projectTitle: string;
-  },
-  props: AgentActivityProps,
-): void {
+function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
+  readonly threadTitle: string;
+  readonly projectTitle: string;
+}): void {
   try {
     if (AgentActivity.getInstances().length > 0) {
       runRegistrationInBackground(
@@ -556,6 +551,8 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(
       );
       return;
     }
+    const props = localWorkStartingWidgetProps(input);
+    publishAgentActivityWidget(props);
     const activity = AgentActivity.start(props);
     logRegistrationDebug("live activity card armed for local work", {
       threadTitle: input.threadTitle,

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -551,6 +551,10 @@ function armAgentAwarenessLiveActivityForLocalWorkNow(input: {
     );
   } catch (error) {
     logRegistrationError("live activity arming failed", error);
+    runRegistrationInBackground(
+      refreshAgentActivityWidget(),
+      "widget refresh after live activity arming failed",
+    );
   }
 }
 

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -1015,7 +1015,7 @@ export function registerLiveActivityPushToken(input: {
           runRegistrationInBackground(
             registerLiveActivityPushTokenValue({
               activityPushToken: event.pushToken,
-            }),
+            }).pipe(Effect.ensuring(refreshAgentActivityWidget())),
             "live activity token listener registration failed",
           );
         }

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -12,6 +12,7 @@ vi.mock("@expo/ui/swift-ui", () => ({
 }));
 
 vi.mock("@expo/ui/swift-ui/modifiers", () => ({
+  aspectRatio: (value: unknown) => ({ aspectRatio: value }),
   containerBackground: (color: unknown, container: unknown) => ({
     containerBackground: { color, container },
   }),
@@ -315,6 +316,7 @@ describe("AgentActivity widget layout", () => {
     expect(mediumJson).toContain("3 active agents");
     expect(mediumJson).toContain("arrow.up.right");
     expect(mediumJson).not.toContain("folder.fill");
+    expect(mediumJson).toContain('"aspectRatio":{"contentMode":"fit"}');
     expect(mediumJson).toContain("arrow.triangle.2.circlepath");
     expect(mediumJson).toContain("checkmark.circle.fill");
     expect(mediumJson).toContain("First project");

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -340,8 +340,29 @@ describe("AgentActivity widget layout", () => {
     const accessoryJson = JSON.stringify(accessory);
     expect(accessory).not.toHaveProperty("banner");
     expect(accessoryJson).toContain('"containerBackground":{"color":"clear","container":"widget"}');
+    expect(accessoryJson).toContain('"widgetURL":"t3code://threads/env-1/thread-1"');
     expect(accessoryJson).toContain('"all":10');
     expect(accessoryJson).not.toContain('"all":14');
+  });
+
+  it("deep links lock-screen accessory widgets", () => {
+    const accessory = AgentActivity(
+      {
+        ...props,
+        activeCount: 2,
+        activities: [
+          makeRow({}),
+          makeRow({
+            threadId: "thread-2",
+            phase: "waiting_for_approval",
+            status: "Approval",
+            deepLink: "/threads/env-1/thread-2",
+          }),
+        ],
+      },
+      widgetEnvironment("accessoryCircular"),
+    );
+    expect(JSON.stringify(accessory)).toContain('"widgetURL":"t3code://threads/env-1/thread-2"');
   });
 
   it("does not apply containerBackground to the Live Activity layout", () => {

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vite-plus/test";
+import type { WidgetEnvironment } from "expo-widgets";
 
 vi.mock("@expo/ui/swift-ui", () => ({
+  Divider: "Divider",
   HStack: "HStack",
   Image: "Image",
   Spacer: "Spacer",
@@ -71,6 +73,16 @@ const lightEnvironment = {
   isLuminanceReduced: false,
 } as const;
 
+function widgetEnvironment(widgetFamily: WidgetEnvironment["widgetFamily"]): WidgetEnvironment {
+  return {
+    date: new Date(0),
+    widgetFamily,
+    colorScheme: "dark",
+    isLuminanceReduced: false,
+    configuration: undefined,
+  };
+}
+
 describe("AgentActivity widget layout", () => {
   it("tints each row by its own phase using the web sidebar's dark palette", () => {
     const layout = AgentActivity(
@@ -82,7 +94,7 @@ describe("AgentActivity widget layout", () => {
           makeRow({ threadId: "thread-2", phase: "waiting_for_approval", status: "Approval" }),
         ],
       },
-      environment as never,
+      environment,
     );
     const banner = JSON.stringify(layout.banner);
     expect(banner).toContain("#7dd3fc"); // sky-300: running
@@ -101,7 +113,7 @@ describe("AgentActivity widget layout", () => {
           makeRow({ threadId: "thread-2", phase: "waiting_for_approval", status: "Approval" }),
         ],
       },
-      lightEnvironment as never,
+      lightEnvironment,
     );
     const banner = JSON.stringify(layout.banner);
     expect(banner).toContain("#0284c7"); // sky-600: running
@@ -125,7 +137,7 @@ describe("AgentActivity widget layout", () => {
           }),
         ],
       },
-      environment as never,
+      environment,
     );
     const banner = JSON.stringify(layout.banner);
     expect(banner.indexOf("Blocked thread")).toBeGreaterThan(-1);
@@ -142,7 +154,7 @@ describe("AgentActivity widget layout", () => {
           makeRow({ threadId: "thread-2", phase: "waiting_for_input", status: "Input" }),
         ],
       },
-      environment as never,
+      environment,
     );
     const banner = JSON.stringify(layout.banner);
     expect(banner).toContain("3 active agents");
@@ -159,7 +171,7 @@ describe("AgentActivity widget layout", () => {
           makeRow({ threadId: "thread-2", phase: "waiting_for_input", status: "Input" }),
         ],
       },
-      environment as never,
+      environment,
     );
     expect(JSON.stringify(layout.compactLeading)).toContain("#a5b4fc"); // indigo-300
     expect(JSON.stringify(layout.compactTrailing)).toContain("Input");
@@ -181,7 +193,7 @@ describe("AgentActivity widget layout", () => {
           }),
         ],
       },
-      environment as never,
+      environment,
     );
     expect(JSON.stringify(layout.banner)).toContain(
       '"widgetURL":"t3code://threads/env-1/thread-2"',
@@ -189,19 +201,19 @@ describe("AgentActivity widget layout", () => {
   });
 
   it("deep links the banner to the first row when nothing needs attention", () => {
-    const layout = AgentActivity({ ...props, activities: [makeRow({})] }, environment as never);
+    const layout = AgentActivity({ ...props, activities: [makeRow({})] }, environment);
     expect(JSON.stringify(layout.banner)).toContain(
       '"widgetURL":"t3code://threads/env-1/thread-1"',
     );
   });
 
   it("omits the deep link for unsafe paths and empty aggregates", () => {
-    expect(JSON.stringify(AgentActivity(props, environment as never))).not.toContain("widgetURL");
+    expect(JSON.stringify(AgentActivity(props, environment))).not.toContain("widgetURL");
     expect(
       JSON.stringify(
         AgentActivity(
           { ...props, activities: [makeRow({ deepLink: "//evil.example" })] },
-          environment as never,
+          environment,
         ),
       ),
     ).not.toContain("widgetURL");
@@ -215,7 +227,7 @@ describe("AgentActivity widget layout", () => {
         activeCount: 0,
         activities: [makeRow({ phase: "completed", status: "Done" })],
       },
-      environment as never,
+      environment,
     );
     const banner = JSON.stringify(layout.banner);
     expect(banner).toContain("Agent work completed");
@@ -236,7 +248,7 @@ describe("AgentActivity widget layout", () => {
         activeCount: 0,
         activities: [makeRow({ phase: "failed", status: "Failed" })],
       },
-      environment as never,
+      environment,
     );
     const banner = JSON.stringify(layout.banner);
     expect(banner).toContain("Agent work failed");
@@ -260,7 +272,7 @@ describe("AgentActivity widget layout", () => {
           makeRow({ threadId: "thread-2", phase: "failed", status: "Failed" }),
         ],
       },
-      environment as never,
+      environment,
     );
     const banner = JSON.stringify(layout.banner);
     expect(banner).toContain("Agent work failed");
@@ -271,30 +283,60 @@ describe("AgentActivity widget layout", () => {
     expect(JSON.stringify(layout.minimal)).toContain("xmark.octagon.fill");
   });
 
-  it("adopts containerBackground and returns a view for home-screen widgets", () => {
-    const medium = AgentActivity({ ...props, activities: [makeRow({})] }, {
-      ...environment,
-      widgetFamily: "systemMedium",
-    } as never);
+  it("renders branded, top-aligned home-screen layouts", () => {
+    const medium = AgentActivity(
+      {
+        ...props,
+        activeCount: 3,
+        activities: [
+          makeRow({ threadTitle: "First thread", projectTitle: "First project" }),
+          makeRow({
+            threadId: "thread-2",
+            threadTitle: "Second thread",
+            projectTitle: "Second project",
+          }),
+          makeRow({
+            threadId: "thread-3",
+            threadTitle: "Overflow thread",
+            phase: "completed",
+            status: "Done",
+          }),
+        ],
+      },
+      widgetEnvironment("systemMedium"),
+    );
     const mediumJson = JSON.stringify(medium);
     expect(medium).not.toHaveProperty("banner");
     expect(mediumJson).toContain('"containerBackground":{"color":"clear","container":"widget"}');
-    expect(mediumJson).toContain('"all":14');
+    expect(mediumJson).toContain("T3Mark");
+    expect(mediumJson).toContain("Code");
+    expect(mediumJson).toContain("3 active agents");
+    expect(mediumJson).toContain("arrow.up.right");
+    expect(mediumJson).toContain("folder.fill");
+    expect(mediumJson.indexOf("T3Mark")).toBeLessThan(mediumJson.indexOf("First thread"));
+    expect(mediumJson.indexOf("First thread")).toBeLessThan(mediumJson.indexOf("Second thread"));
+    expect(mediumJson).not.toContain("Overflow thread");
+    expect(mediumJson).not.toContain('"all":14');
 
-    const small = AgentActivity({ ...props, activities: [makeRow({})] }, {
-      ...environment,
-      widgetFamily: "systemSmall",
-    } as never);
+    const small = AgentActivity(
+      { ...props, activities: [makeRow({})] },
+      widgetEnvironment("systemSmall"),
+    );
     const smallJson = JSON.stringify(small);
     expect(small).not.toHaveProperty("banner");
     expect(smallJson).toContain('"containerBackground":{"color":"clear","container":"widget"}');
-    expect(smallJson).toContain('"all":10');
+    expect(smallJson).toContain("T3Mark");
+    expect(smallJson).toContain("Code");
+    expect(smallJson).toContain("1 active agent");
+    expect(smallJson).toContain("folder.fill");
+    expect(smallJson.indexOf("T3Mark")).toBeLessThan(smallJson.indexOf("Thread"));
+    expect(smallJson).not.toContain('"all":10');
     expect(smallJson).not.toContain('"all":14');
 
-    const accessory = AgentActivity({ ...props, activities: [makeRow({})] }, {
-      ...environment,
-      widgetFamily: "accessoryRectangular",
-    } as never);
+    const accessory = AgentActivity(
+      { ...props, activities: [makeRow({})] },
+      widgetEnvironment("accessoryRectangular"),
+    );
     const accessoryJson = JSON.stringify(accessory);
     expect(accessory).not.toHaveProperty("banner");
     expect(accessoryJson).toContain('"containerBackground":{"color":"clear","container":"widget"}');
@@ -303,19 +345,13 @@ describe("AgentActivity widget layout", () => {
   });
 
   it("does not apply containerBackground to the Live Activity layout", () => {
-    const layout = AgentActivity({ ...props, activities: [makeRow({})] }, environment as never);
+    const layout = AgentActivity({ ...props, activities: [makeRow({})] }, environment);
     expect(layout).toHaveProperty("banner");
     expect(JSON.stringify(layout)).not.toContain("containerBackground");
   });
 
   it("renders an idle home-screen widget when props are missing", () => {
-    const view = AgentActivity(
-      {} as AgentActivityProps,
-      {
-        ...environment,
-        widgetFamily: "systemMedium",
-      } as never,
-    );
+    const view = AgentActivity({} as AgentActivityProps, widgetEnvironment("systemMedium"));
     const json = JSON.stringify(view);
     expect(json).toContain("No active agents");
     expect(json).toContain('"containerBackground":{"color":"clear","container":"widget"}');
@@ -331,7 +367,7 @@ describe("AgentActivity widget layout", () => {
           makeRow({ threadId: `t${n}`, threadTitle: `Thread ${n}` }),
         ),
       },
-      environment as never,
+      environment,
     );
     const banner = JSON.stringify(layout.banner);
     for (const visible of [1, 2, 3, 4, 5]) {

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -10,6 +10,9 @@ vi.mock("@expo/ui/swift-ui", () => ({
 }));
 
 vi.mock("@expo/ui/swift-ui/modifiers", () => ({
+  containerBackground: (color: unknown, container: unknown) => ({
+    containerBackground: { color, container },
+  }),
   font: (value: unknown) => value,
   foregroundStyle: (value: unknown) => value,
   frame: (value: unknown) => value,
@@ -22,6 +25,11 @@ vi.mock("@expo/ui/swift-ui/modifiers", () => ({
 
 vi.mock("expo-widgets", () => ({
   createLiveActivity: vi.fn((name: string, layout: unknown) => ({ layout, name })),
+  createWidget: vi.fn((name: string, layout: unknown) => ({
+    layout,
+    name,
+    updateSnapshot: vi.fn(),
+  })),
 }));
 
 import {
@@ -261,6 +269,47 @@ describe("AgentActivity widget layout", () => {
     expect(JSON.stringify(layout.compactTrailing)).toContain("Failed");
     expect(JSON.stringify(layout.expandedLeading)).toContain("Failed");
     expect(JSON.stringify(layout.minimal)).toContain("xmark.octagon.fill");
+  });
+
+  it("adopts containerBackground and returns a view for home-screen widgets", () => {
+    const medium = AgentActivity({ ...props, activities: [makeRow({})] }, {
+      ...environment,
+      widgetFamily: "systemMedium",
+    } as never);
+    const mediumJson = JSON.stringify(medium);
+    expect(medium).not.toHaveProperty("banner");
+    expect(mediumJson).toContain('"containerBackground":{"color":"clear","container":"widget"}');
+    expect(mediumJson).toContain('"all":14');
+
+    const small = AgentActivity({ ...props, activities: [makeRow({})] }, {
+      ...environment,
+      widgetFamily: "systemSmall",
+    } as never);
+    const smallJson = JSON.stringify(small);
+    expect(small).not.toHaveProperty("banner");
+    expect(smallJson).toContain('"containerBackground":{"color":"clear","container":"widget"}');
+    expect(smallJson).toContain('"all":10');
+    expect(smallJson).not.toContain('"all":14');
+  });
+
+  it("does not apply containerBackground to the Live Activity layout", () => {
+    const layout = AgentActivity({ ...props, activities: [makeRow({})] }, environment as never);
+    expect(layout).toHaveProperty("banner");
+    expect(JSON.stringify(layout)).not.toContain("containerBackground");
+  });
+
+  it("renders an idle home-screen widget when props are missing", () => {
+    const view = AgentActivity(
+      {} as AgentActivityProps,
+      {
+        ...environment,
+        widgetFamily: "systemMedium",
+      } as never,
+    );
+    const json = JSON.stringify(view);
+    expect(json).toContain("No active agents");
+    expect(json).toContain('"containerBackground":{"color":"clear","container":"widget"}');
+    expect(json).not.toContain("0 active");
   });
 
   it("renders up to five rows in the banner", () => {

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -283,7 +283,7 @@ describe("AgentActivity widget layout", () => {
     expect(JSON.stringify(layout.minimal)).toContain("xmark.octagon.fill");
   });
 
-  it("renders branded, top-aligned home-screen layouts", () => {
+  it("renders branded, top-aligned home-screen layouts with status icons", () => {
     const medium = AgentActivity(
       {
         ...props,
@@ -294,6 +294,8 @@ describe("AgentActivity widget layout", () => {
             threadId: "thread-2",
             threadTitle: "Second thread",
             projectTitle: "Second project",
+            phase: "completed",
+            status: "Done",
           }),
           makeRow({
             threadId: "thread-3",
@@ -312,7 +314,11 @@ describe("AgentActivity widget layout", () => {
     expect(mediumJson).toContain("Code");
     expect(mediumJson).toContain("3 active agents");
     expect(mediumJson).toContain("arrow.up.right");
-    expect(mediumJson).toContain("folder.fill");
+    expect(mediumJson).not.toContain("folder.fill");
+    expect(mediumJson).toContain("arrow.triangle.2.circlepath");
+    expect(mediumJson).toContain("checkmark.circle.fill");
+    expect(mediumJson).toContain("First project");
+    expect(mediumJson).toContain("Second project");
     expect(mediumJson.indexOf("T3Mark")).toBeLessThan(mediumJson.indexOf("First thread"));
     expect(mediumJson.indexOf("First thread")).toBeLessThan(mediumJson.indexOf("Second thread"));
     expect(mediumJson).not.toContain("Overflow thread");
@@ -328,7 +334,9 @@ describe("AgentActivity widget layout", () => {
     expect(smallJson).toContain("T3Mark");
     expect(smallJson).toContain("Code");
     expect(smallJson).toContain("1 active agent");
-    expect(smallJson).toContain("folder.fill");
+    expect(smallJson).not.toContain("folder.fill");
+    expect(smallJson).toContain("arrow.triangle.2.circlepath");
+    expect(smallJson).toContain("Project");
     expect(smallJson.indexOf("T3Mark")).toBeLessThan(smallJson.indexOf("Thread"));
     expect(smallJson).not.toContain('"all":10');
     expect(smallJson).not.toContain('"all":14');

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -290,6 +290,16 @@ describe("AgentActivity widget layout", () => {
     expect(smallJson).toContain('"containerBackground":{"color":"clear","container":"widget"}');
     expect(smallJson).toContain('"all":10');
     expect(smallJson).not.toContain('"all":14');
+
+    const accessory = AgentActivity({ ...props, activities: [makeRow({})] }, {
+      ...environment,
+      widgetFamily: "accessoryRectangular",
+    } as never);
+    const accessoryJson = JSON.stringify(accessory);
+    expect(accessory).not.toHaveProperty("banner");
+    expect(accessoryJson).toContain('"containerBackground":{"color":"clear","container":"widget"}');
+    expect(accessoryJson).toContain('"all":10');
+    expect(accessoryJson).not.toContain('"all":14');
   });
 
   it("does not apply containerBackground to the Live Activity layout", () => {

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -382,11 +382,13 @@ describe("AgentActivity widget layout", () => {
   });
 
   it("renders an idle home-screen widget when props are missing", () => {
-    const view = AgentActivity({} as AgentActivityProps, widgetEnvironment("systemMedium"));
-    const json = JSON.stringify(view);
-    expect(json).toContain("No active agents");
-    expect(json).toContain('"containerBackground":{"color":"clear","container":"widget"}');
-    expect(json).not.toContain("0 active");
+    for (const family of ["systemSmall", "systemMedium"] as const) {
+      const view = AgentActivity({} as AgentActivityProps, widgetEnvironment(family));
+      const json = JSON.stringify(view);
+      expect(json.match(/No active agents/g)).toHaveLength(1);
+      expect(json).toContain('"containerBackground":{"color":"clear","container":"widget"}');
+      expect(json).not.toContain("0 active");
+    }
   });
 
   it("renders up to five rows in the banner", () => {

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -391,6 +391,45 @@ describe("AgentActivity widget layout", () => {
     }
   });
 
+  it.each(["systemSmall", "systemMedium", "accessoryRectangular"] as const)(
+    "distinguishes unavailable counts from idle in the serialized %s widget layout",
+    (family) => {
+      const view = AgentActivity(
+        { ...props, activeCount: null, activities: [makeRow({})] },
+        widgetEnvironment(family),
+      );
+      const json = JSON.stringify(view);
+      expect(json).toContain(
+        family === "accessoryRectangular" ? "Count unavailable" : "Activity count unavailable",
+      );
+      expect(json).toContain("Working");
+      expect(json).not.toContain("No active agents");
+      expect(json).not.toContain("null active");
+    },
+  );
+
+  it.each(["systemSmall", "systemMedium", "accessoryRectangular"] as const)(
+    "labels retained observations in the serialized %s widget layout",
+    (family) => {
+      const view = AgentActivity(
+        { ...props, isStale: true, activities: [makeRow({})] },
+        widgetEnvironment(family),
+      );
+      expect(JSON.stringify(view)).toContain("Last observed: 1 active");
+      const done = AgentActivity(
+        {
+          ...props,
+          isStale: true,
+          activeCount: 0,
+          activities: [makeRow({ phase: "completed", status: "Done" })],
+        },
+        widgetEnvironment(family),
+      );
+      expect(JSON.stringify(done)).toContain("Last observed:");
+      expect(JSON.stringify(done)).toContain("Done");
+    },
+  );
+
   it("renders up to five rows in the banner", () => {
     const layout = AgentActivity(
       {

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -37,6 +37,8 @@ vi.mock("expo-widgets", () => ({
 
 import {
   AgentActivity,
+  AgentActivityWidget,
+  publishAgentActivityWidget,
   type AgentActivityProps,
   type AgentActivityRowProps,
 } from "./AgentActivity";
@@ -447,4 +449,12 @@ describe("AgentActivity widget layout", () => {
     }
     expect(banner).not.toContain("Thread 6");
   });
+});
+
+it("reports a failed native widget snapshot so the caller can retry", () => {
+  vi.mocked(AgentActivityWidget.updateSnapshot).mockImplementationOnce(() => {
+    throw new Error("native update failed");
+  });
+  expect(publishAgentActivityWidget(props)).toBe(false);
+  expect(publishAgentActivityWidget(props)).toBe(true);
 });

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -1,6 +1,7 @@
 import { HStack, Image, Spacer, Text, VStack, ZStack } from "@expo/ui/swift-ui";
 import type { ComponentProps } from "react";
 import {
+  containerBackground,
   font,
   foregroundStyle,
   frame,
@@ -12,11 +13,10 @@ import {
 } from "@expo/ui/swift-ui/modifiers";
 import {
   createLiveActivity,
+  createWidget,
   type LiveActivityComponent,
   type LiveActivityLayout,
 } from "expo-widgets";
-
-type LiveActivityEnvironment = Parameters<LiveActivityComponent<AgentActivityProps>>[1];
 
 export type AgentActivityPhase =
   | "starting"
@@ -47,14 +47,43 @@ export interface AgentActivityProps {
   readonly activities: ReadonlyArray<AgentActivityRowProps>;
 }
 
+type LiveActivityEnvironment = Parameters<LiveActivityComponent<AgentActivityProps>>[1];
+
+// Home-screen widgets pass widgetFamily; Live Activities do not. The same
+// serialized function serves both surfaces.
+type AgentActivityEnvironment = LiveActivityEnvironment & {
+  readonly widgetFamily?:
+    | "systemSmall"
+    | "systemMedium"
+    | "systemLarge"
+    | "systemExtraLarge"
+    | "accessoryCircular"
+    | "accessoryRectangular"
+    | "accessoryInline";
+};
+
 // This function is serialized into the widget extension's JS bundle, so it
 // must stay self-contained: no references to module-scope helpers, only the
 // imported view/modifier factories.
 export function AgentActivity(
   props: AgentActivityProps,
-  environment: LiveActivityEnvironment,
+  environment: AgentActivityEnvironment,
 ): LiveActivityLayout {
   "widget";
+
+  // Placeholder / first-paint entries arrive with empty props. Treat missing
+  // fields as idle rather than throwing inside the widget JS runtime.
+  const activities = Array.isArray(props.activities) ? props.activities : [];
+  const activeCount = typeof props.activeCount === "number" ? props.activeCount : 0;
+  const widgetFamily = environment.widgetFamily;
+  const isHomeScreenWidget = typeof widgetFamily === "string";
+  const useCompactWidget =
+    widgetFamily === "systemSmall" ||
+    widgetFamily === "accessoryCircular" ||
+    widgetFamily === "accessoryInline";
+  // expo-widgets 56 stopped applying this natively. iOS 17+ home-screen
+  // widgets that omit it render "Please adopt containerBackground API".
+  const homeScreenBackground = isHomeScreenWidget ? [containerBackground("clear", "widget")] : [];
 
   // Use SwiftUI's semantic label colors rather than fixed hex keyed off the
   // device color scheme. A Live Activity banner always renders over a dark
@@ -100,20 +129,18 @@ export function AgentActivity(
     if (phase === "running" || phase === "starting") return 2;
     return 3;
   };
-  const ordered = [...props.activities].sort(
-    (a, b) => phasePriority(a.phase) - phasePriority(b.phase),
-  );
+  const ordered = [...activities].sort((a, b) => phasePriority(a.phase) - phasePriority(b.phase));
   const row0 = ordered[0];
   const row1 = ordered[1];
   const row2 = ordered[2];
   const row3 = ordered[3];
   const row4 = ordered[4];
 
-  const attentionRows = props.activities.filter(
+  const attentionRows = activities.filter(
     (row) => row.phase === "waiting_for_approval" || row.phase === "waiting_for_input",
   );
   const attentionRow = attentionRows[0];
-  const failedRow = props.activities.find((row) => row.phase === "failed");
+  const failedRow = activities.find((row) => row.phase === "failed");
   const heroRow = attentionRow ?? failedRow ?? row0;
   const tint = phaseTint(heroRow?.phase);
   // Headline count leans on the accent when a human is actually blocked.
@@ -130,20 +157,25 @@ export function AgentActivity(
   // terminal row): every presentation — header text, tint, count slots,
   // minimal glyph — must agree, and a failure anywhere should dominate a
   // newer success.
-  const allDone = props.activeCount === 0;
-  const doneLabel = failedRow ? "Failed" : "Done";
-  const outcomeLabel = failedRow ? "Agent work failed" : "Agent work completed";
+  const allDone = activeCount === 0;
+  const hasRows = activities.length > 0;
+  const doneLabel = failedRow ? "Failed" : hasRows ? "Done" : "Idle";
+  const outcomeLabel = failedRow
+    ? "Agent work failed"
+    : hasRows
+      ? "Agent work completed"
+      : "No active agents";
 
   // Header copy: "5 active agents" + (", 1 needs attention"). The banner renders
   // the two parts in-line so the attention half can carry the accent color;
   // `summary` is the short form for tight spots (expanded center, watch card).
-  const agentWord = props.activeCount === 1 ? "agent" : "agents";
-  const agentsLabel = allDone ? outcomeLabel : `${props.activeCount} active ${agentWord}`;
+  const agentWord = activeCount === 1 ? "agent" : "agents";
+  const agentsLabel = allDone ? outcomeLabel : `${activeCount} active ${agentWord}`;
   const attentionSuffix =
     attentionRows.length > 0
       ? `${attentionRows.length} need${attentionRows.length === 1 ? "s" : ""} attention`
       : "";
-  const activeLabel = allDone ? doneLabel : `${props.activeCount} active`;
+  const activeLabel = allDone ? doneLabel : `${activeCount} active`;
   const summary = attentionSuffix || activeLabel;
 
   // Any registered scheme variant routes back to this app; taps are delivered
@@ -235,94 +267,109 @@ export function AgentActivity(
     </HStack>
   );
 
-  return {
-    banner: (
-      <VStack
-        alignment="leading"
-        spacing={6}
-        modifiers={deepLink ? [padding({ all: 14 }), widgetURL(deepLink)] : [padding({ all: 14 })]}
-      >
-        {/* Logo pinned to the leading edge; the status texts centered across the
-            full width (ZStack so the logo doesn't skew the centering). No footer —
-            overflow beyond the visible rows is inferable from the count. */}
-        <ZStack>
-          <HStack spacing={0} alignment="center">
-            {renderLogo(13, primaryForeground)}
-            <Spacer minLength={0} />
-          </HStack>
-          <HStack spacing={6} alignment="center">
-            <Spacer minLength={0} />
-            <Text
-              modifiers={[
-                font({ weight: "semibold", size: 13 }),
-                // The all-done header carries the outcome tint (emerald /
-                // red) the way the Done/Failed status labels do.
-                foregroundStyle(allDone ? headerTint : primaryForeground),
-                lineLimit(1),
-              ]}
-            >
-              {agentsLabel}
-            </Text>
-            {attentionSuffix ? (
-              <Text modifiers={[font({ size: 13 }), foregroundStyle(secondaryForeground)]}>·</Text>
-            ) : null}
-            {attentionSuffix ? (
-              <Text
-                modifiers={[
-                  font({ weight: "semibold", size: 13 }),
-                  foregroundStyle(headerTint),
-                  lineLimit(1),
-                ]}
-              >
-                {attentionSuffix}
-              </Text>
-            ) : null}
-            <Spacer minLength={0} />
-          </HStack>
-        </ZStack>
-        {row0 ? renderCompactRow(row0) : null}
-        {row1 ? renderCompactRow(row1) : null}
-        {row2 ? renderCompactRow(row2) : null}
-        {row3 ? renderCompactRow(row3) : null}
-        {row4 ? renderCompactRow(row4) : null}
-      </VStack>
-    ),
-    // Compact card for the watchOS Smart Stack + CarPlay (the `.small` family):
-    // brand + count, then the single most important agent with its status glyph.
-    bannerSmall: (
-      <VStack alignment="leading" spacing={5} modifiers={[padding({ all: 10 })]}>
-        <HStack spacing={7} alignment="center">
-          {renderLogo(14, primaryForeground)}
+  const banner = (
+    <VStack
+      alignment="leading"
+      spacing={6}
+      modifiers={[
+        padding({ all: 14 }),
+        ...(deepLink ? [widgetURL(deepLink)] : []),
+        ...homeScreenBackground,
+      ]}
+    >
+      {/* Logo pinned to the leading edge; the status texts centered across the
+          full width (ZStack so the logo doesn't skew the centering). No footer —
+          overflow beyond the visible rows is inferable from the count. */}
+      <ZStack>
+        <HStack spacing={0} alignment="center">
+          {renderLogo(13, primaryForeground)}
+          <Spacer minLength={0} />
+        </HStack>
+        <HStack spacing={6} alignment="center">
+          <Spacer minLength={0} />
           <Text
             modifiers={[
-              font({ weight: "bold", size: 13 }),
-              foregroundStyle(headerTint),
+              font({ weight: "semibold", size: 13 }),
+              // The all-done header carries the outcome tint (emerald /
+              // red) the way the Done/Failed status labels do.
+              foregroundStyle(allDone ? headerTint : primaryForeground),
               lineLimit(1),
             ]}
           >
-            {attentionRows.length > 0 ? summary : activeLabel}
+            {agentsLabel}
           </Text>
-          <Spacer minLength={6} />
-        </HStack>
-        {row0 ? (
-          <HStack spacing={7} alignment="center">
+          {attentionSuffix ? (
+            <Text modifiers={[font({ size: 13 }), foregroundStyle(secondaryForeground)]}>·</Text>
+          ) : null}
+          {attentionSuffix ? (
             <Text
               modifiers={[
-                font({ weight: "semibold", size: 12 }),
-                foregroundStyle(primaryForeground),
+                font({ weight: "semibold", size: 13 }),
+                foregroundStyle(headerTint),
                 lineLimit(1),
               ]}
             >
-              {row0.threadTitle}
+              {attentionSuffix}
             </Text>
-            <Spacer minLength={6} />
-            <Text modifiers={[font({ size: 11 }), foregroundStyle(phaseTint(row0.phase))]}>
-              {row0.status}
-            </Text>
-          </HStack>
-        ) : null}
-      </VStack>
-    ),
+          ) : null}
+          <Spacer minLength={0} />
+        </HStack>
+      </ZStack>
+      {row0 ? renderCompactRow(row0) : null}
+      {row1 ? renderCompactRow(row1) : null}
+      {row2 ? renderCompactRow(row2) : null}
+      {row3 ? renderCompactRow(row3) : null}
+      {row4 ? renderCompactRow(row4) : null}
+    </VStack>
+  );
+  // Compact card for the watchOS Smart Stack + CarPlay (the `.small` family)
+  // and the home-screen systemSmall widget.
+  const bannerSmall = (
+    <VStack
+      alignment="leading"
+      spacing={5}
+      modifiers={[padding({ all: 10 }), ...homeScreenBackground]}
+    >
+      <HStack spacing={7} alignment="center">
+        {renderLogo(14, primaryForeground)}
+        <Text
+          modifiers={[
+            font({ weight: "bold", size: 13 }),
+            foregroundStyle(headerTint),
+            lineLimit(1),
+          ]}
+        >
+          {attentionRows.length > 0 ? summary : activeLabel}
+        </Text>
+        <Spacer minLength={6} />
+      </HStack>
+      {row0 ? (
+        <HStack spacing={7} alignment="center">
+          <Text
+            modifiers={[
+              font({ weight: "semibold", size: 12 }),
+              foregroundStyle(primaryForeground),
+              lineLimit(1),
+            ]}
+          >
+            {row0.threadTitle}
+          </Text>
+          <Spacer minLength={6} />
+          <Text modifiers={[font({ size: 11 }), foregroundStyle(phaseTint(row0.phase))]}>
+            {row0.status}
+          </Text>
+        </HStack>
+      ) : null}
+    </VStack>
+  );
+
+  if (isHomeScreenWidget) {
+    return (useCompactWidget ? bannerSmall : banner) as unknown as LiveActivityLayout;
+  }
+
+  return {
+    banner,
+    bannerSmall,
     compactLeading: renderLogo(14, tint),
     compactTrailing: (
       <Text modifiers={[font({ weight: "semibold", size: 11 }), foregroundStyle(tint)]}>
@@ -344,7 +391,7 @@ export function AgentActivity(
       <HStack spacing={5} alignment="center" modifiers={[padding({ leading: 4, vertical: 4 })]}>
         {renderLogo(15, tint)}
         <Text modifiers={[font({ weight: "bold", size: 13 }), foregroundStyle(tint)]}>
-          {allDone ? doneLabel : `${props.activeCount}`}
+          {allDone ? doneLabel : `${activeCount}`}
         </Text>
       </HStack>
     ),
@@ -376,6 +423,19 @@ export function AgentActivity(
       </VStack>
     ),
   };
+}
+
+export const AgentActivityWidget = createWidget<AgentActivityProps>(
+  "AgentActivity",
+  AgentActivity as never,
+);
+
+export function publishAgentActivityWidget(props: AgentActivityProps): void {
+  try {
+    AgentActivityWidget.updateSnapshot(props);
+  } catch {
+    // Personal-team and Android builds have no widget extension.
+  }
 }
 
 export default createLiveActivity<AgentActivityProps>("AgentActivity", AgentActivity);

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -315,8 +315,8 @@ export function AgentActivity(
     ];
     const homeSummaryTint = allDone && !hasRows ? secondaryForeground : headerTint;
     const homeSummary = attentionSuffix || agentsLabel;
-    const renderHomeProjectIcon = (size: number) =>
-      renderGlyph("folder.fill", size, secondaryForeground);
+    const renderHomeStatusIcon = (row: AgentActivityRowProps, size: number) =>
+      renderGlyph(phaseSymbol(row.phase), size, phaseTint(row.phase));
 
     if (widgetFamily === "systemSmall") {
       return (
@@ -360,7 +360,7 @@ export function AgentActivity(
           )}
           {heroRow ? (
             <HStack spacing={5} alignment="center">
-              {renderHomeProjectIcon(11)}
+              {renderHomeStatusIcon(heroRow, 11)}
               <Text
                 modifiers={[font({ size: 11 }), foregroundStyle(secondaryForeground), lineLimit(1)]}
               >
@@ -386,7 +386,7 @@ export function AgentActivity(
 
     const renderHomeRow = (row: AgentActivityRowProps) => (
       <HStack spacing={9} alignment="center">
-        {renderHomeProjectIcon(17)}
+        {renderHomeStatusIcon(row, 17)}
         <VStack alignment="leading" spacing={1}>
           <Text
             modifiers={[

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -1,5 +1,5 @@
-import { HStack, Image, Spacer, Text, VStack, ZStack } from "@expo/ui/swift-ui";
-import type { ComponentProps } from "react";
+import { Divider, HStack, Image, Spacer, Text, VStack, ZStack } from "@expo/ui/swift-ui";
+import type { ComponentProps, JSX } from "react";
 import {
   containerBackground,
   font,
@@ -14,8 +14,9 @@ import {
 import {
   createLiveActivity,
   createWidget,
-  type LiveActivityComponent,
+  type LiveActivityEnvironment,
   type LiveActivityLayout,
+  type WidgetEnvironment,
 } from "expo-widgets";
 
 export type AgentActivityPhase =
@@ -47,44 +48,28 @@ export interface AgentActivityProps {
   readonly activities: ReadonlyArray<AgentActivityRowProps>;
 }
 
-type LiveActivityEnvironment = Parameters<LiveActivityComponent<AgentActivityProps>>[1];
-
-// Home-screen widgets pass widgetFamily; Live Activities do not. The same
-// serialized function serves both surfaces.
-type AgentActivityEnvironment = LiveActivityEnvironment & {
-  readonly widgetFamily?:
-    | "systemSmall"
-    | "systemMedium"
-    | "systemLarge"
-    | "systemExtraLarge"
-    | "accessoryCircular"
-    | "accessoryRectangular"
-    | "accessoryInline";
-};
-
 // This function is serialized into the widget extension's JS bundle, so it
 // must stay self-contained: no references to module-scope helpers, only the
 // imported view/modifier factories.
 export function AgentActivity(
   props: AgentActivityProps,
-  environment: AgentActivityEnvironment,
-): LiveActivityLayout {
+  environment: WidgetEnvironment,
+): JSX.Element;
+export function AgentActivity(
+  props: AgentActivityProps,
+  environment: LiveActivityEnvironment,
+): LiveActivityLayout;
+export function AgentActivity(
+  props: AgentActivityProps,
+  environment: WidgetEnvironment | LiveActivityEnvironment,
+): JSX.Element | LiveActivityLayout {
   "widget";
 
   // Placeholder / first-paint entries arrive with empty props. Treat missing
   // fields as idle rather than throwing inside the widget JS runtime.
   const activities = Array.isArray(props.activities) ? props.activities : [];
   const activeCount = typeof props.activeCount === "number" ? props.activeCount : 0;
-  const widgetFamily = environment.widgetFamily;
-  const isHomeScreenWidget = typeof widgetFamily === "string";
-  const useCompactWidget =
-    widgetFamily === "systemSmall" ||
-    widgetFamily === "accessoryCircular" ||
-    widgetFamily === "accessoryInline" ||
-    widgetFamily === "accessoryRectangular";
-  // expo-widgets 56 stopped applying this natively. iOS 17+ home-screen
-  // widgets that omit it render "Please adopt containerBackground API".
-  const homeScreenBackground = isHomeScreenWidget ? [containerBackground("clear", "widget")] : [];
+  const widgetFamily = "widgetFamily" in environment ? environment.widgetFamily : undefined;
 
   // Use SwiftUI's semantic label colors rather than fixed hex keyed off the
   // device color scheme. A Live Activity banner always renders over a dark
@@ -268,15 +253,214 @@ export function AgentActivity(
     </HStack>
   );
 
+  // Compact card for the watchOS Smart Stack + CarPlay (the `.small` family)
+  // and lock-screen accessory widgets.
+  const renderCompactLayout = () => (
+    <VStack
+      alignment="leading"
+      spacing={5}
+      modifiers={[
+        padding({ all: 10 }),
+        ...(widgetFamily ? [containerBackground("clear", "widget")] : []),
+      ]}
+    >
+      <HStack spacing={7} alignment="center">
+        {renderLogo(14, primaryForeground)}
+        <Text
+          modifiers={[
+            font({ weight: "bold", size: 13 }),
+            foregroundStyle(headerTint),
+            lineLimit(1),
+          ]}
+        >
+          {attentionRows.length > 0 ? summary : activeLabel}
+        </Text>
+        <Spacer minLength={6} />
+      </HStack>
+      {row0 ? (
+        <HStack spacing={7} alignment="center">
+          <Text
+            modifiers={[
+              font({ weight: "semibold", size: 12 }),
+              foregroundStyle(primaryForeground),
+              lineLimit(1),
+            ]}
+          >
+            {row0.threadTitle}
+          </Text>
+          <Spacer minLength={6} />
+          <Text modifiers={[font({ size: 11 }), foregroundStyle(phaseTint(row0.phase))]}>
+            {row0.status}
+          </Text>
+        </HStack>
+      ) : null}
+    </VStack>
+  );
+
+  if (
+    widgetFamily === "accessoryCircular" ||
+    widgetFamily === "accessoryInline" ||
+    widgetFamily === "accessoryRectangular"
+  ) {
+    return renderCompactLayout();
+  }
+
+  if (widgetFamily) {
+    // iOS supplies content margins for home-screen widgets, so adding explicit
+    // padding here would double-inset the layout.
+    const widgetModifiers = [
+      ...(deepLink ? [widgetURL(deepLink)] : []),
+      containerBackground("clear", "widget"),
+    ];
+    const homeSummaryTint = allDone && !hasRows ? secondaryForeground : headerTint;
+    const homeSummary = attentionSuffix || agentsLabel;
+    const renderHomeProjectIcon = (size: number) =>
+      renderGlyph("folder.fill", size, secondaryForeground);
+
+    if (widgetFamily === "systemSmall") {
+      return (
+        <VStack alignment="leading" spacing={5} modifiers={widgetModifiers}>
+          <HStack spacing={5} alignment="center" modifiers={[padding({ bottom: 3 })]}>
+            {renderLogo(12, primaryForeground)}
+            <Text
+              modifiers={[
+                font({ weight: "medium", size: 12 }),
+                foregroundStyle(secondaryForeground),
+              ]}
+            >
+              Code
+            </Text>
+            <Spacer minLength={4} />
+            {renderGlyph("arrow.up.right", 10, secondaryForeground)}
+          </HStack>
+          <Text
+            modifiers={[
+              font({ weight: "bold", size: 15 }),
+              foregroundStyle(homeSummaryTint),
+              lineLimit(1),
+            ]}
+          >
+            {homeSummary}
+          </Text>
+          {heroRow ? (
+            <Text
+              modifiers={[
+                font({ weight: "semibold", size: 12 }),
+                foregroundStyle(primaryForeground),
+                lineLimit(2),
+              ]}
+            >
+              {heroRow.threadTitle}
+            </Text>
+          ) : (
+            <Text modifiers={[font({ size: 11 }), foregroundStyle(secondaryForeground)]}>
+              {outcomeLabel}
+            </Text>
+          )}
+          {heroRow ? (
+            <HStack spacing={5} alignment="center">
+              {renderHomeProjectIcon(11)}
+              <Text
+                modifiers={[font({ size: 11 }), foregroundStyle(secondaryForeground), lineLimit(1)]}
+              >
+                {heroRow.projectTitle}
+              </Text>
+              <Spacer minLength={4} />
+              <Text
+                modifiers={[
+                  font({ weight: "semibold", size: 11 }),
+                  foregroundStyle(phaseTint(heroRow.phase)),
+                  lineLimit(1),
+                  layoutPriority(1),
+                ]}
+              >
+                {heroRow.status}
+              </Text>
+            </HStack>
+          ) : null}
+          <Spacer minLength={0} />
+        </VStack>
+      );
+    }
+
+    const renderHomeRow = (row: AgentActivityRowProps) => (
+      <HStack spacing={9} alignment="center">
+        {renderHomeProjectIcon(17)}
+        <VStack alignment="leading" spacing={1}>
+          <Text
+            modifiers={[
+              font({ weight: "semibold", size: 13 }),
+              foregroundStyle(primaryForeground),
+              lineLimit(1),
+            ]}
+          >
+            {row.threadTitle}
+          </Text>
+          <Text
+            modifiers={[font({ size: 11 }), foregroundStyle(secondaryForeground), lineLimit(1)]}
+          >
+            {row.projectTitle}
+          </Text>
+        </VStack>
+        <Spacer minLength={8} />
+        <Text
+          modifiers={[
+            font({ weight: "semibold", size: 12 }),
+            foregroundStyle(phaseTint(row.phase)),
+            layoutPriority(1),
+          ]}
+        >
+          {row.status}
+        </Text>
+      </HStack>
+    );
+
+    return (
+      <VStack alignment="leading" spacing={0} modifiers={widgetModifiers}>
+        <HStack spacing={5} alignment="center" modifiers={[padding({ bottom: 10 })]}>
+          {renderLogo(13, primaryForeground)}
+          <Text
+            modifiers={[font({ weight: "medium", size: 13 }), foregroundStyle(secondaryForeground)]}
+          >
+            Code
+          </Text>
+          <Spacer minLength={8} />
+          <Text
+            modifiers={[
+              font({ weight: "semibold", size: 12 }),
+              foregroundStyle(homeSummaryTint),
+              lineLimit(1),
+              layoutPriority(1),
+            ]}
+          >
+            {homeSummary}
+          </Text>
+          {renderGlyph("arrow.up.right", 10, secondaryForeground)}
+        </HStack>
+        {row0 ? (
+          renderHomeRow(row0)
+        ) : (
+          <Text
+            modifiers={[
+              font({ weight: "semibold", size: 14 }),
+              foregroundStyle(secondaryForeground),
+            ]}
+          >
+            {outcomeLabel}
+          </Text>
+        )}
+        {row1 ? <Divider modifiers={[padding({ vertical: 7, leading: 26 })]} /> : null}
+        {row1 ? renderHomeRow(row1) : null}
+        <Spacer minLength={0} />
+      </VStack>
+    );
+  }
+
   const banner = (
     <VStack
       alignment="leading"
       spacing={6}
-      modifiers={[
-        padding({ all: 14 }),
-        ...(deepLink ? [widgetURL(deepLink)] : []),
-        ...homeScreenBackground,
-      ]}
+      modifiers={[padding({ all: 14 }), ...(deepLink ? [widgetURL(deepLink)] : [])]}
     >
       {/* Logo pinned to the leading edge; the status texts centered across the
           full width (ZStack so the logo doesn't skew the centering). No footer —
@@ -323,54 +507,10 @@ export function AgentActivity(
       {row4 ? renderCompactRow(row4) : null}
     </VStack>
   );
-  // Compact card for the watchOS Smart Stack + CarPlay (the `.small` family),
-  // the home-screen systemSmall widget, and lock-screen accessory families.
-  const bannerSmall = (
-    <VStack
-      alignment="leading"
-      spacing={5}
-      modifiers={[padding({ all: 10 }), ...homeScreenBackground]}
-    >
-      <HStack spacing={7} alignment="center">
-        {renderLogo(14, primaryForeground)}
-        <Text
-          modifiers={[
-            font({ weight: "bold", size: 13 }),
-            foregroundStyle(headerTint),
-            lineLimit(1),
-          ]}
-        >
-          {attentionRows.length > 0 ? summary : activeLabel}
-        </Text>
-        <Spacer minLength={6} />
-      </HStack>
-      {row0 ? (
-        <HStack spacing={7} alignment="center">
-          <Text
-            modifiers={[
-              font({ weight: "semibold", size: 12 }),
-              foregroundStyle(primaryForeground),
-              lineLimit(1),
-            ]}
-          >
-            {row0.threadTitle}
-          </Text>
-          <Spacer minLength={6} />
-          <Text modifiers={[font({ size: 11 }), foregroundStyle(phaseTint(row0.phase))]}>
-            {row0.status}
-          </Text>
-        </HStack>
-      ) : null}
-    </VStack>
-  );
-
-  if (isHomeScreenWidget) {
-    return (useCompactWidget ? bannerSmall : banner) as unknown as LiveActivityLayout;
-  }
 
   return {
     banner,
-    bannerSmall,
+    bannerSmall: renderCompactLayout(),
     compactLeading: renderLogo(14, tint),
     compactTrailing: (
       <Text modifiers={[font({ weight: "semibold", size: 11 }), foregroundStyle(tint)]}>
@@ -426,10 +566,7 @@ export function AgentActivity(
   };
 }
 
-export const AgentActivityWidget = createWidget<AgentActivityProps>(
-  "AgentActivity",
-  AgentActivity as never,
-);
+export const AgentActivityWidget = createWidget<AgentActivityProps>("AgentActivity", AgentActivity);
 
 export function publishAgentActivityWidget(props: AgentActivityProps): void {
   try {

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -80,7 +80,8 @@ export function AgentActivity(
   const useCompactWidget =
     widgetFamily === "systemSmall" ||
     widgetFamily === "accessoryCircular" ||
-    widgetFamily === "accessoryInline";
+    widgetFamily === "accessoryInline" ||
+    widgetFamily === "accessoryRectangular";
   // expo-widgets 56 stopped applying this natively. iOS 17+ home-screen
   // widgets that omit it render "Please adopt containerBackground API".
   const homeScreenBackground = isHomeScreenWidget ? [containerBackground("clear", "widget")] : [];
@@ -322,8 +323,8 @@ export function AgentActivity(
       {row4 ? renderCompactRow(row4) : null}
     </VStack>
   );
-  // Compact card for the watchOS Smart Stack + CarPlay (the `.small` family)
-  // and the home-screen systemSmall widget.
+  // Compact card for the watchOS Smart Stack + CarPlay (the `.small` family),
+  // the home-screen systemSmall widget, and lock-screen accessory families.
   const bannerSmall = (
     <VStack
       alignment="leading"

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -261,6 +261,7 @@ export function AgentActivity(
       spacing={5}
       modifiers={[
         padding({ all: 10 }),
+        ...(deepLink ? [widgetURL(deepLink)] : []),
         ...(widgetFamily ? [containerBackground("clear", "widget")] : []),
       ]}
     >

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -1,6 +1,7 @@
 import { Divider, HStack, Image, Spacer, Text, VStack, ZStack } from "@expo/ui/swift-ui";
 import type { ComponentProps, JSX } from "react";
 import {
+  aspectRatio,
   containerBackground,
   font,
   foregroundStyle,
@@ -196,10 +197,14 @@ export function AgentActivity(
   };
 
   // SF Symbols, like the logo, ignore frame/foregroundStyle applied directly to
-  // the image; size + tint them through a container the resizable symbol fills.
+  // the image; size + tint them through a container. Preserve the symbol's
+  // intrinsic aspect ratio when the resizable image fills that frame.
   const renderGlyph = (systemName: SFName, size: number, color: string) => (
     <HStack modifiers={[frame({ width: size, height: size }), foregroundStyle(color)]}>
-      <Image systemName={systemName} modifiers={[resizable()]} />
+      <Image
+        systemName={systemName}
+        modifiers={[resizable(), aspectRatio({ contentMode: "fit" })]}
+      />
     </HStack>
   );
 

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -44,7 +44,8 @@ export interface AgentActivityRowProps {
 export interface AgentActivityProps {
   readonly title: string;
   readonly subtitle: string;
-  readonly activeCount: number;
+  readonly activeCount: number | null;
+  readonly isStale?: boolean;
   readonly updatedAt: string;
   readonly activities: ReadonlyArray<AgentActivityRowProps>;
 }
@@ -69,7 +70,12 @@ export function AgentActivity(
   // Placeholder / first-paint entries arrive with empty props. Treat missing
   // fields as idle rather than throwing inside the widget JS runtime.
   const activities = Array.isArray(props.activities) ? props.activities : [];
-  const activeCount = typeof props.activeCount === "number" ? props.activeCount : 0;
+  const activeCount =
+    props.activeCount === null
+      ? null
+      : typeof props.activeCount === "number"
+        ? props.activeCount
+        : 0;
   const widgetFamily = "widgetFamily" in environment ? environment.widgetFamily : undefined;
 
   // Use SwiftUI's semantic label colors rather than fixed hex keyed off the
@@ -157,12 +163,20 @@ export function AgentActivity(
   // the two parts in-line so the attention half can carry the accent color;
   // `summary` is the short form for tight spots (expanded center, watch card).
   const agentWord = activeCount === 1 ? "agent" : "agents";
-  const agentsLabel = allDone ? outcomeLabel : `${activeCount} active ${agentWord}`;
+  const countLabel =
+    activeCount === null
+      ? "Activity count unavailable"
+      : allDone
+        ? outcomeLabel
+        : `${activeCount} active ${agentWord}`;
+  const agentsLabel = props.isStale ? `Last observed: ${countLabel}` : countLabel;
   const attentionSuffix =
     attentionRows.length > 0
       ? `${attentionRows.length} need${attentionRows.length === 1 ? "s" : ""} attention`
       : "";
-  const activeLabel = allDone ? doneLabel : `${activeCount} active`;
+  const currentLabel =
+    activeCount === null ? "Count unavailable" : allDone ? doneLabel : `${activeCount} active`;
+  const activeLabel = props.isStale ? `Last observed: ${currentLabel}` : currentLabel;
   const summary = attentionSuffix || activeLabel;
 
   // Any registered scheme variant routes back to this app; taps are delivered
@@ -279,7 +293,11 @@ export function AgentActivity(
             lineLimit(1),
           ]}
         >
-          {attentionRows.length > 0 ? summary : activeLabel}
+          {props.isStale || activeCount === null
+            ? activeLabel
+            : attentionRows.length > 0
+              ? summary
+              : activeLabel}
         </Text>
         <Spacer minLength={6} />
       </HStack>
@@ -319,7 +337,8 @@ export function AgentActivity(
       containerBackground("clear", "widget"),
     ];
     const homeSummaryTint = allDone && !hasRows ? secondaryForeground : headerTint;
-    const homeSummary = attentionSuffix || agentsLabel;
+    const homeSummary =
+      props.isStale || activeCount === null ? agentsLabel : attentionSuffix || agentsLabel;
     const renderHomeStatusIcon = (row: AgentActivityRowProps, size: number) =>
       renderGlyph(phaseSymbol(row.phase), size, phaseTint(row.phase));
 
@@ -343,7 +362,7 @@ export function AgentActivity(
             modifiers={[
               font({ weight: "bold", size: 15 }),
               foregroundStyle(homeSummaryTint),
-              lineLimit(1),
+              lineLimit(props.isStale || activeCount === null ? 2 : 1),
             ]}
           >
             {homeSummary}
@@ -431,7 +450,7 @@ export function AgentActivity(
             modifiers={[
               font({ weight: "semibold", size: 12 }),
               foregroundStyle(homeSummaryTint),
-              lineLimit(1),
+              lineLimit(props.isStale || activeCount === null ? 2 : 1),
               layoutPriority(1),
             ]}
           >
@@ -523,7 +542,7 @@ export function AgentActivity(
       <HStack spacing={5} alignment="center" modifiers={[padding({ leading: 4, vertical: 4 })]}>
         {renderLogo(15, tint)}
         <Text modifiers={[font({ weight: "bold", size: 13 }), foregroundStyle(tint)]}>
-          {allDone ? doneLabel : `${activeCount}`}
+          {activeCount === null ? "?" : allDone ? doneLabel : `${activeCount}`}
         </Text>
       </HStack>
     ),

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -358,11 +358,7 @@ export function AgentActivity(
             >
               {heroRow.threadTitle}
             </Text>
-          ) : (
-            <Text modifiers={[font({ size: 11 }), foregroundStyle(secondaryForeground)]}>
-              {outcomeLabel}
-            </Text>
-          )}
+          ) : null}
           {heroRow ? (
             <HStack spacing={5} alignment="center">
               {renderHomeStatusIcon(heroRow, 11)}
@@ -443,18 +439,7 @@ export function AgentActivity(
           </Text>
           {renderGlyph("arrow.up.right", 10, secondaryForeground)}
         </HStack>
-        {row0 ? (
-          renderHomeRow(row0)
-        ) : (
-          <Text
-            modifiers={[
-              font({ weight: "semibold", size: 14 }),
-              foregroundStyle(secondaryForeground),
-            ]}
-          >
-            {outcomeLabel}
-          </Text>
-        )}
+        {row0 ? renderHomeRow(row0) : null}
         {row1 ? <Divider modifiers={[padding({ vertical: 7, leading: 26 })]} /> : null}
         {row1 ? renderHomeRow(row1) : null}
         <Spacer minLength={0} />

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -578,11 +578,13 @@ export function AgentActivity(
 
 export const AgentActivityWidget = createWidget<AgentActivityProps>("AgentActivity", AgentActivity);
 
-export function publishAgentActivityWidget(props: AgentActivityProps): void {
+export function publishAgentActivityWidget(props: AgentActivityProps): boolean {
   try {
     AgentActivityWidget.updateSnapshot(props);
+    return true;
   } catch {
     // Personal-team and Android builds have no widget extension.
+    return false;
   }
 }
 

--- a/infra/relay/src/agentActivity/MobileRegistrations.test.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.test.ts
@@ -3,6 +3,7 @@ import type {
   RelayDeviceRegistrationRequest,
 } from "@t3tools/contracts/relay";
 import type { SignedApnsDeliveryJob } from "./apnsDeliveryJobs.ts";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import * as NodeCryptoLayer from "@effect/platform-node/NodeCrypto";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -419,6 +420,62 @@ describe("MobileRegistrations", () => {
       ),
     );
   });
+
+  it.effect("excludes local environments before counting and selecting the five relay rows", () =>
+    Effect.gen(function* () {
+      const local = EnvironmentId.make("local");
+      const remote = EnvironmentId.make("remote");
+      const states: RelayAgentActivityState[] = Array.from({ length: 14 }, (_, index) => ({
+        environmentId: index < 6 ? local : remote,
+        threadId: ThreadId.make(`thread-${index}`),
+        projectTitle: "Project",
+        threadTitle: `Task ${index}`,
+        modelTitle: "Test model",
+        phase: index < 6 ? "waiting_for_approval" : "running",
+        headline: "Working",
+        updatedAt: "1970-01-01T00:00:10.000Z",
+        deepLink: `/threads/${index < 6 ? local : remote}/thread-${index}`,
+      }));
+      const registrations = yield* MobileRegistrations.make.pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(Devices.Devices, makeDevices()),
+            Layer.succeed(
+              AgentActivityRows.AgentActivityRows,
+              makeAgentActivityRows({
+                listForUser: () => Effect.succeed(states),
+              }),
+            ),
+            Layer.succeed(LiveActivities.LiveActivities, makeLiveActivities()),
+            Layer.succeed(
+              AgentActivityPublisher.AgentActivityPublisher,
+              makeAgentActivityPublisher(),
+            ),
+          ),
+        ),
+      );
+      const global = yield* registrations.getAgentActivitySnapshot({ userId: "user" });
+      expect(global.excludedEnvironmentIds).toEqual([]);
+      expect(global.aggregate?.activeCount).toBe(14);
+      expect(global.aggregate?.activities.every((row) => row.environmentId === local)).toBe(true);
+      const filtered = yield* registrations.getAgentActivitySnapshot({
+        userId: "user",
+        excludedEnvironmentIds: [local, local],
+      });
+      expect(filtered.excludedEnvironmentIds).toEqual([local]);
+      expect(filtered.aggregate?.activeCount).toBe(8);
+      expect(filtered.aggregate?.activities).toHaveLength(5);
+      expect(filtered.aggregate?.activities.every((row) => row.environmentId === remote)).toBe(
+        true,
+      );
+      expect(
+        yield* registrations.getAgentActivitySnapshot({
+          userId: "user",
+          excludedEnvironmentIds: [local, remote],
+        }),
+      ).toEqual({ aggregate: null, excludedEnvironmentIds: [local, remote] });
+    }),
+  );
 
   it.effect(
     "does not remotely start a Live Activity when a device registers after work is already active",

--- a/infra/relay/src/agentActivity/MobileRegistrations.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.ts
@@ -3,6 +3,7 @@ import type {
   RelayDeviceRegistrationRequest,
   RelayLiveActivityRegistrationRequest,
 } from "@t3tools/contracts/relay";
+import type { EnvironmentId } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -36,6 +37,7 @@ export class MobileRegistrations extends Context.Service<
     }) => Effect.Effect<{ readonly ok: true }, MobileRegistrationError>;
     readonly getAgentActivitySnapshot: (input: {
       readonly userId: string;
+      readonly excludedEnvironmentIds?: ReadonlyArray<EnvironmentId>;
     }) => Effect.Effect<RelayAgentActivitySnapshotResponse, MobileRegistrationError>;
   }
 >()("t3code-relay/agentActivity/MobileRegistrations") {}
@@ -94,9 +96,12 @@ export const make = Effect.gen(function* () {
       function* (input) {
         const activeStates = yield* rows.listForUser({ userId: input.userId });
         const now = yield* DateTime.now;
+        const excludedEnvironmentIds = [...new Set(input.excludedEnvironmentIds ?? [])];
+        const excluded = new Set(excludedEnvironmentIds);
         return {
+          excludedEnvironmentIds,
           aggregate: AgentActivityPublisher.makeAggregateState({
-            activeStates,
+            activeStates: activeStates.filter((state) => !excluded.has(state.environmentId)),
             terminalState: null,
             nowMs: now.epochMilliseconds,
           }),

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -498,13 +498,16 @@ export const mobileApi = HttpApiBuilder.group(
       )
       .handle(
         "getAgentActivitySnapshot",
-        Effect.fn("relay.api.mobile.getAgentActivitySnapshot")(function* () {
+        Effect.fn("relay.api.mobile.getAgentActivitySnapshot")(function* ({ query }) {
           const { userId, token } = yield* RelayClientPrincipal;
           const proofKeyThumbprint = yield* requireDpopPrincipalScope("mobile:registration");
           yield* requireDpopThumbprint(proofKeyThumbprint, {
             expectedAccessToken: token,
           }).pipe(Effect.provideService(DpopProofs.DpopProofReplay, dpopProofs));
-          return yield* registrations.getAgentActivitySnapshot({ userId });
+          return yield* registrations.getAgentActivitySnapshot({
+            userId,
+            excludedEnvironmentIds: query.excludedEnvironmentIds ?? [],
+          });
         }, mapRelayCommonApiErrors("invalid_dpop")),
       )
       .handle(

--- a/packages/client-runtime/src/relay/managedRelay.test.ts
+++ b/packages/client-runtime/src/relay/managedRelay.test.ts
@@ -2,6 +2,7 @@ import { EnvironmentId } from "@t3tools/contracts";
 import {
   RelayEnvironmentConnectScope,
   RelayEnvironmentStatusScope,
+  RelayMobileRegistrationScope,
 } from "@t3tools/contracts/relay";
 import { describe, expect, it } from "@effect/vitest";
 import * as Duration from "effect/Duration";
@@ -47,6 +48,54 @@ function clerkToken(subject: string, nonce: string): string {
 }
 
 describe("ManagedRelayClient", () => {
+  it.effect.each([false, true])(
+    "keeps global reads compatible and signs the filtered request (legacy=%s)",
+    (legacy) => {
+      const requests: URL[] = [];
+      const excludedEnvironmentIds = [EnvironmentId.make("local-1"), EnvironmentId.make("local-2")];
+      const fetchFn = ((input, init) => {
+        const url = new URL(String(input));
+        if (url.pathname === "/v1/client/dpop-token") {
+          return Promise.resolve(
+            Response.json({
+              access_token: "relay-token",
+              token_type: "DPoP",
+              issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+              expires_in: 1_800,
+              scope: RelayMobileRegistrationScope,
+            }),
+          );
+        }
+        requests.push(url);
+        expect(new Headers(init?.headers).get("dpop")).toBe(`proof:${url}`);
+        return Promise.resolve(
+          Response.json({
+            aggregate: null,
+            ...(legacy
+              ? {}
+              : { excludedEnvironmentIds: url.searchParams.getAll("excludedEnvironmentIds") }),
+          }),
+        );
+      }) satisfies typeof globalThis.fetch;
+      return Effect.gen(function* () {
+        const client = yield* ManagedRelay.ManagedRelayClient;
+        const input = { clerkToken: clerkToken("user", "session") };
+        const global = yield* client.getAgentActivitySnapshot(input);
+        const filtered = yield* client.getAgentActivitySnapshot({
+          ...input,
+          excludedEnvironmentIds,
+        });
+        expect(requests[0]?.search).toBe("");
+        expect(requests[1]?.searchParams.getAll("excludedEnvironmentIds")).toEqual(
+          excludedEnvironmentIds,
+        );
+        expect(global.excludedEnvironmentIds).toEqual(legacy ? undefined : []);
+        expect(filtered.excludedEnvironmentIds).toEqual(
+          legacy ? undefined : excludedEnvironmentIds,
+        );
+      }).pipe(Effect.provide(managedRelayTestLayer(fetchFn)));
+    },
+  );
   it.effect("owns tracing at service and implementation boundaries", () => {
     const spanNames: Array<string> = [];
     const tracer = Tracer.make({

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -299,6 +299,9 @@ export class ManagedRelayClient extends Context.Service<
     }) => Effect.Effect<RelayOkResponse, ManagedRelayClientError>;
     readonly getAgentActivitySnapshot: (input: {
       readonly clerkToken: string;
+      readonly excludedEnvironmentIds?: ReadonlyArray<
+        RelayClientEnvironmentRecord["environmentId"]
+      >;
     }) => Effect.Effect<RelayAgentActivitySnapshotResponse, ManagedRelayClientError>;
     readonly resetTokenCache: Effect.Effect<void>;
   }
@@ -471,9 +474,11 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
       method: RelayUnregisterDeviceEndpoint.method,
       url: urlBuilder.mobile.unregisterDevice({ params: { deviceId } }),
     }),
-    getAgentActivitySnapshot: (): DpopProofTarget => ({
+    getAgentActivitySnapshot: (
+      excludedEnvironmentIds?: ReadonlyArray<RelayClientEnvironmentRecord["environmentId"]>,
+    ): DpopProofTarget => ({
       method: RelayAgentActivitySnapshotEndpoint.method,
-      url: urlBuilder.mobile.getAgentActivitySnapshot(),
+      url: urlBuilder.mobile.getAgentActivitySnapshot({ query: { excludedEnvironmentIds } }),
     }),
     registerLiveActivity: (): DpopProofTarget => ({
       method: RelayRegisterLiveActivityEndpoint.method,
@@ -893,12 +898,13 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
         return yield* mobileRegistrationRequest(
           {
             clerkToken: input.clerkToken,
-            target: dpopProofTargets.getAgentActivitySnapshot(),
+            target: dpopProofTargets.getAgentActivitySnapshot(input.excludedEnvironmentIds),
           },
           (authorization) =>
             client.mobile
               .getAgentActivitySnapshot({
                 headers: dpopHeaders(authorization),
+                query: { excludedEnvironmentIds: input.excludedEnvironmentIds },
               })
               .pipe(
                 Effect.mapError(relayRequestError("read relay agent activity snapshot")),

--- a/packages/contracts/src/relay.test.ts
+++ b/packages/contracts/src/relay.test.ts
@@ -1,9 +1,32 @@
 import { describe, expect, it } from "vite-plus/test";
 import * as OpenApi from "effect/unstable/httpapi/OpenApi";
+import * as Schema from "effect/Schema";
 
-import { RelayApi } from "./relay.ts";
+import {
+  RelayApi,
+  RelayAgentActivitySnapshotResponse,
+  RelayAgentActivitySnapshotEndpoint,
+} from "./relay.ts";
 
 describe("RelayApi security", () => {
+  it("decodes an older global snapshot without inventing filter support", () => {
+    const decode = Schema.decodeUnknownSync(RelayAgentActivitySnapshotResponse);
+    expect(decode({ aggregate: null })).toEqual({ aggregate: null });
+    expect(decode({ aggregate: null, excludedEnvironmentIds: [] })).toEqual({
+      aggregate: null,
+      excludedEnvironmentIds: [],
+    });
+  });
+  it("decodes absent, single and repeated exclusion query values", () => {
+    const decode = Schema.decodeUnknownSync(RelayAgentActivitySnapshotEndpoint.query!);
+    expect(decode({})).toEqual({});
+    expect(decode({ excludedEnvironmentIds: "local" })).toEqual({
+      excludedEnvironmentIds: ["local"],
+    });
+    expect(decode({ excludedEnvironmentIds: ["local", "other"] })).toEqual({
+      excludedEnvironmentIds: ["local", "other"],
+    });
+  });
   it("describes DPoP access tokens using the HTTP DPoP authorization scheme", () => {
     const document = OpenApi.fromApi(RelayApi);
 

--- a/packages/contracts/src/relay.test.ts
+++ b/packages/contracts/src/relay.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import type * as HttpApiEndpoint from "effect/unstable/httpapi/HttpApiEndpoint";
 import * as OpenApi from "effect/unstable/httpapi/OpenApi";
 import * as Schema from "effect/Schema";
 
@@ -18,7 +19,11 @@ describe("RelayApi security", () => {
     });
   });
   it("decodes absent, single and repeated exclusion query values", () => {
-    const decode = Schema.decodeUnknownSync(RelayAgentActivitySnapshotEndpoint.query!);
+    const decode = Schema.decodeUnknownSync(
+      RelayAgentActivitySnapshotEndpoint.query as HttpApiEndpoint.Query<
+        typeof RelayAgentActivitySnapshotEndpoint
+      >,
+    );
     expect(decode({})).toEqual({});
     expect(decode({ excludedEnvironmentIds: "local" })).toEqual({
       excludedEnvironmentIds: ["local"],

--- a/packages/contracts/src/relay.ts
+++ b/packages/contracts/src/relay.ts
@@ -919,6 +919,8 @@ export const RelayRegisterLiveActivityEndpoint = HttpApiEndpoint.post(
 
 export const RelayAgentActivitySnapshotResponse = Schema.Struct({
   aggregate: Schema.NullOr(RelayAgentActivityAggregateState),
+  // Absent on older relays, which may ignore an unknown query parameter.
+  excludedEnvironmentIds: Schema.optional(Schema.Array(EnvironmentId)),
 });
 export type RelayAgentActivitySnapshotResponse = typeof RelayAgentActivitySnapshotResponse.Type;
 
@@ -929,6 +931,9 @@ export const RelayAgentActivitySnapshotEndpoint = HttpApiEndpoint.get(
   "getAgentActivitySnapshot",
   "/v1/mobile/agent-activity",
   {
+    query: {
+      excludedEnvironmentIds: Schema.optional(Schema.ArrayEnsure(EnvironmentId)),
+    },
     headers: RelayDpopRequestHeaders,
     success: RelayAgentActivitySnapshotResponse,
     error: RelayAuthAndInternalErrors,


### PR DESCRIPTION
## Before

<img width="1320" height="660" alt="image" src="https://github.com/user-attachments/assets/9b5fc954-fd15-49ec-ae02-a0c53731df5c" />

## After

<img width="660" height="320" alt="Screenshot 2026-08-13 at 12 51 15 PM" src="https://github.com/user-attachments/assets/282db4ee-3a77-42d4-b341-5ace64950274" />

## What Changed

iOS home-screen Agent Activity widgets now render instead of Apple's "Please adopt containerBackground API" placeholder.

- Apply `containerBackground("clear", "widget")` on the home-screen view (small, medium, lock-screen rectangular).
- Register the same layout with `createWidget`, not only `createLiveActivity`.
- Publish widget snapshots from the existing Live Activity refresh/arming path.
- Treat missing first-paint props as idle so the widget JS runtime does not throw.

Live Activity / Dynamic Island layouts are unchanged.

## Why

expo-widgets 56 stopped applying `containerBackground` for us, and the home-screen widget never received a `createWidget` layout (that API writes a different App Group key than Live Activities). iOS 17+ then refused to render the widget.

## UI Changes

**Before:** adding the Agent Activity widget showed a white card with a stop icon and "Please adopt containerBackground API".

**After:** not captured on a device in this change (needs a native iOS rebuild and adding the widget). After opening the updated app once, the widget should show agent rows or "No active agents" on the system widget chrome.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Made-with: Grok 4.6 (T3 Code)

## Maintainer verification, September 6

Related report: [#6641](https://github.com/pingdotgg/t3code/issues/6641). Jake Leventhal's original branch and contributor credit are preserved. This section supersedes the earlier maintainer assessment. The author description above records the original implementation, not every follow-up below.

Current candidate: [04c3648f](https://github.com/pingdotgg/t3code/commit/04c3648f8b102d5238735b6f6ddb369cbd758ef5). **Not ready to merge:** current native rendering and live-update evidence remain missing. Current-head CI is terminal, with 15 successful checks, eight skipped and neutral Approvability requiring human review of the broader change. No unresolved review threads remain. The maintainer approved live updates, connected-local precedence, and a compatible filtered API with an honest older-relay fallback. Those scope questions are no longer awaiting an answer.

### Live updates and reconciliation

Regular widgets now observe complete live environment shells while the app is foregrounded. Starts, completion and deletion update the widget without waiting for relay publication or a later foreground event. A complete live shell owns its whole environment, including an empty one. The early optimistic seed remains only for the separate Live Activity, so a delayed local send cannot replace observed widget rows with a fabricated Connecting row.

Disconnected, cached and synchronizing environments retain their last complete observation and explicitly say Last observed. A relay read retires that observation only after confirming it against sufficiently recent rows; omission from a capped result is not confirmation. A new complete local snapshot, catalog removal or account teardown updates that ownership. This is session-memory retention, not a new offline database, expiry timer or background polling service.

The existing snapshot API accepts optional excluded environment IDs and optionally echoes the applied scope. A compatible relay filters before computing the total and selecting five rows. The original global request remains query-free and is still used for Live Activity priming. Older responses decode without claiming filter support. When their capped global result cannot establish a combined total, the widget says Activity count unavailable while retaining the available rows. A failed first relay read also allows known local rows without inventing a global total.

Review caught two further priming races. A local send could create a card during the final snapshot read, followed by a duplicate card from the refresh. The final instance recheck now adopts that card. A scope-only widget refresh could cancel the original operation's priming result and leave active work without a card. Superseded widget publication now retains the unfiltered result for priming, while account invalidation still discards it. Priming rechecks account ownership and foreground state. No extra requests or retries were added, and the final widget refresh still publishes work that became idle while preferences loaded.

### Verification

A subsequent review reproduced an existing-card account-switch race. A suspended widget refresh could resume with an ended activity from the prior account and register its token using the new account. The refresh now rechecks account generation before either path continues. Three focused controls cover unchanged ownership, sign-out and account switching. Both stale controls fail on the preceding head and pass here.

The orchestrator reviewed the full 13-file cumulative change and independently passed all 149 focused tests in seven files in 21.60 seconds. Tests exercise the observer/registration lifecycle with synthetic atoms and controlled asynchronous receipts, contract decoding, managed-relay HTTP serialization with fake fetch, relay aggregation and existing HTTP authorization controls. Native layout tests inspect serialized layout with mocked native factories; they are not native rendering proof.

Independent negative replays reproduce three old false-idle/stale-relay failures, the first-read publication and single-query-value failures, both duplicate-prime windows, and both global/scoped priming-cancellation windows. The final eight cancellation controls also verify sign-out, account change, background suppression and foreground recovery. All pass on this candidate.

The separate account-switch review finding did not reproduce through the supported caller. CloudAuthBridge deactivates before awaiting relay-environment removal and other cleanup, then activates the new account. Two independent controls using the actual registry, catalog stream and command completion confirm immediate widget resubscription excludes removed relay environments, with and without another catalog subscriber. Independent direct connections intentionally remain. This is bounded runtime evidence, not an installed-client account-switch claim.

CI on the prior head caught a type error in the new contract test's endpoint query decoder. The test now retains the endpoint's declared query type without changing its runtime schema. Scoped contracts, mobile, client-runtime and relay typechecks pass, as do changed-file lint, formatting and diff checks. No repo-wide local suite, live relay account, paid provider turn or live user database was used. The orchestrator inspected all current-head check results, annotations, reviews and comments at 04:21 UTC. Correctness and Effect conventions pass. Approvability remains neutral for human review, not green. A filtered review note also identifies that a failed final priming read can defer the lock-screen card until a later refresh. The final read is necessary to avoid priming from work that ended while preferences loaded; no stale-snapshot fallback or new retry policy is claimed here.

The candidate integrates main [eee05575](https://github.com/pingdotgg/t3code/commit/eee05575ebd514db36f61d7eb05d2258a10c96bd). All existing changed paths are byte-identical through [b438447f](https://github.com/pingdotgg/t3code/commit/b438447f67b6b61bbe6f564d8b78fd90702117c5), committed at 02:22:39 UTC. Its other mobile theme changes were reviewed separately; this is named-path equivalence, not a current-main client run.

### Historical native rendering evidence only

These matched captures verified the original blank-widget correction before the live-update and count changes. They are retained as historical evidence, not proof of the current candidate.

Before, main-equivalent widget source at [f8b4c464](https://github.com/pingdotgg/t3code/commit/f8b4c464b4760d73e0ece7e68011c738803d8b69):

![Historical before: medium iOS widget remains a red Debug placeholder after opening the app](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ec258d70124d2c21/6641-before-widget-after-open.jpg)

After, the prior implementation whose production bytes match [845ed3d2](https://github.com/pingdotgg/t3code/commit/845ed3d2d1c37e12c940871669fc7dfb75f58a4f):

![Historical after: the same medium iOS widget displays T3 Code and No active agents](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/36a5dc23b1d9b140/6641-after-widget-initial.jpg)

Both used the same iPhone 17 Pro Max simulator, iOS 26.5, compatible installed Debug extension, widget placement and empty activity state. No widget preferences were manually seeded. This did not reproduce the reporter's exact release build or black widget on iOS 26.3.1(a).

Current simulator verification is paused after the retained test fixture was removed during host disk cleanup. Available host capacity is below the isolated-testing safety floor, so no replacement checkout, dependency install, native rebuild or cleanup has been attempted. Required follow-up includes actual local start/completion/deletion, reconnect and background/foreground transitions, newer/older fake-relay reconciliation, and fallback readability in small, medium and accessory layouts. Physical devices, watch/CarPlay and continuous background widget updates are not verified. The shared renderer changes glyph scaling, empty Live Activity labels and compact deep links, so the original claim of entirely unchanged Live Activity layouts is too broad. No auto-merge is enabled.

Maintainer audit and follow-up fixes by GPT 6 Astra via Codex in T3 Code. Original contributor attribution above is preserved.




<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iOS home-screen widget `containerBackground` error with native widget layouts
> - Adds `createWidget` registration for `AgentActivity` with family-specific layouts: small/medium home-screen, compact accessory, and lock-screen circular, each with a proper widget `containerBackground` — Live Activity layouts remain unchanged and do not serialize a container background
> - Introduces a live widget activity atom in [liveWidgetActivity.ts](https://github.com/pingdotgg/t3code/pull/6464/files#diff-20b26431e1df0a3e9f107ad701773e929fcd7ea64ab8ffcccb04f85df672deb4) that observes catalog environments with live shells, maps thread phases to widget labels, and expires terminal rows after 15 minutes
> - Adds a widget refresh workflow in [remoteRegistration.ts](https://github.com/pingdotgg/t3code/pull/6464/files#diff-ac13745728627647bf60cf50ea2b1d61f0b216df0229029b70f9e6be23887f47) that reconciles relay snapshots with locally observed activity, publishes deduplicated widget content, and guards against stale account or superseded refreshes via generation counters
> - Extends the relay activity-snapshot endpoint to accept excluded-environment query parameters for scoped reads, with backward-compatible decoding of legacy responses
> - Risk: `AgentActivityProps.activeCount` is now nullable (represents unavailable count); any out-of-tree caller that assumes a non-null number will need updating. The `isStale` flag is optional and defaults to false.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a497f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds async widget publishing on sign-out, foreground refresh, and local arming with generation guards—wrong ordering could briefly show stale agent state, but changes are scoped to iOS widget/Live Activity registration, not auth or data storage.
> 
> **Overview**
> Fixes iOS home-screen **Agent Activity** widgets that showed Apple’s “adopt containerBackground” placeholder by registering a **`createWidget`** layout (alongside the existing Live Activity) with **`containerBackground("clear", "widget")`**, dedicated small/medium/accessory UI, and safer handling of empty first-paint props (“No active agents”).
> 
> **`publishAgentActivityWidget`** pushes relay/local snapshots via **`updateSnapshot`**. **`remoteRegistration`** now refreshes the widget whenever Live Activity reconciliation runs (including when Live Activities are off or a card is already armed), seeds a “Connecting” snapshot when local work starts, clears to idle on cloud sign-out, and uses **`widgetRefreshGeneration`** so slower relay reads cannot overwrite newer local seeds or post–sign-out idle state.
> 
> Live Activity / Dynamic Island layouts are intentionally unchanged; tests cover refresh timing, races, and sign-out guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5ebc8a770a7bd372480ae858b93647a2e3f8ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added home-screen and lock-screen agent activity widgets across supported widget sizes.
  * Widgets display active work, idle states, unavailable counts, deep links, and status updates.
  * Activity refreshes automatically as work starts, completes, or changes between foreground and background.
  * Local activity is reconciled with relay data to reduce stale or missing results.
  * Local environments can be excluded from shared activity results to prevent duplicate reporting.
  * Signing out clears the widget and displays its idle state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->