### PR TITLE
fix(mobile): extend blockquotes across wrapped lines

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownBlock.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownBlock.ios.tsx
@@ -4,16 +4,13 @@ import type { MarkdownNode } from "react-native-nitro-markdown/headless";
 
 import { CopyTextButton } from "./CopyTextButton";
 import { MarkdownTextPrimitive } from "./MarkdownTextPrimitive";
-import {
-  nativeMarkdownDocumentRuns,
-  nativeMarkdownListItemBlocks,
-  nativeMarkdownTextRuns,
-} from "./nativeMarkdownText";
+import { nativeMarkdownDocumentRuns, nativeMarkdownListItemBlocks } from "./nativeMarkdownText";
 import { NativeMarkdownSelectableText } from "./NativeMarkdownSelectableText.ios";
 import type {
   MarkdownCodeHighlighter,
   MarkdownHighlightedToken,
   NativeMarkdownTextStyle,
+  SelectableMarkdownSkill,
 } from "./SelectableMarkdownText.types";
 
 type HighlightedCode = ReadonlyArray<ReadonlyArray<MarkdownHighlightedToken>>;
@@ -48,12 +45,13 @@ function documentFor(node: MarkdownNode): MarkdownNode {
 
 function SelectableNode(props: {
   readonly node: MarkdownNode;
+  readonly skills: ReadonlyArray<SelectableMarkdownSkill>;
   readonly textStyle: NativeMarkdownTextStyle;
   readonly onLinkPress?: (href: string) => void;
 }) {
   return (
     <NativeMarkdownSelectableText
-      runs={nativeMarkdownDocumentRuns(documentFor(props.node))}
+      runs={nativeMarkdownDocumentRuns(documentFor(props.node), props.skills)}
       textStyle={props.textStyle}
       onLinkPress={props.onLinkPress}
     />
@@ -322,6 +320,7 @@ function collectTableRows(node: MarkdownNode): MarkdownNode[] {
 
 function NativeTable(props: {
   readonly node: MarkdownNode;
+  readonly skills: ReadonlyArray<SelectableMarkdownSkill>;
   readonly textStyle: NativeMarkdownTextStyle;
   readonly onLinkPress?: (href: string) => void;
 }) {
@@ -359,7 +358,7 @@ function NativeTable(props: {
                 }}
               >
                 <NativeMarkdownSelectableText
-                  runs={nativeMarkdownTextRuns(cell).map((run) =>
+                  runs={nativeMarkdownDocumentRuns(documentFor(cell), props.skills).map((run) =>
                     rowIndex === 0 || cell.isHeader ? { ...run, bold: true } : run,
                   )}
                   textStyle={props.textStyle}
@@ -376,6 +375,7 @@ function NativeTable(props: {
 
 function NativeMarkdownImage(props: {
   readonly node: MarkdownNode;
+  readonly skills: ReadonlyArray<SelectableMarkdownSkill>;
   readonly textStyle: NativeMarkdownTextStyle;
   readonly onLinkPress?: (href: string) => void;
 }) {
@@ -384,6 +384,7 @@ function NativeMarkdownImage(props: {
     return (
       <SelectableNode
         node={props.node}
+        skills={props.skills}
         textStyle={props.textStyle}
         onLinkPress={props.onLinkPress}
       />
@@ -445,6 +446,7 @@ function inlineGroups(nodes: ReadonlyArray<MarkdownNode>): MarkdownNode[] {
 
 function NativeMixedParagraph(props: {
   readonly node: MarkdownNode;
+  readonly skills: ReadonlyArray<SelectableMarkdownSkill>;
   readonly textStyle: NativeMarkdownTextStyle;
   readonly onLinkPress?: (href: string) => void;
 }) {
@@ -455,6 +457,7 @@ function NativeMixedParagraph(props: {
           <NativeMarkdownImage
             key={nodeKey(child, index)}
             node={child}
+            skills={props.skills}
             textStyle={props.textStyle}
             onLinkPress={props.onLinkPress}
           />
@@ -462,6 +465,7 @@ function NativeMixedParagraph(props: {
           <SelectableNode
             key={nodeKey(child, index)}
             node={child}
+            skills={props.skills}
             textStyle={props.textStyle}
             onLinkPress={props.onLinkPress}
           />
@@ -473,6 +477,7 @@ function NativeMixedParagraph(props: {
 
 function NativeList(props: {
   readonly node: MarkdownNode;
+  readonly skills: ReadonlyArray<SelectableMarkdownSkill>;
   readonly textStyle: NativeMarkdownTextStyle;
   readonly highlightCode: MarkdownCodeHighlighter;
   readonly onLinkPress?: (href: string) => void;
@@ -534,6 +539,7 @@ function NativeList(props: {
                 <NativeMarkdownBlock
                   key={nodeKey(child, childIndex)}
                   node={child}
+                  skills={props.skills}
                   textStyle={props.textStyle}
                   highlightCode={props.highlightCode}
                   onLinkPress={props.onLinkPress}
@@ -551,6 +557,7 @@ function NativeList(props: {
 
 export function NativeMarkdownBlock(props: {
   readonly node: MarkdownNode;
+  readonly skills: ReadonlyArray<SelectableMarkdownSkill>;
   readonly textStyle: NativeMarkdownTextStyle;
   readonly highlightCode: MarkdownCodeHighlighter;
   readonly onLinkPress?: (href: string) => void;
@@ -566,6 +573,7 @@ export function NativeMarkdownBlock(props: {
             <NativeMarkdownBlock
               key={nodeKey(child, index)}
               node={child}
+              skills={props.skills}
               textStyle={props.textStyle}
               highlightCode={props.highlightCode}
               onLinkPress={props.onLinkPress}
@@ -587,6 +595,7 @@ export function NativeMarkdownBlock(props: {
       return (
         <NativeTable
           node={props.node}
+          skills={props.skills}
           textStyle={props.textStyle}
           onLinkPress={props.onLinkPress}
         />
@@ -595,6 +604,7 @@ export function NativeMarkdownBlock(props: {
       return (
         <NativeMarkdownImage
           node={props.node}
+          skills={props.skills}
           textStyle={props.textStyle}
           onLinkPress={props.onLinkPress}
         />
@@ -624,6 +634,7 @@ export function NativeMarkdownBlock(props: {
             <NativeMarkdownBlock
               key={nodeKey(child, index)}
               node={child}
+              skills={props.skills}
               textStyle={props.textStyle}
               highlightCode={props.highlightCode}
               onLinkPress={props.onLinkPress}
@@ -637,6 +648,7 @@ export function NativeMarkdownBlock(props: {
       return (
         <NativeList
           node={props.node}
+          skills={props.skills}
           textStyle={props.textStyle}
           highlightCode={props.highlightCode}
           onLinkPress={props.onLinkPress}
@@ -647,12 +659,14 @@ export function NativeMarkdownBlock(props: {
       return (props.node.children ?? []).some((child) => child.type === "image") ? (
         <NativeMixedParagraph
           node={props.node}
+          skills={props.skills}
           textStyle={props.textStyle}
           onLinkPress={props.onLinkPress}
         />
       ) : (
         <SelectableNode
           node={props.node}
+          skills={props.skills}
           textStyle={props.textStyle}
           onLinkPress={props.onLinkPress}
         />
@@ -673,6 +687,7 @@ export function NativeMarkdownBlock(props: {
         >
           <SelectableNode
             node={props.node}
+            skills={props.skills}
             textStyle={props.textStyle}
             onLinkPress={props.onLinkPress}
           />
@@ -690,6 +705,7 @@ export function NativeMarkdownBlock(props: {
             <NativeMarkdownBlock
               key={nodeKey(child, index)}
               node={child}
+              skills={props.skills}
               textStyle={props.textStyle}
               highlightCode={props.highlightCode}
               onLinkPress={props.onLinkPress}
@@ -703,6 +719,7 @@ export function NativeMarkdownBlock(props: {
       return (
         <SelectableNode
           node={props.node}
+          skills={props.skills}
           textStyle={props.textStyle}
           onLinkPress={props.onLinkPress}
         />

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
@@ -69,6 +69,7 @@ export function SelectableMarkdownText({
           chunk.kind === "rich" ? (
             <NativeMarkdownBlock
               node={chunk.node}
+              skills={skills}
               textStyle={textStyle}
               highlightCode={highlightCode}
               onLinkPress={onLinkPress}

--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -661,6 +661,7 @@ function appendDocumentBlock(
 function containsRichBlock(node: MarkdownNode): boolean {
   if (
     node.type === "code_block" ||
+    node.type === "blockquote" ||
     node.type === "table" ||
     node.type === "image" ||
     node.type === "horizontal_rule" ||

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -328,7 +328,7 @@ describe("nativeMarkdownDocumentRuns", () => {
     ]);
   });
 
-  it("includes quotes and fenced code in the same selectable string", () => {
+  it("preserves quotes and fenced code in document runs", () => {
     const node: MarkdownNode = {
       type: "document",
       children: [
@@ -414,6 +414,39 @@ describe("nativeMarkdownListItemBlocks", () => {
 });
 
 describe("nativeMarkdownDocumentChunks", () => {
+  it("renders plain blockquotes as rich blocks so their marker spans wrapped lines", () => {
+    const blockquote: MarkdownNode = {
+      type: "blockquote",
+      beg: 0,
+      end: 120,
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              content:
+                "Persistent random per-result keys are the strongest design, even when this text wraps.",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      nativeMarkdownDocumentChunks({
+        type: "document",
+        children: [blockquote],
+      }),
+    ).toEqual([
+      {
+        kind: "rich",
+        key: "rich:blockquote:0:120",
+        node: blockquote,
+      },
+    ]);
+  });
+
   it("keeps headings and plain lists in one selectable document", () => {
     const document: MarkdownNode = {
       type: "document",

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -173,6 +173,25 @@ describe("nativeMarkdownDocumentRuns", () => {
     ]);
   });
 
+  it("decorates known skill references inside blockquotes", () => {
+    const node: MarkdownNode = {
+      type: "blockquote",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", content: "Use $ui for this." }],
+        },
+      ],
+    };
+
+    expect(nativeMarkdownDocumentRuns(node, [{ name: "ui", displayName: "UI" }])).toContainEqual({
+      text: "$ui",
+      role: "body",
+      skillName: "ui",
+      skillLabel: "UI",
+    });
+  });
+
   it("leaves unknown skill-like text unchanged", () => {
     const node: MarkdownNode = {
       type: "document",


### PR DESCRIPTION
## What Changed

- Route React Native blockquotes through the existing bordered block renderer so the quote marker spans every visually wrapped line in both user and assistant messages.
- Add regression coverage that keeps plain blockquotes in rich Markdown chunks.
- Verify the change with the focused Markdown tests, mobile typecheck, targeted lint, and an iOS Simulator pass.

## Why

The iOS React Native selectable Markdown path represented a blockquote with a literal `│` text glyph. That marker only appeared on the first rendered line when a single Markdown line wrapped, even though the provider output was correct. Rendering the blockquote as a bordered container makes the marker follow the measured height of its content.

## UI Changes

### Before

<img width="100%" alt="Before: blockquote markers stop after the first rendered line" src="https://raw.githubusercontent.com/chrisdeeming/t3code/pr-assets/mobile-markdown-blockquote-wrap/.github/pr-assets/mobile-markdown-blockquote-wrap/before.png">

### After

<img width="100%" alt="After: blockquote borders span all wrapped lines" src="https://raw.githubusercontent.com/chrisdeeming/t3code/pr-assets/mobile-markdown-blockquote-wrap/.github/pr-assets/mobile-markdown-blockquote-wrap/after.png">

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] A video is not applicable because this change has no animation or interaction

Created with **gpt-5.6-sol** using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only markdown presentation and prop threading; no auth, data, or API changes.
> 
> **Overview**
> **Plain blockquotes** on iOS now use the **rich** markdown path (`containsRichBlock` includes `blockquote`) so they render via `NativeMarkdownBlock`’s **left border** instead of a `│` character in selectable text—fixing markers that disappeared after the first wrapped line.
> 
> **`skills`** is threaded through `NativeMarkdownBlock` and nested renderers, and selectable/table text uses **`nativeMarkdownDocumentRuns`** (with skills) instead of **`nativeMarkdownTextRuns`**, so **`$skill`** decoration still works inside blockquotes and table cells. Regression tests cover rich blockquote chunking and skills in quotes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a24be2958aa8bd480c0f77b999a33058c2b135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix blockquote rendering to extend across wrapped lines on mobile
> - Adds `node.type === "blockquote"` to `containsRichBlock` in [nativeMarkdownText.ts](https://github.com/pingdotgg/t3code/pull/6482/files#diff-6ca1a8722a1053a74dedf7789620201e8345f0d095c5b9f9307c754fa0a4147a), routing blockquotes through the rich rendering path so they render correctly across line wraps.
> - Propagates a `skills` array through `NativeMarkdownBlock` and all child components (`SelectableNode`, `NativeTable`, `NativeMarkdownImage`, `NativeMixedParagraph`, `NativeList`) so skill-link decoration applies inside rich blocks including blockquotes.
> - Replaces `nativeMarkdownTextRuns` with `nativeMarkdownDocumentRuns` in table cells and selectable nodes to support skill decoration.
> - Behavioral Change: `NativeMarkdownBlock` now requires a `skills` prop; callers must pass it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0a24be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->