### PR TITLE
feat(terminals): add observable tmux sessions

### DIFF
--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -1,4 +1,9 @@
-import { DEFAULT_TERMINAL_ID, EnvironmentId, ThreadId } from "@t3tools/contracts";
+import {
+  DEFAULT_TERMINAL_ID,
+  EnvironmentId,
+  ThreadId,
+  type TmuxSessionDiscovery,
+} from "@t3tools/contracts";
 import { type KnownTerminalSession } from "@t3tools/client-runtime/state/terminal";
 import type { MenuAction } from "@react-native-menu/menu";
 import { SymbolView } from "../../components/AppSymbol";
@@ -165,6 +170,10 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   const clearTerminal = useAtomCommand(terminalEnvironment.clear, "terminal clear");
   const closeTerminal = useAtomCommand(terminalEnvironment.close, "terminal close");
   const openTerminal = useAtomCommand(terminalEnvironment.open, "terminal open");
+  const listTmuxSessions = useAtomCommand(
+    terminalEnvironment.listTmuxSessions,
+    "tmux session discovery",
+  );
   const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, "environment retry");
   const appearanceScheme = useColorScheme() === "light" ? "light" : "dark";
   const { state: workspaceState } = useWorkspaceState();
@@ -250,6 +259,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   );
   const [keyboardFocusRequest, setKeyboardFocusRequest] = useState(0);
   const [isAccessoryDismissed, setIsAccessoryDismissed] = useState(false);
+  const [tmuxDiscovery, setTmuxDiscovery] = useState<TmuxSessionDiscovery | null>(null);
   const bufferReplayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const firstNonEmptyBufferLoggedRef = useRef(false);
   const lastBufferReplayKeyRef = useRef<string | null>(null);
@@ -546,6 +556,23 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
       terminalId,
     ],
   );
+
+  useEffect(() => {
+    if (!selectedThread || !isEnvironmentReady) return;
+    let active = true;
+    setTmuxDiscovery(null);
+    void listTmuxSessions({ environmentId: selectedThread.environmentId, input: {} }).then(
+      (result) => {
+        if (!active) return;
+        setTmuxDiscovery(
+          result._tag === "Success" ? result.value : { status: "unavailable", sessions: [] },
+        );
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [isEnvironmentReady, listTmuxSessions, selectedThread]);
 
   useEffect(() => {
     if (pendingLaunchEntry.key === launchTargetKey) {
@@ -918,6 +945,53 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     );
   }, [navigation, selectedThread, terminalId, terminalMenuSessions]);
 
+  const handleAttachTmuxSession = useCallback(
+    (sessionName: string) => {
+      if (!selectedThread || !selectedThreadProject?.workspaceRoot) return;
+      const nextTerminalId = nextOpenTerminalId({
+        listedTerminalIds: terminalMenuSessions.map((session) => session.terminalId),
+        activeRouteTerminalId: terminalId,
+      });
+      const openLocation = launchLocation ?? {
+        cwd: selectedThreadProject.workspaceRoot,
+        worktreePath: selectedThread.worktreePath ?? null,
+      };
+      void (async () => {
+        const result = await openTerminal({
+          environmentId: selectedThread.environmentId,
+          input: {
+            threadId: selectedThread.id,
+            terminalId: nextTerminalId,
+            cwd: openLocation.cwd,
+            worktreePath: openLocation.worktreePath,
+            cols: lastGridSize.cols,
+            rows: lastGridSize.rows,
+            launch: { kind: "tmux", sessionName },
+          },
+        });
+        if (result._tag !== "Success") return;
+        navigation.dispatch(
+          StackActions.replace("ThreadTerminal", {
+            environmentId: String(selectedThread.environmentId),
+            threadId: String(selectedThread.id),
+            terminalId: nextTerminalId,
+          }),
+        );
+      })();
+    },
+    [
+      lastGridSize.cols,
+      lastGridSize.rows,
+      launchLocation,
+      navigation,
+      openTerminal,
+      selectedThread,
+      selectedThreadProject?.workspaceRoot,
+      terminalId,
+      terminalMenuSessions,
+    ],
+  );
+
   const handleDecreaseFontSize = useCallback(() => {
     setTerminalFontSize(stepTerminalFontSize(fontSize, -1));
   }, [fontSize, setTerminalFontSize]);
@@ -963,8 +1037,42 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         image: "plus",
         subtitle: `Start another shell in ${basename(selectedThreadProject?.workspaceRoot ?? null) ?? "this workspace"}`,
       },
+      {
+        id: "tmux-attach",
+        title: "Attach tmux session",
+        subactions:
+          tmuxDiscovery === null
+            ? [
+                {
+                  id: "tmux-status",
+                  title: "Looking for tmux sessions...",
+                  attributes: { disabled: true },
+                },
+              ]
+            : tmuxDiscovery.status === "unavailable"
+              ? [
+                  {
+                    id: "tmux-status",
+                    title: "tmux is not installed",
+                    attributes: { disabled: true },
+                  },
+                ]
+              : tmuxDiscovery.sessions.length === 0
+                ? [{ id: "tmux-status", title: "No tmux sessions", attributes: { disabled: true } }]
+                : tmuxDiscovery.sessions.map((session) => ({
+                    id: `tmux-session:${session.name}`,
+                    title: session.name,
+                    subtitle: `${session.windows} windows · ${session.attachedClients} attached`,
+                  })),
+      },
     ],
-    [fontSize, selectedThreadProject?.workspaceRoot, terminalId, terminalMenuSessions],
+    [
+      fontSize,
+      selectedThreadProject?.workspaceRoot,
+      terminalId,
+      terminalMenuSessions,
+      tmuxDiscovery,
+    ],
   );
 
   const handleAndroidTerminalMenuAction = useCallback(
@@ -984,9 +1092,19 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
       }
       if (id.startsWith("terminal-session:")) {
         handleSelectTerminal(id.slice("terminal-session:".length));
+        return;
+      }
+      if (id.startsWith("tmux-session:")) {
+        handleAttachTmuxSession(id.slice("tmux-session:".length));
       }
     },
-    [handleDecreaseFontSize, handleIncreaseFontSize, handleOpenNewTerminal, handleSelectTerminal],
+    [
+      handleAttachTmuxSession,
+      handleDecreaseFontSize,
+      handleIncreaseFontSize,
+      handleOpenNewTerminal,
+      handleSelectTerminal,
+    ],
   );
 
   const handleClearTerminal = useCallback(() => {
@@ -1186,6 +1304,35 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
                 <NativeHeaderToolbar.Label>{session.displayLabel}</NativeHeaderToolbar.Label>
               </NativeHeaderToolbar.MenuAction>
             ))}
+            <NativeHeaderToolbar.Menu icon="rectangle.stack" inline title="Attach tmux session">
+              <NativeHeaderToolbar.Label>Attach tmux session</NativeHeaderToolbar.Label>
+              {tmuxDiscovery === null ? (
+                <NativeHeaderToolbar.MenuAction disabled>
+                  <NativeHeaderToolbar.Label>
+                    Looking for tmux sessions...
+                  </NativeHeaderToolbar.Label>
+                </NativeHeaderToolbar.MenuAction>
+              ) : tmuxDiscovery.status === "unavailable" ? (
+                <NativeHeaderToolbar.MenuAction disabled>
+                  <NativeHeaderToolbar.Label>tmux is not installed</NativeHeaderToolbar.Label>
+                </NativeHeaderToolbar.MenuAction>
+              ) : tmuxDiscovery.sessions.length === 0 ? (
+                <NativeHeaderToolbar.MenuAction disabled>
+                  <NativeHeaderToolbar.Label>No tmux sessions</NativeHeaderToolbar.Label>
+                </NativeHeaderToolbar.MenuAction>
+              ) : (
+                tmuxDiscovery.sessions.map((session) => (
+                  <NativeHeaderToolbar.MenuAction
+                    key={session.name}
+                    icon="rectangle.stack"
+                    onPress={() => handleAttachTmuxSession(session.name)}
+                    subtitle={`${session.windows} windows · ${session.attachedClients} attached`}
+                  >
+                    <NativeHeaderToolbar.Label>{session.name}</NativeHeaderToolbar.Label>
+                  </NativeHeaderToolbar.MenuAction>
+                ))
+              )}
+            </NativeHeaderToolbar.Menu>
             <NativeHeaderToolbar.MenuAction
               icon="plus"
               onPress={handleOpenNewTerminal}

--- a/apps/mobile/src/features/terminal/terminalMenu.test.ts
+++ b/apps/mobile/src/features/terminal/terminalMenu.test.ts
@@ -53,6 +53,7 @@ function makeKnownSession(input: {
             exitSignal: null,
             hasRunningSubprocess: false,
             label: getTerminalLabel(input.terminalId),
+            launch: { kind: "shell" },
             updatedAt: input.updatedAt ?? "2026-04-15T20:00:00.000Z",
           }
         : null,

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -105,6 +105,8 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.terminalClear]: AuthTerminalOperateScope,
   [WS_METHODS.terminalRestart]: AuthTerminalOperateScope,
   [WS_METHODS.terminalClose]: AuthTerminalOperateScope,
+  [WS_METHODS.terminalListTmuxSessions]: AuthTerminalOperateScope,
+  [WS_METHODS.terminalKillTmuxSession]: AuthTerminalOperateScope,
   [WS_METHODS.subscribeTerminalEvents]: AuthTerminalOperateScope,
   [WS_METHODS.subscribeTerminalMetadata]: AuthTerminalOperateScope,
   [WS_METHODS.previewOpen]: AuthOrchestrationOperateScope,

