### PR TITLE
fix(web): preserve project filter through settings

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -136,6 +136,7 @@ function ProjectProjectionRetention() {
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
   const legacySidebarEnabled = useLegacySidebarEnabled();
+  const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
   // Settings routes show the settings nav in place of whichever thread
   // sidebar is active.
   const pathname = useLocation({ select: (location) => location.pathname });
@@ -231,7 +232,10 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         ) : legacySidebarEnabled ? (
           <LegacyThreadSidebar />
         ) : (
-          <ThreadSidebar />
+          <ThreadSidebar
+            projectScopeKey={projectScopeKey}
+            onProjectScopeKeyChange={setProjectScopeKey}
+          />
         )}
         <SidebarRail onDoubleClick={resetSidebarWidth} />
       </Sidebar>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1591,9 +1591,13 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
   );
 });
 
-export default function Sidebar() {
+export default function Sidebar(props: {
+  projectScopeKey: string | null;
+  onProjectScopeKeyChange: (key: string | null) => void;
+}) {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
+  const { projectScopeKey, onProjectScopeKeyChange: setProjectScopeKey } = props;
   const threads = useThreadShells();
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
@@ -1824,7 +1828,6 @@ export default function Sidebar() {
 
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
-  const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
   const scopedProjectGroup = useMemo(
     () =>
       projectScopeKey === null
@@ -1847,7 +1850,7 @@ export default function Sidebar() {
     if (projectScopeKey !== null && scopedProjectGroup === null) {
       setProjectScopeKey(null);
     }
-  }, [projectScopeKey, scopedProjectGroup]);
+  }, [projectScopeKey, scopedProjectGroup, setProjectScopeKey]);
   // Count-only subscription: the parent needs "are there draft rows" for the
   // empty state, while SidebarDraftBlock owns the per-keystroke content
   // subscription. Selecting a number keeps typing in a draft composer from


### PR DESCRIPTION
## Problem

The new sidebar kept its project filter in `ThreadSidebar` component state. Opening Settings replaces that component with the settings navigation, so returning to the thread sidebar reset the filter to “All projects.”

## Fix

Hoist the selected project scope into `AppSidebarLayout`, which remains mounted across Settings navigation, and pass the value and setter into `ThreadSidebar`. Existing project validation and filtering behavior remains unchanged, and the filter is not persisted across reloads.

## Impact

Users can open Settings and return without losing their selected sidebar project filter.

## Validation

- Manual web verification of filter → Settings → Back
- `pnpm --filter @t3tools/web typecheck`
- `vp test run src/components/Sidebar.logic.test.ts src/components/ui/sidebar.test.tsx --project unit` (111 tests)
- Formatting and `git diff --check`

No screenshots included because the change only preserves state across navigation and has no visual before/after difference.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve project filter in sidebar across settings navigation
> Lifts `projectScopeKey` state from [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/6480/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) into [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/6480/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) so the selected project filter survives re-renders caused by navigating through settings. The sidebar now receives the key and its change handler as props instead of managing its own local state.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2439c03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small React state lift with no API, auth, or persistence changes; behavior is limited to preserving in-session UI state across sidebar swaps.
> 
> **Overview**
> Fixes the new thread sidebar resetting its **project filter** to “All projects” after visiting Settings.
> 
> **`projectScopeKey`** is lifted from `Sidebar` into **`AppSidebarLayout`**, which stays mounted when Settings replaces the thread sidebar with settings nav. `ThreadSidebar` now receives **`projectScopeKey`** and **`onProjectScopeKeyChange`** as props instead of owning local state. Existing validation (clearing the scope when the project disappears) and list filtering behavior are unchanged; the filter is still not persisted across reloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2439c0363ac7074911ef8f020e9bac6caed8ae42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->