### PR TITLE
fix window titles for time tracking apps

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -541,10 +541,6 @@ export const make = Effect.gen(function* () {
       }
     });
 
-    window.on("page-title-updated", (event) => {
-      event.preventDefault();
-      window.setTitle(environment.displayName);
-    });
     window.on("resize", scheduleBoundsPersist);
     window.on("move", scheduleBoundsPersist);
     window.on("maximize", scheduleBoundsPersist);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
   type ErrorComponentProps,
   useLocation,
   useNavigate,
+  useParams,
 } from "@tanstack/react-router";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 
@@ -50,7 +51,8 @@ import {
   primaryServerConfigEventAtom,
   primaryServerWelcomeAtom,
 } from "../state/server";
-import { readProject, setActiveEnvironmentId, useActiveEnvironmentId } from "../state/entities";
+import { readProject, setActiveEnvironmentId, useActiveEnvironmentId, useProject, useThreadShell } from "../state/entities";
+import { resolveThreadRouteRef } from "../threadRoutes";
 import {
   createKeybindingsUpdateToastController,
   type KeybindingsUpdateToastController,
@@ -193,14 +195,20 @@ function FontAppearanceSync() {
 }
 
 function DocumentTitleSync() {
+  const threadRef = useParams({ strict: false, select: resolveThreadRouteRef });
+  const thread = useThreadShell(threadRef);
+  const project = useProject(
+    thread ? scopeProjectRef(thread.environmentId, thread.projectId) : null,
+  );
   const primaryServerVersion =
     useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
-  const title = resolveServerBackedAppDisplayName({
+  const appTitle = resolveServerBackedAppDisplayName({
     baseName: APP_BASE_NAME,
     fallbackDisplayName: APP_DISPLAY_NAME,
     fallbackStageLabel: APP_STAGE_LABEL,
     primaryServerVersion,
   });
+  const title = thread && project ? `${thread.title} — ${project.title}` : appTitle;
 
   useEffect(() => {
     document.title = title;


### PR DESCRIPTION
T3 Code currently reports every thread as `T3 Code (Alpha)`, so time tracking apps cannot distinguish work by project or thread.

This updates the window title to include the active thread and project.

- [x] This is a small PR
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Title-only UX changes with no impact on auth, data, or core app behavior.
> 
> **Overview**
> **Window titles now reflect the active thread and project** so time-tracking tools can distinguish sessions instead of always seeing the generic app name.
> 
> The web shell’s `DocumentTitleSync` reads the current thread route and sets `document.title` to `{thread title} — {project title}` when both are available, otherwise it keeps the existing server-backed app display name.
> 
> On desktop, the main window **stops overriding** `page-title-updated` to force `environment.displayName`, so the native window title can follow renderer `document.title` updates (initial load still resets to the app name until the route sync runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc7a339ec643c0ba1f49bca4070cb5eaaa9f2db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->