--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -57,6 +57,8 @@ const makeTerminalManagerLayer = (
     clear: () => Effect.void,
     restart: () => Effect.die(new Error("unused")),
     close: () => Effect.void,
+    listTmuxSessions: Effect.succeed({ status: "available" as const, sessions: [] }),
+    killTmuxSession: () => Effect.succeed({ status: "killed" as const }),
     subscribe: () => Effect.succeed(() => undefined),
     subscribeMetadata: () => Effect.succeed(() => undefined),
   });
@@ -105,6 +107,7 @@ describe("ProjectSetupScriptRunner", () => {
           exitCode: null,
           exitSignal: null,
           label: "setup-setup",
+          launch: { kind: "shell" as const },
           updatedAt: "2026-01-01T00:00:00.000Z",
         }),
       );

--- a/apps/server/src/provider/BackgroundTerminalInstructions.ts
+++ b/apps/server/src/provider/BackgroundTerminalInstructions.ts
@@ -1,0 +1,6 @@
+export const BACKGROUND_TERMINAL_INSTRUCTIONS = `
+
+## Observable background commands
+
+For servers, watchers, long builds, and other commands intentionally left running, use a named detached tmux session when tmux is available. Tell the user the session name so they can attach from T3 Code. Continue to use normal command execution for one-off commands.
+`;

--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -1,4 +1,5 @@
 import type { ProviderInteractionMode } from "@t3tools/contracts";
+import { BACKGROUND_TERMINAL_INSTRUCTIONS } from "./BackgroundTerminalInstructions.ts";
 
 const T3_CODE_BROWSER_TOOL_INSTRUCTIONS = `
 
@@ -139,7 +140,7 @@ Do not ask "should I proceed?" in the final output. The user can easily switch o
 Only produce at most one \`<proposed_plan>\` block per turn, and only when you are presenting a complete spec.
 
 If the user stays in Plan mode and asks for revisions after a prior \`<proposed_plan>\`, any new \`<proposed_plan>\` must be a complete replacement. If the user indicates that the prior plan is not acceptable but does not provide enough information to produce a complete replacement, address the concern and continue planning without producing a \`<proposed_plan>\` block. If the follow-up neither requires changes nor calls the plan into question (e.g. clarifying question), answer it before the block, then reproduce the prior \`<proposed_plan>\` unchanged.
-${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
+${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}${BACKGROUND_TERMINAL_INSTRUCTIONS}
 </collaboration_mode>`;
 
 export const CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Collaboration Mode: Default
@@ -153,7 +154,7 @@ Your active mode changes only when new developer instructions with a different \
 Use the \`request_user_input\` tool only when it is listed in the available tools for this turn.
 
 In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
-${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
+${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}${BACKGROUND_TERMINAL_INSTRUCTIONS}
 </collaboration_mode>`;
 
 export interface CodexRuntimeInfo {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -355,6 +355,13 @@ describe("ClaudeAdapterLive", () => {
       assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
       assert.equal(createInput?.options.permissionMode, "bypassPermissions");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
+      const systemPrompt = createInput?.options.systemPrompt;
+      assert.equal(typeof systemPrompt, "object");
+      if (systemPrompt && !Array.isArray(systemPrompt) && typeof systemPrompt !== "string") {
+        assert.equal(systemPrompt.type, "preset");
+        assert.equal(systemPrompt.preset, "claude_code");
+        assert.match(systemPrompt.append ?? "", /named detached tmux session/);
+      }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -75,6 +75,7 @@ import * as Stream from "effect/Stream";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import { BACKGROUND_TERMINAL_INSTRUCTIONS } from "../BackgroundTerminalInstructions.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import {
@@ -4102,7 +4103,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(input.cwd ? { cwd: input.cwd } : {}),
         ...(apiModelId ? { model: apiModelId } : {}),
         pathToClaudeCodeExecutable: claudeBinaryPath,
-        systemPrompt: { type: "preset", preset: "claude_code" },
+        systemPrompt: {
+          type: "preset",
+          preset: "claude_code",
+          append: BACKGROUND_TERMINAL_INSTRUCTIONS,
+        },
         settingSources: [...CLAUDE_SETTING_SOURCES],
         // `ultracode` is a Claude Code setting, not an API effort level. It is
         // normalized to `xhigh` above and paired with `settings.ultracode`.

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -307,6 +307,19 @@ describe("T3 browser developer instructions", () => {
   });
 });
 
+describe("background terminal developer instructions", () => {
+  it("guides both collaboration modes to use named tmux sessions for long-running work", () => {
+    for (const instructions of [
+      CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
+      CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
+    ]) {
+      NodeAssert.match(instructions, /named detached tmux session/);
+      NodeAssert.match(instructions, /one-off commands/);
+      NodeAssert.match(instructions, /Tell the user the session name/);
+    }
+  });
+});
+
 describe("hasConfiguredMcpServer", () => {
   it("detects inline Codex MCP configuration arguments", () => {
     NodeAssert.equal(hasConfiguredMcpServer(undefined), false);

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7907,6 +7907,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         exitCode: null,
         exitSignal: null,
         label: "Primary",
+        launch: { kind: "shell" as const },
         updatedAt: "2026-01-01T00:00:00.000Z",
       };
 
@@ -7919,6 +7920,8 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             clear: () => Effect.void,
             restart: () => Effect.succeed(snapshot),
             close: () => Effect.void,
+            listTmuxSessions: Effect.succeed({ status: "available" as const, sessions: [] }),
+            killTmuxSession: () => Effect.succeed({ status: "killed" as const }),
           },
         },
       });
@@ -7978,6 +7981,18 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         ),
       );
       assert.equal(restarted.terminalId, "default");
