### PR TITLE
fix(web): verify pull request snapshots before hydration

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -53,6 +53,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.cloudGetRelayClientStatus]: AuthRelayReadScope,
   [WS_METHODS.cloudInstallRelayClient]: AuthRelayWriteScope,
   [WS_METHODS.pullRequestsList]: AuthOrchestrationReadScope,
+  [WS_METHODS.pullRequestsViewers]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsListStats]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsDetail]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsActivity]: AuthOrchestrationReadScope,

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -92,6 +92,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.connectionProbe).toBe(true);
       expect(second.capabilities.attachmentUploads).toBe(true);
       expect(second.capabilities.pullRequests).toBe(true);
+      expect(second.capabilities.pullRequestViewers).toBe(true);
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
       expect(second.capabilities.threadPullRequestLinking).toBe(true);
       expect(second.capabilities.agentActivityPublishing).toBe(false);

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -148,6 +148,7 @@ export const make = Effect.gen(function* () {
       connectionProbe: true,
       attachmentUploads: true,
       pullRequests: true,
+      pullRequestViewers: true,
       threadSettlement: true,
       threadSnooze: true,
       threadPinning: true,

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -667,6 +667,9 @@ it.effect("reads snapshot viewer identity freshly after the host account changes
     viewer = "Octocat";
     const identity = yield* service.viewers({});
     assert.deepStrictEqual(identity.viewers, { "github.com": "Octocat" });
+
+    const refreshedListing = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(refreshedListing.viewers, { "github.com": "Octocat" });
   }),
 );
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -1,5 +1,7 @@
 import { assert, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as TestClock from "effect/testing/TestClock";
 import type {
@@ -670,6 +672,91 @@ it.effect("reads snapshot viewer identity freshly after the host account changes
 
     const refreshedListing = yield* service.list({ state: "open" });
     assert.deepStrictEqual(refreshedListing.viewers, { "github.com": "Octocat" });
+  }),
+);
+
+it.effect("keeps a healthy host when another host's viewer verification fails", () =>
+  Effect.gen(function* () {
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "github", workspaceRoot: "/a", repository: "acme/web" }),
+        project({
+          id: "p2",
+          title: "gitlab",
+          workspaceRoot: "/b",
+          repository: "acme/api",
+          provider: "gitlab",
+        }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () => Effect.fail(requestFailed),
+        }),
+        fakeProvider("gitlab", {
+          getViewer: () => Effect.succeed("healthy-viewer"),
+        }),
+      ],
+    });
+
+    const result = yield* service.viewers({});
+
+    assert.deepStrictEqual(result.viewers, { "gitlab.com": "healthy-viewer" });
+  }),
+);
+
+it.effect("strands a list that was in flight when the host account changed", () =>
+  Effect.gen(function* () {
+    const firstListStarted = yield* Deferred.make<void>();
+    const releaseFirstList = yield* Deferred.make<void>();
+    let viewer = "Bilal";
+    let listCalls = 0;
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () => Effect.succeed(viewer),
+          listChangeRequests: () =>
+            Effect.gen(function* () {
+              listCalls += 1;
+              const call = listCalls;
+              if (call === 1) {
+                yield* Deferred.succeed(firstListStarted, undefined);
+                yield* Deferred.await(releaseFirstList);
+              }
+              return {
+                items: [changeRequest(call, `2026-07-0${call}T00:00:00Z`)],
+                truncated: false,
+                continues: true,
+              };
+            }),
+        }),
+      ],
+    });
+
+    const oldListing = yield* service.list({ state: "open" }).pipe(Effect.forkChild);
+    yield* Deferred.await(firstListStarted);
+
+    viewer = "Octocat";
+    assert.deepStrictEqual((yield* service.viewers({})).viewers, { "github.com": "Octocat" });
+
+    const current = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(current.viewers, { "github.com": "Octocat" });
+    assert.deepStrictEqual(
+      current.entries.map((entry) => entry.number),
+      [2],
+    );
+
+    yield* Deferred.succeed(releaseFirstList, undefined);
+    assert.deepStrictEqual((yield* Fiber.join(oldListing)).viewers, { "github.com": "Bilal" });
+
+    const cached = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(
+      cached.entries.map((entry) => entry.number),
+      [2],
+    );
+    assert.strictEqual(listCalls, 2);
   }),
 );
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -613,6 +613,25 @@ it.effect("calls a transient viewer failure a failed operation, not a signed-out
   }),
 );
 
