### PR TITLE
fix(server): validate OpenCode refresh metadata

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -12,6 +12,7 @@ import { ServerConfig } from "../../config.ts";
 import {
   OpenCodeRuntime,
   OpenCodeRuntimeError,
+  parseModelsCliOutput,
   type OpenCodeRuntimeShape,
 } from "../opencodeRuntime.ts";
 import { checkOpenCodeProviderStatus } from "./OpenCodeProvider.ts";
@@ -226,6 +227,38 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
       NodeAssert.equal(
         snapshot.message,
         "Failed to execute OpenCode CLI health check: opencode models failed",
+      );
+    }),
+  );
+
+  it.effect("does not crash refresh when CLI model metadata is malformed", () =>
+    Effect.gen(function* () {
+      const parsed = parseModelsCliOutput(
+        [
+          "anthropic/null-model",
+          "null",
+          "anthropic/numeric-name",
+          '{"id":"numeric-name","name":123}',
+          "anthropic/invalid-variants",
+          '{"id":"invalid-variants","name":"Invalid variants","variants":[]}',
+          "openai/gpt-4o",
+          '{"id":"gpt-4o","name":"GPT-4o"}',
+        ].join("\n"),
+      );
+      runtimeMock.state.inventory = {
+        providerList: {
+          connected: parsed.connected,
+          all: [...parsed.providers.values()],
+        },
+        agents: [],
+      };
+
+      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+
+      NodeAssert.equal(snapshot.status, "ready");
+      NodeAssert.deepEqual(
+        snapshot.models.map((model) => model.slug),
+        ["openai/gpt-4o"],
       );
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -21,8 +21,9 @@ import {
   OpenCodeRuntime,
   openCodeRuntimeErrorDetail,
   type OpenCodeInventory,
+  type OpenCodeInventoryAgent,
+  type OpenCodeInventoryModel,
 } from "../opencodeRuntime.ts";
-import type { Agent, ProviderListResponse } from "@opencode-ai/sdk/v2";
 
 const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
@@ -160,7 +161,7 @@ function inferDefaultVariant(
   return undefined;
 }
 
-function inferDefaultAgent(agents: ReadonlyArray<Agent>): string | undefined {
+function inferDefaultAgent(agents: ReadonlyArray<OpenCodeInventoryAgent>): string | undefined {
   return agents.find((agent) => agent.name === "build")?.name ?? agents[0]?.name ?? undefined;
 }
 
@@ -170,8 +171,8 @@ const DEFAULT_OPENCODE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabi
 
 function openCodeCapabilitiesForModel(input: {
   readonly providerID: string;
-  readonly model: ProviderListResponse["all"][number]["models"][string];
-  readonly agents: ReadonlyArray<Agent>;
+  readonly model: OpenCodeInventoryModel;
+  readonly agents: ReadonlyArray<OpenCodeInventoryAgent>;
 }): ModelCapabilities {
   const variantValues = Object.keys(input.model.variants ?? {});
   const defaultVariant = inferDefaultVariant(input.providerID, variantValues);

--- a/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
@@ -79,6 +79,29 @@ describe("parseModelsCliOutput", () => {
     NodeAssert.ok(provider.models["claude-haiku-4-5"]);
   });
 
+  it.each([
+    ["null", null],
+    ["array", []],
+    ["string", "model"],
+    ["numeric-id", { id: 123, name: "Numeric ID" }],
+    ["numeric-name", { id: "numeric-name", name: 123 }],
+    ["null-variants", { id: "null-variants", name: "Null variants", variants: null }],
+    ["array-variants", { id: "array-variants", name: "Array variants", variants: [] }],
+    ["string-variants", { id: "string-variants", name: "String variants", variants: "high" }],
+  ])("skips valid JSON with malformed %s model metadata", (modelID, metadata) => {
+    const stdout = [
+      `anthropic/${modelID}`,
+      JSON.stringify(metadata),
+      "openai/gpt-4o",
+      JSON.stringify({ id: "gpt-4o", providerID: "openai", name: "GPT-4o" }),
+    ].join("\n");
+
+    const result = parseModelsCliOutput(stdout);
+    NodeAssert.deepEqual([...result.connected], ["openai"]);
+    NodeAssert.equal(result.providers.size, 1);
+    NodeAssert.deepEqual(Object.keys(result.providers.get("openai")!.models), ["gpt-4o"]);
+  });
+
   it("handles Windows-style CRLF line endings", () => {
     const stdout =
       "anthropic/claude-sonnet-4-5\r\n" +
@@ -91,37 +114,34 @@ describe("parseModelsCliOutput", () => {
   });
 
   it("handles model JSON with variants and nested fields", () => {
-    const stdout = [
-      "opencode/gpt-5.4",
-      JSON.stringify({
-        id: "gpt-5.4",
-        providerID: "opencode",
-        name: "GPT-5.4",
-        family: "gpt",
-        capabilities: {
-          temperature: true,
-          reasoning: true,
-          attachment: false,
-          toolcall: true,
-          input: { text: true, audio: false, image: false, video: false, pdf: false },
-          output: { text: true, audio: false, image: false, video: false, pdf: false },
-          interleaved: false,
-        },
-        cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
-        limit: { context: 200000, input: 160000, output: 32000 },
-        status: "active",
-        options: {},
-        headers: {},
-        release_date: "2025-01-01",
-        variants: { none: {}, low: {}, medium: {}, high: {} },
-      }),
-    ].join("\n");
+    const metadata = {
+      id: "gpt-5.4",
+      providerID: "opencode",
+      name: "GPT-5.4",
+      family: "gpt",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 200000, input: 160000, output: 32000 },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2025-01-01",
+      variants: { none: {}, low: {}, medium: {}, high: {} },
+    };
+    const stdout = ["opencode/gpt-5.4", JSON.stringify(metadata)].join("\n");
 
     const result = parseModelsCliOutput(stdout);
     const model = result.providers.get("opencode")!.models["gpt-5.4"]!;
     NodeAssert.ok(model);
-    NodeAssert.ok(model.capabilities);
-    NodeAssert.equal(model.capabilities!.reasoning, true);
+    NodeAssert.deepEqual(model.capabilities, metadata.capabilities);
     NodeAssert.ok(model.variants);
     NodeAssert.equal(model.variants!["medium"] !== undefined, true);
   });

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -1,0 +1,69 @@
+import * as NodeAssert from "node:assert/strict";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import type { OpencodeClient } from "@opencode-ai/sdk/v2";
+import { it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { OpenCodeRuntime, OpenCodeRuntimeLive } from "./opencodeRuntime.ts";
+
+const testLayer = OpenCodeRuntimeLive.pipe(Layer.provideMerge(NodeServices.layer));
+
+it.layer(testLayer)("loadOpenCodeInventory", (it) => {
+  it.effect("rejects malformed model metadata from a configured OpenCode server", () =>
+    Effect.gen(function* () {
+      const runtime = yield* OpenCodeRuntime;
+      const client = {
+        provider: {
+          list: async () => ({
+            data: {
+              connected: ["evil"],
+              all: [
+                {
+                  id: "evil",
+                  name: "Evil",
+                  models: { bad: null },
+                },
+              ],
+            },
+          }),
+        },
+        app: { agents: async () => ({ data: [] }) },
+      } as unknown as OpencodeClient;
+
+      const error = yield* runtime.loadOpenCodeInventory(client).pipe(Effect.flip);
+
+      NodeAssert.equal(error.operation, "provider.list");
+      NodeAssert.equal(error.detail, "OpenCode provider list contained invalid model metadata.");
+    }),
+  );
+
+  it.effect("rejects malformed agent metadata from a configured OpenCode server", () =>
+    Effect.gen(function* () {
+      const runtime = yield* OpenCodeRuntime;
+      const client = {
+        provider: {
+          list: async () => ({
+            data: {
+              connected: ["openai"],
+              all: [
+                {
+                  id: "openai",
+                  name: "OpenAI",
+                  models: { "gpt-4o": { id: "gpt-4o", name: "GPT-4o" } },
+                },
+              ],
+            },
+          }),
+        },
+        app: { agents: async () => ({ data: [null] }) },
+      } as unknown as OpencodeClient;
+
+      const error = yield* runtime.loadOpenCodeInventory(client).pipe(Effect.flip);
+
+      NodeAssert.equal(error.operation, "app.agents");
+      NodeAssert.equal(error.detail, "OpenCode agent list contained invalid metadata.");
+    }),
+  );
+});

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -5,10 +5,8 @@ import {
   createOpencodeClient,
   type Agent,
   type FilePartInput,
-  type Model,
   type OpencodeClient,
   type PermissionRuleset,
-  type ProviderListResponse,
   type QuestionAnswer,
   type QuestionRequest,
 } from "@opencode-ai/sdk/v2";
@@ -23,7 +21,6 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as P from "effect/Predicate";
 import * as Ref from "effect/Ref";
-import * as Result from "effect/Result";
 import * as Scope from "effect/Scope";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
@@ -35,6 +32,46 @@ import * as NetService from "@t3tools/shared/Net";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
+const OpenCodeInventoryModelSchema = Schema.StructWithRest(
+  Schema.Struct({
+    id: Schema.String,
+    name: Schema.String,
+    providerID: Schema.optionalKey(Schema.String),
+    variants: Schema.optionalKey(Schema.Record(Schema.String, Schema.Unknown)),
+  }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+);
+const decodeOpenCodeCliModelExit = Schema.decodeUnknownExit(
+  Schema.fromJsonString(OpenCodeInventoryModelSchema),
+);
+const OpenCodeProviderListSchema = Schema.StructWithRest(
+  Schema.Struct({
+    all: Schema.Array(
+      Schema.StructWithRest(
+        Schema.Struct({
+          id: Schema.String,
+          name: Schema.String,
+          models: Schema.Record(Schema.String, OpenCodeInventoryModelSchema),
+        }),
+        [Schema.Record(Schema.String, Schema.Unknown)],
+      ),
+    ),
+    connected: Schema.Array(Schema.String),
+  }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+);
+const decodeOpenCodeProviderList = Schema.decodeUnknownEffect(OpenCodeProviderListSchema);
+const OpenCodeInventoryAgentSchema = Schema.StructWithRest(
+  Schema.Struct({
+    name: Schema.String,
+    mode: Schema.Literals(["subagent", "primary", "all"]),
+    hidden: Schema.optionalKey(Schema.Boolean),
+  }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+);
+const decodeOpenCodeInventoryAgents = Schema.decodeUnknownEffect(
+  Schema.Array(OpenCodeInventoryAgentSchema),
+);
 const OPENCODE_EMPTY_CONFIG_CONTENT = "{}";
 
 const OPENCODE_SERVER_READY_PREFIX = "opencode server listening";
@@ -99,9 +136,12 @@ export interface OpenCodeCommandResult {
 }
 
 export interface OpenCodeInventory {
-  readonly providerList: ProviderListResponse;
-  readonly agents: ReadonlyArray<Agent>;
+  readonly providerList: typeof OpenCodeProviderListSchema.Type;
+  readonly agents: ReadonlyArray<OpenCodeInventoryAgent>;
 }
+
+export type OpenCodeInventoryModel = typeof OpenCodeInventoryModelSchema.Type;
+export type OpenCodeInventoryAgent = typeof OpenCodeInventoryAgentSchema.Type;
 
 export interface ParsedOpenCodeModelSlug {
   readonly providerID: string;
@@ -177,13 +217,17 @@ const KNOWN_HIDDEN_AGENTS = new Set(["compaction", "summary", "title"]);
 export function parseModelsCliOutput(stdout: string): {
   readonly providers: ReadonlyMap<
     string,
-    { readonly id: string; readonly name: string; readonly models: { [key: string]: Model } }
+    {
+      readonly id: string;
+      readonly name: string;
+      readonly models: { [key: string]: OpenCodeInventoryModel };
+    }
   >;
   readonly connected: ReadonlyArray<string>;
 } {
   const providers = new Map<
     string,
-    { id: string; name: string; models: { [key: string]: Model } }
+    { id: string; name: string; models: { [key: string]: OpenCodeInventoryModel } }
   >();
   const lines = stdout.split("\n");
   let currentSlug: string | null = null;
@@ -193,8 +237,8 @@ export function parseModelsCliOutput(stdout: string): {
     if (currentSlug !== null && jsonLines.length > 0) {
       const jsonStr = jsonLines.join("\n").trim();
       if (jsonStr.length > 0) {
-        try {
-          const model = JSON.parse(jsonStr) as Model;
+        const decodedModel = decodeOpenCodeCliModelExit(jsonStr);
+        if (Exit.isSuccess(decodedModel)) {
           const separator = currentSlug.indexOf("/");
           if (separator > 0) {
             const providerID = currentSlug.slice(0, separator);
@@ -204,10 +248,8 @@ export function parseModelsCliOutput(stdout: string): {
               provider = { id: providerID, name: providerID, models: {} };
               providers.set(providerID, provider);
             }
-            provider.models[modelID] = model;
+            provider.models[modelID] = decodedModel.value;
           }
-        } catch {
-          // Skip unparseable model JSON
         }
       }
     }
@@ -636,23 +678,43 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
 
   const loadProviders = (client: OpencodeClient) =>
     runOpenCodeSdk("provider.list", () => client.provider.list()).pipe(
-      Effect.filterMapOrFail(
-        (list) =>
-          list.data
-            ? Result.succeed(list.data)
-            : Result.fail(
-                new OpenCodeRuntimeError({
-                  operation: "provider.list",
-                  detail: "OpenCode provider list was empty.",
-                }),
+      Effect.flatMap((list) =>
+        list.data
+          ? decodeOpenCodeProviderList(list.data).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new OpenCodeRuntimeError({
+                    operation: "provider.list",
+                    detail: "OpenCode provider list contained invalid model metadata.",
+                    cause,
+                  }),
               ),
-        (result) => result,
+            )
+          : Effect.fail(
+              new OpenCodeRuntimeError({
+                operation: "provider.list",
+                detail: "OpenCode provider list was empty.",
+              }),
+            ),
       ),
     );
 
   const loadAgents = (client: OpencodeClient) =>
     runOpenCodeSdk("app.agents", () => client.app.agents()).pipe(
-      Effect.map((result) => result.data ?? []),
+      Effect.flatMap((result) =>
+        result.data
+          ? decodeOpenCodeInventoryAgents(result.data).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new OpenCodeRuntimeError({
+                    operation: "app.agents",
+                    detail: "OpenCode agent list contained invalid metadata.",
+                    cause,
+                  }),
+              ),
+            )
+          : Effect.succeed([]),
+      ),
     );
 
   const loadOpenCodeInventory: OpenCodeRuntimeShape["loadOpenCodeInventory"] = (client) =>
@@ -713,16 +775,16 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
 
       const parsed = parseModelsCliOutput(modelsResult.value.stdout);
       const connected = [...parsed.connected];
-      const allProviders: ProviderListResponse["all"] = [...parsed.providers.values()].map(
-        (provider) => ({
-          id: provider.id,
-          name: provider.name,
-          source: "config" as const,
-          env: [],
-          options: {},
-          models: provider.models,
-        }),
-      );
+      const allProviders: OpenCodeInventory["providerList"]["all"] = [
+        ...parsed.providers.values(),
+      ].map((provider) => ({
+        id: provider.id,
+        name: provider.name,
+        source: "config" as const,
+        env: [],
+        options: {},
+        models: provider.models,
+      }));
 
       // Agent metadata enriches model capabilities but is not required for an
       // authoritative model inventory, so it may still degrade to an empty list.


### PR DESCRIPTION
## What Changed

- Decode OpenCode CLI model blocks with Effect Schema before adding them to the provider inventory.
- Runtime-validate configured-server provider, model, and agent metadata, converting invalid payloads into typed OpenCode runtime failures.
- Add regressions for malformed parser inputs, the complete refresh path, and configured-server inventory decoding.

## Why

Malformed OpenCode metadata could enter snapshot construction as trusted data. Values such as null models, non-string names, invalid variants, or null agents could throw and crash provider refresh instead of producing a controlled provider error.

Validating at the CLI and SDK boundaries preserves existing behavior for well-formed metadata while containing malformed external output.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes *(not applicable: no UI changes)*
- [x] I included a video for animation/interaction changes *(not applicable: no animation or interaction changes)*

Generated with GPT-5.6 (Codex harness).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OpenCode provider inventory and refresh path, but changes are defensive validation and controlled errors rather than new behavior for well-formed data.
> 
> **Overview**
> **OpenCode provider refresh** no longer trusts raw CLI JSON or configured-server SDK payloads. Model, provider-list, and agent inventory are decoded through Effect Schema before they reach snapshot construction.
> 
> **CLI path:** `parseModelsCliOutput` validates each model block (required string `id`/`name`, optional `variants` as a record) and **silently skips** invalid entries instead of storing untyped data that could throw later. Valid models still surface normally.
> 
> **Configured-server path:** `loadOpenCodeInventory` schema-decodes `provider.list` and `app.agents` responses and returns typed **`OpenCodeRuntimeError`** failures when metadata is invalid (e.g. `null` models or agents).
> 
> Inventory types are narrowed to **`OpenCodeInventoryModel`** / **`OpenCodeInventoryAgent`** in the OpenCode provider layer instead of broad SDK types. Regressions cover malformed scalar/variant shapes, end-to-end refresh with bad CLI output, and server inventory decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a3b5700d6ce5b352e19eb40019be92f03bd265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate OpenCode inventory model and agent metadata against schemas at runtime
> - Introduces Zod-style schema validators (`OpenCodeInventoryModelSchema`, `OpenCodeProviderListSchema`, `OpenCodeInventoryAgentSchema`) in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/6478/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) to validate provider list and agent responses.
> - CLI-parsed models that fail schema validation are now silently skipped rather than accepted or throwing a parse error.
> - `loadOpenCodeInventory` now throws a typed `OpenCodeRuntimeError` (with `operation` set to `'provider.list'` or `'app.agents'`) when API responses contain invalid metadata, instead of passing malformed data through.
> - Behavioral Change: previously malformed model/agent metadata would silently propagate; now it either causes a typed error (API path) or is dropped (CLI path).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1a3b57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