+
+      const tmuxDiscovery = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) => client[WS_METHODS.terminalListTmuxSessions]({})),
+      );
+      assert.deepEqual(tmuxDiscovery, { status: "available", sessions: [] });
+
+      const tmuxKill = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[WS_METHODS.terminalKillTmuxSession]({ sessionName: "long-build" }),
+        ),
+      );
+      assert.deepEqual(tmuxKill, { status: "killed" });
 
       yield* Effect.scoped(
         withWsRpcClient(wsUrl, (client) =>

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -7,6 +7,9 @@ import {
   type TerminalMetadataStreamEvent,
   type TerminalOpenInput,
   type TerminalRestartInput,
+  type TmuxSessionDiscovery,
+  type TmuxSessionKillInput,
+  type TmuxSessionKillResult,
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Data from "effect/Data";
@@ -213,6 +216,8 @@ interface CreateManagerOptions {
   processKillGraceMs?: number;
   maxRetainedInactiveSessions?: number;
   ptyAdapter?: FakePtyAdapter;
+  tmuxSessionLister?: () => Effect.Effect<TmuxSessionDiscovery>;
+  tmuxSessionKiller?: (input: TmuxSessionKillInput) => Effect.Effect<TmuxSessionKillResult>;
 }
 
 interface ManagerFixture {
@@ -254,6 +259,12 @@ const createManager = (
         ...(options.maxRetainedInactiveSessions !== undefined
           ? { maxRetainedInactiveSessions: options.maxRetainedInactiveSessions }
           : {}),
+        ...(options.tmuxSessionLister !== undefined
+          ? { tmuxSessionLister: options.tmuxSessionLister }
+          : {}),
+        ...(options.tmuxSessionKiller !== undefined
+          ? { tmuxSessionKiller: options.tmuxSessionKiller }
+          : {}),
       });
       const eventsRef = yield* Ref.make<ReadonlyArray<TerminalEvent>>([]);
       const unsubscribe = yield* manager.subscribe((event) =>
@@ -279,6 +290,82 @@ it.layer(
   Layer.merge(NodeServices.layer, ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer))),
   { excludeTestServices: true },
 )("TerminalManager", (it) => {
+  it("parses, filters, and sorts tmux discovery rows", () => {
+    expect(
+      TerminalManager.parseTmuxSessions("zeta\t1\t2\ninvalid\nalpha\t0\t3\nnegative\t-1\t1\n"),
+    ).toEqual([
+      { name: "alpha", attachedClients: 0, windows: 3 },
+      { name: "zeta", attachedClients: 1, windows: 2 },
+    ]);
+  });
+
+  it.effect("returns discovered tmux sessions without retaining them as terminals", () =>
+    Effect.gen(function* () {
+      const discovery = {
+        status: "available" as const,
+        sessions: [{ name: "dev", attachedClients: 1, windows: 2 }],
+      };
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        tmuxSessionLister: () => Effect.succeed(discovery),
+      });
+
+      expect(yield* manager.listTmuxSessions).toEqual(discovery);
+      expect(ptyAdapter.spawnInputs).toHaveLength(0);
+    }),
+  );
+
+  it.effect("stops one exact tmux session through the injected host boundary", () =>
+    Effect.gen(function* () {
+      const killedNames = yield* Ref.make<ReadonlyArray<string>>([]);
+      const { manager } = yield* createManager(5, {
+        tmuxSessionKiller: (input) =>
+          Ref.update(killedNames, (names) => [...names, input.sessionName]).pipe(
+            Effect.as({ status: "killed" as const }),
+          ),
+      });
+
+      expect(yield* manager.killTmuxSession({ sessionName: "long-build" })).toEqual({
+        status: "killed",
+      });
+      expect(yield* Ref.get(killedNames)).toEqual(["long-build"]);
+    }),
+  );
+
+  it.effect("attaches to tmux directly and closes only the attach process", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      const snapshot = yield* manager.open(
+        openInput({ launch: { kind: "tmux", sessionName: "long-build" } }),
+      );
+
+      expect(ptyAdapter.spawnInputs[0]).toMatchObject({
+        shell: "tmux",
+        args: ["attach-session", "-t", "=long-build"],
+      });
+      expect(snapshot.launch).toEqual({ kind: "tmux", sessionName: "long-build" });
+      expect(snapshot.label).toBe("tmux: long-build");
+
+      yield* manager.close({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID });
+      expect(ptyAdapter.processes[0]?.killed).toBe(true);
+      expect(ptyAdapter.processes[0]?.writes).toEqual([]);
+    }),
+  );
+
+  it.effect("does not fall back to a shell when tmux attachment fails to spawn", () =>
+    Effect.gen(function* () {
+      const ptyAdapter = new FakePtyAdapter();
+      ptyAdapter.spawnFailures.push(new Error("tmux not found"));
+      const { manager } = yield* createManager(5, { ptyAdapter });
+
+      const snapshot = yield* manager.open(
+        openInput({ launch: { kind: "tmux", sessionName: "missing" } }),
+      );
+      expect(snapshot.status).toBe("error");
+      expect(ptyAdapter.spawnInputs).toHaveLength(1);
+      expect(ptyAdapter.spawnInputs[0]?.shell).toBe("tmux");
+    }),
+  );
+
   it.effect("spawns lazily and reuses running terminal per thread", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -8,6 +8,7 @@
  */
 import {
   DEFAULT_TERMINAL_ID,
+  DEFAULT_TERMINAL_LAUNCH,
   TerminalCwdError,
   TerminalCwdNotDirectoryError,
   TerminalCwdNotFoundError,
@@ -30,7 +31,12 @@ import {
   type TerminalSessionSnapshot,
   type TerminalSessionStatus,
   type TerminalSummary,
+  type TerminalLaunch,
   type TerminalWriteInput,
+  type TmuxSession,
+  type TmuxSessionDiscovery,
+  type TmuxSessionKillInput,
+  type TmuxSessionKillResult,
 } from "@t3tools/contracts";
 import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
@@ -168,6 +174,12 @@ export class TerminalManager extends Context.Service<
      */
     readonly close: (input: TerminalCloseInput) => Effect.Effect<void, TerminalError>;
 
+    /** Discover tmux sessions in the server environment without retaining them in T3 state. */
+    readonly listTmuxSessions: Effect.Effect<TmuxSessionDiscovery>;
+
+    /** Stop one exact tmux session in the server environment. */
+    readonly killTmuxSession: (input: TmuxSessionKillInput) => Effect.Effect<TmuxSessionKillResult>;
+
     /**
      * Subscribe to terminal runtime events with a direct callback.
      *
@@ -254,6 +266,7 @@ export interface TerminalSessionState {
   /** Normalized child command name when `hasRunningSubprocess`; cleared when idle. */
   childCommandLabel: string | null;
   runtimeEnv: Record<string, string> | null;
+  launch: TerminalLaunch;
 }
 
 interface PersistHistoryRequest {
@@ -314,6 +327,9 @@ function normalizeChildCommandName(raw: string, platform: NodeJS.Platform): stri
 }
 
 function terminalWireLabel(session: TerminalSessionState): string {
+  if (session.launch.kind === "tmux") {
+    return truncateTerminalWireLabel(`tmux: ${session.launch.sessionName}`);
+  }
   if (session.hasRunningSubprocess && session.childCommandLabel) {
     const trimmed = session.childCommandLabel.trim();
     if (trimmed.length > 0) {
@@ -335,6 +351,7 @@ function snapshot(session: TerminalSessionState): TerminalSessionSnapshot {
     exitCode: session.exitCode,
     exitSignal: session.exitSignal,
     label: terminalWireLabel(session),
+    launch: session.launch,
     updatedAt: session.updatedAt,
     sequence: session.eventSequence,
   };
@@ -352,6 +369,7 @@ function summary(session: TerminalSessionState): TerminalSummary {
     exitSignal: session.exitSignal,
     hasRunningSubprocess: session.hasRunningSubprocess,
     label: terminalWireLabel(session),
+    launch: session.launch,
     updatedAt: session.updatedAt,
   };
 }
@@ -562,6 +580,35 @@ function resolveShellCandidates(
     shellCandidateFromCommand("bash", platform),
     shellCandidateFromCommand("sh", platform),
   ]);
+}
+
+export function parseTmuxSessions(stdout: string): ReadonlyArray<TmuxSession> {
+  const sessions: TmuxSession[] = [];
+  for (const line of stdout.split(/\r?\n/g)) {
+    const [rawName, rawAttachedClients, rawWindows, ...extra] = line.split("\t");
+    const name = rawName?.trim() ?? "";
+    const attachedClients = Number(rawAttachedClients);
+    const windows = Number(rawWindows);
+    if (
+      extra.length > 0 ||
+      name.length === 0 ||
+      name.length > 128 ||
+      !Number.isInteger(attachedClients) ||
+      attachedClients < 0 ||
+      !Number.isInteger(windows) ||
+      windows < 0
+    ) {
+      continue;
+    }
+    sessions.push({ name, attachedClients, windows });
+  }
+  return sessions.toSorted((left, right) => left.name.localeCompare(right.name));
+}
+
+const TMUX_UNAVAILABLE: TmuxSessionDiscovery = { status: "unavailable", sessions: [] };
+
+function resolveTerminalLaunch(launch: TerminalLaunch | undefined): TerminalLaunch {
+  return launch ?? DEFAULT_TERMINAL_LAUNCH;
 }
 
 function isRetryableShellSpawnError(error: PtyAdapter.PtySpawnError): boolean {
@@ -1186,6 +1233,8 @@ interface TerminalManagerOptions {
   subprocessPollIntervalMs?: number;
   processKillGraceMs?: number;
   maxRetainedInactiveSessions?: number;
+  tmuxSessionLister?: () => Effect.Effect<TmuxSessionDiscovery>;
+  tmuxSessionKiller?: (input: TmuxSessionKillInput) => Effect.Effect<TmuxSessionKillResult>;
   registerTerminalProcesses?: (input: {
     readonly threadId: string;
     readonly terminalId: string;
@@ -1227,6 +1276,75 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const baseEnv = options.env ?? process.env;
   const shellResolver = options.shellResolver ?? (() => defaultShellResolver(platform, baseEnv));
   const processRunner = yield* ProcessRunner.ProcessRunner;
+  const tmuxSessionLister =
+    options.tmuxSessionLister ??
+    Effect.fn("terminal.listTmuxSessionsFromHost")(function* () {
+      const listResult = yield* processRunner
+        .run({
+          command: "tmux",
+          args: ["list-sessions", "-F", "#{session_name}\t#{session_attached}\t#{session_windows}"],
+          timeout: "2 seconds",
+          maxOutputBytes: 65_536,
+          outputMode: "truncate",
+          timeoutBehavior: "timedOutResult",
+        })
+        .pipe(Effect.option);
+      if (Option.isSome(listResult) && listResult.value.code === 0 && !listResult.value.timedOut) {
+        return {
+          status: "available" as const,
+          sessions: parseTmuxSessions(listResult.value.stdout),
+        };
+      }
+
+      const versionResult = yield* processRunner
+        .run({
+          command: "tmux",
+          args: ["-V"],
+          timeout: "2 seconds",
+          maxOutputBytes: 8_192,
+          outputMode: "truncate",
+          timeoutBehavior: "timedOutResult",
+        })
+        .pipe(Effect.option);
+      return Option.isSome(versionResult) &&
+        versionResult.value.code === 0 &&
+        !versionResult.value.timedOut
+        ? { status: "available" as const, sessions: [] }
+        : TMUX_UNAVAILABLE;
+    });
+  const tmuxSessionKiller =
+    options.tmuxSessionKiller ??
+    Effect.fn("terminal.killTmuxSessionOnHost")(function* (input: TmuxSessionKillInput) {
+      const killResult = yield* processRunner
+        .run({
+          command: "tmux",
+          args: ["kill-session", "-t", `=${input.sessionName}`],
+          timeout: "2 seconds",
+          maxOutputBytes: 8_192,
+          outputMode: "truncate",
+          timeoutBehavior: "timedOutResult",
+        })
+        .pipe(Effect.option);
+      if (Option.isSome(killResult) && killResult.value.code === 0 && !killResult.value.timedOut) {
+        return { status: "killed" as const };
+      }
+
+      const versionResult = yield* processRunner
+        .run({
+          command: "tmux",
+          args: ["-V"],
+          timeout: "2 seconds",
+          maxOutputBytes: 8_192,
+          outputMode: "truncate",
+          timeoutBehavior: "timedOutResult",
+        })
+        .pipe(Effect.option);
+      return Option.isSome(versionResult) &&
+        versionResult.value.code === 0 &&
+        !versionResult.value.timedOut
+        ? { status: "notFound" as const }
+        : { status: "unavailable" as const };
+    });
   const subprocessInspector =
     options.subprocessInspector ??
     ((terminalPid) =>
@@ -1906,6 +2024,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       session.exitSignal = null;
       session.hasRunningSubprocess = false;
       session.childCommandLabel = null;
+      session.launch = resolveTerminalLaunch(input.launch);
       session.pendingProcessEvents = [];
       session.pendingProcessEventIndex = 0;
       session.processEventDrainRunning = false;
@@ -1920,7 +2039,15 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
         Effect.andThen(
           Effect.gen(function* () {
-            const shellCandidates = resolveShellCandidates(shellResolver, platform, baseEnv);
+            const shellCandidates =
+              session.launch.kind === "tmux"
+                ? [
+                    {
+                      shell: "tmux",
+                      args: ["attach-session", "-t", `=${session.launch.sessionName}`],
+                    },
+                  ]
+                : resolveShellCandidates(shellResolver, platform, baseEnv);
             const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;
@@ -2215,6 +2342,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         hasRunningSubprocess: false,
         childCommandLabel: null,
         runtimeEnv: normalizedRuntimeEnv(input.env),
+        launch: resolveTerminalLaunch(input.launch),
       };
 
       const createdSession = session;
@@ -2235,6 +2363,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           cols,
           rows,
           ...(input.env ? { env: input.env } : {}),
+          launch: session.launch,
         },
         "started",
       );
@@ -2243,6 +2372,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
     const liveSession = existing.value;
     const nextRuntimeEnv = normalizedRuntimeEnv(input.env);
+    const nextLaunch = resolveTerminalLaunch(input.launch);
     const currentRuntimeEnv = liveSession.runtimeEnv;
     const targetCols = input.cols ?? liveSession.cols;
     const targetRows = input.rows ?? liveSession.rows;
@@ -2253,12 +2383,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.cwd !== input.cwd ||
       runtimeEnvChanged ||
       liveSession.worktreePath !== nextWorktreePath;
+    const launchChanged = !Equal.equals(liveSession.launch, nextLaunch);
 
-    if (launchContextChanged) {
+    if (launchContextChanged || launchChanged) {
       yield* stopProcess(liveSession);
       liveSession.cwd = input.cwd;
       liveSession.worktreePath = nextWorktreePath;
       liveSession.runtimeEnv = nextRuntimeEnv;
+      liveSession.launch = nextLaunch;
       liveSession.history = "";
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
@@ -2287,6 +2419,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           cols: targetCols,
           rows: targetRows,
           ...(input.env ? { env: input.env } : {}),
+          launch: liveSession.launch,
         },
         "started",
       );
@@ -2627,6 +2760,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             hasRunningSubprocess: false,
             childCommandLabel: null,
             runtimeEnv: normalizedRuntimeEnv(input.env),
+            launch: resolveTerminalLaunch(input.launch),
           };
           const createdSession = session;
           yield* modifyManagerState((state) => {
@@ -2641,6 +2775,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           session.cwd = input.cwd;
           session.worktreePath = input.worktreePath ?? null;
           session.runtimeEnv = normalizedRuntimeEnv(input.env);
+          session.launch = resolveTerminalLaunch(input.launch);
         }
 
         const cols = input.cols ?? session.cols;
@@ -2662,6 +2797,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             cols,
             rows,
             ...(input.env ? { env: input.env } : {}),
+            launch: session.launch,
           },
           "restarted",
         );
@@ -2691,6 +2827,10 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }),
     );
 
+  const listTmuxSessions: TerminalManager["Service"]["listTmuxSessions"] = tmuxSessionLister();
+  const killTmuxSession: TerminalManager["Service"]["killTmuxSession"] = (input) =>
+    tmuxSessionKiller(input);
+
   return TerminalManager.of({
     open,
     attachStream,
@@ -2699,6 +2839,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     clear,
     restart,
     close,
+    listTmuxSessions,
+    killTmuxSession,
     subscribe,
     subscribeMetadata,
   });

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2059,6 +2059,10 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.terminalClose, terminalManager.close(input), {
             "rpc.aggregate": "terminal",
           }),
