### PR TITLE
fix(web): return from footer pages to active thread

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -5,7 +5,7 @@ import {
   SettingsIcon,
 } from "lucide-react";
 import { memo, useCallback } from "react";
-import { Link, useLocation, useNavigate } from "@tanstack/react-router";
+import { Link, useCanGoBack, useLocation, useNavigate } from "@tanstack/react-router";
 
 import { useEnvironmentIdentificationMode } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
@@ -119,6 +119,7 @@ function T3Wordmark() {
 
 export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
   const navigate = useNavigate();
+  const canGoBack = useCanGoBack();
   const { isMobile, setOpenMobile } = useSidebar();
   const currentFooterPage = useLocation({
     select: (location) =>
@@ -157,8 +158,12 @@ export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
 
   const handleBackClick = useCallback(() => {
     closeMobileSidebar();
+    if (canGoBack) {
+      window.history.back();
+      return;
+    }
     void navigate({ to: "/" });
-  }, [closeMobileSidebar, navigate]);
+  }, [canGoBack, closeMobileSidebar, navigate]);
 
   return (
     <SidebarFooter className="p-[var(--sidebar-content-inset)]">


### PR DESCRIPTION
## Problem

Opening Usage or Pull Requests from an active thread replaces the footer actions with a Back button, but that button always navigated to `/`. This discarded the originating thread and showed the new-thread screen.

## Fix

Use the router's in-app history state for the shared sidebar Back action. When history is available, the button returns to the route that opened the footer page; direct entries still fall back to `/`.

## Impact

Users return to the active thread they came from after viewing Usage or Pull Requests. Direct links retain the existing safe fallback.

## Validation

- `./node_modules/.bin/vp run --filter @t3tools/web typecheck`
- Manually verified from an active thread in an isolated local T3 environment

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix footer back button to return to active thread using browser history
> The footer back button in `SidebarChromeFooter` now calls `window.history.back()` when a browser history entry exists, falling back to navigating to `/` when there is no history. This uses the `useCanGoBack` hook from `@tanstack/react-router` to determine which path to take.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cfbf04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation-only change in the sidebar footer with a safe `/` fallback when history is empty.
> 
> **Overview**
> The sidebar **Back** control on Usage and Pull Requests no longer always routes to `/`. **`SidebarChromeFooter`** now uses **`useCanGoBack`** from TanStack Router: when in-app history exists, **`handleBackClick`** calls **`window.history.back()`** so users return to the thread (or route) they came from; if there is no history (e.g. direct entry), it still navigates to `/`.
> 
> This matches the back-navigation pattern already used in settings-related screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cfbf044615c1206433707ef9d98ce0a339457dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->