+it.effect("reads snapshot viewer identity freshly after the host account changes", () =>
+  Effect.gen(function* () {
+    let viewer = "Bilal";
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [fakeProvider("github", { getViewer: () => Effect.succeed(viewer) })],
+    });
+
+    const listing = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(listing.viewers, { "github.com": "Bilal" });
+
+    viewer = "Octocat";
+    const identity = yield* service.viewers({});
+    assert.deepStrictEqual(identity.viewers, { "github.com": "Octocat" });
+  }),
+);
+
 it.effect("reports an unusable host over a merely failing one", () =>
   Effect.gen(function* () {
     const service = yield* makeService({

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -212,6 +212,44 @@ it.effect("refines unknown self-hosted GitLab projects before listing merge requ
   }),
 );
 
+it.effect("does not refine legacy projects outside the requested project ids", () =>
+  Effect.gen(function* () {
+    const asked: string[] = [];
+    const service = yield* makeService({
+      projects: [
+        project({
+          id: "p1",
+          title: "selected",
+          workspaceRoot: "/selected",
+          repository: "group/selected",
+          provider: "unknown",
+          host: "selected.example.test",
+        }),
+        project({
+          id: "p2",
+          title: "unrelated",
+          workspaceRoot: "/unrelated",
+          repository: "group/unrelated",
+          provider: "unknown",
+          host: "unrelated.example.test",
+        }),
+      ],
+      providers: [fakeProvider("gitlab")],
+      resolveHandle: ({ cwd, context }) => {
+        asked.push(cwd);
+        return Effect.succeed({
+          context: { ...context!, provider: { ...context!.provider, kind: "gitlab" } },
+          provider: undefined as never,
+        });
+      },
+    });
+
+    yield* service.viewers({ projectIds: ["p1" as ProjectId] });
+
+    assert.deepStrictEqual(asked, ["/selected"]);
+  }),
+);
+
 it.effect("derives a legacy repository host after refining its provider", () =>
   Effect.gen(function* () {
     const current = project({

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -704,6 +704,8 @@ export const make = Effect.gen(function* () {
   // per read, three reads per page. Only a success is believed for a while: a failure is the
   // "is this host set up" answer the provider switcher shows, and holding it would keep saying
   // signed-out after the reader has signed in.
+  let epochCounter = 0;
+  let listingsEpoch = 0;
   const viewersByHost = new Map<string, { readonly at: number; readonly result: ResolvedViewer }>();
 
   const resolveViewers = (
@@ -737,9 +739,26 @@ export const make = Effect.gen(function* () {
               error: null as PullRequestProviderError | null,
             })),
             Effect.tap((result) =>
-              Effect.map(Clock.currentTimeMillis, (at) => viewersByHost.set(host, { at, result })),
+              Effect.map(Clock.currentTimeMillis, (at) => {
+                if (
+                  options.fresh === true &&
+                  held !== undefined &&
+                  held.result.viewer !== result.viewer
+                ) {
+                  listingsEpoch = ++epochCounter;
+                }
+                viewersByHost.set(host, { at, result });
+              }),
             ),
-            Effect.catch((error) => Effect.succeed({ host, kind: api.kind, viewer: null, error })),
+            Effect.catch((error) =>
+              Effect.sync(() => {
+                if (options.fresh === true && held !== undefined && held.result.viewer !== null) {
+                  listingsEpoch = ++epochCounter;
+                }
+                viewersByHost.delete(host);
+                return { host, kind: api.kind, viewer: null, error };
+              }),
+            ),
           );
         }),
       { concurrency: REPOSITORY_CONCURRENCY },
@@ -1877,8 +1896,6 @@ export const make = Effect.gen(function* () {
   // epoch strands every entry made under the old one — no enumerating a cache whose keys
   // (cursors, commits) nothing holds a list of. The counter is shared and monotonic so a
   // scope re-entering `refEpochs` after eviction can never mint a key an old entry still has.
-  let epochCounter = 0;
-  let listingsEpoch = 0;
   const refEpochs = new Map<string, number>();
   const REF_EPOCH_CAPACITY = 2_048;
   const refScope = (ref: PullRequestRef) => `${ref.projectId} ${ref.repository} ${ref.number}`;

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -43,6 +43,8 @@ import {
   type PullRequestThreadCommentsInput,
   type PullRequestThreadCommentsResult,
   type PullRequestUpdateInput,
+  type PullRequestViewerInput,
+  type PullRequestViewerResult,
   type SourceControlProviderInfo,
   type SourceControlProviderKind,
 } from "@t3tools/contracts";
@@ -116,6 +118,9 @@ export type PullRequestError = PullRequestUnavailableError | PullRequestOperatio
 export class PullRequestService extends Context.Service<
   PullRequestService,
   {
+    readonly viewers: (
+      input: PullRequestViewerInput,
+    ) => Effect.Effect<PullRequestViewerResult, PullRequestError>;
     readonly list: (
       input: PullRequestListInput,
     ) => Effect.Effect<PullRequestListResult, PullRequestError>;
@@ -703,13 +708,18 @@ export const make = Effect.gen(function* () {
   const resolveViewers = (
     projects: ReadonlyArray<SupportedProject>,
     viewerRoots: WorkspaceProjects["viewerRoots"],
+    options: { readonly fresh?: boolean } = {},
   ) =>
     Effect.forEach(
       [...new Set(projects.map(({ host }) => host))],
       (host) =>
         Effect.flatMap(Clock.currentTimeMillis, (now): Effect.Effect<ResolvedViewer> => {
           const held = viewersByHost.get(host);
-          if (held !== undefined && now - held.at <= Duration.toMillis(VIEWER_CACHE_TTL)) {
+          if (
+            options.fresh !== true &&
+            held !== undefined &&
+            now - held.at <= Duration.toMillis(VIEWER_CACHE_TTL)
+          ) {
             return Effect.succeed(held.result);
           }
           const forHost = projects.filter((project) => project.host === host);
@@ -732,6 +742,23 @@ export const make = Effect.gen(function* () {
           );
         }),
       { concurrency: REPOSITORY_CONCURRENCY },
+    );
+
+  // Snapshot hydration needs identity before the slower repository listing has answered. This
+  // read deliberately bypasses the viewer cache: an account can be switched outside T3, and a
+  // cached identity must never authorize rows persisted for the previous account.
+  const viewers: PullRequestService["Service"]["viewers"] = (input) =>
+    listWorkspaceProjects(input).pipe(
+      Effect.flatMap(({ supported, viewerRoots }) =>
+        resolveViewers(supported, viewerRoots, { fresh: true }),
+      ),
+      Effect.map((results) => ({
+        viewers: Object.fromEntries(
+          results.flatMap((result) =>
+            result.viewer === null ? [] : [[result.host, result.viewer] as const],
+          ),
+        ),
+      })),
     );
 
   /**
@@ -2086,6 +2113,7 @@ export const make = Effect.gen(function* () {
       );
 
   return PullRequestService.of({
+    viewers,
     list,
     listStats,
     detail,

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -497,7 +497,7 @@ export const make = Effect.gen(function* () {
 
   const refineUnknownProjectKinds = (
     projects: ReadonlyArray<OrchestrationProjectShell>,
-    filter: Pick<PullRequestListInput, "projectId" | "host">,
+    filter: Pick<PullRequestListInput, "projectId" | "projectIds" | "host">,
   ) => {
     type RefinementCandidate = {
       readonly project: OrchestrationProjectShell;
@@ -508,6 +508,7 @@ export const make = Effect.gen(function* () {
     const refinements = new Map<string, RefinementCandidate[]>();
     for (const project of projects) {
       if (filter.projectId !== undefined && project.id !== filter.projectId) continue;
+      if (filter.projectIds !== undefined && !filter.projectIds.includes(project.id)) continue;
       const identity = project.repositoryIdentity;
       if (identity?.provider !== "unknown" || repositoryIdentityOf(project) === null) continue;
       const host = pullRequestHostOf(identity, "unknown");

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1796,6 +1796,10 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.pullRequestsList, pullRequests.list(input), {
             "rpc.aggregate": "pull-requests",
           }),
+        [WS_METHODS.pullRequestsViewers]: (input) =>
+          observeRpcEffect(WS_METHODS.pullRequestsViewers, pullRequests.viewers(input), {
+            "rpc.aggregate": "pull-requests",
+          }),
         [WS_METHODS.pullRequestsListStats]: (input) =>
           observeRpcEffect(WS_METHODS.pullRequestsListStats, pullRequests.listStats(input), {
             "rpc.aggregate": "pull-requests",

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -7,6 +7,8 @@ import {
   mergePullRequestLists,
   pullRequestEntryKey,
   pullRequestEnvironmentSetKey,
+  pullRequestViewersMatch,
+  pullRequestViewersMatchForEnvironments,
   groupPullRequestsByInvolvement,
   matchesPullRequestFilters,
   matchesPullRequestQuery,
@@ -585,6 +587,39 @@ describe("the list snapshot across a reload", () => {
     viewers: Record<string, string> = { "github.com": "Bilal" },
     now = NOW,
   ) => readPullRequestListSnapshot(storage, environmentKey, { viewers, now });
+
+  it("compares viewer identities independently of host insertion order", () => {
+    expect(
+      pullRequestViewersMatch(
+        { "env-1 github.com": "Bilal", "env-2 gitlab.com": "Theo" },
+        { "env-2 gitlab.com": "Theo", "env-1 github.com": "Bilal" },
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatch({ "env-1 github.com": "Bilal" }, { "env-1 github.com": "Octocat" }),
+    ).toBe(false);
+  });
+
+  it("compares only the viewer-capable environments in a mixed-server list", () => {
+    const capable = new Set(["env-1"]);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        { "env-1 github.com": "Bilal" },
+        capable,
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        { "env-1 github.com": "Octocat" },
+        capable,
+      ),
+    ).toBe(false);
+    expect(
+      pullRequestViewersMatchForEnvironments({ "env-1 github.com": "Bilal" }, {}, capable),
+    ).toBe(false);
+  });
 
   it("hydrates the retained rows so ghosts never replace them", () => {
     const storage = makeStorage();

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -696,6 +696,39 @@ describe("the list snapshot across a reload", () => {
     expect(snapshot?.data.entries.map((item) => item.number)).toEqual([1]);
   });
 
+  it("hydrates across scopes only when every relevant row keeps its viewer", () => {
+    const storage = makeStorage();
+    const github = entry({ environmentId: ENV_1, host: "github.com", number: 1 });
+    const gitlab = entry({ environmentId: ENV_1, host: "gitlab.com", number: 2 });
+    writePullRequestListSnapshot(
+      storage,
+      "env-1",
+      {
+        scope: "broad",
+        data: {
+          entries: [github, gitlab],
+          viewers: { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+          providers: [],
+          errors: [],
+          truncated: false,
+          nextCursors: {},
+          truncatedEnvironments: [],
+        },
+      },
+      NOW,
+    );
+    const readGithub = (viewer: string | undefined) =>
+      readPullRequestListSnapshot(storage, "env-1", {
+        viewers: viewer === undefined ? {} : { "env-1 github.com": viewer },
+        now: NOW,
+        includeEntry: (item) => item.host === "github.com",
+      });
+
+    expect(readGithub("Bilal")?.data.entries).toHaveLength(2);
+    expect(readGithub("Octocat")).toBeNull();
+    expect(readGithub(undefined)).toBeNull();
+  });
+
   it("carries neither stale failures nor stale cursors", () => {
     const storage = makeStorage();
     writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -628,6 +628,21 @@ describe("the list snapshot across a reload", () => {
     ).toBe(true);
   });
 
+  it("accepts a verified continuation page from only the hosts with cursors", () => {
+    const capable = new Set(["env-1", "env-2"]);
+    const verified = {
+      "env-1 github.com": "Bilal",
+      "env-2 github.com": "Octocat",
+    };
+
+    expect(
+      pullRequestListViewersMatchVerification({ "env-1 github.com": "Bilal" }, verified, capable),
+    ).toBe(true);
+    expect(
+      pullRequestListViewersMatchVerification({ "env-1 github.com": "Octocat" }, verified, capable),
+    ).toBe(false);
+  });
+
   it("hydrates the retained rows so ghosts never replace them", () => {
     const storage = makeStorage();
     writePullRequestListSnapshot(storage, "env-1", { scope: "env-1:open:all::", data }, NOW);

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -562,6 +562,7 @@ describe("partitioning with the hosts' own priority reads", () => {
 });
 
 describe("the list snapshot across a reload", () => {
+  const NOW = Date.parse("2026-08-13T12:00:00Z");
   const makeStorage = () => {
     const held = new Map<string, string>();
     return {
@@ -577,27 +578,49 @@ describe("the list snapshot across a reload", () => {
     truncated: true,
     nextCursors: { "pingdotgg/t3code": "cursor-1" },
   } as never;
+  const readSnapshot = (
+    storage: ReturnType<typeof makeStorage> | undefined,
+    environmentKey: string,
+    viewers: Record<string, string> = { "github.com": "Bilal" },
+    now = NOW,
+  ) => readPullRequestListSnapshot(storage, environmentKey, { viewers, now });
 
   it("hydrates the retained rows so ghosts never replace them", () => {
     const storage = makeStorage();
-    writePullRequestListSnapshot(storage, "env-1", { scope: "env-1:open:all::", data });
-    const snapshot = readPullRequestListSnapshot(storage, "env-1");
+    writePullRequestListSnapshot(storage, "env-1", { scope: "env-1:open:all::", data }, NOW);
+    const snapshot = readSnapshot(storage, "env-1");
     expect(snapshot?.scope).toBe("env-1:open:all::");
     expect(snapshot?.data.entries.map((item) => item.number)).toEqual([1]);
   });
 
   it("carries neither stale failures nor stale cursors", () => {
     const storage = makeStorage();
-    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data });
-    const snapshot = readPullRequestListSnapshot(storage, "env-1");
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+    const snapshot = readSnapshot(storage, "env-1");
     expect(snapshot?.data.errors).toEqual([]);
     expect(snapshot?.data.nextCursors).toEqual({});
   });
 
   it("answers nothing for another environment", () => {
     const storage = makeStorage();
-    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data });
-    expect(readPullRequestListSnapshot(storage, "env-2")).toBeNull();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+    expect(readSnapshot(storage, "env-2")).toBeNull();
+  });
+
+  it("rejects snapshots from another host account", () => {
+    const storage = makeStorage();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+
+    expect(readSnapshot(storage, "env-1", { "github.com": "Octocat" })).toBeNull();
+  });
+
+  it("rejects snapshots after their short reload window", () => {
+    const storage = makeStorage();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+
+    expect(
+      readSnapshot(storage, "env-1", { "github.com": "Bilal" }, NOW + 5 * 60 * 1_000 + 1),
+    ).toBeNull();
   });
 
   it("rejects a snapshot whose rows do not decode as entries", () => {
@@ -606,19 +629,19 @@ describe("the list snapshot across a reload", () => {
       "t3.pullRequests.list:env-1",
       JSON.stringify({ scope: "s", data: { entries: [null] } }),
     );
-    expect(readPullRequestListSnapshot(storage, "env-1")).toBeNull();
+    expect(readSnapshot(storage, "env-1")).toBeNull();
     storage.setItem(
       "t3.pullRequests.list:env-1",
       JSON.stringify({ scope: "s", data: { entries: [{ host: "github.com" }] } }),
     );
-    expect(readPullRequestListSnapshot(storage, "env-1")).toBeNull();
+    expect(readSnapshot(storage, "env-1")).toBeNull();
   });
 
   it("shrugs off corrupt storage and no storage at all", () => {
     const storage = makeStorage();
     storage.setItem("t3.pullRequests.list:env-1", "{not json");
-    expect(readPullRequestListSnapshot(storage, "env-1")).toBeNull();
-    expect(readPullRequestListSnapshot(undefined, "env-1")).toBeNull();
+    expect(readSnapshot(storage, "env-1")).toBeNull();
+    expect(readSnapshot(undefined, "env-1")).toBeNull();
   });
 
   it("caps the accumulated rows but keeps the whole host set", () => {
@@ -654,8 +677,8 @@ describe("the list snapshot across a reload", () => {
       truncated: true,
       nextCursors: {},
     } as never;
-    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data: accumulated });
-    const snapshot = readPullRequestListSnapshot(storage, "env-1");
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data: accumulated }, NOW);
+    const snapshot = readSnapshot(storage, "env-1", viewers);
     expect(snapshot?.data.entries).toHaveLength(99);
     expect(snapshot?.data.viewers).toEqual(viewers);
     expect(snapshot?.data.providers).toEqual(providers);

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -20,6 +20,7 @@ import {
   scorePullRequestMatch,
   withDiffStat,
   resolveProjectScope,
+  resolvePullRequestViewerGate,
   resolveQueryEnvironmentIds,
   resolveSelectedEnvironmentId,
   type EnvironmentPullRequestEntry,
@@ -614,6 +615,13 @@ describe("the list snapshot across a reload", () => {
     expect(readSnapshot(storage, "env-1", { "github.com": "Octocat" })).toBeNull();
   });
 
+  it("rejects an existing snapshot when viewer verification failed", () => {
+    const storage = makeStorage();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+
+    expect(readPullRequestListSnapshot(storage, "env-1", { viewers: null, now: NOW })).toBeNull();
+  });
+
   it("rejects snapshots after their short reload window", () => {
     const storage = makeStorage();
     writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
@@ -687,6 +695,22 @@ describe("the list snapshot across a reload", () => {
 
 const ENV_1 = "env-1" as EnvironmentId;
 const ENV_2 = "env-2" as EnvironmentId;
+
+describe("viewer verification gating", () => {
+  it("withholds a capable server while account verification races an in-flight list", () => {
+    const gate = resolvePullRequestViewerGate([ENV_1], new Set([ENV_1]), [ENV_1], true);
+
+    expect(gate.listEnvironmentIds).toEqual([]);
+    expect(gate.canHydrateSnapshot).toBe(false);
+  });
+
+  it("keeps live lists working on old servers without trusting their snapshots", () => {
+    const gate = resolvePullRequestViewerGate([ENV_1], new Set(), [], false);
+
+    expect(gate.listEnvironmentIds).toEqual([ENV_1]);
+    expect(gate.canHydrateSnapshot).toBe(false);
+  });
+});
 
 describe("merging the environments' own listings", () => {
   const answer = (

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -702,6 +702,7 @@ describe("viewer verification gating", () => {
 
     expect(gate.listEnvironmentIds).toEqual([]);
     expect(gate.canHydrateSnapshot).toBe(false);
+    expect(gate.shouldClearRetainedRows).toBe(false);
   });
 
   it("keeps live lists working on old servers without trusting their snapshots", () => {
@@ -709,6 +710,15 @@ describe("viewer verification gating", () => {
 
     expect(gate.listEnvironmentIds).toEqual([ENV_1]);
     expect(gate.canHydrateSnapshot).toBe(false);
+    expect(gate.shouldClearRetainedRows).toBe(false);
+  });
+
+  it("clears retained rows once viewer verification has actually failed", () => {
+    const gate = resolvePullRequestViewerGate([ENV_1], new Set([ENV_1]), [], false);
+
+    expect(gate.listEnvironmentIds).toEqual([]);
+    expect(gate.canHydrateSnapshot).toBe(false);
+    expect(gate.shouldClearRetainedRows).toBe(true);
   });
 });
 

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -7,6 +7,7 @@ import {
   mergePullRequestLists,
   pullRequestEntryKey,
   pullRequestEnvironmentSetKey,
+  pullRequestListViewersMatchVerification,
   pullRequestViewersMatch,
   pullRequestViewersMatchForEnvironments,
   groupPullRequestsByInvolvement,
@@ -619,6 +620,12 @@ describe("the list snapshot across a reload", () => {
     expect(
       pullRequestViewersMatchForEnvironments({ "env-1 github.com": "Bilal" }, {}, capable),
     ).toBe(false);
+  });
+
+  it("accepts live rows when the current scope queries only legacy servers", () => {
+    expect(
+      pullRequestListViewersMatchVerification({ "env-2 github.com": "Legacy" }, null, new Set()),
+    ).toBe(true);
   });
 
   it("hydrates the retained rows so ghosts never replace them", () => {

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -8,6 +8,7 @@ import {
   pullRequestEntryKey,
   pullRequestEnvironmentSetKey,
   pullRequestListViewersMatchVerification,
+  retainPullRequestEntriesForVerifiedViewers,
   pullRequestViewersMatch,
   pullRequestViewersMatchForEnvironments,
   groupPullRequestsByInvolvement,
@@ -703,6 +704,25 @@ describe("the list snapshot across a reload", () => {
         new Set(["env-1"]),
       ),
     ).toBe(false);
+  });
+
+  it("retains only rows whose capable hosts still have the same verified viewer", () => {
+    const github = entry({ environmentId: ENV_1, host: "github.com", number: 1 });
+    const gitlab = entry({ environmentId: ENV_1, host: "gitlab.com", number: 2 });
+    const legacy = entry({ environmentId: ENV_2, host: "github.com", number: 3 });
+
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        [github, gitlab, legacy],
+        {
+          "env-1 github.com": "Bilal",
+          "env-1 gitlab.com": "Theo",
+          "env-2 github.com": "Legacy",
+        },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ).map((item) => item.number),
+    ).toEqual([1, 3]);
   });
 
   it("hydrates the retained rows so ghosts never replace them", () => {

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -622,6 +622,34 @@ describe("the list snapshot across a reload", () => {
     ).toBe(false);
   });
 
+  it("compares only retained hosts relevant to a narrower scope", () => {
+    const capable = new Set(["env-1"]);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        capable,
+        new Set(["env-1 github.com"]),
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Octocat" },
+        capable,
+        new Set(["env-1 github.com"]),
+      ),
+    ).toBe(false);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        capable,
+        new Set(["env-1 gitlab.com"]),
+      ),
+    ).toBe(false);
+  });
+
   it("accepts live rows when the current scope queries only legacy servers", () => {
     expect(
       pullRequestListViewersMatchVerification({ "env-2 github.com": "Legacy" }, null, new Set()),

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -731,6 +731,16 @@ describe("the list snapshot across a reload", () => {
         new Set(["env-1", "env-2"]),
       ).map((item) => item.number),
     ).toEqual([1]);
+
+    const alreadyVerified = [github, legacy];
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        alreadyVerified,
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ),
+    ).toBe(alreadyVerified);
   });
 
   it("hydrates the retained rows so ghosts never replace them", () => {

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -723,6 +723,14 @@ describe("the list snapshot across a reload", () => {
         new Set(["env-1"]),
       ).map((item) => item.number),
     ).toEqual([1, 3]);
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        [github, entry({ environmentId: ENV_2, host: "github.com", number: 4 })],
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Octocat" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1", "env-2"]),
+      ).map((item) => item.number),
+    ).toEqual([1]);
   });
 
   it("hydrates the retained rows so ghosts never replace them", () => {

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -688,6 +688,23 @@ describe("the list snapshot across a reload", () => {
     ).toBe(false);
   });
 
+  it("accepts live rows when fresh verification could not read one host", () => {
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Octocat", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ),
+    ).toBe(false);
+  });
+
   it("hydrates the retained rows so ghosts never replace them", () => {
     const storage = makeStorage();
     writePullRequestListSnapshot(storage, "env-1", { scope: "env-1:open:all::", data }, NOW);

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -731,6 +731,14 @@ describe("the list snapshot across a reload", () => {
         new Set(["env-1", "env-2"]),
       ).map((item) => item.number),
     ).toEqual([1]);
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        [github, legacy],
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        {},
+        new Set(["env-1"]),
+      ).map((item) => item.number),
+    ).toEqual([3]);
 
     const alreadyVerified = [github, legacy];
     expect(

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -628,6 +628,23 @@ describe("the list snapshot across a reload", () => {
     ).toBe(true);
   });
 
+  it("accepts legacy rows when a separate capable server fails viewer verification", () => {
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-2 github.com": "Legacy" },
+        null,
+        new Set(["env-1"]),
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Bilal" },
+        null,
+        new Set(["env-1"]),
+      ),
+    ).toBe(false);
+  });
+
   it("accepts a verified continuation page from only the hosts with cursors", () => {
     const capable = new Set(["env-1", "env-2"]);
     const verified = {

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -724,7 +724,7 @@ describe("the list snapshot across a reload", () => {
         includeEntry: (item) => item.host === "github.com",
       });
 
-    expect(readGithub("Bilal")?.data.entries).toHaveLength(2);
+    expect(readGithub("Bilal")?.data.entries.map((item) => item.host)).toEqual(["github.com"]);
     expect(readGithub("Octocat")).toBeNull();
     expect(readGithub(undefined)).toBeNull();
   });

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -705,14 +705,13 @@ export function readPullRequestListSnapshot(
     if (context.includeEntry === undefined) {
       if (!pullRequestViewersMatch(decoded.value.data.viewers, viewers)) return null;
     } else {
+      const includedEntries = decoded.value.data.entries.filter(context.includeEntry);
+      const includedAuthored = decoded.value.partitions?.authored.filter(context.includeEntry);
+      const includedReviewing = decoded.value.partitions?.reviewing.filter(context.includeEntry);
       const requiredViewerKeys = new Set(
-        [
-          ...decoded.value.data.entries,
-          ...(decoded.value.partitions?.authored ?? []),
-          ...(decoded.value.partitions?.reviewing ?? []),
-        ]
-          .filter(context.includeEntry)
-          .map(pullRequestViewerKey),
+        [...includedEntries, ...(includedAuthored ?? []), ...(includedReviewing ?? [])].map(
+          pullRequestViewerKey,
+        ),
       );
       if (
         [...requiredViewerKeys].some(
@@ -723,6 +722,15 @@ export function readPullRequestListSnapshot(
       ) {
         return null;
       }
+      return {
+        ...decoded.value,
+        data: { ...decoded.value.data, entries: includedEntries },
+        ...(decoded.value.partitions === undefined
+          ? {}
+          : {
+              partitions: { authored: includedAuthored ?? [], reviewing: includedReviewing ?? [] },
+            }),
+      };
     }
     return decoded.value;
   } catch {

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -614,6 +614,15 @@ export const pullRequestViewersMatchForEnvironments = (
   );
 };
 
+export const pullRequestListViewersMatchVerification = (
+  listedViewers: PullRequestViewers,
+  verifiedViewers: PullRequestViewers | null,
+  verifiedEnvironmentIds: ReadonlySet<string>,
+): boolean =>
+  verifiedEnvironmentIds.size === 0 ||
+  (verifiedViewers !== null &&
+    pullRequestViewersMatchForEnvironments(listedViewers, verifiedViewers, verifiedEnvironmentIds));
+
 /**
  * Decoded with the contract's own schema rather than trusted from a cast: storage is writable
  * by anything in the origin and by any past version of this app, and one malformed row would

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -523,6 +523,8 @@ export function mergePullRequestLists(
 
 /** One page is what the list itself starts with, and all a cold start needs to look warm. */
 const SNAPSHOT_MAX_ENTRIES = 99;
+/** A persisted list is only a short bridge across a reload, never a durable source of truth. */
+const SNAPSHOT_MAX_AGE_MS = 5 * 60 * 1_000;
 
 type SnapshotStorage = Pick<Storage, "getItem" | "setItem">;
 
@@ -548,10 +550,14 @@ export interface PullRequestPartitionsSnapshot {
 }
 
 export interface PullRequestListSnapshot {
+  readonly writtenAt: number;
   readonly scope: string;
   readonly data: MergedPullRequestList;
   readonly partitions?: PullRequestPartitionsSnapshot | undefined;
 }
+
+const viewerIdentity = (viewers: PullRequestViewers): string =>
+  JSON.stringify(Object.entries(viewers).toSorted(([left], [right]) => left.localeCompare(right)));
 
 /**
  * Decoded with the contract's own schema rather than trusted from a cast: storage is writable
@@ -571,6 +577,7 @@ const EnvironmentPullRequestErrorSchema = Schema.Struct({
 
 const decodeSnapshot = Schema.decodeUnknownOption(
   Schema.Struct({
+    writtenAt: Schema.Number,
     scope: Schema.String,
     data: Schema.Struct({
       ...PullRequestListResult.fields,
@@ -600,12 +607,19 @@ const decodeSnapshot = Schema.decodeUnknownOption(
 export function readPullRequestListSnapshot(
   storage: SnapshotStorage | undefined,
   environmentSetKey: string,
+  context: { readonly viewers: PullRequestViewers; readonly now?: number },
 ): PullRequestListSnapshot | null {
   try {
     const raw = storage?.getItem(snapshotStorageKey(environmentSetKey));
     if (!raw) return null;
     const decoded = decodeSnapshot(JSON.parse(raw));
-    return decoded._tag === "Some" ? decoded.value : null;
+    if (decoded._tag === "None") return null;
+    const now = context.now ?? Date.now();
+    if (decoded.value.writtenAt > now || now - decoded.value.writtenAt > SNAPSHOT_MAX_AGE_MS) {
+      return null;
+    }
+    if (viewerIdentity(decoded.value.data.viewers) !== viewerIdentity(context.viewers)) return null;
+    return decoded.value;
   } catch {
     return null;
   }
@@ -614,12 +628,14 @@ export function readPullRequestListSnapshot(
 export function writePullRequestListSnapshot(
   storage: SnapshotStorage | undefined,
   environmentSetKey: string,
-  snapshot: PullRequestListSnapshot,
+  snapshot: Omit<PullRequestListSnapshot, "writtenAt">,
+  now = Date.now(),
 ): void {
   try {
     storage?.setItem(
       snapshotStorageKey(environmentSetKey),
       JSON.stringify({
+        writtenAt: now,
         scope: snapshot.scope,
         data: {
           ...snapshot.data,

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -620,13 +620,14 @@ export const pullRequestListViewersMatchVerification = (
   verifiedEnvironmentIds: ReadonlySet<string>,
 ): boolean => {
   if (verifiedEnvironmentIds.size === 0) return true;
-  if (verifiedViewers === null) return false;
 
   const prefixes = [...verifiedEnvironmentIds].map((environmentId) => `${environmentId} `);
-  return Object.entries(listedViewers).every(
-    ([key, viewer]) =>
-      !prefixes.some((prefix) => key.startsWith(prefix)) || verifiedViewers[key] === viewer,
+  const scopedViewers = Object.entries(listedViewers).filter(([key]) =>
+    prefixes.some((prefix) => key.startsWith(prefix)),
   );
+  if (scopedViewers.length === 0) return true;
+  if (verifiedViewers === null) return false;
+  return scopedViewers.every(([key, viewer]) => verifiedViewers[key] === viewer);
 };
 
 /**

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -685,10 +685,15 @@ const decodeSnapshot = Schema.decodeUnknownOption(
 export function readPullRequestListSnapshot(
   storage: SnapshotStorage | undefined,
   environmentSetKey: string,
-  context: { readonly viewers: PullRequestViewers | null; readonly now?: number },
+  context: {
+    readonly viewers: PullRequestViewers | null;
+    readonly now?: number;
+    readonly includeEntry?: (entry: EnvironmentPullRequestEntry) => boolean;
+  },
 ): PullRequestListSnapshot | null {
   try {
     if (context.viewers === null) return null;
+    const viewers = context.viewers;
     const raw = storage?.getItem(snapshotStorageKey(environmentSetKey));
     if (!raw) return null;
     const decoded = decodeSnapshot(JSON.parse(raw));
@@ -697,7 +702,28 @@ export function readPullRequestListSnapshot(
     if (decoded.value.writtenAt > now || now - decoded.value.writtenAt > SNAPSHOT_MAX_AGE_MS) {
       return null;
     }
-    if (!pullRequestViewersMatch(decoded.value.data.viewers, context.viewers)) return null;
+    if (context.includeEntry === undefined) {
+      if (!pullRequestViewersMatch(decoded.value.data.viewers, viewers)) return null;
+    } else {
+      const requiredViewerKeys = new Set(
+        [
+          ...decoded.value.data.entries,
+          ...(decoded.value.partitions?.authored ?? []),
+          ...(decoded.value.partitions?.reviewing ?? []),
+        ]
+          .filter(context.includeEntry)
+          .map(pullRequestViewerKey),
+      );
+      if (
+        [...requiredViewerKeys].some(
+          (key) =>
+            decoded.value.data.viewers[key] === undefined ||
+            decoded.value.data.viewers[key] !== viewers[key],
+        )
+      ) {
+        return null;
+      }
+    }
     return decoded.value;
   } catch {
     return null;

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -536,6 +536,32 @@ type SnapshotStorage = Pick<Storage, "getItem" | "setItem">;
 export const pullRequestEnvironmentSetKey = (environmentIds: ReadonlyArray<string>): string =>
   [...environmentIds].sort((left, right) => left.localeCompare(right)).join(",");
 
+export function resolvePullRequestViewerGate<Id extends string>(
+  environmentIds: ReadonlyArray<Id>,
+  viewerCapableEnvironmentIds: ReadonlySet<Id>,
+  verifiedEnvironmentIds: ReadonlyArray<Id>,
+  verificationPending: boolean,
+): {
+  readonly listEnvironmentIds: ReadonlyArray<Id>;
+  readonly canHydrateSnapshot: boolean;
+} {
+  const verified = new Set(verifiedEnvironmentIds);
+  return {
+    listEnvironmentIds: environmentIds.filter(
+      (environmentId) =>
+        !viewerCapableEnvironmentIds.has(environmentId) ||
+        (!verificationPending && verified.has(environmentId)),
+    ),
+    canHydrateSnapshot:
+      environmentIds.length > 0 &&
+      !verificationPending &&
+      environmentIds.every(
+        (environmentId) =>
+          viewerCapableEnvironmentIds.has(environmentId) && verified.has(environmentId),
+      ),
+  };
+}
+
 const snapshotStorageKey = (environmentSetKey: string) =>
   `t3.pullRequests.list:${environmentSetKey}`;
 
@@ -607,9 +633,10 @@ const decodeSnapshot = Schema.decodeUnknownOption(
 export function readPullRequestListSnapshot(
   storage: SnapshotStorage | undefined,
   environmentSetKey: string,
-  context: { readonly viewers: PullRequestViewers; readonly now?: number },
+  context: { readonly viewers: PullRequestViewers | null; readonly now?: number },
 ): PullRequestListSnapshot | null {
   try {
+    if (context.viewers === null) return null;
     const raw = storage?.getItem(snapshotStorageKey(environmentSetKey));
     if (!raw) return null;
     const decoded = decodeSnapshot(JSON.parse(raw));

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -647,12 +647,14 @@ export const retainPullRequestEntriesForVerifiedViewers = (
   listedViewers: PullRequestViewers,
   verifiedViewers: PullRequestViewers,
   verifiedEnvironmentIds: ReadonlySet<string>,
-): ReadonlyArray<EnvironmentPullRequestEntry> =>
-  entries.filter((entry) => {
+): ReadonlyArray<EnvironmentPullRequestEntry> => {
+  const retained = entries.filter((entry) => {
     if (!verifiedEnvironmentIds.has(entry.environmentId)) return true;
     const key = pullRequestViewerKey(entry);
     return listedViewers[key] !== undefined && listedViewers[key] === verifiedViewers[key];
   });
+  return retained.length === entries.length ? entries : retained;
+};
 
 /**
  * Decoded with the contract's own schema rather than trusted from a cast: storage is writable

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -642,6 +642,18 @@ export const pullRequestListViewersMatchVerification = (
   );
 };
 
+export const retainPullRequestEntriesForVerifiedViewers = (
+  entries: ReadonlyArray<EnvironmentPullRequestEntry>,
+  listedViewers: PullRequestViewers,
+  verifiedViewers: PullRequestViewers,
+  verifiedEnvironmentIds: ReadonlySet<string>,
+): ReadonlyArray<EnvironmentPullRequestEntry> =>
+  entries.filter((entry) => {
+    if (!verifiedEnvironmentIds.has(entry.environmentId)) return true;
+    const key = pullRequestViewerKey(entry);
+    return listedViewers[key] !== undefined && listedViewers[key] === verifiedViewers[key];
+  });
+
 /**
  * Decoded with the contract's own schema rather than trusted from a cast: storage is writable
  * by anything in the origin and by any past version of this app, and one malformed row would

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -618,10 +618,16 @@ export const pullRequestListViewersMatchVerification = (
   listedViewers: PullRequestViewers,
   verifiedViewers: PullRequestViewers | null,
   verifiedEnvironmentIds: ReadonlySet<string>,
-): boolean =>
-  verifiedEnvironmentIds.size === 0 ||
-  (verifiedViewers !== null &&
-    pullRequestViewersMatchForEnvironments(listedViewers, verifiedViewers, verifiedEnvironmentIds));
+): boolean => {
+  if (verifiedEnvironmentIds.size === 0) return true;
+  if (verifiedViewers === null) return false;
+
+  const prefixes = [...verifiedEnvironmentIds].map((environmentId) => `${environmentId} `);
+  return Object.entries(listedViewers).every(
+    ([key, viewer]) =>
+      !prefixes.some((prefix) => key.startsWith(prefix)) || verifiedViewers[key] === viewer,
+  );
+};
 
 /**
  * Decoded with the contract's own schema rather than trusted from a cast: storage is writable

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -544,8 +544,13 @@ export function resolvePullRequestViewerGate<Id extends string>(
 ): {
   readonly listEnvironmentIds: ReadonlyArray<Id>;
   readonly canHydrateSnapshot: boolean;
+  readonly shouldClearRetainedRows: boolean;
 } {
   const verified = new Set(verifiedEnvironmentIds);
+  const hasUnverifiedCapableEnvironment = environmentIds.some(
+    (environmentId) =>
+      viewerCapableEnvironmentIds.has(environmentId) && !verified.has(environmentId),
+  );
   return {
     listEnvironmentIds: environmentIds.filter(
       (environmentId) =>
@@ -559,6 +564,9 @@ export function resolvePullRequestViewerGate<Id extends string>(
         (environmentId) =>
           viewerCapableEnvironmentIds.has(environmentId) && verified.has(environmentId),
       ),
+    // A refresh in flight still carries the identity this session already verified. Keep those
+    // rows visible until the read settles; only a settled failure proves they cannot be retained.
+    shouldClearRetainedRows: !verificationPending && hasUnverifiedCapableEnvironment,
   };
 }
 

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -602,16 +602,23 @@ export const pullRequestViewersMatchForEnvironments = (
   listedViewers: PullRequestViewers,
   verifiedViewers: PullRequestViewers,
   environmentIds: ReadonlySet<string>,
+  requiredViewerKeys?: ReadonlySet<string>,
 ): boolean => {
   const prefixes = [...environmentIds].map((environmentId) => `${environmentId} `);
-  return pullRequestViewersMatch(
-    Object.fromEntries(
-      Object.entries(listedViewers).filter(([key]) =>
-        prefixes.some((prefix) => key.startsWith(prefix)),
-      ),
+  const scopedListedViewers = Object.fromEntries(
+    Object.entries(listedViewers).filter(([key]) =>
+      prefixes.some((prefix) => key.startsWith(prefix)),
     ),
-    verifiedViewers,
   );
+  if (requiredViewerKeys === undefined) {
+    return pullRequestViewersMatch(scopedListedViewers, verifiedViewers);
+  }
+  return [...requiredViewerKeys]
+    .filter((key) => prefixes.some((prefix) => key.startsWith(prefix)))
+    .every(
+      (key) =>
+        scopedListedViewers[key] !== undefined && scopedListedViewers[key] === verifiedViewers[key],
+    );
 };
 
 export const pullRequestListViewersMatchVerification = (

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -634,7 +634,12 @@ export const pullRequestListViewersMatchVerification = (
   );
   if (scopedViewers.length === 0) return true;
   if (verifiedViewers === null) return false;
-  return scopedViewers.every(([key, viewer]) => verifiedViewers[key] === viewer);
+  // The gated live list runs after the fresh viewer read. A host omitted by that read has had its
+  // server cache cleared, so the list's own viewer is a fresh retry; only a known disagreement is
+  // an account switch. Snapshot and retained-row checks remain strict about missing identities.
+  return scopedViewers.every(
+    ([key, viewer]) => verifiedViewers[key] === undefined || verifiedViewers[key] === viewer,
+  );
 };
 
 /**

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -593,6 +593,27 @@ export interface PullRequestListSnapshot {
 const viewerIdentity = (viewers: PullRequestViewers): string =>
   JSON.stringify(Object.entries(viewers).toSorted(([left], [right]) => left.localeCompare(right)));
 
+export const pullRequestViewersMatch = (
+  left: PullRequestViewers,
+  right: PullRequestViewers,
+): boolean => viewerIdentity(left) === viewerIdentity(right);
+
+export const pullRequestViewersMatchForEnvironments = (
+  listedViewers: PullRequestViewers,
+  verifiedViewers: PullRequestViewers,
+  environmentIds: ReadonlySet<string>,
+): boolean => {
+  const prefixes = [...environmentIds].map((environmentId) => `${environmentId} `);
+  return pullRequestViewersMatch(
+    Object.fromEntries(
+      Object.entries(listedViewers).filter(([key]) =>
+        prefixes.some((prefix) => key.startsWith(prefix)),
+      ),
+    ),
+    verifiedViewers,
+  );
+};
+
 /**
  * Decoded with the contract's own schema rather than trusted from a cast: storage is writable
  * by anything in the origin and by any past version of this app, and one malformed row would
@@ -653,7 +674,7 @@ export function readPullRequestListSnapshot(
     if (decoded.value.writtenAt > now || now - decoded.value.writtenAt > SNAPSHOT_MAX_AGE_MS) {
       return null;
     }
-    if (viewerIdentity(decoded.value.data.viewers) !== viewerIdentity(context.viewers)) return null;
+    if (!pullRequestViewersMatch(decoded.value.data.viewers, context.viewers)) return null;
     return decoded.value;
   } catch {
     return null;

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -43,6 +43,7 @@ import {
   rankPullRequestMatches,
   pullRequestEnvironmentSetKey,
   readPullRequestListSnapshot,
+  resolvePullRequestViewerGate,
   resolveProjectScope,
   resolveQueryEnvironmentIds,
   resolveSelectedEnvironmentId,
@@ -660,20 +661,24 @@ function PullRequestsRouteView() {
   // changed. Do not race a warm list hit against that read, and never ask an environment whose
   // identity check failed. Older servers without this method keep their live-list behavior, but
   // cannot hydrate a persisted snapshot because their identity cannot be verified independently.
-  const verifiedEnvironmentIds = useMemo(
+  const viewerGate = useMemo(
     () =>
-      new Set([
-        ...environmentQueries.flatMap(({ environmentId }) =>
-          viewerCapableEnvironmentIds.has(environmentId) ? [] : [environmentId],
-        ),
-        ...(viewerQuery.isPending ? [] : viewerQuery.environmentIds),
-      ]),
+      resolvePullRequestViewerGate(
+        environmentQueries.map(({ environmentId }) => environmentId),
+        viewerCapableEnvironmentIds,
+        viewerQuery.environmentIds,
+        viewerQuery.isPending,
+      ),
     [
       environmentQueries,
       viewerCapableEnvironmentIds,
       viewerQuery.environmentIds,
       viewerQuery.isPending,
     ],
+  );
+  const verifiedEnvironmentIds = useMemo(
+    () => new Set(viewerGate.listEnvironmentIds),
+    [viewerGate.listEnvironmentIds],
   );
   const verifiedListTargets = useMemo(
     () => listTargets.filter(({ environmentId }) => verifiedEnvironmentIds.has(environmentId)),
@@ -831,7 +836,11 @@ function PullRequestsRouteView() {
   // with ghosts. Waiting for identity prevents one CLI account from seeing another's stored rows.
   useEffect(() => {
     const viewers = viewerQuery.viewers;
-    if (environmentKey.length === 0 || viewers === null || viewerQuery.isPending) return;
+    if (environmentKey.length === 0) return;
+    if (!viewerGate.canHydrateSnapshot) {
+      setLoaded(null);
+      return;
+    }
     setLoaded((current) => {
       // Rows read from a different set of environments cannot even be narrowed — one of them may
       // no longer be connected at all — so that set's own snapshot beats holding them.
@@ -850,7 +859,7 @@ function PullRequestsRouteView() {
         ...(snapshot.partitions === undefined ? {} : { partitions: snapshot.partitions }),
       };
     });
-  }, [environmentKey, viewerQuery.isPending, viewerQuery.viewers]);
+  }, [environmentKey, viewerGate.canHydrateSnapshot, viewerQuery.viewers]);
   useEffect(() => {
     // Only once this query has settled. While a search is being swapped in or out the text has
     // already changed and the data has not, so recording them together would file the previous

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -624,8 +624,6 @@ function PullRequestsRouteView() {
       sentParsed.text,
     ],
   );
-  const listQuery = usePullRequestList(listTargets);
-
   // Verify the account independently of the slower repository listing. This is deliberately a
   // fresh server read: the host CLI account can change outside T3 between two page loads.
   const viewerTargets = useMemo(
@@ -641,6 +639,11 @@ function PullRequestsRouteView() {
     [environmentQueries, scopedProjectId, search.host],
   );
   const viewerQuery = usePullRequestViewers(viewerTargets);
+  // The fresh viewer read also invalidates server-side listing caches when the CLI account has
+  // changed. Do not race a warm list hit against that read: once this gate opens, every listing
+  // is keyed under the identity the page just verified.
+  const viewerVerified = !viewerQuery.isPending && viewerQuery.viewers !== null;
+  const listQuery = usePullRequestList(viewerVerified ? listTargets : NO_LIST_TARGETS);
 
   /**
    * The same filters with nothing typed, read whether or not anything is. It is the same atom the
@@ -676,7 +679,7 @@ function PullRequestsRouteView() {
       search.state,
     ],
   );
-  const baselineQuery = usePullRequestList(baselineTargets);
+  const baselineQuery = usePullRequestList(viewerVerified ? baselineTargets : NO_LIST_TARGETS);
   // The priority groups' own reads. The feed below is paginated by recency, so an older authored
   // or review-requested row can be missing from its first page; partitioned from these
   // server-filtered reads instead, the priority view is complete up front and a continuation can
@@ -711,8 +714,12 @@ function PullRequestsRouteView() {
     search.host,
     search.state,
   ]);
-  const authoredQuery = usePullRequestList(partitionTargets.authored);
-  const reviewingQuery = usePullRequestList(partitionTargets.reviewing);
+  const authoredQuery = usePullRequestList(
+    viewerVerified ? partitionTargets.authored : NO_LIST_TARGETS,
+  );
+  const reviewingQuery = usePullRequestList(
+    viewerVerified ? partitionTargets.reviewing : NO_LIST_TARGETS,
+  );
   // The header's refresh punches through the server's cache before re-reading; the error and
   // empty states retry plainly, because a failure is never cached.
   const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -751,10 +751,12 @@ function PullRequestsRouteView() {
   // A reload recreates the registry the queries live in, so with nothing held the page would
   // cold-start into skeletons even though almost every row is unchanged. The last answer for
   // this set of environments is kept across reloads and hydrated here as the carried rows: they
-  // render at once — narrowed to the current filters like any carried answer — and the live read
-  // reconciles them in place by key rather than replacing them with ghosts.
+  // render once the current host identities are known — narrowed to the current filters like any
+  // carried answer — and the live read reconciles them in place by key rather than replacing them
+  // with ghosts. Waiting for identity prevents one CLI account from seeing another's stored rows.
   useEffect(() => {
-    if (environmentKey.length === 0) return;
+    const baseline = baselineQuery.data;
+    if (environmentKey.length === 0 || baseline === null) return;
     setLoaded((current) => {
       // Rows read from a different set of environments cannot even be narrowed — one of them may
       // no longer be connected at all — so that set's own snapshot beats holding them.
@@ -762,6 +764,7 @@ function PullRequestsRouteView() {
       const snapshot = readPullRequestListSnapshot(
         typeof window === "undefined" ? undefined : window.localStorage,
         environmentKey,
+        { viewers: baseline.viewers },
       );
       if (snapshot === null) return null;
       return {
@@ -772,7 +775,7 @@ function PullRequestsRouteView() {
         ...(snapshot.partitions === undefined ? {} : { partitions: snapshot.partitions }),
       };
     });
-  }, [environmentKey]);
+  }, [baselineQuery.data, environmentKey]);
   useEffect(() => {
     // Only once this query has settled. While a search is being swapped in or out the text has
     // already changed and the data has not, so recording them together would file the previous

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -798,6 +798,57 @@ function PullRequestsRouteView() {
   const verifiedBaselineData = acceptVerifiedData(baselineQuery.data);
   const verifiedAuthoredData = acceptVerifiedData(authoredQuery.data);
   const verifiedReviewingData = acceptVerifiedData(reviewingQuery.data);
+  const rejectedRefreshes = useRef(new Map<string, () => void>());
+  useEffect(() => {
+    const viewers = viewerQuery.viewers;
+    if (viewerQuery.isPending || viewerQuery.error !== null || viewers === null) return;
+
+    const queries = [
+      ["list", listQuery, verifiedListData],
+      ["baseline", baselineQuery, verifiedBaselineData],
+      ["authored", authoredQuery, verifiedAuthoredData],
+      ["reviewing", reviewingQuery, verifiedReviewingData],
+    ] as const;
+    for (const [name, query, accepted] of queries) {
+      if (query.data === null || accepted !== null) {
+        rejectedRefreshes.current.delete(name);
+        continue;
+      }
+      if (
+        query.isPending ||
+        query.error !== null ||
+        rejectedRefreshes.current.get(name) === query.refresh
+      ) {
+        continue;
+      }
+      rejectedRefreshes.current.set(name, query.refresh);
+      query.refresh();
+    }
+  }, [
+    authoredQuery.data,
+    authoredQuery.error,
+    authoredQuery.isPending,
+    authoredQuery.refresh,
+    baselineQuery.data,
+    baselineQuery.error,
+    baselineQuery.isPending,
+    baselineQuery.refresh,
+    listQuery.data,
+    listQuery.error,
+    listQuery.isPending,
+    listQuery.refresh,
+    reviewingQuery.data,
+    reviewingQuery.error,
+    reviewingQuery.isPending,
+    reviewingQuery.refresh,
+    verifiedAuthoredData,
+    verifiedBaselineData,
+    verifiedListData,
+    verifiedReviewingData,
+    viewerQuery.error,
+    viewerQuery.isPending,
+    viewerQuery.viewers,
+  ]);
   // The header's refresh punches through the server's cache before re-reading; the error and
   // empty states retry plainly, because a failure is never cached.
   const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
@@ -1010,12 +1061,18 @@ function PullRequestsRouteView() {
     (loaded?.scope === scopeKey ? loaded.data : null) ??
     narrowed;
   const listData = answered ?? carried;
+  const baselineAnswers = sentQuery.length === 0 && sentCursors === null && pageSize === PAGE_SIZE;
+  const answerRejected = baselineAnswers
+    ? baselineQuery.data !== null && verifiedBaselineData === null
+    : listQuery.data !== null && verifiedListData === null;
   /** The rows on screen answer the previous question, held while this one is on its way. */
   const showingCarried = answered === null && carried !== null;
   const loadingMore = listQuery.isPending && listData !== null;
-  /** Nothing read and nothing to carry, which is the one thing skeletons are for. */
-  const firstLoad = (viewerQuery.isPending || listQuery.isPending) && listData === null;
   const listError = viewerQuery.error ?? listQuery.error;
+  /** Nothing read and nothing to carry, which is the one thing skeletons are for. */
+  const firstLoad =
+    (viewerQuery.isPending || listQuery.isPending || (answerRejected && listError === null)) &&
+    listData === null;
 
   // `ordered` is declared above, ahead of the snapshot write, but grown here from this round's
   // own answer.

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -42,6 +42,7 @@ import {
   pullRequestEntryViewer,
   rankPullRequestMatches,
   pullRequestEnvironmentSetKey,
+  pullRequestViewersMatchForEnvironments,
   readPullRequestListSnapshot,
   resolvePullRequestViewerGate,
   resolveProjectScope,
@@ -775,6 +776,25 @@ function PullRequestsRouteView() {
   );
   const authoredQuery = usePullRequestList(verifiedAuthoredTargets);
   const reviewingQuery = usePullRequestList(verifiedReviewingTargets);
+  const acceptVerifiedData = (data: MergedPullRequestList | null) => {
+    if (data === null || viewerCapableEnvironmentIds.size === 0) return data;
+    const verifiedViewers = viewerQuery.viewers;
+    return verifiedViewers !== null &&
+      pullRequestViewersMatchForEnvironments(
+        data.viewers,
+        verifiedViewers,
+        viewerCapableEnvironmentIds,
+      )
+      ? data
+      : null;
+  };
+  // Query atoms retain their previous success while refreshing. Keep that useful behavior for
+  // the same account, but never render the retained answer after fresh verification identifies
+  // another account.
+  const verifiedListData = acceptVerifiedData(listQuery.data);
+  const verifiedBaselineData = acceptVerifiedData(baselineQuery.data);
+  const verifiedAuthoredData = acceptVerifiedData(authoredQuery.data);
+  const verifiedReviewingData = acceptVerifiedData(reviewingQuery.data);
   // The header's refresh punches through the server's cache before re-reading; the error and
   // empty states retry plainly, because a failure is never cached.
   const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
@@ -837,11 +857,29 @@ function PullRequestsRouteView() {
   useEffect(() => {
     const viewers = viewerQuery.viewers;
     if (environmentKey.length === 0) return;
-    if (!viewerGate.canHydrateSnapshot) {
-      if (viewerGate.shouldClearRetainedRows) setLoaded(null);
+    if (viewerGate.shouldClearRetainedRows) {
+      setLoaded(null);
       return;
     }
+    // A pending read is not a mismatch: keep what this session already verified until the fresh
+    // identity arrives. A legacy-only environment has no independent identity to compare and
+    // continues to use live rows, but never hydrates persisted ones.
+    if (viewerQuery.isPending || viewers === null) return;
     setLoaded((current) => {
+      // Fresh identity is authoritative for viewer-capable environments, including when a mixed
+      // list also contains a legacy server whose identity cannot be checked independently.
+      if (
+        current !== null &&
+        current.environmentKey === environmentKey &&
+        !pullRequestViewersMatchForEnvironments(
+          current.data.viewers,
+          viewers,
+          viewerCapableEnvironmentIds,
+        )
+      ) {
+        return null;
+      }
+      if (!viewerGate.canHydrateSnapshot) return current;
       // Rows read from a different set of environments cannot even be narrowed — one of them may
       // no longer be connected at all — so that set's own snapshot beats holding them.
       if (current !== null && current.environmentKey === environmentKey) return current;
@@ -859,22 +897,28 @@ function PullRequestsRouteView() {
         ...(snapshot.partitions === undefined ? {} : { partitions: snapshot.partitions }),
       };
     });
-  }, [environmentKey, viewerGate, viewerQuery.viewers]);
+  }, [
+    environmentKey,
+    viewerCapableEnvironmentIds,
+    viewerGate,
+    viewerQuery.isPending,
+    viewerQuery.viewers,
+  ]);
   useEffect(() => {
     // Only once this query has settled. While a search is being swapped in or out the text has
     // already changed and the data has not, so recording them together would file the previous
     // answer under the new question — which is how a search's answer came to speak for the
     // workspace after the search was cleared.
-    if (!listQuery.data || listQuery.isPending) return;
-    const data = listQuery.data;
+    if (!verifiedListData || listQuery.isPending) return;
+    const data = verifiedListData;
     setLoaded((current) => {
       // The partitions arrive on their own clock, so this records whichever have landed by
       // now and runs again when the rest do. Until then the ones already held for this scope
       // stay — hydrated or previously answered — rather than being dropped for a feed that
       // merely settled first.
       const partitions =
-        partitionsWanted && authoredQuery.data !== null && reviewingQuery.data !== null
-          ? { authored: authoredQuery.data.entries, reviewing: reviewingQuery.data.entries }
+        partitionsWanted && verifiedAuthoredData !== null && verifiedReviewingData !== null
+          ? { authored: verifiedAuthoredData.entries, reviewing: verifiedReviewingData.entries }
           : current !== null &&
               current.environmentKey === environmentKey &&
               current.scope === scopeKey
@@ -899,8 +943,8 @@ function PullRequestsRouteView() {
             data: {
               ...data,
               entries: accumulatedEntries,
-              viewers: baselineQuery.data?.viewers ?? data.viewers,
-              providers: baselineQuery.data?.providers ?? data.providers,
+              viewers: verifiedBaselineData?.viewers ?? data.viewers,
+              providers: verifiedBaselineData?.providers ?? data.providers,
             },
             ...(partitions === undefined ? {} : { partitions }),
           },
@@ -918,14 +962,14 @@ function PullRequestsRouteView() {
     environmentKey,
     scopeKey,
     sentQuery,
-    listQuery.data,
+    verifiedListData,
     listQuery.isPending,
     partitionsWanted,
-    authoredQuery.data,
-    reviewingQuery.data,
+    verifiedAuthoredData,
+    verifiedReviewingData,
     ordered,
     filterKey,
-    baselineQuery.data,
+    verifiedBaselineData,
   ]);
   // Changing a filter asks a question nothing has answered yet, and the page is already holding
   // perfectly good rows for the last one. Rather than blank out for the round trip, those rows
@@ -953,13 +997,13 @@ function PullRequestsRouteView() {
   // have its extra rows thrown away for the ninety-nine the baseline keeps answering with.
   const answered =
     (sentQuery.length === 0 && sentCursors === null && pageSize === PAGE_SIZE
-      ? baselineQuery.data
-      : listQuery.data) ??
+      ? verifiedBaselineData
+      : verifiedListData) ??
     (loaded?.scope === scopeKey && loaded.query === sentQuery ? loaded.data : null);
   // Clearing a search returns to a list that has already been read, so it comes back at once
   // rather than after another round trip: the search was the temporary state, not the list.
   const carried =
-    (sentQuery.length === 0 ? baselineQuery.data : undefined) ??
+    (sentQuery.length === 0 ? verifiedBaselineData : undefined) ??
     (loaded?.scope === scopeKey ? loaded.data : null) ??
     narrowed;
   const listData = answered ?? carried;
@@ -1068,18 +1112,18 @@ function PullRequestsRouteView() {
     { enabled: pullRequestsSupported },
   );
 
-  const viewers = baselineQuery.data?.viewers ?? listData?.viewers ?? EMPTY_VIEWERS;
-  const listErrors = baselineQuery.data?.errors ?? listData?.errors ?? [];
+  const viewers = verifiedBaselineData?.viewers ?? listData?.viewers ?? EMPTY_VIEWERS;
+  const listErrors = verifiedBaselineData?.errors ?? listData?.errors ?? [];
 
   /** The hosts that narrowed the listing themselves, so their answer is not narrowed again. */
   const searchingHosts = useMemo(
     () =>
       new Set(
-        (baselineQuery.data?.providers ?? listData?.providers ?? []).flatMap((provider) =>
+        (verifiedBaselineData?.providers ?? listData?.providers ?? []).flatMap((provider) =>
           provider.searchesOnHost ? [provider.host] : [],
         ),
       ),
-    [baselineQuery.data?.providers, listData?.providers],
+    [verifiedBaselineData?.providers, listData?.providers],
   );
 
   const entries = useMemo(() => {
@@ -1203,10 +1247,10 @@ function PullRequestsRouteView() {
             matchesPullRequestFilters(entry, localFilters, pullRequestEntryViewer(entry, viewers)),
           );
     const authored = narrow(
-      partitionsWanted ? (authoredQuery.data?.entries ?? held?.authored) : undefined,
+      partitionsWanted ? (verifiedAuthoredData?.entries ?? held?.authored) : undefined,
     );
     const reviewing = narrow(
-      partitionsWanted ? (reviewingQuery.data?.entries ?? held?.reviewing) : undefined,
+      partitionsWanted ? (verifiedReviewingData?.entries ?? held?.reviewing) : undefined,
     );
     if (authored === undefined || reviewing === undefined) {
       return groupPullRequestsByInvolvement(entries, viewers);
@@ -1215,12 +1259,12 @@ function PullRequestsRouteView() {
   }, [
     hasLocalFilters,
     localFilters,
-    authoredQuery.data?.entries,
+    verifiedAuthoredData?.entries,
     entries,
     environmentKey,
     loaded,
     partitionsWanted,
-    reviewingQuery.data?.entries,
+    verifiedReviewingData?.entries,
     scopeKey,
     search.involvement,
     viewers,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -964,7 +964,20 @@ function PullRequestsRouteView() {
       const snapshot = readPullRequestListSnapshot(
         typeof window === "undefined" ? undefined : window.localStorage,
         environmentKey,
-        { viewers },
+        {
+          viewers,
+          includeEntry: (entry) => {
+            const projectIds = projectScopes.get(entry.environmentId);
+            return (
+              (projectIds === undefined || projectIds.includes(entry.projectId)) &&
+              narrowPullRequestsToFilters([entry], {
+                state: search.state,
+                projectId: scopedProjectId,
+                host: search.host,
+              }).length > 0
+            );
+          },
+        },
       );
       if (snapshot === null) return null;
       return {

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -42,6 +42,7 @@ import {
   pullRequestEntryViewer,
   pullRequestViewerKey,
   rankPullRequestMatches,
+  retainPullRequestEntriesForVerifiedViewers,
   pullRequestEnvironmentSetKey,
   pullRequestListViewersMatchVerification,
   pullRequestViewersMatchForEnvironments,
@@ -946,10 +947,50 @@ function PullRequestsRouteView() {
         queriedViewerEnvironmentIds,
         retainedViewerKeys,
       );
-    if (viewerGate.shouldClearRetainedRows || retainedViewerMismatch) {
+    if (viewerGate.shouldClearRetainedRows) {
       setLoaded(null);
       setOrdered(null);
       setPage({ key: filterKey, size: PAGE_SIZE, cursors: null, regrown: [] });
+      return;
+    }
+    if (retainedViewerMismatch) {
+      const retainVerified = (entries: ReadonlyArray<EnvironmentPullRequestEntry>) =>
+        retainPullRequestEntriesForVerifiedViewers(
+          entries,
+          loaded.data.viewers,
+          viewers,
+          queriedViewerEnvironmentIds,
+        );
+      const retainedOrdered =
+        ordered?.key === filterKey
+          ? retainVerified(ordered.entries)
+          : retainVerified(loaded.data.entries);
+      setLoaded((current) =>
+        current === null
+          ? null
+          : {
+              ...current,
+              data: { ...current.data, entries: retainVerified(current.data.entries) },
+              ...(current.partitions === undefined
+                ? {}
+                : {
+                    partitions: {
+                      authored: retainVerified(current.partitions.authored),
+                      reviewing: retainVerified(current.partitions.reviewing),
+                    },
+                  }),
+            },
+      );
+      setOrdered({ key: filterKey, entries: retainedOrdered });
+      setPage({
+        key: filterKey,
+        size: Math.min(
+          Math.max(pageSize, Math.ceil(retainedOrdered.length / PAGE_SIZE) * PAGE_SIZE),
+          MAX_PAGE_SIZE,
+        ),
+        cursors: null,
+        regrown: [],
+      });
       return;
     }
     // A pending read is not a mismatch: keep what this session already verified until the fresh
@@ -994,6 +1035,7 @@ function PullRequestsRouteView() {
     filterKey,
     loaded,
     ordered,
+    pageSize,
     queriedViewerEnvironmentIds,
     scopedProjectId,
     search.host,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -98,6 +98,7 @@ import {
   pullRequestEnvironment,
   usePullRequestList,
   usePullRequestListStats,
+  usePullRequestViewers,
   type EnvironmentQueryTarget,
 } from "../state/pullRequests";
 import { useAtomCommand } from "../state/use-atom-command";
@@ -625,6 +626,22 @@ function PullRequestsRouteView() {
   );
   const listQuery = usePullRequestList(listTargets);
 
+  // Verify the account independently of the slower repository listing. This is deliberately a
+  // fresh server read: the host CLI account can change outside T3 between two page loads.
+  const viewerTargets = useMemo(
+    () =>
+      environmentQueries.map(({ environmentId, projectIds }) => ({
+        environmentId,
+        input: {
+          ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
+          ...(projectIds ? { projectIds } : {}),
+          ...(search.host ? { host: search.host } : {}),
+        },
+      })),
+    [environmentQueries, scopedProjectId, search.host],
+  );
+  const viewerQuery = usePullRequestViewers(viewerTargets);
+
   /**
    * The same filters with nothing typed, read whether or not anything is. It is the same atom the
    * list itself uses while no search is on, so it costs nothing then; while one is, it is what the
@@ -755,8 +772,8 @@ function PullRequestsRouteView() {
   // carried answer — and the live read reconciles them in place by key rather than replacing them
   // with ghosts. Waiting for identity prevents one CLI account from seeing another's stored rows.
   useEffect(() => {
-    const baseline = baselineQuery.data;
-    if (environmentKey.length === 0 || baseline === null) return;
+    const viewers = viewerQuery.viewers;
+    if (environmentKey.length === 0 || viewers === null || viewerQuery.isPending) return;
     setLoaded((current) => {
       // Rows read from a different set of environments cannot even be narrowed — one of them may
       // no longer be connected at all — so that set's own snapshot beats holding them.
@@ -764,7 +781,7 @@ function PullRequestsRouteView() {
       const snapshot = readPullRequestListSnapshot(
         typeof window === "undefined" ? undefined : window.localStorage,
         environmentKey,
-        { viewers: baseline.viewers },
+        { viewers },
       );
       if (snapshot === null) return null;
       return {
@@ -775,7 +792,7 @@ function PullRequestsRouteView() {
         ...(snapshot.partitions === undefined ? {} : { partitions: snapshot.partitions }),
       };
     });
-  }, [baselineQuery.data, environmentKey]);
+  }, [environmentKey, viewerQuery.isPending, viewerQuery.viewers]);
   useEffect(() => {
     // Only once this query has settled. While a search is being swapped in or out the text has
     // already changed and the data has not, so recording them together would file the previous

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -947,13 +947,17 @@ function PullRequestsRouteView() {
         queriedViewerEnvironmentIds,
         retainedViewerKeys,
       );
-    if (viewerGate.shouldClearRetainedRows) {
+    if (viewerGate.shouldClearRetainedRows && viewers === null) {
       setLoaded(null);
       setOrdered(null);
       setPage({ key: filterKey, size: PAGE_SIZE, cursors: null, regrown: [] });
       return;
     }
-    if (retainedViewerMismatch) {
+    if (
+      (viewerGate.shouldClearRetainedRows || retainedViewerMismatch) &&
+      loaded !== null &&
+      viewers !== null
+    ) {
       const retainVerified = (entries: ReadonlyArray<EnvironmentPullRequestEntry>) =>
         retainPullRequestEntriesForVerifiedViewers(
           entries,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -771,7 +771,7 @@ function PullRequestsRouteView() {
     statsQuery.refresh();
     setDetailRefreshToken((token) => token + 1);
   };
-  const refreshing = invalidating || listQuery.isPending;
+  const refreshing = invalidating || viewerQuery.isPending || listQuery.isPending;
 
   // Every page size and every search is its own query, and a new one starts empty. The last
   // answer for these filters is held so the page grows and narrows in place rather than blanking

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -237,6 +237,17 @@ function PullRequestsRouteView() {
         .toSorted((left, right) => left.environmentId.localeCompare(right.environmentId)),
     [environments],
   );
+  const viewerCapableEnvironmentIds = useMemo(
+    () =>
+      new Set(
+        capableEnvironments.flatMap((environment) =>
+          environment.serverConfig?.environment.capabilities.pullRequestViewers === true
+            ? [environment.environmentId]
+            : [],
+        ),
+      ),
+    [capableEnvironments],
+  );
   // The server the URL asks for, kept only while it is one the page could read: a link naming a
   // server this workspace no longer has falls back to all of them rather than to nothing.
   const scopedEnvironmentId =
@@ -628,23 +639,41 @@ function PullRequestsRouteView() {
   // fresh server read: the host CLI account can change outside T3 between two page loads.
   const viewerTargets = useMemo(
     () =>
-      environmentQueries.map(({ environmentId, projectIds }) => ({
-        environmentId,
-        input: {
-          ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
-          ...(projectIds ? { projectIds } : {}),
-          ...(search.host ? { host: search.host } : {}),
-        },
-      })),
-    [environmentQueries, scopedProjectId, search.host],
+      environmentQueries.flatMap(({ environmentId, projectIds }) =>
+        viewerCapableEnvironmentIds.has(environmentId)
+          ? [
+              {
+                environmentId,
+                input: {
+                  ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
+                  ...(projectIds ? { projectIds } : {}),
+                  ...(search.host ? { host: search.host } : {}),
+                },
+              },
+            ]
+          : [],
+      ),
+    [environmentQueries, scopedProjectId, search.host, viewerCapableEnvironmentIds],
   );
   const viewerQuery = usePullRequestViewers(viewerTargets);
   // The fresh viewer read also invalidates server-side listing caches when the CLI account has
   // changed. Do not race a warm list hit against that read, and never ask an environment whose
-  // identity check failed: every listing is keyed under the identity this page just verified.
+  // identity check failed. Older servers without this method keep their live-list behavior, but
+  // cannot hydrate a persisted snapshot because their identity cannot be verified independently.
   const verifiedEnvironmentIds = useMemo(
-    () => new Set(viewerQuery.isPending ? [] : viewerQuery.environmentIds),
-    [viewerQuery.environmentIds, viewerQuery.isPending],
+    () =>
+      new Set([
+        ...environmentQueries.flatMap(({ environmentId }) =>
+          viewerCapableEnvironmentIds.has(environmentId) ? [] : [environmentId],
+        ),
+        ...(viewerQuery.isPending ? [] : viewerQuery.environmentIds),
+      ]),
+    [
+      environmentQueries,
+      viewerCapableEnvironmentIds,
+      viewerQuery.environmentIds,
+      viewerQuery.isPending,
+    ],
   );
   const verifiedListTargets = useMemo(
     () => listTargets.filter(({ environmentId }) => verifiedEnvironmentIds.has(environmentId)),

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1108,6 +1108,7 @@ function PullRequestsRouteView() {
   // host's rate limit.
   useLiveRefresh(
     () => {
+      viewerQuery.refresh();
       refreshList();
       authoredQuery.refresh();
       reviewingQuery.refresh();

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -943,22 +943,13 @@ function PullRequestsRouteView() {
         queriedViewerEnvironmentIds,
         retainedViewerKeys,
       );
-    if (viewerGate.shouldClearRetainedRows && viewers === null) {
-      setLoaded(null);
-      setOrdered(null);
-      setPage({ key: filterKey, size: PAGE_SIZE, cursors: null, regrown: [] });
-      return;
-    }
-    if (
-      (viewerGate.shouldClearRetainedRows || retainedViewerMismatch) &&
-      loaded !== null &&
-      viewers !== null
-    ) {
+    if ((viewerGate.shouldClearRetainedRows || retainedViewerMismatch) && loaded !== null) {
+      const verifiedViewers = viewers ?? {};
       const retainVerified = (entries: ReadonlyArray<EnvironmentPullRequestEntry>) =>
         retainPullRequestEntriesForVerifiedViewers(
           entries,
           loaded.data.viewers,
-          viewers,
+          verifiedViewers,
           queriedViewerEnvironmentIds,
         );
       const heldOrdered = ordered?.entries ?? loaded.data.entries;

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1103,8 +1103,9 @@ function PullRequestsRouteView() {
       !sentinel ||
       entries.length === 0 ||
       listData?.truncated !== true ||
+      viewerQuery.isPending ||
       listQuery.isPending ||
-      listQuery.error !== null ||
+      listError !== null ||
       // The rows on screen belong to the previous question, so nothing about them says where
       // this one carries on from. Growing the page under them would answer neither.
       showingCarried ||
@@ -1131,10 +1132,11 @@ function PullRequestsRouteView() {
     filterKey,
     canContinue,
     listData?.truncated,
-    listQuery.error,
+    listError,
     listQuery.isPending,
     pageSize,
     showingCarried,
+    viewerQuery.isPending,
   ]);
 
   /**
@@ -1374,7 +1376,10 @@ function PullRequestsRouteView() {
   // so that case waits with the skeletons rather than answering for the hosts. A search says so
   // in its own words and is left to.
   const carriedToNothing =
-    showingCarried && listQuery.isPending && entries.length === 0 && typedQuery.length === 0;
+    showingCarried &&
+    (viewerQuery.isPending || listQuery.isPending) &&
+    entries.length === 0 &&
+    typedQuery.length === 0;
   const listBody = (
     <>
       {!capabilityKnown ? (

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -42,6 +42,7 @@ import {
   pullRequestEntryViewer,
   rankPullRequestMatches,
   pullRequestEnvironmentSetKey,
+  pullRequestListViewersMatchVerification,
   pullRequestViewersMatchForEnvironments,
   readPullRequestListSnapshot,
   resolvePullRequestViewerGate,
@@ -658,6 +659,10 @@ function PullRequestsRouteView() {
     [environmentQueries, scopedProjectId, search.host, viewerCapableEnvironmentIds],
   );
   const viewerQuery = usePullRequestViewers(viewerTargets);
+  const queriedViewerEnvironmentIds = useMemo(
+    () => new Set(viewerTargets.map(({ environmentId }) => environmentId)),
+    [viewerTargets],
+  );
   // The fresh viewer read also invalidates server-side listing caches when the CLI account has
   // changed. Do not race a warm list hit against that read, and never ask an environment whose
   // identity check failed. Older servers without this method keep their live-list behavior, but
@@ -777,14 +782,12 @@ function PullRequestsRouteView() {
   const authoredQuery = usePullRequestList(verifiedAuthoredTargets);
   const reviewingQuery = usePullRequestList(verifiedReviewingTargets);
   const acceptVerifiedData = (data: MergedPullRequestList | null) => {
-    if (data === null || viewerCapableEnvironmentIds.size === 0) return data;
-    const verifiedViewers = viewerQuery.viewers;
-    return verifiedViewers !== null &&
-      pullRequestViewersMatchForEnvironments(
-        data.viewers,
-        verifiedViewers,
-        viewerCapableEnvironmentIds,
-      )
+    if (data === null) return null;
+    return pullRequestListViewersMatchVerification(
+      data.viewers,
+      viewerQuery.viewers,
+      queriedViewerEnvironmentIds,
+    )
       ? data
       : null;
   };
@@ -874,7 +877,7 @@ function PullRequestsRouteView() {
         !pullRequestViewersMatchForEnvironments(
           current.data.viewers,
           viewers,
-          viewerCapableEnvironmentIds,
+          queriedViewerEnvironmentIds,
         )
       ) {
         return null;
@@ -899,7 +902,7 @@ function PullRequestsRouteView() {
     });
   }, [
     environmentKey,
-    viewerCapableEnvironmentIds,
+    queriedViewerEnvironmentIds,
     viewerGate,
     viewerQuery.isPending,
     viewerQuery.viewers,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -997,7 +997,9 @@ function PullRequestsRouteView() {
                   }),
             },
       );
-      setOrdered({ key: filterKey, entries: retainedOrdered });
+      if (retainedOrdered !== heldOrdered) {
+        setOrdered({ key: filterKey, entries: retainedOrdered });
+      }
       setPage({
         key: filterKey,
         size: Math.min(

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -838,7 +838,7 @@ function PullRequestsRouteView() {
     const viewers = viewerQuery.viewers;
     if (environmentKey.length === 0) return;
     if (!viewerGate.canHydrateSnapshot) {
-      setLoaded(null);
+      if (viewerGate.shouldClearRetainedRows) setLoaded(null);
       return;
     }
     setLoaded((current) => {
@@ -859,7 +859,7 @@ function PullRequestsRouteView() {
         ...(snapshot.partitions === undefined ? {} : { partitions: snapshot.partitions }),
       };
     });
-  }, [environmentKey, viewerGate.canHydrateSnapshot, viewerQuery.viewers]);
+  }, [environmentKey, viewerGate, viewerQuery.viewers]);
   useEffect(() => {
     // Only once this query has settled. While a search is being swapped in or out the text has
     // already changed and the data has not, so recording them together would file the previous

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -913,6 +913,7 @@ function PullRequestsRouteView() {
     if (environmentKey.length === 0) return;
     if (viewerGate.shouldClearRetainedRows) {
       setLoaded(null);
+      setOrdered(null);
       return;
     }
     // A pending read is not a mismatch: keep what this session already verified until the fresh

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1105,7 +1105,7 @@ function PullRequestsRouteView() {
       listData?.truncated !== true ||
       viewerQuery.isPending ||
       listQuery.isPending ||
-      listError !== null ||
+      listQuery.error !== null ||
       // The rows on screen belong to the previous question, so nothing about them says where
       // this one carries on from. Growing the page under them would answer neither.
       showingCarried ||
@@ -1132,7 +1132,7 @@ function PullRequestsRouteView() {
     filterKey,
     canContinue,
     listData?.truncated,
-    listError,
+    listQuery.error,
     listQuery.isPending,
     pageSize,
     showingCarried,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -40,6 +40,7 @@ import {
   partitionPullRequestsWithPriority,
   pullRequestEntryKey,
   pullRequestEntryViewer,
+  pullRequestViewerKey,
   rankPullRequestMatches,
   pullRequestEnvironmentSetKey,
   pullRequestListViewersMatchVerification,
@@ -911,6 +912,29 @@ function PullRequestsRouteView() {
   useEffect(() => {
     const viewers = viewerQuery.viewers;
     if (environmentKey.length === 0) return;
+    const retainedEntries =
+      loaded === null
+        ? []
+        : [
+            ...(ordered?.key === filterKey ? ordered.entries : loaded.data.entries),
+            ...(loaded.partitions?.authored ?? []),
+            ...(loaded.partitions?.reviewing ?? []),
+          ];
+    const projectScopes = new Map(
+      environmentQueries.map(({ environmentId, projectIds }) => [environmentId, projectIds]),
+    );
+    const retainedViewerKeys = new Set(
+      narrowPullRequestsToFilters(retainedEntries, {
+        state: search.state,
+        projectId: scopedProjectId,
+        host: search.host,
+      })
+        .filter((entry) => {
+          const projectIds = projectScopes.get(entry.environmentId);
+          return projectIds === undefined || projectIds.includes(entry.projectId);
+        })
+        .map(pullRequestViewerKey),
+    );
     const retainedViewerMismatch =
       !viewerQuery.isPending &&
       loaded !== null &&
@@ -920,6 +944,7 @@ function PullRequestsRouteView() {
         loaded.data.viewers,
         viewers,
         queriedViewerEnvironmentIds,
+        retainedViewerKeys,
       );
     if (viewerGate.shouldClearRetainedRows || retainedViewerMismatch) {
       setLoaded(null);
@@ -952,9 +977,14 @@ function PullRequestsRouteView() {
     });
   }, [
     environmentKey,
+    environmentQueries,
     filterKey,
     loaded,
+    ordered,
     queriedViewerEnvironmentIds,
+    scopedProjectId,
+    search.host,
+    search.state,
     viewerGate,
     viewerQuery.isPending,
     viewerQuery.viewers,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1455,10 +1455,17 @@ function PullRequestsRouteView() {
         </div>
       )}
 
-      {listQuery.error && listData !== null ? (
+      {listError && listData !== null ? (
         <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs">
           <span>The latest request failed. Showing the last pull requests loaded.</span>
-          <Button size="xs" variant="outline" onClick={() => listQuery.refresh()}>
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={() => {
+              viewerQuery.refresh();
+              listQuery.refresh();
+            }}
+          >
             Retry
           </Button>
         </div>

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -911,9 +911,20 @@ function PullRequestsRouteView() {
   useEffect(() => {
     const viewers = viewerQuery.viewers;
     if (environmentKey.length === 0) return;
-    if (viewerGate.shouldClearRetainedRows) {
+    const retainedViewerMismatch =
+      !viewerQuery.isPending &&
+      loaded !== null &&
+      loaded.environmentKey === environmentKey &&
+      viewers !== null &&
+      !pullRequestViewersMatchForEnvironments(
+        loaded.data.viewers,
+        viewers,
+        queriedViewerEnvironmentIds,
+      );
+    if (viewerGate.shouldClearRetainedRows || retainedViewerMismatch) {
       setLoaded(null);
       setOrdered(null);
+      setPage({ key: filterKey, size: PAGE_SIZE, cursors: null, regrown: [] });
       return;
     }
     // A pending read is not a mismatch: keep what this session already verified until the fresh
@@ -921,19 +932,6 @@ function PullRequestsRouteView() {
     // continues to use live rows, but never hydrates persisted ones.
     if (viewerQuery.isPending || viewers === null) return;
     setLoaded((current) => {
-      // Fresh identity is authoritative for viewer-capable environments, including when a mixed
-      // list also contains a legacy server whose identity cannot be checked independently.
-      if (
-        current !== null &&
-        current.environmentKey === environmentKey &&
-        !pullRequestViewersMatchForEnvironments(
-          current.data.viewers,
-          viewers,
-          queriedViewerEnvironmentIds,
-        )
-      ) {
-        return null;
-      }
       if (!viewerGate.canHydrateSnapshot) return current;
       // Rows read from a different set of environments cannot even be narrowed — one of them may
       // no longer be connected at all — so that set's own snapshot beats holding them.
@@ -954,6 +952,8 @@ function PullRequestsRouteView() {
     });
   }, [
     environmentKey,
+    filterKey,
+    loaded,
     queriedViewerEnvironmentIds,
     viewerGate,
     viewerQuery.isPending,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -917,7 +917,7 @@ function PullRequestsRouteView() {
       loaded === null
         ? []
         : [
-            ...(ordered?.key === filterKey ? ordered.entries : loaded.data.entries),
+            ...(ordered?.entries ?? loaded.data.entries),
             ...(loaded.partitions?.authored ?? []),
             ...(loaded.partitions?.reviewing ?? []),
           ];
@@ -925,11 +925,7 @@ function PullRequestsRouteView() {
       environmentQueries.map(({ environmentId, projectIds }) => [environmentId, projectIds]),
     );
     const retainedViewerKeys = new Set(
-      narrowPullRequestsToFilters(retainedEntries, {
-        state: search.state,
-        projectId: scopedProjectId,
-        host: search.host,
-      })
+      retainedEntries
         .filter((entry) => {
           const projectIds = projectScopes.get(entry.environmentId);
           return projectIds === undefined || projectIds.includes(entry.projectId);
@@ -965,7 +961,7 @@ function PullRequestsRouteView() {
           viewers,
           queriedViewerEnvironmentIds,
         );
-      const heldOrdered = ordered?.key === filterKey ? ordered.entries : loaded.data.entries;
+      const heldOrdered = ordered?.entries ?? loaded.data.entries;
       const retainedOrdered = retainVerified(heldOrdered);
       const retainedDataEntries = retainVerified(loaded.data.entries);
       const retainedAuthored =
@@ -981,29 +977,41 @@ function PullRequestsRouteView() {
       ) {
         return;
       }
-      setLoaded((current) =>
-        current === null
-          ? null
-          : {
-              ...current,
-              data: { ...current.data, entries: retainedDataEntries },
-              ...(current.partitions === undefined
-                ? {}
-                : {
-                    partitions: {
-                      authored: retainedAuthored ?? [],
-                      reviewing: retainedReviewing ?? [],
-                    },
-                  }),
-            },
-      );
+      if (
+        retainedDataEntries !== loaded.data.entries ||
+        (loaded.partitions !== undefined &&
+          (retainedAuthored !== loaded.partitions.authored ||
+            retainedReviewing !== loaded.partitions.reviewing))
+      ) {
+        setLoaded((current) =>
+          current === null
+            ? null
+            : {
+                ...current,
+                data: { ...current.data, entries: retainedDataEntries },
+                ...(current.partitions === undefined
+                  ? {}
+                  : {
+                      partitions: {
+                        authored: retainedAuthored ?? [],
+                        reviewing: retainedReviewing ?? [],
+                      },
+                    }),
+              },
+        );
+      }
       if (retainedOrdered !== heldOrdered) {
-        setOrdered({ key: filterKey, entries: retainedOrdered });
+        setOrdered({ key: ordered?.key ?? filterKey, entries: retainedOrdered });
+      }
+      const heldVisible = ordered?.key === filterKey ? heldOrdered : loaded.data.entries;
+      const retainedVisible = ordered?.key === filterKey ? retainedOrdered : retainedDataEntries;
+      if (retainedVisible === heldVisible) {
+        return;
       }
       setPage({
         key: filterKey,
         size: Math.min(
-          Math.max(pageSize, Math.ceil(retainedOrdered.length / PAGE_SIZE) * PAGE_SIZE),
+          Math.max(pageSize, Math.ceil(retainedVisible.length / PAGE_SIZE) * PAGE_SIZE),
           MAX_PAGE_SIZE,
         ),
         cursors: null,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1065,10 +1065,21 @@ function PullRequestsRouteView() {
   const answerRejected = baselineAnswers
     ? baselineQuery.data !== null && verifiedBaselineData === null
     : listQuery.data !== null && verifiedListData === null;
+  const answerQueryName = baselineAnswers ? "baseline" : "list";
+  const answerQuery = baselineAnswers ? baselineQuery : listQuery;
+  const verificationFailed =
+    answerRejected &&
+    !answerQuery.isPending &&
+    rejectedRefreshes.current.get(answerQueryName) === answerQuery.refresh;
   /** The rows on screen answer the previous question, held while this one is on its way. */
   const showingCarried = answered === null && carried !== null;
   const loadingMore = listQuery.isPending && listData !== null;
-  const listError = viewerQuery.error ?? listQuery.error;
+  const listError =
+    viewerQuery.error ??
+    listQuery.error ??
+    (verificationFailed
+      ? "Could not verify the pull request account. Retry to load safely."
+      : null);
   /** Nothing read and nothing to carry, which is the one thing skeletons are for. */
   const firstLoad =
     (viewerQuery.isPending || listQuery.isPending || (answerRejected && listError === null)) &&

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -965,22 +965,34 @@ function PullRequestsRouteView() {
           viewers,
           queriedViewerEnvironmentIds,
         );
-      const retainedOrdered =
-        ordered?.key === filterKey
-          ? retainVerified(ordered.entries)
-          : retainVerified(loaded.data.entries);
+      const heldOrdered = ordered?.key === filterKey ? ordered.entries : loaded.data.entries;
+      const retainedOrdered = retainVerified(heldOrdered);
+      const retainedDataEntries = retainVerified(loaded.data.entries);
+      const retainedAuthored =
+        loaded.partitions === undefined ? undefined : retainVerified(loaded.partitions.authored);
+      const retainedReviewing =
+        loaded.partitions === undefined ? undefined : retainVerified(loaded.partitions.reviewing);
+      if (
+        retainedOrdered === heldOrdered &&
+        retainedDataEntries === loaded.data.entries &&
+        (loaded.partitions === undefined ||
+          (retainedAuthored === loaded.partitions.authored &&
+            retainedReviewing === loaded.partitions.reviewing))
+      ) {
+        return;
+      }
       setLoaded((current) =>
         current === null
           ? null
           : {
               ...current,
-              data: { ...current.data, entries: retainVerified(current.data.entries) },
+              data: { ...current.data, entries: retainedDataEntries },
               ...(current.partitions === undefined
                 ? {}
                 : {
                     partitions: {
-                      authored: retainVerified(current.partitions.authored),
-                      reviewing: retainVerified(current.partitions.reviewing),
+                      authored: retainedAuthored ?? [],
+                      reviewing: retainedReviewing ?? [],
                     },
                   }),
             },

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -643,8 +643,8 @@ function PullRequestsRouteView() {
   // changed. Do not race a warm list hit against that read, and never ask an environment whose
   // identity check failed: every listing is keyed under the identity this page just verified.
   const verifiedEnvironmentIds = useMemo(
-    () => new Set(viewerQuery.environmentIds),
-    [viewerQuery.environmentIds],
+    () => new Set(viewerQuery.isPending ? [] : viewerQuery.environmentIds),
+    [viewerQuery.environmentIds, viewerQuery.isPending],
   );
   const verifiedListTargets = useMemo(
     () => listTargets.filter(({ environmentId }) => verifiedEnvironmentIds.has(environmentId)),

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -969,6 +969,17 @@ function PullRequestsRouteView() {
         return;
       }
       if (
+        retainedOrdered.length === 0 &&
+        retainedDataEntries.length === 0 &&
+        (loaded.partitions === undefined ||
+          (retainedAuthored?.length === 0 && retainedReviewing?.length === 0))
+      ) {
+        setLoaded(null);
+        setOrdered(null);
+        setPage({ key: filterKey, size: PAGE_SIZE, cursors: null, regrown: [] });
+        return;
+      }
+      if (
         retainedDataEntries !== loaded.data.entries ||
         (loaded.partitions !== undefined &&
           (retainedAuthored !== loaded.partitions.authored ||

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -640,10 +640,17 @@ function PullRequestsRouteView() {
   );
   const viewerQuery = usePullRequestViewers(viewerTargets);
   // The fresh viewer read also invalidates server-side listing caches when the CLI account has
-  // changed. Do not race a warm list hit against that read: once this gate opens, every listing
-  // is keyed under the identity the page just verified.
-  const viewerVerified = !viewerQuery.isPending && viewerQuery.viewers !== null;
-  const listQuery = usePullRequestList(viewerVerified ? listTargets : NO_LIST_TARGETS);
+  // changed. Do not race a warm list hit against that read, and never ask an environment whose
+  // identity check failed: every listing is keyed under the identity this page just verified.
+  const verifiedEnvironmentIds = useMemo(
+    () => new Set(viewerQuery.environmentIds),
+    [viewerQuery.environmentIds],
+  );
+  const verifiedListTargets = useMemo(
+    () => listTargets.filter(({ environmentId }) => verifiedEnvironmentIds.has(environmentId)),
+    [listTargets, verifiedEnvironmentIds],
+  );
+  const listQuery = usePullRequestList(verifiedListTargets);
 
   /**
    * The same filters with nothing typed, read whether or not anything is. It is the same atom the
@@ -679,7 +686,11 @@ function PullRequestsRouteView() {
       search.state,
     ],
   );
-  const baselineQuery = usePullRequestList(viewerVerified ? baselineTargets : NO_LIST_TARGETS);
+  const verifiedBaselineTargets = useMemo(
+    () => baselineTargets.filter(({ environmentId }) => verifiedEnvironmentIds.has(environmentId)),
+    [baselineTargets, verifiedEnvironmentIds],
+  );
+  const baselineQuery = usePullRequestList(verifiedBaselineTargets);
   // The priority groups' own reads. The feed below is paginated by recency, so an older authored
   // or review-requested row can be missing from its first page; partitioned from these
   // server-filtered reads instead, the priority view is complete up front and a continuation can
@@ -714,12 +725,22 @@ function PullRequestsRouteView() {
     search.host,
     search.state,
   ]);
-  const authoredQuery = usePullRequestList(
-    viewerVerified ? partitionTargets.authored : NO_LIST_TARGETS,
+  const verifiedAuthoredTargets = useMemo(
+    () =>
+      partitionTargets.authored.filter(({ environmentId }) =>
+        verifiedEnvironmentIds.has(environmentId),
+      ),
+    [partitionTargets.authored, verifiedEnvironmentIds],
   );
-  const reviewingQuery = usePullRequestList(
-    viewerVerified ? partitionTargets.reviewing : NO_LIST_TARGETS,
+  const verifiedReviewingTargets = useMemo(
+    () =>
+      partitionTargets.reviewing.filter(({ environmentId }) =>
+        verifiedEnvironmentIds.has(environmentId),
+      ),
+    [partitionTargets.reviewing, verifiedEnvironmentIds],
   );
+  const authoredQuery = usePullRequestList(verifiedAuthoredTargets);
+  const reviewingQuery = usePullRequestList(verifiedReviewingTargets);
   // The header's refresh punches through the server's cache before re-reading; the error and
   // empty states retry plainly, because a failure is never cached.
   const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
@@ -743,6 +764,7 @@ function PullRequestsRouteView() {
       setInvalidating(false);
     }
     refreshList();
+    viewerQuery.refresh();
     baselineQuery.refresh();
     authoredQuery.refresh();
     reviewingQuery.refresh();
@@ -907,7 +929,8 @@ function PullRequestsRouteView() {
   const showingCarried = answered === null && carried !== null;
   const loadingMore = listQuery.isPending && listData !== null;
   /** Nothing read and nothing to carry, which is the one thing skeletons are for. */
-  const firstLoad = listQuery.isPending && listData === null;
+  const firstLoad = (viewerQuery.isPending || listQuery.isPending) && listData === null;
+  const listError = viewerQuery.error ?? listQuery.error;
 
   // `ordered` is declared above, ahead of the snapshot write, but grown here from this round's
   // own answer.
@@ -1363,8 +1386,14 @@ function PullRequestsRouteView() {
         />
       ) : firstLoad ? (
         <PullRequestListGhost rows={7} />
-      ) : listQuery.error && listData === null ? (
-        <PullRequestsUnavailableState error={listQuery.error} onRetry={() => listQuery.refresh()} />
+      ) : listError && listData === null ? (
+        <PullRequestsUnavailableState
+          error={listError}
+          onRetry={() => {
+            viewerQuery.refresh();
+            listQuery.refresh();
+          }}
+        />
       ) : carriedToNothing ? (
         <PullRequestListGhost rows={7} />
       ) : entries.length === 0 ? (

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -34,6 +34,8 @@ export interface EnvironmentQueryTarget<Input> {
 interface MergedEnvironmentQueryView<A> {
   /** One entry per environment that has answered, in the order the targets were given. */
   readonly values: ReadonlyArray<readonly [EnvironmentId, A]>;
+  /** Current successes only. A failed refresh may still leave its prior answer in `values`. */
+  readonly successfulValues: ReadonlyArray<readonly [EnvironmentId, A]>;
   /** The first environment that failed. Others may still have answered — this is not fatal. */
   readonly error: string | null;
   readonly isPending: boolean;
@@ -57,6 +59,7 @@ function createMergedEnvironmentQuery<Input, A>(
     Atom.make((get): MergedEnvironmentQueryView<A> => {
       const targets = JSON.parse(key) as ReadonlyArray<EnvironmentQueryTarget<Input>>;
       const values: Array<readonly [EnvironmentId, A]> = [];
+      const successfulValues: Array<readonly [EnvironmentId, A]> = [];
       let error: string | null = null;
       let isPending = false;
       for (const target of targets) {
@@ -67,12 +70,16 @@ function createMergedEnvironmentQuery<Input, A>(
         }
         const value = Option.getOrNull(AsyncResult.value(result));
         if (value !== null) values.push([target.environmentId, value]);
+        if (result._tag === "Success") {
+          successfulValues.push([target.environmentId, result.value]);
+        }
       }
-      return { values, error, isPending };
+      return { values, successfulValues, error, isPending };
     }).pipe(Atom.withLabel(`${label}:${key}`)),
   );
   const empty = Atom.make<MergedEnvironmentQueryView<A>>({
     values: [],
+    successfulValues: [],
     error: null,
     isPending: false,
   }).pipe(Atom.withLabel(`${label}:empty`));
@@ -123,20 +130,20 @@ export function usePullRequestViewers(
   const query = usePullRequestViewersQuery(targets);
   const viewers = useMemo(
     () =>
-      query.values.length === 0
+      query.successfulValues.length === 0
         ? null
         : Object.fromEntries(
-            query.values.flatMap(([environmentId, result]) =>
+            query.successfulValues.flatMap(([environmentId, result]) =>
               Object.entries(result.viewers).map(
                 ([host, viewer]) => [`${environmentId} ${host}`, viewer] as const,
               ),
             ),
           ),
-    [query.values],
+    [query.successfulValues],
   );
   const environmentIds = useMemo(
-    () => query.values.map(([environmentId]) => environmentId),
-    [query.values],
+    () => query.successfulValues.map(([environmentId]) => environmentId),
+    [query.successfulValues],
   );
   return {
     viewers,

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -7,6 +7,7 @@ import type {
   EnvironmentId,
   PullRequestListInput,
   PullRequestListStatsInput,
+  PullRequestViewerInput,
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
@@ -92,6 +93,11 @@ const usePullRequestListsQuery = createMergedEnvironmentQuery(
   pullRequestEnvironment.list,
 );
 
+const usePullRequestViewersQuery = createMergedEnvironmentQuery(
+  "web-pull-requests:viewers",
+  pullRequestEnvironment.viewers,
+);
+
 const usePullRequestStatsQuery = createMergedEnvironmentQuery(
   "web-pull-requests:list-stats",
   pullRequestEnvironment.listStats,
@@ -102,6 +108,27 @@ export interface MergedPullRequestListView {
   readonly error: string | null;
   readonly isPending: boolean;
   readonly refresh: () => void;
+}
+
+/** Fresh host identities, scoped by environment so equal hostnames on two servers stay distinct. */
+export function usePullRequestViewers(
+  targets: ReadonlyArray<EnvironmentQueryTarget<PullRequestViewerInput>>,
+): { readonly viewers: Readonly<Record<string, string>> | null; readonly isPending: boolean } {
+  const query = usePullRequestViewersQuery(targets);
+  const viewers = useMemo(
+    () =>
+      query.values.length === 0
+        ? null
+        : Object.fromEntries(
+            query.values.flatMap(([environmentId, result]) =>
+              Object.entries(result.viewers).map(
+                ([host, viewer]) => [`${environmentId} ${host}`, viewer] as const,
+              ),
+            ),
+          ),
+    [query.values],
+  );
+  return { viewers, isPending: query.isPending };
 }
 
 /** One listing per environment, merged into the single list the page renders. */

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -113,7 +113,13 @@ export interface MergedPullRequestListView {
 /** Fresh host identities, scoped by environment so equal hostnames on two servers stay distinct. */
 export function usePullRequestViewers(
   targets: ReadonlyArray<EnvironmentQueryTarget<PullRequestViewerInput>>,
-): { readonly viewers: Readonly<Record<string, string>> | null; readonly isPending: boolean } {
+): {
+  readonly viewers: Readonly<Record<string, string>> | null;
+  readonly environmentIds: ReadonlyArray<EnvironmentId>;
+  readonly error: string | null;
+  readonly isPending: boolean;
+  readonly refresh: () => void;
+} {
   const query = usePullRequestViewersQuery(targets);
   const viewers = useMemo(
     () =>
@@ -128,7 +134,17 @@ export function usePullRequestViewers(
           ),
     [query.values],
   );
-  return { viewers, isPending: query.isPending };
+  const environmentIds = useMemo(
+    () => query.values.map(([environmentId]) => environmentId),
+    [query.values],
+  );
+  return {
+    viewers,
+    environmentIds,
+    error: query.error,
+    isPending: query.isPending,
+    refresh: query.refresh,
+  };
 }
 
 /** One listing per environment, merged into the single list the page renders. */

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -66,6 +66,11 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     key: ({ environmentId }: { readonly environmentId: string }) => environmentId,
   } as const;
   return {
+    viewers: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:pull-requests:viewers",
+      tag: WS_METHODS.pullRequestsViewers,
+      staleTimeMs: 0,
+    }),
     list: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:list",
       tag: WS_METHODS.pullRequestsList,

--- a/packages/contracts/src/environment.test.ts
+++ b/packages/contracts/src/environment.test.ts
@@ -16,6 +16,7 @@ const descriptor = {
 describe("ExecutionEnvironmentDescriptor", () => {
   it("treats a missing pull-request capability as unsupported under version skew", () => {
     expect(decodeDescriptor(descriptor).capabilities.pullRequests).toBeUndefined();
+    expect(decodeDescriptor(descriptor).capabilities.pullRequestViewers).toBeUndefined();
   });
 
   it("preserves an advertised pull-request capability", () => {
@@ -24,6 +25,12 @@ describe("ExecutionEnvironmentDescriptor", () => {
         ...descriptor,
         capabilities: { ...descriptor.capabilities, pullRequests: true },
       }).capabilities.pullRequests,
+    ).toBe(true);
+    expect(
+      decodeDescriptor({
+        ...descriptor,
+        capabilities: { ...descriptor.capabilities, pullRequestViewers: true },
+      }).capabilities.pullRequestViewers,
     ).toBe(true);
   });
 

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -53,6 +53,9 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   /** Server exposes the pull-request list, detail, activity, diff, and mutation APIs. Absent on
       servers from before the pull-request workspace shipped, so clients must not probe them. */
   pullRequests: Schema.optionalKey(Schema.Boolean),
+  /** Server exposes the fresh pull-request viewer identity API. Absent on servers from before
+      snapshot identity verification shipped, so clients keep live listing but skip hydration. */
+  pullRequestViewers: Schema.optionalKey(Schema.Boolean),
   /** Server understands thread.settle / thread.unsettle commands. Absent on
       pre-settlement servers, so clients treat missing as unsupported and
       never send the commands under version skew. */

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -528,6 +528,24 @@ export const PullRequestListInput = Schema.Struct({
 export type PullRequestListInput = typeof PullRequestListInput.Type;
 
 /**
+ * The project and host scope whose signed-in identities a client needs before it can safely
+ * hydrate a persisted listing. Kept separate from the listing so account verification does not
+ * wait for every repository to be read.
+ */
+export const PullRequestViewerInput = Schema.Struct({
+  projectId: Schema.optional(ProjectId),
+  projectIds: Schema.optional(Schema.Array(ProjectId).check(Schema.isMaxLength(100))),
+  host: Schema.optional(TrimmedNonEmptyString),
+});
+export type PullRequestViewerInput = typeof PullRequestViewerInput.Type;
+
+export const PullRequestViewerResult = Schema.Struct({
+  /** The currently signed-in account per host. Unreadable hosts are absent. */
+  viewers: Schema.Record(TrimmedNonEmptyString, TrimmedNonEmptyString),
+});
+export type PullRequestViewerResult = typeof PullRequestViewerResult.Type;
+
+/**
  * A host the workspace has projects on, and whether it can be read right now. Drives the host
  * switcher and explains projects the list leaves out.
  *

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -93,6 +93,8 @@ import {
   PullRequestListResult,
   PullRequestListStatsInput,
   PullRequestListStatsResult,
+  PullRequestViewerInput,
+  PullRequestViewerResult,
   PullRequestOperationError,
   PullRequestReactionInput,
   PullRequestRef,
@@ -298,6 +300,7 @@ export const WS_METHODS = {
 
   // Pull request methods
   pullRequestsList: "pullRequests.list",
+  pullRequestsViewers: "pullRequests.viewers",
   pullRequestsListStats: "pullRequests.listStats",
   pullRequestsDetail: "pullRequests.detail",
   pullRequestsActivity: "pullRequests.activity",
@@ -497,6 +500,12 @@ const PullRequestRpcError = Schema.Union([
 export const WsPullRequestsListRpc = Rpc.make(WS_METHODS.pullRequestsList, {
   payload: PullRequestListInput,
   success: PullRequestListResult,
+  error: PullRequestRpcError,
+});
+
+export const WsPullRequestsViewersRpc = Rpc.make(WS_METHODS.pullRequestsViewers, {
+  payload: PullRequestViewerInput,
+  success: PullRequestViewerResult,
   error: PullRequestRpcError,
 });
 
@@ -1042,6 +1051,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsCloudGetRelayClientStatusRpc,
   WsCloudInstallRelayClientRpc,
   WsPullRequestsListRpc,
+  WsPullRequestsViewersRpc,
   WsPullRequestsListStatsRpc,
   WsPullRequestsDetailRpc,
   WsPullRequestsActivityRpc,


### PR DESCRIPTION
## What Changed

Persisted pull request rows now carry a short expiration and are hydrated only after a lightweight server read freshly verifies the signed-in account for every host. The identity read is separate from the repository listing, so safe snapshots can still render while the slower live list is loading.

## Why

Snapshots were scoped only by environment IDs. Switching a host CLI to another account could therefore briefly expose the previous account's pull requests, and an offline host could retain old rows indefinitely. Waiting for the full list would prevent the leak but also defeat early hydration, so account verification now has its own focused RPC.

## UI Changes

No visual design changes. The loading behavior is unchanged for a valid, recent snapshot; expired or differently owned snapshots fall back to the existing loading state.

## Validation

- `vp test run apps/server/src/pullRequest/PullRequestService.test.ts apps/web/src/components/pullRequest/pullRequestList.logic.test.ts packages/contracts/src/pullRequest.test.ts apps/server/src/auth/RpcAuthorization.test.ts` (209 tests passed)
- `vp run --filter @t3tools/contracts typecheck`
- `vp run --filter @t3tools/client-runtime typecheck`
- `vp run --filter t3 typecheck`
- `vp run --filter @t3tools/web typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual UI change requires before/after screenshots
- [x] No animation or interaction change requires a video

Generated with GPT-5.6 in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how pull-request rows are authorized and cached across CLI account switches and multi-environment merges; incorrect gating could hide lists or briefly show stale retained rows, though the design explicitly invalidates on identity mismatch.
> 
> **Overview**
> Adds a dedicated **`pullRequests.viewers`** RPC and server **`PullRequestService.viewers`** path that re-reads signed-in host CLI identity with **`fresh: true`** (no viewer TTL cache). When a fresh read disagrees with a cached identity, the server bumps **`listingsEpoch`** so in-flight or cached listings cannot serve the previous account. **`refineUnknownProjectKinds`** now honors **`projectIds`** for that scope.
> 
> The pull-requests route runs **`usePullRequestViewers`** first and **`resolvePullRequestViewerGate`** blocks list/baseline/partition queries—and localStorage hydration—until capable environments verify (or legacy servers without **`pullRequestViewers`** keep live listing only). Snapshots get **`writtenAt`**, a **5-minute** max age, mandatory viewer context on read, and helpers to match, filter, and drop rows when verification fails or accounts change.
> 
> **Behavioral note:** snapshots missing **`writtenAt`** no longer decode; refresh and pagination wait on viewer verification where the capability is advertised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa30e5a33736a52dfcb1beb92f21e08f7ec169a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify pull request viewer identity before snapshot hydration
> - Adds a `viewers` RPC and `PullRequestService.viewers` method to fetch fresh host identities, scoped to environments that advertise the new `pullRequestViewers` capability.
> - `readPullRequestListSnapshot` in [pullRequestList.logic.ts](https://github.com/pingdotgg/t3code/pull/6470/files#diff-f8ca5dc8d0f0bac3b412ba2abaf7fca00497f36286660cfeb38242768c60e478) now requires a viewer context and a `writtenAt` timestamp, rejecting snapshots older than 5 minutes or with mismatched viewer identities.
> - The PR route gates list queries, snapshot hydration, and infinite scroll on verification status, pruning retained rows for environments that fail verification.
> - Behavioral Change: `readPullRequestListSnapshot` and `writePullRequestListSnapshot` signatures changed to require context objects; persisted snapshots missing `writtenAt` will fail to decode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa30e5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->