+        [WS_METHODS.terminalListTmuxSessions]: (_input) =>
+          observeRpcEffect(WS_METHODS.terminalListTmuxSessions, terminalManager.listTmuxSessions, {
+            "rpc.aggregate": "terminal",
+          }),
         [WS_METHODS.subscribeTerminalEvents]: (_input) =>
           observeRpcStream(
             WS_METHODS.subscribeTerminalEvents,
@@ -2069,6 +2073,12 @@ const makeWsRpcLayer = (
               ),
             ),
             { "rpc.aggregate": "terminal" },
+          ),
+        [WS_METHODS.terminalKillTmuxSession]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.terminalKillTmuxSession,
+            terminalManager.killTmuxSession(input),
+            { input },
           ),
         [WS_METHODS.subscribeTerminalMetadata]: (_input) =>
           observeRpcStream(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -21,6 +21,7 @@ import {
   ProviderDriverKind,
   RuntimeMode,
   TerminalOpenInput,
+  type TmuxSession,
 } from "@t3tools/contracts";
 import {
   connectionStatusTitle,
@@ -101,6 +102,7 @@ import {
   type PendingUserInputDraftAnswer,
 } from "../pendingUserInput";
 import { useUiStateStore } from "../uiStateStore";
+import { notifyTmuxSessionsChanged } from "../terminal/tmuxSessionEvents";
 import {
   buildPlanImplementationThreadTitle,
   buildPlanImplementationPrompt,
@@ -251,6 +253,7 @@ import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import { resolveTimelineIsAtEnd } from "./chat/MessagesTimeline.logic";
 import { ChatHeader } from "./chat/ChatHeader";
+import { TmuxSessionStatusStrip } from "./chat/TmuxSessionStatusStrip";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
@@ -912,6 +915,50 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     openTerminal,
   ]);
 
+  const attachTmuxSession = useCallback(
+    (sessionName: string) => {
+      if (!cwd) return;
+      const terminalId = nextTerminalId(allocatableTerminalIds);
+      void (async () => {
+        const result = await openTerminal({
+          environmentId: threadRef.environmentId,
+          input: {
+            threadId,
+            terminalId,
+            cwd,
+            ...(effectiveWorktreePath != null ? { worktreePath: effectiveWorktreePath } : {}),
+            env: runtimeEnv,
+            launch: { kind: "tmux", sessionName },
+          },
+        });
+        if (result._tag !== "Success") return;
+        storeNewTerminal(threadRef, terminalId);
+        bumpFocusRequestId();
+      })();
+    },
+    [
+      allocatableTerminalIds,
+      bumpFocusRequestId,
+      cwd,
+      effectiveWorktreePath,
+      openTerminal,
+      runtimeEnv,
+      storeNewTerminal,
+      threadId,
+      threadRef,
+    ],
+  );
+
+  const tmuxTerminalIds = useMemo(
+    () =>
+      new Set(
+        knownTerminalSessions
+          .filter((session) => session.state.summary?.launch.kind === "tmux")
+          .map((session) => session.target.terminalId),
+      ),
+    [knownTerminalSessions],
+  );
+
   const activateTerminal = useCallback(
     (terminalId: string) => {
       storeSetActiveTerminal(threadRef, terminalId);
@@ -937,12 +984,19 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
             deleteHistory: true,
           },
         });
-        if (closeResult._tag === "Failure" && !isAtomCommandInterrupted(closeResult)) {
+        if (
+          closeResult._tag === "Failure" &&
+          !isAtomCommandInterrupted(closeResult) &&
+          !tmuxTerminalIds.has(terminalId)
+        ) {
           await fallbackExitWrite();
         }
       })();
 
       storeCloseTerminal(threadRef, terminalId);
+      if (tmuxTerminalIds.has(terminalId)) {
+        notifyTmuxSessionsChanged();
+      }
       bumpFocusRequestId();
     },
     [
@@ -951,6 +1005,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
       threadId,
       threadRef,
       closeTerminalMutation,
+      tmuxTerminalIds,
       writeTerminal,
     ],
   );
@@ -988,6 +1043,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         onSplitTerminal={splitTerminal}
         onSplitTerminalVertical={splitTerminalVertical}
         onNewTerminal={createNewTerminal}
+        onAttachTmuxSession={attachTmuxSession}
         splitShortcutLabel={visible ? splitShortcutLabel : undefined}
         splitVerticalShortcutLabel={visible ? splitVerticalShortcutLabel : undefined}
         newShortcutLabel={visible ? newShortcutLabel : undefined}
@@ -997,6 +1053,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         onCloseTerminal={closeTerminal}
         onHeightChange={setTerminalHeight}
         onAddTerminalContext={handleAddTerminalContext}
+        forceTerminalSidebar={tmuxTerminalIds.size > 0}
         terminalLabelsById={terminalLabelsById}
         terminalLaunchLocationsById={terminalLaunchLocationsById}
       />
@@ -1014,6 +1071,7 @@ interface PersistentThreadTerminalPanelProps {
   onSplitTerminal: () => void;
   onSplitTerminalVertical: () => void;
   onNewTerminal: () => void;
+  onAttachTmuxSession: (sessionName: string) => void;
   onActiveTerminalChange: (terminalId: string) => void;
   onCloseTerminal: (terminalId: string) => void;
   splitShortcutLabel?: string | undefined;
@@ -1032,6 +1090,7 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
   onSplitTerminal,
   onSplitTerminalVertical,
   onNewTerminal,
+  onAttachTmuxSession,
   onActiveTerminalChange,
   onCloseTerminal,
   splitShortcutLabel,
@@ -1158,6 +1217,7 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
       onSplitTerminal={onSplitTerminal}
       onSplitTerminalVertical={onSplitTerminalVertical}
       onNewTerminal={onNewTerminal}
+      onAttachTmuxSession={onAttachTmuxSession}
       splitShortcutLabel={splitShortcutLabel}
       splitVerticalShortcutLabel={splitVerticalShortcutLabel}
       newShortcutLabel={newShortcutLabel}
@@ -1572,6 +1632,15 @@ function ChatViewContent(props: ChatViewProps) {
     }
     return labels;
   }, [activeThreadKnownSessions]);
