### PR TITLE
feat(web): show update download progress in sidebar

### DIFF
--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -1,10 +1,14 @@
+import type {
+  DesktopBridge,
+  DesktopUpdateActionResult,
+  DesktopUpdateState,
+} from "@t3tools/contracts";
 import { DownloadIcon, RefreshCwIcon, RotateCwIcon, TriangleAlertIcon } from "lucide-react";
-import { useCallback, useState } from "react";
+import { type CSSProperties, useCallback, useState } from "react";
 import { isElectron } from "../../env";
 import { cn } from "../../lib/utils";
 import { ensureLocalApi } from "../../localApi";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
-import { stackedThreadToast, toastManager } from "../ui/toast";
 import {
   canCheckForUpdate,
   getArm64IntelBuildWarningDescription,
@@ -20,7 +24,131 @@ import { showDesktopUpdateDownloadedToast } from "../desktopUpdate.toast";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { Separator } from "../ui/separator";
 import { SidebarMenuItem } from "../ui/sidebar";
+import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+const UPDATE_AVAILABLE_TOOLTIP_STYLE: CSSProperties = {
+  background:
+    "color-mix(in srgb, var(--update) 18%, color-mix(in srgb, var(--popover) var(--glass-opacity), transparent))",
+  borderColor: "var(--update-foreground)",
+};
+
+function updateActionErrorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function toastUpdateError(title: string, description: string) {
+  toastManager.add(
+    stackedThreadToast({
+      type: "error",
+      title,
+      description,
+    }),
+  );
+}
+
+function toastFailedUpdateAction(title: string, result: DesktopUpdateActionResult) {
+  if (!shouldToastDesktopUpdateActionResult(result)) return;
+  const actionError = getDesktopUpdateActionError(result);
+  if (!actionError) return;
+  toastUpdateError(title, actionError);
+}
+
+function startDownloadUpdate(bridge: DesktopBridge, onDone: () => void) {
+  void bridge
+    .downloadUpdate()
+    .then((result) => {
+      if (result.completed) {
+        showDesktopUpdateDownloadedToast(bridge, result.state);
+      }
+      toastFailedUpdateAction("Could not download update", result);
+    })
+    .catch((error) => {
+      toastUpdateError(
+        "Could not start update download",
+        updateActionErrorMessage(error, "An unexpected error occurred."),
+      );
+    })
+    .finally(onDone);
+}
+
+function startInstallUpdate(bridge: DesktopBridge, onDone: () => void) {
+  void bridge
+    .installUpdate()
+    .then((result) => {
+      toastFailedUpdateAction("Could not install update", result);
+    })
+    .catch((error) => {
+      toastUpdateError(
+        "Could not install update",
+        updateActionErrorMessage(error, "An unexpected error occurred."),
+      );
+    })
+    .finally(onDone);
+}
+
+function startCheckForUpdate(bridge: DesktopBridge, onDone: () => void) {
+  void bridge
+    .checkForUpdate()
+    .then((result) => {
+      if (result.checked) return;
+      toastUpdateError(
+        "Could not check for updates",
+        result.state.message ?? "Automatic updates are not available in this build.",
+      );
+    })
+    .catch((error) => {
+      toastUpdateError(
+        "Could not check for updates",
+        updateActionErrorMessage(error, "Update check failed."),
+      );
+    })
+    .finally(onDone);
+}
+
+function getSidebarUpdateTooltip(state: DesktopUpdateState | null, isUpdateState: boolean) {
+  if (isUpdateState) {
+    return state ? getDesktopUpdateButtonTooltip(state) : "Update available";
+  }
+  if (state?.status === "checking") {
+    return "Checking for updates…";
+  }
+  return "Check for updates";
+}
+
+/** Track around the update button. `percent` is 0–100; SVG `pathLength` makes dashoffset a percentage. */
+function DownloadProgressRing({ percent }: { readonly percent: number }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 size-full -rotate-90"
+      viewBox="0 0 32 32"
+    >
+      <circle
+        cx="16"
+        cy="16"
+        r="14.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        opacity="0.2"
+      />
+      <circle
+        cx="16"
+        cy="16"
+        r="14.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        pathLength="100"
+        strokeDasharray="100 100"
+        strokeDashoffset={100 - percent}
+        strokeLinecap="round"
+        className="transition-[stroke-dashoffset] duration-300 ease-out"
+      />
+    </svg>
+  );
+}
 
 function keyReleaseNoteItems(items: ReadonlyArray<string>) {
   const occurrences = new Map<string, number>();
@@ -35,7 +163,7 @@ function SidebarUpdateReleaseNotesTooltip({
   state,
   tooltip,
 }: {
-  readonly state: NonNullable<ReturnType<typeof useDesktopUpdateState>>;
+  readonly state: DesktopUpdateState;
   readonly tooltip: string;
 }) {
   if (state.channel !== "nightly" || state.releaseNotes.length === 0) {
@@ -70,7 +198,7 @@ function SidebarUpdateReleaseNotesTooltip({
               </h3>
               <ul className="mt-2 space-y-1.5 pl-4 text-xs leading-5 text-popover-foreground/90">
                 {keyReleaseNoteItems(releaseNote.items).map(({ item, key }) => (
-                  <li className="list-disc break-words" key={key}>
+                  <li className="list-disc wrap-break-word" key={key}>
                     {item}
                   </li>
                 ))}
@@ -113,15 +241,12 @@ function SidebarUpdateControl() {
 
   const action = state ? resolveDesktopUpdateButtonAction(state) : "none";
   const isDownloading = state?.status === "downloading";
+  const downloadPercent = Math.max(0, Math.min(100, state?.downloadPercent ?? 0));
   const isUpdateState = action !== "none" || isDownloading;
-  const tooltip = isUpdateState
-    ? state
-      ? getDesktopUpdateButtonTooltip(state)
-      : "Update available"
-    : state?.status === "checking"
-      ? "Checking for updates…"
-      : "Check for updates";
+  const tooltip = getSidebarUpdateTooltip(state, isUpdateState);
   const disabled = isUpdateState ? isDesktopUpdateButtonDisabled(state) : !canCheckForUpdate(state);
+  const showNightlyReleaseNotes =
+    isUpdateState && state?.channel === "nightly" && state.releaseNotes.length > 0;
 
   const handleAction = useCallback(async () => {
     const bridge = window.desktopBridge;
@@ -129,35 +254,10 @@ function SidebarUpdateControl() {
     if (disabled || isActionPending) return;
 
     setIsActionPending(true);
+    const clearPending = () => setIsActionPending(false);
 
     if (action === "download") {
-      void bridge
-        .downloadUpdate()
-        .then((result) => {
-          if (result.completed) {
-            showDesktopUpdateDownloadedToast(bridge, result.state);
-          }
-          if (!shouldToastDesktopUpdateActionResult(result)) return;
-          const actionError = getDesktopUpdateActionError(result);
-          if (!actionError) return;
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not download update",
-              description: actionError,
-            }),
-          );
-        })
-        .catch((error) => {
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not start update download",
-              description: error instanceof Error ? error.message : "An unexpected error occurred.",
-            }),
-          );
-        })
-        .finally(() => setIsActionPending(false));
+      startDownloadUpdate(bridge, clearPending);
       return;
     }
 
@@ -168,70 +268,22 @@ function SidebarUpdateControl() {
           getDesktopUpdateInstallConfirmationMessage(state, navigator.platform),
         );
       } catch (error) {
-        setIsActionPending(false);
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Could not confirm update",
-            description: error instanceof Error ? error.message : "Update confirmation failed.",
-          }),
+        clearPending();
+        toastUpdateError(
+          "Could not confirm update",
+          updateActionErrorMessage(error, "Update confirmation failed."),
         );
         return;
       }
       if (!confirmed) {
-        setIsActionPending(false);
+        clearPending();
         return;
       }