+  const activeTmuxTerminalIds = useMemo(
+    () =>
+      new Set(
+        activeThreadKnownSessions
+          .filter((session) => session.state.summary?.launch.kind === "tmux")
+          .map((session) => session.target.terminalId),
+      ),
+    [activeThreadKnownSessions],
+  );
   const activeThreadRef = useMemo(
     () =>
       activeThreadEnvironmentId && activeThreadId
@@ -1628,6 +1697,15 @@ function ChatViewContent(props: ChatViewProps) {
       ),
     [rightPanelState.surfaces],
   );
+  const activeDrawerTmuxTerminalIdBySessionName = useMemo(() => {
+    const terminalIds = new Map<string, string>();
+    for (const session of activeThreadKnownSessions) {
+      const launch = session.state.summary?.launch;
+      if (launch?.kind !== "tmux" || panelTerminalIds.has(session.target.terminalId)) continue;
+      terminalIds.set(launch.sessionName, session.target.terminalId);
+    }
+    return terminalIds;
+  }, [activeThreadKnownSessions, panelTerminalIds]);
   const allocatableActiveTerminalIds = useMemo(
     () => [...new Set([...activeKnownTerminalIds, ...panelTerminalIds])],
     [activeKnownTerminalIds, panelTerminalIds],
@@ -2293,6 +2371,7 @@ function ChatViewContent(props: ChatViewProps) {
     threadError,
   });
   const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const tmuxRefreshKey = isWorking ? "working" : `${activeLatestTurn?.turnId ?? "no-turn"}:settled`;
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
     activeThread?.session ?? null,
@@ -2922,6 +3001,69 @@ function ChatViewContent(props: ChatViewProps) {
     gitCwd,
     storeNewTerminal,
   ]);
+  const openTmuxSessionsFromStatus = useCallback(
+    (sessions: ReadonlyArray<TmuxSession>) => {
+      if (!activeThreadRef || !activeThreadId || !activeProject) return;
+      const cwdForOpen = gitCwd ?? activeProject.workspaceRoot;
+      if (!cwdForOpen) return;
+
+      storeSetTerminalOpen(activeThreadRef, true);
+      void (async () => {
+        const allocatedTerminalIds = [...allocatableActiveTerminalIds];
+        let activeTmuxTerminalId: string | null = null;
+
+        for (const session of sessions) {
+          const existingTerminalId = activeDrawerTmuxTerminalIdBySessionName.get(session.name);
+          if (existingTerminalId) {
+            storeNewTerminal(activeThreadRef, existingTerminalId);
+            activeTmuxTerminalId = existingTerminalId;
+            continue;
+          }
+
+          const terminalId = nextTerminalId(allocatedTerminalIds);
+          allocatedTerminalIds.push(terminalId);
+          const result = await openTerminal({
+            environmentId,
+            input: {
+              threadId: activeThreadId,
+              terminalId,
+              cwd: cwdForOpen,
+              ...(activeThreadWorktreePath != null
+                ? { worktreePath: activeThreadWorktreePath }
+                : {}),
+              env: projectScriptRuntimeEnv({
+                project: { cwd: activeProject.workspaceRoot },
+                worktreePath: activeThreadWorktreePath,
+              }),
+              launch: { kind: "tmux", sessionName: session.name },
+            },
+          });
+          if (result._tag !== "Success") continue;
+          storeNewTerminal(activeThreadRef, terminalId);
+          activeTmuxTerminalId = terminalId;
+        }
+
+        if (activeTmuxTerminalId) {
+          storeSetActiveTerminal(activeThreadRef, activeTmuxTerminalId);
+          setTerminalFocusRequestId((value) => value + 1);
+        }
+      })();
+    },
+    [
+      activeProject,
+      activeDrawerTmuxTerminalIdBySessionName,
+      activeThreadId,
+      activeThreadRef,
+      activeThreadWorktreePath,
+      allocatableActiveTerminalIds,
+      environmentId,
+      gitCwd,
+      openTerminal,
+      storeNewTerminal,
+      storeSetActiveTerminal,
+      storeSetTerminalOpen,
+    ],
+  );
   const closeTerminal = useCallback(
     (terminalId: string) => {
       if (!activeThreadId || !activeThreadRef) return;
@@ -2939,16 +3081,24 @@ function ChatViewContent(props: ChatViewProps) {
             deleteHistory: true,
           },
         });
-        if (closeResult._tag === "Failure" && !isAtomCommandInterrupted(closeResult)) {
+        if (
+          closeResult._tag === "Failure" &&
+          !isAtomCommandInterrupted(closeResult) &&
+          !activeTmuxTerminalIds.has(terminalId)
+        ) {
           await fallbackExitWrite();
         }
       })();
       storeCloseTerminal(activeThreadRef, terminalId);
+      if (activeTmuxTerminalIds.has(terminalId)) {
+        notifyTmuxSessionsChanged();
+      }
       setTerminalFocusRequestId((value) => value + 1);
     },
     [
       activeThreadId,
       activeThreadRef,
+      activeTmuxTerminalIds,
       closeTerminalMutation,
       environmentId,
       storeCloseTerminal,
@@ -3348,6 +3498,41 @@ function ChatViewContent(props: ChatViewProps) {
     gitCwd,
     openTerminal,
   ]);
+  const attachTmuxSessionToPanel = useCallback(
+    (sessionName: string) => {
+      if (!activeThreadRef || !activeThreadId || !activeProject) return;
+      const cwd = gitCwd ?? activeProject.workspaceRoot;
+      const terminalId = nextTerminalId(allocatableActiveTerminalIds);
+      void (async () => {
+        const result = await openTerminal({
+          environmentId: activeThreadRef.environmentId,
+          input: {
+            threadId: activeThreadId,
+            terminalId,
+            cwd,
+            ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
+            env: projectScriptRuntimeEnv({
+              project: { cwd: activeProject.workspaceRoot },
+              worktreePath: activeThreadWorktreePath,
+            }),
+            launch: { kind: "tmux", sessionName },
+          },
+        });
+        if (result._tag !== "Success") return;
+        useRightPanelStore.getState().openTerminal(activeThreadRef, terminalId);
+        setTerminalFocusRequestId((value) => value + 1);
+      })();
+    },
+    [
+      activeProject,
+      activeThreadId,
+      activeThreadRef,
+      activeThreadWorktreePath,
+      allocatableActiveTerminalIds,
+      gitCwd,
+      openTerminal,
+    ],
+  );
   const splitPanelTerminal = useCallback(
     (direction: "horizontal" | "vertical" = "horizontal") => {
       if (
@@ -6049,6 +6234,7 @@ function ChatViewContent(props: ChatViewProps) {
         onSplitTerminal={splitPanelTerminal}
         onSplitTerminalVertical={splitPanelTerminalVertical}
         onNewTerminal={addTerminalSurface}
+        onAttachTmuxSession={attachTmuxSessionToPanel}
         onActiveTerminalChange={activatePanelTerminal}
         onCloseTerminal={closePanelTerminal}
         splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
@@ -6315,6 +6501,13 @@ function ChatViewContent(props: ChatViewProps) {
                   )}
                   {threadSyncPhase && !activeEnvironmentUnavailable ? (
                     <ThreadSyncStatusPill phase={threadSyncPhase} />
+                  ) : null}
+                  {!isDraftHeroState ? (
+                    <TmuxSessionStatusStrip
+                      environmentId={activeThread.environmentId}
+                      refreshKey={tmuxRefreshKey}
+                      onOpenSessions={openTmuxSessionsFromStatus}
+                    />
                   ) : null}
                   <div
                     className="relative"

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -6,6 +6,7 @@ import {
 import { type TerminalSessionState } from "@t3tools/client-runtime/state/terminal";
 import {
   Plus,
+  PanelsTopLeft,
   SquareSplitHorizontal,
   SquareSplitVertical,
   TerminalSquare,
@@ -16,6 +17,7 @@ import {
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
   type ThreadId,
+  type TmuxSessionDiscovery,
 } from "@t3tools/contracts";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import * as Schema from "effect/Schema";
@@ -31,6 +33,28 @@ import {
   useState,
 } from "react";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuSeparator,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from "~/components/ui/menu";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+import { toastManager } from "~/components/ui/toast";
+import { notifyTmuxSessionsChanged } from "~/terminal/tmuxSessionEvents";
 import { writeTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { cn } from "~/lib/utils";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
@@ -881,6 +905,7 @@ interface ThreadTerminalDrawerProps {
   onSplitTerminal: () => void;
   onSplitTerminalVertical: () => void;
   onNewTerminal: () => void;
+  onAttachTmuxSession: (sessionName: string) => void;
   splitShortcutLabel?: string | undefined;
   splitVerticalShortcutLabel?: string | undefined;
   newShortcutLabel?: string | undefined;
@@ -890,10 +915,154 @@ interface ThreadTerminalDrawerProps {
   onHeightChange: (height: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   keybindings: ResolvedKeybindingsConfig;
+  /** Keep the right-hand session rail visible even when it contains one terminal. */
+  forceTerminalSidebar?: boolean;
   /** Prefer server-provided tab titles when present (e.g. active subprocess name). */
   terminalLabelsById?: ReadonlyMap<string, string>;
   /** Prefer per-session launch locations when the server already knows a terminal. */
   terminalLaunchLocationsById?: ReadonlyMap<string, TerminalLaunchLocation>;
+}
+
+interface TmuxSessionMenuProps {
+  className: string;
+  environmentId: ScopedThreadRef["environmentId"];
+  onAttach: (sessionName: string) => void;
+  showLabel?: boolean;
+}
+
+function TmuxSessionMenu({
+  className,
+  environmentId,
+  onAttach,
+  showLabel = false,
+}: TmuxSessionMenuProps) {
+  const listTmuxSessions = useAtomCommand(
+    terminalEnvironment.listTmuxSessions,
+    "tmux session discovery",
+  );
+  const killTmuxSession = useAtomCommand(terminalEnvironment.killTmuxSession, {
+    reportFailure: false,
+  });
+  const [discovery, setDiscovery] = useState<TmuxSessionDiscovery | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [pendingKillSessionName, setPendingKillSessionName] = useState<string | null>(null);
+  const [killInFlight, setKillInFlight] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const result = await listTmuxSessions({ environmentId, input: {} });
+    setDiscovery(
+      result._tag === "Success" ? result.value : { status: "unavailable", sessions: [] },
+    );
+    setLoading(false);
+  }, [environmentId, listTmuxSessions]);
+
+  const confirmKillSession = useCallback(async () => {
+    if (!pendingKillSessionName) return;
+    setKillInFlight(true);
+    const result = await killTmuxSession({
+      environmentId,
+      input: { sessionName: pendingKillSessionName },
+    });
+    setKillInFlight(false);
+    setPendingKillSessionName(null);
+    if (result._tag === "Success" && result.value.status === "killed") {
+      toastManager.add({ type: "success", title: `Stopped ${pendingKillSessionName}` });
+      notifyTmuxSessionsChanged();
+    } else if (result._tag === "Success" && result.value.status === "notFound") {
+      toastManager.add({
+        type: "warning",
+        title: `${pendingKillSessionName} is no longer running`,
+      });
+      notifyTmuxSessionsChanged();
+    } else if (!isAtomCommandInterrupted(result)) {
+      toastManager.add({ type: "error", title: `Could not stop ${pendingKillSessionName}` });
+    }
+    await refresh();
+  }, [environmentId, killTmuxSession, pendingKillSessionName, refresh]);
+
+  return (
+    <>
+      <Menu
+        onOpenChange={(open) => {
+          if (open) void refresh();
+        }}
+      >
+        <MenuTrigger className={className} aria-label="Attach tmux session">
+          <PanelsTopLeft className="size-3.25" />
+          {showLabel ? <span>Attach tmux session</span> : null}
+        </MenuTrigger>
+        <MenuPopup align="end" side="bottom" sideOffset={6} className="min-w-52">
+          {loading || discovery === null ? (
+            <MenuItem disabled>Looking for tmux sessions...</MenuItem>
+          ) : discovery.status === "unavailable" ? (
+            <MenuItem disabled>tmux is not installed</MenuItem>
+          ) : discovery.sessions.length === 0 ? (
+            <MenuItem disabled>No tmux sessions</MenuItem>
+          ) : (
+            <>
+              {discovery.sessions.map((session) => (
+                <MenuItem key={session.name} onClick={() => onAttach(session.name)}>
+                  <PanelsTopLeft />
+                  <span className="min-w-0 flex-1 truncate">{session.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {session.windows}w · {session.attachedClients}a
+                  </span>
+                </MenuItem>
+              ))}
+              <MenuSeparator />
+              <MenuSub>
+                <MenuSubTrigger>
+                  <Trash2 />
+                  Stop session
+                </MenuSubTrigger>
+                <MenuSubPopup>
+                  {discovery.sessions.map((session) => (
+                    <MenuItem
+                      key={session.name}
+                      variant="destructive"
+                      onClick={() => setPendingKillSessionName(session.name)}
+                    >
+                      <Trash2 />
+                      <span className="truncate">{session.name}</span>
+                    </MenuItem>
+                  ))}
+                </MenuSubPopup>
+              </MenuSub>
+            </>
+          )}
+        </MenuPopup>
+      </Menu>
+      <AlertDialog
+        open={pendingKillSessionName !== null}
+        onOpenChange={(open) => {
+          if (!open && !killInFlight) setPendingKillSessionName(null);
+        }}
+      >
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Stop tmux session “{pendingKillSessionName}”?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This terminates the session and every process running inside it. This cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" disabled={killInFlight} />}>
+              Cancel
+            </AlertDialogClose>
+            <Button
+              variant="destructive"
+              disabled={killInFlight}
+              onClick={() => void confirmKillSession()}
+            >
+              {killInFlight ? "Stopping..." : "Stop session"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </>
+  );
 }
 
 interface TerminalActionButtonProps {
@@ -942,6 +1111,7 @@ export default function ThreadTerminalDrawer({
   onSplitTerminal,
   onSplitTerminalVertical,
   onNewTerminal,
+  onAttachTmuxSession,
   splitShortcutLabel,
   splitVerticalShortcutLabel,
   newShortcutLabel,
@@ -951,6 +1121,7 @@ export default function ThreadTerminalDrawer({
   onHeightChange,
   onAddTerminalContext,
   keybindings,
+  forceTerminalSidebar = false,
   terminalLabelsById,
   terminalLaunchLocationsById,
 }: ThreadTerminalDrawerProps) {
@@ -1103,7 +1274,7 @@ export default function ThreadTerminalDrawer({
     (normalizedTerminalIds.length > 0 ? [resolvedActiveTerminalId] : []);
   const splitDirection =
     resolvedTerminalGroups[resolvedActiveGroupIndex]?.splitDirection ?? "horizontal";
-  const hasTerminalSidebar = normalizedTerminalIds.length > 1;
+  const hasTerminalSidebar = forceTerminalSidebar || normalizedTerminalIds.length > 1;
   const isSplitView = visibleTerminalIds.length > 1;
   const showGroupHeaders =
     resolvedTerminalGroups.length > 1 ||
@@ -1279,13 +1450,21 @@ export default function ThreadTerminalDrawer({
         ) : null}
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-4 py-6 text-center text-sm text-muted-foreground">
           <p>No terminal sessions for this thread yet.</p>
-          <button
-            type="button"
-            className="rounded-md border border-border/80 bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-            onClick={onNewTerminalAction}
-          >
-            {newTerminalActionLabel}
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="rounded-md border border-border/80 bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+              onClick={onNewTerminalAction}
+            >
+              {newTerminalActionLabel}
+            </button>
+            <TmuxSessionMenu
+              className="inline-flex items-center gap-1.5 rounded-md border border-border/80 bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+              environmentId={threadRef.environmentId}
+              onAttach={onAttachTmuxSession}
+              showLabel
+            />
+          </div>
         </div>
       </aside>
     );
@@ -1346,6 +1525,12 @@ export default function ThreadTerminalDrawer({
             >
               <Plus className="size-3.25" />
             </TerminalActionButton>
+            <div className="h-4 w-px bg-border/80" />
+            <TmuxSessionMenu
+              className="p-1 text-foreground/90 transition-colors hover:bg-accent"
+              environmentId={threadRef.environmentId}
+              onAttach={onAttachTmuxSession}
+            />
             <div className="h-4 w-px bg-border/80" />
             <TerminalActionButton
               className="p-1 text-foreground/90 transition-colors hover:bg-accent"
@@ -1482,6 +1667,11 @@ export default function ThreadTerminalDrawer({
                   >
                     <Plus className="size-3.25" />
                   </TerminalActionButton>
+                  <TmuxSessionMenu
+                    className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"
+                    environmentId={threadRef.environmentId}
+                    onAttach={onAttachTmuxSession}
+                  />
                   <TerminalActionButton
                     className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"
                     onClick={() => onCloseTerminal(resolvedActiveTerminalId)}

--- a/apps/web/src/components/chat/TmuxSessionStatusStrip.tsx
+++ b/apps/web/src/components/chat/TmuxSessionStatusStrip.tsx
@@ -1,0 +1,73 @@
+import { type EnvironmentId, type TmuxSession } from "@t3tools/contracts";
+import { PanelsTopLeft } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { terminalEnvironment } from "../../state/terminal";
+import { useAtomCommand } from "../../state/use-atom-command";
+import { subscribeTmuxSessionsChanged } from "../../terminal/tmuxSessionEvents";
+
+interface TmuxSessionStatusStripProps {
+  environmentId: EnvironmentId;
+  refreshKey: string;
+  onOpenSessions: (sessions: ReadonlyArray<TmuxSession>) => void;
+}
+
+function StatusContents({ count }: { count: number }) {
+  return (
+    <>
+      <span className="size-1.5 shrink-0 rounded-full bg-emerald-500" aria-hidden />
+      <PanelsTopLeft className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <span className="min-w-0 truncate text-left">
+        {count === 1 ? "1 background session running" : `${count} background tasks running`}
+      </span>
+    </>
+  );
+}
+
+export function TmuxSessionStatusStrip({
+  environmentId,
+  refreshKey,
+  onOpenSessions,
+}: TmuxSessionStatusStripProps) {
+  const listTmuxSessions = useAtomCommand(terminalEnvironment.listTmuxSessions, {
+    label: "tmux session discovery",
+    reportFailure: false,
+  });
+  const [sessions, setSessions] = useState<ReadonlyArray<TmuxSession>>([]);
+  const refreshSequenceRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const refreshSequence = refreshSequenceRef.current + 1;
+    refreshSequenceRef.current = refreshSequence;
+    const result = await listTmuxSessions({ environmentId, input: {} });
+    if (refreshSequenceRef.current !== refreshSequence) return;
+    setSessions(
+      result._tag === "Success" && result.value.status === "available" ? result.value.sessions : [],
+    );
+  }, [environmentId, listTmuxSessions]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh, refreshKey]);
+
+  useEffect(() => subscribeTmuxSessionsChanged(() => void refresh()), [refresh]);
+
+  if (sessions.length === 0) return null;
+
+  const className =
+    "pointer-events-auto flex h-6 min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-t-[10px] border border-b-0 border-border/70 bg-card/95 px-2.5 text-xs font-medium text-foreground shadow-sm backdrop-blur transition-colors hover:bg-accent";
+  const onlySession = sessions.length === 1 ? sessions[0] : undefined;
+
+  return (
+    <div className="relative z-0 -mb-px mx-auto flex w-[calc(100%-2.75rem)] max-w-[calc(48rem-2.75rem)] justify-end pe-2">
+      <button
+        type="button"
+        className={className}
+        aria-label={onlySession ? `Open tmux session ${onlySession.name}` : "Open tmux sessions"}
+        onClick={() => onOpenSessions(sessions)}
+      >
+        <StatusContents count={sessions.length} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/terminal/tmuxSessionEvents.ts
+++ b/apps/web/src/terminal/tmuxSessionEvents.ts
@@ -1,0 +1,10 @@
+const listeners = new Set<() => void>();
+
+export function notifyTmuxSessionsChanged(): void {
+  for (const listener of listeners) listener();
+}
+
+export function subscribeTmuxSessionsChanged(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/docs/user/terminals.md
+++ b/docs/user/terminals.md
@@ -1,0 +1,11 @@
+# Terminals and long-running work
+
+T3 Code asks Codex and Claude to use named tmux sessions for servers, watchers, long builds, and other commands that are intentionally left running. Normal one-off commands continue to use the provider's regular command execution.
+
+Use **Attach tmux session** in the terminal controls to list sessions in the connected environment. Selecting a session opens it in the existing T3 Code terminal, including when the environment is remote.
+
+When an environment has running tmux sessions, a small status tab appears above the composer. Click it to open the terminal drawer. T3 attaches every discovered session and lists them in the drawer's right-hand session rail. The rail stays visible when there is only one tmux session.
+
+Closing the T3 Code terminal detaches from tmux without stopping the session or its processes. On web and desktop, terminate a session by opening the tmux menu in the terminal drawer, choosing **Stop session**, and confirming. This stops every process inside that tmux session.
+
+Provider-native background tasks are not automatically converted to tmux sessions and cannot be attached through this menu.

--- a/packages/client-runtime/src/state/terminal.ts
+++ b/packages/client-runtime/src/state/terminal.ts
@@ -89,6 +89,14 @@ export function createTerminalEnvironmentAtoms<R, E>(
       scheduler: lifecycleScheduler,
       concurrency: lifecycleConcurrency,
     }),
+    listTmuxSessions: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:terminal:list-tmux-sessions",
+      tag: WS_METHODS.terminalListTmuxSessions,
+    }),
+    killTmuxSession: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:terminal:kill-tmux-session",
+      tag: WS_METHODS.terminalKillTmuxSession,
+    }),
   };
 }
 

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -27,6 +27,7 @@ const BASE_SNAPSHOT: TerminalSessionSnapshot = {
   exitCode: null,
   exitSignal: null,
   label: "Terminal 1",
+  launch: { kind: "shell" },
   updatedAt: "2026-04-01T00:00:00.000Z",
 };
 
@@ -47,6 +48,7 @@ describe("terminal session reducers", () => {
           updatedAt: BASE_SNAPSHOT.updatedAt,
           hasRunningSubprocess: false,
           label: BASE_SNAPSHOT.label,
+          launch: BASE_SNAPSHOT.launch,
         },
       ],
     })[0]!;
@@ -80,6 +82,7 @@ describe("terminal session reducers", () => {
           updatedAt: BASE_SNAPSHOT.updatedAt,
           hasRunningSubprocess: false,
           label: BASE_SNAPSHOT.label,
+          launch: BASE_SNAPSHOT.launch,
         },
       ],
     })[0]!;
@@ -149,6 +152,7 @@ describe("terminal session reducers", () => {
           updatedAt: BASE_SNAPSHOT.updatedAt,
           hasRunningSubprocess: false,
           label: BASE_SNAPSHOT.label,
+          launch: BASE_SNAPSHOT.launch,
         },
       ],
     });

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -126,6 +126,9 @@ import {
   TerminalRestartInput,
   TerminalSessionSnapshot,
   TerminalWriteInput,
+  TmuxSessionDiscovery,
+  TmuxSessionKillInput,
+  TmuxSessionKillResult,
 } from "./terminal.ts";
 import {
   DiscoveredLocalServerList,
@@ -235,6 +238,8 @@ export const WS_METHODS = {
   terminalClear: "terminal.clear",
   terminalRestart: "terminal.restart",
   terminalClose: "terminal.close",
+  terminalListTmuxSessions: "terminal.listTmuxSessions",
+  terminalKillTmuxSession: "terminal.killTmuxSession",
 
   // Preview methods
   previewOpen: "preview.open",
@@ -783,6 +788,18 @@ export const WsTerminalCloseRpc = Rpc.make(WS_METHODS.terminalClose, {
   error: Schema.Union([TerminalError, EnvironmentAuthorizationError]),
 });
 
+export const WsTerminalListTmuxSessionsRpc = Rpc.make(WS_METHODS.terminalListTmuxSessions, {
+  payload: Schema.Struct({}),
+  success: TmuxSessionDiscovery,
+  error: EnvironmentAuthorizationError,
+});
+
+export const WsTerminalKillTmuxSessionRpc = Rpc.make(WS_METHODS.terminalKillTmuxSession, {
+  payload: TmuxSessionKillInput,
+  success: TmuxSessionKillResult,
+  error: EnvironmentAuthorizationError,
+});
+
 export const WsPreviewOpenRpc = Rpc.make(WS_METHODS.previewOpen, {
   payload: PreviewOpenInput,
   success: PreviewSessionSnapshot,
@@ -1042,6 +1059,8 @@ export const WsRpcGroup = RpcGroup.make(
   WsTerminalClearRpc,
   WsTerminalRestartRpc,
   WsTerminalCloseRpc,
+  WsTerminalListTmuxSessionsRpc,
+  WsTerminalKillTmuxSessionRpc,
   WsSubscribeTerminalEventsRpc,
   WsSubscribeTerminalMetadataRpc,
   WsPreviewOpenRpc,

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -8,10 +8,14 @@ import {
   TerminalCloseInput,
   TerminalEvent,
   TerminalOpenInput,
+  TerminalLaunch,
   TerminalResizeInput,
   TerminalSessionSnapshot,
   TerminalThreadInput,
   TerminalWriteInput,
+  TmuxSessionDiscovery,
+  TmuxSessionKillInput,
+  TmuxSessionKillResult,
 } from "./terminal.ts";
 
 function decodeSync<S extends Schema.Top>(schema: S, input: unknown): Schema.Schema.Type<S> {
@@ -95,6 +99,23 @@ describe("TerminalOpenInput", () => {
     expect(parsed.worktreePath).toBe("/tmp/project/.t3/worktrees/feature-a");
   });
 
+  it("accepts omitted shell launch and an explicit tmux launch", () => {
+    const shell = decodeSync(TerminalOpenInput, {
+      threadId: "thread-1",
+      terminalId: DEFAULT_TERMINAL_ID,
+      cwd: "/tmp/project",
+    });
+    const tmux = decodeSync(TerminalOpenInput, {
+      threadId: "thread-1",
+      terminalId: DEFAULT_TERMINAL_ID,
+      cwd: "/tmp/project",
+      launch: { kind: "tmux", sessionName: " long-build " },
+    });
+
+    expect(shell.launch).toBeUndefined();
+    expect(tmux.launch).toEqual({ kind: "tmux", sessionName: "long-build" });
+  });
+
   it("rejects invalid env keys", () => {
     expect(
       decodes(TerminalOpenInput, {
@@ -105,6 +126,38 @@ describe("TerminalOpenInput", () => {
         env: {
           "bad-key": "1",
         },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("tmux schemas", () => {
+  it("rejects blank and oversized tmux session names", () => {
+    expect(decodes(TerminalLaunch, { kind: "tmux", sessionName: "   " })).toBe(false);
+    expect(decodes(TerminalLaunch, { kind: "tmux", sessionName: "x".repeat(129) })).toBe(false);
+  });
+
+  it("decodes exact kill requests and structured outcomes", () => {
+    expect(decodeSync(TmuxSessionKillInput, { sessionName: " long-build " })).toEqual({
+      sessionName: "long-build",
+    });
+    for (const status of ["killed", "notFound", "unavailable"] as const) {
+      expect(decodes(TmuxSessionKillResult, { status })).toBe(true);
+    }
+  });
+
+  it("decodes available and unavailable discovery states", () => {
+    expect(
+      decodes(TmuxSessionDiscovery, {
+        status: "available",
+        sessions: [{ name: "dev", attachedClients: 1, windows: 2 }],
+      }),
+    ).toBe(true);
+    expect(decodes(TmuxSessionDiscovery, { status: "unavailable", sessions: [] })).toBe(true);
+    expect(
+      decodes(TmuxSessionDiscovery, {
+        status: "unavailable",
+        sessions: [{ name: "dev", attachedClients: 0, windows: 1 }],
       }),
     ).toBe(false);
   });
@@ -225,6 +278,7 @@ describe("TerminalSessionSnapshot", () => {
         exitCode: null,
         exitSignal: null,
         label: "Primary",
+        launch: { kind: "shell" },
         updatedAt: isoTimestamp,
       }),
     ).toBe(true);
@@ -296,6 +350,7 @@ describe("TerminalEvent", () => {
           exitCode: null,
           exitSignal: null,
           label: "Primary",
+          launch: { kind: "shell" },
           updatedAt: isoTimestamp,
         },
       }),

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -1,5 +1,5 @@
 import * as Schema from "effect/Schema";
-import { TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 /**
  * Client-side id for the first shell opened on a thread. Ids are uniformly
@@ -23,6 +23,46 @@ const TerminalEnvValueSchema = Schema.String.check(Schema.isMaxLength(8_192));
 const TerminalEnvSchema = Schema.Record(TerminalEnvKeySchema, TerminalEnvValueSchema).check(
   Schema.isMaxProperties(128),
 );
+const TmuxSessionNameSchema = TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(128));
+
+export const TerminalLaunch = Schema.Union([
+  Schema.Struct({ kind: Schema.Literal("shell") }),
+  Schema.Struct({
+    kind: Schema.Literal("tmux"),
+    sessionName: TmuxSessionNameSchema,
+  }),
+]);
+export type TerminalLaunch = typeof TerminalLaunch.Type;
+export const DEFAULT_TERMINAL_LAUNCH: TerminalLaunch = { kind: "shell" };
+
+export const TmuxSession = Schema.Struct({
+  name: TmuxSessionNameSchema,
+  attachedClients: NonNegativeInt,
+  windows: NonNegativeInt,
+});
+export type TmuxSession = typeof TmuxSession.Type;
+
+export const TmuxSessionDiscovery = Schema.Union([
+  Schema.Struct({
+    status: Schema.Literal("available"),
+    sessions: Schema.Array(TmuxSession),
+  }),
+  Schema.Struct({
+    status: Schema.Literal("unavailable"),
+    sessions: Schema.Tuple([]),
+  }),
+]);
+export type TmuxSessionDiscovery = typeof TmuxSessionDiscovery.Type;
+
+export const TmuxSessionKillInput = Schema.Struct({
+  sessionName: TmuxSessionNameSchema,
+});
+export type TmuxSessionKillInput = typeof TmuxSessionKillInput.Type;
+
+export const TmuxSessionKillResult = Schema.Struct({
+  status: Schema.Literals(["killed", "notFound", "unavailable"]),
+});
+export type TmuxSessionKillResult = typeof TmuxSessionKillResult.Type;
 
 export const TerminalThreadInput = Schema.Struct({
   threadId: TrimmedNonEmptyStringSchema,
@@ -43,6 +83,7 @@ export const TerminalOpenInput = Schema.Struct({
   cols: Schema.optional(TerminalColsSchema),
   rows: Schema.optional(TerminalRowsSchema),
   env: Schema.optional(TerminalEnvSchema),
+  launch: Schema.optional(TerminalLaunch),
 });
 export type TerminalOpenInput = Schema.Codec.Encoded<typeof TerminalOpenInput>;
 
@@ -80,6 +121,7 @@ export const TerminalRestartInput = Schema.Struct({
   cols: TerminalColsSchema,
   rows: TerminalRowsSchema,
   env: Schema.optional(TerminalEnvSchema),
+  launch: Schema.optional(TerminalLaunch),
 });
 export type TerminalRestartInput = Schema.Codec.Encoded<typeof TerminalRestartInput>;
 
@@ -105,6 +147,7 @@ export const TerminalSessionSnapshot = Schema.Struct({
   exitSignal: Schema.NullOr(Schema.Int),
   /** Server-computed display title (idle shell vs subprocess command). */
   label: Schema.String.check(Schema.isMaxLength(128)),
+  launch: TerminalLaunch,
   updatedAt: Schema.String,
   sequence: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
 });
@@ -122,6 +165,7 @@ export const TerminalSummary = Schema.Struct({
   hasRunningSubprocess: Schema.Boolean,
   /** Server-computed display title (idle shell vs subprocess command). */
   label: Schema.String.check(Schema.isMaxLength(128)),
+  launch: TerminalLaunch,
   updatedAt: Schema.String,
 });
 export type TerminalSummary = typeof TerminalSummary.Type;


### PR DESCRIPTION
## What Changed

T3 Code now exposes intentional long-running work through the existing terminal experience:

- Codex and Claude receive guidance to place servers, watchers, and long builds in named detached tmux sessions.
- The server discovers, attaches to, and stops exact tmux sessions through typed terminal RPCs.
- Web and desktop show a compact running-task tab above the composer and open discovered sessions in the terminal drawer.
- The drawer lists attached sessions in its right-hand rail and provides a confirmed Stop session action.
- Mobile can discover and attach to tmux sessions from its terminal menu.

Tmux remains the source of truth for process lifetime and scrollback. Discovery runs on lifecycle events and user actions, without a polling loop or a second persisted task model.

## Why

Provider background shells make long-running processes difficult to observe, especially from remote clients. T3 Code already has a remotely accessible PTY surface, while tmux already provides detached lifetime, scrollback, and multi-client attachment. Connecting those systems gives users visibility and control with a small runtime model.

## UI Changes

| Before | Running sessions |
| --- | --- |
| ![Composer without a background-session indicator](https://raw.githubusercontent.com/arekhalpern/t3code/7a8352693a941d324131e94997c320412304e54e/.github/pr-assets/tmux-before.png) | ![Composer showing two background tasks](https://raw.githubusercontent.com/arekhalpern/t3code/7a8352693a941d324131e94997c320412304e54e/.github/pr-assets/tmux-after.png) |

![Terminal drawer showing attached tmux sessions in the right-hand rail](https://raw.githubusercontent.com/arekhalpern/t3code/7a8352693a941d324131e94997c320412304e54e/.github/pr-assets/tmux-drawer.png)

[Interaction video: open all running sessions from the composer tab](https://raw.githubusercontent.com/arekhalpern/t3code/7a8352693a941d324131e94997c320412304e54e/.github/pr-assets/tmux-interaction.mp4)

## Verification

- 88 focused contract, terminal manager, and authorization tests passed.
- Contracts, client-runtime, server, and web typechecks passed.
- Targeted lint and diff validation passed.
- Integrated web pass covered two-session discovery, composer status, drawer attachment, live output, session switching, and session termination refresh.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] I included a video for the interaction change

Built with GPT-5.6-Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal lifecycle, host `tmux` execution, and provider instructions; kill-session is destructive but scoped to exact session names with confirmation in the UI.
> 
> **Overview**
> **Observable long-running work** is wired through the existing terminal stack instead of a new task model. Codex and Claude get appended instructions to use **named detached tmux sessions** for servers, watchers, and long builds; Claude’s system prompt gets the same block.
> 
> **Server & contracts:** `TerminalOpenInput` gains optional `launch` (`shell` vs `tmux` + session name). The terminal manager discovers sessions via `tmux list-sessions`, attaches with `tmux attach-session` (no shell fallback on spawn failure), and kills exact sessions via `tmux kill-session`. Snapshots/summaries carry `launch` and tmux-specific labels. New RPCs `terminal.listTmuxSessions` and `terminal.killTmuxSession` are authorized like other terminal operate methods.
> 
> **Web:** Composer **status strip** when tmux sessions exist; clicking opens the drawer and attaches all (reusing drawer tabs when already open). **Thread terminal drawer** adds attach/stop-session menus, keeps the session rail visible for tmux-only cases, and closes tmux tabs without sending `exit` to the PTY. **Mobile** mirrors attach via terminal menus with loading/unavailable/empty states.
> 
> **Docs:** User-facing note on attach, detach-on-close, and stop-session behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b39660900de11e9ffa1c27875c6d84ad3536ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add observable tmux sessions to terminal UI and AI provider instructions
> - Extends the terminal contract with `TerminalLaunch` (shell vs tmux), `TmuxSessionDiscovery`, and kill/list schemas; snapshots and summaries now include a required `launch` field.
> - Adds `listTmuxSessions` and `killTmuxSession` to `TerminalManager`, exposing them via two new WebSocket RPCs (`terminal.listTmuxSessions`, `terminal.killTmuxSession`) with `AuthTerminalOperateScope` enforcement.
> - Opening a terminal with `launch.kind === 'tmux'` now spawns `tmux attach-session` instead of a shell; if spawn fails, no shell fallback is attempted.
> - Adds a `TmuxSessionStatusStrip` in the chat view and a `TmuxSessionMenu` in the terminal drawer/panel so users can list, attach to, and stop tmux sessions from both web and mobile UIs.
> - Appends `BACKGROUND_TERMINAL_INSTRUCTIONS` to Claude and Codex system prompts, instructing the AI to use named detached tmux sessions for long-running background commands.
> - Risk: existing clients consuming `TerminalSessionSnapshot` or `TerminalSummary` must handle the new required `launch` field.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5b39660. 15 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->