-      void bridge
-        .installUpdate()
-        .then((result) => {
-          if (!shouldToastDesktopUpdateActionResult(result)) return;
-          const actionError = getDesktopUpdateActionError(result);
-          if (!actionError) return;
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not install update",
-              description: actionError,
-            }),
-          );
-        })
-        .catch((error) => {
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not install update",
-              description: error instanceof Error ? error.message : "An unexpected error occurred.",
-            }),
-          );
-        })
-        .finally(() => setIsActionPending(false));
+      startInstallUpdate(bridge, clearPending);
       return;
     }
 
-    void bridge
-      .checkForUpdate()
-      .then((result) => {
-        if (result.checked) return;
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Could not check for updates",
-            description:
-              result.state.message ?? "Automatic updates are not available in this build.",
-          }),
-        );
-      })
-      .catch((error) => {
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Could not check for updates",
-            description: error instanceof Error ? error.message : "Update check failed.",
-          }),
-        );
-      })
-      .finally(() => setIsActionPending(false));
+    startCheckForUpdate(bridge, clearPending);
   }, [action, disabled, isActionPending, state]);
 
   return (
@@ -245,13 +297,15 @@ function SidebarUpdateControl() {
               aria-disabled={disabled || isActionPending || undefined}
               disabled={disabled || isActionPending}
               className={cn(
-                "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors enabled:cursor-pointer focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60",
+                "relative inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors enabled:cursor-pointer focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60",
                 isUpdateState
                   ? "bg-update-surface text-update-foreground enabled:hover:bg-update/12"
-                  : "text-[var(--sidebar-icon-color)] enabled:hover:bg-sidebar-row-hover enabled:hover:text-sidebar-foreground",
+                  : "text-(--sidebar-icon-color) enabled:hover:bg-sidebar-row-hover enabled:hover:text-sidebar-foreground",
               )}
               onClick={handleAction}
             >
+              {isDownloading ? <DownloadProgressRing percent={downloadPercent} /> : null}
+
               {action === "install" ? (
                 <RotateCwIcon className="size-4" />
               ) : isUpdateState ? (
@@ -267,22 +321,14 @@ function SidebarUpdateControl() {
         <TooltipPopup
           align="center"
           className={
-            isUpdateState && state?.channel === "nightly" && state.releaseNotes.length > 0
+            showNightlyReleaseNotes
               ? // pointer-events-auto overrides the positioner's pointer-events-none so the
                 // release notes stay open (and scrollable) when the cursor moves into them.
                 "pointer-events-auto max-w-none text-balance"
               : undefined
           }
           side="top"
-          style={
-            isUpdateState
-              ? {
-                  background:
-                    "color-mix(in srgb, var(--update) 18%, color-mix(in srgb, var(--popover) var(--glass-opacity), transparent))",
-                  borderColor: "var(--update-foreground)",
-                }
-              : undefined
-          }
+          style={isUpdateState ? UPDATE_AVAILABLE_TOOLTIP_STYLE : undefined}
           variant={isUpdateState ? "glass" : "default"}
         >
           {isUpdateState && state ? (


### PR DESCRIPTION
## What Changed

Added a circular download progress indicator around the existing desktop update button in the sidebar.

The progress ring is shown only while the update state is `downloading` and uses the existing `downloadPercent` value. The existing download icon remains centered inside the button.

Once the download completes, the progress ring disappears and the existing restart/install icon is shown as before.

This is a UI-only change. It does not modify the updater, IPC contract, preload API, update state machine, or the existing ~10% progress update cadence.

## Why

Download progress is already tracked and displayed in the update tooltip, but there is no visible progress feedback unless the user hovers the button.

Showing that existing progress as a small ring around the update control makes it immediately clear that the download is active and progressing without adding any new update plumbing or behavior.

Closes #6459 

## UI Changes

### Before

The download button remains visually static while the update is downloading.

<img width="800" height="586" alt="ScreenRecording2026-08-13at6 07 26PM-ezgif com-optimize" src="https://github.com/user-attachments/assets/f8d4af9b-ecea-4965-a336-9c9b76fa9511" />

### After

The existing download icon is surrounded by a circular progress indicator while the update is downloading.

<img width="800" height="586" alt="ScreenRecording2026-08-13at6 08 12PM-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/de411fb4-243a-4b58-95a3-3d8c7a60157d" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar component refactor; update behavior and contracts are unchanged.
> 
> **Overview**
> Adds a **circular SVG progress ring** around the desktop sidebar update button while `status` is `downloading`, driven by the existing clamped `downloadPercent` (no updater or IPC changes).
> 
> The same change **refactors** `SidebarUpdatePill`: desktop bridge download/install/check flows and error toasts move into small helpers, tooltip copy is centralized, and update-available tooltip styling uses a shared constant. Minor class tweaks (`relative` on the button, `wrap-break-word` on release notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2be5acee940f5d0ed022768589b0756d2e242b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show download progress ring around the update button in the sidebar
> - Adds a `DownloadProgressRing` SVG component that renders a circular progress indicator around the sidebar update button while an update is downloading, driven by the current download percent (clamped 0–100).
> - Extracts update action logic (download, install, check) into helper functions in [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/6467/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf), centralizing error toasting and pending state cleanup.
> - Tooltip text is now computed via `getSidebarUpdateTooltip` based on `DesktopUpdateState` rather than inline logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9234b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->